### PR TITLE
fix: knowledge pipeline apply — column targeting, enum schemas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
-	github.com/txn2/mcp-datahub v0.7.1
+	github.com/txn2/mcp-datahub v0.7.2
 	github.com/txn2/mcp-s3 v0.2.1
 	github.com/txn2/mcp-trino v0.8.0
 	github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v0.7.1 h1:C7qtytnsPU20OJXyuiOs03OWFo1v4MM5tlE3XqXbLI8=
-github.com/txn2/mcp-datahub v0.7.1/go.mod h1:UyXoTLT9H5DFkrdi/k0G82x+fZN5N4PSjom6FPGTkI0=
+github.com/txn2/mcp-datahub v0.7.2 h1:6BgsBrRC5czWP2ur9FncUhktelfM0d7w3Q83iOoy4eI=
+github.com/txn2/mcp-datahub v0.7.2/go.mod h1:UyXoTLT9H5DFkrdi/k0G82x+fZN5N4PSjom6FPGTkI0=
 github.com/txn2/mcp-s3 v0.2.1 h1:vicoQLka+4S2pFzJ5qxXS9ayToPIi2pLi1rE5ZjRQhg=
 github.com/txn2/mcp-s3 v0.2.1/go.mod h1:ygY1Bz6aXO4/3jvhfooR6y/BTXJ35Rsvwsl75zKktXg=
 github.com/txn2/mcp-trino v0.8.0 h1:1fdyn4nGyQqgYo1eFMmhIb5vvLUDy+CtxWM9WKACVNM=

--- a/pkg/admin/knowledge_test.go
+++ b/pkg/admin/knowledge_test.go
@@ -202,6 +202,10 @@ func (*mockDataHubWriter) AddDocumentationLink(_ context.Context, _, _, _ string
 	return nil
 }
 
