### PR TITLE
feat: resource templates, progress notifications, and client logging (#102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ Every tool call is logged with user identity, persona, request details, and timi
 ### Knowledge Capture
 AI sessions generate valuable domain knowledge: column meanings, data quality issues, business rules. The `capture_insight` tool records these observations during sessions, and `apply_knowledge` provides admins with a structured review workflow. Approved insights are written back to DataHub with full changeset tracking and rollback. An [Admin REST API](https://txn2.github.io/mcp-data-platform/knowledge/admin-api/) supports integration with existing governance tools. See the [Knowledge Capture documentation](https://txn2.github.io/mcp-data-platform/knowledge/overview/) for details.
 
+### Resource Templates
+Browse platform data as parameterized MCP resources using RFC 6570 URI templates. Three built-in templates expose table schemas (`schema://catalog.schema/table`), glossary terms (`glossary://term`), and data availability (`availability://catalog.schema/table`) without making tool calls.
+
+### Progress Notifications
+Long-running Trino queries send granular progress updates to MCP clients (executing, formatting, complete). Clients that provide a `_meta.progressToken` receive real-time status. Zero overhead when disabled.
+
+### Client Logging
+Server-to-client log messages give AI agents visibility into platform decisions (enrichment applied, timing). Uses the MCP `logging/setLevel` protocol — zero overhead if the client hasn't opted in.
+
 ### Extensible Middleware Architecture
 Add custom authentication, rate limiting, or logging. Swap providers to integrate different semantic layers or query engines. The Go library exposes everything—build the platform your organization needs.
 
@@ -367,6 +376,7 @@ database:
 | `pkg/semantic` | Semantic metadata provider abstraction |
 | `pkg/query` | Query execution provider abstraction |
 | `pkg/middleware` | Request/response middleware chain |
+| `pkg/mcpcontext` | MCP session/progress context helpers |
 | `pkg/registry` | Toolkit registration and management |
 | `pkg/audit` | Audit logging with PostgreSQL storage |
 | `pkg/tuning` | Prompts, hints, and operational rules |

--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -280,6 +280,26 @@ tuning:
 #   persona: admin              # persona required for admin access (default: "admin")
 #   path_prefix: /api/v1/admin  # URL prefix for admin endpoints
 
+# Resource templates (RFC 6570 URI templates)
+# Exposes platform data as browseable, parameterized MCP resources.
+# Templates: schema://{catalog}.{schema}/{table}, glossary://{term},
+#            availability://{catalog}.{schema}/{table}
+# resources:
+#   enabled: true
+
+# Progress notifications
+# Sends granular progress updates to MCP clients during long-running
+# Trino queries (requires client to send _meta.progressToken).
+# progress:
+#   enabled: true
+
+# Client logging
+# Sends server-to-client log messages (enrichment decisions, timing)
+# via MCP logging/setLevel protocol. Zero overhead if client hasn't
+# called setLevel.
+# client_logging:
+#   enabled: true
+
 # Audit logging
 audit:
   enabled: false

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -26,6 +26,12 @@ The only requirement is DataHub (https://datahubproject.io/). Add Trino (https:/
 
 - **Personas**: Define who can use which tools. Analysts get read access. Admins get everything. Map from your identity provider's roles.
 
+- **Resource Templates**: Browse platform data as parameterized MCP resources using RFC 6570 URI templates. Three built-in templates: table schemas (`schema://catalog.schema/table`), glossary terms (`glossary://term`), and data availability (`availability://catalog.schema/table`).
+
+- **Progress Notifications**: Long-running Trino queries send granular progress updates (executing, formatting, complete) to clients that provide `_meta.progressToken`. Zero overhead when disabled.
+
+- **Client Logging**: Server-to-client log messages for platform decisions (enrichment, timing) via MCP `logging/setLevel` protocol. Zero overhead if the client hasn't opted in.
+
 ---
 
 # The Data Stack: DataHub + Trino + S3
@@ -287,6 +293,33 @@ No patterns configured means all tools are visible. When both are set, allow is 
 | `admin.path_prefix` | string | `/api/v1/admin` | URL prefix for admin endpoints |
 
 When `admin.portal: true`, an interactive web dashboard is served at the admin path prefix. It provides audit log exploration, tool execution testing, and system monitoring.
+
+## Resource Templates Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `resources.enabled` | bool | `false` | Enable MCP resource templates |
+
+When enabled, three RFC 6570 URI templates are registered:
+- `schema://{catalog}.{schema_name}/{table}` — Table schema with semantic context
+- `glossary://{term}` — Glossary term definition and related assets
+- `availability://{catalog}.{schema_name}/{table}` — Data availability status and row count
+
+## Progress Notifications Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `progress.enabled` | bool | `false` | Enable progress notifications for Trino queries |
+
+When enabled, Trino query tools send three progress notifications per query: before execution, after query returns, and after formatting. Clients must include `_meta.progressToken` in their tool call to receive notifications.
+
+## Client Logging Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `client_logging.enabled` | bool | `false` | Enable server-to-client log messages |
+
+When enabled, the platform sends log notifications to clients after enrichment is applied (tool name, duration). Uses MCP `logging/setLevel` protocol — zero overhead if the client hasn't called `setLevel`.
 
 ## Audit Configuration
 
@@ -1001,6 +1034,7 @@ Use the library when you need to:
 | `pkg/semantic` | Semantic provider interface |
 | `pkg/query` | Query provider interface |
 | `pkg/middleware` | Request/response processing |
+| `pkg/mcpcontext` | MCP session/progress context helpers |
 | `pkg/persona` | Role-based tool filtering |
 | `pkg/auth` | OIDC and API key validation |
 | `pkg/admin` | Admin REST API for knowledge management |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,7 +11,7 @@
 - [Home](index.md): Introduction, quick start, and key features
 - [Server Overview](server/overview.md): What the platform does, architecture, request flow
 - [Installation](server/installation.md): Install via go install, Homebrew, Docker, or from source
-- [Configuration](server/configuration.md): YAML configuration with environment variable expansion, config versioning (apiVersion field, version lifecycle, migrate-config CLI), config store options (file vs database mode), tool visibility filtering (allow/deny patterns for tools/list token reduction), admin API and portal, database, audit, and session configuration
+- [Configuration](server/configuration.md): YAML configuration with environment variable expansion, config versioning (apiVersion field, version lifecycle, migrate-config CLI), config store options (file vs database mode), tool visibility filtering (allow/deny patterns for tools/list token reduction), resource templates, progress notifications, client logging, admin API and portal, database, audit, and session configuration
 - [Operating Modes](server/operating-modes.md): Three deployment modes — standalone (no database), full-config file + database, bootstrap + database config. Feature availability by mode, example configurations, decision guide
 - [Admin Portal](server/admin-portal.md): Built-in web dashboard for monitoring and managing the platform. Dashboard with activity timelines, performance percentiles, error monitoring. Tools overview with connection grid and tool inventory. Interactive tool explorer with semantic enrichment display. Searchable audit log with event detail drawer. Knowledge insight governance with approve/reject workflow and changeset tracking. Local dev with MSW mock data
 - [Admin API](server/admin-api.md): REST endpoints for system info, config management, personas, auth keys, audit, knowledge. Authentication, operating mode behavior, request/response reference. Interactive Swagger UI at `/api/v1/admin/docs/`
@@ -73,7 +73,7 @@
 - [Tools API](reference/tools-api.md): Complete tool specifications with parameters and responses
 - [Configuration](reference/configuration.md): Full YAML schema with all options
 - [Providers](reference/providers.md): Semantic, query, and storage provider interfaces
-- [Middleware](reference/middleware.md): Request processing chain including tool visibility middleware
+- [Middleware](reference/middleware.md): Request processing chain including tool visibility middleware, client logging, progress notifications
 
 ## Support
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,8 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
 	github.com/txn2/mcp-datahub v0.7.0
 	github.com/txn2/mcp-s3 v0.2.0
-	github.com/txn2/mcp-trino v0.5.0
+	github.com/txn2/mcp-trino v0.6.1
+	github.com/yosida95/uritemplate/v3 v3.0.2
 	golang.org/x/crypto v0.48.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -102,7 +103,6 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/trinodb/trino-go-client v0.333.0 // indirect
-	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/txn2/mcp-datahub v0.7.0 h1:gzBGJmYzjy7GBB0HGXm4o6pZdvVrPrhVbNEC3c5fpX
 github.com/txn2/mcp-datahub v0.7.0/go.mod h1:UyXoTLT9H5DFkrdi/k0G82x+fZN5N4PSjom6FPGTkI0=
 github.com/txn2/mcp-s3 v0.2.0 h1:hycUsa8j6hz1rHDIr0OOe6wbDxW/aJgrCYTvqrAcgSM=
 github.com/txn2/mcp-s3 v0.2.0/go.mod h1:ygY1Bz6aXO4/3jvhfooR6y/BTXJ35Rsvwsl75zKktXg=
-github.com/txn2/mcp-trino v0.5.0 h1:xxJ8kDVNbNVvWajQYuID96ywbppcRMhO+f/VxNpODwI=
-github.com/txn2/mcp-trino v0.5.0/go.mod h1:6m5jlHTExGTr2swFRFp2McDBHti8l/F7mHi2b1cYHk4=
+github.com/txn2/mcp-trino v0.6.1 h1:IZnBlyccHXftIfiKZciltRvQ/JtOPEz8Bxa4CxfwB7A=
+github.com/txn2/mcp-trino v0.6.1/go.mod h1:6m5jlHTExGTr2swFRFp2McDBHti8l/F7mHi2b1cYHk4=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/pkg/mcpcontext/mcpcontext.go
+++ b/pkg/mcpcontext/mcpcontext.go
@@ -1,0 +1,39 @@
+// Package mcpcontext provides context helpers for MCP session state.
+// These are in a separate package to avoid import cycles between
+// middleware and toolkit packages.
+package mcpcontext
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// contextKey is a private type for context keys.
+type contextKey int
+
+const (
+	serverSessionKey contextKey = iota
+	progressTokenKey
+)
+
+// WithServerSession adds a ServerSession to the context.
+func WithServerSession(ctx context.Context, ss *mcp.ServerSession) context.Context {
+	return context.WithValue(ctx, serverSessionKey, ss)
+}
+
+// GetServerSession retrieves the ServerSession from the context.
+func GetServerSession(ctx context.Context) *mcp.ServerSession {
+	ss, _ := ctx.Value(serverSessionKey).(*mcp.ServerSession)
+	return ss
+}
+
+// WithProgressToken adds a progress token to the context.
+func WithProgressToken(ctx context.Context, token any) context.Context {
+	return context.WithValue(ctx, progressTokenKey, token)
+}
+
+// GetProgressToken retrieves the progress token from the context.
+func GetProgressToken(ctx context.Context) any {
+	return ctx.Value(progressTokenKey)
+}

--- a/pkg/mcpcontext/mcpcontext_test.go
+++ b/pkg/mcpcontext/mcpcontext_test.go
@@ -1,0 +1,58 @@
+package mcpcontext
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestServerSessionContext(t *testing.T) {
+	t.Run("not set returns nil", func(t *testing.T) {
+		got := GetServerSession(context.Background())
+		if got != nil {
+			t.Error("expected nil for empty context")
+		}
+	})
+
+	t.Run("nil session stored", func(t *testing.T) {
+		ctx := WithServerSession(context.Background(), (*mcp.ServerSession)(nil))
+		got := GetServerSession(ctx)
+		if got != nil {
+			t.Error("expected nil for nil *ServerSession stored in context")
+		}
+	})
+}
+
+func TestProgressTokenContext(t *testing.T) {
+	t.Run("round-trip string token", func(t *testing.T) {
+		ctx := WithProgressToken(context.Background(), "tok-123")
+		got := GetProgressToken(ctx)
+		if got != "tok-123" {
+			t.Errorf("GetProgressToken() = %v, want %q", got, "tok-123")
+		}
+	})
+
+	t.Run("round-trip int token", func(t *testing.T) {
+		ctx := WithProgressToken(context.Background(), 42)
+		got := GetProgressToken(ctx)
+		if got != 42 {
+			t.Errorf("GetProgressToken() = %v, want %d", got, 42)
+		}
+	})
+
+	t.Run("not set returns nil", func(t *testing.T) {
+		got := GetProgressToken(context.Background())
+		if got != nil {
+			t.Errorf("GetProgressToken() = %v, want nil", got)
+		}
+	})
+
+	t.Run("nil token stored", func(t *testing.T) {
+		ctx := WithProgressToken(context.Background(), nil)
+		got := GetProgressToken(ctx)
+		if got != nil {
+			t.Errorf("GetProgressToken() = %v, want nil", got)
+		}
+	})
+}

--- a/pkg/middleware/context.go
+++ b/pkg/middleware/context.go
@@ -4,6 +4,10 @@ package middleware
 import (
 	"context"
 	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/mcpcontext"
 )
 
 // contextKey is a private type for context keys.
@@ -93,4 +97,28 @@ func GetToken(ctx context.Context) string {
 		return token
 	}
 	return ""
+}
+
+// WithServerSession adds a ServerSession to the context.
+// Delegates to mcpcontext to share context keys with toolkit packages.
+func WithServerSession(ctx context.Context, ss *mcp.ServerSession) context.Context {
+	return mcpcontext.WithServerSession(ctx, ss)
+}
+
+// GetServerSession retrieves the ServerSession from the context.
+// Delegates to mcpcontext to share context keys with toolkit packages.
+func GetServerSession(ctx context.Context) *mcp.ServerSession {
+	return mcpcontext.GetServerSession(ctx)
+}
+
+// WithProgressToken adds a progress token to the context.
+// Delegates to mcpcontext to share context keys with toolkit packages.
+func WithProgressToken(ctx context.Context, token any) context.Context {
+	return mcpcontext.WithProgressToken(ctx, token)
+}
+
+// GetProgressToken retrieves the progress token from the context.
+// Delegates to mcpcontext to share context keys with toolkit packages.
+func GetProgressToken(ctx context.Context) any {
+	return mcpcontext.GetProgressToken(ctx)
 }

--- a/pkg/middleware/context_test.go
+++ b/pkg/middleware/context_test.go
@@ -3,6 +3,8 @@ package middleware
 import (
 	"context"
 	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func TestPlatformContext(t *testing.T) {
@@ -87,6 +89,59 @@ func TestTokenContext(t *testing.T) {
 		got := GetToken(ctx)
 		if got != "" {
 			t.Errorf("GetToken() = %q, want empty string", got)
+		}
+	})
+}
+
+func TestServerSessionContext(t *testing.T) {
+	t.Run("round-trip", func(t *testing.T) {
+		// We can't construct a real ServerSession (private fields), but we can
+		// verify nil handling and type safety of the context helpers.
+		ctx := context.Background()
+		got := GetServerSession(ctx)
+		if got != nil {
+			t.Error("expected nil for empty context")
+		}
+	})
+
+	t.Run("nil session stored", func(t *testing.T) {
+		ctx := WithServerSession(context.Background(), (*mcp.ServerSession)(nil))
+		got := GetServerSession(ctx)
+		if got != nil {
+			t.Error("expected nil for nil *ServerSession stored in context")
+		}
+	})
+}
+
+func TestProgressTokenContext(t *testing.T) {
+	t.Run("round-trip string token", func(t *testing.T) {
+		ctx := WithProgressToken(context.Background(), "tok-123")
+		got := GetProgressToken(ctx)
+		if got != "tok-123" {
+			t.Errorf("GetProgressToken() = %v, want %q", got, "tok-123")
+		}
+	})
+
+	t.Run("round-trip int token", func(t *testing.T) {
+		ctx := WithProgressToken(context.Background(), 42)
+		got := GetProgressToken(ctx)
+		if got != 42 {
+			t.Errorf("GetProgressToken() = %v, want %d", got, 42)
+		}
+	})
+
+	t.Run("not set returns nil", func(t *testing.T) {
+		got := GetProgressToken(context.Background())
+		if got != nil {
+			t.Errorf("GetProgressToken() = %v, want nil", got)
+		}
+	})
+
+	t.Run("nil token stored", func(t *testing.T) {
+		ctx := WithProgressToken(context.Background(), nil)
+		got := GetProgressToken(ctx)
+		if got != nil {
+			t.Errorf("GetProgressToken() = %v, want nil", got)
 		}
 	})
 }

--- a/pkg/middleware/mcp_logging.go
+++ b/pkg/middleware/mcp_logging.go
@@ -1,0 +1,83 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/mcpcontext"
+)
+
+// sessionLogger abstracts the ServerSession.Log method for testability.
+type sessionLogger interface {
+	Log(ctx context.Context, params *mcp.LoggingMessageParams) error
+}
+
+// ClientLoggingConfig configures server-to-client logging middleware.
+type ClientLoggingConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+// MCPClientLoggingMiddleware creates MCP protocol-level middleware that sends
+// log notifications to the client via ServerSession.Log().
+//
+// After the handler and enrichment run, this middleware checks whether
+// enrichment was applied and sends an info-level log to the client. The client
+// only receives the log if it has previously called logging/setLevel; otherwise
+// ServerSession.Log() is a silent no-op (zero overhead).
+func MCPClientLoggingMiddleware(cfg ClientLoggingConfig) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		if !cfg.Enabled {
+			return next
+		}
+
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			if method != methodToolsCall {
+				return next(ctx, method, req)
+			}
+
+			result, err := next(ctx, method, req)
+
+			sendClientLog(ctx, result, err)
+
+			return result, err
+		}
+	}
+}
+
+// sendClientLog sends a log notification to the client if enrichment was
+// applied and a server session is available. All errors are silently ignored
+// to keep logging best-effort.
+func sendClientLog(ctx context.Context, _ mcp.Result, handlerErr error) {
+	if handlerErr != nil {
+		return
+	}
+
+	pc := GetPlatformContext(ctx)
+	if pc == nil || !pc.EnrichmentApplied {
+		return
+	}
+
+	session := mcpcontext.GetServerSession(ctx)
+	if session == nil {
+		return
+	}
+
+	emitClientLog(ctx, session, pc)
+}
+
+// emitClientLog builds and sends a log notification to the client.
+func emitClientLog(ctx context.Context, logger sessionLogger, pc *PlatformContext) {
+	msg := fmt.Sprintf("enriched %s response with semantic context (%.0fms)",
+		pc.ToolName, float64(pc.Duration.Milliseconds()))
+
+	if err := logger.Log(ctx, &mcp.LoggingMessageParams{
+		Level:  "info",
+		Logger: "mcp-data-platform",
+		Data:   msg,
+	}); err != nil {
+		slog.Debug("client logging: failed to send log notification", "error", err)
+	}
+}

