### PR TITLE
feat: per-persona read-only enforcement for SQL tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,13 @@ personas:
         deny: ["*_delete_*"]
       prompts:
         system_prefix: "You are helping a data analyst."
+    viewer:
+      display_name: "Viewer"
+      roles: ["viewer"]
+      tools:
+        allow: ["trino_*", "datahub_search", "datahub_get_*"]
+        deny: ["*_delete_*"]
+        read_only: ["trino_query"]  # Can query, but only SELECT
     admin:
       display_name: "Administrator"
       roles: ["admin"]

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ mcp-data-platform implements a **fail-closed** security model designed for enter
 | **Required JWT Claims** | Tokens must include `sub` and `exp` claims |
 | **TLS for HTTP Transport** | Configurable TLS with warnings for plaintext connections |
 | **Prompt Injection Protection** | Metadata sanitization prevents injection attacks |
-| **Read-Only Mode** | Trino and S3 toolkits support enforced read-only access |
+| **Read-Only Mode** | Instance-level and per-persona read-only enforcement for Trino and S3 |
 | **Default-Deny Personas** | Users without explicit persona assignment have no tool access |
 | **Cryptographic Request IDs** | Request tracing uses secure random identifiers |
 
@@ -330,6 +330,13 @@ personas:
       tools:
         allow: ["trino_*", "datahub_*"]
         deny: ["*_delete_*"]
+    viewer:
+      display_name: "Viewer"
+      roles: ["viewer"]
+      tools:
+        allow: ["trino_*", "datahub_search", "datahub_get_*"]
+        deny: ["*_delete_*"]
+        read_only: ["trino_query"]  # Can query, but only SELECT
     admin:
       display_name: "Administrator"
       roles: ["admin"]

--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -100,6 +100,26 @@ personas:
         You are providing business insights to an executive.
         Focus on what data means, not technical details.
 
+  viewer:
+    display_name: "Viewer"
+    description: "Can query data but only with SELECT statements"
+    roles:
+      - viewer
+    tools:
+      allow:
+        - "trino_*"
+        - "datahub_search"
+        - "datahub_get_*"
+        - "platform_info"
+        - "list_connections"
+      deny:
+        - "*_delete_*"
+        - "*_put_*"
+        - "*_copy_*"
+        - "apply_knowledge"
+      read_only:
+        - "trino_query"
+
   admin:
     display_name: "Administrator"
     roles:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -468,7 +468,7 @@ mcp-data-platform implements a **fail-closed** security model. Missing or invali
 - **Required JWT Claims**: Tokens must include `sub` (subject) and `exp` (expiration)
 - **Default-Deny Personas**: Users without explicit persona have no tool access
 - **Prompt Injection Protection**: DataHub metadata is sanitized before exposure
-- **Read-Only Enforcement**: Trino `read_only: true` blocks write queries at query level
+- **Read-Only Enforcement**: Instance-level (`read_only: true`) blocks all writes; per-persona `read_only` patterns restrict specific tools to SELECT-only
 - **Cryptographic Request IDs**: Secure random identifiers for audit trails
 
 ## stdio Transport (Local)
@@ -1022,6 +1022,13 @@ personas:
       tools:
         allow: ["trino_*", "datahub_*"]
         deny: ["*_delete_*"]
+    viewer:
+      display_name: "Viewer"
+      roles: ["viewer"]
+      tools:
+        allow: ["trino_*", "datahub_search", "datahub_get_*"]
+        deny: ["*_delete_*"]
+        read_only: ["trino_query"]  # Can query, but only SELECT
     admin:
       display_name: "Administrator"
       roles: ["admin"]
@@ -1038,6 +1045,10 @@ Patterns support wildcards:
 - `*_delete_*` matches any delete tool
 
 Evaluation order: deny patterns are checked first, then allow patterns.
