### PR TITLE
feat: add read_resource tool so AI can access MCP resources autonomously

### DIFF
--- a/pkg/platform/custom_resources.go
+++ b/pkg/platform/custom_resources.go
@@ -19,14 +19,18 @@ func (p *Platform) registerCustomResources() {
 			slog.Warn("skipping invalid custom resource", "uri", def.URI, "error", err)
 			continue
 		}
+		handler := func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			return buildCustomResourceResult(def)
+		}
 		p.mcpServer.AddResource(&mcp.Resource{
 			URI:         def.URI,
 			Name:        def.Name,
 			Description: def.Description,
 			MIMEType:    def.MIMEType,
-		}, func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
-			return buildCustomResourceResult(def)
-		})
+		}, handler)
+		if p.resourceRegistry != nil {
+			p.resourceRegistry[def.URI] = handler
+		}
 	}
 }
 

--- a/pkg/platform/hints_resource.go
+++ b/pkg/platform/hints_resource.go
@@ -13,14 +13,18 @@ const hintsResourceURI = "hints://operational"
 
 // registerHintsResource registers the hints resource with the MCP server.
 func (p *Platform) registerHintsResource() {
+	handler := func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		return p.buildHintsResourceResult()
+	}
 	p.mcpServer.AddResource(&mcp.Resource{
 		URI:         hintsResourceURI,
 		Name:        "Tool Hints",
 		Description: "Operational hints and guidance for using platform tools effectively",
 		MIMEType:    "application/json",
-	}, func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
-		return p.buildHintsResourceResult()
-	})
+	}, handler)
+	if p.resourceRegistry != nil {
+		p.resourceRegistry[hintsResourceURI] = handler
+	}
 }
 
 // buildHintsResourceResult creates the resource result with all hints.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -118,6 +118,10 @@ type Platform struct {
 
 	// MCP Apps
 	mcpAppsRegistry *mcpapps.Registry
+
+	// Resource registry maps URIs to handlers so the read_resource tool can
+	// serve them without going through the MCP resources/read protocol path.
+	resourceRegistry map[string]mcp.ResourceHandler
 }
 
 // New creates a new platform instance.
@@ -132,8 +136,9 @@ func New(opts ...Option) (*Platform, error) {
 	}
 
 	p := &Platform{
-		config:    options.Config,
-		lifecycle: NewLifecycle(),
+		config:           options.Config,
+		lifecycle:        NewLifecycle(),
+		resourceRegistry: make(map[string]mcp.ResourceHandler),
 	}
 
 	// Initialize components
@@ -1291,6 +1296,9 @@ func (p *Platform) Start(ctx context.Context) error {
 
 	// Register resource templates (schema, glossary, availability)
 	p.registerResourceTemplates()
+
+	// Register read_resource tool so AI can access registered resources as tools
+	p.registerResourceTool()
 
 	// Validate agent_instructions references against registered tools
 	p.validateAgentInstructions()

--- a/pkg/platform/resource_tool.go
+++ b/pkg/platform/resource_tool.go
@@ -1,0 +1,81 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type readResourceInput struct {
+	URI string `json:"uri"`
+}
+
+// registerResourceTool registers the read_resource tool when there are
+// resources in the registry. Skipped if no resources are configured.
+func (p *Platform) registerResourceTool() {
+	if len(p.resourceRegistry) == 0 {
+		return
+	}
+
+	uris := make([]string, 0, len(p.resourceRegistry))
+	for uri := range p.resourceRegistry {
+		uris = append(uris, uri)
+	}
+	sort.Strings(uris)
+
+	desc := "Read an MCP resource by URI and return its content. " +
+		"Use this to fetch brand assets, operational hints, and other registered resources. " +
+		"Available URIs: " + strings.Join(uris, ", ")
+
+	mcp.AddTool(p.mcpServer, &mcp.Tool{
+		Name:        "read_resource",
+		Title:       "Read Resource",
+		Description: desc,
+		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input readResourceInput) (*mcp.CallToolResult, any, error) {
+		return p.handleReadResource(ctx, req, input.URI)
+	})
+}
+
+// handleReadResource executes a resource read from the platform registry.
+func (p *Platform) handleReadResource(_ context.Context, _ *mcp.CallToolRequest, uri string) (*mcp.CallToolResult, any, error) {
+	handler, ok := p.resourceRegistry[uri]
+	if !ok {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: fmt.Sprintf("resource not found: %s", uri)},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	result, err := handler(context.Background(), &mcp.ReadResourceRequest{
+		Params: &mcp.ReadResourceParams{URI: uri},
+	})
+	if err != nil {
+		return &mcp.CallToolResult{ //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError, not as Go errors
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "error reading resource: " + err.Error()},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	if len(result.Contents) == 0 {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "resource has no content"},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: result.Contents[0].Text},
+		},
+	}, nil, nil
+}

