### PR TITLE
feat: upgrade MCP SDK to v1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/lib/pq v1.11.1
-	github.com/modelcontextprotocol/go-sdk v1.2.0
+	github.com/modelcontextprotocol/go-sdk v1.3.0
 	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/http-swagger/v2 v2.0.2
 	github.com/swaggo/swag v1.16.4
@@ -66,7 +66,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/spec v0.20.6 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
-	github.com/google/jsonschema-go v0.3.0 // indirect
+	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/golang-migrate/migrate/v4 v4.19.1/go.mod h1:CTcgfjxhaUtsLipnLoQRWCrjY
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
-github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -205,8 +205,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/modelcontextprotocol/go-sdk v1.2.0 h1:Y23co09300CEk8iZ/tMxIX1dVmKZkzoSBZOpJwUnc/s=
-github.com/modelcontextprotocol/go-sdk v1.2.0/go.mod h1:6fM3LCm3yV7pAs8isnKLn07oKtB0MP9LHd3DfAcKw10=
+github.com/modelcontextprotocol/go-sdk v1.3.0 h1:gMfZkv3DzQF5q/DcQePo5rahEY+sguyPfXDfNBcT0Zs=
+github.com/modelcontextprotocol/go-sdk v1.3.0/go.mod h1:AnQ//Qc6+4nIyyrB4cxBU7UW9VibK4iOZBeyP/rF1IE=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"errors"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -30,14 +31,12 @@ type UserInfo struct {
 	AuthType string // "oidc", "apikey", etc.
 }
 
-// NewToolResultError creates an error result.
+// NewToolResultError creates an error result using the SDK's SetError method.
+// The underlying error is retrievable via CallToolResult.GetError().
 func NewToolResultError(errMsg string) *mcp.CallToolResult {
-	return &mcp.CallToolResult{
-		IsError: true,
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: errMsg},
-		},
-	}
+	result := &mcp.CallToolResult{}
+	result.SetError(errors.New(errMsg))
+	return result
 }
 
 // NewToolResultText creates a text result.

--- a/pkg/middleware/mcp.go
+++ b/pkg/middleware/mcp.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -224,14 +225,12 @@ func extractToolName(req mcp.Request) (string, error) {
 	return callParams.Name, nil
 }
 
-// createErrorResult creates an MCP result for an authorization error.
+// createErrorResult creates an MCP error result using the SDK's SetError method.
+// The underlying error is retrievable via CallToolResult.GetError().
 func createErrorResult(errMsg string) mcp.Result {
-	return &mcp.CallToolResult{
-		IsError: true,
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: errMsg},
-		},
-	}
+	result := &mcp.CallToolResult{}
+	result.SetError(errors.New(errMsg))
+	return result
 }
 
 // extractBearerOrAPIKey extracts an auth token from HTTP headers.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -745,7 +745,9 @@ func (p *Platform) finalizeSetup() {
 	p.mcpServer = mcp.NewServer(&mcp.Implementation{
 		Name:    p.config.Server.Name,
 		Version: p.config.Server.Version,
-	}, nil)
+	}, &mcp.ServerOptions{
+		SchemaCache: mcp.NewSchemaCache(),
+	})
 
 	// Add MCP protocol-level middleware.
 	//


### PR DESCRIPTION
## Summary

- Upgrade `github.com/modelcontextprotocol/go-sdk` from v1.2.0 to v1.3.0 (released 2026-02-09)
- Upgrade transitive dependency `github.com/google/jsonschema-go` from v0.3.0 to v0.4.2
- Adopt two new SDK features: **SchemaCache** and **SetError/GetError**

## SDK v1.3.0 Changelog Highlights

| Change | Impact |
|--------|--------|
| **SchemaCache** ([#685](https://github.com/modelcontextprotocol/go-sdk/pull/685)) | Caches JSON schema reflection during tool registration. 132x faster, 51x fewer allocations on repeated registrations. Useful for stateless deployments; marginal for long-lived servers but zero-cost to adopt. |
| **GetError/SetError exports** ([#753](https://github.com/modelcontextprotocol/go-sdk/pull/753)) | `CallToolResult.SetError(err)` and `GetError() error` are now public. Canonical way to create/inspect error results. |
| **405 Allow header** ([#757](https://github.com/modelcontextprotocol/go-sdk/pull/757)) | SSE and Streamable HTTP handlers now return `Allow` header on 405 responses per RFC 9110. Fixes compatibility with strict API gateways. |
| **Race condition fix** ([#761](https://github.com/modelcontextprotocol/go-sdk/pull/761)) | Fixed data race in logging buffer read. |
| **SSE Content-Type validation** ([#736](https://github.com/modelcontextprotocol/go-sdk/pull/736)) | Client-side fix: prevents infinite loop on HTML redirect responses. |
| **HTTP error reporting** ([#740](https://github.com/modelcontextprotocol/go-sdk/pull/740)) | Client-side fix: 401/403 now report clear errors instead of "missing endpoint". |
| **jsonschema-go v0.4.2** ([#732](https://github.com/modelcontextprotocol/go-sdk/pull/732)) | Tool schemas now include `PropertyOrder` metadata; empty `Properties` marshal as `{}` instead of being omitted. |
| **Client.Logger removal** ([#744](https://github.com/modelcontextprotocol/go-sdk/pull/744)) | Breaking for client code that sets `client.Logger` directly — must use `ClientOptions.Logger`. **We don't use this pattern; no impact.** |

## What Changed in This PR

### SchemaCache adoption (`pkg/platform/platform.go`)

```go
// Before
mcp.NewServer(impl, nil)

// After
mcp.NewServer(impl, &mcp.ServerOptions{
    SchemaCache: mcp.NewSchemaCache(),
})
```

A single shared cache instance eliminates repeated JSON schema reflection when tools are registered. Future-proofs for stateless deployment patterns.

### SetError adoption (`pkg/middleware/mcp.go`, `pkg/middleware/auth.go`)

Refactored `createErrorResult()` and `NewToolResultError()` to use the SDK's `SetError()` method instead of manually constructing `IsError: true` + `Content` slices:

```go
// Before
return &mcp.CallToolResult{
    IsError: true,
    Content: []mcp.Content{&mcp.TextContent{Text: errMsg}},
}

// After
result := &mcp.CallToolResult{}
result.SetError(errors.New(errMsg))
return result
```

This makes error results compatible with `GetError()` for programmatic inspection downstream. The audit middleware continues to use `extractMCPErrorMessage()` (parsing `Content[0]` text) since that works for all error results regardless of origin — toolkit handlers in mcp-trino/mcp-datahub/mcp-s3 construct errors manually and `GetError()` would return nil for those.

### No breaking changes

All `NewClient()` calls in our codebase pass `nil` for options — the removed `Client.Logger` field is not used. No code changes required for compatibility.

## Test plan

- [x] `make verify` passes (fmt, test, lint, security, coverage, dead-code, mutation, release-check)
- [x] All existing tests pass unchanged — SDK upgrade is fully backward-compatible
- [x] Confirmed no usage of removed `Client.Logger` field in codebase
- [x] Error result behavior unchanged: `IsError`, `Content[0].Text` identical before and after