### PR TITLE
fix: forward tool Title into _meta.ui; bump mcp-datahub to v1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
-	github.com/txn2/mcp-datahub v1.0.0
+	github.com/txn2/mcp-datahub v1.0.1
 	github.com/txn2/mcp-s3 v1.0.0
 	github.com/txn2/mcp-trino v1.0.0
 	github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v1.0.0 h1:m3NLaY3V3kXlastkCFMlmk3EbyaJZsK9xjJkTIxx8Pk=
-github.com/txn2/mcp-datahub v1.0.0/go.mod h1:4RMSmUYrcoGwlmmJBLuiGPbz9kqT5dqZ65eKaMhqDX0=
+github.com/txn2/mcp-datahub v1.0.1 h1:EwbtH70dO5IWF8ujzCKAovb8afxmHiSGGAAYScEaOtA=
+github.com/txn2/mcp-datahub v1.0.1/go.mod h1:4RMSmUYrcoGwlmmJBLuiGPbz9kqT5dqZ65eKaMhqDX0=
 github.com/txn2/mcp-s3 v1.0.0 h1:0772X3H7bAJPqDtuvDNlZTGEK2m1egInfuqQL/Jlq8Y=
 github.com/txn2/mcp-s3 v1.0.0/go.mod h1:hQc0xBl0t/afEgFmrOSKH3OW9uyKdeliFknQwfAzqG0=
 github.com/txn2/mcp-trino v1.0.0 h1:mrVIT4Bq+2ryL1WyCaD8arVanV/AI16bAcfZDGUDzxQ=

--- a/pkg/mcpapps/middleware.go
+++ b/pkg/mcpapps/middleware.go
@@ -50,10 +50,15 @@ func injectToolMetadata(reg *Registry, method string, result mcp.Result) (mcp.Re
 			tool.Meta = make(mcp.Meta)
 		}
 
-		// Add UI metadata.
-		tool.Meta["ui"] = map[string]string{
+		// Add UI metadata. Include title so MCP hosts display the human-readable
+		// tool name in the app panel header instead of falling back to tool.name.
+		uiMeta := map[string]string{
 			"resourceUri": app.ResourceURI,
 		}
+		if tool.Title != "" {
+			uiMeta["title"] = tool.Title
+		}
+		tool.Meta["ui"] = uiMeta
 	}
 
 	return listResult, nil


### PR DESCRIPTION
## Summary

Two related fixes that complete the mcp-datahub v1.0.0 → v1.0.1 integration:

1. **`_meta.ui` title injection** — `injectToolMetadata` now forwards `tool.Title` into the
   `_meta.ui` map when non-empty, so MCP hosts (Claude.ai, Claude Desktop) render the
   human-readable tool name in the app panel header instead of falling back to `tool.name`.

2. **mcp-datahub v1.0.1** — upgrades the DataHub toolkit dependency to the patch release that
   fixes all read handlers returning `nil` structured output, which caused every DataHub tool
   to show "Error occurred during tool execution" in Claude.ai.

---

## Changes

### `pkg/mcpapps/middleware.go`

`injectToolMetadata` builds the `_meta.ui` map conditionally:

```go
// Before
tool.Meta["ui"] = map[string]string{
    "resourceUri": app.ResourceURI,
}

// After
uiMeta := map[string]string{
    "resourceUri": app.ResourceURI,
}
if tool.Title != "" {
    uiMeta["title"] = tool.Title
}
tool.Meta["ui"] = uiMeta
```

The `title` key is only added when the toolkit has set a non-empty `Tool.Title` — tools without
a title are unaffected and the existing `resourceUri` behaviour is preserved.

### `pkg/mcpapps/middleware_test.go`

New sub-test `"injects title into _meta.ui when tool has Title set"` verifies:
- `_meta.ui.title` equals the tool's `Title` field when non-empty
- `_meta.ui.resourceUri` is still correctly set alongside the title

New helper `assertToolUITitle` avoids duplicating the map-cast assertion across tests.

### `go.mod` / `go.sum`

`github.com/txn2/mcp-datahub v1.0.0 → v1.0.1`

v1.0.1 ([release notes](https://github.com/txn2/mcp-datahub/releases/tag/v1.0.1)) fixes all
DataHub read handlers to return non-nil `structuredContent`. The root cause: go-sdk skips
`structuredContent` serialization when the handler returns a `nil` second value, but all tools
declared `outputSchema` in `tools/list` (added in v1.0.0), so MCP hosts expected structured
output and surfaced an error when it was absent.

---

## Test plan

- [ ] `go test -race ./...` — all pass
- [ ] `make verify` — all checks pass (coverage 92.7%, lint clean, security clean)
- [ ] In Claude.ai / Claude Desktop: open the DataHub app panel — confirm tool names show as
      human-readable titles (e.g. "Search Catalog" not "datahub_search")
- [ ] Call any DataHub read tool (e.g. `datahub_search`) — confirm it returns results without
      "Error occurred during tool execution"