--- a/pkg/middleware/mcp_logging_test.go
+++ b/pkg/middleware/mcp_logging_test.go
@@ -1,0 +1,162 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/mcpcontext"
+)
+
+func TestMCPClientLoggingMiddleware_Disabled(t *testing.T) {
+	cfg := ClientLoggingConfig{Enabled: false}
+	handlerCalled := false
+	base := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		handlerCalled = true
+		return &mcp.CallToolResult{}, nil
+	}
+
+	handler := MCPClientLoggingMiddleware(cfg)(base)
+	_, err := handler(context.Background(), methodToolsCall, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !handlerCalled {
+		t.Error("expected handler to be called")
+	}
+}
+
+func TestMCPClientLoggingMiddleware_NonToolsCall(t *testing.T) {
+	cfg := ClientLoggingConfig{Enabled: true}
+	handlerCalled := false
+	base := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		handlerCalled = true
+		return &mcp.CallToolResult{}, nil
+	}
+
+	handler := MCPClientLoggingMiddleware(cfg)(base)
+	_, err := handler(context.Background(), "tools/list", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !handlerCalled {
+		t.Error("expected handler to be called for non-tools/call method")
+	}
+}
+
+func TestMCPClientLoggingMiddleware_Passthrough(t *testing.T) {
+	cfg := ClientLoggingConfig{Enabled: true}
+	want := &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
+	}
+
+	base := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return want, nil
+	}
+
+	handler := MCPClientLoggingMiddleware(cfg)(base)
+	got, err := handler(context.Background(), methodToolsCall, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Error("expected result to be passed through unmodified")
+	}
+}
+
+func TestSendClientLog_NilPlatformContext(_ *testing.T) {
+	// Should not panic when PlatformContext is nil.
+	sendClientLog(context.Background(), &mcp.CallToolResult{}, nil)
+}
+
+func TestSendClientLog_NoEnrichment(_ *testing.T) {
+	pc := &PlatformContext{EnrichmentApplied: false}
+	ctx := WithPlatformContext(context.Background(), pc)
+	// Should not panic or send log when enrichment was not applied.
+	sendClientLog(ctx, &mcp.CallToolResult{}, nil)
+}
+
+func TestSendClientLog_HandlerError(_ *testing.T) {
+	pc := &PlatformContext{EnrichmentApplied: true}
+	ctx := WithPlatformContext(context.Background(), pc)
+	// Should not attempt logging when handler returned an error.
+	sendClientLog(ctx, nil, context.DeadlineExceeded)
+}
+
+func TestSendClientLog_NoSession(_ *testing.T) {
+	pc := &PlatformContext{
+		EnrichmentApplied: true,
+		ToolName:          "trino_query",
+		Duration:          50 * time.Millisecond,
+	}
+	ctx := WithPlatformContext(context.Background(), pc)
+	// Should not panic when session is nil.
+	sendClientLog(ctx, &mcp.CallToolResult{}, nil)
+}
+
+func TestSendClientLog_NilTypedSession(_ *testing.T) {
+	pc := &PlatformContext{
+		EnrichmentApplied: true,
+		ToolName:          "trino_query",
+		Duration:          50 * time.Millisecond,
+	}
+	ctx := WithPlatformContext(context.Background(), pc)
+	// Store a typed nil — GetServerSession should return nil.
+	ctx = mcpcontext.WithServerSession(ctx, (*mcp.ServerSession)(nil))
+	sendClientLog(ctx, &mcp.CallToolResult{}, nil)
+}
+
+// mockSessionLogger implements sessionLogger for testing.
+type mockSessionLogger struct {
+	lastParams *mcp.LoggingMessageParams
+	err        error
+}
+
+func (m *mockSessionLogger) Log(_ context.Context, params *mcp.LoggingMessageParams) error {
+	m.lastParams = params
+	return m.err
+}
+
+func TestEmitClientLog_Success(t *testing.T) {
+	mock := &mockSessionLogger{}
+	pc := &PlatformContext{
+		ToolName: "trino_query",
+		Duration: 123 * time.Millisecond,
+	}
+
+	emitClientLog(context.Background(), mock, pc)
+
+	if mock.lastParams == nil {
+		t.Fatal("expected Log to be called")
+	}
+	if mock.lastParams.Level != "info" {
+		t.Errorf("level = %q, want %q", mock.lastParams.Level, "info")
+	}
+	if mock.lastParams.Logger != "mcp-data-platform" {
+		t.Errorf("logger = %q, want %q", mock.lastParams.Logger, "mcp-data-platform")
+	}
+	msg, ok := mock.lastParams.Data.(string)
+	if !ok {
+		t.Fatalf("data type = %T, want string", mock.lastParams.Data)
+	}
+	if msg == "" {
+		t.Error("expected non-empty log message")
+	}
+}
+
+func TestEmitClientLog_Error(t *testing.T) {
+	mock := &mockSessionLogger{err: context.DeadlineExceeded}
+	pc := &PlatformContext{
+		ToolName: "trino_query",
+		Duration: 50 * time.Millisecond,
+	}
+
+	// Should not panic when Log returns an error.
+	emitClientLog(context.Background(), mock, pc)
+
+	if mock.lastParams == nil {
+		t.Fatal("expected Log to be called even when it returns an error")
+	}
+}