+func (*mockDataHubWriter) UpdateColumnDescription(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
 // Verify interface compliance.
 var _ knowledge.DataHubWriter = (*mockDataHubWriter)(nil)
 

--- a/pkg/toolkits/knowledge/datahub_client_writer.go
+++ b/pkg/toolkits/knowledge/datahub_client_writer.go
@@ -56,6 +56,14 @@ func (w *DataHubClientWriter) UpdateDescription(ctx context.Context, urn, descri
 	return nil
 }
 
+// UpdateColumnDescription sets the editable description for a specific column.
+func (w *DataHubClientWriter) UpdateColumnDescription(ctx context.Context, urn, fieldPath, description string) error {
+	if err := w.client.UpdateColumnDescription(ctx, urn, fieldPath, description); err != nil {
+		return fmt.Errorf("updating column description for %s.%s: %w", urn, fieldPath, err)
+	}
+	return nil
+}
+
 // AddTag adds a tag to an entity.
 func (w *DataHubClientWriter) AddTag(ctx context.Context, urn, tag string) error {
 	if err := w.client.AddTag(ctx, urn, tag); err != nil {

--- a/pkg/toolkits/knowledge/datahub_writer.go
+++ b/pkg/toolkits/knowledge/datahub_writer.go
@@ -6,6 +6,7 @@ import "context"
 type DataHubWriter interface {
 	GetCurrentMetadata(ctx context.Context, urn string) (*EntityMetadata, error)
 	UpdateDescription(ctx context.Context, urn string, description string) error
+	UpdateColumnDescription(ctx context.Context, urn string, fieldPath string, description string) error
 	AddTag(ctx context.Context, urn string, tag string) error
 	RemoveTag(ctx context.Context, urn string, tag string) error
 	AddGlossaryTerm(ctx context.Context, urn string, termURN string) error
@@ -26,6 +27,11 @@ func (*NoopDataHubWriter) GetCurrentMetadata(_ context.Context, _ string) (*Enti
 
 // UpdateDescription is a no-op.
 func (*NoopDataHubWriter) UpdateDescription(_ context.Context, _, _ string) error { return nil }
+
+// UpdateColumnDescription is a no-op.
+func (*NoopDataHubWriter) UpdateColumnDescription(_ context.Context, _, _, _ string) error {
+	return nil
+}
 
 // AddTag is a no-op.
 func (*NoopDataHubWriter) AddTag(_ context.Context, _, _ string) error { return nil }

--- a/pkg/toolkits/knowledge/datahub_writer_test.go
+++ b/pkg/toolkits/knowledge/datahub_writer_test.go
@@ -67,6 +67,12 @@ func TestNoopDataHubWriter_AddDocumentationLink(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestNoopDataHubWriter_UpdateColumnDescription(t *testing.T) {
+	writer := &NoopDataHubWriter{}
+	err := writer.UpdateColumnDescription(context.Background(), testDatasetURN, "email", "Email address")
+	assert.NoError(t, err)
+}
+
 // --- Interface compliance ---
 
 func TestNoopDataHubWriter_ImplementsInterface(_ *testing.T) {

--- a/pkg/toolkits/knowledge/schemas.go
+++ b/pkg/toolkits/knowledge/schemas.go
@@ -1,0 +1,135 @@
+package knowledge
+
+import "encoding/json"
+
+// captureInsightSchema is the JSON Schema for the capture_insight tool input.
+// It includes enum constraints for categorical fields so MCP clients can
+// present valid options without trial-and-error discovery.
+var captureInsightSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["category", "insight_text"],
+  "additionalProperties": false,
+  "properties": {
+    "category": {
+      "type": "string",
+      "description": "Type of insight being captured",
+      "enum": ["correction", "business_context", "data_quality", "usage_guidance", "relationship", "enhancement"]
+    },
+    "insight_text": {
+      "type": "string",
+      "description": "The insight content (10-4000 characters)",
+      "minLength": 10,
+      "maxLength": 4000
+    },
+    "confidence": {
+      "type": "string",
+      "description": "Confidence level (defaults to 'medium')",
+      "enum": ["high", "medium", "low"]
+    },
+    "source": {
+      "type": "string",
+      "description": "Origin of the insight (defaults to 'user')",
+      "enum": ["user", "agent_discovery", "enrichment_gap"]
+    },
+    "entity_urns": {
+      "type": "array",
+      "description": "DataHub entity URNs this insight relates to",
+      "items": {"type": "string"},
+      "maxItems": 10
+    },
+    "related_columns": {
+      "type": "array",
+      "description": "Columns related to this insight",
+      "items": {
+        "type": "object",
+        "required": ["urn", "column", "relevance"],
+        "properties": {
+          "urn": {"type": "string", "description": "Dataset URN"},
+          "column": {"type": "string", "description": "Column name"},
+          "relevance": {"type": "string", "description": "How this column relates to the insight"}
+        }
+      },
+      "maxItems": 20
+    },
+    "suggested_actions": {
+      "type": "array",
+      "description": "Proposed catalog changes based on this insight",
+      "items": {
+        "type": "object",
+        "required": ["action_type", "target", "detail"],
+        "properties": {
+          "action_type": {
+            "type": "string",
+            "description": "Type of catalog change to make",
+            "enum": ["update_description", "add_tag", "add_glossary_term", "flag_quality_issue", "add_documentation"]
+          },
+          "target": {
+            "type": "string",
+            "description": "Target for the change. Use 'column:<fieldPath>' for column-level changes (e.g., 'column:location_type_id'), or the entity URN for entity-level changes"
+          },
+          "detail": {
+            "type": "string",
+            "description": "The new value or content for the change"
+          }
+        }
+      },
+      "maxItems": 5
+    }
+  }
+}`)
+
+// applyKnowledgeSchema is the JSON Schema for the apply_knowledge tool input.
+var applyKnowledgeSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["action"],
+  "additionalProperties": false,
+  "properties": {
+    "action": {
+      "type": "string",
+      "description": "The action to perform",
+      "enum": ["bulk_review", "review", "synthesize", "apply", "approve", "reject"]
+    },
+    "entity_urn": {
+      "type": "string",
+      "description": "Target entity URN (required for review, synthesize, apply)"
+    },
+    "insight_ids": {
+      "type": "array",
+      "description": "Insight IDs to operate on (required for approve, reject)",
+      "items": {"type": "string"},
+      "maxItems": 50
+    },
+    "changes": {
+      "type": "array",
+      "description": "Changes to apply (required for apply action)",
+      "items": {
+        "type": "object",
+        "required": ["change_type", "target", "detail"],
+        "properties": {
+          "change_type": {
+            "type": "string",
+            "description": "Type of catalog change",
+            "enum": ["update_description", "add_tag", "add_glossary_term", "flag_quality_issue", "add_documentation"]
+          },
+          "target": {
+            "type": "string",
+            "description": "Target for the change. Use 'column:<fieldPath>' for column-level description updates (e.g., 'column:location_type_id'). For add_documentation, this is the link description. Leave empty for dataset-level updates"
+          },
+          "detail": {
+            "type": "string",
+            "description": "The new value: description text, tag URN, glossary term URN, quality issue description, or documentation URL"
+          }
+        }
+      },
+      "maxItems": 20
+    },
+    "confirm": {
+      "type": "boolean",
+      "description": "Set to true to confirm apply action when confirmation is required"
+    },
+    "review_notes": {
+      "type": "string",
+      "description": "Notes for approve/reject actions"
+    }
+  }
+}`)

--- a/pkg/toolkits/knowledge/schemas_test.go
+++ b/pkg/toolkits/knowledge/schemas_test.go
@@ -1,0 +1,96 @@
+package knowledge
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCaptureInsightSchema_Valid(t *testing.T) {
+	var schema map[string]any
+	err := json.Unmarshal(captureInsightSchema, &schema)
+	require.NoError(t, err)
+
+	assert.Equal(t, "object", schema["type"])
+
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok, "schema should have properties")
+
+	// Verify category enum
+	category, ok := props["category"].(map[string]any)
+	require.True(t, ok, "should have category property")
+	catEnum, ok := category["enum"].([]any)
+	require.True(t, ok, "category should have enum")
+	assert.Len(t, catEnum, 6, "category should have 6 enum values")
+	assert.Contains(t, catEnum, "correction")
+	assert.Contains(t, catEnum, "business_context")
+
+	// Verify confidence enum
+	conf, ok := props["confidence"].(map[string]any)
+	require.True(t, ok, "should have confidence property")
+	confEnum, ok := conf["enum"].([]any)
+	require.True(t, ok, "confidence should have enum")
+	assert.Len(t, confEnum, 3, "confidence should have 3 enum values")
+
+	// Verify source enum
+	src, ok := props["source"].(map[string]any)
+	require.True(t, ok, "should have source property")
+	srcEnum, ok := src["enum"].([]any)
+	require.True(t, ok, "source should have enum")
+	assert.Len(t, srcEnum, 3, "source should have 3 enum values")
+
+	// Verify suggested_actions items have action_type enum
+	sa, ok := props["suggested_actions"].(map[string]any)
+	require.True(t, ok, "should have suggested_actions property")
+	items, ok := sa["items"].(map[string]any)
+	require.True(t, ok, "suggested_actions should have items")
+	itemProps, ok := items["properties"].(map[string]any)
+	require.True(t, ok, "items should have properties")
+	actionType, ok := itemProps["action_type"].(map[string]any)
+	require.True(t, ok, "should have action_type property")
+	atEnum, ok := actionType["enum"].([]any)
+	require.True(t, ok, "action_type should have enum")
+	assert.Len(t, atEnum, 5, "action_type should have 5 enum values")
+}
+
+func TestApplyKnowledgeSchema_Valid(t *testing.T) {
+	var schema map[string]any
+	err := json.Unmarshal(applyKnowledgeSchema, &schema)
+	require.NoError(t, err)
+
+	assert.Equal(t, "object", schema["type"])
+
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok, "schema should have properties")
+
+	// Verify action enum
+	action, ok := props["action"].(map[string]any)
+	require.True(t, ok, "should have action property")
+	actionEnum, ok := action["enum"].([]any)
+	require.True(t, ok, "action should have enum")
+	assert.Len(t, actionEnum, 6, "action should have 6 enum values")
+	assert.Contains(t, actionEnum, "apply")
+	assert.Contains(t, actionEnum, "synthesize")
+
+	// Verify changes items have change_type enum
+	changes, ok := props["changes"].(map[string]any)
+	require.True(t, ok, "should have changes property")
+	items, ok := changes["items"].(map[string]any)
+	require.True(t, ok, "changes should have items")
+	itemProps, ok := items["properties"].(map[string]any)
+	require.True(t, ok, "items should have properties")
+	changeType, ok := itemProps["change_type"].(map[string]any)
+	require.True(t, ok, "should have change_type property")
+	ctEnum, ok := changeType["enum"].([]any)
+	require.True(t, ok, "change_type should have enum")
+	assert.Len(t, ctEnum, 5, "change_type should have 5 enum values")
+
+	// Verify target field has column: documentation
+	target, ok := itemProps["target"].(map[string]any)
+	require.True(t, ok, "should have target property")
+	targetDesc, ok := target["description"].(string)
+	require.True(t, ok, "target should have description")
+	assert.Contains(t, targetDesc, "column:")
+}


### PR DESCRIPTION
## Summary

- **P0 — Column targets ignored**: `executeChanges()` now parses `column:<fieldPath>` targets and routes them to `UpdateColumnDescription` instead of always calling dataset-level `UpdateDescription`
- **P2 — Missing enum constraints**: Both `capture_insight` and `apply_knowledge` tools now include explicit JSON schemas with `enum` arrays for all categorical fields, eliminating trial-and-error discovery by LLM clients
- **P3 — Undocumented behavior**: Tool descriptions now document `column:<fieldPath>` target format and `flag_quality_issue` change type behavior
- **Dependency**: Upgrades `mcp-datahub` from v0.7.1 to [v0.7.2](https://github.com/txn2/mcp-datahub/releases/tag/v0.7.2) which fixes null aspect crashes and adds `UpdateColumnDescription` support

## Column target routing

Previously, `executeChanges()` passed all `update_description` changes to `datahubWriter.UpdateDescription()`, ignoring the `target` field entirely. Column-level targets like `column:location_type_id` were silently treated as dataset-level updates.

Now, the new `parseColumnTarget()` function detects the `column:` prefix and routes to `UpdateColumnDescription()`:

```
target: ""                        → UpdateDescription (dataset-level)
target: "column:email"            → UpdateColumnDescription(urn, "email", detail)
target: "column:address.zip_code" → UpdateColumnDescription(urn, "address.zip_code", detail)
```

Mixed batches work correctly — a single `apply` call can update both dataset and column descriptions alongside tag/glossary changes.

## Enum schemas

The MCP Go SDK's `jsonschema` struct tags only support descriptions, not enums. To expose valid values to LLM clients, both tools now use explicit `InputSchema` (raw JSON) instead of auto-generated schemas from struct types.

Fields with enum constraints:

| Tool | Field | Values |
|------|-------|--------|
| `capture_insight` | `category` | correction, business_context, data_quality, usage_guidance, relationship, enhancement |
| `capture_insight` | `confidence` | high, medium, low |
| `capture_insight` | `source` | user, agent_discovery, enrichment_gap |
| `capture_insight` | `action_type` | update_description, add_tag, add_glossary_term, flag_quality_issue, add_documentation |
| `apply_knowledge` | `action` | bulk_review, review, synthesize, apply, approve, reject |
| `apply_knowledge` | `change_type` | update_description, add_tag, add_glossary_term, flag_quality_issue, add_documentation |

## Files changed

| File | Change |
|------|--------|
| `go.mod` / `go.sum` | mcp-datahub v0.7.1 → v0.7.2 |
| `datahub_writer.go` | Added `UpdateColumnDescription` to `DataHubWriter` interface + noop |
| `datahub_client_writer.go` | Real `UpdateColumnDescription` implementation via mcp-datahub client |
| `toolkit.go` | Column target routing in `executeChanges`, `executeUpdateDescription`, `parseColumnTarget`, explicit `InputSchema` on both tools, improved descriptions |
| `schemas.go` | **New** — JSON schemas with enum constraints for both tools |
| `schemas_test.go` | **New** — Schema validation (valid JSON, enum presence/counts, target docs) |
| `toolkit_test.go` | Column target tests, mixed batch test, error path tests, `parseColumnTarget` table-driven (7 cases) |
| `datahub_client_writer_test.go` | `UpdateColumnDescription` success + error tests |
| `datahub_writer_test.go` | Noop `UpdateColumnDescription` test |
| `admin/knowledge_test.go` | Added `UpdateColumnDescription` to mock for interface compliance |

## Test plan

- [x] `TestExecuteChanges_ColumnTarget` — `column:location_type_id` routes to `UpdateColumnDescription`
- [x] `TestExecuteChanges_DatasetDescription` — empty target routes to `UpdateDescription`
- [x] `TestExecuteChanges_MixedColumnAndDataset` — mixed batch with dataset desc, column desc, and tag
- [x] `TestExecuteChanges_ColumnTargetError` — error wrapping on column write failure
- [x] `TestExecuteChanges_DatasetDescriptionError` — error wrapping on dataset write failure
- [x] `TestParseColumnTarget` — 7 cases: valid, nested, empty, no prefix, empty after prefix, uppercase, URN
- [x] `TestCaptureInsightSchema_Valid` — enum counts for category (6), confidence (3), source (3), action_type (5)
- [x] `TestApplyKnowledgeSchema_Valid` — enum counts for action (6), change_type (5), target docs
- [x] `TestDataHubClientWriter_UpdateColumnDescription` — success via httptest
- [x] `TestDataHubClientWriter_UpdateColumnDescription_Error` — error propagation
- [x] `TestNoopDataHubWriter_UpdateColumnDescription` — noop returns nil
- [x] All new functions at 100% coverage; knowledge package at 96.0%
- [x] All 34 packages pass with race detection

Closes #116