### PR TITLE
feat: upgrade mcp-trino to v0.8.0, register trino_execute tool

### DIFF
--- a/configs/examples/kubernetes/mcpapps-configmap.yaml
+++ b/configs/examples/kubernetes/mcpapps-configmap.yaml
@@ -86,6 +86,7 @@ data:
           entry_point: "index.html"
           tools:
             - trino_query
+            - trino_execute
           csp:
             resource_domains:
               - "https://cdn.jsdelivr.net"

--- a/configs/mcpapps-container.yaml
+++ b/configs/mcpapps-container.yaml
@@ -47,6 +47,7 @@ mcpapps:
       entry_point: "index.html"
       tools:
         - trino_query
+        - trino_execute
       csp:
         resource_domains:
           - "https://cdn.jsdelivr.net"

--- a/configs/mcpapps-dev.yaml
+++ b/configs/mcpapps-dev.yaml
@@ -65,6 +65,7 @@ mcpapps:
       entry_point: "index.html"
       tools:
         - trino_query
+        - trino_execute
       csp:
         resource_domains:
           - "https://cdn.jsdelivr.net"

--- a/configs/mcpapps-docker.yaml
+++ b/configs/mcpapps-docker.yaml
@@ -57,6 +57,7 @@ mcpapps:
       entry_point: "index.html"
       tools:
         - trino_query
+        - trino_execute
       csp:
         resource_domains:
           - "https://cdn.jsdelivr.net"

--- a/docs/auth/overview.md
+++ b/docs/auth/overview.md
@@ -187,7 +187,7 @@ personas:
       display_name: "Data Analyst"
       roles: ["analyst"]
       tools:
-        allow: ["trino_query", "trino_explain", "datahub_*"]
+        allow: ["trino_query", "trino_execute", "trino_explain", "datahub_*"]
         deny: ["*_delete_*"]
   default_persona: analyst  # Required: users need explicit persona
 ```

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -297,6 +297,7 @@ personas:
           - "datahub_get_glossary_term"
           - "datahub_list_domains"
           - "trino_query"
+          - "trino_execute"
           - "trino_list_*"
           - "trino_describe_*"
         deny:
@@ -423,6 +424,7 @@ personas:
           # No direct query access yet
         deny:
           - "trino_query"
+          - "trino_execute"
           - "*_delete_*"
 
       prompts:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -829,7 +829,17 @@ Session hijack prevention: each session stores a SHA-256 hash of the creation to
 
 ### trino_query
 
-Execute a SQL query against Trino.
+Execute a read-only SQL query against Trino. Write operations are rejected. Annotated with `ReadOnlyHint: true`.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | Yes | - | SQL query to execute (read-only) |
+| `limit` | integer | No | 1000 | Maximum rows to return |
+| `connection` | string | No | first configured | Trino connection name |
+
+### trino_execute
+
+Execute any SQL against Trino including write operations (INSERT, UPDATE, DELETE, CREATE, DROP). Annotated with `DestructiveHint: true`.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
@@ -1461,6 +1471,7 @@ mcpapps:
       assets_path: "/etc/mcp-apps/query-results"
       tools:
         - trino_query
+        - trino_execute
       csp:
         resource_domains:
           - "https://cdn.jsdelivr.net"

--- a/docs/mcpapps/configuration.md
+++ b/docs/mcpapps/configuration.md
@@ -13,6 +13,7 @@ mcpapps:
       assets_path: "/etc/mcp-apps/query-results"
       tools:
         - trino_query
+        - trino_execute
 ```
 
 | Field | Type | Required | Description |
@@ -34,6 +35,7 @@ mcpapps:
       resource_uri: "ui://my_app"
       tools:
         - trino_query
+        - trino_execute
       csp:
         resource_domains:
           - "https://cdn.jsdelivr.net"

--- a/docs/mcpapps/overview.md
+++ b/docs/mcpapps/overview.md
@@ -49,7 +49,7 @@ The repository includes an example app at `apps/query-results/` that demonstrate
 - Dark mode support (respects system preference)
 - Stats bar showing query time, row count, query ID
 
-This example is designed for `trino_query` tool output. You can use it as-is, customize it, or write your own apps from scratch.
+This example is designed for `trino_query` and `trino_execute` tool output. You can use it as-is, customize it, or write your own apps from scratch.
 
 ### Expected Data Format
 

--- a/docs/personas/overview.md
+++ b/docs/personas/overview.md
@@ -74,6 +74,7 @@ personas:
           - "s3_get_object_metadata"
         deny:
           - "trino_query"
