### PR TITLE
Bump `mcp-datahub` to v0.3.1 in dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/lib/pq v1.10.9
 	github.com/modelcontextprotocol/go-sdk v1.2.0
-	github.com/txn2/mcp-datahub v0.3.0
+	github.com/txn2/mcp-datahub v0.3.1
 	github.com/txn2/mcp-s3 v0.1.4
 	github.com/txn2/mcp-trino v0.2.1
 	golang.org/x/crypto v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v0.3.0 h1:+4UfEKsYK3bUimnFg20f/C/o2sjYrv28U1w2ZR/QLs0=
-github.com/txn2/mcp-datahub v0.3.0/go.mod h1:9YWiNjhmFjmXMK9PX9QmlQgouaZLu/edqJ5hKC5qZUA=
+github.com/txn2/mcp-datahub v0.3.1 h1:/iIyUY0FCE2twWieMPTYPUWWssIK8ouxifzWgb2M4Aw=
+github.com/txn2/mcp-datahub v0.3.1/go.mod h1:9YWiNjhmFjmXMK9PX9QmlQgouaZLu/edqJ5hKC5qZUA=
 github.com/txn2/mcp-s3 v0.1.4 h1:73VfwofCNUoVAzWQgh1LoaAsNW42jEUTGfRPe1s7Vkk=
 github.com/txn2/mcp-s3 v0.1.4/go.mod h1:yu2m8DZdsHJEWj+Ktkhz1XUk17jqPdVSa4UcyZWetkc=
 github.com/txn2/mcp-trino v0.2.1 h1:gFaSq2IC+aDlWvFB91fww1yx1110xbaBrkgfZNr9jCc=


### PR DESCRIPTION
## Description

This patch release fixes the datahub_get_lineage tool which was broken due to an incompatible GraphQL parameter. The fix ensures compatibility with current DataHub versions.

## Type of Change

Dependency update.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Test improvement (new or updated tests)
- [ ] Documentation update
- [ ] Stability/performance improvement
- [ ] Build/CI improvement

> **Note:** New features are developed by maintainers only. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

## Related Issues

<!-- Link to issues this PR addresses. Use "Fixes #123" for automatic closing -->

Fixes #

## Testing

<!-- How was this tested? Include steps to reproduce if applicable -->

- [x] Ran `make test` locally
- [x] Tested manually
- [ ] Added new tests for changes (if applicable)

## Checklist

- [x] My code follows the project's style guidelines (`make lint`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have updated documentation if needed
- [x] This PR is focused and does not include unrelated changes

