### PR TITLE
feat: filter column enrichment to SQL-referenced columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,7 @@ semantic:
 injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
+  column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
 ```
 
 ### Audit Logging

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ semantic:
 injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
+  column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
 
 audit:
   enabled: true

--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -246,6 +246,13 @@ injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
 
+  # Column context filtering
+  # Limits column-level semantic enrichment to only columns referenced
+  # in the SQL query. Saves tokens when queries touch a subset of wide tables.
+  # Only applies to SQL queries (trino_query); trino_describe_table always
+  # shows all columns. PII/sensitive columns are always included for safety.
+  # column_context_filtering: true   # Default: true
+
   # Session metadata deduplication
   # Avoids repeating large semantic metadata blocks for previously-enriched
   # tables within the same client session, saving LLM context tokens.

--- a/dev/platform.yaml
+++ b/dev/platform.yaml
@@ -187,6 +187,7 @@ query:
 injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
+  # column_context_filtering: true   # Default: true
 
 tuning:
   rules:

--- a/docs/cross-injection/overview.md
+++ b/docs/cross-injection/overview.md
@@ -326,6 +326,7 @@ injection:
   datahub_query_enrichment: true    # DataHub results show Trino availability
   datahub_storage_enrichment: true  # DataHub results show S3 availability
   s3_semantic_enrichment: true      # S3 results get DataHub context
+  column_context_filtering: true    # Only include SQL-referenced columns (default)
 
 # Configure the semantic provider (for Trino/S3 enrichment)
 semantic:
@@ -377,6 +378,7 @@ injection:
   datahub_query_enrichment: true
   datahub_storage_enrichment: true
   s3_semantic_enrichment: true
+  column_context_filtering: true    # Only include SQL-referenced columns (default)
 
 semantic:
   provider: datahub
@@ -590,6 +592,7 @@ Repeat calls return the raw tool result with no enrichment appended.
 ```yaml
 injection:
   trino_semantic_enrichment: true
+  column_context_filtering: true    # Only include SQL-referenced columns (default)
   session_dedup:
     enabled: true          # Default: true
     mode: reference        # reference (default), summary, none

--- a/docs/cross-injection/trino-datahub.md
+++ b/docs/cross-injection/trino-datahub.md
@@ -122,6 +122,7 @@ Enable Trino semantic enrichment:
 ```yaml
 injection:
   trino_semantic_enrichment: true
+  column_context_filtering: true     # Only include SQL-referenced columns (default)
 
 semantic:
   provider: datahub

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -84,6 +84,7 @@ toolkits:
 
 injection:
   trino_semantic_enrichment: true
+  column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
 
   # PII handling configuration
   enrichment:
@@ -272,6 +273,7 @@ toolkits:
 injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
+  column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
 
 semantic:
   provider: datahub
@@ -360,6 +362,7 @@ toolkits:
 injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
+  column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
 
 semantic:
   provider: datahub
@@ -483,6 +486,7 @@ toolkits:
 injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
+  column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
 
 # Full lineage depth for understanding data provenance
 semantic:
@@ -550,6 +554,7 @@ toolkits:
 
 injection:
   trino_semantic_enrichment: true
+  column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
 
   # Quality gates for feature selection
   quality_gates:
@@ -622,6 +627,7 @@ semantic:
 
 injection:
   trino_semantic_enrichment: true
+  column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
 
   # Include full lineage in enrichment
   enrichment:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -232,6 +232,7 @@ toolkits:
 injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
+  column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
 ```
 
 ## Server Configuration
@@ -420,6 +421,7 @@ The `database` store requires `database.dsn`. Database-backed sessions survive r
 | `trino_semantic_enrichment` | bool | false | Add DataHub context to Trino results |
 | `datahub_query_enrichment` | bool | false | Add Trino availability to DataHub results |
 | `s3_semantic_enrichment` | bool | false | Add DataHub context to S3 results |
+| `column_context_filtering` | bool | true | Limit column enrichment to SQL-referenced columns |
 
 ## URN Mapping Configuration
 