+          - "trino_execute"
           - "s3_get_object"
 
   default_persona: viewer

--- a/docs/personas/tool-filtering.md
+++ b/docs/personas/tool-filtering.md
@@ -40,7 +40,7 @@ graph TD
 | Pattern | Matches |
 |---------|---------|
 | `*` | Everything |
-| `trino_*` | trino_query, trino_explain, trino_list_tables, etc. |
+| `trino_*` | trino_query, trino_execute, trino_explain, trino_list_tables, etc. |
 | `*_list_*` | trino_list_catalogs, s3_list_buckets, datahub_list_tags, etc. |
 | `datahub_get_*` | datahub_get_entity, datahub_get_schema, etc. |
 | `s3_*` | All S3 tools |
@@ -71,6 +71,7 @@ tools:
     - "s3_list_*"
     - "s3_get_*"
   deny:
+    - "trino_execute"
     - "s3_put_*"
     - "s3_delete_*"
     - "s3_copy_*"
@@ -86,6 +87,7 @@ tools:
     - "trino_describe_*"
   deny:
     - "trino_query"
+    - "trino_execute"
     - "trino_explain"
 ```
 
@@ -121,7 +123,8 @@ tools:
 Use these exact names in your patterns:
 
 **Trino Tools:**
-- `trino_query`
+- `trino_query` (read-only)
+- `trino_execute` (read-write)
 - `trino_explain`
 - `trino_list_catalogs`
 - `trino_list_schemas`
@@ -186,6 +189,7 @@ data_steward:
       - "trino_describe_*"
     deny:
       - "trino_query"
+      - "trino_execute"
       - "trino_explain"
 ```
 
@@ -214,6 +218,7 @@ viewer:
       - "trino_list_*"
     deny:
       - "trino_query"
+      - "trino_execute"
       - "trino_explain"
       - "trino_describe_*"
       - "s3_*"

--- a/docs/reference/tools-api.md
+++ b/docs/reference/tools-api.md
@@ -10,13 +10,13 @@ Complete specification for all MCP tools provided by mcp-data-platform.
 
 ### trino_query
 
-Execute a SQL query against the Trino cluster.
+Execute a read-only SQL query against the Trino cluster. Write operations (INSERT, UPDATE, DELETE, CREATE, DROP, etc.) are rejected before reaching Trino. Annotated with `ReadOnlyHint: true` for MCP client auto-approval.
 
 **Parameters:**
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `query` | string | Yes | - | SQL query to execute |
+| `query` | string | Yes | - | SQL query to execute (read-only) |
 | `limit` | integer | No | 1000 | Maximum rows to return (capped by max_limit config) |
 | `connection` | string | No | first configured | Trino connection name |
 
@@ -59,6 +59,25 @@ Execute a SQL query against the Trino cluster.
 | `TABLE_NOT_FOUND` | Referenced table doesn't exist |
 | `PERMISSION_DENIED` | Insufficient privileges |
 | `TIMEOUT` | Query exceeded timeout |
+| `WRITE_REJECTED` | Write SQL rejected (use `trino_execute` instead) |
+
+---
+
+### trino_execute
+
+Execute any SQL against the Trino cluster, including write operations (INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, etc.). Annotated with `DestructiveHint: true` so MCP clients prompt for confirmation.
+
+When `read_only: true` is configured at the instance level, write operations are blocked.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | Yes | - | SQL query to execute |
+| `limit` | integer | No | 1000 | Maximum rows to return (capped by max_limit config) |
+| `connection` | string | No | first configured | Trino connection name |
+
+**Response Schema:** Same as `trino_query`.
 
 ---
 

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -240,10 +240,10 @@ tools:
 - Deny only: all tools appear except denied
 - Both: allow patterns are evaluated first, then deny removes from that set
 
-Patterns use `filepath.Match` syntax — `*` matches any sequence of non-separator characters. For example, `trino_*` matches `trino_query` and `trino_describe_table`.
+Patterns use `filepath.Match` syntax — `*` matches any sequence of non-separator characters. For example, `trino_*` matches `trino_query`, `trino_execute`, and `trino_describe_table`.
 
 !!! tip "When to use this"
-    Deployments that only use a subset of toolkits (e.g., only Trino) can hide unused tools to save tokens. A full tool list is 25-32 tools; filtering to `trino_*` reduces it to 7.
+    Deployments that only use a subset of toolkits (e.g., only Trino) can hide unused tools to save tokens. A full tool list is 26-33 tools; filtering to `trino_*` reduces it to 8.
 
 !!! warning "Not a security boundary"
     Tool visibility filtering only affects `tools/list` responses. A user who knows a tool name can still call it via `tools/call` if their persona allows it. Use persona tool filtering for access control.
