### PR TITLE
fix: bump mcp-datahub v1.0.1 → v1.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
-	github.com/txn2/mcp-datahub v1.0.1
+	github.com/txn2/mcp-datahub v1.0.2
 	github.com/txn2/mcp-s3 v1.0.0
 	github.com/txn2/mcp-trino v1.0.0
 	github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -270,6 +270,8 @@ github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25V
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
 github.com/txn2/mcp-datahub v1.0.1 h1:EwbtH70dO5IWF8ujzCKAovb8afxmHiSGGAAYScEaOtA=
 github.com/txn2/mcp-datahub v1.0.1/go.mod h1:4RMSmUYrcoGwlmmJBLuiGPbz9kqT5dqZ65eKaMhqDX0=
+github.com/txn2/mcp-datahub v1.0.2 h1:A1NxRyW93b2KE7j1Hc4T2fZDVs++pohSnOiYaTVCfCc=
+github.com/txn2/mcp-datahub v1.0.2/go.mod h1:4RMSmUYrcoGwlmmJBLuiGPbz9kqT5dqZ65eKaMhqDX0=
 github.com/txn2/mcp-s3 v1.0.0 h1:0772X3H7bAJPqDtuvDNlZTGEK2m1egInfuqQL/Jlq8Y=
 github.com/txn2/mcp-s3 v1.0.0/go.mod h1:hQc0xBl0t/afEgFmrOSKH3OW9uyKdeliFknQwfAzqG0=
 github.com/txn2/mcp-trino v1.0.0 h1:mrVIT4Bq+2ryL1WyCaD8arVanV/AI16bAcfZDGUDzxQ=


### PR DESCRIPTION
## Summary

Upgrades `github.com/txn2/mcp-datahub` from v1.0.1 → v1.0.2.

v1.0.2 ([release notes](https://github.com/txn2/mcp-datahub/releases/tag/v1.0.2)) fixes
the final three DataHub tools that were still failing with "Error occurred during tool
execution" in Claude.ai after v1.0.1.

**Root cause in v1.0.1:** go-sdk validates structured output against `outputSchema` via
`applySchema` before writing `structuredContent`. Three schemas declared incorrect types for
fields that are objects in the actual Go types — causing hard schema validation failures.

### Tools fixed in v1.0.2

| Tool | Mismatches fixed |
|---|---|
| `datahub_get_entity` | `owners`/`tags` items string→object; `domain` string→object; `deprecated`→`deprecation` object; `query_table` handler now stringifies `TableIdentifier` |
| `datahub_get_lineage` | `execution_context.additionalProperties` removed (had `connections []string` and `source string` — not objects) |
| `datahub_get_data_product` | `domain` string→object; `owners` items string→object; `assets` items object→string (URNs) |

All 11 DataHub read tools now pass schema validation and return results correctly.

## Test plan

- [ ] `go test -race ./...` passes
- [ ] Deploy and call `datahub_get_entity`, `datahub_get_lineage`, and
      `datahub_get_data_product` via Claude.ai — confirm all return results without error