--- a/pkg/middleware/mcp_test.go
+++ b/pkg/middleware/mcp_test.go
@@ -688,3 +688,63 @@ func TestMCPToolCallMiddleware_AuthBridgeFromRequestExtra(t *testing.T) {
 		}
 	})
 }
+
+func TestExtractServerSession(t *testing.T) {
+	t.Run("nil request", func(t *testing.T) {
+		ss := extractServerSession(nil)
+		if ss != nil {
+			t.Error("expected nil for nil request")
+		}
+	})
+
+	t.Run("request without session", func(t *testing.T) {
+		req := newMCPTestRequest(mcpTestToolName)
+		ss := extractServerSession(req)
+		if ss != nil {
+			t.Error("expected nil for request without real session")
+		}
+	})
+}
+
+func TestExtractProgressToken(t *testing.T) {
+	t.Run("nil request", func(t *testing.T) {
+		pt := extractProgressToken(nil)
+		if pt != nil {
+			t.Errorf("expected nil, got %v", pt)
+		}
+	})
+
+	t.Run("request without progress token", func(t *testing.T) {
+		req := newMCPTestRequest(mcpTestToolName)
+		pt := extractProgressToken(req)
+		if pt != nil {
+			t.Errorf("expected nil, got %v", pt)
+		}
+	})
+
+	t.Run("request with progress token", func(t *testing.T) {
+		params := &mcp.CallToolParamsRaw{
+			Name: mcpTestToolName,
+		}
+		// Initialize meta map before setting progress token.
+		params.SetMeta(map[string]any{})
+		params.SetProgressToken("tok-abc")
+		req := &mcp.ServerRequest[*mcp.CallToolParamsRaw]{
+			Params: params,
+		}
+		pt := extractProgressToken(req)
+		if pt != "tok-abc" {
+			t.Errorf("expected 'tok-abc', got %v", pt)
+		}
+	})
+
+	t.Run("nil params", func(t *testing.T) {
+		req := &mcp.ServerRequest[*mcp.CallToolParamsRaw]{
+			Params: nil,
+		}
+		pt := extractProgressToken(req)
+		if pt != nil {
+			t.Errorf("expected nil, got %v", pt)
+		}
+	})
+}

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -51,25 +51,28 @@ type ConfigStoreConfig struct {
 
 // Config holds the complete platform configuration.
 type Config struct {
-	APIVersion  string            `yaml:"apiVersion"`
-	ConfigStore ConfigStoreConfig `yaml:"config_store"`
-	Server      ServerConfig      `yaml:"server"`
-	Auth        AuthConfig        `yaml:"auth"`
-	OAuth       OAuthConfig       `yaml:"oauth"`
-	Database    DatabaseConfig    `yaml:"database"`
-	Personas    PersonasConfig    `yaml:"personas"`
-	Toolkits    map[string]any    `yaml:"toolkits"`
-	Tools       ToolsConfig       `yaml:"tools"`
-	Semantic    SemanticConfig    `yaml:"semantic"`
-	Query       QueryConfig       `yaml:"query"`
-	Storage     StorageConfig     `yaml:"storage"`
-	Injection   InjectionConfig   `yaml:"injection"`
-	Tuning      TuningConfig      `yaml:"tuning"`
-	Audit       AuditConfig       `yaml:"audit"`
-	MCPApps     MCPAppsConfig     `yaml:"mcpapps"`
-	Sessions    SessionsConfig    `yaml:"sessions"`
-	Knowledge   KnowledgeConfig   `yaml:"knowledge"`
-	Admin       AdminConfig       `yaml:"admin"`
+	APIVersion    string              `yaml:"apiVersion"`
+	ConfigStore   ConfigStoreConfig   `yaml:"config_store"`
+	Server        ServerConfig        `yaml:"server"`
+	Auth          AuthConfig          `yaml:"auth"`
+	OAuth         OAuthConfig         `yaml:"oauth"`
+	Database      DatabaseConfig      `yaml:"database"`
+	Personas      PersonasConfig      `yaml:"personas"`
+	Toolkits      map[string]any      `yaml:"toolkits"`
+	Tools         ToolsConfig         `yaml:"tools"`
+	Semantic      SemanticConfig      `yaml:"semantic"`
+	Query         QueryConfig         `yaml:"query"`
+	Storage       StorageConfig       `yaml:"storage"`
+	Injection     InjectionConfig     `yaml:"injection"`
+	Tuning        TuningConfig        `yaml:"tuning"`
+	Audit         AuditConfig         `yaml:"audit"`
+	MCPApps       MCPAppsConfig       `yaml:"mcpapps"`
+	Sessions      SessionsConfig      `yaml:"sessions"`
+	Knowledge     KnowledgeConfig     `yaml:"knowledge"`
+	Admin         AdminConfig         `yaml:"admin"`
+	Resources     ResourcesConfig     `yaml:"resources"`
+	Progress      ProgressConfig      `yaml:"progress"`
+	ClientLogging ClientLoggingConfig `yaml:"client_logging"`
 }
 
 // AdminConfig configures the admin REST API.
@@ -413,6 +416,21 @@ type CSPAppConfig struct {
 
 	// ClipboardWrite requests write access to the clipboard.
 	ClipboardWrite bool `yaml:"clipboard_write"`
+}
+
+// ResourcesConfig configures MCP resource templates.
+type ResourcesConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+// ProgressConfig configures progress notifications during tool execution.
+type ProgressConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+// ClientLoggingConfig configures server-to-client log message notifications.
+type ClientLoggingConfig struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 // SessionsConfig configures session externalization.

--- a/pkg/platform/resource_templates.go
+++ b/pkg/platform/resource_templates.go
@@ -1,0 +1,300 @@
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/yosida95/uritemplate/v3"
+
+	"github.com/txn2/mcp-data-platform/pkg/query"
+	"github.com/txn2/mcp-data-platform/pkg/semantic"
+)
+
+// Resource template URI patterns.
+const (
+	schemaTemplateURI       = "schema://{catalog}.{schema_name}/{table}"
+	glossaryTemplateURI     = "glossary://{term}"
+	availabilityTemplateURI = "availability://{catalog}.{schema_name}/{table}"
+)
+
+// registerResourceTemplates registers all MCP resource templates.
+// Only called when resources.enabled is true.
+func (p *Platform) registerResourceTemplates() {
+	if !p.config.Resources.Enabled {
+		return
+	}
+
+	p.mcpServer.AddResourceTemplate(&mcp.ResourceTemplate{
+		URITemplate: schemaTemplateURI,
+		Name:        "Table Schema",
+		Description: "Table schema with column types and semantic context (descriptions, owners, tags, glossary terms)",
+		MIMEType:    "application/json",
+	}, p.handleSchemaResource)
+
+	p.mcpServer.AddResourceTemplate(&mcp.ResourceTemplate{
+		URITemplate: glossaryTemplateURI,
+		Name:        "Glossary Term",
+		Description: "Business glossary term definition and related assets",
+		MIMEType:    "application/json",
+	}, p.handleGlossaryResource)
+
+	p.mcpServer.AddResourceTemplate(&mcp.ResourceTemplate{
+		URITemplate: availabilityTemplateURI,
+		Name:        "Data Availability",
+		Description: "Table availability status including row count and connection info",
+		MIMEType:    "application/json",
+	}, p.handleAvailabilityResource)
+}
+
+// parseTemplateVars extracts named variables from a URI using a URI template.
+// Returns a map of variable names to their values, or an error if the URI
+// doesn't match the template.
+func parseTemplateVars(templateStr, uri string) (map[string]string, error) {
+	tmpl, err := uritemplate.New(templateStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid template %q: %w", templateStr, err)
+	}
+
+	match := tmpl.Match(uri)
+	if match == nil {
+		return nil, fmt.Errorf("uri %q does not match template %q", uri, templateStr)
+	}
+
+	result := make(map[string]string)
+	for _, name := range tmpl.Varnames() {
+		val := match.Get(name)
+		result[name] = val.String()
+	}
+	return result, nil
+}
+
+// schemaResourceResult combines query schema and semantic context.
+type schemaResourceResult struct {
+	Catalog     string                        `json:"catalog"`
+	Schema      string                        `json:"schema"`
+	Table       string                        `json:"table"`
+	Columns     []query.Column                `json:"columns,omitempty"`
+	Semantic    *semantic.TableContext        `json:"semantic,omitempty"`
+	ColumnsMeta map[string]*columnSemanticCtx `json:"columns_semantic,omitempty"`
+}
+
+// columnSemanticCtx is the serializable subset of semantic.ColumnContext.
+type columnSemanticCtx struct {
+	Description   string                  `json:"description,omitempty"`
+	Tags          []string                `json:"tags,omitempty"`
+	GlossaryTerms []semantic.GlossaryTerm `json:"glossary_terms,omitempty"`
+	IsPII         bool                    `json:"is_pii,omitempty"`
+	IsSensitive   bool                    `json:"is_sensitive,omitempty"`
+	BusinessName  string                  `json:"business_name,omitempty"`
+}
+
+// handleSchemaResource handles schema://{catalog}.{schema_name}/{table} requests.
+func (p *Platform) handleSchemaResource(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	uri := req.Params.URI
+	vars, err := parseTemplateVars(schemaTemplateURI, uri)
+	if err != nil {
+		return nil, mcp.ResourceNotFoundError(uri) //nolint:wrapcheck // MCP protocol error returned as-is for SDK type matching
+	}
+
+	catalog := vars["catalog"]
+	schemaName := vars["schema_name"]
+	table := vars["table"]
+
+	if catalog == "" || schemaName == "" || table == "" {
+		return nil, mcp.ResourceNotFoundError(uri) //nolint:wrapcheck // MCP protocol error returned as-is for SDK type matching
+	}
+
+	result := schemaResourceResult{
+		Catalog: catalog,
+		Schema:  schemaName,
+		Table:   table,
+	}
+
+	tableID := query.TableIdentifier{Catalog: catalog, Schema: schemaName, Table: table}
+	semanticTableID := semantic.TableIdentifier{Catalog: catalog, Schema: schemaName, Table: table}
+
+	queryEnriched := p.enrichSchemaFromQuery(ctx, tableID, &result)
+	semanticEnriched := p.enrichSchemaFromSemantic(ctx, semanticTableID, &result)
+	hasData := queryEnriched || semanticEnriched
+
+	if !hasData {
+		return nil, mcp.ResourceNotFoundError(uri) //nolint:wrapcheck // MCP protocol error returned as-is for SDK type matching
+	}
+
+	return marshalResourceResult(uri, result)
+}
+
+// enrichSchemaFromQuery populates the schema result with query provider data.
+// Returns true if any data was added.
+func (p *Platform) enrichSchemaFromQuery(ctx context.Context, tableID query.TableIdentifier, result *schemaResourceResult) bool {
+	if p.queryProvider == nil {
+		return false
+	}
+	schema, err := p.queryProvider.GetTableSchema(ctx, tableID)
+	if err != nil || schema == nil {
+		return false
+	}
+	result.Columns = schema.Columns
+	return true
+}
+
+// enrichSchemaFromSemantic populates the schema result with semantic provider data.
+// Returns true if any data was added.
+func (p *Platform) enrichSchemaFromSemantic(ctx context.Context, tableID semantic.TableIdentifier, result *schemaResourceResult) bool {
+	if p.semanticProvider == nil {
+		return false
+	}
+
+	hasData := false
+
+	tableCtx, err := p.semanticProvider.GetTableContext(ctx, tableID)
+	if err == nil && tableCtx != nil {
+		result.Semantic = tableCtx
+		hasData = true
+	}
+
+	colsCtx, err := p.semanticProvider.GetColumnsContext(ctx, tableID)
+	if err == nil && len(colsCtx) > 0 {
+		result.ColumnsMeta = toColumnSemanticMap(colsCtx)
+		hasData = true
+	}
+
+	return hasData
+}
+
+// toColumnSemanticMap converts semantic column contexts to the serializable format.
+func toColumnSemanticMap(colsCtx map[string]*semantic.ColumnContext) map[string]*columnSemanticCtx {
+	out := make(map[string]*columnSemanticCtx, len(colsCtx))
+	for name, cc := range colsCtx {
+		out[name] = &columnSemanticCtx{
+			Description:   cc.Description,
+			Tags:          cc.Tags,
+			GlossaryTerms: cc.GlossaryTerms,
+			IsPII:         cc.IsPII,
+			IsSensitive:   cc.IsSensitive,
+			BusinessName:  cc.BusinessName,
+		}
+	}
+	return out
+}
+
+// handleGlossaryResource handles glossary://{term} requests.
+func (p *Platform) handleGlossaryResource(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	uri := req.Params.URI
+	vars, err := parseTemplateVars(glossaryTemplateURI, uri)
+	if err != nil {
+		return nil, mcp.ResourceNotFoundError(uri) //nolint:wrapcheck // MCP protocol error
+	}
+
+	term := vars["term"]
+	if term == "" {
+		return nil, mcp.ResourceNotFoundError(uri) //nolint:wrapcheck // MCP protocol error
+	}
+
+	if p.semanticProvider == nil {
+		return nil, mcp.ResourceNotFoundError(uri) //nolint:wrapcheck // MCP protocol error
+	}
+
+	urn := "urn:li:glossaryTerm:" + term
+	glossary, err := p.semanticProvider.GetGlossaryTerm(ctx, urn)
+	if err != nil {
+		return nil, mcp.ResourceNotFoundError(uri) //nolint:wrapcheck // MCP protocol error
+	}
+
+	return marshalResourceResult(uri, glossary)
+}
+
+// availabilityResourceResult wraps availability info for serialization.
+type availabilityResourceResult struct {
+	Catalog    string `json:"catalog"`
+	Schema     string `json:"schema"`
+	Table      string `json:"table"`
+	Available  bool   `json:"available"`
+	QueryTable string `json:"query_table,omitempty"`
+	Connection string `json:"connection,omitempty"`
+	EstRows    *int64 `json:"estimated_rows,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
+// handleAvailabilityResource handles availability://{catalog}.{schema_name}/{table} requests.
+func (p *Platform) handleAvailabilityResource(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+	uri := req.Params.URI
+	vars, err := parseTemplateVars(availabilityTemplateURI, uri)
+	if err != nil {
+		return nil, mcp.ResourceNotFoundError(uri) //nolint:wrapcheck // MCP protocol error
+	}
+
+	catalog := vars["catalog"]
+	schemaName := vars["schema_name"]
+	table := vars["table"]
+
+	if catalog == "" || schemaName == "" || table == "" {
+		return nil, mcp.ResourceNotFoundError(uri) //nolint:wrapcheck // MCP protocol error
+	}
+
+	if p.queryProvider == nil {
+		return nil, mcp.ResourceNotFoundError(uri) //nolint:wrapcheck // MCP protocol error
+	}
+
+	// Build the DataHub URN for lookup.
+	urn := buildDataHubURN(p.config.Semantic.URNMapping, catalog, schemaName, table)
+
+	avail, err := p.queryProvider.GetTableAvailability(ctx, urn)
+	if err != nil {
+		return nil, mcp.ResourceNotFoundError(uri) //nolint:wrapcheck // MCP protocol error
+	}
+
+	result := availabilityResourceResult{
+		Catalog:    catalog,
+		Schema:     schemaName,
+		Table:      table,
+		Available:  avail.Available,
+		QueryTable: avail.QueryTable,
+		Connection: avail.Connection,
+		EstRows:    avail.EstimatedRows,
+		Error:      avail.Error,
+	}
+
+	return marshalResourceResult(uri, result)
+}
+
+// buildDataHubURN constructs a DataHub dataset URN from table components.
+// Uses URN mapping config to determine the platform name and catalog mapping.
+func buildDataHubURN(mapping URNMappingConfig, catalog, schema, table string) string {
+	platform := mapping.Platform
+	if platform == "" {
+		platform = toolkitKindTrino
+	}
+
+	// Apply catalog mapping if configured.
+	mappedCatalog := catalog
+	if mapped, ok := mapping.CatalogMapping[catalog]; ok {
+		mappedCatalog = mapped
+	}
+
+	return fmt.Sprintf("urn:li:dataset:(urn:li:dataPlatform:%s,%s.%s.%s,PROD)",
+		platform,
+		mappedCatalog,
+		schema,
+		table,
+	)
+}
+
+// marshalResourceResult marshals a value to JSON and wraps it in a ReadResourceResult.
+func marshalResourceResult(uri string, v any) (*mcp.ReadResourceResult, error) {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshaling resource %s: %w", uri, err)
+	}
+	return &mcp.ReadResourceResult{
+		Contents: []*mcp.ResourceContents{
+			{
+				URI:      uri,
+				MIMEType: "application/json",
+				Text:     string(data),
+			},
+		},
+	}, nil
+}

--- a/pkg/platform/resource_templates_test.go
+++ b/pkg/platform/resource_templates_test.go
@@ -1,0 +1,490 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/query"
+	"github.com/txn2/mcp-data-platform/pkg/semantic"
+)
+
+func TestParseTemplateVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		uri      string
+		want     map[string]string
+		wantErr  bool
+	}{
+		{
+			name:     "schema URI",
+			template: schemaTemplateURI,
+			uri:      "schema://rdbms.public/transactions",
+			want:     map[string]string{"catalog": "rdbms", "schema_name": "public", "table": "transactions"},
+		},
+		{
+			name:     "glossary URI",
+			template: glossaryTemplateURI,
+			uri:      "glossary://revenue",
+			want:     map[string]string{"term": "revenue"},
+		},
+		{
+			name:     "availability URI",
+			template: availabilityTemplateURI,
+			uri:      "availability://warehouse.analytics/orders",
+			want:     map[string]string{"catalog": "warehouse", "schema_name": "analytics", "table": "orders"},
+		},
+		{
+			name:     "mismatch URI",
+			template: schemaTemplateURI,
+			uri:      "glossary://revenue",
+			wantErr:  true,
+		},
+		{
+			name:     "empty URI",
+			template: schemaTemplateURI,
+			uri:      "",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid template",
+			template: "{{{bad",
+			uri:      "anything",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTemplateVars(tt.template, tt.uri)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseTemplateVars() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			for k, want := range tt.want {
+				if got[k] != want {
+					t.Errorf("parseTemplateVars()[%q] = %q, want %q", k, got[k], want)
+				}
+			}
+		})
+	}
+}
+
+// mockSemanticProvider implements semantic.Provider for testing.
+type mockSemanticProvider struct {
+	tableCtx    *semantic.TableContext
+	tableErr    error
+	colsCtx     map[string]*semantic.ColumnContext
+	colsErr     error
+	glossary    *semantic.GlossaryTerm
+	glossaryErr error
+}
+
+func (*mockSemanticProvider) Name() string { return "mock" }
+
+func (m *mockSemanticProvider) GetTableContext(_ context.Context, _ semantic.TableIdentifier) (*semantic.TableContext, error) {
+	return m.tableCtx, m.tableErr
+}
+
+func (*mockSemanticProvider) GetColumnContext(_ context.Context, _ semantic.ColumnIdentifier) (*semantic.ColumnContext, error) {
+	return nil, nil //nolint:nilnil // mock stub: unused method required by interface
+}
+
+func (m *mockSemanticProvider) GetColumnsContext(_ context.Context, _ semantic.TableIdentifier) (map[string]*semantic.ColumnContext, error) {
+	return m.colsCtx, m.colsErr
+}
+
+func (*mockSemanticProvider) GetLineage(_ context.Context, _ semantic.TableIdentifier, _ semantic.LineageDirection, _ int) (*semantic.LineageInfo, error) {
+	return nil, nil //nolint:nilnil // mock stub: unused method required by interface
+}
+
+func (m *mockSemanticProvider) GetGlossaryTerm(_ context.Context, _ string) (*semantic.GlossaryTerm, error) {
+	return m.glossary, m.glossaryErr
+}
+
+func (*mockSemanticProvider) SearchTables(_ context.Context, _ semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
+	return nil, nil //nolint:nilnil // mock stub: unused method required by interface
+}
+
+func (*mockSemanticProvider) Close() error { return nil }
+
+// mockQueryProvider implements query.Provider for testing.
+type mockQueryProvider struct {
+	schema    *query.TableSchema
+	schemaErr error
+	avail     *query.TableAvailability
+	availErr  error
+}
+
+func (*mockQueryProvider) Name() string { return "mock" }
+
+func (*mockQueryProvider) ResolveTable(_ context.Context, _ string) (*query.TableIdentifier, error) {
+	return nil, nil //nolint:nilnil // mock stub: unused method required by interface
+}
+
+func (m *mockQueryProvider) GetTableAvailability(_ context.Context, _ string) (*query.TableAvailability, error) {
+	return m.avail, m.availErr
+}
+
+func (*mockQueryProvider) GetQueryExamples(_ context.Context, _ string) ([]query.Example, error) {
+	return nil, nil //nolint:nilnil // mock stub: unused method required by interface
+}
+
+func (*mockQueryProvider) GetExecutionContext(_ context.Context, _ []string) (*query.ExecutionContext, error) {
+	return nil, nil //nolint:nilnil // mock stub: unused method required by interface
+}
+
+func (m *mockQueryProvider) GetTableSchema(_ context.Context, _ query.TableIdentifier) (*query.TableSchema, error) {
+	return m.schema, m.schemaErr
+}
+
+func (*mockQueryProvider) Close() error { return nil }
+
+func TestHandleSchemaResource(t *testing.T) {
+	t.Run("both providers", func(t *testing.T) {
+		p := &Platform{
+			config: &Config{},
+			queryProvider: &mockQueryProvider{
+				schema: &query.TableSchema{
+					Columns: []query.Column{
+						{Name: "id", Type: "INTEGER"},
+						{Name: "name", Type: "VARCHAR"},
+					},
+				},
+			},
+			semanticProvider: &mockSemanticProvider{
+				tableCtx: &semantic.TableContext{
+					Description: "Test table",
+				},
+				colsCtx: map[string]*semantic.ColumnContext{
+					"id": {Name: "id", Description: "Primary key"},
+				},
+			},
+		}
+
+		req := &mcp.ReadResourceRequest{
+			Params: &mcp.ReadResourceParams{URI: "schema://rdbms.public/transactions"},
+		}
+		result, err := p.handleSchemaResource(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Contents) != 1 {
+			t.Fatalf("expected 1 content, got %d", len(result.Contents))
+		}
+		if result.Contents[0].Text == "" {
+			t.Error("expected non-empty content")
+		}
+	})
+
+	t.Run("query only", func(t *testing.T) {
+		p := &Platform{
+			config: &Config{},
+			queryProvider: &mockQueryProvider{
+				schema: &query.TableSchema{
+					Columns: []query.Column{{Name: "id", Type: "INTEGER"}},
+				},
+			},
+		}
+
+		req := &mcp.ReadResourceRequest{
+			Params: &mcp.ReadResourceParams{URI: "schema://rdbms.public/transactions"},
+		}
+		result, err := p.handleSchemaResource(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Contents) != 1 {
+			t.Fatalf("expected 1 content, got %d", len(result.Contents))
+		}
+	})
+
+	t.Run("semantic only", func(t *testing.T) {
+		p := &Platform{
+			config: &Config{},
+			semanticProvider: &mockSemanticProvider{
+				tableCtx: &semantic.TableContext{Description: "Test table"},
+			},
+		}
+
+		req := &mcp.ReadResourceRequest{
+			Params: &mcp.ReadResourceParams{URI: "schema://rdbms.public/transactions"},
+		}
+		result, err := p.handleSchemaResource(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Contents) != 1 {
+			t.Fatalf("expected 1 content, got %d", len(result.Contents))
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		p := &Platform{
+			config:           &Config{},
+			queryProvider:    &mockQueryProvider{schemaErr: fmt.Errorf("not found")},
+			semanticProvider: &mockSemanticProvider{tableErr: fmt.Errorf("not found")},
+		}
+
+		req := &mcp.ReadResourceRequest{
+			Params: &mcp.ReadResourceParams{URI: "schema://rdbms.public/missing"},
+		}
+		_, err := p.handleSchemaResource(context.Background(), req)
+		if err == nil {
+			t.Fatal("expected error for not found table")
+		}
+	})
+
+	t.Run("invalid URI", func(t *testing.T) {
+		p := &Platform{config: &Config{}}
+
+		req := &mcp.ReadResourceRequest{
+			Params: &mcp.ReadResourceParams{URI: "glossary://something"},
+		}
+		_, err := p.handleSchemaResource(context.Background(), req)
+		if err == nil {
+			t.Fatal("expected error for invalid URI")
+		}
+	})
+}
+
+func TestHandleGlossaryResource(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		p := &Platform{
+			config: &Config{},
+			semanticProvider: &mockSemanticProvider{
+				glossary: &semantic.GlossaryTerm{
+					URN:         "urn:li:glossaryTerm:revenue",
+					Name:        "revenue",
+					Description: "Total income",
+				},
+			},
+		}
+
+		req := &mcp.ReadResourceRequest{
+			Params: &mcp.ReadResourceParams{URI: "glossary://revenue"},
+		}
+		result, err := p.handleGlossaryResource(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Contents) != 1 {
+			t.Fatalf("expected 1 content, got %d", len(result.Contents))
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		p := &Platform{
+			config: &Config{},
+			semanticProvider: &mockSemanticProvider{
+				glossaryErr: fmt.Errorf("not found"),
+			},
+		}
+
+		req := &mcp.ReadResourceRequest{
+			Params: &mcp.ReadResourceParams{URI: "glossary://missing"},
+		}
+		_, err := p.handleGlossaryResource(context.Background(), req)
+		if err == nil {
+			t.Fatal("expected error for missing term")
+		}
+	})
+
+	t.Run("no semantic provider", func(t *testing.T) {
+		p := &Platform{config: &Config{}}
+
+		req := &mcp.ReadResourceRequest{
+			Params: &mcp.ReadResourceParams{URI: "glossary://revenue"},
+		}
+		_, err := p.handleGlossaryResource(context.Background(), req)
+		if err == nil {
+			t.Fatal("expected error when no semantic provider")
+		}
+	})
+
+	t.Run("invalid URI", func(t *testing.T) {
+		p := &Platform{config: &Config{}}
+
+		req := &mcp.ReadResourceRequest{
+			Params: &mcp.ReadResourceParams{URI: "schema://bad"},
+		}
+		_, err := p.handleGlossaryResource(context.Background(), req)
+		if err == nil {
+			t.Fatal("expected error for invalid URI")
+		}
+	})
+}
+
+func TestHandleAvailabilityResource(t *testing.T) {
+	estRows := int64(1000)
+
+	t.Run("available", func(t *testing.T) {
+		p := &Platform{
+			config: &Config{},
+			queryProvider: &mockQueryProvider{
+				avail: &query.TableAvailability{
+					Available:     true,
+					QueryTable:    "rdbms.public.transactions",
+					Connection:    "default",
+					EstimatedRows: &estRows,
+				},
+			},
+		}
+
+		req := &mcp.ReadResourceRequest{
+			Params: &mcp.ReadResourceParams{URI: "availability://rdbms.public/transactions"},
+		}
+		result, err := p.handleAvailabilityResource(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Contents) != 1 {
+			t.Fatalf("expected 1 content, got %d", len(result.Contents))
+		}
+	})
+
+	t.Run("not available", func(t *testing.T) {
+		p := &Platform{
+			config: &Config{},
+			queryProvider: &mockQueryProvider{
+				avail: &query.TableAvailability{
+					Available: false,
+					Error:     "table does not exist",
+				},
+			},
+		}
+
+		req := &mcp.ReadResourceRequest{
+			Params: &mcp.ReadResourceParams{URI: "availability://rdbms.public/missing"},
+		}
+		result, err := p.handleAvailabilityResource(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Contents) != 1 {
+			t.Fatalf("expected 1 content, got %d", len(result.Contents))
+		}
+	})
+
+	t.Run("provider error", func(t *testing.T) {
+		p := &Platform{
+			config: &Config{},
+			queryProvider: &mockQueryProvider{
+				availErr: fmt.Errorf("connection failed"),
+			},
+		}
+
+		req := &mcp.ReadResourceRequest{
+			Params: &mcp.ReadResourceParams{URI: "availability://rdbms.public/transactions"},
+		}
+		_, err := p.handleAvailabilityResource(context.Background(), req)
+		if err == nil {
+			t.Fatal("expected error on provider failure")
+		}
+	})
+
+	t.Run("no query provider", func(t *testing.T) {
+		p := &Platform{config: &Config{}}
+
+		req := &mcp.ReadResourceRequest{
+			Params: &mcp.ReadResourceParams{URI: "availability://rdbms.public/transactions"},
+		}
+		_, err := p.handleAvailabilityResource(context.Background(), req)
+		if err == nil {
+			t.Fatal("expected error when no query provider")
+		}
+	})
+}
+
+func TestBuildDataHubURN(t *testing.T) {
+	tests := []struct {
+		name    string
+		mapping URNMappingConfig
+		catalog string
+		schema  string
+		table   string
+		want    string
+	}{
+		{
+			name:    "default platform",
+			mapping: URNMappingConfig{},
+			catalog: "rdbms",
+			schema:  "public",
+			table:   "users",
+			want:    "urn:li:dataset:(urn:li:dataPlatform:trino,rdbms.public.users,PROD)",
+		},
+		{
+			name:    "custom platform",
+			mapping: URNMappingConfig{Platform: "postgres"},
+			catalog: "rdbms",
+			schema:  "public",
+			table:   "users",
+			want:    "urn:li:dataset:(urn:li:dataPlatform:postgres,rdbms.public.users,PROD)",
+		},
+		{
+			name: "catalog mapping",
+			mapping: URNMappingConfig{
+				Platform:       "postgres",
+				CatalogMapping: map[string]string{"rdbms": "warehouse"},
+			},
+			catalog: "rdbms",
+			schema:  "public",
+			table:   "users",
+			want:    "urn:li:dataset:(urn:li:dataPlatform:postgres,warehouse.public.users,PROD)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildDataHubURN(tt.mapping, tt.catalog, tt.schema, tt.table)
+			if got != tt.want {
+				t.Errorf("buildDataHubURN() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRegisterResourceTemplates(t *testing.T) {
+	t.Run("disabled", func(_ *testing.T) {
+		s := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "v0.1"}, nil)
+		p := &Platform{
+			config:    &Config{Resources: ResourcesConfig{Enabled: false}},
+			mcpServer: s,
+		}
+		p.registerResourceTemplates()
+		// No panic or error means success — templates not registered.
+	})
+
+	t.Run("enabled", func(_ *testing.T) {
+		s := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "v0.1"}, nil)
+		p := &Platform{
+			config:    &Config{Resources: ResourcesConfig{Enabled: true}},
+			mcpServer: s,
+		}
+		p.registerResourceTemplates()
+		// Verify templates registered by checking no panic.
+	})
+}
+
+func TestMarshalResourceResult(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		result, err := marshalResourceResult("test://uri", map[string]string{"key": "value"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Contents) != 1 {
+			t.Fatalf("expected 1 content, got %d", len(result.Contents))
+		}
+		if result.Contents[0].URI != "test://uri" {
+			t.Errorf("URI = %q, want %q", result.Contents[0].URI, "test://uri")
+		}
+		if result.Contents[0].MIMEType != "application/json" {
+			t.Errorf("MIMEType = %q, want %q", result.Contents[0].MIMEType, "application/json")
+		}
+	})
+}

--- a/pkg/toolkits/trino/progress.go
+++ b/pkg/toolkits/trino/progress.go
@@ -1,0 +1,57 @@
+package trino
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	trinotools "github.com/txn2/mcp-trino/pkg/tools"
+
+	"github.com/txn2/mcp-data-platform/pkg/mcpcontext"
+)
+
+// mcpProgressNotifier adapts *mcp.ServerSession to trinotools.ProgressNotifier.
+// It bridges the platform's MCP session and progress token to the trino toolkit's
+// progress notification interface.
+type mcpProgressNotifier struct {
+	session *mcp.ServerSession
+	token   any
+}
+
+// Notify sends a progress notification to the MCP client via the server session.
+func (n *mcpProgressNotifier) Notify(ctx context.Context, progress, total float64, message string) error {
+	//nolint:wrapcheck // MCP SDK session error returned as-is; wrapping would break protocol handling
+	return n.session.NotifyProgress(ctx, &mcp.ProgressNotificationParams{
+		ProgressToken: n.token,
+		Progress:      progress,
+		Total:         total,
+		Message:       message,
+	})
+}
+
+// ProgressInjector is a trinotools.ToolMiddleware that creates an
+// mcpProgressNotifier per-request from the ServerSession and progress token
+// stored in context by MCPToolCallMiddleware.
+type ProgressInjector struct{}
+
+// Before reads the server session and progress token from context and, if both
+// are present, creates an mcpProgressNotifier and stores it in context via
+// trinotools.WithProgressNotifier.
+func (*ProgressInjector) Before(ctx context.Context, _ *trinotools.ToolContext) (context.Context, error) {
+	session := mcpcontext.GetServerSession(ctx)
+	token := mcpcontext.GetProgressToken(ctx)
+	if session != nil && token != nil {
+		notifier := &mcpProgressNotifier{session: session, token: token}
+		ctx = trinotools.WithProgressNotifier(ctx, notifier)
+	}
+	return ctx, nil
+}
+
+// After is a no-op — progress notifications are sent during tool execution, not after.
+func (*ProgressInjector) After(
+	_ context.Context,
+	_ *trinotools.ToolContext,
+	result *mcp.CallToolResult,
+	handlerErr error,
+) (*mcp.CallToolResult, error) {
+	return result, handlerErr
+}

--- a/pkg/toolkits/trino/progress_test.go
+++ b/pkg/toolkits/trino/progress_test.go
@@ -1,0 +1,118 @@
+package trino
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	trinotools "github.com/txn2/mcp-trino/pkg/tools"
+
+	"github.com/txn2/mcp-data-platform/pkg/mcpcontext"
+)
+
+func TestProgressInjector_Before(t *testing.T) {
+	t.Run("no session or token", func(t *testing.T) {
+		injector := &ProgressInjector{}
+		ctx, err := injector.Before(context.Background(), trinotools.NewToolContext(trinotools.ToolQuery, nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// No notifier should be set
+		notifier := trinotools.GetProgressNotifier(ctx)
+		if notifier != nil {
+			t.Error("expected nil notifier when no session/token")
+		}
+	})
+
+	t.Run("session without token", func(t *testing.T) {
+		injector := &ProgressInjector{}
+		// We can't construct a real ServerSession but we can test nil handling.
+		// Setting a nil session (via typed nil) should not inject a notifier.
+		ctx := mcpcontext.WithServerSession(context.Background(), (*mcp.ServerSession)(nil))
+		ctx, err := injector.Before(ctx, trinotools.NewToolContext(trinotools.ToolQuery, nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		notifier := trinotools.GetProgressNotifier(ctx)
+		if notifier != nil {
+			t.Error("expected nil notifier when no token")
+		}
+	})
+
+	t.Run("token without session", func(t *testing.T) {
+		injector := &ProgressInjector{}
+		ctx := mcpcontext.WithProgressToken(context.Background(), "tok-1")
+		ctx, err := injector.Before(ctx, trinotools.NewToolContext(trinotools.ToolQuery, nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		notifier := trinotools.GetProgressNotifier(ctx)
+		if notifier != nil {
+			t.Error("expected nil notifier when no session")
+		}
+	})
+}
+
+func TestProgressInjector_After(t *testing.T) {
+	injector := &ProgressInjector{}
+	result := &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "test"},
+		},
+	}
+	got, err := injector.After(context.Background(), nil, result, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != result {
+		t.Error("expected result to be passed through")
+	}
+}
+
+func TestMcpProgressNotifier_Notify(_ *testing.T) {
+	// We can't test with a real ServerSession (requires internal wiring),
+	// but we can verify the type implements the interface.
+	var _ trinotools.ProgressNotifier = (*mcpProgressNotifier)(nil)
+}
+
+func TestCreateToolkit_ProgressEnabled(t *testing.T) {
+	// When ProgressEnabled is true, the toolkit should include the ProgressInjector
+	// middleware without panicking.
+	cfg := Config{
+		Host:            "localhost",
+		User:            "test",
+		ProgressEnabled: true,
+	}
+	cfg = applyDefaults("test", cfg)
+
+	client, err := createClient(cfg)
+	if err != nil {
+		t.Fatalf("createClient failed: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	toolkit := createToolkit(client, cfg)
+	if toolkit == nil {
+		t.Fatal("expected non-nil toolkit")
+	}
+}
+
+func TestCreateToolkit_ProgressDisabled(t *testing.T) {
+	cfg := Config{
+		Host:            "localhost",
+		User:            "test",
+		ProgressEnabled: false,
+	}
+	cfg = applyDefaults("test", cfg)
+
+	client, err := createClient(cfg)
+	if err != nil {
+		t.Fatalf("createClient failed: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	toolkit := createToolkit(client, cfg)
+	if toolkit == nil {
+		t.Fatal("expected non-nil toolkit")
+	}
+}

--- a/pkg/toolkits/trino/toolkit.go
+++ b/pkg/toolkits/trino/toolkit.go
@@ -47,6 +47,10 @@ type Config struct {
 	ConnectionName string                      `yaml:"connection_name"`
 	Descriptions   map[string]string           `yaml:"descriptions"`
 	Annotations    map[string]AnnotationConfig `yaml:"annotations"`
+
+	// ProgressEnabled enables progress notifications for query execution.
+	// Injected by the platform from progress.enabled config.
+	ProgressEnabled bool `yaml:"progress_enabled"`
 }
 
 // Toolkit wraps mcp-trino toolkit for the platform.
@@ -173,6 +177,11 @@ func createToolkit(client *trinoclient.Client, cfg Config) *trinotools.Toolkit {
 	// Add annotation overrides if configured
 	if len(cfg.Annotations) > 0 {
 		opts = append(opts, trinotools.WithAnnotations(toTrinoAnnotations(cfg.Annotations)))
+	}
+
+	// Add progress notifier injector if enabled
+	if cfg.ProgressEnabled {
+		opts = append(opts, trinotools.WithMiddleware(&ProgressInjector{}))
 	}
 
 	return trinotools.NewToolkit(client, trinotools.Config{


### PR DESCRIPTION
## Summary

Implements **Phases 3 and 4** of the MCP protocol capabilities expansion plan (#102). Adds three new capability families that make the platform a richer MCP citizen — browseable resource templates, real-time progress feedback during queries, and server-to-client logging of enrichment decisions.

- **Resource Templates** (Phase 3): Three RFC 6570 URI templates expose platform data as parameterized MCP resources that agents can read for context without making tool calls
- **Progress Notifications** (Phase 4): Granular real-time progress during Trino queries via `ServerSession.NotifyProgress()`, bridged to the mcp-trino toolkit through a `ToolMiddleware` adapter
- **Client Logging** (Phase 4): Enrichment decisions sent to MCP clients that opt in via `setLevel` — zero overhead when unused

All three features are gated by config flags and have zero overhead when disabled.

## Resource Templates (Phase 3)

| Template | URI Pattern | Source |
|---|---|---|
| Table Schema | `schema://{catalog}.{schema}/{table}` | `queryProvider.GetTableSchema()` + `semanticProvider.GetTableContext()` + `GetColumnsContext()` |
| Glossary Term | `glossary://{term}` | `semanticProvider.GetGlossaryTerm()` |
| Data Availability | `availability://{catalog}.{schema}/{table}` | `queryProvider.GetTableAvailability()` |

Each handler merges data from both query and semantic providers, returning `ResourceNotFoundError` when neither provider has data. URI variable parsing uses `yosida95/uritemplate/v3` (transitive dependency via MCP SDK).

## Progress Notifications (Phase 4)

```
MCP Request with _meta.progressToken
  → Auth middleware: stores ServerSession + progressToken in ctx
    → ProgressInjector.Before(): creates MCPProgressNotifier from ctx
      → handleQuery():
        → Notify(0/3, "Executing query...")
        → trinoClient.Query()
        → Notify(1/3, "Query returned N rows, formatting...")
        → format output
        → Notify(2/3, "Query complete")
```

- **Upstream**: mcp-trino v0.6.1 defines `ProgressNotifier` interface + context helpers (txn2/mcp-trino#36)
- **Platform**: `mcpProgressNotifier` adapter bridges `*mcp.ServerSession` to the toolkit interface
- **Injection**: `ProgressInjector` ToolMiddleware reads session + token from context per-request
- **Context propagation**: New `WithServerSession`/`WithProgressToken` helpers in `pkg/mcpcontext` (extracted to break import cycle between middleware and toolkits/trino)

## Client Logging (Phase 4)

- `MCPClientLoggingMiddleware` sits between enrichment and rule enforcement in the middleware chain
- After enrichment runs, reads `PlatformContext.EnrichmentApplied` and sends an `info`-level log via `session.Log()`
- Silent no-op when client hasn't called `setLevel` — `session.Log()` returns immediately

## Middleware Chain (updated)

```
7. Tool visibility (outermost)     — filters tools/list
6. Apps metadata                   — injects _meta.ui
5. Auth/Authz                      — creates PlatformContext, stores ServerSession + token
4. Audit                           — logs tool calls to DB
3. Rule enforcement                — adds operational guidance
2. Client logging (NEW)            — logs enrichment to client
1. Semantic enrichment (innermost) — enriches responses
```

## Changes

| File | Description |
|---|---|
| `pkg/mcpcontext/mcpcontext.go` | New package — shared context keys for ServerSession and ProgressToken |
| `pkg/platform/resource_templates.go` | Three resource template handlers + URI parsing |
| `pkg/toolkits/trino/progress.go` | MCPProgressNotifier adapter + ProgressInjector middleware |
| `pkg/middleware/mcp_logging.go` | Client logging middleware |
| `pkg/middleware/context.go` | ServerSession + ProgressToken context propagation |
| `pkg/middleware/mcp.go` | Extract and store ServerSession + progress token in MCPToolCallMiddleware |
| `pkg/platform/platform.go` | Wire resource templates, logging middleware, progress config injection |
| `pkg/platform/config.go` | `ResourcesConfig`, `ProgressConfig`, `ClientLoggingConfig` types |
| `pkg/toolkits/trino/toolkit.go` | `ProgressEnabled` field for config injection |
| `go.mod` | Upgrade mcp-trino v0.5.0 → v0.6.1 |
| `configs/platform.yaml` | Example config for all three features |
| `README.md`, `docs/llms.txt`, `docs/llms-full.txt` | Documentation updates |

## Configuration

```yaml
resources:
  enabled: true        # default: false

progress:
  enabled: true        # default: false

client_logging:
  enabled: true        # default: false
```

## Test Plan

- [x] Unit tests for URI template parsing (valid, mismatched, empty, malformed)
- [x] Unit tests for each resource handler (both providers, single provider, not found, errors)
- [x] Unit tests for ProgressNotifier context round-trip, nil safety, overwrite
- [x] Unit tests for ProgressInjector Before/After (session+token present, missing, nil guards)
- [x] Unit tests for client logging middleware (enabled/disabled, enrichment applied/not, nil session)
- [x] Unit tests for ServerSession/ProgressToken context propagation
- [x] Unit tests for `injectToolkitPlatformConfig` (nil toolkits, no trino, type mismatches)
- [x] `make verify` passes — all checks green (tests, lint, security, coverage ≥80%, mutation ≥60%, release)