### PR TITLE
feat: build-time version info, header display, and timeline tick fix

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,6 +37,8 @@ builds:
     ldflags:
       - -s -w
       - -X github.com/txn2/mcp-data-platform/internal/server.Version={{.Version}}
+      - -X github.com/txn2/mcp-data-platform/internal/server.Commit={{.ShortCommit}}
+      - -X github.com/txn2/mcp-data-platform/internal/server.Date={{.Date}}
 
 archives:
   - id: default

--- a/admin-ui/src/api/types.ts
+++ b/admin-ui/src/api/types.ts
@@ -3,6 +3,8 @@
 export interface SystemInfo {
   name: string;
   version: string;
+  commit: string;
+  build_date: string;
   description: string;
   transport: string;
   config_mode: string;

--- a/admin-ui/src/components/charts/TimeseriesChart.tsx
+++ b/admin-ui/src/components/charts/TimeseriesChart.tsx
@@ -15,17 +15,26 @@ interface TimeseriesChartProps {
   data: TimeseriesBucket[] | undefined;
   isLoading: boolean;
   height?: number;
+  preset?: "1h" | "6h" | "24h" | "7d";
 }
 
-function formatTime(iso: string) {
+function formatTick(iso: string, preset?: string) {
   const d = new Date(iso);
-  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  switch (preset) {
+    case "7d":
+      return d.toLocaleDateString([], { month: "short", day: "numeric" });
+    case "24h":
+      return d.toLocaleTimeString([], { hour: "numeric" });
+    default:
+      return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
 }
 
 export function TimeseriesChart({
   data,
   isLoading,
   height = 250,
+  preset,
 }: TimeseriesChartProps) {
   if (isLoading || !data) return <ChartSkeleton height={height} />;
 
@@ -35,7 +44,7 @@ export function TimeseriesChart({
         <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
         <XAxis
           dataKey="bucket"
-          tickFormatter={formatTime}
+          tickFormatter={(v) => formatTick(v as string, preset)}
           className="text-xs"
           tick={{ fill: "hsl(var(--muted-foreground))" }}
         />

--- a/admin-ui/src/components/layout/Header.tsx
+++ b/admin-ui/src/components/layout/Header.tsx
@@ -1,4 +1,5 @@
 import { useThemeStore } from "@/stores/theme";
+import { useSystemInfo } from "@/api/hooks";
 import { Sun, Moon, Monitor } from "lucide-react";
 
 interface HeaderProps {
@@ -13,25 +14,40 @@ const themeOptions = [
 
 export function Header({ title }: HeaderProps) {
   const { theme, setTheme } = useThemeStore();
+  const { data: systemInfo } = useSystemInfo();
+  const version = systemInfo?.version ?? "dev";
+  const tooltip = systemInfo
+    ? `${systemInfo.version}\nCommit: ${systemInfo.commit}\nBuilt: ${systemInfo.build_date}`
+    : "";
 
   return (
     <header className="flex h-14 items-center justify-between border-b bg-card px-6">
       <h1 className="text-lg font-semibold">{title}</h1>
-      <div className="flex gap-0.5 rounded-md border p-0.5">
-        {themeOptions.map((opt) => (
-          <button
-            key={opt.value}
-            onClick={() => setTheme(opt.value)}
-            title={opt.label}
-            className={`rounded-sm p-1.5 transition-colors ${
-              theme === opt.value
-                ? "bg-muted text-foreground"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
+      <div className="flex items-center gap-3">
+        {systemInfo && (
+          <span
+            className="text-xs text-muted-foreground"
+            title={tooltip}
           >
-            <opt.icon className="h-3.5 w-3.5" />
-          </button>
-        ))}
+            v{version}
+          </span>
+        )}
+        <div className="flex gap-0.5 rounded-md border p-0.5">
+          {themeOptions.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => setTheme(opt.value)}
+              title={opt.label}
+              className={`rounded-sm p-1.5 transition-colors ${
+                theme === opt.value
+                  ? "bg-muted text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              <opt.icon className="h-3.5 w-3.5" />
+            </button>
+          ))}
+        </div>
       </div>
     </header>
   );

--- a/admin-ui/src/mocks/data/system.ts
+++ b/admin-ui/src/mocks/data/system.ts
@@ -7,6 +7,8 @@ import type {
 export const mockSystemInfo: SystemInfo = {
   name: "acme-data-platform",
   version: "1.4.2",
+  commit: "a1b2c3d",
+  build_date: "2025-01-15T10:30:00Z",
   description: "ACME Corporation Retail Data Platform",
   transport: "http",
   config_mode: "database",

--- a/admin-ui/src/pages/dashboard/DashboardPage.tsx
+++ b/admin-ui/src/pages/dashboard/DashboardPage.tsx
@@ -142,7 +142,7 @@ export function DashboardPage() {
       {/* Activity Chart */}
       <div className="rounded-lg border bg-card p-4">
         <h2 className="mb-3 text-sm font-medium">Activity</h2>
-        <TimeseriesChart data={timeseries.data} isLoading={timeseries.isLoading} />
+        <TimeseriesChart data={timeseries.data} isLoading={timeseries.isLoading} preset={preset} />
       </div>
 
       {/* Charts Grid */}

--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -123,7 +123,8 @@ func run() error {
 	opts := parseFlags()
 
 	if opts.showVersion {
-		fmt.Printf("mcp-data-platform version %s\n", mcpserver.Version)
+		fmt.Printf("mcp-data-platform version %s (commit: %s, built: %s)\n",
+			mcpserver.Version, mcpserver.Commit, mcpserver.Date)
 		return nil
 	}
 

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -2166,6 +2166,12 @@ const docTemplate = `{
         "admin.systemInfoResponse": {
             "type": "object",
             "properties": {
+                "build_date": {
+                    "type": "string"
+                },
+                "commit": {
+                    "type": "string"
+                },
                 "config_mode": {
                     "type": "string"
                 },

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -2160,6 +2160,12 @@
         "admin.systemInfoResponse": {
             "type": "object",
             "properties": {
+                "build_date": {
+                    "type": "string"
+                },
+                "commit": {
+                    "type": "string"
+                },
                 "config_mode": {
                     "type": "string"
                 },

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -264,6 +264,10 @@ definitions:
     type: object
   admin.systemInfoResponse:
     properties:
+      build_date:
+        type: string
+      commit:
+        type: string
       config_mode:
         type: string
       description:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,8 +10,14 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/platform"
 )
 
-// Version is set at build time.
+// Version is set at build time via ldflags.
 var Version = "dev"
+
+// Commit is the git short commit hash, set at build time via ldflags.
+var Commit = "none"
+
+// Date is the build timestamp, set at build time via ldflags.
+var Date = "unknown"
 
 // New creates a new MCP server with the given configuration.
 func New(cfg *platform.Config) (*mcp.Server, *platform.Platform, error) {

--- a/pkg/admin/system.go
+++ b/pkg/admin/system.go
@@ -10,18 +10,20 @@ import (
 
 // systemInfoResponse is returned by GET /system/info.
 type systemInfoResponse struct {
-	Name         string         `json:"name"`
-	Version      string         `json:"version"`
-	Description  string         `json:"description"`
-	Transport    string         `json:"transport"`
-	ConfigMode   string         `json:"config_mode"`
-	PortalTitle      string         `json:"portal_title"`
-	PortalLogo       string         `json:"portal_logo"`
-	PortalLogoLight  string         `json:"portal_logo_light"`
-	PortalLogoDark   string         `json:"portal_logo_dark"`
-	Features         systemFeatures `json:"features"`
-	ToolkitCount int            `json:"toolkit_count"`
-	PersonaCount int            `json:"persona_count"`
+	Name            string         `json:"name"`
+	Version         string         `json:"version"`
+	Commit          string         `json:"commit"`
+	BuildDate       string         `json:"build_date"`
+	Description     string         `json:"description"`
+	Transport       string         `json:"transport"`
+	ConfigMode      string         `json:"config_mode"`
+	PortalTitle     string         `json:"portal_title"`
+	PortalLogo      string         `json:"portal_logo"`
+	PortalLogoLight string         `json:"portal_logo_light"`
+	PortalLogoDark  string         `json:"portal_logo_dark"`
+	Features        systemFeatures `json:"features"`
+	ToolkitCount    int            `json:"toolkit_count"`
+	PersonaCount    int            `json:"persona_count"`
 }
 
 // systemFeatures lists platform features based on runtime availability.
@@ -47,6 +49,8 @@ func (h *Handler) getSystemInfo(w http.ResponseWriter, _ *http.Request) {
 	cfg := h.deps.Config
 	resp := systemInfoResponse{
 		Version:    mcpserver.Version,
+		Commit:     mcpserver.Commit,
+		BuildDate:  mcpserver.Date,
 		ConfigMode: configModeFile,
 	}
 	if cfg != nil {

--- a/pkg/admin/system_test.go
+++ b/pkg/admin/system_test.go
@@ -10,11 +10,20 @@ import (
 	"github.com/stretchr/testify/require"
 
 	_ "github.com/txn2/mcp-data-platform/internal/apidocs" // register swagger docs
+	mcpserver "github.com/txn2/mcp-data-platform/internal/server"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
 )
 
 func TestGetSystemInfo(t *testing.T) {
 	t.Run("returns runtime feature availability", func(t *testing.T) {
+		origCommit, origDate := mcpserver.Commit, mcpserver.Date
+		mcpserver.Commit = "abc1234"
+		mcpserver.Date = "2025-01-15T10:30:00Z"
+		t.Cleanup(func() {
+			mcpserver.Commit = origCommit
+			mcpserver.Date = origDate
+		})
+
 		cfg := testConfig()
 		cfg.Server.Name = "test-platform"
 		cfg.Server.Description = "Test description"
@@ -56,6 +65,8 @@ func TestGetSystemInfo(t *testing.T) {
 		var body systemInfoResponse
 		require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
 		assert.Equal(t, "test-platform", body.Name)
+		assert.Equal(t, "abc1234", body.Commit)
+		assert.Equal(t, "2025-01-15T10:30:00Z", body.BuildDate)
 		assert.Equal(t, "Test description", body.Description)
 		assert.Equal(t, "http", body.Transport)
 		assert.Equal(t, "https://cdn.example.com/logo.svg", body.PortalLogo)

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -80,10 +80,10 @@ type Config struct {
 
 // AdminConfig configures the admin REST API.
 type AdminConfig struct {
-	Enabled     bool   `yaml:"enabled"`
-	Portal      bool   `yaml:"portal"`       // enable admin UI portal (default: false)
-	Persona     string `yaml:"persona"`      // required admin persona (default: "admin")
-	PathPrefix  string `yaml:"path_prefix"`  // URL prefix (default: "/api/v1/admin")
+	Enabled         bool   `yaml:"enabled"`
+	Portal          bool   `yaml:"portal"`            // enable admin UI portal (default: false)
+	Persona         string `yaml:"persona"`           // required admin persona (default: "admin")
+	PathPrefix      string `yaml:"path_prefix"`       // URL prefix (default: "/api/v1/admin")
 	PortalTitle     string `yaml:"portal_title"`      // sidebar title (default: "Admin Portal")
 	PortalLogo      string `yaml:"portal_logo"`       // URL to logo (fallback for both themes)
 	PortalLogoLight string `yaml:"portal_logo_light"` // URL to logo for light theme


### PR DESCRIPTION
## Summary

Closes #123. Three related improvements to build provenance and admin UI:

- **Build-time version injection**: GoReleaser now sets `Commit` (short hash) and `Date` via ldflags alongside the existing `Version`. The `--version` flag prints all three: `mcp-data-platform version 0.22.3 (commit: abc1234, built: 2025-01-15T10:30:00Z)`.
- **Admin header version display**: The admin portal header shows the platform version (`v1.4.2`) to the left of the theme toggle. Hovering reveals a tooltip with full version, commit hash, and build timestamp.
- **Activity timeline tick fix**: The x-axis tick formatter is now resolution-aware — `HH:MM` for 1h/6h, hour-only (e.g. `11 PM`) for 24h, and date (e.g. `Feb 13`) for 7d. Previously all ranges used the same `HH:MM` format which was unreadable for wider time windows.

## Changes

### Go backend
| File | Change |
|------|--------|
| `internal/server/server.go` | Add `Commit` and `Date` package-level vars with sensible defaults (`"none"`, `"unknown"`) |
| `.goreleaser.yml` | Add `-X` ldflags for `Commit={{.ShortCommit}}` and `Date={{.Date}}` |
| `cmd/mcp-data-platform/main.go` | `--version` output now includes commit and build date |
| `pkg/admin/system.go` | Add `commit` and `build_date` fields to `systemInfoResponse`, wired from server vars |
| `pkg/admin/system_test.go` | Test sets/restores build vars and asserts they appear in the API response |
| `pkg/platform/config.go` | `gofmt` alignment fix for `AdminConfig` struct fields |
| `internal/apidocs/` | Regenerated Swagger docs (new `commit` and `build_date` in schema) |

### Admin UI (TypeScript/React)
| File | Change |
|------|--------|
| `admin-ui/src/api/types.ts` | Add `commit` and `build_date` to `SystemInfo` interface |
| `admin-ui/src/mocks/data/system.ts` | Add mock values for new fields |
| `admin-ui/src/components/layout/Header.tsx` | Fetch system info, render version string with tooltip left of theme toggle |
| `admin-ui/src/components/charts/TimeseriesChart.tsx` | Add `preset` prop; replace `formatTime` with resolution-aware `formatTick` |
| `admin-ui/src/pages/dashboard/DashboardPage.tsx` | Pass `preset` to `TimeseriesChart` |

## Test plan

- [x] `make verify` passes (fmt, tests, lint, security, coverage, mutation, release-check)
- [x] `npm run typecheck` and `npm run lint` pass clean
- [x] Visual verification with `VITE_MSW=true npm run dev`:
  - Header shows `v1.4.2` left of theme toggle
  - Hover tooltip shows version, commit hash, and build date
  - Activity chart: 1h/6h presets show `HH:MM` ticks
  - Activity chart: 24h preset shows hour-only ticks (e.g. `11 PM`)
  - Activity chart: 7d preset shows date ticks (e.g. `Feb 13`)
- [ ] `mcp-data-platform --version` prints full provenance after GoReleaser build