### PR TITLE
feat: surface curated query availability in DataHub search enrichment

### DIFF
--- a/pkg/middleware/middleware_chain_test.go
+++ b/pkg/middleware/middleware_chain_test.go
@@ -399,6 +399,10 @@ func (*mockSemanticProvider) GetGlossaryTerm(_ context.Context, _ string) (*sema
 func (m *mockSemanticProvider) SearchTables(_ context.Context, _ semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
 	return m.searchResults, nil
 }
+
+func (*mockSemanticProvider) GetCuratedQueryCount(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
 func (*mockSemanticProvider) Close() error { return nil }
 
 // mockQueryProvider returns canned query availability.

--- a/pkg/platform/resource_templates_test.go
+++ b/pkg/platform/resource_templates_test.go
@@ -111,6 +111,10 @@ func (*mockSemanticProvider) SearchTables(_ context.Context, _ semantic.SearchFi
 	return nil, nil //nolint:nilnil // mock stub: unused method required by interface
 }
 
+func (*mockSemanticProvider) GetCuratedQueryCount(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+
 func (*mockSemanticProvider) Close() error { return nil }
 
 // mockQueryProvider implements query.Provider for testing.

--- a/pkg/semantic/datahub/adapter.go
+++ b/pkg/semantic/datahub/adapter.go
@@ -55,6 +55,7 @@ type Client interface {
 	GetLineage(ctx context.Context, urn string, opts ...dhclient.LineageOption) (*types.LineageResult, error)
 	GetColumnLineage(ctx context.Context, urn string) (*types.ColumnLineage, error)
 	GetGlossaryTerm(ctx context.Context, urn string) (*types.GlossaryTerm, error)
+	GetQueries(ctx context.Context, urn string) (*types.QueryList, error)
 	Ping(ctx context.Context) error
 	Close() error
 }
@@ -273,6 +274,15 @@ func (a *Adapter) SearchTables(ctx context.Context, filter semantic.SearchFilter
 	}
 
 	return results, nil
+}
+
+// GetCuratedQueryCount returns the number of curated/saved queries for a dataset.
+func (a *Adapter) GetCuratedQueryCount(ctx context.Context, urn string) (int, error) {
+	queries, err := a.client.GetQueries(ctx, urn)
+	if err != nil {
+		return 0, fmt.Errorf("getting curated query count: %w", err)
+	}
+	return queries.Total, nil
 }
 
 // Close releases resources.

--- a/pkg/semantic/noop.go
+++ b/pkg/semantic/noop.go
@@ -49,6 +49,11 @@ func (*NoopProvider) SearchTables(_ context.Context, _ SearchFilter) ([]TableSea
 	return []TableSearchResult{}, nil
 }
 
+// GetCuratedQueryCount returns zero for the noop provider.
+func (*NoopProvider) GetCuratedQueryCount(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+
 // Close does nothing.
 func (*NoopProvider) Close() error {
 	return nil

--- a/pkg/semantic/noop_test.go
+++ b/pkg/semantic/noop_test.go
@@ -101,6 +101,18 @@ func TestNoopProvider_SearchTables(t *testing.T) {
 	}
 }
 
+func TestNoopProvider_GetCuratedQueryCount(t *testing.T) {
+	provider := NewNoopProvider()
+	ctx := context.Background()
+	count, err := provider.GetCuratedQueryCount(ctx, "urn:li:dataset:test")
+	if err != nil {
+		t.Errorf("GetCuratedQueryCount() error = %v", err)
+	}
+	if count != 0 {
+		t.Errorf("GetCuratedQueryCount() = %d, want 0", count)
+	}
+}
+
 func TestNoopProvider_Close(t *testing.T) {
 	provider := NewNoopProvider()
 	if err := provider.Close(); err != nil {

--- a/pkg/semantic/provider.go
+++ b/pkg/semantic/provider.go
@@ -26,6 +26,9 @@ type Provider interface {
 	// SearchTables searches for tables matching the filter.
 	SearchTables(ctx context.Context, filter SearchFilter) ([]TableSearchResult, error)
 
+	// GetCuratedQueryCount returns the number of curated/saved queries for a dataset.
+	GetCuratedQueryCount(ctx context.Context, urn string) (int, error)
+
 	// Close releases resources.
 	Close() error
 }

--- a/pkg/toolkits/trino/elicitation_test.go
+++ b/pkg/toolkits/trino/elicitation_test.go
@@ -431,6 +431,10 @@ func (*mockSemanticProvider) SearchTables(_ context.Context, _ semantic.SearchFi
 	return nil, nil //nolint:nilnil // mock returns zero values
 }
 
+func (*mockSemanticProvider) GetCuratedQueryCount(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+
 func (*mockSemanticProvider) Close() error { return nil }
 
 func TestClientSupportsElicitation(t *testing.T) {
@@ -651,6 +655,10 @@ func (*errSemanticProvider) GetGlossaryTerm(_ context.Context, _ string) (*seman
 
 func (*errSemanticProvider) SearchTables(_ context.Context, _ semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
 	return nil, nil //nolint:nilnil // mock
+}
+
+func (*errSemanticProvider) GetCuratedQueryCount(_ context.Context, _ string) (int, error) {
+	return 0, nil
 }
 func (*errSemanticProvider) Close() error { return nil }
 


### PR DESCRIPTION
## Summary

Implements **Part A** of #133 — surfaces curated query availability in DataHub search results so agents discover saved queries without the 3-call discovery chain.

- When `datahub_search` returns results, the enrichment middleware now calls `semantic.Provider.GetCuratedQueryCount()` for each URN and appends a `curated_query_context` block for datasets that have curated queries
- URNs with zero curated queries are omitted entirely (no `has_curated_queries: false` noise)
- Agents can then fetch the actual queries with a single `datahub_get_queries(urn)` call
- **Discovery path reduced from 3 calls → 2 calls** (`datahub_search` → `datahub_get_queries`)

### Parts B and C status

- **Part C (curated query execution tool) — dropped**: curated queries are examples with hardcoded values, not parameterized templates. The agent is better served studying the pattern and writing its own query via `trino_query`.
- **Part B (curated query creation) — blocked**: mcp-datahub has no write API for Query entities. Upstream issue: [txn2/mcp-datahub#62](https://github.com/txn2/mcp-datahub/issues/62). Downstream tracking: #141.

## Changes

### Interface (`pkg/semantic/provider.go`)
- Added `GetCuratedQueryCount(ctx, urn) (int, error)` to `semantic.Provider`

### DataHub adapter (`pkg/semantic/datahub/adapter.go`)
- Added `GetQueries` to the local `Client` interface
- Implemented `GetCuratedQueryCount` via existing `client.GetQueries().Total` — no changes to mcp-datahub needed

### Cache (`pkg/semantic/cache.go`)
- New `curatedQueryCache` map with the same TTL as other caches (default 5m)
- Cleared on `Invalidate()`

### Noop (`pkg/semantic/noop.go`)
- Returns `0, nil`

### Enrichment middleware (`pkg/middleware/semantic.go`)
- New `enrichDataHubResultWithCuratedQueries()` — extracts URNs, calls `GetCuratedQueryCount`, skips zeros and errors
- New `appendCuratedQueryContext()` — serializes to JSON content block
- Wired into `enrichDataHubResultWithAll()` gated by `EnrichDataHubResults` config + non-nil semantic provider
- Extracted `enrichDataHubQueryAndStorage()` helper to keep cyclomatic complexity ≤10

### Output format

```json
{
  "curated_query_context": {
    "urn:li:dataset:(urn:li:dataPlatform:trino,rdbms.public.sale_events,PROD)": {
      "has_curated_queries": true,
      "curated_query_count": 3
    }
  }
}
```

## Test plan

- [x] `TestGetCuratedQueryCount` — adapter success, empty, and error paths
- [x] `TestCachedProvider_GetCuratedQueryCount_Caches` — verifies cache hit with call counting
- [x] `TestCachedProvider_GetCuratedQueryCount_Expires` — verifies cache expiry triggers re-fetch
- [x] `TestNoopProvider_GetCuratedQueryCount` — returns 0
- [x] `TestEnrichDataHubResultWithCuratedQueries` — URN extraction, count inclusion, zero omission, error graceful skip
- [x] `TestEnrichDataHubResultWithAll` — curated context in combined enrichment, nil provider guard
- [x] `make verify` passes all gates (fmt, test, lint, security, coverage ≥80%, mutation ≥60%, release-check)

Closes #133 (Part A).