### PR TITLE
fix: gate admin portal on config and strip mockServiceWorker.js from prod builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ before:
   hooks:
     - go mod download
     - go mod verify
-    - bash -c "if [ -f admin-ui/package.json ]; then cd admin-ui && npm ci && npm run build && rm -rf ../internal/adminui/dist/* && cp -r dist/* ../internal/adminui/dist/; fi"
+    - bash -c "if [ -f admin-ui/package.json ]; then cd admin-ui && npm ci && npm run build && rm -rf ../internal/adminui/dist/* && cp -r dist/* ../internal/adminui/dist/ && rm -f ../internal/adminui/dist/mockServiceWorker.js; fi"
 
 builds:
   - id: mcp-data-platform

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ GOLINT := golangci-lint
 
 .PHONY: all build test lint fmt clean install help docs-serve docs-build verify \
 	tools-check dead-code mutate patch-coverage doc-check swagger swagger-check \
-	semgrep codeql sast \
+	semgrep codeql sast embed-clean \
 	frontend-install frontend-build frontend-dev frontend-test frontend-storybook \
 	e2e-up e2e-down e2e-seed e2e-test e2e e2e-logs e2e-clean \
 	dev-up dev-down
@@ -252,8 +252,13 @@ tools-check:
 	fi
 	@echo "All required tools found."
 
+## embed-clean: Reset admin UI embed dir to .gitkeep only (matches CI clean checkout)
+embed-clean:
+	@echo "Cleaning admin UI embed directory..."
+	@find $(ADMIN_UI_EMBED_DIR) -not -name '.gitkeep' -not -path $(ADMIN_UI_EMBED_DIR) -delete 2>/dev/null || true
+
 ## verify: Run the full CI-equivalent check suite (test, lint, security, SAST, coverage, mutation, release)
-verify: tools-check fmt swagger-check test lint security semgrep codeql coverage-report patch-coverage doc-check dead-code mutate release-check
+verify: tools-check fmt swagger-check embed-clean test lint security semgrep codeql coverage-report patch-coverage doc-check dead-code mutate release-check
 	@echo ""
 	@echo "=== All checks passed ==="
 
@@ -293,6 +298,7 @@ frontend-build: frontend-install
 	@echo "Copying dist to embed directory..."
 	@rm -rf $(ADMIN_UI_EMBED_DIR)/*
 	@cp -r $(ADMIN_UI_DIR)/dist/* $(ADMIN_UI_EMBED_DIR)/
+	@rm -f $(ADMIN_UI_EMBED_DIR)/mockServiceWorker.js
 	@echo "Admin UI built and embedded."
 
 ## frontend-dev: Run admin UI dev server (hot reload)

--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -259,6 +259,7 @@ tuning:
 # Admin REST API
 # admin:
 #   enabled: true
+#   portal: true                # enable admin UI portal (default: false)
 #   persona: admin              # persona required for admin access (default: "admin")
 #   path_prefix: /api/v1/admin  # URL prefix for admin endpoints
 

--- a/dev/platform.yaml
+++ b/dev/platform.yaml
@@ -202,6 +202,7 @@ knowledge:
 
 admin:
   enabled: true
+  portal: true
   persona: admin
   path_prefix: /api/v1/admin
 

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -74,6 +74,7 @@ type Config struct {
 // AdminConfig configures the admin REST API.
 type AdminConfig struct {
 	Enabled     bool   `yaml:"enabled"`
+	Portal      bool   `yaml:"portal"`       // enable admin UI portal (default: false)
 	Persona     string `yaml:"persona"`      // required admin persona (default: "admin")
 	PathPrefix  string `yaml:"path_prefix"`  // URL prefix (default: "/api/v1/admin")
 	PortalTitle string `yaml:"portal_title"` // sidebar title (default: "Admin Portal")


### PR DESCRIPTION
## Summary

Closes #70 (AC-13: "When `admin.enabled` is false, `/admin/` returns 404").

Two problems fixed in one branch:

1. **Admin portal config gate** — The admin UI was auto-mounted at `/admin/` whenever the embedded dist assets existed in the binary. There was no config option to disable it. This adds `admin.portal` (default: `false`) so the portal requires explicit opt-in, matching the original intent of AC-13.

2. **mockServiceWorker.js in production** — MSW's dev-only service worker file (`mockServiceWorker.js`) was shipped in the production dist via `admin-ui/public/`. Browsers flagged the page as insecure because a service worker was registering and intercepting requests in production. The file is now stripped from the embed directory after copying in both the Makefile and GoReleaser build hooks.

## Changes

### Config gate (`admin.portal`)

- **`pkg/platform/config.go`** — Added `Portal bool` field to `AdminConfig` (yaml: `portal`, default: `false`)
- **`cmd/mcp-data-platform/main.go`** — Extracted `mountAdminPortal()` helper that gates on `p.Config().Admin.Portal && adminui.Available()`. This also reduced `startHTTPServer` cyclomatic complexity back under the ≤10 threshold.
- **`configs/platform.yaml`** — Added `portal: true` to the commented example block
- **`dev/platform.yaml`** — Added `portal: true` so the dev environment continues to serve the SPA

### mockServiceWorker.js removal

- **`Makefile`** — Added `@rm -f $(ADMIN_UI_EMBED_DIR)/mockServiceWorker.js` after the `cp -r` in `frontend-build`
- **`.goreleaser.yml`** — Added `&& rm -f ../internal/adminui/dist/mockServiceWorker.js` to the before-hook build step
- Deleted the existing copy from disk (file was not git-tracked)

### Test fixes

- **`cmd/mcp-data-platform/main_test.go`** — Added `TestAdminPortalGate` with 4 subtests: default false, not mounted when false, mounted when true + assets available, nil-safe
- **`internal/adminui/embed_test.go`** — Fixed pre-existing broken assertions that assumed an empty dist directory (the frontend assets were committed in #91 but the tests were never updated to match)

## Test plan

- [x] `make verify` passes (all 14 stages: fmt, test, lint, security, coverage, dead-code, mutation, release-check)
- [x] `mountAdminPortal` has 100% test coverage
- [x] With `admin.portal: false` (default) — `/admin/` is not mounted
- [x] With `admin.portal: true` — `/admin/` serves the SPA
- [x] `internal/adminui/dist/` has no `mockServiceWorker.js` after build
- [ ] Manual: run locally with `admin.portal: true`, confirm no service worker registration in browser console
- [ ] Manual: run locally with `admin.portal: false` (or omitted), confirm `/admin/` returns 404