--- a/pkg/platform/resource_tool_test.go
+++ b/pkg/platform/resource_tool_test.go
@@ -1,0 +1,199 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTestResourcePlatform returns a minimal Platform with the given resource registry.
+func makeTestResourcePlatform(registry map[string]mcp.ResourceHandler) *Platform {
+	return &Platform{resourceRegistry: registry}
+}
+
+func TestHandleReadResource_Found(t *testing.T) {
+	p := makeTestResourcePlatform(map[string]mcp.ResourceHandler{
+		"brand://theme": func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			return &mcp.ReadResourceResult{
+				Contents: []*mcp.ResourceContents{{URI: "brand://theme", Text: `{"color":"blue"}`}},
+			}, nil
+		},
+	})
+
+	result, extra, err := p.handleReadResource(context.Background(), &mcp.CallToolRequest{}, "brand://theme")
+	require.NoError(t, err)
+	assert.Nil(t, extra)
+	require.NotNil(t, result)
+	assert.False(t, result.IsError)
+	require.Len(t, result.Content, 1)
+	text, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Equal(t, `{"color":"blue"}`, text.Text)
+}
+
+func TestHandleReadResource_NotFound(t *testing.T) {
+	p := makeTestResourcePlatform(map[string]mcp.ResourceHandler{})
+
+	result, extra, err := p.handleReadResource(context.Background(), &mcp.CallToolRequest{}, "brand://missing")
+	require.NoError(t, err)
+	assert.Nil(t, extra)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+	text, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, text.Text, "not found")
+	assert.Contains(t, text.Text, "brand://missing")
+}
+
+func TestHandleReadResource_HandlerError(t *testing.T) {
+	p := makeTestResourcePlatform(map[string]mcp.ResourceHandler{
+		"brand://broken": func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			return nil, errors.New("disk read failure")
+		},
+	})
+
+	result, _, err := p.handleReadResource(context.Background(), &mcp.CallToolRequest{}, "brand://broken")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+	text, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, text.Text, "disk read failure")
+}
+
+func TestHandleReadResource_EmptyContents(t *testing.T) {
+	p := makeTestResourcePlatform(map[string]mcp.ResourceHandler{
+		"brand://empty": func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			return &mcp.ReadResourceResult{Contents: []*mcp.ResourceContents{}}, nil
+		},
+	})
+
+	result, _, err := p.handleReadResource(context.Background(), &mcp.CallToolRequest{}, "brand://empty")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+	text, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, text.Text, "no content")
+}
+
+func TestRegisterResourceTool_Empty(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0.0"}, nil)
+	p := &Platform{
+		mcpServer:        server,
+		resourceRegistry: map[string]mcp.ResourceHandler{},
+	}
+
+	// Must not panic; tool should NOT be registered.
+	p.registerResourceTool()
+
+	// Verify tool is absent by trying to call it through a real transport.
+	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+
+	ctx := context.Background()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: httpServer.URL}, nil)
+	require.NoError(t, err)
+	defer func() { _ = session.Close() }()
+
+	_, err = session.CallTool(ctx, &mcp.CallToolParams{Name: "read_resource"})
+	assert.Error(t, err, "read_resource should not exist when registry is empty")
+}
+
+func TestRegisterResourceTool_NonEmpty(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0.0"}, nil)
+	p := &Platform{
+		mcpServer: server,
+		resourceRegistry: map[string]mcp.ResourceHandler{
+			"brand://theme": func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+				return &mcp.ReadResourceResult{
+					Contents: []*mcp.ResourceContents{{URI: "brand://theme", Text: "{}"}},
+				}, nil
+			},
+			"hints://operational": func(_ context.Context, _ *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+				return &mcp.ReadResourceResult{
+					Contents: []*mcp.ResourceContents{{URI: "hints://operational", Text: "[]"}},
+				}, nil
+			},
+		},
+	}
+
+	p.registerResourceTool()
+
+	// Exercise through real transport — verifies the tool is registered and callable.
+	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+
+	ctx := context.Background()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: httpServer.URL}, nil)
+	require.NoError(t, err)
+	defer func() { _ = session.Close() }()
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "read_resource",
+		Arguments: map[string]any{"uri": "brand://theme"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.IsError)
+
+	// Also verify both URIs appear in the description — list tools to check.
+	tools, err := session.ListTools(ctx, nil)
+	require.NoError(t, err)
+	var desc string
+	for _, t := range tools.Tools {
+		if t.Name == "read_resource" {
+			desc = t.Description
+			break
+		}
+	}
+	assert.Contains(t, desc, "brand://theme")
+	assert.Contains(t, desc, "hints://operational")
+}
+
+func TestResourceRegistryPopulatedFromCustomResources(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0.0"}, nil)
+	p := &Platform{
+		mcpServer:        server,
+		resourceRegistry: make(map[string]mcp.ResourceHandler),
+		config: &Config{
+			Resources: ResourcesConfig{
+				Custom: []CustomResourceDef{
+					{
+						URI:      "brand://theme",
+						Name:     "Brand Theme",
+						MIMEType: "application/json",
+						Content:  `{"color":"blue"}`,
+					},
+					{
+						URI:      "brand://logo",
+						Name:     "Brand Logo",
+						MIMEType: "image/svg+xml",
+						Content:  `<svg/>`,
+					},
+				},
+			},
+		},
+	}
+
+	p.registerCustomResources()
+
+	assert.Contains(t, p.resourceRegistry, "brand://theme", "registry should contain brand://theme")
+	assert.Contains(t, p.resourceRegistry, "brand://logo", "registry should contain brand://logo")
+
+	// Handlers must be callable and return the configured content.
+	result, err := p.resourceRegistry["brand://theme"](context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, result.Contents, 1)
+	assert.Equal(t, `{"color":"blue"}`, result.Contents[0].Text)
+}