@@ -772,6 +774,7 @@ Session dedup tracks which tables have been enriched per client session. First c
 ```yaml
 injection:
   trino_semantic_enrichment: true
+  column_context_filtering: true    # Only include SQL-referenced columns (default)
   session_dedup:
     enabled: true          # Default: true
     mode: reference        # reference (default), summary, none

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -29,6 +29,7 @@
 - [S3 Enrichment](cross-injection/s3.md): S3 operations include semantic context
 - [Lineage Inheritance](cross-injection/lineage.md): Automatic column metadata inheritance from upstream datasets via DataHub lineage
 - [Session Dedup](cross-injection/overview.md#session-metadata-deduplication): Avoids repeating semantic metadata for previously-enriched tables within a session, saving LLM context tokens
+- [Column Context Filtering](cross-injection/trino-datahub.md#column-level-enrichment): Limits column-level enrichment to columns referenced in the SQL query, reducing token usage for wide tables (default: enabled)
 
 ## Authentication & Security
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -587,6 +587,7 @@ injection:
   datahub_query_enrichment: true
   s3_semantic_enrichment: true
   datahub_storage_enrichment: true
+  column_context_filtering: true
   session_dedup:
     enabled: true
     mode: reference
@@ -600,6 +601,7 @@ injection:
 | `datahub_query_enrichment` | bool | `false` | Enrich DataHub with Trino |
 | `s3_semantic_enrichment` | bool | `false` | Enrich S3 with DataHub |
 | `datahub_storage_enrichment` | bool | `false` | Enrich DataHub with S3 |
+| `column_context_filtering` | bool | `true` | Limit column enrichment to SQL-referenced columns |
 
 **Session Dedup** (`injection.session_dedup`):
 
@@ -766,6 +768,7 @@ injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
   s3_semantic_enrichment: true
+  column_context_filtering: true
   session_dedup:
     enabled: true
     mode: reference

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -56,6 +56,7 @@ injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
   s3_semantic_enrichment: true
+  column_context_filtering: true     # Only include SQL-referenced columns (default: true)
 ```
 
 ## Config Versioning
@@ -429,6 +430,7 @@ injection:
   datahub_query_enrichment: true     # Add Trino availability to DataHub results
   s3_semantic_enrichment: true       # Add DataHub context to S3 results
   datahub_storage_enrichment: true   # Add S3 availability to DataHub results
+  column_context_filtering: true     # Only include SQL-referenced columns (default: true)
 
   # Session metadata deduplication (avoids repeating metadata for same table)
   session_dedup:
@@ -444,6 +446,7 @@ injection:
 | `datahub_query_enrichment` | bool | `false` | Add query availability to DataHub search results |
 | `s3_semantic_enrichment` | bool | `false` | Enrich S3 results with DataHub metadata |
 | `datahub_storage_enrichment` | bool | `false` | Add S3 availability to DataHub results |
+| `column_context_filtering` | bool | `true` | Limit column enrichment to SQL-referenced columns |
 | `session_dedup.enabled` | bool | `true` | Whether session dedup is active |
 | `session_dedup.mode` | string | `reference` | Repeat query content: `reference`, `summary`, `none` |
 | `session_dedup.entry_ttl` | duration | semantic cache TTL | How long a table stays "already sent" |
@@ -769,6 +772,7 @@ injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
   s3_semantic_enrichment: true
+  column_context_filtering: true
 
 resources:
   enabled: true

--- a/docs/server/deployment.md
+++ b/docs/server/deployment.md
@@ -240,6 +240,7 @@ personas:
 injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
+  column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
 
 audit:
   enabled: true
@@ -416,6 +417,7 @@ config:
   injection:
     trino_semantic_enrichment: true
     datahub_query_enrichment: true
+    column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
 
   audit:
     enabled: true

--- a/docs/server/multi-provider.md
+++ b/docs/server/multi-provider.md
@@ -141,6 +141,7 @@ storage:
 injection:
   trino_semantic_enrichment: true   # All Trino results get DataHub context
   datahub_query_enrichment: true    # DataHub results show Trino availability