+
+### Per-Persona Read-Only
+
+The `read_only` list restricts specific tools to read-only operations without removing access. When a tool matches a `read_only` pattern, write operations (INSERT, UPDATE, DELETE, etc.) are blocked by toolkit interceptors. This is distinct from instance-level `read_only: true` which blocks writes for all users.
 
 ---
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -41,7 +41,7 @@
 ## Personas
 
 - [Overview](personas/overview.md): Role-based tool access control
-- [Tool Filtering](personas/tool-filtering.md): Allow/deny patterns with wildcards. Distinction between persona-level filtering (security boundary) and global tool visibility (token optimization)
+- [Tool Filtering](personas/tool-filtering.md): Allow/deny/read_only patterns with wildcards. Per-persona read-only enforcement (e.g., viewer can SELECT but not INSERT). Distinction between persona-level filtering (security boundary) and global tool visibility (token optimization)
 - [Role Mapping](personas/role-mapping.md): Map OIDC roles to personas
 
 ## Go Library

--- a/pkg/mcpcontext/mcpcontext.go
+++ b/pkg/mcpcontext/mcpcontext.go
@@ -15,6 +15,7 @@ type contextKey int
 const (
 	serverSessionKey contextKey = iota
 	progressTokenKey
+	readOnlyEnforcedKey
 )
 
 // WithServerSession adds a ServerSession to the context.
@@ -36,4 +37,17 @@ func WithProgressToken(ctx context.Context, token any) context.Context {
 // GetProgressToken retrieves the progress token from the context.
 func GetProgressToken(ctx context.Context) any {
 	return ctx.Value(progressTokenKey)
+}
+
+// WithReadOnlyEnforced marks the context as read-only enforced.
+// Set by MCPToolCallMiddleware when the persona's read_only rules match
+// the tool; read by toolkit interceptors to block write operations.
+func WithReadOnlyEnforced(ctx context.Context, enforced bool) context.Context {
+	return context.WithValue(ctx, readOnlyEnforcedKey, enforced)
+}
+
+// IsReadOnlyEnforced returns true if the persona's read_only rules matched.
+func IsReadOnlyEnforced(ctx context.Context) bool {
+	v, _ := ctx.Value(readOnlyEnforcedKey).(bool)
+	return v
 }

--- a/pkg/mcpcontext/mcpcontext_test.go
+++ b/pkg/mcpcontext/mcpcontext_test.go
@@ -56,3 +56,25 @@ func TestProgressTokenContext(t *testing.T) {
 		}
 	})
 }
+
+func TestReadOnlyEnforcedContext(t *testing.T) {
+	t.Run("not set returns false", func(t *testing.T) {
+		if IsReadOnlyEnforced(context.Background()) {
+			t.Error("expected false for empty context")
+		}
+	})
+
+	t.Run("set true returns true", func(t *testing.T) {
+		ctx := WithReadOnlyEnforced(context.Background(), true)
+		if !IsReadOnlyEnforced(ctx) {
+			t.Error("expected true after WithReadOnlyEnforced(true)")
+		}
+	})
+
+	t.Run("set false returns false", func(t *testing.T) {
+		ctx := WithReadOnlyEnforced(context.Background(), false)
+		if IsReadOnlyEnforced(ctx) {
+			t.Error("expected false after WithReadOnlyEnforced(false)")
+		}
+	})
+}

