### PR TITLE
feat(admin): replay tool call from audit detail drawer

### DIFF
--- a/admin-ui/src/components/RecentErrorsList.tsx
+++ b/admin-ui/src/components/RecentErrorsList.tsx
@@ -5,9 +5,10 @@ import { EventDrawer } from "@/components/EventDrawer";
 
 interface RecentErrorsListProps {
   events: AuditEvent[] | undefined;
+  onNavigate?: (path: string) => void;
 }
 
-export function RecentErrorsList({ events }: RecentErrorsListProps) {
+export function RecentErrorsList({ events, onNavigate }: RecentErrorsListProps) {
   const [selectedEvent, setSelectedEvent] = useState<AuditEvent | null>(null);
 
   if (!events || events.length === 0) {
@@ -40,6 +41,7 @@ export function RecentErrorsList({ events }: RecentErrorsListProps) {
         <EventDrawer
           event={selectedEvent}
           onClose={() => setSelectedEvent(null)}
+          onNavigate={onNavigate}
         />
       )}
     </>

--- a/admin-ui/src/components/layout/AppShell.tsx
+++ b/admin-ui/src/components/layout/AppShell.tsx
@@ -41,7 +41,7 @@ export function AppShell() {
             <ToolsPage key={currentPath} initialTab={initialTab} />
           )}
           {route === "/audit" && (
-            <AuditLogPage key={currentPath} initialTab={initialTab} />
+            <AuditLogPage key={currentPath} initialTab={initialTab} onNavigate={setCurrentPath} />
           )}
           {route === "/knowledge" && (
             <KnowledgePage key={currentPath} initialTab={initialTab} />

--- a/admin-ui/src/pages/audit/AuditLogPage.tsx
+++ b/admin-ui/src/pages/audit/AuditLogPage.tsx
@@ -29,7 +29,7 @@ const TAB_ITEMS: { key: Tab; label: string }[] = [
   { key: "help", label: "Help" },
 ];
 
-export function AuditLogPage({ initialTab }: { initialTab?: string }) {
+export function AuditLogPage({ initialTab, onNavigate }: { initialTab?: string; onNavigate?: (path: string) => void }) {
   const [tab, setTab] = useState<Tab>(
     (["overview", "events", "help"].includes(initialTab ?? "") ? initialTab : "overview") as Tab,
   );
@@ -53,8 +53,8 @@ export function AuditLogPage({ initialTab }: { initialTab?: string }) {
         ))}
       </div>
 
-      {tab === "overview" && <OverviewTab />}
-      {tab === "events" && <EventsTab />}
+      {tab === "overview" && <OverviewTab onNavigate={onNavigate} />}
+      {tab === "events" && <EventsTab onNavigate={onNavigate} />}
       {tab === "help" && <AuditHelpTab />}
     </div>
   );
@@ -80,7 +80,7 @@ function getResolution(preset: TimeRangePreset): Resolution {
   }
 }
 
-function OverviewTab() {
+function OverviewTab({ onNavigate }: { onNavigate?: (path: string) => void }) {
   const { preset, setPreset, getStartTime, getEndTime } = useTimeRangeStore();
   const { startTime, endTime } = useMemo(
     () => ({ startTime: getStartTime(), endTime: getEndTime() }),
@@ -209,7 +209,7 @@ function OverviewTab() {
         {/* Recent Errors */}
         <div className="rounded-lg border bg-card p-4">
           <h2 className="mb-3 text-sm font-medium">Recent Errors</h2>
-          <RecentErrorsList events={recentErrors.data?.data} />
+          <RecentErrorsList events={recentErrors.data?.data} onNavigate={onNavigate} />
         </div>
       </div>
     </div>
@@ -236,7 +236,7 @@ const COLUMNS: readonly {
   { key: "enrichment_applied", label: "Enriched",   thClass: "text-center", spanClass: "justify-center" },
 ];
 
-function EventsTab() {
+function EventsTab({ onNavigate }: { onNavigate?: (path: string) => void }) {
   const [page, setPage] = useState(1);
   const [userId, setUserId] = useState("");
   const [toolName, setToolName] = useState("");
@@ -518,6 +518,7 @@ function EventsTab() {
         <EventDrawer
           event={selectedEvent}
           onClose={() => setSelectedEvent(null)}
+          onNavigate={onNavigate}
         />
       )}
     </>

--- a/admin-ui/src/pages/dashboard/DashboardPage.tsx
+++ b/admin-ui/src/pages/dashboard/DashboardPage.tsx
@@ -35,7 +35,7 @@ function getResolution(preset: TimeRangePreset): Resolution {
   }
 }
 
-export function DashboardPage() {
+export function DashboardPage({ onNavigate }: { onNavigate?: (path: string) => void }) {
   const { preset, setPreset, getStartTime, getEndTime } = useTimeRangeStore();
   const { startTime, endTime } = useMemo(
     () => ({ startTime: getStartTime(), endTime: getEndTime() }),
@@ -202,7 +202,7 @@ export function DashboardPage() {
         {/* Recent Errors */}
         <div className="rounded-lg border bg-card p-4">
           <h2 className="mb-3 text-sm font-medium">Recent Errors</h2>
-          <RecentErrorsList events={recentErrors.data?.data} />
+          <RecentErrorsList events={recentErrors.data?.data} onNavigate={onNavigate} />
         </div>
       </div>
 

--- a/admin-ui/src/pages/home/HomePage.tsx
+++ b/admin-ui/src/pages/home/HomePage.tsx
@@ -38,7 +38,7 @@ export function HomePage({
         ))}
       </div>
 
-      {tab === "dashboard" && <DashboardPage />}
+      {tab === "dashboard" && <DashboardPage onNavigate={onNavigate} />}
       {tab === "help" && <HelpTab onNavigate={onNavigate} />}
     </div>
   );

--- a/admin-ui/src/stores/inspector.ts
+++ b/admin-ui/src/stores/inspector.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+
+export interface ReplayIntent {
+  tool_name: string;
+  connection: string;
+  parameters: Record<string, unknown>;
+  event_id: string;
+  event_timestamp: string;
+}
+
+interface InspectorState {
+  replayIntent: ReplayIntent | null;
+  setReplayIntent: (intent: ReplayIntent) => void;
+  consumeReplayIntent: () => ReplayIntent | null;
+}
+
+export const useInspectorStore = create<InspectorState>((set, get) => ({
+  replayIntent: null,
+  setReplayIntent: (intent) => set({ replayIntent: intent }),
+  consumeReplayIntent: () => {
+    const intent = get().replayIntent;
+    if (intent) set({ replayIntent: null });
+    return intent;
+  },
+}));


### PR DESCRIPTION
Closes #122

## Summary

- Add **"Replay in Inspector"** button to the audit event detail drawer that navigates to Tools > Explore with the tool pre-selected and parameters pre-filled from the audit event
- Bridges auditing and debugging into a single workflow — admins can reproduce any historical tool call with one click

## How It Works

```mermaid
sequenceDiagram
    participant Admin
    participant Drawer as Event Detail Drawer
    participant Store as Zustand Inspector Store
    participant Explorer as Tools > Explore Tab

    Admin->>Drawer: Click audit event row
    Drawer->>Drawer: Check tool exists in current catalog
    Admin->>Drawer: Click "Replay in Inspector"
    Drawer->>Store: setReplayIntent({ tool, connection, params, event_id })
    Drawer->>Explorer: onNavigate("/tools#explore")
    Explorer->>Store: consumeReplayIntent() on mount
    Explorer->>Explorer: Pre-select tool, pre-fill form, show banner
    Admin->>Explorer: Click Execute manually
```

**Key design decision**: A Zustand store (`stores/inspector.ts`) carries the replay payload between pages. This avoids threading a complex data object through many intermediate components and follows the existing store patterns (`timerange.ts`, `theme.ts`, `auth.ts`). The store provides an atomic `consumeReplayIntent()` that reads and clears in one call, preventing stale replays.

## Changes

| File | Change |
|------|--------|
| `stores/inspector.ts` | **New** — Zustand store with `ReplayIntent` type and `consumeReplayIntent()` |
| `EventDrawer.tsx` | Replay button with tool availability check via `useToolSchemas` |
| `AppShell.tsx` | Pass `onNavigate` to `AuditLogPage` |
| `AuditLogPage.tsx` | Accept and thread `onNavigate` to `OverviewTab`, `EventsTab`, drawers |
| `RecentErrorsList.tsx` | Accept and thread `onNavigate` to `EventDrawer` |
| `HomePage.tsx` | Pass `onNavigate` to `DashboardPage` |
| `DashboardPage.tsx` | Accept and thread `onNavigate` to `RecentErrorsList` |
| `ToolsPage.tsx` | Consume replay intent on mount, `initialValue` prop on `FieldInput`, replay banner with dismiss |

## Acceptance Criteria

- [x] **AC-1**: Audit detail drawer displays "Replay in Inspector" button below event details
- [x] **AC-2**: Clicking the button navigates to Tools > Explore with the correct tool selected
- [x] **AC-3**: Inspector form is pre-populated with exact input parameters from the audit event
- [x] **AC-4**: Admin must manually click Execute — no auto-execution
- [x] **AC-5**: Button is disabled with explanation when tool not in current catalog
- [x] **AC-6**: Works for all tool types (Trino, DataHub, S3, platform) — uses generic schema-driven form
- [x] **Bonus**: Replay also works from Dashboard > Recent Errors drawer

## Test Plan

- [ ] `cd admin-ui && npx tsc --noEmit` — TypeScript compiles cleanly
- [ ] `npx eslint src/` — no new lint errors (5 pre-existing warnings unchanged)
- [ ] `VITE_MSW=true npm run dev` — manual verification:
  - Open **Audit > Events**, click any row, verify "Replay in Inspector" button appears
  - Click button → navigates to **Tools > Explore** with tool selected and form pre-filled
  - Banner shows "Replaying audit event `<id>` from `<timestamp>`"
  - Dismiss banner; selecting a different tool also clears it
  - No auto-execution — must click Execute
  - Open **Dashboard > Recent Errors**, click error → drawer also has replay button
  - For a tool that doesn't exist in the catalog, button is disabled with "Tool not found" message