+  column_context_filtering: true    # Only enrich columns referenced in SQL (default: true)
 ```
 
 With this configuration:

--- a/docs/server/operating-modes.md
+++ b/docs/server/operating-modes.md
@@ -59,6 +59,7 @@ query:
 injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
+  column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
 
 personas:
   definitions:
@@ -148,6 +149,7 @@ query:
 injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
+  column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
 
 personas:
   definitions:

--- a/docs/server/overview.md
+++ b/docs/server/overview.md
@@ -100,6 +100,7 @@ toolkits:
 injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
+  column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
 ```
 
 ## Next Steps

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -523,6 +523,17 @@ injection:
   suppress_enrichment_warnings: true
 ```
 
+### Column enrichment shows all columns instead of referenced ones
+
+Column context filtering limits enrichment to columns mentioned in the SQL query. If you see all columns:
+
+```yaml
+injection:
+  column_context_filtering: true  # Default: true — set to false to include all columns
+```
+
+Note: `trino_describe_table` always returns all columns. Filtering only applies to `trino_query` results. PII/sensitive columns are always included regardless of this setting.
+
 ---
 
 ## Performance Issues

--- a/pkg/middleware/sqlident.go
+++ b/pkg/middleware/sqlident.go
@@ -1,0 +1,153 @@
+package middleware
+
+import "strings"
+
+// ExtractIdentifiers lexes a SQL string and returns all identifiers found,
+// lowercased. This is dialect-agnostic because it operates at the lexical
+// level (tokenization), not at the grammar level (parsing). String literals,
+// block comments, and line comments are skipped entirely. Double-quoted
+// identifiers are extracted and lowercased.
+//
+// The function runs in O(n) time with a single pass over the input.
+func ExtractIdentifiers(sql string) map[string]bool {
+	ids := make(map[string]bool)
+	n := len(sql)
+	pos := 0
+
+	for pos < n {
+		pos = lexOne(sql, pos, n, ids)
+	}
+
+	return ids
+}
+
+// lexOne processes one token at position pos and returns the next position.
+// Identifiers found are added to ids.
+func lexOne(sql string, pos, n int, ids map[string]bool) int {
+	ch := sql[pos]
+
+	if ch == '\'' {
+		return skipSingleQuoted(sql, pos, n)
+	}
+	if ch == '"' {
+		return lexDoubleQuoted(sql, pos, n, ids)
+	}
+	if isBlockCommentStart(sql, pos, n) {
+		return skipBlockComment(sql, pos, n)
+	}
+	if isLineCommentStart(sql, pos, n) {
+		return skipLineComment(sql, pos, n)
+	}
+	if isIdentStart(ch) {
+		return lexBareword(sql, pos, n, ids)
+	}
+	return pos + 1
+}
+
+// lexDoubleQuoted reads a double-quoted identifier and adds it to ids.
+func lexDoubleQuoted(sql string, pos, n int, ids map[string]bool) int {
+	id, next := readDoubleQuoted(sql, pos, n)
+	if id != "" {
+		ids[strings.ToLower(id)] = true
+	}
+	return next
+}
+
+// lexBareword reads a bareword identifier and adds it to ids.
+func lexBareword(sql string, pos, n int, ids map[string]bool) int {
+	word, next := readBareword(sql, pos, n)
+	ids[strings.ToLower(word)] = true
+	return next
+}
+
+// isBlockCommentStart returns true if pos is at the start of a block comment.
+func isBlockCommentStart(sql string, pos, n int) bool {
+	return sql[pos] == '/' && pos+1 < n && sql[pos+1] == '*'
+}
+
+// isLineCommentStart returns true if pos is at the start of a line comment.
+func isLineCommentStart(sql string, pos, n int) bool {
+	return sql[pos] == '-' && pos+1 < n && sql[pos+1] == '-'
+}
+
+// skipSingleQuoted advances past a single-quoted string literal, handling
+// escaped quotes (”).
+func skipSingleQuoted(sql string, pos, n int) int {
+	pos++ // skip opening quote
+	for pos < n {
+		if sql[pos] == '\'' {
+			pos++
+			// '' is an escaped quote inside the literal
+			if pos < n && sql[pos] == '\'' {
+				pos++
+				continue
+			}
+			return pos
+		}
+		pos++
+	}
+	return pos
+}
+
+// readDoubleQuoted reads a double-quoted identifier and returns it along
+// with the position after the closing quote. Double-quotes inside are
+// escaped as "".
+func readDoubleQuoted(sql string, pos, n int) (id string, next int) {
+	pos++ // skip opening quote
+	var b strings.Builder
+	for pos < n {
+		if sql[pos] == '"' {
+			pos++
+			// "" is an escaped double-quote inside the identifier
+			if pos < n && sql[pos] == '"' {
+				b.WriteByte('"')
+				pos++
+				continue
+			}
+			return b.String(), pos
+		}
+		b.WriteByte(sql[pos])
+		pos++
+	}
+	return b.String(), pos
+}
+
+// skipBlockComment advances past a /* ... */ block comment.
+func skipBlockComment(sql string, pos, n int) int {
+	pos += 2 // skip /*
+	for pos+1 < n {
+		if sql[pos] == '*' && sql[pos+1] == '/' {
+			return pos + 2
+		}
+		pos++
+	}
+	return n
+}
+
+// skipLineComment advances past a -- line comment to end of line.
+func skipLineComment(sql string, pos, n int) int {
+	pos += 2 // skip --
+	for pos < n && sql[pos] != '\n' {
+		pos++
+	}
+	return pos
+}
+
+// readBareword reads an unquoted identifier (letters, digits, underscores).
+func readBareword(sql string, pos, n int) (word string, next int) {
+	start := pos
+	for pos < n && isIdentChar(sql[pos]) {
+		pos++
+	}
+	return sql[start:pos], pos
+}
+
+// isIdentStart returns true if ch can start an identifier (letter or underscore).
+func isIdentStart(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_'
+}
+
+// isIdentChar returns true if ch can continue an identifier.
+func isIdentChar(ch byte) bool {
+	return isIdentStart(ch) || (ch >= '0' && ch <= '9')
+}

--- a/pkg/middleware/sqlident_test.go
+++ b/pkg/middleware/sqlident_test.go
@@ -1,0 +1,183 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractIdentifiers(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		wantSet  map[string]bool // identifiers that MUST be present
+		wantSkip []string        // tokens that must NOT be present
+	}{
+		{
+			name:    "simple SELECT",
+			sql:     "SELECT id, name FROM users WHERE age > 30",
+			wantSet: map[string]bool{"select": true, "id": true, "name": true, "from": true, "users": true, "where": true, "age": true},
+		},
+		{
+			name:    "case insensitive",
+			sql:     "SELECT Id, NAME from Users",
+			wantSet: map[string]bool{"select": true, "id": true, "name": true, "from": true, "users": true},
+		},
+		{
+			name:    "string literals are skipped",
+			sql:     "SELECT * FROM t WHERE name = 'John O''Brien'",
+			wantSet: map[string]bool{"select": true, "t": true, "name": true, "where": true},
+			wantSkip: []string{
+				"john",  // inside string literal
+				"brien", // inside string literal
+				"o",     // inside string literal (before escaped quote)
+			},
+		},
+		{
+			name:    "double-quoted identifiers are extracted",
+			sql:     `SELECT "MyColumn" FROM "My Table"`,
+			wantSet: map[string]bool{"select": true, "from": true, "mycolumn": true, "my table": true},
+		},
+		{
+			name: "double-quoted escaped quotes",
+			sql:  `SELECT "col""name" FROM t`,
+			wantSet: map[string]bool{
+				"select":   true,
+				"from":     true,
+				"t":        true,
+				`col"name`: true,
+			},
+		},
+		{
+			name:     "block comments are skipped",
+			sql:      "SELECT /* this is id, name */ col1 FROM t",
+			wantSet:  map[string]bool{"select": true, "col1": true, "from": true, "t": true},
+			wantSkip: []string{"this", "is"},
+		},
+		{
+			name:     "line comments are skipped",
+			sql:      "SELECT col1 -- this is a comment\nFROM t",
+			wantSet:  map[string]bool{"select": true, "col1": true, "from": true, "t": true},
+			wantSkip: []string{"this", "is", "a", "comment"},
+		},
+		{
+			name:    "empty input",
+			sql:     "",
+			wantSet: map[string]bool{},
+		},
+		{
+			name:    "only whitespace",
+			sql:     "   \t\n  ",
+			wantSet: map[string]bool{},
+		},
+		{
+			name:    "numbers and operators are skipped",
+			sql:     "SELECT 123 + col FROM t WHERE x = 42",
+			wantSet: map[string]bool{"select": true, "col": true, "from": true, "t": true, "where": true, "x": true},
+		},
+		{
+			name:    "dotted identifiers become separate tokens",
+			sql:     "SELECT t.col1, s.col2 FROM myschema.mytable t",
+			wantSet: map[string]bool{"select": true, "t": true, "col1": true, "s": true, "col2": true, "from": true, "myschema": true, "mytable": true},
+		},
+		{
+			name:    "underscored identifiers",
+			sql:     "SELECT _private, my_col_2 FROM my_table_v3",
+			wantSet: map[string]bool{"select": true, "_private": true, "my_col_2": true, "from": true, "my_table_v3": true},
+		},
+		{
+			name: "complex Trino ES raw_query with embedded JSON",
+			sql: `SELECT JSON_EXTRACT_SCALAR(doc, '$.location_type_id') AS location_type_id,
+                    JSON_EXTRACT_SCALAR(doc, '$.total_amount') AS total_amount
+             FROM TABLE(elasticsearch.default.raw_query(
+                    'transactions',
+                    '{ "size": 0, "aggs": { "by_loc": { "terms": { "field": "location_type_id" }, "aggs": { "total": { "sum": { "field": "total_amount" } } } } } }'
+                  )) t(doc)`,
+			wantSet: map[string]bool{
+				"select":              true,
+				"json_extract_scalar": true,
+				"doc":                 true,
+				"as":                  true,
+				"location_type_id":    true,
+				"total_amount":        true,
+				"from":                true,
+				"table":               true,
+				"elasticsearch":       true,
+				"default":             true,
+				"raw_query":           true,
+				"t":                   true,
+			},
+			wantSkip: []string{
+				"size",  // inside JSON string literal
+				"aggs",  // inside JSON string literal
+				"field", // inside JSON string literal
+			},
+		},
+		{
+			name:    "CROSS JOIN UNNEST pattern",
+			sql:     "SELECT t.id, u.val FROM mytable t CROSS JOIN UNNEST(t.items) AS u(val)",
+			wantSet: map[string]bool{"select": true, "t": true, "id": true, "u": true, "val": true, "from": true, "mytable": true, "cross": true, "join": true, "unnest": true, "items": true, "as": true},
+		},
+		{
+			name:     "unterminated string at end",
+			sql:      "SELECT col FROM t WHERE name = 'unterminated",
+			wantSet:  map[string]bool{"select": true, "col": true, "from": true, "t": true, "where": true, "name": true},
+			wantSkip: []string{"unterminated"},
+		},
+		{
+			name:     "unterminated block comment at end",
+			sql:      "SELECT col /* still going",
+			wantSet:  map[string]bool{"select": true, "col": true},
+			wantSkip: []string{"still", "going"},
+		},
+		{
+			name:    "unterminated double-quoted identifier",
+			sql:     `SELECT "never_closed`,
+			wantSet: map[string]bool{"select": true, "never_closed": true},
+		},
+		{
+			name:    "mixed comments and strings",
+			sql:     "SELECT /* skip 'this' */ col -- 'and this'\nFROM t WHERE x = 'literal'",
+			wantSet: map[string]bool{"select": true, "col": true, "from": true, "t": true, "where": true, "x": true},
+			wantSkip: []string{
+				"skip",    // inside block comment
+				"and",     // inside line comment
+				"literal", // inside string
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractIdentifiers(tt.sql)
+
+			for id := range tt.wantSet {
+				assert.True(t, got[id], "expected identifier %q to be present", id)
+			}
+			for _, id := range tt.wantSkip {
+				assert.False(t, got[id], "expected identifier %q to NOT be present", id)
+			}
+		})
+	}
+}
+
+func TestExtractIdentifiers_EmptyResult(t *testing.T) {
+	got := ExtractIdentifiers("42 + 3.14 / (2 - 1)")
+	// Only operators and numbers — no identifiers
+	assert.Empty(t, got)
+}
+
+func TestSkipSingleQuoted_EscapedQuotes(t *testing.T) {
+	// Verify internal helper directly: 'it''s a test'
+	sql := "'it''s a test' rest"
+	pos := skipSingleQuoted(sql, 0, len(sql))
+	// Should end right after the closing quote, before " rest"
+	assert.Equal(t, len("'it''s a test'"), pos)
+}
+
+func TestReadDoubleQuoted_EscapedQuotes(t *testing.T) {
+	sql := `"col""name" rest`
+	id, pos := readDoubleQuoted(sql, 0, len(sql))
+	assert.Equal(t, `col"name`, id)
+	assert.Equal(t, len(`"col""name"`), pos)
+}

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -315,6 +315,20 @@ type InjectionConfig struct {
 	DataHubStorageEnrichment bool               `yaml:"datahub_storage_enrichment"`
 	EstimateRowCounts        bool               `yaml:"estimate_row_counts"`
 	SessionDedup             SessionDedupConfig `yaml:"session_dedup"`
+
+	// ColumnContextFiltering limits column-level semantic enrichment to
+	// columns referenced in the SQL query. Saves tokens when queries
+	// touch a subset of a wide table. Defaults to true (nil = enabled).
+	ColumnContextFiltering *bool `yaml:"column_context_filtering"`
+}
+
+// IsColumnContextFilteringEnabled returns whether column context filtering
+// is enabled, defaulting to true when not explicitly set.
+func (c *InjectionConfig) IsColumnContextFilteringEnabled() bool {
+	if c.ColumnContextFiltering == nil {
+		return true
+	}
+	return *c.ColumnContextFiltering
 }
 
 // SessionDedupConfig configures session-level metadata deduplication.

