### PR TITLE
Document session metadata deduplication feature

### DIFF
--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -211,6 +211,15 @@ injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
 
+  # Session metadata deduplication
+  # Avoids repeating large semantic metadata blocks for previously-enriched
+  # tables within the same client session, saving LLM context tokens.
+  session_dedup:
+    enabled: true               # Default: true (dedup is on by default)
+    mode: reference             # reference (default), summary, none
+    # entry_ttl: 5m             # How long a table stays "already sent" (defaults to semantic.cache.ttl)
+    # session_timeout: 30m      # Idle session cleanup (defaults to server.streamable.session_timeout)
+
 # Tuning
 tuning:
   rules:

--- a/docs/cross-injection/overview.md
+++ b/docs/cross-injection/overview.md
@@ -510,6 +510,111 @@ The cache is time-based. For immediate updates:
 
 ---
 
+## Session Metadata Deduplication
+
+### The Problem
+
+When Trino enrichment is enabled, every tool call targeting a table receives ~2KB of semantic metadata (owners, tags, columns, glossary terms). In a typical AI session querying the same table 5-10 times, this repeats 10-20KB of identical metadata, consuming LLM context tokens with no new information.
+
+### How It Works
+
+Session dedup tracks which tables have been enriched per client session. On the first call, full metadata is sent. On repeat calls within the TTL, reduced content is sent based on the configured mode.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Platform
+    participant Trino
+    participant DataHub
+
+    Note over Client,DataHub: First call - full enrichment
+    Client->>Platform: trino_describe_table(orders)
+    Platform->>Trino: Describe table
+    Trino-->>Platform: Columns, types
+    Platform->>DataHub: Get semantic context
+    DataHub-->>Platform: Owners, tags, glossary terms
+    Platform-->>Client: Result + semantic_context + column_context
+
+    Note over Client,DataHub: Repeat call - dedup active
+    Client->>Platform: trino_query(SELECT * FROM orders)
+    Platform->>Trino: Execute query
+    Trino-->>Platform: Query results
+    Note over Platform: Session cache hit for "orders"
+    Platform-->>Client: Result + metadata_reference
+```
+
+### Dedup Modes
+
+| Mode | First Call | Repeat Calls | Use Case |
+|------|-----------|--------------|----------|
+| `reference` (default) | Full `semantic_context` + `column_context` | `metadata_reference` with table names and a note | Most scenarios - minimal tokens, LLM can refer back |
+| `summary` | Full | Table-level `semantic_context` only, no column details | When LLM needs a reminder of table-level context |
+| `none` | Full | No enrichment appended | Maximum token savings |
+
+#### Mode: `reference` (default)
+
+Repeat calls return a compact reference:
+
+```json
+{
+  "metadata_reference": {
+    "tables": ["hive.sales.orders"],
+    "note": "Full semantic metadata was provided earlier in this session. Refer to previous responses for column descriptions, tags, owners, and glossary terms."
+  }
+}
+```
+
+#### Mode: `summary`
+
+Repeat calls return table-level context without column details:
+
+```json
+{
+  "semantic_context": {
+    "description": "Customer orders with line items",
+    "owners": [{"name": "Data Team", "type": "group"}],
+    "tags": ["pii", "financial"],
+    "domain": {"name": "Sales"},
+    "quality_score": 0.92
+  },
+  "note": "Summary only. Full column metadata was provided earlier in this session."
+}
+```
+
+#### Mode: `none`
+
+Repeat calls return the raw tool result with no enrichment appended.
+
+### Configuration
+
+```yaml
+injection:
+  trino_semantic_enrichment: true
+  session_dedup:
+    enabled: true          # Default: true
+    mode: reference        # reference (default), summary, none
+    entry_ttl: 5m          # Defaults to semantic.cache.ttl
+    session_timeout: 30m   # Defaults to server.streamable.session_timeout
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Whether session dedup is active |
+| `mode` | string | `reference` | What to send for repeat queries: `reference`, `summary`, `none` |
+| `entry_ttl` | duration | semantic cache TTL | How long a table is considered "already sent" |
+| `session_timeout` | duration | streamable session timeout | Idle time before a session's dedup state is cleaned up |
+
+### Behavior Notes
+
+- **Enabled by default**: Session dedup activates automatically when `trino_semantic_enrichment: true`. Set `session_dedup.enabled: false` to disable.
+- **Trino-only**: Dedup applies only to Trino tool calls. DataHub and S3 enrichment is not deduplicated.
+- **In-memory state**: Session state is stored in memory and lost on restart. This is by design - after restart, the LLM gets fresh metadata.
+- **Session isolation**: Each client session has independent dedup state. Two sessions querying the same table both get full metadata on their first call.
+- **TTL defaults**: `entry_ttl` defaults to the semantic cache TTL (typically 5m). `session_timeout` defaults to the streamable HTTP session timeout (typically 30m).
+- **SQL parsing**: The dedup logic extracts table names from SQL queries, so `SELECT * FROM orders JOIN products` correctly tracks both tables independently.
+
+---
+
 ## Advanced Patterns
 
 ### Multi-Cluster Enrichment

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -583,6 +583,45 @@ When lineage inheritance is active, responses include column context with proven
 
 **Data lakes**: Parquet files derived from operational databases. Aliases provide explicit mapping when lineage isn't tracked.
 
