### PR TITLE
feat: config-driven tool visibility filtering (#90)

### DIFF
--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -119,6 +119,17 @@ personas:
     user_personas:
       "admin@example.com": "admin"
 
+# Tool visibility filter
+# Reduces token usage by hiding tools from tools/list responses.
+# This is a visibility filter, not a security boundary — persona auth
+# continues to gate tools/call independently.
+# tools:
+#   allow:
+#     - "trino_*"
+#     - "datahub_*"
+#   deny:
+#     - "*_delete_*"
+
 # Toolkit instances
 toolkits:
   trino:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -257,13 +257,36 @@ Setting `dsn` enables audit logging, knowledge capture, session externalization,
 
 **`database` mode**: Configuration persisted to PostgreSQL. Requires `database.dsn`. Supports runtime mutations via the admin API. Bootstrap fields (`server`, `database`, `auth`, `admin`, `config_store`, `apiVersion`) always load from YAML.
 
+## Tool Visibility Configuration
+
+Reduce LLM token usage by hiding tools from `tools/list` responses. This is a visibility optimization, not a security boundary — persona-level tool filtering continues to gate `tools/call`.
+
+```yaml
+tools:
+  allow:
+    - "trino_*"
+    - "datahub_*"
+  deny:
+    - "*_delete_*"
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `tools.allow` | array | `[]` | Tool name patterns to include in `tools/list` |
+| `tools.deny` | array | `[]` | Tool name patterns to exclude from `tools/list` |
+
+No patterns configured means all tools are visible. When both are set, allow is evaluated first, then deny removes from the result. Patterns use `filepath.Match` syntax (`*` matches any sequence of characters).
+
 ## Admin API Configuration
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `admin.enabled` | bool | `false` | Enable admin REST API |
+| `admin.portal` | bool | `false` | Enable the admin web portal UI |
 | `admin.persona` | string | `admin` | Persona required for admin access |
 | `admin.path_prefix` | string | `/api/v1/admin` | URL prefix for admin endpoints |
+
+When `admin.portal: true`, an interactive web dashboard is served at the admin path prefix. It provides audit log exploration, tool execution testing, and system monitoring.
 
 ## Audit Configuration
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,9 +11,9 @@
 - [Home](index.md): Introduction, quick start, and key features
 - [Server Overview](server/overview.md): What the platform does, architecture, request flow
 - [Installation](server/installation.md): Install via go install, Homebrew, Docker, or from source
-- [Configuration](server/configuration.md): YAML configuration with environment variable expansion, config versioning (apiVersion field, version lifecycle, migrate-config CLI), config store options (file vs database mode), database, admin API, audit, and session configuration
+- [Configuration](server/configuration.md): YAML configuration with environment variable expansion, config versioning (apiVersion field, version lifecycle, migrate-config CLI), config store options (file vs database mode), tool visibility filtering (allow/deny patterns for tools/list token reduction), admin API and portal, database, audit, and session configuration
 - [Operating Modes](server/operating-modes.md): Three deployment modes — standalone (no database), full-config file + database, bootstrap + database config. Feature availability by mode, example configurations, decision guide
-- [Admin API](server/admin-api.md): REST endpoints for system info, config management, personas, auth keys, audit, knowledge. Authentication, operating mode behavior, request/response reference. Interactive Swagger UI at `/api/v1/admin/docs/`
+- [Admin API](server/admin-api.md): REST endpoints for system info, config management, personas, auth keys, audit, knowledge. Authentication, operating mode behavior, request/response reference. Interactive Swagger UI at `/api/v1/admin/docs/`. Admin portal web dashboard (`admin.portal: true`) for audit exploration, tool testing, and system monitoring
 - [Tools](server/tools.md): All 27 tools from DataHub, Trino, and S3 toolkits
 - [Multi-Provider](server/multi-provider.md): Connect multiple instances of each service
 - [Audit Logging](server/audit.md): PostgreSQL-backed audit logging for tool calls. Schema, field reference, parameter sanitization, retention, query examples, troubleshooting
@@ -40,7 +40,7 @@
 ## Personas
 
 - [Overview](personas/overview.md): Role-based tool access control
-- [Tool Filtering](personas/tool-filtering.md): Allow/deny patterns with wildcards
+- [Tool Filtering](personas/tool-filtering.md): Allow/deny patterns with wildcards. Distinction between persona-level filtering (security boundary) and global tool visibility (token optimization)
 - [Role Mapping](personas/role-mapping.md): Map OIDC roles to personas
 
 ## Go Library
@@ -72,9 +72,9 @@
 - [Tools API](reference/tools-api.md): Complete tool specifications with parameters and responses
 - [Configuration](reference/configuration.md): Full YAML schema with all options
 - [Providers](reference/providers.md): Semantic, query, and storage provider interfaces
-- [Middleware](reference/middleware.md): Request processing chain
+- [Middleware](reference/middleware.md): Request processing chain including tool visibility middleware
 
 ## Support
 
 - [Troubleshooting](support/troubleshooting.md): Common issues, error codes, debugging guide
-- [Changelog](support/changelog.md): Version history
+- [Changelog](support/changelog.md): Version history — tool visibility filtering, admin portal, admin REST API, knowledge capture/apply, config versioning, session externalization, session dedup

--- a/docs/personas/tool-filtering.md
+++ b/docs/personas/tool-filtering.md
@@ -2,6 +2,11 @@
 
 Tool filtering controls which MCP tools are available to each persona. Rules use wildcard patterns to allow or deny tools by name.
 
+!!! note "Two levels of tool filtering"
+    **Persona tool filtering** (this page) is a **security boundary**. It controls which tools a user can call via `tools/call` based on their persona. Unauthorized calls are rejected.
+
+    **Global tool visibility** (configured via the top-level `tools:` block) is a **token optimization**. It controls which tools appear in `tools/list` responses to reduce LLM context usage. It does not block `tools/call`. See [Tool Visibility Configuration](../server/configuration.md#tool-visibility-configuration) for details.
+
 ## Rule Structure
 
 Each persona has `allow` and `deny` lists:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -460,6 +460,43 @@ semantic:
 
 This maps `elasticsearch.index.rxtxmsg.payload.field_name` to lookup `field_name` in upstream sources.
 
+## Tool Visibility Configuration
+
+Reduce LLM token usage by hiding tools from `tools/list` responses. This is a visibility optimization, not a security boundary — persona-level tool filtering continues to gate `tools/call`.
+
+```yaml
+tools:
+  allow:
+    - "trino_*"
+    - "datahub_*"
+  deny:
+    - "*_delete_*"
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `tools.allow` | array | `[]` | Tool name patterns to include in `tools/list` |
+| `tools.deny` | array | `[]` | Tool name patterns to exclude from `tools/list` |
+
+No patterns configured means all tools are visible. When both are set, allow is evaluated first, then deny removes from the result. Patterns use `filepath.Match` syntax (`*` matches any sequence of characters).
+
+## Admin API Configuration
+
+```yaml
+admin:
+  enabled: true
+  portal: true
+  persona: admin
+  path_prefix: /api/v1/admin
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `admin.enabled` | bool | `false` | Enable admin REST API |
+| `admin.portal` | bool | `false` | Enable the admin web portal UI |
+| `admin.persona` | string | `admin` | Persona required for admin access |
+| `admin.path_prefix` | string | `/api/v1/admin` | URL prefix for admin endpoints |
+
 ## Injection Configuration
 
 ```yaml
@@ -567,6 +604,18 @@ server:
     Enterprise data platform providing unified access to analytics data.
     Includes semantic enrichment from DataHub and query execution via Trino.
   transport: stdio
+
+admin:
+  enabled: true
+  portal: true
+
+tools:
+  allow:
+    - "trino_*"
+    - "datahub_*"
+    - "capture_insight"
+  deny:
+    - "*_delete_*"
 
 auth:
   oidc:

--- a/docs/server/admin-api.md
+++ b/docs/server/admin-api.md
@@ -34,9 +34,27 @@ make swagger
 ```yaml
 admin:
   enabled: true
+  portal: true                # Enable the admin web portal
   persona: admin              # Persona required for admin access
   path_prefix: /api/v1/admin  # URL prefix for all admin endpoints
 ```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable admin REST API |
+| `portal` | bool | `false` | Enable the admin web portal |
+| `persona` | string | `admin` | Persona required for admin access |
+| `path_prefix` | string | `/api/v1/admin` | URL prefix for admin endpoints |
+
+## Admin Portal
+
+When `admin.portal: true`, an interactive web dashboard is served at the admin path prefix (e.g., `http://localhost:8080/api/v1/admin/`). The portal provides:
+
+- **Audit Dashboard**: Browse and filter audit log events with time-series visualization
+- **Tool Execution**: Test tool calls directly from the browser
+- **System Monitoring**: View platform status, connected toolkits, and registered tools
+
+The portal requires authentication — access it with the same credentials used for admin API requests. In production builds, the service worker (`mockServiceWorker.js`) is stripped automatically.
 
 ## Error Format
 

--- a/docs/server/tools.md
+++ b/docs/server/tools.md
@@ -6,6 +6,9 @@ description: MCP tools from DataHub, Trino, S3, and Knowledge toolkits. Search m
 
 mcp-data-platform provides tools from four integrated toolkits. Each tool can be invoked by name through any MCP client.
 
+!!! tip "Reducing token usage with tool visibility"
+    The full tool list is 25-32 tools. Deployments that only use a subset can configure `tools.allow` and `tools.deny` at the top level of `platform.yaml` to hide unused tools from `tools/list` responses. This saves LLM context tokens without affecting authorization. See [Configuration](configuration.md#tool-visibility-configuration) for details.
+
 ## Tools Summary
 
 | Toolkit | Tool | Description |

--- a/docs/support/changelog.md
+++ b/docs/support/changelog.md
@@ -1,3 +1,51 @@
 # Changelog
 
 All releases are documented on the [GitHub Releases page](https://github.com/txn2/mcp-data-platform/releases).
+
+## Recent Changes
+
+### Tool Visibility Filtering
+
+Added config-driven `tools:` allow/deny filter on `tools/list` responses. Reduces LLM token usage by hiding unused tools from discovery. This is a visibility optimization, not a security boundary — persona auth continues to gate `tools/call`.
+
+```yaml
+tools:
+  allow:
+    - "trino_*"
+    - "datahub_*"
+  deny:
+    - "*_delete_*"
+```
+
+### Admin Portal (v0.17.x)
+
+Interactive web dashboard for platform administration. Enable with `admin.portal: true`. Provides audit log exploration, tool execution testing, and system monitoring at the admin path prefix.
+
+### Admin REST API (v0.17.x)
+
+HTTP endpoints for system health, configuration management, persona CRUD, auth key management, audit queries, and knowledge management. Supports three operating modes (standalone, file + DB, bootstrap + DB config). Interactive Swagger UI at `/api/v1/admin/docs/`.
+
+### Knowledge Capture & Apply (v0.17.x)
+
+Two MCP tools for domain knowledge lifecycle:
+
+- `capture_insight`: Records domain knowledge during AI sessions (corrections, business context, data quality observations, usage tips, relationships, enhancements)
+- `apply_knowledge`: Admin-only tool for reviewing, synthesizing, and applying insights to DataHub with changeset tracking and rollback
+
+Admin REST API endpoints for managing insights and changesets outside the MCP protocol.
+
+### Config Schema Versioning (v0.17.x)
+
+`apiVersion` field in configuration files enables safe schema evolution. Migration tooling (`mcp-data-platform migrate-config`) converts between versions while preserving `${VAR}` references.
+
+### Session Externalization (v0.17.x)
+
+Externalize MCP session state to PostgreSQL for zero-downtime restarts and horizontal scaling. Configure with `sessions.store: database`. Includes session hijack prevention via token hash verification.
+
+### Session Metadata Deduplication
+
+Avoids repeating semantic metadata for previously-enriched tables within a session. Saves LLM context tokens on repeat queries to the same tables. Configurable modes: `reference`, `summary`, `none`.
+
+### Query Enrichment Row Estimation
+
+`COUNT(*)` row estimation in DataHub query enrichment is disabled by default to avoid expensive full-table scans on large datasets.

--- a/pkg/middleware/mcp_test.go
+++ b/pkg/middleware/mcp_test.go
@@ -390,8 +390,8 @@ func TestMCPToolCallMiddleware_ToolkitLookup(t *testing.T) {
 		if pc == nil {
 			t.Fatal(mcpTestPCExpected)
 		}
-		if pc.ToolName != "trino_query" {
-			t.Errorf("expected ToolName 'trino_query', got %q", pc.ToolName)
+		if pc.ToolName != testAuditToolName {
+			t.Errorf("expected ToolName %q, got %q", testAuditToolName, pc.ToolName)
 		}
 		if pc.ToolkitKind != "trino" {
 			t.Errorf("expected ToolkitKind 'trino', got %q", pc.ToolkitKind)
@@ -413,7 +413,7 @@ func TestMCPToolCallMiddleware_ToolkitLookup(t *testing.T) {
 	}
 
 	handler := middleware(next)
-	req := newMCPTestRequest("trino_query")
+	req := newMCPTestRequest(testAuditToolName)
 
 	result, err := handler(context.Background(), mcpTestMethod, req)
 	if err != nil {

--- a/pkg/middleware/mcp_visibility.go
+++ b/pkg/middleware/mcp_visibility.go
@@ -1,0 +1,83 @@
+package middleware
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// MCPToolVisibilityMiddleware creates MCP protocol-level middleware that filters
+// tools/list responses based on allow/deny glob patterns. This reduces token
+// usage in LLM clients by hiding tools that are not needed for a deployment.
+//
+// This is a visibility filter, not a security boundary — persona auth continues
+// to gate tools/call independently.
+func MCPToolVisibilityMiddleware(allow, deny []string) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			result, err := next(ctx, method, req)
+			if err != nil {
+				return result, err
+			}
+			return filterToolVisibility(allow, deny, method, result)
+		}
+	}
+}
+
+// filterToolVisibility filters tools from a tools/list response based on
+// allow/deny patterns. Non-tools/list methods pass through unchanged.
+func filterToolVisibility(allow, deny []string, method string, result mcp.Result) (mcp.Result, error) {
+	if method != "tools/list" {
+		return result, nil
+	}
+
+	listResult, ok := result.(*mcp.ListToolsResult)
+	if !ok || listResult == nil {
+		return result, nil
+	}
+
+	filtered := make([]*mcp.Tool, 0, len(listResult.Tools))
+	for _, tool := range listResult.Tools {
+		if isToolVisible(tool.Name, allow, deny) {
+			filtered = append(filtered, tool)
+		}
+	}
+	listResult.Tools = filtered
+
+	return listResult, nil
+}
+
+// isToolVisible determines whether a tool should appear in tools/list based on
+// allow/deny glob patterns. Semantics:
+//   - No patterns configured: all tools visible
+//   - Allow only: only matching tools pass
+//   - Deny only: all pass except denied
+//   - Both: allow first, then deny removes from that set
+//   - Invalid glob patterns are treated as non-matching (silent skip)
+func isToolVisible(name string, allow, deny []string) bool {
+	if len(allow) == 0 && len(deny) == 0 {
+		return true
+	}
+
+	visible := len(allow) == 0 // If no allow rules, default to visible
+
+	for _, pattern := range allow {
+		if matched, err := filepath.Match(pattern, name); err == nil && matched {
+			visible = true
+			break
+		}
+	}
+
+	if !visible {
+		return false
+	}
+
+	for _, pattern := range deny {
+		if matched, err := filepath.Match(pattern, name); err == nil && matched {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/middleware/mcp_visibility_test.go
+++ b/pkg/middleware/mcp_visibility_test.go
@@ -1,0 +1,308 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestIsToolVisible(t *testing.T) {
+	tests := []struct {
+		name    string
+		tool    string
+		allow   []string
+		deny    []string
+		visible bool
+	}{
+		{
+			name:    "no rules - all visible",
+			tool:    testAuditToolName,
+			visible: true,
+		},
+		{
+			name:    "allow only - matching",
+			tool:    testAuditToolName,
+			allow:   []string{"trino_*"},
+			visible: true,
+		},
+		{
+			name:    "allow only - not matching",
+			tool:    "datahub_search",
+			allow:   []string{"trino_*"},
+			visible: false,
+		},
+		{
+			name:    "deny only - matching",
+			tool:    "s3_delete_object",
+			deny:    []string{"s3_delete_*"},
+			visible: false,
+		},
+		{
+			name:    "deny only - not matching",
+			tool:    "s3_list_objects",
+			deny:    []string{"s3_delete_*"},
+			visible: true,
+		},
+		{
+			name:    "allow and deny - allowed then denied",
+			tool:    "trino_delete_table",
+			allow:   []string{"trino_*"},
+			deny:    []string{"*_delete_*"},
+			visible: false,
+		},
+		{
+			name:    "allow and deny - allowed not denied",
+			tool:    testAuditToolName,
+			allow:   []string{"trino_*"},
+			deny:    []string{"*_delete_*"},
+			visible: true,
+		},
+		{
+			name:    "allow and deny - not allowed",
+			tool:    "datahub_search",
+			allow:   []string{"trino_*"},
+			deny:    []string{"*_delete_*"},
+			visible: false,
+		},
+		{
+			name:    "exact match allow",
+			tool:    "platform_info",
+			allow:   []string{"platform_info"},
+			visible: true,
+		},
+		{
+			name:    "exact match deny",
+			tool:    "platform_info",
+			deny:    []string{"platform_info"},
+			visible: false,
+		},
+		{
+			name:    "multiple allow patterns",
+			tool:    "datahub_search",
+			allow:   []string{"trino_*", "datahub_*"},
+			visible: true,
+		},
+		{
+			name:    "multiple deny patterns",
+			tool:    "s3_delete_object",
+			deny:    []string{"trino_delete_*", "s3_delete_*"},
+			visible: false,
+		},
+		{
+			name:    "invalid allow pattern treated as non-match",
+			tool:    testAuditToolName,
+			allow:   []string{"[invalid"},
+			visible: false,
+		},
+		{
+			name:    "invalid deny pattern treated as non-match",
+			tool:    testAuditToolName,
+			deny:    []string{"[invalid"},
+			visible: true,
+		},
+		{
+			name:    "wildcard star matches all",
+			tool:    "anything",
+			allow:   []string{"*"},
+			visible: true,
+		},
+		{
+			name:    "empty allow empty deny slices",
+			tool:    testAuditToolName,
+			allow:   []string{},
+			deny:    []string{},
+			visible: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isToolVisible(tt.tool, tt.allow, tt.deny)
+			if got != tt.visible {
+				t.Errorf("isToolVisible(%q, %v, %v) = %v, want %v",
+					tt.tool, tt.allow, tt.deny, got, tt.visible)
+			}
+		})
+	}
+}
+
+// asListToolsResult extracts a *mcp.ListToolsResult from a mcp.Result,
+// failing the test if the type assertion fails.
+func asListToolsResult(t *testing.T, result mcp.Result) *mcp.ListToolsResult {
+	t.Helper()
+	lr, ok := result.(*mcp.ListToolsResult)
+	if !ok {
+		t.Fatalf("expected *mcp.ListToolsResult, got %T", result)
+	}
+	return lr
+}
+
+func TestFilterToolVisibility(t *testing.T) {
+	makeTools := func(names ...string) []*mcp.Tool {
+		tools := make([]*mcp.Tool, len(names))
+		for i, n := range names {
+			tools[i] = &mcp.Tool{Name: n}
+		}
+		return tools
+	}
+
+	toolNames := func(tools []*mcp.Tool) []string {
+		names := make([]string, len(tools))
+		for i, tool := range tools {
+			names[i] = tool.Name
+		}
+		return names
+	}
+
+	t.Run("non tools/list passthrough", func(t *testing.T) {
+		result := &mcp.CallToolResult{}
+		got, err := filterToolVisibility([]string{"trino_*"}, nil, "tools/call", result)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != result {
+			t.Error("expected same result object for non-tools/list method")
+		}
+	})
+
+	t.Run("nil result passthrough", func(t *testing.T) {
+		got, err := filterToolVisibility([]string{"trino_*"}, nil, "tools/list", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Error("expected nil result to pass through")
+		}
+	})
+
+	t.Run("non ListToolsResult type passthrough", func(t *testing.T) {
+		result := &mcp.CallToolResult{}
+		got, err := filterToolVisibility([]string{"trino_*"}, nil, "tools/list", result)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != result {
+			t.Error("expected non-ListToolsResult to pass through")
+		}
+	})
+
+	t.Run("empty tools list", func(t *testing.T) {
+		result := &mcp.ListToolsResult{Tools: []*mcp.Tool{}}
+		got, err := filterToolVisibility([]string{"trino_*"}, nil, "tools/list", result)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		listResult := asListToolsResult(t, got)
+		if len(listResult.Tools) != 0 {
+			t.Errorf("expected 0 tools, got %d", len(listResult.Tools))
+		}
+	})
+
+	t.Run("allow filters correctly", func(t *testing.T) {
+		result := &mcp.ListToolsResult{
+			Tools: makeTools(testAuditToolName, "trino_describe_table", "datahub_search", "s3_list_objects"),
+		}
+		got, err := filterToolVisibility([]string{"trino_*"}, nil, "tools/list", result)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		listResult := asListToolsResult(t, got)
+		names := toolNames(listResult.Tools)
+		if len(names) != 2 {
+			t.Fatalf("expected 2 tools, got %d: %v", len(names), names)
+		}
+		if names[0] != testAuditToolName || names[1] != "trino_describe_table" {
+			t.Errorf("unexpected tools: %v", names)
+		}
+	})
+
+	t.Run("deny filters correctly", func(t *testing.T) {
+		result := &mcp.ListToolsResult{
+			Tools: makeTools(testAuditToolName, "s3_delete_object", "datahub_search"),
+		}
+		got, err := filterToolVisibility(nil, []string{"s3_delete_*"}, "tools/list", result)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		listResult := asListToolsResult(t, got)
+		names := toolNames(listResult.Tools)
+		if len(names) != 2 {
+			t.Fatalf("expected 2 tools, got %d: %v", len(names), names)
+		}
+		if names[0] != testAuditToolName || names[1] != "datahub_search" {
+			t.Errorf("unexpected tools: %v", names)
+		}
+	})
+
+	t.Run("allow and deny combined", func(t *testing.T) {
+		result := &mcp.ListToolsResult{
+			Tools: makeTools(testAuditToolName, "trino_delete_table", "datahub_search", "s3_list_objects"),
+		}
+		got, err := filterToolVisibility([]string{"trino_*"}, []string{"*_delete_*"}, "tools/list", result)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		listResult := asListToolsResult(t, got)
+		names := toolNames(listResult.Tools)
+		if len(names) != 1 {
+			t.Fatalf("expected 1 tool, got %d: %v", len(names), names)
+		}
+		if names[0] != testAuditToolName {
+			t.Errorf("expected trino_query, got %v", names)
+		}
+	})
+}
+
+func TestMCPToolVisibilityMiddleware(t *testing.T) {
+	tools := []*mcp.Tool{
+		{Name: testAuditToolName},
+		{Name: "trino_describe_table"},
+		{Name: "datahub_search"},
+		{Name: "s3_list_objects"},
+	}
+
+	baseHandler := func(_ context.Context, method string, _ mcp.Request) (mcp.Result, error) {
+		if method == "tools/list" {
+			return &mcp.ListToolsResult{Tools: tools}, nil
+		}
+		return &mcp.CallToolResult{}, nil
+	}
+
+	mw := MCPToolVisibilityMiddleware([]string{"trino_*"}, nil)
+	handler := mw(baseHandler)
+
+	t.Run("filters tools/list", func(t *testing.T) {
+		result, err := handler(context.Background(), "tools/list", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		listResult := asListToolsResult(t, result)
+		if len(listResult.Tools) != 2 {
+			t.Errorf("expected 2 tools, got %d", len(listResult.Tools))
+		}
+	})
+
+	t.Run("passes through non-tools/list", func(t *testing.T) {
+		result, err := handler(context.Background(), "tools/call", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := result.(*mcp.CallToolResult); !ok {
+			t.Error("expected CallToolResult for non-tools/list method")
+		}
+	})
+
+	t.Run("propagates errors from next handler", func(t *testing.T) {
+		errHandler := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			return nil, context.Canceled
+		}
+		errMW := MCPToolVisibilityMiddleware([]string{"trino_*"}, nil)
+		h := errMW(errHandler)
+		_, err := h(context.Background(), "tools/list", nil)
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("expected context.Canceled, got %v", err)
+		}
+	})
+}

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -59,6 +59,7 @@ type Config struct {
 	Database    DatabaseConfig    `yaml:"database"`
 	Personas    PersonasConfig    `yaml:"personas"`
 	Toolkits    map[string]any    `yaml:"toolkits"`
+	Tools       ToolsConfig       `yaml:"tools"`
 	Semantic    SemanticConfig    `yaml:"semantic"`
 	Query       QueryConfig       `yaml:"query"`
 	Storage     StorageConfig     `yaml:"storage"`
@@ -227,6 +228,14 @@ type PersonaDef struct {
 	Prompts     PromptsDef        `yaml:"prompts"`
 	Hints       map[string]string `yaml:"hints,omitempty"`
 	Priority    int               `yaml:"priority,omitempty"`
+}
+
+// ToolsConfig configures global tool visibility filtering for tools/list responses.
+// This is a visibility filter to reduce token usage — not a security boundary.
+// Persona auth continues to gate tools/call independently.
+type ToolsConfig struct {
+	Allow []string `yaml:"allow"`
+	Deny  []string `yaml:"deny"`
 }
 
 // ToolRulesDef defines tool access rules.

--- a/pkg/platform/config_test.go
+++ b/pkg/platform/config_test.go
@@ -1046,3 +1046,60 @@ database:
 		t.Errorf("ConfigStore.Mode = %q, want %q", cfg.ConfigStore.Mode, ConfigStoreModeDatabase)
 	}
 }
+
+func TestLoadConfig_ToolsConfig(t *testing.T) {
+	t.Run("allow and deny", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+tools:
+  allow:
+    - "trino_*"
+    - "datahub_*"
+  deny:
+    - "*_delete_*"
+`)
+		if len(cfg.Tools.Allow) != 2 {
+			t.Fatalf("Tools.Allow length = %d, want 2", len(cfg.Tools.Allow))
+		}
+		if cfg.Tools.Allow[0] != "trino_*" {
+			t.Errorf("Tools.Allow[0] = %q, want %q", cfg.Tools.Allow[0], "trino_*")
+		}
+		if cfg.Tools.Allow[1] != "datahub_*" {
+			t.Errorf("Tools.Allow[1] = %q, want %q", cfg.Tools.Allow[1], "datahub_*")
+		}
+		if len(cfg.Tools.Deny) != 1 {
+			t.Fatalf("Tools.Deny length = %d, want 1", len(cfg.Tools.Deny))
+		}
+		if cfg.Tools.Deny[0] != "*_delete_*" {
+			t.Errorf("Tools.Deny[0] = %q, want %q", cfg.Tools.Deny[0], "*_delete_*")
+		}
+	})
+
+	t.Run("empty tools section", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+tools: {}
+`)
+		if len(cfg.Tools.Allow) != 0 {
+			t.Errorf("Tools.Allow length = %d, want 0", len(cfg.Tools.Allow))
+		}
+		if len(cfg.Tools.Deny) != 0 {
+			t.Errorf("Tools.Deny length = %d, want 0", len(cfg.Tools.Deny))
+		}
+	})
+
+	t.Run("no tools section", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+`)
+		if len(cfg.Tools.Allow) != 0 {
+			t.Errorf("Tools.Allow length = %d, want 0", len(cfg.Tools.Allow))
+		}
+		if len(cfg.Tools.Deny) != 0 {
+			t.Errorf("Tools.Deny length = %d, want 0", len(cfg.Tools.Deny))
+		}
+	})
+}

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -2978,3 +2978,26 @@ func TestPlatform_ConfigStore_FileMode(t *testing.T) {
 		t.Errorf("ConfigStore().Mode() = %q, want %q", cs.Mode(), "file")
 	}
 }
+
+func TestNew_WithToolVisibilityFilter(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Name: testServerName},
+		Semantic: SemanticConfig{Provider: testProviderNoop},
+		Query:    QueryConfig{Provider: testProviderNoop},
+		Storage:  StorageConfig{Provider: testProviderNoop},
+		Tools: ToolsConfig{
+			Allow: []string{"trino_*", "datahub_*"},
+			Deny:  []string{"*_delete_*"},
+		},
+	}
+
+	p, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf(testNewErrFmt, err)
+	}
+	defer func() { _ = p.Close() }()
+
+	if p.MCPServer() == nil {
+		t.Fatal(testMCPServerNilMsg)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds top-level `tools:` config with `allow`/`deny` glob patterns that filter `tools/list` responses, reducing LLM context token usage from 25-32 tools down to only the subset a deployment needs
- Registers `MCPToolVisibilityMiddleware` as the outermost middleware layer so it runs first on `tools/list` responses and last on requests
- Documents the `admin.portal` config option, fills documentation gaps across configuration, middleware, tool filtering, and admin API docs, and adds a real changelog

## Design decisions

**Visibility, not security.** This filter only affects `tools/list` — it hides tools from discovery but does not block `tools/call`. Persona-level tool filtering remains the authorization boundary. This separation is called out explicitly in every doc that mentions the feature.

**Outermost middleware.** Tool visibility runs outside all other middleware (including MCP Apps metadata injection) so the filtering applies to the final tool list after all other middleware has had its say.

**`filepath.Match` patterns.** Same glob semantics as persona tool filtering (`*` matches any sequence of characters). Keeps the mental model consistent — users write the same patterns in both places.

**Conditional registration.** The middleware is only added to the chain when at least one allow or deny pattern is configured. Zero-cost for deployments that don't use it.

## Changes

### Implementation (pkg/)

| File | What |
|------|------|
| `pkg/platform/config.go` | `ToolsConfig` struct with `Allow`/`Deny` fields, added to `Config` |
| `pkg/middleware/mcp_visibility.go` | `MCPToolVisibilityMiddleware`, `filterToolVisibility`, `isToolVisible` — all 100% coverage |
| `pkg/platform/platform.go` | Extracted `addMCPAppsMiddleware()` + `addToolVisibilityMiddleware()` helpers from `finalizeSetup()` to stay under cyclomatic complexity limit |
| `configs/platform.yaml` | Commented `tools:` example section |

### Tests (pkg/)

| File | What |
|------|------|
| `pkg/middleware/mcp_visibility_test.go` | 26 table-driven unit tests for `isToolVisible`, `filterToolVisibility`, and `MCPToolVisibilityMiddleware` |
| `pkg/middleware/middleware_chain_test.go` | 3 integration tests wiring real `mcp.Server` + `AddReceivingMiddleware` + `session.ListTools()` for end-to-end verification (allow-only, deny-only, no-patterns) |
| `pkg/platform/config_test.go` | 3 YAML parsing subtests for `ToolsConfig` |
| `pkg/platform/platform_test.go` | Platform-level test exercising `addToolVisibilityMiddleware` with patterns configured |
| `pkg/middleware/mcp_test.go` | Lint fix — replaced string literal with existing test constant |

### Documentation (docs/)

| File | What |
|------|------|
| `docs/server/configuration.md` | New "Tool Visibility Configuration" section, `admin.portal` added to admin config, both in complete example |
| `docs/reference/configuration.md` | Tool visibility and admin portal config reference, added to complete example |
| `docs/server/tools.md` | Tip about reducing token usage with tool visibility |
| `docs/personas/tool-filtering.md` | Callout distinguishing persona filtering (security) from global visibility (tokens) |
| `docs/server/admin-api.md` | `admin.portal` field, admin portal section with feature description |
| `docs/reference/middleware.md` | Updated diagram with ToolVisibility layer, new `MCPToolVisibilityMiddleware` section, updated ordering examples and registration code |
| `docs/support/changelog.md` | Real changelog covering tool visibility, admin portal, admin API, knowledge capture/apply, config versioning, session externalization, session dedup |
| `docs/llms.txt` | Updated index entries |
| `docs/llms-full.txt` | Added tool visibility and admin portal sections |

## Config example

```yaml
# Hide unused tools from tools/list to save LLM tokens
tools:
  allow:
    - "trino_*"
    - "datahub_*"
  deny:
    - "*_delete_*"
```

## Test plan

- [x] `make verify` passes all gates (fmt, test, lint, security, coverage ≥80%, mutation ≥60%, release-check)
- [x] All new functions at 100% coverage (`MCPToolVisibilityMiddleware`, `filterToolVisibility`, `isToolVisible`, `addToolVisibilityMiddleware`, `addMCPAppsMiddleware`)
- [x] Integration tests prove end-to-end filtering through real `mcp.Server` with `AddReceivingMiddleware`
- [x] Config parsing tests verify YAML deserialization for allow+deny, empty, and missing `tools:` sections
- [x] No patterns configured = all tools visible (no behavior change for existing deployments)
- [ ] Manual: deploy with `tools.allow: ["trino_*"]` and verify only Trino tools appear in `tools/list`