### PR DESCRIPTION
## Problem

MCP resources (`brand://theme`, `brand://logo`, etc.) are registered on the server and advertised via the `resources` capability, but current MCP clients — including Claude Desktop and Claude.ai — do not expose `resources/read` as an AI-callable operation. Resources are designed as a human-driven attachment mechanism (an Attachments panel that was never shipped in any major client). As a result, the AI cannot autonomously fetch resource content even when it needs it for a task.

The `agent_instructions` previously told the AI to call `resources/read` with a URI — but that operation does not exist in the AI's toolset.

## Solution

Add a `read_resource` platform tool that wraps the resource registry, giving the AI autonomous access to registered resources via the standard `tools/call` interface.

This is not a workaround — it is the correct approach given where MCP client implementations actually are. The protocol-level `resources/read` registration is kept intact (resources still appear if/when clients implement the Attachments UI), and the tool provides a parallel path the AI can use today.

## How It Works

Resources are registered at startup via two existing paths:

- `registerCustomResources()` — iterates `config.resources.custom[]`
- `registerHintsResource()` — registers `hints://operational`

Each now also populates `Platform.resourceRegistry` (a `map[string]mcp.ResourceHandler`) alongside the existing `mcpServer.AddResource()` call.

After all resources are registered, `registerResourceTool()` runs. If the registry is non-empty it registers a `read_resource` tool whose description is dynamically built from the registry keys:

```
Read an MCP resource by URI and return its content. Use this to fetch brand
assets, operational hints, and other registered resources.
Available URIs: brand://logo, brand://logo-dark, brand://theme, hints://operational, ...
```

The AI sees the full URI list in `tools/list` at session init — no separate discovery call needed.

## Token Cost Considerations

- **Per session** (tool description in `tools/list`): ~60 tokens — the URI list in the description
- **Per `read_resource` call**: proportional to resource content size — JSON theme data (~400 tokens), compact SVGs (~200–300 tokens each)
- **Raster images or complex SVGs**: serve a CDN URL in the theme JSON instead of content; the AI writes `<img src>` and the binary never enters context

## Changes

### `pkg/platform/resource_tool.go` (new)

- `readResourceInput` — `uri string` input struct
- `registerResourceTool()` — no-op when registry is empty; builds description listing all URIs sorted alphabetically; registers tool with `ReadOnlyHint: true`
- `handleReadResource()` — looks up URI in registry, calls handler, returns `TextContent` or `IsError` result for not-found / handler error / empty contents

### `pkg/platform/platform.go`

- Added `resourceRegistry map[string]mcp.ResourceHandler` field to `Platform` struct
- Initialized `resourceRegistry: make(map[string]mcp.ResourceHandler)` in `New()`
- Added `p.registerResourceTool()` call in `Start()` after `registerResourceTemplates()`

### `pkg/platform/custom_resources.go`

- Extracted handler closure into a named variable so it can be stored in both `mcpServer` and `resourceRegistry`
- Nil-guarded registry write (existing tests construct `Platform` directly without initializing the registry)

### `pkg/platform/hints_resource.go`

- Same pattern as custom resources — handler stored in both `mcpServer` and `resourceRegistry`

### `pkg/platform/resource_tool_test.go` (new)

7 tests, **100% coverage** on both new functions:

| Test | Covers |
|------|--------|
| `TestHandleReadResource_Found` | Happy path — returns text content, `IsError=false` |
| `TestHandleReadResource_NotFound` | Missing URI — `IsError=true`, message contains "not found" |
| `TestHandleReadResource_HandlerError` | Handler returns error — `IsError=true` |
| `TestHandleReadResource_EmptyContents` | Handler returns empty Contents — `IsError=true` |
| `TestRegisterResourceTool_Empty` | Empty registry — tool NOT registered, no panic |
| `TestRegisterResourceTool_NonEmpty` | Non-empty registry — tool registered, callable via real transport, description lists all URIs |
| `TestResourceRegistryPopulatedFromCustomResources` | Registry populated after `registerCustomResources()` runs |

## Verification

```
go test -race ./...                             # all packages pass
go tool cover -func=coverage.out | grep resource_tool
# resource_tool.go:18: registerResourceTool  100.0%
# resource_tool.go:44: handleReadResource    100.0%
# total:                                      92.7%
golangci-lint run ./...                         # clean
```

## Usage

Once deployed, the AI can fetch brand assets and operational hints as tools:

```
read_resource(uri: "brand://theme")       → JSON with colors, typography, logo URI map
read_resource(uri: "brand://logo")        → inline SVG for light backgrounds
read_resource(uri: "brand://logo-dark")   → inline SVG for dark backgrounds
read_resource(uri: "hints://operational") → JSON array of tool usage hints
```

Any resource defined in `config.resources.custom[]` or the hints resource is automatically available. No code changes needed to expose new resources — add them to config, they appear in the tool description at next startup.