+## Session Metadata Deduplication
+
+When Trino enrichment is enabled, every tool call targeting a table receives ~2KB of semantic metadata. In a typical session querying the same table multiple times, this wastes LLM context tokens with repeated information.
+
+Session dedup tracks which tables have been enriched per client session. First call gets full metadata; repeat calls within the TTL get reduced content based on the configured mode.
+
+### Configuration
+
+```yaml
+injection:
+  trino_semantic_enrichment: true
+  session_dedup:
+    enabled: true          # Default: true
+    mode: reference        # reference (default), summary, none
+    entry_ttl: 5m          # Defaults to semantic.cache.ttl
+    session_timeout: 30m   # Defaults to server.streamable.session_timeout
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Whether session dedup is active |
+| `mode` | string | `reference` | What to send for repeat queries |
+| `entry_ttl` | duration | semantic cache TTL | How long a table stays "already sent" |
+| `session_timeout` | duration | streamable session timeout | Idle session cleanup |
+
+### Modes
+
+- **`reference`** (default): Repeat calls return `{"metadata_reference": {"tables": [...], "note": "Full semantic metadata was provided earlier..."}}`. Minimal tokens, LLM can refer back.
+- **`summary`**: Repeat calls return table-level `semantic_context` without column details. LLM gets a reminder of ownership and tags.
+- **`none`**: Repeat calls return raw tool results with no enrichment. Maximum token savings.
+
+### Behavior
+
+- Enabled by default when `trino_semantic_enrichment: true`
+- Trino-only (DataHub/S3 enrichment is not deduplicated)
+- In-memory state, lost on restart (by design)
+- Each client session has independent dedup state
+- SQL parsing tracks multiple tables independently (`JOIN` queries)
+
 ---
 
 # Tools API Reference

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -24,6 +24,7 @@
 - [DataHub to Trino](cross-injection/datahub-trino.md): DataHub results show query availability
 - [S3 Enrichment](cross-injection/s3.md): S3 operations include semantic context
 - [Lineage Inheritance](cross-injection/lineage.md): Automatic column metadata inheritance from upstream datasets via DataHub lineage
+- [Session Dedup](cross-injection/overview.md#session-metadata-deduplication): Avoids repeating semantic metadata for previously-enriched tables within a session, saving LLM context tokens
 
 ## Authentication & Security
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -445,6 +445,11 @@ injection:
   datahub_query_enrichment: true
   s3_semantic_enrichment: true
   datahub_storage_enrichment: true
+  session_dedup:
+    enabled: true
+    mode: reference
+    entry_ttl: 5m
+    session_timeout: 30m
 ```
 
 | Option | Type | Default | Description |
