### PR TITLE
deps: bump mcp-datahub from 0.5.1 to 0.5.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
-	github.com/txn2/mcp-datahub v0.5.1
+	github.com/txn2/mcp-datahub v0.5.2
 	github.com/txn2/mcp-s3 v0.1.4
 	github.com/txn2/mcp-trino v0.3.0
 	golang.org/x/crypto v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v0.5.1 h1:67ijyyuZCh+Yh8456/8yyP+Lt7rSVkHJYwAlM4jl65g=
-github.com/txn2/mcp-datahub v0.5.1/go.mod h1:9YWiNjhmFjmXMK9PX9QmlQgouaZLu/edqJ5hKC5qZUA=
+github.com/txn2/mcp-datahub v0.5.2 h1:Nq2VetunmEwyW2kR7xnpV9Wl487BFnZ+PpKSgDZjh+U=
+github.com/txn2/mcp-datahub v0.5.2/go.mod h1:9YWiNjhmFjmXMK9PX9QmlQgouaZLu/edqJ5hKC5qZUA=
 github.com/txn2/mcp-s3 v0.1.4 h1:73VfwofCNUoVAzWQgh1LoaAsNW42jEUTGfRPe1s7Vkk=
 github.com/txn2/mcp-s3 v0.1.4/go.mod h1:yu2m8DZdsHJEWj+Ktkhz1XUk17jqPdVSa4UcyZWetkc=
 github.com/txn2/mcp-trino v0.3.0 h1:q3mLQPvgDDfODZNgL86JKUrHaDUxpdWhNzaOt6iu6sM=


### PR DESCRIPTION
## Summary
- Bumps `github.com/txn2/mcp-datahub` from v0.5.1 to v0.5.2
- Fixes `UpdateDescription` HTTP 400 on DataHub v1.3.0+ by preserving audit stamps via read-modify-write pattern
- Also fixes revive lint errors for unhandled `WriteRune` calls

## Test plan
- [x] All existing tests pass
- [x] Lint clean