### PR TITLE
feat: omit empty column descriptions from semantic enrichment

### DIFF
--- a/pkg/semantic/types.go
+++ b/pkg/semantic/types.go
@@ -79,6 +79,20 @@ type ColumnContext struct {
 	InheritedFrom *InheritedMetadata `json:"inherited_from,omitempty"`
 }
 
+// HasContent reports whether the column has any meaningful metadata worth
+// including in enrichment responses. Columns with no description, tags,
+// glossary terms, sensitivity flags, business name, or inherited metadata
+// are considered empty and can be omitted to save tokens.
+func (c *ColumnContext) HasContent() bool {
+	return c.Description != "" ||
+		len(c.Tags) > 0 ||
+		len(c.GlossaryTerms) > 0 ||
+		c.IsPII ||
+		c.IsSensitive ||
+		c.BusinessName != "" ||
+		c.InheritedFrom != nil
+}
+
 // InheritedMetadata tracks the provenance of inherited column metadata.
 type InheritedMetadata struct {
 	// SourceURN is the DataHub URN of the upstream dataset.

--- a/pkg/semantic/types_test.go
+++ b/pkg/semantic/types_test.go
@@ -1,6 +1,8 @@
 package semantic
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestTableIdentifier_String(t *testing.T) {
 	tests := []struct {
@@ -30,6 +32,87 @@ func TestTableIdentifier_String(t *testing.T) {
 			got := tt.table.String()
 			if got != tt.want {
 				t.Errorf("TableIdentifier.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestColumnContext_HasContent(t *testing.T) {
+	tests := []struct {
+		name string
+		col  ColumnContext
+		want bool
+	}{
+		{
+			name: "empty column",
+			col:  ColumnContext{Name: "id"},
+			want: false,
+		},
+		{
+			name: "with description",
+			col:  ColumnContext{Name: "id", Description: "Primary key"},
+			want: true,
+		},
+		{
+			name: "with tags",
+			col:  ColumnContext{Name: "id", Tags: []string{"important"}},
+			want: true,
+		},
+		{
+			name: "with glossary terms",
+			col:  ColumnContext{Name: "id", GlossaryTerms: []GlossaryTerm{{URN: "urn:term", Name: "ID"}}},
+			want: true,
+		},
+		{
+			name: "with is_pii",
+			col:  ColumnContext{Name: "ssn", IsPII: true},
+			want: true,
+		},
+		{
+			name: "with is_sensitive",
+			col:  ColumnContext{Name: "salary", IsSensitive: true},
+			want: true,
+		},
+		{
+			name: "with business name",
+			col:  ColumnContext{Name: "loc_id", BusinessName: "Location ID"},
+			want: true,
+		},
+		{
+			name: "with inherited from",
+			col: ColumnContext{
+				Name: "user_id",
+				InheritedFrom: &InheritedMetadata{
+					SourceURN:    "urn:li:dataset:upstream",
+					SourceColumn: "id",
+					Hops:         1,
+					MatchMethod:  "name_exact",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "name only is not content",
+			col:  ColumnContext{Name: "some_column"},
+			want: false,
+		},
+		{
+			name: "empty tags slice is not content",
+			col:  ColumnContext{Name: "id", Tags: []string{}},
+			want: false,
+		},
+		{
+			name: "empty glossary terms slice is not content",
+			col:  ColumnContext{Name: "id", GlossaryTerms: []GlossaryTerm{}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.col.HasContent()
+			if got != tt.want {
+				t.Errorf("ColumnContext.HasContent() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Closes #130.

Semantic enrichment responses previously included a `column_context` entry for **every** column in a table, even when a column had zero meaningful metadata. For wide tables (70+ columns), ~90% of column entries carried no useful information, wasting 2,000+ tokens per query response.

This PR filters out columns with no meaningful metadata from enrichment responses:

- **Added `ColumnContext.HasContent()`** — centralizes the "is this column worth including?" check on the type itself. Returns `true` when any of the following are set: description, tags, glossary terms, PII flag, sensitivity flag, business name, or inherited metadata.
- **Filtered `buildColumnContexts()`** — skips columns where `HasContent()` returns `false`, so only columns with actual catalog metadata appear in responses.
- **Handled the all-filtered case** — when columns exist but none have metadata, a brief `column_context_note` is emitted instead of an empty `column_context` map, so agents still know columns exist but lack catalog coverage.
- Applied the same filtering to both `appendSemanticContextWithColumns()` (single-table tools like `trino_describe_table`) and `appendSemanticContextWithAdditional()` (multi-table SQL query enrichment).

## Files Changed

| File | Change |
|------|--------|
| `pkg/semantic/types.go` | Added `HasContent()` method on `ColumnContext` |
| `pkg/semantic/types_test.go` | 11 table-driven test cases covering each field, empty slices, and zero-value |
| `pkg/middleware/semantic.go` | Added `noteNoColumnMetadata` constant, filtering in `buildColumnContexts()`, note fallback in both `appendSemanticContext*` functions |
| `pkg/middleware/semantic_test.go` | 5 new test cases: empty column filtering, all-filtered note, mixed content/empty columns, in both `buildColumnContexts` and `appendSemanticContextWithColumns` |

## Before / After

**Before** (70-column table, 5 with descriptions):
```json
{
  "column_context": {
    "id": {"description": "", "tags": [], "glossary_terms": [], "is_pii": false, "is_sensitive": false},
    "col2": {"description": "", "tags": [], ...},
    ...65 more empty entries...
    "amount": {"description": "Transaction total", "tags": ["financial"], ...}
  }
}
```

**After**:
```json
{
  "column_context": {
    "amount": {"description": "Transaction total", "tags": ["financial"], ...},
    "user_id": {"description": "User identifier", "is_pii": true, ...}
  }
}
```

**When all columns lack metadata**:
```json
{
  "column_context_note": "No column-level metadata available"
}
```

## Test plan

- [x] `HasContent()` returns `false` for zero-value `ColumnContext` (name-only)
- [x] `HasContent()` returns `true` for each individual metadata field
- [x] `HasContent()` returns `false` for empty slices (`[]string{}`, `[]GlossaryTerm{}`)
- [x] `buildColumnContexts()` filters out empty columns, keeps content columns
- [x] `buildColumnContexts()` returns empty map when all columns lack content
- [x] `appendSemanticContextWithColumns()` emits `column_context_note` when all columns filtered
- [x] `appendSemanticContextWithColumns()` emits `column_context` (not note) when some columns have content
- [x] `make verify` passes (fmt, test, lint, security, coverage, dead-code, mutation, release-check)
- [x] `HasContent()` at 100% coverage