### PR TITLE
fix: disable COUNT(*) row estimation in query enrichment by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,10 @@ ext-apps/
 # Admin UI
 admin-ui/node_modules/
 admin-ui/dist/
+admin-ui/.vite/
+admin-ui/test-results/
+
+# Root node_modules (if any)
+node_modules/
 internal/adminui/dist/*
 !internal/adminui/dist/.gitkeep

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -295,6 +295,7 @@ type InjectionConfig struct {
 	DataHubQueryEnrichment   bool               `yaml:"datahub_query_enrichment"`
 	S3SemanticEnrichment     bool               `yaml:"s3_semantic_enrichment"`
 	DataHubStorageEnrichment bool               `yaml:"datahub_storage_enrichment"`
+	EstimateRowCounts        bool               `yaml:"estimate_row_counts"`
 	SessionDedup             SessionDedupConfig `yaml:"session_dedup"`
 }
 

--- a/pkg/platform/config_test.go
+++ b/pkg/platform/config_test.go
@@ -230,6 +230,9 @@ func TestApplyDefaults(t *testing.T) {
 	if cfg.Server.Shutdown.PreShutdownDelay != cfgTestDefaultPreDelay {
 		t.Errorf("Server.Shutdown.PreShutdownDelay = %v, want %v", cfg.Server.Shutdown.PreShutdownDelay, cfgTestDefaultPreDelay)
 	}
+	if cfg.Injection.EstimateRowCounts {
+		t.Error("Injection.EstimateRowCounts should default to false")
+	}
 }
 
 func TestApplyDefaults_PreservesExisting(t *testing.T) {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -895,20 +895,21 @@ func (p *Platform) createQueryProvider() (query.Provider, error) {
 		}
 
 		adapter, err := trinoquery.New(trinoquery.Config{
-			Host:           trinoCfg.Host,
-			Port:           trinoCfg.Port,
-			User:           trinoCfg.User,
-			Password:       trinoCfg.Password,
-			Catalog:        trinoCfg.Catalog,
-			Schema:         trinoCfg.Schema,
-			SSL:            trinoCfg.SSL,
-			SSLVerify:      trinoCfg.SSLVerify,
-			Timeout:        trinoCfg.Timeout,
-			DefaultLimit:   trinoCfg.DefaultLimit,
-			MaxLimit:       trinoCfg.MaxLimit,
-			ReadOnly:       trinoCfg.ReadOnly,
-			ConnectionName: trinoCfg.ConnectionName,
-			CatalogMapping: p.config.Query.URNMapping.CatalogMapping,
+			Host:              trinoCfg.Host,
+			Port:              trinoCfg.Port,
+			User:              trinoCfg.User,
+			Password:          trinoCfg.Password,
+			Catalog:           trinoCfg.Catalog,
+			Schema:            trinoCfg.Schema,
+			SSL:               trinoCfg.SSL,
+			SSLVerify:         trinoCfg.SSLVerify,
+			Timeout:           trinoCfg.Timeout,
+			DefaultLimit:      trinoCfg.DefaultLimit,
+			MaxLimit:          trinoCfg.MaxLimit,
+			ReadOnly:          trinoCfg.ReadOnly,
+			ConnectionName:    trinoCfg.ConnectionName,
+			CatalogMapping:    p.config.Query.URNMapping.CatalogMapping,
+			EstimateRowCounts: p.config.Injection.EstimateRowCounts,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("creating trino query provider: %w", err)


### PR DESCRIPTION
## Summary

- **Problem**: `GetTableAvailability()` unconditionally ran `SELECT COUNT(*) FROM table` for every URN during DataHub query enrichment. A single DataHub search returning 10 results triggered 10 sequential COUNT(*) queries, causing full table scans and timeouts on large PostgreSQL/Trino tables.
- **Fix**: Added `EstimateRowCounts` config flag to the Trino query adapter, defaulting to `false`. When disabled, `GetTableAvailability()` still verifies table existence via `DescribeTable` but skips the expensive COUNT(*). Extracted `estimateRowCount()` helper to satisfy cyclomatic/cognitive complexity limits.
- **Config**: Set `injection.estimate_row_counts: true` to restore the previous behavior when row count estimates are desired.

## Changes

| File | What |
|---|---|
| `pkg/query/trino/adapter.go` | Added `EstimateRowCounts bool` to `Config`; guarded COUNT(*) behind the flag; extracted `estimateRowCount()` helper |
| `pkg/platform/config.go` | Added `EstimateRowCounts` to `InjectionConfig` (yaml: `estimate_row_counts`) |
| `pkg/platform/platform.go` | Wired `Injection.EstimateRowCounts` into Trino adapter config |
| `pkg/query/trino/adapter_test.go` | Added `TestGetTableAvailability_RowCountsDisabled`; updated existing tests to explicitly set `EstimateRowCounts: true` |
| `pkg/platform/config_test.go` | Added assertion that `EstimateRowCounts` defaults to `false` |
| `.gitignore` | Added `admin-ui/.vite/`, `admin-ui/test-results/`, `node_modules/` |

## Test plan

- [x] `make verify` passes (all lint, security, coverage, mutation, release checks)
- [x] New function coverage: `GetTableAvailability` 100%, `estimateRowCount` 81.8%
- [ ] Deploy with no config change — DataHub searches complete without COUNT(*) overhead
- [ ] Set `injection.estimate_row_counts: true` — row counts appear in enrichment (existing behavior)