### PR TITLE
Resolve all 221 golangci-lint findings with enterprise linter config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -312,6 +312,8 @@ linters:
           - unparam
           - thelper
           - revive
+          - nilnil
+          - nestif
 
       # Allow longer functions in tests
       - path: _test\.go

--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -21,9 +21,11 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/platform"
 )
 
+const defaultReadHeaderTimeout = 10 * time.Second
+
 func main() {
 	if err := run(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }
@@ -41,7 +43,7 @@ func parseFlags() serverOptions {
 	flag.StringVar(&opts.transport, "transport", "stdio", "Transport type: stdio, http")
 	flag.StringVar(&opts.address, "address", ":8080", "Server address for HTTP transports")
 	flag.BoolVar(&opts.showVersion, "version", false, "Show version and exit")
-	flag.Parse()
+	flag.Parse() //nolint:revive // flag.Parse in main-called function is intentional
 	return opts
 }
 
@@ -68,11 +70,17 @@ func createServer(opts serverOptions) (*serverResult, error) {
 
 	if opts.configPath != "" {
 		result.mcpServer, result.platform, err = mcpserver.NewWithConfig(opts.configPath)
-		return result, err
+		if err != nil {
+			return nil, fmt.Errorf("creating server with config: %w", err)
+		}
+		return result, nil
 	}
 
 	result.mcpServer, result.toolkit, err = mcpserver.NewWithDefaults()
-	return result, err
+	if err != nil {
+		return nil, fmt.Errorf("creating server with defaults: %w", err)
+	}
+	return result, nil
 }
 
 func run() error {
@@ -120,7 +128,10 @@ func applyConfigOverrides(p *platform.Platform, opts *serverOptions) {
 func startServer(ctx context.Context, mcpServer *mcp.Server, p *platform.Platform, opts serverOptions) error {
 	switch opts.transport {
 	case "stdio":
-		return mcpServer.Run(ctx, &mcp.StdioTransport{})
+		if err := mcpServer.Run(ctx, &mcp.StdioTransport{}); err != nil {
+			return fmt.Errorf("running stdio server: %w", err)
+		}
+		return nil
 	case "http", "sse":
 		// HTTP serves both SSE (/sse, /message) and Streamable HTTP (/mcp).
 		// "sse" is accepted for backward compatibility.
@@ -264,7 +275,7 @@ func listenAndServe(ctx context.Context, addr string, handler http.Handler, hcfg
 	server := &http.Server{
 		Addr:              addr,
 		Handler:           handler,
-		ReadHeaderTimeout: 10 * time.Second,
+		ReadHeaderTimeout: defaultReadHeaderTimeout,
 	}
 
 	go func() {
@@ -277,14 +288,14 @@ func listenAndServe(ctx context.Context, addr string, handler http.Handler, hcfg
 	if hcfg.tlsEnabled {
 		log.Printf("Starting HTTP server with TLS on %s\n", addr)
 		if err := server.ListenAndServeTLS(hcfg.tlsCertFile, hcfg.tlsKeyFile); err != http.ErrServerClosed {
-			return err
+			return fmt.Errorf("listening with TLS on %s: %w", addr, err)
 		}
 		return nil
 	}
 
 	log.Printf("Starting HTTP server on %s\n", addr)
 	if err := server.ListenAndServe(); err != http.ErrServerClosed {
-		return err
+		return fmt.Errorf("listening on %s: %w", addr, err)
 	}
 	return nil
 }

--- a/cmd/mcp-data-platform/main_test.go
+++ b/cmd/mcp-data-platform/main_test.go
@@ -115,7 +115,7 @@ func TestCorsMiddleware(t *testing.T) {
 }
 
 func TestStartServer_UnknownTransport(t *testing.T) {
-	err := startServer(nil, nil, nil, serverOptions{transport: "websocket"})
+	err := startServer(context.TODO(), nil, nil, serverOptions{transport: "websocket"})
 	if err == nil {
 		t.Fatal("expected error for unknown transport")
 	}
@@ -284,8 +284,7 @@ func TestListenAndServe_GracefulShutdown(t *testing.T) {
 }
 
 func TestListenAndServe_TLSBadCert(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/cmd/mcp-data-platform/streamable_test.go
+++ b/cmd/mcp-data-platform/streamable_test.go
@@ -223,14 +223,14 @@ func makeTestJWT(t *testing.T, signingKey []byte, issuer, userID string, keycloa
 }
 
 // buildProductionMiddleware sets up the full production-like middleware chain:
-// OAuth JWT auth + PersonaAuthorizer with the same config as production.
+// OAuth JWT auth + Authorizer with the same config as production.
 func buildProductionMiddleware(t *testing.T, signingKey []byte, issuer string) (middleware.Authenticator, middleware.Authorizer) {
 	t.Helper()
 
 	// Create OAuth JWT authenticator (same as production)
 	oauthAuth, err := auth.NewOAuthJWTAuthenticator(auth.OAuthJWTConfig{
 		Issuer:        issuer,
-		SigningKey:     signingKey,
+		SigningKey:    signingKey,
 		RoleClaimPath: "realm_access.roles",
 		RolePrefix:    "dp_",
 	})
@@ -260,7 +260,7 @@ func buildProductionMiddleware(t *testing.T, signingKey []byte, issuer string) (
 	})
 	registry.SetDefault("default")
 
-	// Create OIDCRoleMapper + PersonaAuthorizer (same as production)
+	// Create OIDCRoleMapper + Authorizer (same as production)
 	mapper := &persona.OIDCRoleMapper{
 		ClaimPath:  "realm_access.roles",
 		RolePrefix: "dp_",
@@ -270,7 +270,7 @@ func buildProductionMiddleware(t *testing.T, signingKey []byte, issuer string) (
 		},
 		Registry: registry,
 	}
-	authorizer := persona.NewPersonaAuthorizer(registry, mapper)
+	authorizer := persona.NewAuthorizer(registry, mapper)
 
 	// Chain authenticators (same as production)
 	chainedAuth := auth.NewChainedAuthenticator(
@@ -282,7 +282,7 @@ func buildProductionMiddleware(t *testing.T, signingKey []byte, issuer string) (
 }
 
 // TestStreamableHTTP_OAuthJWT_WithRoles tests the full production flow:
-// OAuth JWT with dp_admin role → PersonaAuthorizer → tool call succeeds.
+// OAuth JWT with dp_admin role → Authorizer → tool call succeeds.
 func TestStreamableHTTP_OAuthJWT_WithRoles(t *testing.T) {
 	ctx := context.Background()
 	signingKey := []byte("test-signing-key-32-bytes-long!!")
@@ -349,7 +349,7 @@ func TestStreamableHTTP_OAuthJWT_WithRoles(t *testing.T) {
 
 // TestStreamableHTTP_OAuthJWT_NoRoles_DeniedByPersona reproduces the
 // production bug: OAuth JWT is VALID (auth succeeds) but the Keycloak
-// user has NO dp_* roles, so PersonaAuthorizer falls back to the default
+// user has NO dp_* roles, so Authorizer falls back to the default
 // persona which denies all tools. Claude.ai shows "Tool execution failed".
 func TestStreamableHTTP_OAuthJWT_NoRoles_DeniedByPersona(t *testing.T) {
 	ctx := context.Background()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,10 +28,11 @@ func New(cfg *platform.Config) (*mcp.Server, *platform.Platform, error) {
 	}
 
 	// Create default toolkit and register
+	mcpSrv := p.MCPServer()
 	toolkit := tools.NewToolkit()
-	toolkit.RegisterTools(p.MCPServer())
+	toolkit.RegisterTools(mcpSrv)
 
-	return p.MCPServer(), p, nil
+	return mcpSrv, p, nil
 }
 
 // NewWithDefaults creates a new MCP server with default configuration.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -96,7 +96,7 @@ query:
 storage:
   provider: noop
 `
-		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
 			t.Fatalf("failed to write config file: %v", err)
 		}
 
@@ -134,7 +134,7 @@ server:
 semantic:
   provider: unknown-provider
 `
-		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
 			t.Fatalf("failed to write config file: %v", err)
 		}
 

--- a/pkg/auth/claims.go
+++ b/pkg/auth/claims.go
@@ -105,7 +105,7 @@ func (e *ClaimsExtractor) getStringSlice(claims map[string]any, path string) []s
 }
 
 // getValue gets a value at a dot-separated path.
-func (e *ClaimsExtractor) getValue(claims map[string]any, path string) any {
+func (*ClaimsExtractor) getValue(claims map[string]any, path string) any {
 	if path == "" {
 		return nil
 	}
@@ -114,11 +114,11 @@ func (e *ClaimsExtractor) getValue(claims map[string]any, path string) any {
 	var current any = claims
 
 	for _, part := range parts {
-		if m, ok := current.(map[string]any); ok {
-			current = m[part]
-		} else {
+		m, ok := current.(map[string]any)
+		if !ok {
 			return nil
 		}
+		current = m[part]
 	}
 
 	return current

--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -3,6 +3,7 @@ package auth
 
 import (
 	"context"
+	"slices"
 
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 )
@@ -53,30 +54,15 @@ func GetToken(ctx context.Context) string {
 
 // HasRole checks if the user has a specific role.
 func (uc *UserContext) HasRole(role string) bool {
-	for _, r := range uc.Roles {
-		if r == role {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(uc.Roles, role)
 }
 
 // HasAnyRole checks if the user has any of the specified roles.
 func (uc *UserContext) HasAnyRole(roles ...string) bool {
-	for _, role := range roles {
-		if uc.HasRole(role) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(roles, uc.HasRole)
 }
 
 // InGroup checks if the user is in a specific group.
 func (uc *UserContext) InGroup(group string) bool {
-	for _, g := range uc.Groups {
-		if g == group {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(uc.Groups, group)
 }

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -69,7 +69,7 @@ type BearerTokenExtractor struct {
 }
 
 // Extract extracts a bearer token from the context.
-func (e *BearerTokenExtractor) Extract(ctx context.Context) (string, error) {
+func (*BearerTokenExtractor) Extract(ctx context.Context) (string, error) {
 	// In MCP, we typically get auth info from the request metadata
 	// This is a placeholder - actual extraction depends on transport
 	token := GetToken(ctx)
@@ -78,8 +78,8 @@ func (e *BearerTokenExtractor) Extract(ctx context.Context) (string, error) {
 	}
 
 	// Strip "Bearer " prefix if present
-	if strings.HasPrefix(token, "Bearer ") {
-		return strings.TrimPrefix(token, "Bearer "), nil
+	if after, ok := strings.CutPrefix(token, "Bearer "); ok {
+		return after, nil
 	}
 
 	return token, nil
@@ -92,7 +92,7 @@ type APIKeyExtractor struct {
 }
 
 // Extract extracts an API key from the context.
-func (e *APIKeyExtractor) Extract(ctx context.Context) (string, error) {
+func (*APIKeyExtractor) Extract(ctx context.Context) (string, error) {
 	// This is a placeholder - actual extraction depends on transport
 	token := GetToken(ctx)
 	if token == "" {

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -188,7 +188,9 @@ func TestChainedAuthConfig(t *testing.T) {
 }
 
 // Verify interface compliance.
-var _ middleware.Authenticator = (*mockAuthenticator)(nil)
-var _ middleware.Authenticator = (*ChainedAuthenticator)(nil)
-var _ TokenExtractor = (*BearerTokenExtractor)(nil)
-var _ TokenExtractor = (*APIKeyExtractor)(nil)
+var (
+	_ middleware.Authenticator = (*mockAuthenticator)(nil)
+	_ middleware.Authenticator = (*ChainedAuthenticator)(nil)
+	_ TokenExtractor           = (*BearerTokenExtractor)(nil)
+	_ TokenExtractor           = (*APIKeyExtractor)(nil)
+)

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/golang-jwt/jwt/v5"
 
@@ -34,10 +35,10 @@ type OAuthJWTAuthenticator struct {
 // NewOAuthJWTAuthenticator creates a new OAuth JWT authenticator.
 func NewOAuthJWTAuthenticator(cfg OAuthJWTConfig) (*OAuthJWTAuthenticator, error) {
 	if cfg.Issuer == "" {
-		return nil, fmt.Errorf("OAuth issuer is required")
+		return nil, fmt.Errorf("oauth issuer is required")
 	}
 	if len(cfg.SigningKey) == 0 {
-		return nil, fmt.Errorf("OAuth signing key is required")
+		return nil, fmt.Errorf("oauth signing key is required")
 	}
 
 	extractor := &ClaimsExtractor{
@@ -134,9 +135,7 @@ func (a *OAuthJWTAuthenticator) parseAndValidateToken(tokenString string) (map[s
 
 	// Convert to map[string]any for compatibility
 	claimsMap := make(map[string]any)
-	for k, v := range claims {
-		claimsMap[k] = v
-	}
+	maps.Copy(claimsMap, claims)
 
 	return claimsMap, nil
 }

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -687,7 +687,7 @@ func TestOIDCAuthenticator_getPublicKey(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for nil JWKS")
 		}
-		if err.Error() != "JWKS not loaded" {
+		if err.Error() != "jwks not loaded" {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
@@ -707,7 +707,7 @@ func TestOIDCAuthenticator_getPublicKey(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for expired cache")
 		}
-		if err.Error() != "JWKS cache expired" {
+		if err.Error() != "jwks cache expired" {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
@@ -894,7 +894,7 @@ func TestOIDCAuthenticator_parseAndValidateToken_ValidSignature(t *testing.T) {
 	}
 
 	// Encode public key components for JWKS
-	nBytes := privateKey.PublicKey.N.Bytes()
+	nBytes := privateKey.N.Bytes()
 	nBase64 := base64.RawURLEncoding.EncodeToString(nBytes)
 
 	eBytes := big.NewInt(int64(privateKey.PublicKey.E)).Bytes()
@@ -908,7 +908,7 @@ func TestOIDCAuthenticator_parseAndValidateToken_ValidSignature(t *testing.T) {
 			_, _ = w.Write([]byte(`{"jwks_uri": "` + "http://" + r.Host + `/jwks"}`))
 		case "/jwks":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(fmt.Sprintf(`{
+			_, _ = fmt.Fprintf(w, `{
 				"keys": [
 					{
 						"kty": "RSA",
@@ -918,7 +918,7 @@ func TestOIDCAuthenticator_parseAndValidateToken_ValidSignature(t *testing.T) {
 						"e": "%s"
 					}
 				]
-			}`, nBase64, eBase64)))
+			}`, nBase64, eBase64)
 		}
 	}))
 	defer server.Close()
@@ -962,7 +962,7 @@ func TestOIDCAuthenticator_parseAndValidateToken_InvalidSignature(t *testing.T) 
 	jwksKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 
 	// Encode JWKS key (different from signing key)
-	nBytes := jwksKey.PublicKey.N.Bytes()
+	nBytes := jwksKey.N.Bytes()
 	nBase64 := base64.RawURLEncoding.EncodeToString(nBytes)
 	eBytes := big.NewInt(int64(jwksKey.PublicKey.E)).Bytes()
 	eBase64 := base64.RawURLEncoding.EncodeToString(eBytes)
@@ -974,9 +974,9 @@ func TestOIDCAuthenticator_parseAndValidateToken_InvalidSignature(t *testing.T) 
 			_, _ = w.Write([]byte(`{"jwks_uri": "` + "http://" + r.Host + `/jwks"}`))
 		case "/jwks":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(fmt.Sprintf(`{
+			_, _ = fmt.Fprintf(w, `{
 				"keys": [{"kty": "RSA", "kid": "test-key", "use": "sig", "n": "%s", "e": "%s"}]
-			}`, nBase64, eBase64)))
+			}`, nBase64, eBase64)
 		}
 	}))
 	defer server.Close()

--- a/pkg/database/migrate/migrate.go
+++ b/pkg/database/migrate/migrate.go
@@ -76,13 +76,17 @@ func Run(db *sql.DB) error {
 }
 
 // Version returns the current migration version.
-func Version(db *sql.DB) (uint, bool, error) {
+func Version(db *sql.DB) (version uint, dirty bool, err error) {
 	m, err := migratorFactory(db)
 	if err != nil {
 		return 0, false, err
 	}
 
-	return m.Version()
+	version, dirty, err = m.Version()
+	if err != nil {
+		return 0, false, fmt.Errorf("getting migration version: %w", err)
+	}
+	return version, dirty, nil
 }
 
 // Down rolls back all migrations.

--- a/pkg/database/migrate/migrate_unit_test.go
+++ b/pkg/database/migrate/migrate_unit_test.go
@@ -19,10 +19,10 @@ type mockMigrator struct {
 	versionErr error
 }
 
-func (m *mockMigrator) Up() error                      { return m.upErr }
-func (m *mockMigrator) Down() error                    { return m.downErr }
-func (m *mockMigrator) Steps(_ int) error              { return m.stepsErr }
-func (m *mockMigrator) Version() (uint, bool, error)   { return m.versionVal, m.dirty, m.versionErr }
+func (m *mockMigrator) Up() error                    { return m.upErr }
+func (m *mockMigrator) Down() error                  { return m.downErr }
+func (m *mockMigrator) Steps(_ int) error            { return m.stepsErr }
+func (m *mockMigrator) Version() (uint, bool, error) { return m.versionVal, m.dirty, m.versionErr }
 
 func TestMigrationsEmbedded(t *testing.T) {
 	entries, err := migrations.ReadDir("migrations")

--- a/pkg/http/authmiddleware.go
+++ b/pkg/http/authmiddleware.go
@@ -1,4 +1,4 @@
-// Package http provides HTTP middleware for the MCP data platform.
+//nolint:revive // package name matches directory structure
 package http
 
 import (
@@ -18,8 +18,8 @@ func AuthMiddleware(requireAuth bool) func(http.Handler) http.Handler {
 
 			// Extract Bearer token from Authorization header
 			authHeader := r.Header.Get("Authorization")
-			if strings.HasPrefix(authHeader, "Bearer ") {
-				token = strings.TrimPrefix(authHeader, "Bearer ")
+			if after, ok := strings.CutPrefix(authHeader, "Bearer "); ok {
+				token = after
 			}
 
 			// If no Bearer token, try X-API-Key header
@@ -65,8 +65,8 @@ func MCPAuthGateway(resourceMetadataURL string) func(http.Handler) http.Handler 
 			var token string
 
 			authHeader := r.Header.Get("Authorization")
-			if strings.HasPrefix(authHeader, "Bearer ") {
-				token = strings.TrimPrefix(authHeader, "Bearer ")
+			if after, ok := strings.CutPrefix(authHeader, "Bearer "); ok {
+				token = after
 			}
 			if token == "" {
 				token = r.Header.Get("X-API-Key")
@@ -108,8 +108,8 @@ func RequireAuthWithOAuth(resourceMetadataURL string) func(http.Handler) http.Ha
 			var token string
 
 			authHeader := r.Header.Get("Authorization")
-			if strings.HasPrefix(authHeader, "Bearer ") {
-				token = strings.TrimPrefix(authHeader, "Bearer ")
+			if after, ok := strings.CutPrefix(authHeader, "Bearer "); ok {
+				token = after
 			}
 
 			if token == "" {

--- a/pkg/mcpapps/middleware.go
+++ b/pkg/mcpapps/middleware.go
@@ -15,42 +15,46 @@ import (
 func ToolMetadataMiddleware(reg *Registry) mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
-			// Execute the original handler
 			result, err := next(ctx, method, req)
 			if err != nil {
 				return result, err
 			}
-
-			// Only process tools/list responses
-			if method != "tools/list" {
-				return result, nil
-			}
-
-			// Type assert to ListToolsResult
-			listResult, ok := result.(*mcp.ListToolsResult)
-			if !ok || listResult == nil {
-				return result, nil
-			}
-
-			// Inject UI metadata into tools that have registered apps
-			for _, tool := range listResult.Tools {
-				app := reg.GetForTool(tool.Name)
-				if app == nil {
-					continue
-				}
-
-				// Initialize Meta if nil
-				if tool.Meta == nil {
-					tool.Meta = make(mcp.Meta)
-				}
-
-				// Add UI metadata
-				tool.Meta["ui"] = map[string]string{
-					"resourceUri": app.ResourceURI,
-				}
-			}
-
-			return listResult, nil
+			return injectToolMetadata(reg, method, result)
 		}
 	}
+}
+
+// injectToolMetadata adds UI metadata to tools/list responses for tools that
+// have registered MCP Apps.
+func injectToolMetadata(reg *Registry, method string, result mcp.Result) (mcp.Result, error) {
+	// Only process tools/list responses.
+	if method != "tools/list" {
+		return result, nil
+	}
+
+	// Type assert to ListToolsResult.
+	listResult, ok := result.(*mcp.ListToolsResult)
+	if !ok || listResult == nil {
+		return result, nil
+	}
+
+	// Inject UI metadata into tools that have registered apps.
+	for _, tool := range listResult.Tools {
+		app := reg.GetForTool(tool.Name)
+		if app == nil {
+			continue
+		}
+
+		// Initialize Meta if nil.
+		if tool.Meta == nil {
+			tool.Meta = make(mcp.Meta)
+		}
+
+		// Add UI metadata.
+		tool.Meta["ui"] = map[string]string{
+			"resourceUri": app.ResourceURI,
+		}
+	}
+
+	return listResult, nil
 }

--- a/pkg/mcpapps/registry_test.go
+++ b/pkg/mcpapps/registry_test.go
@@ -1,6 +1,7 @@
 package mcpapps
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -49,7 +50,7 @@ func TestRegistry_Register(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			reg := NewRegistry()
 			err := reg.Register(tt.app)
-			if err != tt.wantErr {
+			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("Register() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -75,7 +76,7 @@ func TestRegistry_RegisterDuplicate(t *testing.T) {
 
 	// Second registration should fail
 	err := reg.Register(app)
-	if err != ErrAppAlreadyRegistered {
+	if !errors.Is(err, ErrAppAlreadyRegistered) {
 		t.Errorf("Second Register() error = %v, want %v", err, ErrAppAlreadyRegistered)
 	}
 }
@@ -99,7 +100,7 @@ func TestRegistry_Get(t *testing.T) {
 	// Test getting existing app
 	got := reg.Get("test-app")
 	if got == nil {
-		t.Error("Get() returned nil for existing app")
+		t.Fatal("Get() returned nil for existing app")
 	}
 	if got.Name != "test-app" {
 		t.Errorf("Get() returned app with wrong name: %s", got.Name)

--- a/pkg/mcpapps/resource.go
+++ b/pkg/mcpapps/resource.go
@@ -204,9 +204,9 @@ func injectConfig(content []byte, config any) []byte {
 			// Use explicit buffer to avoid slice aliasing issues with append
 			endIdx += idx + len("</script>")
 			var buf bytes.Buffer
-			buf.Write(content[:idx])
-			buf.WriteString(configScript)
-			buf.Write(content[endIdx:])
+			_, _ = buf.Write(content[:idx])
+			_, _ = buf.WriteString(configScript)
+			_, _ = buf.Write(content[endIdx:])
 			return buf.Bytes()
 		}
 	}
@@ -215,9 +215,9 @@ func injectConfig(content []byte, config any) []byte {
 	headClose := []byte(`</head>`)
 	if idx := bytes.Index(content, headClose); idx != -1 {
 		var buf bytes.Buffer
-		buf.Write(content[:idx])
-		buf.WriteString(configScript + "\n")
-		buf.Write(content[idx:])
+		_, _ = buf.Write(content[:idx])
+		_, _ = buf.WriteString(configScript + "\n")
+		_, _ = buf.Write(content[idx:])
 		return buf.Bytes()
 	}
 

--- a/pkg/mcpapps/resource_test.go
+++ b/pkg/mcpapps/resource_test.go
@@ -2,6 +2,7 @@ package mcpapps
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -505,14 +506,14 @@ func TestReadAsset(t *testing.T) {
 
 	t.Run("returns error for missing file", func(t *testing.T) {
 		_, err := readAsset(app, "nonexistent.html")
-		if err != ErrAssetNotFound {
+		if !errors.Is(err, ErrAssetNotFound) {
 			t.Errorf("Expected ErrAssetNotFound, got %v", err)
 		}
 	})
 
 	t.Run("prevents path traversal", func(t *testing.T) {
 		_, err := readAsset(app, "../errors.go")
-		if err != ErrPathTraversal {
+		if !errors.Is(err, ErrPathTraversal) {
 			t.Errorf("Expected ErrPathTraversal, got %v", err)
 		}
 	})
@@ -520,7 +521,7 @@ func TestReadAsset(t *testing.T) {
 	t.Run("prevents nested traversal", func(t *testing.T) {
 		// Try accessing file with nested path traversal
 		_, err := readAsset(app, "subdir/../../errors.go")
-		if err != ErrPathTraversal {
+		if !errors.Is(err, ErrPathTraversal) {
 			t.Errorf("Expected ErrPathTraversal, got %v", err)
 		}
 	})

--- a/pkg/mcpapps/types.go
+++ b/pkg/mcpapps/types.go
@@ -7,6 +7,7 @@
 package mcpapps
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -112,7 +113,7 @@ func (a *AppDefinition) ValidateAssets() error {
 		if os.IsNotExist(err) {
 			return ErrEntryPointNotFound
 		}
-		return err
+		return fmt.Errorf("checking entry point %s: %w", entryPath, err)
 	}
 
 	return nil

--- a/pkg/mcpapps/types_test.go
+++ b/pkg/mcpapps/types_test.go
@@ -1,6 +1,7 @@
 package mcpapps
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -102,7 +103,7 @@ func TestAppDefinition_Validate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.app.Validate()
-			if err != tt.wantErr {
+			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -146,7 +147,7 @@ func TestAppDefinition_ValidateAssets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.app.ValidateAssets()
-			if err != tt.wantErr {
+			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("ValidateAssets() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/middleware/audit.go
+++ b/pkg/middleware/audit.go
@@ -34,6 +34,6 @@ type AuditEvent struct {
 type NoopAuditLogger struct{}
 
 // Log does nothing.
-func (n *NoopAuditLogger) Log(_ context.Context, _ AuditEvent) error {
+func (*NoopAuditLogger) Log(_ context.Context, _ AuditEvent) error {
 	return nil
 }

--- a/pkg/middleware/audit_adapter.go
+++ b/pkg/middleware/audit_adapter.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/txn2/mcp-data-platform/pkg/audit"
 	auditpostgres "github.com/txn2/mcp-data-platform/pkg/audit/postgres"
@@ -39,11 +40,14 @@ func (a *auditStoreAdapter) Log(ctx context.Context, event AuditEvent) error {
 	// Override timestamp from the event
 	auditEvent.Timestamp = event.Timestamp
 
-	return a.store.Log(ctx, *auditEvent)
+	if err := a.store.Log(ctx, *auditEvent); err != nil {
+		return fmt.Errorf("logging audit event: %w", err)
+	}
+	return nil
 }
 
 // Close releases resources. The adapter itself has no resources to release,
 // as the store lifecycle is managed by the platform.
-func (a *auditStoreAdapter) Close() error {
+func (*auditStoreAdapter) Close() error {
 	return nil
 }

--- a/pkg/middleware/audit_test.go
+++ b/pkg/middleware/audit_test.go
@@ -22,12 +22,6 @@ func (m *mockAuditLogger) Log(_ context.Context, event AuditEvent) error {
 	return m.logErr
 }
 
-func (m *mockAuditLogger) getEvents() []AuditEvent {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return append([]AuditEvent{}, m.events...)
-}
-
 func TestNoopAuditLogger(t *testing.T) {
 	logger := &NoopAuditLogger{}
 	err := logger.Log(context.Background(), AuditEvent{
@@ -112,5 +106,7 @@ func TestAuditEvent(t *testing.T) {
 }
 
 // Verify interface compliance.
-var _ AuditLogger = (*NoopAuditLogger)(nil)
-var _ AuditLogger = (*mockAuditLogger)(nil)
+var (
+	_ AuditLogger = (*NoopAuditLogger)(nil)
+	_ AuditLogger = (*mockAuditLogger)(nil)
+)

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/registry"
 )
 
 // Authenticator validates authentication credentials.
@@ -15,8 +17,8 @@ type Authenticator interface {
 // ToolkitLookup provides toolkit metadata for a given tool name.
 type ToolkitLookup interface {
 	// GetToolkitForTool returns toolkit info (kind, name, connection) for a tool.
-	// Returns found=false if the tool is not found in any registered toolkit.
-	GetToolkitForTool(toolName string) (kind, name, connection string, found bool)
+	// Returns Found=false if the tool is not found in any registered toolkit.
+	GetToolkitForTool(toolName string) registry.ToolkitMatch
 }
 
 // UserInfo holds authenticated user information.

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -90,5 +90,7 @@ func TestNewToolResultText(t *testing.T) {
 }
 
 // Verify interface compliance.
-var _ Authenticator = (*NoopAuthenticator)(nil)
-var _ Authenticator = (*mockAuthenticator)(nil)
+var (
+	_ Authenticator = (*NoopAuthenticator)(nil)
+	_ Authenticator = (*mockAuthenticator)(nil)
+)

--- a/pkg/middleware/authz.go
+++ b/pkg/middleware/authz.go
@@ -18,7 +18,7 @@ type Authorizer interface {
 type NoopAuthorizer struct{}
 
 // IsAuthorized always returns true with empty persona name.
-func (n *NoopAuthorizer) IsAuthorized(_ context.Context, _ string, _ []string, _ string) (bool, string, string) {
+func (*NoopAuthorizer) IsAuthorized(_ context.Context, _ string, _ []string, _ string) (authorized bool, personaName, reason string) {
 	return true, "", ""
 }
 

--- a/pkg/middleware/authz_test.go
+++ b/pkg/middleware/authz_test.go
@@ -46,5 +46,7 @@ func TestAllowAllAuthorizer(t *testing.T) {
 }
 
 // Verify interface compliance.
-var _ Authorizer = (*NoopAuthorizer)(nil)
-var _ Authorizer = (*mockAuthorizer)(nil)
+var (
+	_ Authorizer = (*NoopAuthorizer)(nil)
+	_ Authorizer = (*mockAuthorizer)(nil)
+)

--- a/pkg/middleware/mcp_audit_test.go
+++ b/pkg/middleware/mcp_audit_test.go
@@ -335,7 +335,13 @@ func TestBuildMCPAuditEvent_IncludesResponseSize(t *testing.T) {
 	}
 	req := createAuditTestRequest(t, "trino_query", nil)
 
-	event := buildMCPAuditEvent(pc, req, result, nil, time.Now(), time.Millisecond)
+	event := buildMCPAuditEvent(pc, auditCallInfo{
+		Request:   req,
+		Result:    result,
+		Err:       nil,
+		StartTime: time.Now(),
+		Duration:  time.Millisecond,
+	})
 
 	assert.Equal(t, 11, event.ResponseChars)
 	assert.Equal(t, 2, event.ResponseTokenEstimate)
@@ -368,7 +374,7 @@ func TestMCPAuditMiddleware_ResponseSizeLogged(t *testing.T) {
 	assert.Equal(t, 4, events[0].ResponseTokenEstimate) // 16/4 = 4
 }
 
-// capturingAuditLogger captures audit events for testing
+// capturingAuditLogger captures audit events for testing.
 type capturingAuditLogger struct {
 	mu     sync.Mutex
 	events []AuditEvent
@@ -395,7 +401,7 @@ func (c *capturingAuditLogger) Events() []AuditEvent {
 	return result
 }
 
-// Helper to create ServerRequest for audit testing
+// Helper to create ServerRequest for audit testing.
 func createAuditTestRequest(t *testing.T, toolName string, args map[string]any) *mcp.ServerRequest[*mcp.CallToolParamsRaw] {
 	t.Helper()
 	var argsJSON json.RawMessage

--- a/pkg/middleware/mcp_enrichment.go
+++ b/pkg/middleware/mcp_enrichment.go
@@ -54,7 +54,7 @@ func MCPSemanticEnrichmentMiddleware(
 			// Get tool name from request
 			toolName, extractErr := extractToolName(req)
 			if extractErr != nil {
-				return result, nil
+				return result, nil //nolint:nilerr // enrichment is best-effort; skip if tool name extraction fails
 			}
 
 			// Determine toolkit kind from tool name prefix

--- a/pkg/middleware/mcp_enrichment_test.go
+++ b/pkg/middleware/mcp_enrichment_test.go
@@ -288,7 +288,7 @@ func TestBuildCallToolRequest_NilParams(t *testing.T) {
 	assert.Nil(t, callReq.Params)
 }
 
-// Helper to create ServerRequest for testing
+// Helper to create ServerRequest for testing.
 func createServerRequest(t *testing.T, toolName string, args map[string]any) *mcp.ServerRequest[*mcp.CallToolParamsRaw] {
 	t.Helper()
 	var argsJSON json.RawMessage

--- a/pkg/middleware/mcp_rules.go
+++ b/pkg/middleware/mcp_rules.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -15,8 +16,8 @@ import (
 // This middleware intercepts tools/call responses and:
 // 1. Checks if the tool is a query tool that should have DataHub context first
 // 2. Adds warnings for rule violations to the response
-// 3. Does NOT block requests - it only adds informational guidance
-func MCPRuleEnforcementMiddleware(engine *tuning.RuleEngine, hints *tuning.HintManager) mcp.Middleware {
+// 3. Does NOT block requests - it only adds informational guidance.
+func MCPRuleEnforcementMiddleware(engine *tuning.RuleEngine, _ *tuning.HintManager) mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
 			// Only intercept tools/call requests
@@ -59,12 +60,7 @@ func isQueryTool(toolName string) bool {
 		"trino_execute",
 	}
 
-	for _, qt := range queryTools {
-		if toolName == qt {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(queryTools, toolName)
 }
 
 // prependHintsToResult adds hints as text content at the beginning of the result.

--- a/pkg/middleware/mcp_rules_test.go
+++ b/pkg/middleware/mcp_rules_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/txn2/mcp-data-platform/pkg/tuning"
 )
 

--- a/pkg/middleware/mcp_test.go
+++ b/pkg/middleware/mcp_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/registry"
 )
 
 // mcpTestAuthenticator implements Authenticator for MCP middleware testing.
@@ -40,11 +42,11 @@ type mcpTestToolkitLookup struct {
 	found      bool
 }
 
-func (m *mcpTestToolkitLookup) GetToolkitForTool(_ string) (string, string, string, bool) {
-	return m.kind, m.name, m.connection, m.found
+func (m *mcpTestToolkitLookup) GetToolkitForTool(_ string) registry.ToolkitMatch {
+	return registry.ToolkitMatch{Kind: m.kind, Name: m.name, Connection: m.connection, Found: m.found}
 }
 
-// mcpTestRequest wraps ServerRequest for testing
+// mcpTestRequest wraps ServerRequest for testing.
 type mcpTestRequest struct {
 	mcp.ServerRequest[*mcp.CallToolParamsRaw]
 }

--- a/pkg/middleware/middleware_chain_test.go
+++ b/pkg/middleware/middleware_chain_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/query"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
 	"github.com/txn2/mcp-data-platform/pkg/storage"
 	"github.com/txn2/mcp-data-platform/pkg/tuning"
@@ -59,11 +60,11 @@ type testToolkitLookup struct {
 	tools map[string]struct{ kind, name, conn string }
 }
 
-func (l *testToolkitLookup) GetToolkitForTool(toolName string) (string, string, string, bool) {
+func (l *testToolkitLookup) GetToolkitForTool(toolName string) registry.ToolkitMatch {
 	if info, ok := l.tools[toolName]; ok {
-		return info.kind, info.name, info.conn, true
+		return registry.ToolkitMatch{Kind: info.kind, Name: info.name, Connection: info.conn, Found: true}
 	}
-	return "", "", "", false
+	return registry.ToolkitMatch{}
 }
 
 // connectClientServer creates an in-memory MCP client-server pair.
@@ -262,7 +263,7 @@ func TestMiddlewareChain_WrongOrder_AuditGetsNilContext(t *testing.T) {
 
 // mockSemanticProvider returns canned semantic metadata.
 type mockSemanticProvider struct {
-	tableContext   *semantic.TableContext
+	tableContext  *semantic.TableContext
 	columnsCtx    map[string]*semantic.ColumnContext
 	searchResults []semantic.TableSearchResult
 }
@@ -271,18 +272,23 @@ func (m *mockSemanticProvider) Name() string { return "mock" }
 func (m *mockSemanticProvider) GetTableContext(_ context.Context, _ semantic.TableIdentifier) (*semantic.TableContext, error) {
 	return m.tableContext, nil
 }
+
 func (m *mockSemanticProvider) GetColumnContext(_ context.Context, _ semantic.ColumnIdentifier) (*semantic.ColumnContext, error) {
 	return nil, nil
 }
+
 func (m *mockSemanticProvider) GetColumnsContext(_ context.Context, _ semantic.TableIdentifier) (map[string]*semantic.ColumnContext, error) {
 	return m.columnsCtx, nil
 }
+
 func (m *mockSemanticProvider) GetLineage(_ context.Context, _ semantic.TableIdentifier, _ semantic.LineageDirection, _ int) (*semantic.LineageInfo, error) {
 	return nil, nil
 }
+
 func (m *mockSemanticProvider) GetGlossaryTerm(_ context.Context, _ string) (*semantic.GlossaryTerm, error) {
 	return nil, nil
 }
+
 func (m *mockSemanticProvider) SearchTables(_ context.Context, _ semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
 	return m.searchResults, nil
 }
@@ -297,15 +303,19 @@ func (m *mockQueryProvider) Name() string { return "mock" }
 func (m *mockQueryProvider) ResolveTable(_ context.Context, _ string) (*query.TableIdentifier, error) {
 	return nil, nil
 }
+
 func (m *mockQueryProvider) GetTableAvailability(_ context.Context, _ string) (*query.TableAvailability, error) {
 	return m.availability, nil
 }
-func (m *mockQueryProvider) GetQueryExamples(_ context.Context, _ string) ([]query.QueryExample, error) {
+
+func (m *mockQueryProvider) GetQueryExamples(_ context.Context, _ string) ([]query.Example, error) {
 	return nil, nil
 }
+
 func (m *mockQueryProvider) GetExecutionContext(_ context.Context, _ []string) (*query.ExecutionContext, error) {
 	return nil, nil
 }
+
 func (m *mockQueryProvider) GetTableSchema(_ context.Context, _ query.TableIdentifier) (*query.TableSchema, error) {
 	return nil, nil
 }

--- a/pkg/middleware/semantic_test.go
+++ b/pkg/middleware/semantic_test.go
@@ -647,18 +647,23 @@ func (m *mockSemanticProvider) GetTableContext(ctx context.Context, table semant
 	}
 	return nil, nil
 }
+
 func (m *mockSemanticProvider) GetColumnContext(_ context.Context, _ semantic.ColumnIdentifier) (*semantic.ColumnContext, error) {
 	return nil, nil
 }
+
 func (m *mockSemanticProvider) GetColumnsContext(_ context.Context, _ semantic.TableIdentifier) (map[string]*semantic.ColumnContext, error) {
 	return nil, nil
 }
+
 func (m *mockSemanticProvider) GetLineage(_ context.Context, _ semantic.TableIdentifier, _ semantic.LineageDirection, _ int) (*semantic.LineageInfo, error) {
 	return nil, nil
 }
+
 func (m *mockSemanticProvider) GetGlossaryTerm(_ context.Context, _ string) (*semantic.GlossaryTerm, error) {
 	return nil, nil
 }
+
 func (m *mockSemanticProvider) SearchTables(ctx context.Context, filter semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
 	if m.searchTablesFunc != nil {
 		return m.searchTablesFunc(ctx, filter)
@@ -676,18 +681,22 @@ func (m *mockQueryProvider) Name() string { return "mock" }
 func (m *mockQueryProvider) ResolveTable(_ context.Context, _ string) (*query.TableIdentifier, error) {
 	return nil, nil
 }
+
 func (m *mockQueryProvider) GetTableAvailability(ctx context.Context, urn string) (*query.TableAvailability, error) {
 	if m.getTableAvailabilityFunc != nil {
 		return m.getTableAvailabilityFunc(ctx, urn)
 	}
 	return nil, nil
 }
-func (m *mockQueryProvider) GetQueryExamples(_ context.Context, _ string) ([]query.QueryExample, error) {
+
+func (m *mockQueryProvider) GetQueryExamples(_ context.Context, _ string) ([]query.Example, error) {
 	return nil, nil
 }
+
 func (m *mockQueryProvider) GetExecutionContext(_ context.Context, _ []string) (*query.ExecutionContext, error) {
 	return nil, nil
 }
+
 func (m *mockQueryProvider) GetTableSchema(_ context.Context, _ query.TableIdentifier) (*query.TableSchema, error) {
 	return nil, nil
 }
@@ -702,15 +711,18 @@ func (m *mockStorageProvider) Name() string { return "mock" }
 func (m *mockStorageProvider) ResolveDataset(_ context.Context, _ string) (*storage.DatasetIdentifier, error) {
 	return nil, nil
 }
+
 func (m *mockStorageProvider) GetDatasetAvailability(ctx context.Context, urn string) (*storage.DatasetAvailability, error) {
 	if m.getDatasetAvailabilityFunc != nil {
 		return m.getDatasetAvailabilityFunc(ctx, urn)
 	}
 	return nil, nil
 }
+
 func (m *mockStorageProvider) GetAccessExamples(_ context.Context, _ string) ([]storage.AccessExample, error) {
 	return nil, nil
 }
+
 func (m *mockStorageProvider) ListObjects(_ context.Context, _ storage.DatasetIdentifier, _ int) ([]storage.ObjectInfo, error) {
 	return nil, nil
 }

--- a/pkg/middleware/sqlextract.go
+++ b/pkg/middleware/sqlextract.go
@@ -77,16 +77,16 @@ func extractCTENames(sql string) map[string]bool {
 
 // Regex patterns for SQL table extraction.
 var (
-	// ES raw_query patterns (non-standard Trino syntax)
+	// ES raw_query patterns (non-standard Trino syntax).
 	rawQueryPattern    = regexp.MustCompile(`(?i)TABLE\s*\(\s*elasticsearch\.system\.raw_query\s*\(`)
 	indexParamPattern  = regexp.MustCompile(`(?i)index\s*=>\s*'([^']+)'`)
 	schemaParamPattern = regexp.MustCompile(`(?i)schema\s*=>\s*'([^']+)'`)
 
-	// CTE name pattern - matches "WITH name AS" or ", name AS" for chained CTEs
+	// CTE name pattern - matches "WITH name AS" or ", name AS" for chained CTEs.
 	cteNamePattern = regexp.MustCompile(`(?i)(?:WITH|,)\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+AS\s*\(`)
 
 	// Table reference patterns for Trino 3-part names
-	// Matches: FROM/JOIN catalog.schema.table or schema.table or table
+	// Matches: FROM/JOIN catalog.schema.table or schema.table or table.
 	tableRefPattern = regexp.MustCompile(`(?i)(?:FROM|JOIN)\s+` +
 		`([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*){0,2})` +
 		`(?:\s+(?:AS\s+)?[a-zA-Z_][a-zA-Z0-9_]*)?(?:\s|,|$|ON|WHERE|GROUP|ORDER|LIMIT|LEFT|RIGHT|INNER|OUTER|CROSS|NATURAL)`)
@@ -121,13 +121,16 @@ func extractTablesWithRegex(sql string) []TableRef {
 	return tables
 }
 
+// tableNamePartsCount is the expected number of parts in a fully-qualified table name (catalog.schema.table).
+const tableNamePartsCount = 3
+
 // parseTablePath parses a dot-separated table path into TableRef.
 func parseTablePath(path string) TableRef {
 	parts := strings.Split(path, ".")
 	ref := TableRef{FullPath: path}
 
 	switch len(parts) {
-	case 3:
+	case tableNamePartsCount:
 		ref.Catalog = parts[0]
 		ref.Schema = parts[1]
 		ref.Table = parts[2]

--- a/pkg/oauth/dcr.go
+++ b/pkg/oauth/dcr.go
@@ -11,6 +11,18 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+// DCR credential size constants.
+const (
+	// clientIDByteLength is the byte length for generated client IDs.
+	clientIDByteLength = 32
+
+	// clientSecretByteLength is the byte length for generated client secrets.
+	clientSecretByteLength = 48
+
+	// idByteLength is the byte length for generated unique IDs.
+	idByteLength = 16
+)
+
 // DCRConfig configures Dynamic Client Registration.
 type DCRConfig struct {
 	// Enabled enables DCR.
@@ -87,12 +99,12 @@ func (s *DCRService) Register(ctx context.Context, req DCRRequest) (*DCRResponse
 	}
 
 	// Generate client credentials
-	clientID, err := generateSecureToken(32)
+	clientID, err := generateSecureToken(clientIDByteLength)
 	if err != nil {
 		return nil, fmt.Errorf("generating client ID: %w", err)
 	}
 
-	clientSecret, err := generateSecureToken(48)
+	clientSecret, err := generateSecureToken(clientSecretByteLength)
 	if err != nil {
 		return nil, fmt.Errorf("generating client secret: %w", err)
 	}
@@ -154,14 +166,14 @@ func (s *DCRService) isAllowedRedirectURI(uri string) bool {
 func generateSecureToken(length int) (string, error) {
 	bytes := make([]byte, length)
 	if _, err := rand.Read(bytes); err != nil {
-		return "", err
+		return "", fmt.Errorf("reading random bytes: %w", err)
 	}
 	return base64.RawURLEncoding.EncodeToString(bytes), nil
 }
 
 // generateID generates a unique ID.
 func generateID() string {
-	bytes := make([]byte, 16)
+	bytes := make([]byte, idByteLength)
 	_, _ = rand.Read(bytes)
 	return base64.RawURLEncoding.EncodeToString(bytes)
 }

--- a/pkg/oauth/dcr_test.go
+++ b/pkg/oauth/dcr_test.go
@@ -321,7 +321,7 @@ func TestGenerateSecureToken(t *testing.T) {
 
 	t.Run("generates unique tokens", func(t *testing.T) {
 		tokens := make(map[string]bool)
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			token, err := generateSecureToken(32)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -337,7 +337,7 @@ func TestGenerateSecureToken(t *testing.T) {
 func TestGenerateID(t *testing.T) {
 	t.Run("generates unique IDs", func(t *testing.T) {
 		ids := make(map[string]bool)
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			id := generateID()
 			if ids[id] {
 				t.Error("duplicate ID generated")

--- a/pkg/oauth/pkce.go
+++ b/pkg/oauth/pkce.go
@@ -16,13 +16,19 @@ const (
 
 	// PKCEMethodS256 uses SHA-256 hashing (recommended).
 	PKCEMethodS256 PKCEMethod = "S256"
+
+	// pkceMinLength is the minimum length for code verifiers and challenges per RFC 7636.
+	pkceMinLength = 43
+
+	// pkceMaxLength is the maximum length for code verifiers and challenges per RFC 7636.
+	pkceMaxLength = 128
 )
 
 // ValidateCodeVerifier validates a code verifier.
 // Per RFC 7636, it must be 43-128 characters of [A-Z] / [a-z] / [0-9] / "-" / "." / "_" / "~".
 func ValidateCodeVerifier(verifier string) error {
-	if len(verifier) < 43 || len(verifier) > 128 {
-		return fmt.Errorf("code verifier must be between 43 and 128 characters")
+	if len(verifier) < pkceMinLength || len(verifier) > pkceMaxLength {
+		return fmt.Errorf("code verifier must be between %d and %d characters", pkceMinLength, pkceMaxLength)
 	}
 
 	validPattern := regexp.MustCompile(`^[A-Za-z0-9\-._~]+$`)
@@ -35,8 +41,8 @@ func ValidateCodeVerifier(verifier string) error {
 
 // ValidateCodeChallenge validates a code challenge.
 func ValidateCodeChallenge(challenge string) error {
-	if len(challenge) < 43 || len(challenge) > 128 {
-		return fmt.Errorf("code challenge must be between 43 and 128 characters")
+	if len(challenge) < pkceMinLength || len(challenge) > pkceMaxLength {
+		return fmt.Errorf("code challenge must be between %d and %d characters", pkceMinLength, pkceMaxLength)
 	}
 
 	// Base64 URL-safe characters

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -90,7 +90,6 @@ func TestServerAuthorize(t *testing.T) {
 			RedirectURI:  "http://localhost:8080/callback",
 			Scope:        "read",
 		}, "user-123", map[string]any{"role": "admin"})
-
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -285,7 +284,6 @@ func TestServerRegisterClient(t *testing.T) {
 			ClientName:   "Test",
 			RedirectURIs: []string{"http://localhost:8080"},
 		})
-
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -568,7 +566,6 @@ func TestHandleAuthorizationCodeGrant(t *testing.T) {
 			ClientID:     "client-123",
 			ClientSecret: "secret",
 		})
-
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -761,7 +758,6 @@ func TestHandleAuthorizationCodeGrant(t *testing.T) {
 			ClientID:     "client-123",
 			ClientSecret: "secret",
 		})
-
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -812,7 +808,6 @@ func TestHandleAuthorizationCodeGrant(t *testing.T) {
 			ClientID:     "client-123",
 			ClientSecret: "secret",
 		})
-
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -901,7 +896,6 @@ func TestHandleAuthorizationCodeGrant(t *testing.T) {
 			RedirectURI:  "http://localhost:8080/callback",
 			CodeVerifier: codeVerifier,
 		})
-
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1033,7 +1027,6 @@ func TestHandleRefreshTokenGrant(t *testing.T) {
 			ClientID:     "client-123",
 			ClientSecret: "secret",
 		})
-
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1195,7 +1188,6 @@ func TestHandleRefreshTokenGrant(t *testing.T) {
 			ClientSecret: "secret",
 			Scope:        "read",
 		})
-
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1417,7 +1409,6 @@ func TestRefreshTokenDeleteIgnoresError(t *testing.T) {
 		ClientID:     "client-123",
 		ClientSecret: "secret",
 	})
-
 	// Should succeed despite delete error
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -1536,7 +1527,6 @@ func TestValidatePKCEPlain(t *testing.T) {
 		CodeChallenge:       codeChallenge,
 		CodeChallengeMethod: "plain",
 	}, "user-123", nil)
-
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/oauth/state_test.go
+++ b/pkg/oauth/state_test.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -41,7 +42,7 @@ func TestMemoryStateStore(t *testing.T) {
 
 	t.Run("get nonexistent state", func(t *testing.T) {
 		_, err := store.Get("nonexistent")
-		if err != ErrStateNotFound {
+		if !errors.Is(err, ErrStateNotFound) {
 			t.Errorf("expected ErrStateNotFound, got %v", err)
 		}
 	})
@@ -53,7 +54,7 @@ func TestMemoryStateStore(t *testing.T) {
 		}
 
 		_, err = store.Get("key-1")
-		if err != ErrStateNotFound {
+		if !errors.Is(err, ErrStateNotFound) {
 			t.Error("expected state to be deleted")
 		}
 	})
@@ -81,7 +82,7 @@ func TestMemoryStateStore(t *testing.T) {
 
 		// Old should be gone
 		_, err = store.Get("old-key")
-		if err != ErrStateNotFound {
+		if !errors.Is(err, ErrStateNotFound) {
 			t.Error("expected old state to be cleaned up")
 		}
 

--- a/pkg/oauth/storage.go
+++ b/pkg/oauth/storage.go
@@ -4,6 +4,7 @@ package oauth
 import (
 	"context"
 	"net/url"
+	"slices"
 	"time"
 )
 
@@ -130,10 +131,5 @@ func matchesRedirectURI(registered, requested string) bool {
 
 // SupportsGrantType checks if the client supports a grant type.
 func (c *Client) SupportsGrantType(grantType string) bool {
-	for _, gt := range c.GrantTypes {
-		if gt == grantType {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.GrantTypes, grantType)
 }

--- a/pkg/oauth/storage_test.go
+++ b/pkg/oauth/storage_test.go
@@ -199,4 +199,3 @@ func TestRefreshTokenIsExpired(t *testing.T) {
 		}
 	})
 }
-

--- a/pkg/persona/filter.go
+++ b/pkg/persona/filter.go
@@ -18,7 +18,7 @@ func NewToolFilter(registry *Registry) *ToolFilter {
 }
 
 // IsAllowed checks if a tool is allowed for a persona.
-func (f *ToolFilter) IsAllowed(persona *Persona, toolName string) bool {
+func (*ToolFilter) IsAllowed(persona *Persona, toolName string) bool {
 	if persona == nil {
 		return false // DENY if no persona - fail closed
 	}
@@ -67,16 +67,16 @@ func matchPattern(pattern, name string) bool {
 	return matched
 }
 
-// PersonaAuthorizer implements middleware.Authorizer using personas.
-type PersonaAuthorizer struct {
+// Authorizer implements middleware.Authorizer using personas.
+type Authorizer struct {
 	registry   *Registry
 	roleMapper RoleMapper
 	filter     *ToolFilter
 }
 
-// NewPersonaAuthorizer creates a new persona-based authorizer.
-func NewPersonaAuthorizer(registry *Registry, mapper RoleMapper) *PersonaAuthorizer {
-	return &PersonaAuthorizer{
+// NewAuthorizer creates a new persona-based authorizer.
+func NewAuthorizer(registry *Registry, mapper RoleMapper) *Authorizer {
+	return &Authorizer{
 		registry:   registry,
 		roleMapper: mapper,
 		filter:     NewToolFilter(registry),
@@ -85,14 +85,13 @@ func NewPersonaAuthorizer(registry *Registry, mapper RoleMapper) *PersonaAuthori
 
 // IsAuthorized checks if the user is authorized for the tool.
 // Returns the resolved persona name for audit logging.
-func (a *PersonaAuthorizer) IsAuthorized(ctx context.Context, userID string, roles []string, toolName string) (bool, string, string) {
+func (a *Authorizer) IsAuthorized(ctx context.Context, _ string, roles []string, toolName string) (allowed bool, personaName, reason string) {
 	// Get persona for roles
 	persona, err := a.roleMapper.MapToPersona(ctx, roles)
 	if err != nil {
 		return false, "", "failed to determine persona"
 	}
 
-	personaName := ""
 	if persona != nil {
 		personaName = persona.Name
 	}
@@ -106,4 +105,4 @@ func (a *PersonaAuthorizer) IsAuthorized(ctx context.Context, userID string, rol
 }
 
 // Verify interface compliance.
-var _ middleware.Authorizer = (*PersonaAuthorizer)(nil)
+var _ middleware.Authorizer = (*Authorizer)(nil)

--- a/pkg/persona/filter_test.go
+++ b/pkg/persona/filter_test.go
@@ -179,7 +179,7 @@ func (m *mockRoleMapper) MapToRoles(claims map[string]any) ([]string, error) {
 	return nil, nil
 }
 
-func TestPersonaAuthorizer_IsAuthorized(t *testing.T) {
+func TestAuthorizer_IsAuthorized(t *testing.T) {
 	reg := NewRegistry()
 
 	t.Run("mapper error returns not authorized", func(t *testing.T) {
@@ -188,7 +188,7 @@ func TestPersonaAuthorizer_IsAuthorized(t *testing.T) {
 				return nil, errors.New("mapper error")
 			},
 		}
-		auth := NewPersonaAuthorizer(reg, mapper)
+		auth := NewAuthorizer(reg, mapper)
 
 		authorized, personaName, reason := auth.IsAuthorized(context.Background(), "user1", []string{"role1"}, "tool1")
 		if authorized {
@@ -212,7 +212,7 @@ func TestPersonaAuthorizer_IsAuthorized(t *testing.T) {
 				return persona, nil
 			},
 		}
-		auth := NewPersonaAuthorizer(reg, mapper)
+		auth := NewAuthorizer(reg, mapper)
 
 		authorized, personaName, reason := auth.IsAuthorized(context.Background(), "user1", []string{"analyst"}, "s3_list_buckets")
 		if authorized {
@@ -236,7 +236,7 @@ func TestPersonaAuthorizer_IsAuthorized(t *testing.T) {
 				return persona, nil
 			},
 		}
-		auth := NewPersonaAuthorizer(reg, mapper)
+		auth := NewAuthorizer(reg, mapper)
 
 		authorized, personaName, reason := auth.IsAuthorized(context.Background(), "user1", []string{"admin"}, "any_tool")
 		if !authorized {
@@ -252,5 +252,7 @@ func TestPersonaAuthorizer_IsAuthorized(t *testing.T) {
 }
 
 // Verify interface compliance.
-var _ RoleMapper = (*mockRoleMapper)(nil)
-var _ middleware.Authorizer = (*PersonaAuthorizer)(nil)
+var (
+	_ RoleMapper            = (*mockRoleMapper)(nil)
+	_ middleware.Authorizer = (*Authorizer)(nil)
+)

--- a/pkg/persona/mapper.go
+++ b/pkg/persona/mapper.go
@@ -117,12 +117,12 @@ type StaticRoleMapper struct {
 }
 
 // MapToRoles returns static roles (not used for static mapping).
-func (m *StaticRoleMapper) MapToRoles(_ map[string]any) ([]string, error) {
+func (*StaticRoleMapper) MapToRoles(_ map[string]any) ([]string, error) {
 	return []string{}, nil
 }
 
 // MapToPersona maps based on static configuration.
-func (m *StaticRoleMapper) MapToPersona(ctx context.Context, _ []string) (*Persona, error) {
+func (m *StaticRoleMapper) MapToPersona(_ context.Context, _ []string) (*Persona, error) {
 	// This would need user ID from context - placeholder for now
 	// In practice, you'd extract user info from context
 
@@ -182,11 +182,11 @@ func getNestedValue(data map[string]any, path string) any {
 	var current any = data
 
 	for _, part := range parts {
-		if m, ok := current.(map[string]any); ok {
-			current = m[part]
-		} else {
+		m, ok := current.(map[string]any)
+		if !ok {
 			return nil
 		}
+		current = m[part]
 	}
 
 	return current

--- a/pkg/persona/persona.go
+++ b/pkg/persona/persona.go
@@ -1,6 +1,11 @@
 // Package persona provides persona-based access control and customization.
 package persona
 
+import "strings"
+
+// defaultPersonaPriority is the default priority for built-in personas.
+const defaultPersonaPriority = 100
+
 // Persona defines a user persona with associated permissions and customizations.
 type Persona struct {
 	// Name is the unique identifier for this persona.
@@ -80,7 +85,7 @@ func AdminPersona() *Persona {
 		},
 		Prompts:  PromptConfig{},
 		Hints:    make(map[string]string),
-		Priority: 100,
+		Priority: defaultPersonaPriority,
 	}
 }
 
@@ -103,9 +108,10 @@ func (p *Persona) GetFullSystemPrompt() string {
 		return ""
 	}
 
-	result := parts[0]
+	var result strings.Builder
+	_, _ = result.WriteString(parts[0])
 	for i := 1; i < len(parts); i++ {
-		result += "\n\n" + parts[i]
+		_, _ = result.WriteString("\n\n" + parts[i])
 	}
-	return result
+	return result.String()
 }

--- a/pkg/persona/registry.go
+++ b/pkg/persona/registry.go
@@ -2,6 +2,7 @@ package persona
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 )
 
@@ -106,17 +107,15 @@ func (r *Registry) GetForRoles(roles []string) (*Persona, bool) {
 // matchesAnyRole checks if any persona role matches any user role.
 func matchesAnyRole(personaRoles, userRoles []string) bool {
 	for _, pr := range personaRoles {
-		for _, ur := range userRoles {
-			if pr == ur {
-				return true
-			}
+		if slices.Contains(userRoles, pr) {
+			return true
 		}
 	}
 	return false
 }
 
 // LoadFromConfig loads personas from a configuration map.
-func (r *Registry) LoadFromConfig(config map[string]*PersonaConfig) error {
+func (r *Registry) LoadFromConfig(config map[string]*Config) error {
 	for name, cfg := range config {
 		p := &Persona{
 			Name:        name,
@@ -143,8 +142,8 @@ func (r *Registry) LoadFromConfig(config map[string]*PersonaConfig) error {
 	return nil
 }
 
-// PersonaConfig is the configuration format for personas.
-type PersonaConfig struct {
+// Config is the configuration format for personas.
+type Config struct {
 	DisplayName string            `yaml:"display_name"`
 	Description string            `yaml:"description,omitempty"`
 	Roles       []string          `yaml:"roles"`

--- a/pkg/persona/registry_test.go
+++ b/pkg/persona/registry_test.go
@@ -122,7 +122,7 @@ func TestRegistry(t *testing.T) {
 
 	t.Run("LoadFromConfig", func(t *testing.T) {
 		reg := NewRegistry()
-		config := map[string]*PersonaConfig{
+		config := map[string]*Config{
 			"analyst": {
 				DisplayName: "Data Analyst",
 				Description: "Analyst persona",
@@ -191,7 +191,7 @@ func TestRegistry(t *testing.T) {
 
 	t.Run("LoadFromConfig empty", func(t *testing.T) {
 		reg := NewRegistry()
-		config := map[string]*PersonaConfig{}
+		config := map[string]*Config{}
 
 		if err := reg.LoadFromConfig(config); err != nil {
 			t.Errorf("LoadFromConfig() with empty config error = %v", err)
@@ -200,7 +200,7 @@ func TestRegistry(t *testing.T) {
 
 	t.Run("LoadFromConfig with empty name", func(t *testing.T) {
 		reg := NewRegistry()
-		config := map[string]*PersonaConfig{
+		config := map[string]*Config{
 			"": {DisplayName: "Invalid"}, // Empty name should fail Register
 		}
 

--- a/pkg/platform/config_test.go
+++ b/pkg/platform/config_test.go
@@ -24,7 +24,7 @@ auth:
   api_keys:
     enabled: false
 `
-		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
 			t.Fatalf("failed to write config file: %v", err)
 		}
 
@@ -47,7 +47,7 @@ auth:
 	t.Run("invalid yaml", func(t *testing.T) {
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, "config.yaml")
-		if err := os.WriteFile(configPath, []byte("invalid: yaml: content:"), 0644); err != nil {
+		if err := os.WriteFile(configPath, []byte("invalid: yaml: content:"), 0o644); err != nil {
 			t.Fatalf("failed to write config file: %v", err)
 		}
 
@@ -66,7 +66,7 @@ auth:
 server:
   name: ${TEST_SERVER_NAME}
 `
-		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
 			t.Fatalf("failed to write config file: %v", err)
 		}
 
@@ -94,7 +94,7 @@ semantic:
       rdbms: warehouse
       iceberg: datalake
 `
-		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
 			t.Fatalf("failed to write config file: %v", err)
 		}
 

--- a/pkg/platform/fuzz_test.go
+++ b/pkg/platform/fuzz_test.go
@@ -65,7 +65,7 @@ storage:
 		// Create temp file
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, "config.yaml")
-		if err := os.WriteFile(configPath, []byte(yamlContent), 0600); err != nil {
+		if err := os.WriteFile(configPath, []byte(yamlContent), 0o600); err != nil {
 			return
 		}
 

--- a/pkg/platform/hints_resource.go
+++ b/pkg/platform/hints_resource.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -28,7 +29,7 @@ func (p *Platform) buildHintsResourceResult() (*mcp.ReadResourceResult, error) {
 
 	content, err := json.MarshalIndent(hints, "", "  ")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("marshaling hints: %w", err)
 	}
 
 	return &mcp.ReadResourceResult{

--- a/pkg/platform/hints_resource_test.go
+++ b/pkg/platform/hints_resource_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/txn2/mcp-data-platform/pkg/tuning"
 )
 

--- a/pkg/platform/info_tool.go
+++ b/pkg/platform/info_tool.go
@@ -10,8 +10,8 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// PlatformInfo contains information about the platform deployment.
-type PlatformInfo struct {
+// Info contains information about the platform deployment.
+type Info struct {
 	Name              string        `json:"name"`
 	Version           string        `json:"version"`
 	Description       string        `json:"description,omitempty"`
@@ -46,7 +46,7 @@ func (p *Platform) registerInfoTool() {
 		Name:        "platform_info",
 		Description: p.buildInfoToolDescription(),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ platformInfoInput) (*mcp.CallToolResult, any, error) {
-		return p.handlePlatformInfo(ctx, req)
+		return p.handleInfo(ctx, req)
 	})
 }
 
@@ -63,8 +63,8 @@ func (p *Platform) buildInfoToolDescription() string {
 		"Call this first to understand what data and capabilities are available."
 }
 
-// handlePlatformInfo handles the platform_info tool call.
-func (p *Platform) handlePlatformInfo(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, any, error) {
+// handleInfo handles the platform_info tool call.
+func (p *Platform) handleInfo(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, any, error) {
 	// Collect enabled toolkits
 	var toolkits []string
 	if p.config.Toolkits != nil {
@@ -84,7 +84,7 @@ func (p *Platform) handlePlatformInfo(_ context.Context, _ *mcp.CallToolRequest)
 		})
 	}
 
-	info := PlatformInfo{
+	info := Info{
 		Name:              p.config.Server.Name,
 		Version:           p.config.Server.Version,
 		Description:       p.config.Server.Description,
@@ -102,7 +102,7 @@ func (p *Platform) handlePlatformInfo(_ context.Context, _ *mcp.CallToolRequest)
 
 	data, err := json.MarshalIndent(info, "", "  ")
 	if err != nil {
-		return &mcp.CallToolResult{
+		return &mcp.CallToolResult{ //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError, not as Go errors
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: "Error: " + err.Error()},
 			},

--- a/pkg/platform/info_tool_test.go
+++ b/pkg/platform/info_tool_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 )
 
-func TestHandlePlatformInfo(t *testing.T) {
+func TestHandleInfo(t *testing.T) {
 	tests := []struct {
 		name                  string
 		config                Config
@@ -81,7 +82,7 @@ func TestHandlePlatformInfo(t *testing.T) {
 				personaRegistry: persona.NewRegistry(),
 			}
 
-			result, extra, err := p.handlePlatformInfo(context.Background(), &mcp.CallToolRequest{})
+			result, extra, err := p.handleInfo(context.Background(), &mcp.CallToolRequest{})
 
 			require.NoError(t, err)
 			assert.Nil(t, extra)
@@ -91,7 +92,7 @@ func TestHandlePlatformInfo(t *testing.T) {
 			textContent, ok := result.Content[0].(*mcp.TextContent)
 			require.True(t, ok, "expected TextContent")
 
-			var info PlatformInfo
+			var info Info
 			err = json.Unmarshal([]byte(textContent.Text), &info)
 			require.NoError(t, err)
 
@@ -104,7 +105,7 @@ func TestHandlePlatformInfo(t *testing.T) {
 	}
 }
 
-func TestPlatformInfoFeatures(t *testing.T) {
+func TestInfoFeatures(t *testing.T) {
 	config := Config{
 		Server: ServerConfig{
 			Name:    "feature-test",
@@ -125,12 +126,12 @@ func TestPlatformInfoFeatures(t *testing.T) {
 		config:          &config,
 		personaRegistry: persona.NewRegistry(),
 	}
-	result, _, err := p.handlePlatformInfo(context.Background(), &mcp.CallToolRequest{})
+	result, _, err := p.handleInfo(context.Background(), &mcp.CallToolRequest{})
 
 	require.NoError(t, err)
 	textContent := result.Content[0].(*mcp.TextContent)
 
-	var info PlatformInfo
+	var info Info
 	err = json.Unmarshal([]byte(textContent.Text), &info)
 	require.NoError(t, err)
 
@@ -205,7 +206,7 @@ func TestBuildInfoToolDescription(t *testing.T) {
 	}
 }
 
-func TestPlatformInfoToolkits(t *testing.T) {
+func TestInfoToolkits(t *testing.T) {
 	config := Config{
 		Server: ServerConfig{
 			Name:    "toolkit-test",
@@ -222,12 +223,12 @@ func TestPlatformInfoToolkits(t *testing.T) {
 		config:          &config,
 		personaRegistry: persona.NewRegistry(),
 	}
-	result, _, err := p.handlePlatformInfo(context.Background(), &mcp.CallToolRequest{})
+	result, _, err := p.handleInfo(context.Background(), &mcp.CallToolRequest{})
 
 	require.NoError(t, err)
 	textContent := result.Content[0].(*mcp.TextContent)
 
-	var info PlatformInfo
+	var info Info
 	err = json.Unmarshal([]byte(textContent.Text), &info)
 	require.NoError(t, err)
 
@@ -237,7 +238,7 @@ func TestPlatformInfoToolkits(t *testing.T) {
 	assert.Contains(t, info.Toolkits, "s3")
 }
 
-func TestPlatformInfoPersonas(t *testing.T) {
+func TestInfoPersonas(t *testing.T) {
 	config := Config{
 		Server: ServerConfig{
 			Name:    "persona-test",
@@ -261,12 +262,12 @@ func TestPlatformInfoPersonas(t *testing.T) {
 		config:          &config,
 		personaRegistry: registry,
 	}
-	result, _, err := p.handlePlatformInfo(context.Background(), &mcp.CallToolRequest{})
+	result, _, err := p.handleInfo(context.Background(), &mcp.CallToolRequest{})
 
 	require.NoError(t, err)
 	textContent := result.Content[0].(*mcp.TextContent)
 
-	var info PlatformInfo
+	var info Info
 	err = json.Unmarshal([]byte(textContent.Text), &info)
 	require.NoError(t, err)
 

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -1470,7 +1470,7 @@ func createTestAppDir(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	indexPath := filepath.Join(dir, "index.html")
-	if err := os.WriteFile(indexPath, []byte("<html><head></head><body>test</body></html>"), 0600); err != nil {
+	if err := os.WriteFile(indexPath, []byte("<html><head></head><body>test</body></html>"), 0o600); err != nil {
 		t.Fatalf("Failed to create test index.html: %v", err)
 	}
 	return dir

--- a/pkg/query/noop.go
+++ b/pkg/query/noop.go
@@ -11,17 +11,17 @@ func NewNoopProvider() *NoopProvider {
 }
 
 // Name returns the provider name.
-func (n *NoopProvider) Name() string {
+func (*NoopProvider) Name() string {
 	return "noop"
 }
 
-// ResolveTable returns nil.
-func (n *NoopProvider) ResolveTable(_ context.Context, _ string) (*TableIdentifier, error) {
-	return nil, nil
+// ResolveTable returns an empty identifier.
+func (*NoopProvider) ResolveTable(_ context.Context, _ string) (*TableIdentifier, error) {
+	return &TableIdentifier{}, nil
 }
 
 // GetTableAvailability returns unavailable.
-func (n *NoopProvider) GetTableAvailability(_ context.Context, _ string) (*TableAvailability, error) {
+func (*NoopProvider) GetTableAvailability(_ context.Context, _ string) (*TableAvailability, error) {
 	return &TableAvailability{
 		Available: false,
 		Error:     "no query provider configured",
@@ -29,12 +29,12 @@ func (n *NoopProvider) GetTableAvailability(_ context.Context, _ string) (*Table
 }
 
 // GetQueryExamples returns empty examples.
-func (n *NoopProvider) GetQueryExamples(_ context.Context, _ string) ([]QueryExample, error) {
-	return []QueryExample{}, nil
+func (*NoopProvider) GetQueryExamples(_ context.Context, _ string) ([]Example, error) {
+	return []Example{}, nil
 }
 
 // GetExecutionContext returns empty context.
-func (n *NoopProvider) GetExecutionContext(_ context.Context, _ []string) (*ExecutionContext, error) {
+func (*NoopProvider) GetExecutionContext(_ context.Context, _ []string) (*ExecutionContext, error) {
 	return &ExecutionContext{
 		Tables:      []TableInfo{},
 		Connections: []string{},
@@ -42,14 +42,14 @@ func (n *NoopProvider) GetExecutionContext(_ context.Context, _ []string) (*Exec
 }
 
 // GetTableSchema returns empty schema.
-func (n *NoopProvider) GetTableSchema(_ context.Context, _ TableIdentifier) (*TableSchema, error) {
+func (*NoopProvider) GetTableSchema(_ context.Context, _ TableIdentifier) (*TableSchema, error) {
 	return &TableSchema{
 		Columns: []Column{},
 	}, nil
 }
 
 // Close does nothing.
-func (n *NoopProvider) Close() error {
+func (*NoopProvider) Close() error {
 	return nil
 }
 

--- a/pkg/query/noop_test.go
+++ b/pkg/query/noop_test.go
@@ -20,8 +20,8 @@ func TestNoopProvider(t *testing.T) {
 		if err != nil {
 			t.Errorf("ResolveTable() error = %v", err)
 		}
-		if result != nil {
-			t.Error("ResolveTable() expected nil for noop")
+		if result == nil {
+			t.Error("ResolveTable() returned nil, expected empty identifier")
 		}
 	})
 

--- a/pkg/query/provider.go
+++ b/pkg/query/provider.go
@@ -15,7 +15,7 @@ type Provider interface {
 	GetTableAvailability(ctx context.Context, urn string) (*TableAvailability, error)
 
 	// GetQueryExamples returns sample queries for a table.
-	GetQueryExamples(ctx context.Context, urn string) ([]QueryExample, error)
+	GetQueryExamples(ctx context.Context, urn string) ([]Example, error)
 
 	// GetExecutionContext returns context for querying multiple tables.
 	GetExecutionContext(ctx context.Context, urns []string) (*ExecutionContext, error)
@@ -30,7 +30,7 @@ type Provider interface {
 // Executor can execute queries against the query engine.
 type Executor interface {
 	// Execute runs a query and returns results.
-	Execute(ctx context.Context, sql string, limit int) (*QueryResult, error)
+	Execute(ctx context.Context, sql string, limit int) (*Result, error)
 
 	// Describe returns information about a table.
 	Describe(ctx context.Context, table TableIdentifier) (*TableSchema, error)

--- a/pkg/query/types.go
+++ b/pkg/query/types.go
@@ -1,4 +1,6 @@
 // Package query provides abstractions for query execution providers.
+//
+//nolint:revive // package contains related DTO types
 package query
 
 // TableIdentifier uniquely identifies a table in the query engine.
@@ -26,8 +28,8 @@ type TableAvailability struct {
 	Error         string `json:"error,omitempty"`
 }
 
-// QueryExample provides a sample query for a table.
-type QueryExample struct {
+// Example provides a sample query for a table.
+type Example struct {
 	Description string `json:"description"`
 	SQL         string `json:"sql"`
 }
@@ -60,9 +62,9 @@ type TableSchema struct {
 	PrimaryKey []string `json:"primary_key,omitempty"`
 }
 
-// QueryResult represents the result of a query.
-type QueryResult struct {
-	Columns []string        `json:"columns"`
-	Rows    [][]interface{} `json:"rows"`
-	Count   int             `json:"count"`
+// Result represents the result of a query.
+type Result struct {
+	Columns []string `json:"columns"`
+	Rows    [][]any  `json:"rows"`
+	Count   int      `json:"count"`
 }

--- a/pkg/registry/factories.go
+++ b/pkg/registry/factories.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"fmt"
+
 	datahubkit "github.com/txn2/mcp-data-platform/pkg/toolkits/datahub"
 	s3kit "github.com/txn2/mcp-data-platform/pkg/toolkits/s3"
 	trinokit "github.com/txn2/mcp-data-platform/pkg/toolkits/trino"
@@ -17,25 +19,37 @@ func RegisterBuiltinFactories(r *Registry) {
 func TrinoFactory(name string, cfg map[string]any) (Toolkit, error) {
 	config, err := trinokit.ParseConfig(cfg)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing trino config: %w", err)
 	}
-	return trinokit.New(name, config)
+	tk, err := trinokit.New(name, config)
+	if err != nil {
+		return nil, fmt.Errorf("creating trino toolkit: %w", err)
+	}
+	return tk, nil
 }
 
 // DataHubFactory creates a DataHub toolkit from configuration.
 func DataHubFactory(name string, cfg map[string]any) (Toolkit, error) {
 	config, err := datahubkit.ParseConfig(cfg)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing datahub config: %w", err)
 	}
-	return datahubkit.New(name, config)
+	tk, err := datahubkit.New(name, config)
+	if err != nil {
+		return nil, fmt.Errorf("creating datahub toolkit: %w", err)
+	}
+	return tk, nil
 }
 
 // S3Factory creates an S3 toolkit from configuration.
 func S3Factory(name string, cfg map[string]any) (Toolkit, error) {
 	config, err := s3kit.ParseConfig(cfg)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing s3 config: %w", err)
 	}
-	return s3kit.New(name, config)
+	tk, err := s3kit.New(name, config)
+	if err != nil {
+		return nil, fmt.Errorf("creating s3 toolkit: %w", err)
+	}
+	return tk, nil
 }

--- a/pkg/registry/loader.go
+++ b/pkg/registry/loader.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"maps"
 )
 
 // LoaderConfig holds configuration for loading toolkits.
@@ -37,12 +38,8 @@ func (l *Loader) Load(cfg LoaderConfig) error {
 		for name, instanceCfg := range kindCfg.Instances {
 			// Merge kind-level config with instance config
 			mergedCfg := make(map[string]any)
-			for k, v := range kindCfg.Config {
-				mergedCfg[k] = v
-			}
-			for k, v := range instanceCfg {
-				mergedCfg[k] = v
-			}
+			maps.Copy(mergedCfg, kindCfg.Config)
+			maps.Copy(mergedCfg, instanceCfg)
 
 			toolkitCfg := ToolkitConfig{
 				Kind:    kind,
@@ -83,12 +80,8 @@ func (l *Loader) LoadFromMap(toolkits map[string]any) error {
 
 			// Merge configs
 			mergedCfg := make(map[string]any)
-			for k, val := range kindConfig {
-				mergedCfg[k] = val
-			}
-			for k, val := range instanceCfg {
-				mergedCfg[k] = val
-			}
+			maps.Copy(mergedCfg, kindConfig)
+			maps.Copy(mergedCfg, instanceCfg)
 
 			toolkitCfg := ToolkitConfig{
 				Kind:    kind,

--- a/pkg/registry/loader_test.go
+++ b/pkg/registry/loader_test.go
@@ -57,7 +57,7 @@ func TestLoader_Load(t *testing.T) {
 		registry := NewRegistry()
 
 		// Register a test factory
-		registry.RegisterFactory("test", func(name string, config map[string]interface{}) (Toolkit, error) {
+		registry.RegisterFactory("test", func(name string, config map[string]any) (Toolkit, error) {
 			return &mockToolkit{
 				kind: "test",
 				name: name,
@@ -151,7 +151,7 @@ func TestLoader_LoadFromMap(t *testing.T) {
 	t.Run("enabled toolkit", func(t *testing.T) {
 		registry := NewRegistry()
 
-		registry.RegisterFactory("test", func(name string, config map[string]interface{}) (Toolkit, error) {
+		registry.RegisterFactory("test", func(name string, config map[string]any) (Toolkit, error) {
 			return &mockToolkit{
 				kind: "test",
 				name: name,
@@ -218,4 +218,3 @@ func TestLoader_LoadFromMap(t *testing.T) {
 		}
 	})
 }
-

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
 )
 
-// mockToolkit is a simple mock for testing
+// mockToolkit is a simple mock for testing.
 type mockToolkit struct {
 	kind       string
 	name       string
@@ -310,18 +310,18 @@ func TestGetToolkitForTool(t *testing.T) {
 			tools:      []string{"trino_query", "trino_describe"},
 		})
 
-		kind, name, connection, found := reg.GetToolkitForTool("trino_query")
-		if !found {
+		match := reg.GetToolkitForTool("trino_query")
+		if !match.Found {
 			t.Error("expected to find tool")
 		}
-		if kind != "trino" {
-			t.Errorf("expected kind 'trino', got %q", kind)
+		if match.Kind != "trino" {
+			t.Errorf("expected kind 'trino', got %q", match.Kind)
 		}
-		if name != "production" {
-			t.Errorf("expected name 'production', got %q", name)
+		if match.Name != "production" {
+			t.Errorf("expected name 'production', got %q", match.Name)
 		}
-		if connection != "prod-trino" {
-			t.Errorf("expected connection 'prod-trino', got %q", connection)
+		if match.Connection != "prod-trino" {
+			t.Errorf("expected connection 'prod-trino', got %q", match.Connection)
 		}
 	})
 
@@ -334,11 +334,11 @@ func TestGetToolkitForTool(t *testing.T) {
 			tools:      []string{"trino_query"},
 		})
 
-		kind, name, connection, found := reg.GetToolkitForTool("unknown_tool")
-		if found {
+		match := reg.GetToolkitForTool("unknown_tool")
+		if match.Found {
 			t.Error("expected tool not to be found")
 		}
-		if kind != "" || name != "" || connection != "" {
+		if match.Kind != "" || match.Name != "" || match.Connection != "" {
 			t.Error("expected empty strings when not found")
 		}
 	})
@@ -366,11 +366,11 @@ func TestGetToolkitForTool(t *testing.T) {
 
 		// Test finding tool in each toolkit
 		tests := []struct {
-			tool       string
-			wantKind   string
-			wantName   string
-			wantConn   string
-			wantFound  bool
+			tool      string
+			wantKind  string
+			wantName  string
+			wantConn  string
+			wantFound bool
 		}{
 			{"trino_query", "trino", "production", "prod-trino", true},
 			{"datahub_search", "datahub", "main", "main-datahub", true},
@@ -380,18 +380,18 @@ func TestGetToolkitForTool(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.tool, func(t *testing.T) {
-				kind, name, conn, found := reg.GetToolkitForTool(tt.tool)
-				if found != tt.wantFound {
-					t.Errorf("found = %v, want %v", found, tt.wantFound)
+				match := reg.GetToolkitForTool(tt.tool)
+				if match.Found != tt.wantFound {
+					t.Errorf("found = %v, want %v", match.Found, tt.wantFound)
 				}
-				if kind != tt.wantKind {
-					t.Errorf("kind = %q, want %q", kind, tt.wantKind)
+				if match.Kind != tt.wantKind {
+					t.Errorf("kind = %q, want %q", match.Kind, tt.wantKind)
 				}
-				if name != tt.wantName {
-					t.Errorf("name = %q, want %q", name, tt.wantName)
+				if match.Name != tt.wantName {
+					t.Errorf("name = %q, want %q", match.Name, tt.wantName)
 				}
-				if conn != tt.wantConn {
-					t.Errorf("connection = %q, want %q", conn, tt.wantConn)
+				if match.Connection != tt.wantConn {
+					t.Errorf("connection = %q, want %q", match.Connection, tt.wantConn)
 				}
 			})
 		}

--- a/pkg/registry/toolkit.go
+++ b/pkg/registry/toolkit.go
@@ -37,13 +37,13 @@ type Toolkit interface {
 }
 
 // ToolkitFactory creates a toolkit from configuration.
-type ToolkitFactory func(name string, config map[string]interface{}) (Toolkit, error)
+type ToolkitFactory func(name string, config map[string]any) (Toolkit, error)
 
 // ToolkitConfig holds configuration for a toolkit instance.
 type ToolkitConfig struct {
 	Kind    string
 	Name    string
 	Enabled bool
-	Config  map[string]interface{}
+	Config  map[string]any
 	Default bool
 }

--- a/pkg/semantic/cache_test.go
+++ b/pkg/semantic/cache_test.go
@@ -221,18 +221,23 @@ func (e *errorProvider) Name() string { return "error" }
 func (e *errorProvider) GetTableContext(_ context.Context, _ TableIdentifier) (*TableContext, error) {
 	return nil, &mockError{}
 }
+
 func (e *errorProvider) GetColumnContext(_ context.Context, _ ColumnIdentifier) (*ColumnContext, error) {
 	return nil, &mockError{}
 }
+
 func (e *errorProvider) GetColumnsContext(_ context.Context, _ TableIdentifier) (map[string]*ColumnContext, error) {
 	return nil, &mockError{}
 }
+
 func (e *errorProvider) GetLineage(_ context.Context, _ TableIdentifier, _ LineageDirection, _ int) (*LineageInfo, error) {
 	return nil, &mockError{}
 }
+
 func (e *errorProvider) GetGlossaryTerm(_ context.Context, _ string) (*GlossaryTerm, error) {
 	return nil, &mockError{}
 }
+
 func (e *errorProvider) SearchTables(_ context.Context, _ SearchFilter) ([]TableSearchResult, error) {
 	return nil, &mockError{}
 }

--- a/pkg/semantic/datahub/lineage_config.go
+++ b/pkg/semantic/datahub/lineage_config.go
@@ -1,6 +1,17 @@
 package datahub
 
-import "time"
+import (
+	"slices"
+	"time"
+)
+
+const (
+	// defaultCacheTTL is the default cache TTL for lineage graphs.
+	defaultCacheTTL = 10 * time.Minute
+
+	// defaultLineageTimeout is the default timeout for the entire inheritance operation.
+	defaultLineageTimeout = 5 * time.Second
+)
 
 // LineageConfig controls lineage-aware semantic enrichment.
 type LineageConfig struct {
@@ -68,17 +79,12 @@ func DefaultLineageConfig() LineageConfig {
 		Inherit:             []string{"glossary_terms", "descriptions"},
 		ConflictResolution:  "nearest",
 		PreferColumnLineage: true,
-		CacheTTL:            10 * time.Minute,
-		Timeout:             5 * time.Second,
+		CacheTTL:            defaultCacheTTL,
+		Timeout:             defaultLineageTimeout,
 	}
 }
 
 // shouldInherit checks if a metadata type should be inherited.
 func (c *LineageConfig) shouldInherit(metadataType string) bool {
-	for _, t := range c.Inherit {
-		if t == metadataType {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.Inherit, metadataType)
 }

--- a/pkg/semantic/datahub/lineage_resolver_test.go
+++ b/pkg/semantic/datahub/lineage_resolver_test.go
@@ -438,7 +438,13 @@ func TestInheritMetadata(t *testing.T) {
 		Tags: []types.Tag{{Name: "important"}},
 	}
 
-	resolver.inheritMetadata(target, source, "urn:upstream", "source_col", 1, "name_exact")
+	resolver.inheritMetadata(target, inheritSource{
+		Field:       source,
+		URN:         "urn:upstream",
+		Column:      "source_col",
+		Hops:        1,
+		MatchMethod: "name_exact",
+	})
 
 	if target.Description != "Source description" {
 		t.Errorf("expected inherited description, got %q", target.Description)
@@ -479,7 +485,13 @@ func TestInheritMetadata_NoInheritanceWhenTargetPopulated(t *testing.T) {
 		Description: "Source description",
 	}
 
-	resolver.inheritMetadata(target, source, "urn:upstream", "source_col", 1, "name_exact")
+	resolver.inheritMetadata(target, inheritSource{
+		Field:       source,
+		URN:         "urn:upstream",
+		Column:      "source_col",
+		Hops:        1,
+		MatchMethod: "name_exact",
+	})
 
 	if target.Description != "Already has description" {
 		t.Errorf("description should not be overwritten, got %q", target.Description)

--- a/pkg/semantic/noop.go
+++ b/pkg/semantic/noop.go
@@ -11,27 +11,27 @@ func NewNoopProvider() *NoopProvider {
 }
 
 // Name returns the provider name.
-func (n *NoopProvider) Name() string {
+func (*NoopProvider) Name() string {
 	return "noop"
 }
 
 // GetTableContext returns empty context.
-func (n *NoopProvider) GetTableContext(_ context.Context, _ TableIdentifier) (*TableContext, error) {
+func (*NoopProvider) GetTableContext(_ context.Context, _ TableIdentifier) (*TableContext, error) {
 	return &TableContext{}, nil
 }
 
 // GetColumnContext returns empty context.
-func (n *NoopProvider) GetColumnContext(_ context.Context, _ ColumnIdentifier) (*ColumnContext, error) {
+func (*NoopProvider) GetColumnContext(_ context.Context, _ ColumnIdentifier) (*ColumnContext, error) {
 	return &ColumnContext{}, nil
 }
 
 // GetColumnsContext returns empty map.
-func (n *NoopProvider) GetColumnsContext(_ context.Context, _ TableIdentifier) (map[string]*ColumnContext, error) {
+func (*NoopProvider) GetColumnsContext(_ context.Context, _ TableIdentifier) (map[string]*ColumnContext, error) {
 	return make(map[string]*ColumnContext), nil
 }
 
 // GetLineage returns empty lineage.
-func (n *NoopProvider) GetLineage(_ context.Context, _ TableIdentifier, dir LineageDirection, maxDepth int) (*LineageInfo, error) {
+func (*NoopProvider) GetLineage(_ context.Context, _ TableIdentifier, dir LineageDirection, maxDepth int) (*LineageInfo, error) {
 	return &LineageInfo{
 		Direction: dir,
 		Entities:  []LineageEntity{},
@@ -39,18 +39,18 @@ func (n *NoopProvider) GetLineage(_ context.Context, _ TableIdentifier, dir Line
 	}, nil
 }
 
-// GetGlossaryTerm returns nil.
-func (n *NoopProvider) GetGlossaryTerm(_ context.Context, _ string) (*GlossaryTerm, error) {
-	return nil, nil
+// GetGlossaryTerm returns an empty term.
+func (*NoopProvider) GetGlossaryTerm(_ context.Context, _ string) (*GlossaryTerm, error) {
+	return &GlossaryTerm{}, nil
 }
 
 // SearchTables returns empty results.
-func (n *NoopProvider) SearchTables(_ context.Context, _ SearchFilter) ([]TableSearchResult, error) {
+func (*NoopProvider) SearchTables(_ context.Context, _ SearchFilter) ([]TableSearchResult, error) {
 	return []TableSearchResult{}, nil
 }
 
 // Close does nothing.
-func (n *NoopProvider) Close() error {
+func (*NoopProvider) Close() error {
 	return nil
 }
 

--- a/pkg/semantic/noop_test.go
+++ b/pkg/semantic/noop_test.go
@@ -61,7 +61,7 @@ func TestNoopProvider(t *testing.T) {
 			t.Errorf("GetLineage() error = %v", err)
 		}
 		if result == nil {
-			t.Error("GetLineage() returned nil")
+			t.Fatal("GetLineage() returned nil")
 		}
 		if result.Direction != LineageUpstream {
 			t.Errorf("GetLineage() Direction = %v, want %v", result.Direction, LineageUpstream)
@@ -74,8 +74,8 @@ func TestNoopProvider(t *testing.T) {
 		if err != nil {
 			t.Errorf("GetGlossaryTerm() error = %v", err)
 		}
-		if result != nil {
-			t.Error("GetGlossaryTerm() expected nil result for noop")
+		if result == nil {
+			t.Error("GetGlossaryTerm() returned nil, expected empty term")
 		}
 	})
 

--- a/pkg/semantic/sanitize.go
+++ b/pkg/semantic/sanitize.go
@@ -10,6 +10,9 @@ import (
 // MaxStringLength is the maximum length for sanitized strings.
 const MaxStringLength = 2000
 
+// maxTagLength is the maximum allowed length for a tag name.
+const maxTagLength = 100
+
 // SanitizeConfig configures sanitization behavior.
 type SanitizeConfig struct {
 	// MaxLength is the maximum length for strings (default: 2000).
@@ -74,7 +77,7 @@ func (s *Sanitizer) SanitizeDescription(desc string) string {
 
 // SanitizeTag validates and sanitizes a tag name.
 // Returns empty string if the tag is invalid.
-func (s *Sanitizer) SanitizeTag(tag string) string {
+func (*Sanitizer) SanitizeTag(tag string) string {
 	if tag == "" {
 		return ""
 	}
@@ -84,8 +87,8 @@ func (s *Sanitizer) SanitizeTag(tag string) string {
 		return ""
 	}
 
-	// Truncate to reasonable tag length (100 chars)
-	if len(tag) > 100 {
+	// Truncate to reasonable tag length
+	if len(tag) > maxTagLength {
 		return ""
 	}
 
@@ -114,7 +117,7 @@ func (s *Sanitizer) SanitizeTags(tags []string) []string {
 
 // DetectInjection checks if the input contains potential prompt injection patterns.
 // Returns true if injection is detected along with matched patterns.
-func (s *Sanitizer) DetectInjection(input string) (bool, []string) {
+func (*Sanitizer) DetectInjection(input string) (detected bool, patterns []string) {
 	return detectInjectionPatterns(input)
 }
 
@@ -126,7 +129,7 @@ func removeControlChars(s string) string {
 	for _, r := range s {
 		// Allow printable characters, newline, and tab
 		if unicode.IsPrint(r) || r == '\n' || r == '\t' {
-			result.WriteRune(r)
+			_, _ = result.WriteRune(r)
 		}
 		// Skip all other control characters
 	}
@@ -214,7 +217,7 @@ var injectionPatternNames = []string{
 }
 
 // detectInjectionPatterns checks for prompt injection patterns.
-func detectInjectionPatterns(input string) (bool, []string) {
+func detectInjectionPatterns(input string) (detected bool, patterns []string) {
 	if input == "" {
 		return false, nil
 	}

--- a/pkg/semantic/sanitize_test.go
+++ b/pkg/semantic/sanitize_test.go
@@ -467,7 +467,7 @@ func TestSanitizer_SanitizeTableContext_EmptyOwners(t *testing.T) {
 		Owners: []Owner{},
 	}
 	result := s.SanitizeTableContext(tc)
-	if result.Owners != nil && len(result.Owners) != 0 {
+	if len(result.Owners) != 0 {
 		t.Errorf("expected empty owners to be nil or empty")
 	}
 }
@@ -503,7 +503,7 @@ func TestSanitizer_SanitizeTableContext_EmptyProperties(t *testing.T) {
 		CustomProperties: map[string]string{},
 	}
 	result := s.SanitizeTableContext(tc)
-	if result.CustomProperties != nil && len(result.CustomProperties) != 0 {
+	if len(result.CustomProperties) != 0 {
 		t.Error("expected empty properties to be nil or empty")
 	}
 }
@@ -531,7 +531,7 @@ func TestSanitizer_SanitizeTableContext_EmptyGlossaryTerms(t *testing.T) {
 		GlossaryTerms: []GlossaryTerm{},
 	}
 	result := s.SanitizeTableContext(tc)
-	if result.GlossaryTerms != nil && len(result.GlossaryTerms) != 0 {
+	if len(result.GlossaryTerms) != 0 {
 		t.Error("expected empty glossary terms to be nil or empty")
 	}
 }
@@ -576,8 +576,7 @@ func BenchmarkSanitizeString(b *testing.B) {
 	s := NewSanitizer(DefaultSanitizeConfig())
 	input := strings.Repeat("This is a test description with some content. ", 50)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		s.SanitizeString(input)
 	}
 }
@@ -586,8 +585,7 @@ func BenchmarkDetectInjection(b *testing.B) {
 	s := NewSanitizer(DefaultSanitizeConfig())
 	input := "This is a normal description that should not trigger any detection patterns."
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		s.DetectInjection(input)
 	}
 }

--- a/pkg/semantic/types.go
+++ b/pkg/semantic/types.go
@@ -1,7 +1,11 @@
 // Package semantic provides abstractions for semantic metadata providers.
+//
+//nolint:revive // package contains related semantic data types
 package semantic
 
 import "time"
+
+const identifierSeparator = "."
 
 // TableIdentifier uniquely identifies a table.
 type TableIdentifier struct {
@@ -13,9 +17,9 @@ type TableIdentifier struct {
 // String returns a dot-separated representation.
 func (t TableIdentifier) String() string {
 	if t.Catalog != "" {
-		return t.Catalog + "." + t.Schema + "." + t.Table
+		return t.Catalog + identifierSeparator + t.Schema + identifierSeparator + t.Table
 	}
-	return t.Schema + "." + t.Table
+	return t.Schema + identifierSeparator + t.Table
 }
 
 // ColumnIdentifier uniquely identifies a column.
@@ -26,7 +30,7 @@ type ColumnIdentifier struct {
 
 // String returns a dot-separated representation including the column.
 func (c ColumnIdentifier) String() string {
-	return c.TableIdentifier.String() + "." + c.Column
+	return c.TableIdentifier.String() + identifierSeparator + c.Column
 }
 
 // TableContext provides semantic context for a table.
@@ -102,6 +106,7 @@ type Owner struct {
 // OwnerType indicates the type of owner.
 type OwnerType string
 
+// Owner type constants.
 const (
 	OwnerTypeUser  OwnerType = "user"
 	OwnerTypeGroup OwnerType = "group"
@@ -132,6 +137,7 @@ type Deprecation struct {
 // LineageDirection indicates the direction of lineage traversal.
 type LineageDirection string
 
+// Lineage direction constants.
 const (
 	LineageUpstream   LineageDirection = "upstream"
 	LineageDownstream LineageDirection = "downstream"

--- a/pkg/storage/noop.go
+++ b/pkg/storage/noop.go
@@ -11,32 +11,32 @@ func NewNoopProvider() *NoopProvider {
 }
 
 // Name returns the provider name.
-func (p *NoopProvider) Name() string {
+func (*NoopProvider) Name() string {
 	return "noop"
 }
 
-// ResolveDataset returns nil for no-op.
-func (p *NoopProvider) ResolveDataset(_ context.Context, _ string) (*DatasetIdentifier, error) {
-	return nil, nil
+// ResolveDataset returns an empty identifier for no-op.
+func (*NoopProvider) ResolveDataset(_ context.Context, _ string) (*DatasetIdentifier, error) {
+	return &DatasetIdentifier{}, nil
 }
 
 // GetDatasetAvailability returns unavailable for no-op.
-func (p *NoopProvider) GetDatasetAvailability(_ context.Context, _ string) (*DatasetAvailability, error) {
+func (*NoopProvider) GetDatasetAvailability(_ context.Context, _ string) (*DatasetAvailability, error) {
 	return &DatasetAvailability{Available: false}, nil
 }
 
 // GetAccessExamples returns empty for no-op.
-func (p *NoopProvider) GetAccessExamples(_ context.Context, _ string) ([]AccessExample, error) {
-	return nil, nil
+func (*NoopProvider) GetAccessExamples(_ context.Context, _ string) ([]AccessExample, error) {
+	return []AccessExample{}, nil
 }
 
 // ListObjects returns empty for no-op.
-func (p *NoopProvider) ListObjects(_ context.Context, _ DatasetIdentifier, _ int) ([]ObjectInfo, error) {
-	return nil, nil
+func (*NoopProvider) ListObjects(_ context.Context, _ DatasetIdentifier, _ int) ([]ObjectInfo, error) {
+	return []ObjectInfo{}, nil
 }
 
 // Close is a no-op.
-func (p *NoopProvider) Close() error {
+func (*NoopProvider) Close() error {
 	return nil
 }
 

--- a/pkg/storage/s3/adapter_test.go
+++ b/pkg/storage/s3/adapter_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/storage"
 )
 
-// mockS3Client implements the S3Client interface for testing.
+// mockS3Client implements the Client interface for testing.
 type mockS3Client struct {
 	listObjectsOutput *s3client.ListObjectsOutput
 	listObjectsErr    error

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -53,8 +53,8 @@ func TestNoopProvider(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if result != nil {
-			t.Errorf("expected nil, got %v", result)
+		if result == nil {
+			t.Error("expected non-nil empty identifier")
 		}
 	})
 
@@ -76,8 +76,8 @@ func TestNoopProvider(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if result != nil {
-			t.Errorf("expected nil, got %v", result)
+		if len(result) != 0 {
+			t.Errorf("expected empty slice, got %v", result)
 		}
 	})
 
@@ -86,8 +86,8 @@ func TestNoopProvider(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if result != nil {
-			t.Errorf("expected nil, got %v", result)
+		if len(result) != 0 {
+			t.Errorf("expected empty slice, got %v", result)
 		}
 	})
 

--- a/pkg/toolkits/datahub/config.go
+++ b/pkg/toolkits/datahub/config.go
@@ -8,10 +8,10 @@ import (
 // ParseConfig parses a DataHub toolkit configuration from a map.
 func ParseConfig(cfg map[string]any) (Config, error) {
 	c := Config{
-		Timeout:         30 * time.Second,
-		DefaultLimit:    10,
-		MaxLimit:        100,
-		MaxLineageDepth: 5,
+		Timeout:         defaultTimeout,
+		DefaultLimit:    defaultDataHubLimit,
+		MaxLimit:        defaultMaxLimit,
+		MaxLineageDepth: defaultMaxLineageDepth,
 	}
 
 	// Required URL field (supports both "url" and "endpoint" keys)
@@ -67,7 +67,11 @@ func getInt(cfg map[string]any, key string, defaultVal int) int {
 // getDuration extracts a duration value from a config map.
 func getDuration(cfg map[string]any, key string) (time.Duration, error) {
 	if v, ok := cfg[key].(string); ok {
-		return time.ParseDuration(v)
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return 0, fmt.Errorf("parsing duration %q: %w", v, err)
+		}
+		return d, nil
 	}
 	if v, ok := cfg[key].(int); ok {
 		return time.Duration(v) * time.Second, nil

--- a/pkg/toolkits/datahub/toolkit_test.go
+++ b/pkg/toolkits/datahub/toolkit_test.go
@@ -1,6 +1,7 @@
 package datahub
 
 import (
+	"slices"
 	"testing"
 	"time"
 
@@ -279,13 +280,7 @@ func TestToolkit_Methods(t *testing.T) {
 		}
 
 		for _, expected := range expectedTools {
-			found := false
-			for _, tool := range tools {
-				if tool == expected {
-					found = true
-					break
-				}
-			}
+			found := slices.Contains(tools, expected)
 			if !found {
 				t.Errorf("missing expected tool: %s", expected)
 			}

--- a/pkg/toolkits/s3/config.go
+++ b/pkg/toolkits/s3/config.go
@@ -4,13 +4,24 @@ import (
 	"time"
 )
 
+const (
+	// DefaultTimeout is the default HTTP client timeout for S3 operations.
+	DefaultTimeout = 30 * time.Second
+
+	// DefaultMaxGetSize is the default maximum size for S3 GET operations (10MB).
+	DefaultMaxGetSize = 10 * 1024 * 1024
+
+	// DefaultMaxPutSize is the default maximum size for S3 PUT operations (100MB).
+	DefaultMaxPutSize = 100 * 1024 * 1024
+)
+
 // ParseConfig parses an S3 toolkit configuration from a map.
 func ParseConfig(cfg map[string]any) (Config, error) {
 	c := Config{
 		Region:     "us-east-1",
-		Timeout:    30 * time.Second,
-		MaxGetSize: 10 * 1024 * 1024,
-		MaxPutSize: 100 * 1024 * 1024,
+		Timeout:    DefaultTimeout,
+		MaxGetSize: DefaultMaxGetSize,
+		MaxPutSize: DefaultMaxPutSize,
 	}
 
 	// String fields

--- a/pkg/toolkits/s3/toolkit.go
+++ b/pkg/toolkits/s3/toolkit.go
@@ -68,13 +68,13 @@ func applyDefaults(name string, cfg Config) Config {
 		cfg.Region = "us-east-1"
 	}
 	if cfg.Timeout == 0 {
-		cfg.Timeout = 30 * time.Second
+		cfg.Timeout = DefaultTimeout
 	}
 	if cfg.MaxGetSize == 0 {
-		cfg.MaxGetSize = 10 * 1024 * 1024 // 10MB
+		cfg.MaxGetSize = DefaultMaxGetSize
 	}
 	if cfg.MaxPutSize == 0 {
-		cfg.MaxPutSize = 100 * 1024 * 1024 // 100MB
+		cfg.MaxPutSize = DefaultMaxPutSize
 	}
 	if cfg.ConnectionName == "" {
 		cfg.ConnectionName = name
@@ -119,7 +119,7 @@ func createToolkit(client *s3client.Client, cfg Config) *s3tools.Toolkit {
 }
 
 // Kind returns the toolkit kind.
-func (t *Toolkit) Kind() string {
+func (*Toolkit) Kind() string {
 	return "s3"
 }
 
@@ -175,7 +175,9 @@ func (t *Toolkit) SetQueryProvider(provider query.Provider) {
 // Close releases resources.
 func (t *Toolkit) Close() error {
 	if t.client != nil {
-		return t.client.Close()
+		if err := t.client.Close(); err != nil {
+			return fmt.Errorf("closing s3 client: %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/toolkits/trino/readonly.go
+++ b/pkg/toolkits/trino/readonly.go
@@ -45,7 +45,7 @@ var writePattern = regexp.MustCompile(
 )
 
 // Intercept checks if the query is a write operation and blocks it in read-only mode.
-func (r *ReadOnlyInterceptor) Intercept(_ context.Context, sql string, _ trinotools.ToolName) (string, error) {
+func (*ReadOnlyInterceptor) Intercept(_ context.Context, sql string, _ trinotools.ToolName) (string, error) {
 	if isWriteQuery(sql) {
 		return "", fmt.Errorf("write operations not allowed in read-only mode")
 	}

--- a/pkg/tools/toolkit.go
+++ b/pkg/tools/toolkit.go
@@ -32,7 +32,7 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 }
 
 // handleExampleTool handles the example_tool MCP call.
-func (t *Toolkit) handleExampleTool(_ context.Context, _ *mcp.CallToolRequest, args ExampleToolArgs) (*mcp.CallToolResult, any, error) {
+func (*Toolkit) handleExampleTool(_ context.Context, _ *mcp.CallToolRequest, args ExampleToolArgs) (*mcp.CallToolResult, any, error) {
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: "Echo: " + args.Message},
@@ -41,6 +41,6 @@ func (t *Toolkit) handleExampleTool(_ context.Context, _ *mcp.CallToolRequest, a
 }
 
 // Close cleans up any resources used by the toolkit.
-func (t *Toolkit) Close() error {
+func (*Toolkit) Close() error {
 	return nil
 }

--- a/pkg/tuning/hints.go
+++ b/pkg/tuning/hints.go
@@ -1,5 +1,7 @@
 package tuning
 
+import "maps"
+
 // HintManager manages tool hints.
 type HintManager struct {
 	hints map[string]string // tool name -> hint
@@ -25,17 +27,13 @@ func (m *HintManager) GetHint(toolName string) (string, bool) {
 
 // SetHints sets multiple hints at once.
 func (m *HintManager) SetHints(hints map[string]string) {
-	for k, v := range hints {
-		m.hints[k] = v
-	}
+	maps.Copy(m.hints, hints)
 }
 
 // All returns all hints.
 func (m *HintManager) All() map[string]string {
 	result := make(map[string]string)
-	for k, v := range m.hints {
-		result[k] = v
-	}
+	maps.Copy(result, m.hints)
 	return result
 }
 

--- a/pkg/tuning/prompts.go
+++ b/pkg/tuning/prompts.go
@@ -2,6 +2,8 @@
 package tuning
 
 import (
+	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,7 +39,7 @@ func (m *PromptManager) LoadPrompts() error {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return err
+		return fmt.Errorf("reading prompts directory: %w", err)
 	}
 
 	for _, entry := range entries {
@@ -90,9 +92,7 @@ func (m *PromptManager) Set(name, content string) {
 // All returns all prompts.
 func (m *PromptManager) All() map[string]string {
 	result := make(map[string]string)
-	for k, v := range m.prompts {
-		result[k] = v
-	}
+	maps.Copy(result, m.prompts)
 	return result
 }
 

--- a/pkg/tuning/prompts_test.go
+++ b/pkg/tuning/prompts_test.go
@@ -48,7 +48,7 @@ func TestPromptManagerLoadPrompts(t *testing.T) {
 	t.Run("path is file not directory", func(t *testing.T) {
 		dir := t.TempDir()
 		filePath := filepath.Join(dir, "not_a_dir")
-		if err := os.WriteFile(filePath, []byte("file content"), 0644); err != nil {
+		if err := os.WriteFile(filePath, []byte("file content"), 0o644); err != nil {
 			t.Fatalf("failed to create file: %v", err)
 		}
 
@@ -66,14 +66,14 @@ func TestPromptManagerLoadPrompts(t *testing.T) {
 		dir := t.TempDir()
 
 		// Create test prompt files
-		if err := os.WriteFile(filepath.Join(dir, "greeting.txt"), []byte("Hello, {{name}}!"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "greeting.txt"), []byte("Hello, {{name}}!"), 0o644); err != nil {
 			t.Fatalf("failed to write file: %v", err)
 		}
-		if err := os.WriteFile(filepath.Join(dir, "farewell.md"), []byte("Goodbye!"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "farewell.md"), []byte("Goodbye!"), 0o644); err != nil {
 			t.Fatalf("failed to write file: %v", err)
 		}
 		// Create a file that should be ignored
-		if err := os.WriteFile(filepath.Join(dir, "ignored.json"), []byte("{}"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "ignored.json"), []byte("{}"), 0o644); err != nil {
 			t.Fatalf("failed to write file: %v", err)
 		}
 
@@ -115,12 +115,12 @@ func TestPromptManagerLoadPrompts(t *testing.T) {
 
 		// Create a subdirectory
 		subdir := filepath.Join(dir, "subdir")
-		if err := os.Mkdir(subdir, 0755); err != nil {
+		if err := os.Mkdir(subdir, 0o755); err != nil {
 			t.Fatalf("failed to create subdir: %v", err)
 		}
 
 		// Create a file inside subdir (should be ignored)
-		if err := os.WriteFile(filepath.Join(subdir, "nested.txt"), []byte("nested"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(subdir, "nested.txt"), []byte("nested"), 0o644); err != nil {
 			t.Fatalf("failed to write file: %v", err)
 		}
 
@@ -252,4 +252,3 @@ func TestBuildSystemPrompt(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/tuning/rules.go
+++ b/pkg/tuning/rules.go
@@ -1,5 +1,13 @@
 package tuning
 
+const (
+	// defaultQualityThreshold is the minimum quality score for data access.
+	defaultQualityThreshold = 0.7
+
+	// defaultMaxQueryLimit is the maximum number of rows a query can return.
+	defaultMaxQueryLimit = 10000
+)
+
 // Rules defines operational rules for the platform.
 type Rules struct {
 	// RequireDataHubCheck requires checking DataHub before writing queries.
@@ -26,8 +34,8 @@ func DefaultRules() *Rules {
 	return &Rules{
 		RequireDataHubCheck:      true,
 		WarnOnDeprecated:         true,
-		QualityThreshold:         0.7,
-		MaxQueryLimit:            10000,
+		QualityThreshold:         defaultQualityThreshold,
+		MaxQueryLimit:            defaultMaxQueryLimit,
 		RequirePIIAcknowledgment: false,
 		Custom:                   make(map[string]any),
 	}
@@ -57,6 +65,7 @@ type Violation struct {
 // Severity indicates the severity of a violation.
 type Severity string
 
+// Severity levels for operational rules.
 const (
 	SeverityInfo    Severity = "info"
 	SeverityWarning Severity = "warning"


### PR DESCRIPTION
## Summary

- Upgraded `.golangci.yml` to enterprise-grade configuration with 30+ linters enabled
- Resolved all **221 pre-existing lint findings** across 106 files — golangci-lint now reports **0 issues**

## Key changes

**Linter configuration** (`.golangci.yml`):
- Enabled revive, wrapcheck, errorlint, nilerr, nilnil, staticcheck, goconst, gocritic, gocognit, nestif, gosec, and more
- Test files excluded from noisy linters (errcheck, gosec, nestif, etc.)

**Type renames to fix stuttered names** (revive `exported`):
- `persona.PersonaAuthorizer` → `persona.Authorizer`
- `persona.PersonaConfig` → `persona.Config`
- `platform.PlatformInfo` → `platform.Info`
- `s3.S3Client` → `s3.Client`
- `query.QueryExample` → `query.Example`, `query.QueryResult` → `query.Result`

**Struct refactors to reduce parameter counts** (revive `argument-limit`, `function-result-limit`):
- `registry.GetToolkitForTool` returns `ToolkitMatch` struct (was 4 return values)
- `authenticateAndAuthorize` uses `authParams` struct (was 8 params)
- `buildMCPAuditEvent` uses `auditCallInfo` struct (was 6 params)
- `inheritMetadata` uses `inheritSource` struct (was 7 params)

**Other fixes across all packages**:
- ~100 magic numbers extracted to named constants
- ~30 unused receivers converted to unnamed `(*Type)` form
- All external errors wrapped with `fmt.Errorf` context (wrapcheck)
- Error strings lowercased per Go conventions (revive `string-format`)
- Cognitive complexity reduced via helper extraction (gocognit, nestif)
- Early-return patterns applied throughout (revive `early-return`)
- `maps.Copy`, `slices.Contains`, `strings.CutPrefix` modernizations

## Test plan

- [x] `go test -race ./...` — all 24 packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gosec ./...` — 0 issues
- [x] `goreleaser release --snapshot --clean --skip=publish,sign,sbom` — builds succeed