### PR TITLE
feat: anticipatory schema preview in search results

### DIFF
--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -246,6 +246,13 @@ injection:
   trino_semantic_enrichment: true
   datahub_query_enrichment: true
 
+  # Search schema preview
+  # Adds a bounded column-name+type preview to datahub_search query_context
+  # for available tables, so agents can write SQL without an intermediate
+  # datahub_get_schema or trino_describe_table call.
+  # search_schema_preview: true            # Default: true
+  # schema_preview_max_columns: 15         # Default: 15
+
   # Column context filtering
   # Limits column-level semantic enrichment to only columns referenced
   # in the SQL query. Saves tokens when queries touch a subset of wide tables.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -422,6 +422,8 @@ The `database` store requires `database.dsn`. Database-backed sessions survive r
 | `datahub_query_enrichment` | bool | false | Add Trino availability to DataHub results |
 | `s3_semantic_enrichment` | bool | false | Add DataHub context to S3 results |
 | `column_context_filtering` | bool | true | Limit column enrichment to SQL-referenced columns |
+| `search_schema_preview` | bool | true | Add bounded column-name+type preview to datahub_search query_context |
+| `schema_preview_max_columns` | int | 15 | Max columns per entity in schema preview |
 
 ## URN Mapping Configuration
 
@@ -638,22 +640,30 @@ Five calls to understand one table. With cross-injection, step 1 gives you every
 
 ## Query Context (added to DataHub results)
 
+When `search_schema_preview` is enabled (default), available tables also include a bounded column preview so agents can write SQL without an intermediate `datahub_get_schema` call:
+
 ```json
 {
   "query_context": {
     "urn:li:dataset:orders": {
-      "queryable": true,
+      "available": true,
+      "query_table": "hive.sales.orders",
       "connection": "production",
-      "table_identifier": {
-        "catalog": "hive",
-        "schema": "sales",
-        "table": "orders"
-      },
-      "sample_query": "SELECT * FROM hive.sales.orders LIMIT 10"
+      "estimated_rows": 1500000,
+      "schema_preview": [
+        {"name": "order_id", "type": "integer"},
+        {"name": "customer_id", "type": "integer"},
+        {"name": "order_date", "type": "date"},
+        {"name": "total_amount", "type": "decimal(10,2)"},
+        {"name": "status", "type": "varchar"}
+      ],
+      "total_columns": 42
     }
   }
 }
 ```