--- a/pkg/middleware/authz.go
+++ b/pkg/middleware/authz.go
@@ -26,3 +26,11 @@ func (*NoopAuthorizer) IsAuthorized(_ context.Context, _ string, _ []string, _ s
 func AllowAllAuthorizer() Authorizer {
 	return &NoopAuthorizer{}
 }
+
+// ReadOnlyChecker is an optional interface for authorizers that support
+// per-persona read-only enforcement. MCPToolCallMiddleware checks for this
+// via type assertion on the Authorizer — if the authorizer does not implement
+// it, read-only enforcement is skipped (zero impact on existing code).
+type ReadOnlyChecker interface {
+	IsToolReadOnly(ctx context.Context, roles []string, toolName string) bool
+}

--- a/pkg/middleware/context.go
+++ b/pkg/middleware/context.go
@@ -46,6 +46,10 @@ type PlatformContext struct {
 	Transport string // "stdio" or "http"
 	Source    string // "mcp", "admin", "inspector"
 
+	// ReadOnlyEnforced is true when the persona's read_only rules match the
+	// current tool. Toolkit interceptors check this flag to block writes.
+	ReadOnlyEnforced bool
+
 	// Enrichment tracking (set by enrichment middleware, read by audit)
 	EnrichmentApplied bool
 

--- a/pkg/persona/persona.go
+++ b/pkg/persona/persona.go
@@ -41,6 +41,11 @@ type ToolRules struct {
 
 	// Deny patterns for denied tools (takes precedence over Allow).
 	Deny []string `json:"deny" yaml:"deny"`
+
+	// ReadOnly patterns for tools that should be restricted to read-only operations.
+	// When a tool matches, PlatformContext.ReadOnlyEnforced is set to true and
+	// toolkit-level interceptors block write operations (e.g., SQL INSERT/UPDATE/DELETE).
+	ReadOnly []string `json:"read_only,omitempty" yaml:"read_only,omitempty"`
 }
 
 // PromptConfig defines prompt customizations for a persona.

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -246,8 +246,9 @@ type ToolsConfig struct {
 
 // ToolRulesDef defines tool access rules.
 type ToolRulesDef struct {
-	Allow []string `yaml:"allow"`
-	Deny  []string `yaml:"deny"`
+	Allow    []string `yaml:"allow"`
+	Deny     []string `yaml:"deny"`
+	ReadOnly []string `yaml:"read_only,omitempty"`
 }
 
 // PromptsDef defines prompt customizations.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1053,8 +1053,9 @@ func (p *Platform) loadPersonas() error {
 			Description: def.Description,
 			Roles:       def.Roles,
 			Tools: persona.ToolRules{
-				Allow: def.Tools.Allow,
-				Deny:  def.Tools.Deny,
+				Allow:    def.Tools.Allow,
+				Deny:     def.Tools.Deny,
+				ReadOnly: def.Tools.ReadOnly,
 			},
 			Prompts: persona.PromptConfig{
 				SystemPrefix: def.Prompts.SystemPrefix,

--- a/pkg/toolkits/trino/toolkit.go
+++ b/pkg/toolkits/trino/toolkit.go
@@ -203,7 +203,11 @@ func toTrinoToolNames(m map[string]string) map[trinotools.ToolName]string {
 func createToolkit(client *trinoclient.Client, cfg Config, elicit *ElicitationMiddleware) *trinotools.Toolkit {
 	var opts []trinotools.ToolkitOption
 
-	// Add read-only interceptor if configured
+	// Always add persona-aware read-only interceptor.
+	// This is a no-op when PlatformContext.ReadOnlyEnforced is false.
+	opts = append(opts, trinotools.WithQueryInterceptor(NewPersonaReadOnlyInterceptor()))
+
+	// Add instance-level read-only interceptor if configured.
 	if cfg.ReadOnly {
 		opts = append(opts, trinotools.WithQueryInterceptor(NewReadOnlyInterceptor()))
 	}


### PR DESCRIPTION
## Summary

- Adds a `read_only` pattern list to persona tool rules, enabling per-persona SQL write restrictions without removing tool access entirely
- A viewer persona can use `trino_query` for SELECTs while an analyst gets full read-write access on the same Trino instance
- Uses an optional `ReadOnlyChecker` interface with type assertion — existing authorizers (including `NoopAuthorizer`) are completely unaffected

## Problem

Previously, `read_only: true` was a per-toolkit-instance setting that blocked ALL write SQL for ALL users. Personas could only allow or deny tool access entirely — there was no way to say "this persona can query, but only SELECT." Deployers faced a binary choice: either everyone can write, or nobody can.

## Design

Two layers of read-only enforcement can coexist independently:

- **Instance-level** (`read_only: true` on toolkit config): blocks ALL writes for ALL users (existing, unchanged)
- **Persona-level** (`tools.read_only: ["trino_query"]`): blocks writes only for that persona (new)

### Request flow

```
MCPToolCallMiddleware                 Trino Toolkit Handler
   │                                        │
   ├─ Resolves persona                      │
   ├─ Type-asserts ReadOnlyChecker          │
   ├─ If match: sets context flag ─────────>│
   │                                        ├─ PersonaReadOnlyInterceptor
   │                                        │   reads mcpcontext.IsReadOnlyEnforced()
   │                                        │   blocks write SQL if true
   │                                        ├─ ReadOnlyInterceptor (instance-level)
   │                                        │   blocks writes if read_only: true
   │                                        ├─ Executes query
```

### Import cycle avoidance

The read-only flag is propagated via `mcpcontext` (the same package already used for `ServerSession` and `ProgressToken`) rather than having the trino toolkit import `middleware` directly, which would create `middleware → registry → toolkits/trino → middleware`.

## Config example

```yaml
personas:
  definitions:
    analyst:
      tools:
        allow: ["trino_*", "datahub_*"]
        deny: ["*_delete_*"]
        # No read_only — full read-write access
    viewer:
      tools:
        allow: ["trino_*", "datahub_search", "datahub_get_*"]
        deny: ["*_delete_*"]
        read_only: ["trino_query"]  # Can query, but only SELECT
```

## Changes

| File | Change |
|------|--------|
| `pkg/persona/persona.go` | Add `ReadOnly []string` to `ToolRules` |
| `pkg/middleware/context.go` | Add `ReadOnlyEnforced bool` to `PlatformContext` |
| `pkg/middleware/authz.go` | Add `ReadOnlyChecker` optional interface |
| `pkg/middleware/mcp.go` | Set flag via type assertion after authorization |
| `pkg/persona/filter.go` | `IsReadOnly` on `ToolFilter`, `IsToolReadOnly` on `Authorizer` |
| `pkg/mcpcontext/mcpcontext.go` | `WithReadOnlyEnforced` / `IsReadOnlyEnforced` context helpers |
| `pkg/toolkits/trino/readonly.go` | `PersonaReadOnlyInterceptor` reads context flag |
| `pkg/toolkits/trino/toolkit.go` | Always register persona interceptor in query chain |
| `pkg/platform/config.go` | Add `ReadOnly` to `ToolRulesDef` for YAML parsing |
| `pkg/platform/platform.go` | Map `ReadOnly` in `loadPersonas()` |

## Documentation

Updated 6 documentation files: `README.md`, `CLAUDE.md`, `configs/platform.yaml`, `docs/personas/tool-filtering.md`, `docs/llms.txt`, `docs/llms-full.txt` — all include the new `read_only` field with examples and a mermaid diagram showing the evaluation flow.

## Test plan

- [x] `ToolFilter.IsReadOnly` — exact match, wildcard match, no match, nil persona, empty list
- [x] `Authorizer.IsToolReadOnly` — resolves persona and checks read_only; mapper error, nil persona return false
- [x] `MCPToolCallMiddleware` — sets `ReadOnlyEnforced` when `ReadOnlyChecker` returns true; does not set when false; does not set when authorizer doesn't implement interface
- [x] `PersonaReadOnlyInterceptor` — blocks writes when enforced, allows reads when enforced, allows writes when not enforced, correct error message
- [x] `mcpcontext.IsReadOnlyEnforced` — round-trip true/false/unset
- [x] All new functions at 100% coverage
- [x] `make verify` passes (fmt, test, lint, security, coverage ≥80%, dead-code, mutation, CodeQL, release dry-run)