--- a/pkg/platform/config_test.go
+++ b/pkg/platform/config_test.go
@@ -1094,3 +1094,52 @@ server:
 		}
 	})
 }
+
+func TestInjectionConfig_IsColumnContextFilteringEnabled(t *testing.T) {
+	t.Run("nil defaults to true", func(t *testing.T) {
+		cfg := &InjectionConfig{}
+		if !cfg.IsColumnContextFilteringEnabled() {
+			t.Error("expected nil ColumnContextFiltering to default to true")
+		}
+	})
+
+	t.Run("explicit true", func(t *testing.T) {
+		v := true
+		cfg := &InjectionConfig{ColumnContextFiltering: &v}
+		if !cfg.IsColumnContextFilteringEnabled() {
+			t.Error("expected explicit true to return true")
+		}
+	})
+
+	t.Run("explicit false", func(t *testing.T) {
+		v := false
+		cfg := &InjectionConfig{ColumnContextFiltering: &v}
+		if cfg.IsColumnContextFilteringEnabled() {
+			t.Error("expected explicit false to return false")
+		}
+	})
+
+	t.Run("YAML loading with column_context_filtering false", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+injection:
+  column_context_filtering: false
+`)
+		if cfg.Injection.IsColumnContextFilteringEnabled() {
+			t.Error("expected column_context_filtering: false to disable filtering")
+		}
+	})
+
+	t.Run("YAML loading without column_context_filtering", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+injection:
+  trino_semantic_enrichment: true
+`)
+		if !cfg.Injection.IsColumnContextFilteringEnabled() {
+			t.Error("expected missing column_context_filtering to default to true")
+		}
+	})
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -904,6 +904,7 @@ func (p *Platform) buildEnrichmentConfig() middleware.EnrichmentConfig {
 		EnrichS3Results:             p.config.Injection.S3SemanticEnrichment,
 		EnrichDataHubStorageResults: p.config.Injection.DataHubStorageEnrichment,
 		ResourceLinksEnabled:        p.config.Resources.Enabled,
+		ColumnContextFiltering:      p.config.Injection.IsColumnContextFilteringEnabled(),
 	}
 
 	if p.config.Injection.SessionDedup.IsEnabled() {


### PR DESCRIPTION
## Summary

Closes #132

When enriching Trino query results with semantic column metadata from DataHub, the platform previously included **all** columns with metadata — even if the query only referenced 3 of 70 columns. This wastes LLM context tokens on irrelevant column descriptions.

This PR filters column-level enrichment to only columns whose names appear in the SQL query, with safety guarantees:

- **SQL lexer** (`pkg/middleware/sqlident.go`): Dialect-agnostic, single-pass O(n) state machine that extracts identifiers from SQL text. Skips string literals (including embedded JSON in Trino ES `raw_query`), block comments, and line comments. Handles double-quoted identifiers and escaped quotes.
- **Column intersection**: After fetching column metadata from the semantic provider, intersects column names with SQL identifiers.
- **Safety-relevant columns always included**: PII, sensitive, and critical-tag columns are never filtered out, regardless of whether they appear in the SQL.
- **Graceful degradation**: If zero column names match (e.g., `SELECT *`), all columns are returned.
- **Scope**: Only applies to `trino_query` (SQL path). `trino_describe_table` always returns all columns since the user is explicitly asking about the table structure.
- **Default: enabled** via `column_context_filtering: true` (nil defaults to true, `*bool` pattern matching existing `session_dedup.enabled`).

## Key Design Decisions

**Why a lexer instead of a SQL parser?**
No Go SQL parser supports Trino natively. PostgreSQL/MySQL parsers fail on `TABLE()` functions, `CROSS JOIN UNNEST`, `JSON_EXTRACT_SCALAR`, and nested JSON string literals inside `raw_query`. A lexer operates at the tokenization level (dialect-agnostic) rather than the grammar level, making it robust across all SQL dialects.

**Why include PII/sensitive columns unconditionally?**
An LLM that doesn't see PII warnings might inadvertently expose sensitive data in its response. Including these columns ensures the model always has the safety context it needs.

## Files Changed

### New Files
| File | Description |
|------|-------------|
| `pkg/middleware/sqlident.go` | SQL identifier lexer — `ExtractIdentifiers()` with helpers for each token type |
| `pkg/middleware/sqlident_test.go` | 18 table-driven test cases including complex Trino ES `raw_query` with embedded JSON |

### Modified (Implementation)
| File | Change |
|------|--------|
| `pkg/middleware/semantic.go` | Added `filterColumnsBySQL()`, `isSafetyRelevant()`, wired into enrichment pipeline |
| `pkg/middleware/semantic_test.go` | Added `TestFilterColumnsBySQL` (7 subtests), `TestIsSafetyRelevant` (9 subtests), `TestEnrichTrinoResult_ColumnFiltering` (3 subtests); updated mocks and existing call sites |
| `pkg/platform/config.go` | Added `ColumnContextFiltering *bool` to `InjectionConfig` with `IsColumnContextFilteringEnabled()` |
| `pkg/platform/config_test.go` | 5 config tests (nil defaults, explicit true/false, YAML loading) |
| `pkg/platform/platform.go` | Wired config into `buildEnrichmentConfig()` |

### Modified (Configuration)
| File | Change |
|------|--------|
| `configs/platform.yaml` | Added commented-out `column_context_filtering` option |
| `dev/platform.yaml` | Added commented-out `column_context_filtering` option |

### Modified (Documentation — 14 files)
All injection config blocks across documentation now include `column_context_filtering`:
CLAUDE.md, README.md, `docs/llms.txt`, `docs/llms-full.txt`, `docs/server/configuration.md`, `docs/server/deployment.md`, `docs/server/overview.md`, `docs/server/operating-modes.md`, `docs/server/multi-provider.md`, `docs/reference/configuration.md`, `docs/cross-injection/overview.md`, `docs/cross-injection/trino-datahub.md`, `docs/examples/index.md`, `docs/support/troubleshooting.md`

## Test Plan

- [x] `make verify` passes (all checks green)
- [x] 100% coverage on all new functions
- [x] Lexer handles: simple SQL, complex Trino ES `raw_query` with embedded JSON, `CROSS JOIN UNNEST`, string escaping (`''`), double-quoted identifiers (`""`), block/line comments, unterminated tokens, empty input
- [x] Column filtering: referenced columns only, PII/sensitive always included, empty SQL returns all, zero matches returns all, case-insensitive matching
- [x] Config: nil defaults to true, explicit true/false, YAML round-trip
- [x] Existing enrichment tests updated and passing (no regressions)
- [x] `trino_describe_table` path unchanged (always shows all columns)