+
+Primary key columns are listed first. `total_columns` indicates when the preview is truncated. The preview is omitted (not empty) when schema lookup fails or the table is unavailable.
 
 ## Lineage-Aware Column Inheritance
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -30,6 +30,7 @@
 - [Lineage Inheritance](cross-injection/lineage.md): Automatic column metadata inheritance from upstream datasets via DataHub lineage
 - [Session Dedup](cross-injection/overview.md#session-metadata-deduplication): Avoids repeating semantic metadata for previously-enriched tables within a session, saving LLM context tokens
 - [Column Context Filtering](cross-injection/trino-datahub.md#column-level-enrichment): Limits column-level enrichment to columns referenced in the SQL query, reducing token usage for wide tables (default: enabled)
+- [Schema Preview](cross-injection/datahub-trino.md#schema-preview): Adds bounded column-name+type preview to datahub_search query_context, eliminating intermediate datahub_get_schema calls (default: enabled, max 15 columns)
 
 ## Authentication & Security
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -588,6 +588,8 @@ injection:
   s3_semantic_enrichment: true
   datahub_storage_enrichment: true
   column_context_filtering: true
+  search_schema_preview: true
+  schema_preview_max_columns: 15
   session_dedup:
     enabled: true
     mode: reference
@@ -602,6 +604,8 @@ injection:
 | `s3_semantic_enrichment` | bool | `false` | Enrich S3 with DataHub |
 | `datahub_storage_enrichment` | bool | `false` | Enrich DataHub with S3 |
 | `column_context_filtering` | bool | `true` | Limit column enrichment to SQL-referenced columns |
+| `search_schema_preview` | bool | `true` | Add column preview to search query_context |
+| `schema_preview_max_columns` | int | `15` | Max columns per entity in schema preview |
 
 **Session Dedup** (`injection.session_dedup`):
 
@@ -769,6 +773,8 @@ injection:
   datahub_query_enrichment: true
   s3_semantic_enrichment: true
   column_context_filtering: true
+  search_schema_preview: true
+  schema_preview_max_columns: 15
   session_dedup:
     enabled: true
     mode: reference

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -320,6 +320,16 @@ type InjectionConfig struct {
 	// columns referenced in the SQL query. Saves tokens when queries
 	// touch a subset of a wide table. Defaults to true (nil = enabled).
 	ColumnContextFiltering *bool `yaml:"column_context_filtering"`
+
+	// SearchSchemaPreview adds a bounded column-name+type preview to
+	// datahub_search query_context, eliminating the intermediate
+	// datahub_get_schema or trino_describe_table call before writing SQL.
+	// Defaults to true (nil = enabled).
+	SearchSchemaPreview *bool `yaml:"search_schema_preview"`
+
+	// SchemaPreviewMaxColumns caps how many columns appear in each
+	// schema preview. Defaults to 15 (nil = 15).
+	SchemaPreviewMaxColumns *int `yaml:"schema_preview_max_columns"`
 }
 
 // IsColumnContextFilteringEnabled returns whether column context filtering
@@ -329,6 +339,27 @@ func (c *InjectionConfig) IsColumnContextFilteringEnabled() bool {
 		return true
 	}
 	return *c.ColumnContextFiltering
+}
+
+// defaultSchemaPreviewMaxColumns is the default cap for schema preview columns.
+const defaultSchemaPreviewMaxColumns = 15
+
+// IsSearchSchemaPreviewEnabled returns whether search schema preview
+// is enabled, defaulting to true when not explicitly set.
+func (c *InjectionConfig) IsSearchSchemaPreviewEnabled() bool {
+	if c.SearchSchemaPreview == nil {
+		return true
+	}
+	return *c.SearchSchemaPreview
+}
+
+// EffectiveSchemaPreviewMaxColumns returns the configured max columns
+// for schema preview, defaulting to 15 when not explicitly set.
+func (c *InjectionConfig) EffectiveSchemaPreviewMaxColumns() int {
+	if c.SchemaPreviewMaxColumns == nil {
+		return defaultSchemaPreviewMaxColumns
+	}
+	return *c.SchemaPreviewMaxColumns
 }
 
 // SessionDedupConfig configures session-level metadata deduplication.

--- a/pkg/platform/config_test.go
+++ b/pkg/platform/config_test.go
@@ -1143,3 +1143,69 @@ injection:
 		}
 	})
 }
