### PR TITLE
fix: resolve user emails in Knowledge UI and audit chart timescale

### DIFF
--- a/admin-ui/src/pages/audit/AuditLogPage.tsx
+++ b/admin-ui/src/pages/audit/AuditLogPage.tsx
@@ -152,7 +152,7 @@ function OverviewTab({ onNavigate }: { onNavigate?: (path: string) => void }) {
       {/* Activity Chart */}
       <div className="rounded-lg border bg-card p-4">
         <h2 className="mb-3 text-sm font-medium">Activity</h2>
-        <TimeseriesChart data={timeseries.data} isLoading={timeseries.isLoading} />
+        <TimeseriesChart data={timeseries.data} isLoading={timeseries.isLoading} preset={preset} />
       </div>
 
       {/* Charts Grid */}

--- a/admin-ui/src/pages/knowledge/KnowledgePage.tsx
+++ b/admin-ui/src/pages/knowledge/KnowledgePage.tsx
@@ -5,6 +5,7 @@ import {
   useUpdateInsightStatus,
   useChangesets,
   useRollbackChangeset,
+  useAuditFilters,
 } from "@/api/hooks";
 import { StatCard } from "@/components/cards/StatCard";
 import { StatusBadge } from "@/components/cards/StatusBadge";
@@ -474,6 +475,8 @@ function InsightsTab() {
   const [categoryFilter, setCategoryFilter] = useState("");
   const [confidenceFilter, setConfidenceFilter] = useState("");
   const [selectedInsight, setSelectedInsight] = useState<Insight | null>(null);
+  const { data: filters } = useAuditFilters();
+  const ul = filters?.user_labels ?? {};
 
   const params = useMemo(
     () => ({
@@ -609,7 +612,7 @@ function InsightsTab() {
                 <td className="px-3 py-2 text-xs">
                   {new Date(insight.created_at).toLocaleString()}
                 </td>
-                <td className="px-3 py-2 text-xs" title={insight.captured_by}>{formatUser(insight.captured_by)}</td>
+                <td className="px-3 py-2 text-xs" title={insight.captured_by}>{formatUser(insight.captured_by, ul[insight.captured_by])}</td>
                 <td className="px-3 py-2 text-xs">
                   {formatCategory(insight.category)}
                 </td>
@@ -682,6 +685,7 @@ function InsightsTab() {
         <InsightDrawer
           insight={selectedInsight}
           onClose={() => setSelectedInsight(null)}
+          userLabels={ul}
         />
       )}
     </>
@@ -695,9 +699,11 @@ function InsightsTab() {
 function InsightDrawer({
   insight,
   onClose,
+  userLabels,
 }: {
   insight: Insight;
   onClose: () => void;
+  userLabels: Record<string, string>;
 }) {
   const [reviewNotes, setReviewNotes] = useState(insight.review_notes ?? "");
   const updateStatus = useUpdateInsightStatus();
@@ -739,7 +745,7 @@ function InsightDrawer({
             </div>
             <div>
               <p className="text-xs text-muted-foreground">Captured By</p>
-              <p title={insight.captured_by}>{formatUser(insight.captured_by)}</p>
+              <p title={insight.captured_by}>{formatUser(insight.captured_by, userLabels[insight.captured_by])}</p>
             </div>
             <div>
               <p className="text-xs text-muted-foreground">Persona</p>
@@ -870,7 +876,7 @@ function InsightDrawer({
             <div className="grid grid-cols-2 gap-3 border-t pt-3 text-sm">
               <div>
                 <p className="text-xs text-muted-foreground">Reviewed By</p>
-                <p title={insight.reviewed_by}>{formatUser(insight.reviewed_by!)}</p>
+                <p title={insight.reviewed_by}>{formatUser(insight.reviewed_by!, userLabels[insight.reviewed_by!])}</p>
               </div>
               <div>
                 <p className="text-xs text-muted-foreground">Reviewed At</p>
@@ -887,7 +893,7 @@ function InsightDrawer({
             <div className="grid grid-cols-2 gap-3 border-t pt-3 text-sm">
               <div>
                 <p className="text-xs text-muted-foreground">Applied By</p>
-                <p title={insight.applied_by}>{formatUser(insight.applied_by!)}</p>
+                <p title={insight.applied_by}>{formatUser(insight.applied_by!, userLabels[insight.applied_by!])}</p>
               </div>
               <div>
                 <p className="text-xs text-muted-foreground">Applied At</p>
@@ -954,6 +960,8 @@ function ChangesetsTab() {
   const [selectedChangeset, setSelectedChangeset] = useState<Changeset | null>(
     null,
   );
+  const { data: filters } = useAuditFilters();
+  const ul = filters?.user_labels ?? {};
 
   const params = useMemo(
     () => ({
@@ -1034,7 +1042,7 @@ function ChangesetsTab() {
                 <td className="px-3 py-2 text-xs">
                   {formatCategory(changeset.change_type)}
                 </td>
-                <td className="px-3 py-2 text-xs" title={changeset.applied_by}>{formatUser(changeset.applied_by)}</td>
+                <td className="px-3 py-2 text-xs" title={changeset.applied_by}>{formatUser(changeset.applied_by, ul[changeset.applied_by])}</td>
                 <td className="px-3 py-2 text-center">
                   <StatusBadge
                     variant={changeset.rolled_back ? "error" : "success"}
@@ -1090,6 +1098,7 @@ function ChangesetsTab() {
         <ChangesetDrawer
           changeset={selectedChangeset}
           onClose={() => setSelectedChangeset(null)}
+          userLabels={ul}
         />
       )}
     </>
@@ -1103,9 +1112,11 @@ function ChangesetsTab() {
 function ChangesetDrawer({
   changeset,
   onClose,
+  userLabels,
 }: {
   changeset: Changeset;
   onClose: () => void;
+  userLabels: Record<string, string>;
 }) {
   const rollback = useRollbackChangeset();
 
@@ -1158,11 +1169,11 @@ function ChangesetDrawer({
             </div>
             <div>
               <p className="text-xs text-muted-foreground">Approved By</p>
-              <p title={changeset.approved_by}>{formatUser(changeset.approved_by)}</p>
+              <p title={changeset.approved_by}>{formatUser(changeset.approved_by, userLabels[changeset.approved_by])}</p>
             </div>
             <div>
               <p className="text-xs text-muted-foreground">Applied By</p>
-              <p title={changeset.applied_by}>{formatUser(changeset.applied_by)}</p>
+              <p title={changeset.applied_by}>{formatUser(changeset.applied_by, userLabels[changeset.applied_by])}</p>
             </div>
           </div>
 
@@ -1205,7 +1216,7 @@ function ChangesetDrawer({
             <div className="grid grid-cols-2 gap-3 border-t pt-3 text-sm">
               <div>
                 <p className="text-xs text-muted-foreground">Rolled Back By</p>
-                <p title={changeset.rolled_back_by}>{formatUser(changeset.rolled_back_by ?? "")}</p>
+                <p title={changeset.rolled_back_by}>{formatUser(changeset.rolled_back_by ?? "", userLabels[changeset.rolled_back_by ?? ""])}</p>
               </div>
               <div>
                 <p className="text-xs text-muted-foreground">Rolled Back At</p>

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
-	github.com/txn2/mcp-datahub v0.8.0
+	github.com/txn2/mcp-datahub v0.8.1
 	github.com/txn2/mcp-s3 v0.2.1
 	github.com/txn2/mcp-trino v0.8.0
 	github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v0.8.0 h1:QE4xaKvALSY7nSASlj1uJgJfAa8hUoyjV9VPODTGNns=
-github.com/txn2/mcp-datahub v0.8.0/go.mod h1:UyXoTLT9H5DFkrdi/k0G82x+fZN5N4PSjom6FPGTkI0=
+github.com/txn2/mcp-datahub v0.8.1 h1:VEfh77e7LbtM3RkEVLlDcODjGP49sqgRLkAY22kWA/I=
+github.com/txn2/mcp-datahub v0.8.1/go.mod h1:UyXoTLT9H5DFkrdi/k0G82x+fZN5N4PSjom6FPGTkI0=
 github.com/txn2/mcp-s3 v0.2.1 h1:vicoQLka+4S2pFzJ5qxXS9ayToPIi2pLi1rE5ZjRQhg=
 github.com/txn2/mcp-s3 v0.2.1/go.mod h1:ygY1Bz6aXO4/3jvhfooR6y/BTXJ35Rsvwsl75zKktXg=
 github.com/txn2/mcp-trino v0.8.0 h1:1fdyn4nGyQqgYo1eFMmhIb5vvLUDy+CtxWM9WKACVNM=

--- a/pkg/toolkits/knowledge/datahub_client_writer_test.go
+++ b/pkg/toolkits/knowledge/datahub_client_writer_test.go
@@ -335,9 +335,7 @@ func TestDataHubClientWriter_CreateCuratedQuery(t *testing.T) {
 						"source": "MANUAL",
 						"statement": {"value": "SELECT date, SUM(amount) FROM sales GROUP BY date", "language": "SQL"}
 					},
-					"subjects": {
-						"datasets": [{"dataset": {"urn": "` + testURN + `"}}]
-					}
+					"subjects": [{"dataset": {"urn": "` + testURN + `"}}]
 				}
 			}`),
 		}


### PR DESCRIPTION
## Summary

Three bugs in the Admin portal:

- **Knowledge > Insights tab**: "Captured By" column displayed raw UUIDs instead of user email addresses. Same for "Reviewed By" and "Applied By" in the insight detail drawer.
- **Knowledge > Changesets tab**: "Applied By" column displayed raw UUIDs. Same for "Approved By", "Applied By", and "Rolled Back By" in the changeset detail drawer.
- **Audit > Overview tab**: Activity chart X-axis labels didn't adapt to the selected time range (always showed HH:MM regardless of 1h/6h/24h/7d selection).

## Changes

### Knowledge user email resolution (`KnowledgePage.tsx`)

The audit filters endpoint already returns `user_labels: Record<string, string>` mapping user IDs to emails, and `formatUser(id, email?)` already handles display. The Knowledge page simply wasn't consuming this data.

- Added `useAuditFilters()` hook call in both `InsightsTab` and `ChangesetsTab`
- Updated all 8 `formatUser(id)` calls to `formatUser(id, userLabels[id])`:
  - `InsightsTab` table row (`captured_by`)
  - `InsightDrawer` metadata (`captured_by`), lifecycle (`reviewed_by`, `applied_by`)
  - `ChangesetsTab` table row (`applied_by`)
  - `ChangesetDrawer` metadata (`approved_by`, `applied_by`), rollback (`rolled_back_by`)
- Passed `userLabels` as a prop from tab components into drawer components

### Audit chart timescale (`AuditLogPage.tsx`)

The `TimeseriesChart` component already accepts an optional `preset` prop that controls X-axis label formatting (HH:MM for 1h/6h, hour-only for 24h, Mon DD for 7d). The `OverviewTab` had `preset` from `useTimeRangeStore()` but wasn't passing it through.

- Added `preset={preset}` to the `TimeseriesChart` invocation (one-line fix)

### Dependency bump (`go.mod`, `go.sum`, test)

- Bumped `mcp-datahub` v0.8.0 → v0.8.1 (fixes Query mutation schema for flat `subjects` array)
- Aligned `datahub_client_writer_test.go` mock response with the new response format

## Test plan

- [ ] `npm run build` in `admin-ui/` — no TypeScript errors
- [ ] `make verify` — full CI suite passes (fmt, test, lint, security, coverage, mutation, release-check)
- [ ] Open Admin UI → Knowledge → Insights tab: "Captured By" shows email addresses instead of UUIDs
- [ ] Click an insight row → drawer shows email for "Captured By", "Reviewed By", "Applied By"
- [ ] Knowledge → Changesets tab: "Applied By" shows email addresses
- [ ] Click a changeset row → drawer shows email for "Approved By", "Applied By", "Rolled Back By"
- [ ] Audit → Overview tab: switch between 1h/6h/24h/7d and verify X-axis labels adapt (HH:MM → hour → Mon DD)