### PR TITLE
fix: platform_info version fallback, replay SQL newlines, browser navigation

### DIFF
--- a/admin-ui/src/pages/tools/ToolsPage.tsx
+++ b/admin-ui/src/pages/tools/ToolsPage.tsx
@@ -646,6 +646,33 @@ function ExploreTab() {
 }
 
 // ---------------------------------------------------------------------------
+// SqlTextarea — controlled textarea that preserves newlines on replay
+// ---------------------------------------------------------------------------
+
+function SqlTextarea({
+  name,
+  required,
+  initialValue,
+}: {
+  name: string;
+  required: boolean;
+  initialValue: string;
+}) {
+  const [val, setVal] = useState(initialValue);
+  return (
+    <textarea
+      name={name}
+      required={required}
+      rows={6}
+      value={val}
+      onChange={(e) => setVal(e.target.value)}
+      className="w-full rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none ring-ring focus:ring-2"
+      placeholder="SELECT ..."
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
 // FieldInput — renders the appropriate input for a tool parameter
 // ---------------------------------------------------------------------------
 
@@ -664,13 +691,10 @@ function FieldInput({
 
   if (prop.type === "string" && prop.format === "sql") {
     return (
-      <textarea
+      <SqlTextarea
         name={name}
         required={required}
-        rows={6}
-        defaultValue={String(resolvedDefault ?? "")}
-        className="w-full rounded-md border bg-background px-3 py-2 font-mono text-sm outline-none ring-ring focus:ring-2"
-        placeholder="SELECT ..."
+        initialValue={String(resolvedDefault ?? "")}
       />
     );
   }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,6 +21,11 @@ var Date = "unknown"
 
 // New creates a new MCP server with the given configuration.
 func New(cfg *platform.Config) (*mcp.Server, *platform.Platform, error) {
+	// Use build-time version when config doesn't specify one
+	if cfg.Server.Version == "" {
+		cfg.Server.Version = Version
+	}
+
 	// Create platform
 	p, err := platform.New(platform.WithConfig(cfg))
 	if err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -61,6 +61,59 @@ func TestNew(t *testing.T) {
 		}
 	})
 
+	t.Run("sets build-time version when config version is empty", func(t *testing.T) {
+		cfg := &platform.Config{
+			Server: platform.ServerConfig{
+				Name:      "test-server",
+				Transport: "stdio",
+			},
+			Semantic: platform.SemanticConfig{Provider: "noop"},
+			Query:    platform.QueryConfig{Provider: "noop"},
+			Storage:  platform.StorageConfig{Provider: "noop"},
+		}
+
+		_, p, err := New(cfg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer func() {
+			if err := p.Close(); err != nil {
+				t.Logf("Close() error (non-fatal): %v", err)
+			}
+		}()
+
+		if cfg.Server.Version != Version {
+			t.Errorf("expected version %q, got %q", Version, cfg.Server.Version)
+		}
+	})
+
+	t.Run("preserves explicit config version", func(t *testing.T) {
+		cfg := &platform.Config{
+			Server: platform.ServerConfig{
+				Name:      "test-server",
+				Version:   "custom-v1",
+				Transport: "stdio",
+			},
+			Semantic: platform.SemanticConfig{Provider: "noop"},
+			Query:    platform.QueryConfig{Provider: "noop"},
+			Storage:  platform.StorageConfig{Provider: "noop"},
+		}
+
+		_, p, err := New(cfg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer func() {
+			if err := p.Close(); err != nil {
+				t.Logf("Close() error (non-fatal): %v", err)
+			}
+		}()
+
+		if cfg.Server.Version != "custom-v1" {
+			t.Errorf("expected version %q, got %q", "custom-v1", cfg.Server.Version)
+		}
+	})
+
 	t.Run("with invalid semantic provider", func(t *testing.T) {
 		cfg := &platform.Config{
 			Server: platform.ServerConfig{Name: "test"},

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -613,9 +613,6 @@ func applyServerDefaults(cfg *Config) {
 	if cfg.Server.Name == "" {
 		cfg.Server.Name = defaultServerName
 	}
-	if cfg.Server.Version == "" {
-		cfg.Server.Version = "1.0.0"
-	}
 	if cfg.Server.Transport == "" {
 		cfg.Server.Transport = "stdio"
 	}


### PR DESCRIPTION
## Summary

Three bug fixes for the admin portal and platform_info tool:

- **platform_info version**: When `server.version` is not set in YAML config, `platform_info` reported a hardcoded `"1.0.0"` instead of the actual build-time version (which the Admin UI system info page already displayed correctly). Now `internal/server.New()` sets the build-time ldflags version when config version is empty, and the hardcoded fallback in `applyServerDefaults()` is removed.
- **Replay inspector SQL corruption**: Replaying a successful audit event from the Inspector stripped newline characters from multi-line SQL. The `FieldInput` textarea used React's uncontrolled `defaultValue`, which is only set at mount time and lost newlines during the replay state transition. Replaced with a controlled `SqlTextarea` component (`value` + `onChange` via `useState`), keyed by `formVersion` so it reinitializes on each replay.
- **Browser back/forward broken**: The admin portal used pure React `useState` for routing with zero browser history integration. Clicking sidebar links updated component state but never called `history.pushState()`, so back/forward buttons navigated away from the site entirely. `AppShell` now syncs route state with `history.pushState` on navigate and listens for `popstate` on back/forward. URLs are clean paths (`/admin/tools`, `/admin/audit`) — the Go server's SPA handler already serves `index.html` for unmatched routes under `/admin/`.

## Changes

### Go backend (2 files)
| File | Change |
|------|--------|
| `pkg/platform/config.go` | Remove hardcoded `"1.0.0"` version default from `applyServerDefaults()` |
| `internal/server/server.go` | `New()` sets `cfg.Server.Version = Version` (ldflags) when config version is empty |
| `internal/server/server_test.go` | Two new test cases: version propagation when empty, explicit version preserved |

### Admin UI (2 files)
| File | Change |
|------|--------|
| `admin-ui/src/components/layout/AppShell.tsx` | Path-based routing via `history.pushState` + `popstate` listener; `readPath()` derives route from `window.location.pathname` stripping the Vite base prefix; deep-link tab fragments (`#help`) still work via URL hash |
| `admin-ui/src/pages/tools/ToolsPage.tsx` | New `SqlTextarea` controlled component replaces uncontrolled `<textarea defaultValue>` for SQL fields |

## Root causes

### Version fallback
`applyServerDefaults()` set `cfg.Server.Version = "1.0.0"` before the server factory could inject the build-time version. The platform package can't import `internal/server` (circular dependency), so the fix moves the fallback to `internal/server.New()` which has access to the ldflags `Version` variable.

### SQL newline stripping
React's `defaultValue` on `<textarea>` is only applied at mount time. When replaying an audit event, `FieldInput` was already mounted — React ignored the new `defaultValue` with the replayed SQL. The controlled component approach (`value` + `onChange`) ensures the textarea always reflects the current state, and since `FieldInput` is keyed by `formVersion`, React unmounts/remounts on replay so `useState` initializes with the correct value.

### Browser navigation
All navigation was `setState(path)` with no corresponding `history.pushState()` call. The browser history stack was never modified, so back/forward had nothing to navigate. The fix adds `pushState` on every navigate and a `popstate` listener to sync state when the user clicks back/forward.

## Test plan

- [ ] `make verify` passes (full CI suite including coverage, lint, security, mutation)
- [ ] `npm run build` in `admin-ui/` produces no TS errors
- [ ] **Version**: Call `platform_info` tool without `server.version` in config — returns build-time version, not `"1.0.0"`
- [ ] **Version**: Set `server.version: custom` in config — `platform_info` returns `"custom"`
- [ ] **SQL replay**: Open Inspector, find an audit event with multi-line SQL, click Replay — textarea shows proper newlines, query executes successfully
- [ ] **Navigation**: Click through sidebar pages, press browser Back — returns to previous page (not away from site)
- [ ] **Navigation**: Press browser Forward after Back — navigates forward correctly
- [ ] **Deep links**: Navigate to `/admin/tools` directly — loads Tools page
- [ ] **Tab deep links**: Navigate to `/admin/tools#help` — loads Tools page on Help tab
- [ ] **Refresh**: Refresh browser on `/admin/audit` — stays on Audit page (SPA fallback)