+
+func TestInjectionConfig_IsSearchSchemaPreviewEnabled(t *testing.T) {
+	t.Run("nil defaults to true", func(t *testing.T) {
+		cfg := &InjectionConfig{}
+		if !cfg.IsSearchSchemaPreviewEnabled() {
+			t.Error("expected nil SearchSchemaPreview to default to true")
+		}
+	})
+
+	t.Run("explicit true", func(t *testing.T) {
+		v := true
+		cfg := &InjectionConfig{SearchSchemaPreview: &v}
+		if !cfg.IsSearchSchemaPreviewEnabled() {
+			t.Error("expected explicit true to return true")
+		}
+	})
+
+	t.Run("explicit false", func(t *testing.T) {
+		v := false
+		cfg := &InjectionConfig{SearchSchemaPreview: &v}
+		if cfg.IsSearchSchemaPreviewEnabled() {
+			t.Error("expected explicit false to return false")
+		}
+	})
+
+	t.Run("YAML loading with search_schema_preview false", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+injection:
+  search_schema_preview: false
+`)
+		if cfg.Injection.IsSearchSchemaPreviewEnabled() {
+			t.Error("expected search_schema_preview: false to disable")
+		}
+	})
+}
+
+func TestInjectionConfig_EffectiveSchemaPreviewMaxColumns(t *testing.T) {
+	t.Run("nil defaults to 15", func(t *testing.T) {
+		cfg := &InjectionConfig{}
+		if cfg.EffectiveSchemaPreviewMaxColumns() != defaultSchemaPreviewMaxColumns {
+			t.Errorf("expected %d, got %d", defaultSchemaPreviewMaxColumns, cfg.EffectiveSchemaPreviewMaxColumns())
+		}
+	})
+
+	t.Run("explicit value", func(t *testing.T) {
+		v := 5
+		cfg := &InjectionConfig{SchemaPreviewMaxColumns: &v}
+		if cfg.EffectiveSchemaPreviewMaxColumns() != 5 {
+			t.Errorf("expected 5, got %d", cfg.EffectiveSchemaPreviewMaxColumns())
+		}
+	})
+
+	t.Run("YAML loading", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+injection:
+  schema_preview_max_columns: 10
+`)
+		if cfg.Injection.EffectiveSchemaPreviewMaxColumns() != 10 {
+			t.Errorf("expected 10, got %d", cfg.Injection.EffectiveSchemaPreviewMaxColumns())
+		}
+	})
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -905,6 +905,8 @@ func (p *Platform) buildEnrichmentConfig() middleware.EnrichmentConfig {
 		EnrichDataHubStorageResults: p.config.Injection.DataHubStorageEnrichment,
 		ResourceLinksEnabled:        p.config.Resources.Enabled,
 		ColumnContextFiltering:      p.config.Injection.IsColumnContextFilteringEnabled(),
+		SearchSchemaPreview:         p.config.Injection.IsSearchSchemaPreviewEnabled(),
+		SchemaPreviewMaxColumns:     p.config.Injection.EffectiveSchemaPreviewMaxColumns(),
 	}
 
 	if p.config.Injection.SessionDedup.IsEnabled() {


### PR DESCRIPTION
## Summary

Closes #139

Adds a bounded column-name+type preview to `datahub_search` query_context for available tables. Agents currently need an intermediate `datahub_get_schema` or `trino_describe_table` call after search just to get column names before writing SQL. This eliminates that round-trip — ~100 tokens of preview saves a full schema response (~500+ tokens) plus the LLM pass-through.

- New `queryContextEntry` type extends availability with optional `schema_preview` and `total_columns`
- `fetchSchemaPreview` resolves URN → table → schema via the query provider (best-effort, errors silently skipped)
- `buildSchemaPreview` prioritizes primary key columns first, then remaining columns up to the configured max
- Configurable via `search_schema_preview` (default: true) and `schema_preview_max_columns` (default: 15)
- Converted `enrichDataHubResult` from standalone function to method on `semanticEnricher` to access config

## Example enriched output

```json
{
  "query_context": {
    "urn:li:dataset:(urn:li:dataPlatform:trino,hive.sales.orders,PROD)": {
      "available": true,
      "query_table": "hive.sales.orders",
      "connection": "production",
      "estimated_rows": 1500000,
      "schema_preview": [
        {"name": "order_id", "type": "integer"},
        {"name": "customer_id", "type": "integer"},
        {"name": "order_date", "type": "date"},
        {"name": "total_amount", "type": "decimal(10,2)"}
      ],
      "total_columns": 42
    }
  }
}
```

## Changes by area

### Config (`config.go`, `platform.go`)
- `SearchSchemaPreview *bool` — defaults to true (nil = enabled)
- `SchemaPreviewMaxColumns *int` — defaults to 15 (nil = 15)
- `IsSearchSchemaPreviewEnabled()` and `EffectiveSchemaPreviewMaxColumns()` helpers
- Wired into `buildEnrichmentConfig()` in platform.go

### Enrichment (`semantic.go`)
- `schemaPreviewColumn` and `queryContextEntry` types replace raw `*query.TableAvailability` in query context
- `enrichDataHubResult` converted from standalone func to `semanticEnricher` method (accesses config + provider)
- `fetchSchemaPreview(ctx, provider, urn, maxCols)` — resolves URN → TableIdentifier → TableSchema, returns nil on any error
- `buildSchemaPreview(schema, maxCols)` — PK columns first, then remaining, capped at max
- `appendQueryContext` signature updated for new `queryContextEntry` type

### Documentation
- `docs/cross-injection/datahub-trino.md` — new Schema Preview section with config and JSON example
- `docs/reference/configuration.md` — added to injection config table and YAML examples
- `docs/llms.txt` / `docs/llms-full.txt` — updated cross-injection references
- `configs/platform.yaml` — commented examples for new config options

## Test plan

- [x] Schema preview appears in query_context for available tables (3 columns, total_columns=3)
- [x] Preview bounded by `SchemaPreviewMaxColumns` (20 cols → 5 in preview, total_columns=20)
- [x] Primary key columns listed first regardless of table column order
- [x] Preview omitted (not empty array) when table is unavailable
- [x] Preview omitted when `ResolveTable` fails
- [x] Preview omitted when `GetTableSchema` fails or returns empty columns
- [x] Preview disabled when `SearchSchemaPreview: false`
- [x] `buildSchemaPreview` unit tests: under max, truncation, PK ordering, PK fills max
- [x] `fetchSchemaPreview` unit tests: success, resolve error, schema error, empty columns
- [x] Config defaults: nil → true/15, explicit values, YAML loading
- [x] All new functions 93-100% coverage
- [x] `make verify` — all checks passed (lint, tests, coverage, security, mutation, release)