### PR TITLE
fix: bump mcp-datahub v1.0.2 → v1.0.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
-	github.com/txn2/mcp-datahub v1.0.2
+	github.com/txn2/mcp-datahub v1.0.3
 	github.com/txn2/mcp-s3 v1.0.0
 	github.com/txn2/mcp-trino v1.0.0
 	github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v1.0.2 h1:A1NxRyW93b2KE7j1Hc4T2fZDVs++pohSnOiYaTVCfCc=
-github.com/txn2/mcp-datahub v1.0.2/go.mod h1:4RMSmUYrcoGwlmmJBLuiGPbz9kqT5dqZ65eKaMhqDX0=
+github.com/txn2/mcp-datahub v1.0.3 h1:REOnVtRqNkIPRA0vRzLnTEo9qAwz/30g7tUKWtdoB74=
+github.com/txn2/mcp-datahub v1.0.3/go.mod h1:4RMSmUYrcoGwlmmJBLuiGPbz9kqT5dqZ65eKaMhqDX0=
 github.com/txn2/mcp-s3 v1.0.0 h1:0772X3H7bAJPqDtuvDNlZTGEK2m1egInfuqQL/Jlq8Y=
 github.com/txn2/mcp-s3 v1.0.0/go.mod h1:hQc0xBl0t/afEgFmrOSKH3OW9uyKdeliFknQwfAzqG0=
 github.com/txn2/mcp-trino v1.0.0 h1:mrVIT4Bq+2ryL1WyCaD8arVanV/AI16bAcfZDGUDzxQ=


### PR DESCRIPTION
## Summary

- Bumps `github.com/txn2/mcp-datahub` from v1.0.2 to v1.0.3
- Picks up the OutputSchema / response-shape fixes for tools failing through the Anthropic proxy

## What's fixed in v1.0.3

Three tools were returning "Anthropic Proxy: Invalid content from server" through Claude.ai because structured output responses did not match their declared `OutputSchema`:

- `datahub_get_entity` — entity fields now flat at top level (no wrapper key); schema field names corrected
- `datahub_get_lineage` — lineage fields now flat at top level; `start`/`nodes`/`edges`/`depth` match `types.LineageResult`
- `datahub_get_data_product` — schema now includes the `properties` field

See https://github.com/txn2/mcp-datahub/releases/tag/v1.0.3 for full details.

## Test plan

- [ ] `make verify` passes (all tests, lint, coverage — Docker daemon not running locally so GoReleaser dry-run skipped, pre-existing)
- [ ] After deploy: call `datahub_get_entity`, `datahub_get_lineage`, `datahub_get_data_product` through Claude.ai and confirm no proxy errors