@@ -539,6 +539,7 @@ mcpapps:
       assets_path: "/etc/mcp-apps/query-results"
       tools:
         - trino_query
+        - trino_execute
       csp:
         resource_domains:
           - "https://cdn.jsdelivr.net"
@@ -790,7 +791,7 @@ personas:
       display_name: "Data Analyst"
       roles: ["analyst"]
       tools:
-        allow: ["trino_query", "trino_explain", "datahub_*"]
+        allow: ["trino_query", "trino_execute", "trino_explain", "datahub_*"]
         deny: ["*_delete_*"]
     admin:
       display_name: "Administrator"

--- a/docs/server/tools.md
+++ b/docs/server/tools.md
@@ -13,7 +13,8 @@ mcp-data-platform provides tools from four integrated toolkits. Each tool can be
 
 | Toolkit | Tool | Description |
 |---------|------|-------------|
-| Trino | `trino_query` | Execute SQL queries |
+| Trino | `trino_query` | Execute read-only SQL queries (SELECT, SHOW, DESCRIBE, EXPLAIN) |
+| Trino | `trino_execute` | Execute any SQL including write operations (INSERT, UPDATE, DELETE, CREATE, DROP) |
 | Trino | `trino_explain` | Get query execution plans |
 | Trino | `trino_list_catalogs` | List available catalogs |
 | Trino | `trino_list_schemas` | List schemas in a catalog |
@@ -49,13 +50,15 @@ mcp-data-platform provides tools from four integrated toolkits. Each tool can be
 
 ### trino_query
 
-Execute a SQL query against Trino.
+Execute a read-only SQL query against Trino. Write operations (INSERT, UPDATE, DELETE, CREATE, DROP, etc.) are rejected with a clear error directing users to `trino_execute`.
+
+Annotated with `ReadOnlyHint: true` so MCP clients can auto-approve calls to this tool.
 
 **Parameters:**
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `query` | string | Yes | - | SQL query to execute |
+| `query` | string | Yes | - | SQL query to execute (read-only) |
 | `limit` | integer | No | 1000 | Maximum rows to return |
 | `connection` | string | No | default | Connection name to use |
 