@@ -453,6 +458,17 @@ injection:
 | `datahub_query_enrichment` | bool | `false` | Enrich DataHub with Trino |
 | `s3_semantic_enrichment` | bool | `false` | Enrich S3 with DataHub |
 | `datahub_storage_enrichment` | bool | `false` | Enrich DataHub with S3 |
+
+**Session Dedup** (`injection.session_dedup`):
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | bool | `true` | Whether session dedup is active |
+| `mode` | string | `reference` | Content for repeat queries: `reference`, `summary`, `none` |
+| `entry_ttl` | duration | semantic cache TTL | How long a table stays "already sent" |
+| `session_timeout` | duration | streamable session timeout | Idle session cleanup interval |
+
+See [Session Metadata Deduplication](../cross-injection/overview.md#session-metadata-deduplication) for detailed behavior and JSON examples.
 
 ## Tuning Configuration
 
@@ -573,6 +589,9 @@ injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
   s3_semantic_enrichment: true
+  session_dedup:
+    enabled: true
+    mode: reference
 
 audit:
   enabled: true

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -230,6 +230,13 @@ injection:
   datahub_query_enrichment: true     # Add Trino availability to DataHub results
   s3_semantic_enrichment: true       # Add DataHub context to S3 results
   datahub_storage_enrichment: true   # Add S3 availability to DataHub results
+
+  # Session metadata deduplication (avoids repeating metadata for same table)
+  session_dedup:
+    enabled: true             # Default: true
+    mode: reference           # reference (default), summary, none
+    entry_ttl: 5m             # Defaults to semantic.cache.ttl
+    session_timeout: 30m      # Defaults to server.streamable.session_timeout
 ```
 
 | Field | Type | Default | Description |
@@ -238,6 +245,10 @@ injection:
 | `datahub_query_enrichment` | bool | `false` | Add query availability to DataHub search results |
 | `s3_semantic_enrichment` | bool | `false` | Enrich S3 results with DataHub metadata |
 | `datahub_storage_enrichment` | bool | `false` | Add S3 availability to DataHub results |
+| `session_dedup.enabled` | bool | `true` | Whether session dedup is active |
+| `session_dedup.mode` | string | `reference` | Repeat query content: `reference`, `summary`, `none` |
+| `session_dedup.entry_ttl` | duration | semantic cache TTL | How long a table stays "already sent" |
+| `session_dedup.session_timeout` | duration | streamable session timeout | Idle session cleanup interval |
 
 ## Semantic and Query Provider Configuration
 


### PR DESCRIPTION
## Summary

- Documents the session metadata deduplication feature across all doc surfaces
- Adds `session_dedup` configuration block to `configs/platform.yaml` with all 4 fields
- Adds comprehensive section to `docs/cross-injection/overview.md` with Mermaid sequence diagram, mode comparison table, JSON examples for all 3 modes, configuration reference, and behavior notes
- Updates `docs/server/configuration.md` and `docs/reference/configuration.md` with session_dedup fields and defaults
- Updates `docs/llms.txt` and `docs/llms-full.txt` per llmstxt.org spec

## Context

PR #59 introduced session metadata deduplication (~300 lines across 4 source files, 16 unit tests + 4 integration tests) but shipped with zero documentation. This PR adds the missing docs without any code changes.

## Test plan

- [ ] `go test -race ./...` passes (docs-only, no code changes)
- [ ] `go build ./...` succeeds
- [ ] YAML snippets match `SessionDedupConfig` struct fields in `pkg/platform/config.go`
- [ ] Default values match `applySessionDedupDefaults()` and `IsEnabled()`/`EffectiveMode()` helpers
- [ ] Mode names match `DedupMode` constants in `pkg/middleware/session_cache.go`
- [ ] JSON examples match actual output from `appendMetadataReference()` and `appendSemanticSummary()`