### PR TITLE
Fix Release Build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,12 @@ graph TB
 
 6. **Diagrams**: Use Mermaid for all diagrams. Never use ASCII art.
 
-7. **Documentation Updates**: When modifying documentation in `docs/`, also update the LLM-readable files:
+7. **Pinned Dependencies**: All external dependencies must be pinned to specific versions with SHA digests for reproducibility and security:
+   - Docker base images: `alpine:3.21@sha256:...`
+   - GitHub Actions: `actions/checkout@sha256:...`
+   - Go modules are pinned via `go.sum`
+
+8. **Documentation Updates**: When modifying documentation in `docs/`, also update the LLM-readable files:
    - `docs/llms.txt` - Index of documentation with brief descriptions
    - `docs/llms-full.txt` - Full documentation content for AI consumption
    These files follow the [llmstxt.org](https://llmstxt.org/) specification.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM alpine:3.23@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
+FROM alpine:3.21@sha256:5405e8f36ce1878720f71217d664aa3dea32e5e5df11acbf07fc78ef5661465b
 
 # Install ca-certificates for TLS connections
 RUN apk add --no-cache ca-certificates


### PR DESCRIPTION
Fixed Dockerfile using non-existent Alpine version.

## Changes

- `Dockerfile`: Changed `alpine:3.23` (doesn't exist) to `alpine:3.21` with pinned SHA digest
- `CLAUDE.md`: Added requirement to pin all dependencies with SHA digests

## Verification

```
$ goreleaser release --snapshot --clean --skip=sbom,sign
...
• docker images (v2)
  • created images id=alpine digest=sha256:feae5dcc70c714d6d67dfdae4f6cb92fd0567dd6ee5e5339baa8df1d31c77519
  • created images id=alpine digest=sha256:4c1c671a29768a91773c194bd0a0f19ad5a4ff92007bd137e658f762757b2064
• release succeeded after 47s
```