@@ -72,6 +75,24 @@ Tool call: `trino_query` with query `SELECT customer_id, SUM(amount) as revenue 
 - Query results as formatted table or JSON
 - Row count and execution time
 - **Semantic context** (if enabled): table description, owners, tags, quality score, deprecation warnings
+
+---
+
+### trino_execute
+
+Execute any SQL against Trino, including write operations (INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, etc.). Use this tool for data modification.
+
+Annotated with `DestructiveHint: true` so MCP clients will prompt for user confirmation.
+
+When `read_only: true` is configured at the instance level, write operations are blocked on this tool as well.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | Yes | - | SQL query to execute |
+| `limit` | integer | No | 1000 | Maximum rows to return |
+| `connection` | string | No | default | Connection name to use |
 
 ---
 

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -447,7 +447,7 @@ personas:
 
 | Pattern | Matches | Doesn't Match |
 |---------|---------|---------------|
-| `trino_*` | `trino_query`, `trino_list_tables` | `datahub_search` |
+| `trino_*` | `trino_query`, `trino_execute`, `trino_list_tables` | `datahub_search` |
 | `*_delete_*` | `s3_delete_object`, `trino_delete_row` | `s3_list_buckets` |
 | `*` | Everything | Nothing |
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
 	github.com/txn2/mcp-datahub v0.7.1
 	github.com/txn2/mcp-s3 v0.2.1
-	github.com/txn2/mcp-trino v0.6.2
+	github.com/txn2/mcp-trino v0.8.0
 	github.com/yosida95/uritemplate/v3 v3.0.2
 	golang.org/x/crypto v0.48.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/txn2/mcp-datahub v0.7.1 h1:C7qtytnsPU20OJXyuiOs03OWFo1v4MM5tlE3XqXbLI
 github.com/txn2/mcp-datahub v0.7.1/go.mod h1:UyXoTLT9H5DFkrdi/k0G82x+fZN5N4PSjom6FPGTkI0=
 github.com/txn2/mcp-s3 v0.2.1 h1:vicoQLka+4S2pFzJ5qxXS9ayToPIi2pLi1rE5ZjRQhg=
 github.com/txn2/mcp-s3 v0.2.1/go.mod h1:ygY1Bz6aXO4/3jvhfooR6y/BTXJ35Rsvwsl75zKktXg=
-github.com/txn2/mcp-trino v0.6.2 h1:ogOlfx5OWD/+yb7skKvlyS5ZZfCUnJVyzX/yut+4uYs=
-github.com/txn2/mcp-trino v0.6.2/go.mod h1:6m5jlHTExGTr2swFRFp2McDBHti8l/F7mHi2b1cYHk4=
+github.com/txn2/mcp-trino v0.8.0 h1:1fdyn4nGyQqgYo1eFMmhIb5vvLUDy+CtxWM9WKACVNM=
+github.com/txn2/mcp-trino v0.8.0/go.mod h1:6m5jlHTExGTr2swFRFp2McDBHti8l/F7mHi2b1cYHk4=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/pkg/toolkits/trino/readonly.go
+++ b/pkg/toolkits/trino/readonly.go
@@ -4,14 +4,12 @@ package trino
 import (
 	"context"
 	"fmt"
-	"regexp"
-	"strings"
 
 	trinotools "github.com/txn2/mcp-trino/pkg/tools"
 )
 
 // ReadOnlyInterceptor blocks write operations when read_only mode is enabled.
-// This interceptor detects SQL statements that modify data or schema.
+// It delegates write detection to the upstream mcp-trino IsWriteSQL function.
 type ReadOnlyInterceptor struct{}
 
 // NewReadOnlyInterceptor creates a new read-only query interceptor.
@@ -19,44 +17,12 @@ func NewReadOnlyInterceptor() *ReadOnlyInterceptor {
 	return &ReadOnlyInterceptor{}
 }
 
-// writeKeywords are SQL keywords that indicate write operations.
-// These are matched at the beginning of SQL statements (after stripping comments/whitespace).
-var writeKeywords = []string{
-	"INSERT",
-	"UPDATE",
-	"DELETE",
-	"DROP",
-	"CREATE",
-	"ALTER",
-	"TRUNCATE",
-	"GRANT",
-	"REVOKE",
-	"MERGE",
-	"CALL",
-	"EXECUTE",
-}
-
-// writePattern matches SQL statements that start with write keywords.
-// Handles optional leading whitespace and common comment styles.
-var writePattern = regexp.MustCompile(
-	`(?i)^\s*(?:--[^\n]*\n\s*|/\*[\s\S]*?\*/\s*)*\s*(` +
-		strings.Join(writeKeywords, "|") +
-		`)(?:\s|$|;|\()`,
-)
-
 // Intercept checks if the query is a write operation and blocks it in read-only mode.
 func (*ReadOnlyInterceptor) Intercept(_ context.Context, sql string, _ trinotools.ToolName) (string, error) {
-	if isWriteQuery(sql) {
+	if trinotools.IsWriteSQL(sql) {
 		return "", fmt.Errorf("write operations not allowed in read-only mode")
 	}
 	return sql, nil
-}
-
-// isWriteQuery checks if the SQL query is a write operation.
-func isWriteQuery(sql string) bool {
-	// Normalize whitespace and check against pattern
-	normalized := strings.TrimSpace(sql)
-	return writePattern.MatchString(normalized)
 }
 
 // Verify interface compliance.

--- a/pkg/toolkits/trino/readonly_test.go
+++ b/pkg/toolkits/trino/readonly_test.go
@@ -187,18 +187,17 @@ func TestReadOnlyInterceptor_ErrorMessage(t *testing.T) {
 	}
 }
 
-func TestIsWriteQuery(t *testing.T) {
+func TestIsWriteSQL_DelegatesToUpstream(t *testing.T) {
 	t.Run("SELECT with subquery containing write keyword is allowed", func(t *testing.T) {
-		// This should be allowed because DELETE is not at the start
 		sql := "SELECT * FROM users WHERE delete_flag = true"
-		if isWriteQuery(sql) {
+		if trinotools.IsWriteSQL(sql) {
 			t.Errorf("SELECT with 'delete' in WHERE should be allowed: %q", sql)
 		}
 	})
 
 	t.Run("SELECT with INSERT in column name is allowed", func(t *testing.T) {
 		sql := "SELECT insert_date FROM orders"
-		if isWriteQuery(sql) {
+		if trinotools.IsWriteSQL(sql) {
 			t.Errorf("SELECT with 'insert' in column name should be allowed: %q", sql)
 		}
 	})

--- a/pkg/toolkits/trino/toolkit.go
+++ b/pkg/toolkits/trino/toolkit.go
@@ -286,6 +286,7 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 	if t.trinoToolkit != nil {
 		t.trinoToolkit.Register(s,
 			trinotools.ToolQuery,
+			trinotools.ToolExecute,
 			trinotools.ToolExplain,
 			trinotools.ToolListCatalogs,
 			trinotools.ToolListSchemas,
@@ -299,6 +300,7 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 func (*Toolkit) Tools() []string {
 	return []string{
 		"trino_query",
+		"trino_execute",
 		"trino_explain",
 		"trino_list_catalogs",
 		"trino_list_schemas",

--- a/pkg/toolkits/trino/toolkit_test.go
+++ b/pkg/toolkits/trino/toolkit_test.go
@@ -304,6 +304,7 @@ func TestToolkit_Tools(t *testing.T) {
 
 	expectedTools := []string{
 		"trino_query",
+		"trino_execute",
 		"trino_explain",
 		"trino_list_catalogs",
 		"trino_list_schemas",


### PR DESCRIPTION
## Summary

Upgrades `mcp-trino` from v0.6.2 to v0.8.0, which introduces the `trino_query` / `trino_execute` split:

- **`trino_query`** is now strictly read-only (`ReadOnlyHint: true`) — write SQL is rejected before reaching Trino
- **`trino_execute`** is the new tool for write operations (`DestructiveHint: true`) — INSERT, UPDATE, DELETE, CREATE, DROP, etc.

This gives MCP clients clear signals for auto-approval (`trino_query` is always safe) vs confirmation prompts (`trino_execute` may modify data), and lets persona allow/deny lists control write access without any new framework concepts.

## Changes

### Code (5 files)

- **`go.mod`** — `mcp-trino v0.6.2` → `v0.8.0`
- **`pkg/toolkits/trino/toolkit.go`** — Register `ToolExecute` in `RegisterTools()` and `Tools()` (7 → 8 tools)
- **`pkg/toolkits/trino/readonly.go`** — Simplified to delegate to upstream `trinotools.IsWriteSQL()` instead of maintaining a duplicate regex and keyword list
- **`pkg/toolkits/trino/toolkit_test.go`** — Added `"trino_execute"` to expected tools
- **`pkg/toolkits/trino/readonly_test.go`** — Updated to use `trinotools.IsWriteSQL()`

### Documentation (12 files)

- **`docs/server/tools.md`** — Added `trino_execute` to summary table and full tool section with parameters
- **`docs/reference/tools-api.md`** — Added `trino_execute` API spec; updated `trino_query` as read-only with `WRITE_REJECTED` error code
- **`docs/personas/tool-filtering.md`** — Added `trino_execute` to tool names reference, wildcard examples, and all deny lists (read-only, metadata-only, data steward, viewer)
- **`docs/personas/overview.md`** — Added `trino_execute` to viewer deny list
- **`docs/server/configuration.md`** — Updated tool count (26-33), mcpapps tool list, persona allow list
- **`docs/auth/overview.md`** — Added `trino_execute` to analyst allow list example
- **`docs/examples/index.md`** — Added `trino_execute` to business analyst allow list and new hire deny list
- **`docs/mcpapps/overview.md`** — Updated query-results app tool reference
- **`docs/mcpapps/configuration.md`** — Added `trino_execute` to tool lists in both examples
- **`docs/support/troubleshooting.md`** — Updated wildcard match example
- **`docs/llms-full.txt`** — Added `trino_execute` tool spec and mcpapps tools

### Config (4 files)

- **`configs/mcpapps-container.yaml`**, **`configs/mcpapps-docker.yaml`**, **`configs/mcpapps-dev.yaml`**, **`configs/examples/kubernetes/mcpapps-configmap.yaml`** — Added `trino_execute` to query-results app tool lists

## How it works

Three layers of write control now coexist:

1. **Tool semantics** (upstream) — `trino_query` always rejects writes; `trino_execute` always allows them
2. **Instance-level ReadOnly** (platform) — when `read_only: true`, the platform's `ReadOnlyInterceptor` blocks writes on both tools
3. **Persona allow/deny** (platform) — deny `trino_execute` for read-only personas, allow it for write personas

Existing persona configs using `trino_*` wildcards automatically pick up `trino_execute`. Personas that explicitly list `trino_query` only get read access with no config changes needed.

## Test plan

- [x] `make verify` passes (tests, lint, security, coverage, mutation, release-check)
- [ ] Verify `trino_query` rejects write SQL (e.g., `INSERT INTO ...`)
- [ ] Verify `trino_execute` allows write SQL
- [ ] Verify `read_only: true` blocks writes on both tools
- [ ] Verify persona with `deny: ["trino_execute"]` cannot call `trino_execute`