### PR TITLE
fix: knowledge pipeline apply — URN normalization, gosec, mcp-datahub v0.7.3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -332,6 +332,13 @@ linters:
           - revive
         text: "add-constant"
 
+      # Test files legitimately contain hardcoded test credentials (G101) and
+      # httptest handlers that echo request data (G705 XSS false positives)
+      - path: _test\.go
+        linters:
+          - gosec
+        text: "G101|G705"
+
       # DTO/types packages naturally exceed 5 public structs — their job is to define types
       - path: pkg/audit/
         linters:

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
-	github.com/txn2/mcp-datahub v0.7.2
+	github.com/txn2/mcp-datahub v0.7.3
 	github.com/txn2/mcp-s3 v0.2.1
 	github.com/txn2/mcp-trino v0.8.0
 	github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v0.7.2 h1:6BgsBrRC5czWP2ur9FncUhktelfM0d7w3Q83iOoy4eI=
-github.com/txn2/mcp-datahub v0.7.2/go.mod h1:UyXoTLT9H5DFkrdi/k0G82x+fZN5N4PSjom6FPGTkI0=
+github.com/txn2/mcp-datahub v0.7.3 h1:KHr0VYnxOXFoGfQ6nkuqZxhyjb4BEEXpSySWJuKSJu4=
+github.com/txn2/mcp-datahub v0.7.3/go.mod h1:UyXoTLT9H5DFkrdi/k0G82x+fZN5N4PSjom6FPGTkI0=
 github.com/txn2/mcp-s3 v0.2.1 h1:vicoQLka+4S2pFzJ5qxXS9ayToPIi2pLi1rE5ZjRQhg=
 github.com/txn2/mcp-s3 v0.2.1/go.mod h1:ygY1Bz6aXO4/3jvhfooR6y/BTXJ35Rsvwsl75zKktXg=
 github.com/txn2/mcp-trino v0.8.0 h1:1fdyn4nGyQqgYo1eFMmhIb5vvLUDy+CtxWM9WKACVNM=

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -370,7 +370,7 @@ func (a *OIDCAuthenticator) discoverJWKSURI(ctx context.Context) (string, error)
 		return "", fmt.Errorf("creating discovery request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL from admin-controlled OIDC issuer config
 	if err != nil {
 		return "", fmt.Errorf("fetching discovery document: %w", err)
 	}
@@ -401,7 +401,7 @@ func (a *OIDCAuthenticator) fetchAndParseJWKS(ctx context.Context, jwksURI strin
 		return nil, nil, fmt.Errorf("creating JWKS request: %w", err)
 	}
 
-	jwksResp, err := http.DefaultClient.Do(jwksReq)
+	jwksResp, err := http.DefaultClient.Do(jwksReq) // #nosec G704 -- URL from OIDC discovery document
 	if err != nil {
 		return nil, nil, fmt.Errorf("fetching JWKS: %w", err)
 	}

--- a/pkg/oauth/dcr.go
+++ b/pkg/oauth/dcr.go
@@ -78,7 +78,7 @@ type DCRRequest struct {
 // DCRResponse is a Dynamic Client Registration response.
 type DCRResponse struct {
 	ClientID              string   `json:"client_id"`
-	ClientSecret          string   `json:"client_secret,omitempty"`
+	ClientSecret          string   `json:"client_secret,omitempty"` // #nosec G117 -- required by OAuth 2.0 DCR spec (RFC 7591)
 	ClientName            string   `json:"client_name"`
 	RedirectURIs          []string `json:"redirect_uris"`
 	GrantTypes            []string `json:"grant_types"`

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -98,7 +98,7 @@ type UpstreamConfig struct {
 	ClientID string
 
 	// ClientSecret is the MCP server's client secret.
-	ClientSecret string
+	ClientSecret string // #nosec G117 -- required for upstream IdP token exchange
 
 	// RedirectURI is the callback URL for the upstream IdP.
 	RedirectURI string
@@ -160,18 +160,18 @@ type TokenRequest struct {
 	Code         string
 	RedirectURI  string
 	ClientID     string
-	ClientSecret string
+	ClientSecret string // #nosec G117 -- required by OAuth 2.1 token request (RFC 6749 §4.1.3)
 	CodeVerifier string
-	RefreshToken string
+	RefreshToken string // #nosec G117 -- required by OAuth 2.1 refresh grant (RFC 6749 §6)
 	Scope        string
 }
 
 // TokenResponse represents a token response.
 type TokenResponse struct {
-	AccessToken  string `json:"access_token"`
+	AccessToken  string `json:"access_token"` // #nosec G117 -- required by OAuth 2.1 token response (RFC 6749 §5.1)
 	TokenType    string `json:"token_type"`
 	ExpiresIn    int    `json:"expires_in"`
-	RefreshToken string `json:"refresh_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"` // #nosec G117 -- required by OAuth 2.1 token response (RFC 6749 §5.1)
 	Scope        string `json:"scope,omitempty"`
 }
 
@@ -748,10 +748,10 @@ func (s *Server) buildUpstreamAuthURLWithPrompt(state string, usePromptNone bool
 
 // upstreamTokenResponse represents the token response from the upstream IdP.
 type upstreamTokenResponse struct {
-	AccessToken  string `json:"access_token"`
+	AccessToken  string `json:"access_token"` // #nosec G117 -- upstream IdP token exchange response
 	TokenType    string `json:"token_type"`
 	ExpiresIn    int    `json:"expires_in"`
-	RefreshToken string `json:"refresh_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"` // #nosec G117 -- upstream IdP token exchange response
 	IDToken      string `json:"id_token,omitempty"`
 }
 
@@ -772,7 +772,7 @@ func (s *Server) exchangeUpstreamCode(ctx context.Context, code string) (*upstre
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := s.httpClient.Do(req)
+	resp, err := s.httpClient.Do(req) // #nosec G704 -- URL from admin-controlled upstream IdP config
 	if err != nil {
 		return nil, fmt.Errorf("sending token request: %w", err)
 	}

--- a/pkg/oauth/storage.go
+++ b/pkg/oauth/storage.go
@@ -35,7 +35,7 @@ type Storage interface {
 type Client struct {
 	ID           string    `json:"id"`
 	ClientID     string    `json:"client_id"`
-	ClientSecret string    `json:"client_secret"` // bcrypt hashed
+	ClientSecret string    `json:"client_secret"` // #nosec G117 -- bcrypt hashed, required for OAuth client storage
 	Name         string    `json:"name"`
 	RedirectURIs []string  `json:"redirect_uris"`
 	GrantTypes   []string  `json:"grant_types"`

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -194,7 +194,7 @@ type OAuthConfig struct {
 // OAuthClientConfig defines a pre-registered OAuth client.
 type OAuthClientConfig struct {
 	ID           string   `yaml:"id"`
-	Secret       string   `yaml:"secret"`
+	Secret       string   `yaml:"secret"` // #nosec G117 -- API key secret from admin YAML config
 	RedirectURIs []string `yaml:"redirect_uris"`
 }
 
@@ -208,7 +208,7 @@ type DCRConfig struct {
 type UpstreamIDPConfig struct {
 	Issuer       string `yaml:"issuer"`        // Keycloak issuer URL
 	ClientID     string `yaml:"client_id"`     // MCP Server's client ID in Keycloak
-	ClientSecret string `yaml:"client_secret"` // MCP Server's client secret
+	ClientSecret string `yaml:"client_secret"` // #nosec G117 -- MCP Server's client secret from admin YAML config
 	RedirectURI  string `yaml:"redirect_uri"`  // Callback URL (e.g., http://localhost:8080/oauth/callback)
 }
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1305,7 +1305,7 @@ type trinoConfig struct {
 	Host           string
 	Port           int
 	User           string
-	Password       string
+	Password       string // #nosec G117 -- Trino connection credential from admin config
 	Catalog        string
 	Schema         string
 	SSL            bool

--- a/pkg/query/trino/adapter.go
+++ b/pkg/query/trino/adapter.go
@@ -26,7 +26,7 @@ type Config struct {
 	Host           string
 	Port           int
 	User           string
-	Password       string
+	Password       string // #nosec G117 -- Trino connection credential from admin config
 	Catalog        string
 	Schema         string
 	SSL            bool

--- a/pkg/session/handler_test.go
+++ b/pkg/session/handler_test.go
@@ -411,6 +411,26 @@ func TestHashToken(t *testing.T) {
 	assert.NotEqual(t, h, hashToken("other"), "different input should produce different hash")
 }
 
+func TestSanitizeLogValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"clean", "abc-123", "abc-123"},
+		{"newlines", "line1\nline2\n", "line1line2"},
+		{"carriage return", "a\rb", "ab"},
+		{"tabs", "a\tb", "ab"},
+		{"mixed control chars", "a\n\r\tb", "ab"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sanitizeLogValue(tt.input))
+		})
+	}
+}
+
 func TestHandler_ConcurrentAccess(t *testing.T) {
 	handler, store, _ := newTestHandler()
 	ctx := context.Background()

--- a/pkg/toolkits/knowledge/schemas.go
+++ b/pkg/toolkits/knowledge/schemas.go
@@ -65,11 +65,11 @@ var captureInsightSchema = json.RawMessage(`{
           },
           "target": {
             "type": "string",
-            "description": "Target for the change. Use 'column:<fieldPath>' for column-level changes (e.g., 'column:location_type_id'), or the entity URN for entity-level changes"
+            "description": "Where to apply the change. Use 'column:<fieldPath>' for column-level descriptions (e.g., 'column:location_type_id'). For add_documentation, this is the URL. Leave empty for dataset-level updates"
           },
           "detail": {
             "type": "string",
-            "description": "The new value or content for the change"
+            "description": "The content for the change: description text, tag name or URN, glossary term name or URN, quality issue description, or documentation link description"
           }
         }
       },
@@ -113,11 +113,11 @@ var applyKnowledgeSchema = json.RawMessage(`{
           },
           "target": {
             "type": "string",
-            "description": "Target for the change. Use 'column:<fieldPath>' for column-level description updates (e.g., 'column:location_type_id'). For add_documentation, this is the link description. Leave empty for dataset-level updates"
+            "description": "Where to apply the change. Use 'column:<fieldPath>' for column-level descriptions (e.g., 'column:location_type_id'). For add_documentation, this is the URL. Leave empty for dataset-level updates"
           },
           "detail": {
             "type": "string",
-            "description": "The new value: description text, tag URN, glossary term URN, quality issue description, or documentation URL"
+            "description": "The content for the change: description text, tag name or URN (e.g., 'pii' or 'urn:li:tag:pii'), glossary term name or URN, quality issue description, or documentation link description"
           }
         }
       },

--- a/pkg/toolkits/s3/toolkit.go
+++ b/pkg/toolkits/s3/toolkit.go
@@ -20,7 +20,7 @@ type Config struct {
 	Endpoint        string                      `yaml:"endpoint"`
 	AccessKeyID     string                      `yaml:"access_key_id"`
 	SecretAccessKey string                      `yaml:"secret_access_key"`
-	SessionToken    string                      `yaml:"session_token"`
+	SessionToken    string                      `yaml:"session_token"` // #nosec G117 -- S3 session token from admin YAML config
 	Profile         string                      `yaml:"profile"`
 	UsePathStyle    bool                        `yaml:"use_path_style"`
 	Timeout         time.Duration               `yaml:"timeout"`

--- a/pkg/toolkits/trino/elicitation.go
+++ b/pkg/toolkits/trino/elicitation.go
@@ -370,11 +370,11 @@ func formatRowCount(n int64) string {
 	}
 
 	var result []byte
-	for i, c := range s {
+	for i := 0; i < len(s); i++ {
 		if i > 0 && (len(s)-i)%commaGroupSize == 0 {
 			result = append(result, ',')
 		}
-		result = append(result, byte(c))
+		result = append(result, s[i])
 	}
 	return string(result)
 }

--- a/pkg/toolkits/trino/toolkit.go
+++ b/pkg/toolkits/trino/toolkit.go
@@ -35,7 +35,7 @@ type Config struct {
 	Host           string                      `yaml:"host"`
 	Port           int                         `yaml:"port"`
 	User           string                      `yaml:"user"`
-	Password       string                      `yaml:"password"`
+	Password       string                      `yaml:"password"` // #nosec G117 -- Trino credential from admin YAML config
 	Catalog        string                      `yaml:"catalog"`
 	Schema         string                      `yaml:"schema"`
 	SSL            bool                        `yaml:"ssl"`


### PR DESCRIPTION
## Summary

Fixes all remaining `apply_knowledge` pipeline failures from end-to-end regression testing, upgrades mcp-datahub to v0.7.3 (which fixes AddGlossaryTerm/AddLink 422 errors), and resolves all 20 gosec findings across the codebase.

### Knowledge pipeline fixes
- **Tag URN normalization**: `add_tag` with short names like `"pii"` auto-normalizes to `urn:li:tag:pii`; full URNs pass through unchanged
- **Glossary term URN normalization**: `add_glossary_term` with short names auto-normalizes to `urn:li:glossaryTerm:<name>`
- **`flag_quality_issue` fixed**: Now creates valid `urn:li:tag:quality_issue_<sanitized_slug>` tags instead of malformed `quality_issue:<free text>` strings
- **`add_documentation` param swap**: `detail` = description, `target` = URL — consistent with every other change type where `detail` is always the content
- **Schema descriptions updated**: `target` and `detail` field descriptions now document the semantics for each change type

### Security (gosec)
- **G117** (14 hits): `#nosec` with RFC/spec justification on OAuth 2.1, Trino, S3, and config struct fields that must contain secrets by design
- **G704** (3 hits): `#nosec` on SSRF false positives — URLs constructed from admin-controlled OIDC issuer and upstream IdP config
- **G706** (1 hit): Added `sanitizeLogValue()` to strip control characters from session IDs before structured logging
- **G115** (1 hit): Changed `formatRowCount` to iterate bytes directly instead of rune→byte cast
- **golangci-lint config**: Exclude G101 (hardcoded credentials) and G705 (XSS) false positives in `_test.go` files

### Dependency
- Upgrade `mcp-datahub` v0.7.2 → v0.7.3 (fixes `auditStamp` missing from GlossaryTerms, `createStamp` JSON tag on InstitutionalMemory)

## Test plan

- [x] `make verify` passes (fmt, test, lint, gosec, govulncheck, coverage, mutation, release-check)
- [x] All new functions at 100% coverage: `normalizeTagURN`, `normalizeGlossaryTermURN`, `qualityIssueTagURN`, `sanitizeTagSlug`, `collapseUnderscores`, `sanitizeLogValue`
- [x] Existing tests updated for param swap and URN normalization
- [x] Table-driven tests for edge cases (empty strings, special chars, long slugs, mixed column/dataset targets)
- [ ] Manual end-to-end test of `apply_knowledge` against real DataHub instance with all change types

Closes #118