### PR TITLE
feat: enforce platform_info as mandatory first call via session gating middleware

### DIFF
--- a/pkg/middleware/mcp_session_gate.go
+++ b/pkg/middleware/mcp_session_gate.go
@@ -1,0 +1,227 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ErrCategorySetupRequired is the error category for session gate violations.
+const ErrCategorySetupRequired = "setup_required"
+
+// defaultGateSessionTTL is the default TTL for session gate entries.
+const defaultGateSessionTTL = 30
+
+// SessionGateConfig configures the session initialization gate middleware.
+type SessionGateConfig struct {
+	// InitTool is the tool that initializes the session (e.g., "platform_info").
+	InitTool string
+
+	// ExemptTools lists tool names that bypass the gate.
+	ExemptTools []string
+
+	// SessionTTL is how long an initialized session is remembered.
+	// Defaults to 30 minutes.
+	SessionTTL time.Duration
+
+	// CleanupInterval is how often the cleanup routine runs.
+	// Defaults to 1 minute.
+	CleanupInterval time.Duration
+}
+
+// SessionGate tracks which sessions have called the init tool.
+// It is safe for concurrent use.
+type SessionGate struct {
+	mu         sync.RWMutex
+	sessions   map[string]time.Time // session ID → initialization time
+	initTool   string
+	exemptSet  map[string]bool
+	sessionTTL time.Duration
+	done       chan struct{}
+	gateCount  int64 // total gating violations
+	retryCount int64 // total successful retries (init after gate)
+}
+
+// NewSessionGate creates a new session gate tracker.
+func NewSessionGate(cfg SessionGateConfig) *SessionGate {
+	ttl := cfg.SessionTTL
+	if ttl == 0 {
+		ttl = defaultGateSessionTTL * time.Minute
+	}
+
+	exemptSet := make(map[string]bool, len(cfg.ExemptTools)+1)
+	// The init tool itself is always exempt.
+	exemptSet[cfg.InitTool] = true
+	for _, t := range cfg.ExemptTools {
+		exemptSet[t] = true
+	}
+
+	return &SessionGate{
+		sessions:   make(map[string]time.Time),
+		initTool:   cfg.InitTool,
+		exemptSet:  exemptSet,
+		sessionTTL: ttl,
+		done:       make(chan struct{}),
+	}
+}
+
+// RecordInit marks a session as initialized.
+func (g *SessionGate) RecordInit(sessionID string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	_, existed := g.sessions[sessionID]
+	g.sessions[sessionID] = time.Now()
+
+	if existed {
+		g.retryCount++
+	}
+}
+
+// IsInitialized returns true if the session has called the init tool.
+func (g *SessionGate) IsInitialized(sessionID string) bool {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	initTime, ok := g.sessions[sessionID]
+	if !ok {
+		return false
+	}
+	// Check TTL expiration.
+	return time.Since(initTime) < g.sessionTTL
+}
+
+// IsExempt returns true if the tool bypasses the gate.
+func (g *SessionGate) IsExempt(toolName string) bool {
+	return g.exemptSet[toolName]
+}
+
+// IncrementGateCount increments the gating violation counter and returns the new count.
+func (g *SessionGate) IncrementGateCount() int64 {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.gateCount++
+	return g.gateCount
+}
+
+// Stats returns current gate statistics.
+func (g *SessionGate) Stats() (gateViolations, retries, activeSessions int64) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.gateCount, g.retryCount, int64(len(g.sessions))
+}
+
+// StartCleanup starts a background goroutine that evicts expired sessions.
+func (g *SessionGate) StartCleanup(interval time.Duration) {
+	if interval == 0 {
+		interval = 1 * time.Minute
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-g.done:
+				return
+			case <-ticker.C:
+				g.cleanup()
+			}
+		}
+	}()
+}
+
+// Stop stops the background cleanup goroutine.
+func (g *SessionGate) Stop() {
+	close(g.done)
+}
+
+// cleanup evicts sessions that have expired.
+func (g *SessionGate) cleanup() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	now := time.Now()
+	for id, initTime := range g.sessions {
+		if now.Sub(initTime) > g.sessionTTL {
+			delete(g.sessions, id)
+		}
+	}
+}
+
+// MCPSessionGateMiddleware creates MCP protocol-level middleware that gates
+// all tool calls until the init tool (e.g., platform_info) has been called
+// in the current session.
+//
+// This middleware must be positioned INNER to MCPToolCallMiddleware so that
+// PlatformContext (with SessionID and ToolName) is available. It should be
+// positioned OUTER to rule enforcement and enrichment so that gated calls
+// never reach those layers.
+func MCPSessionGateMiddleware(gate *SessionGate) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			if method != methodToolsCall {
+				return next(ctx, method, req)
+			}
+			pc := GetPlatformContext(ctx)
+			if pc == nil {
+				return next(ctx, method, req)
+			}
+			if errResult := gate.checkAccess(pc); errResult != nil {
+				return errResult, nil
+			}
+			return next(ctx, method, req)
+		}
+	}
+}
+
+// checkAccess evaluates whether a tool call should proceed or be gated.
+// Returns nil if the call is allowed; returns an error result if gated.
+func (g *SessionGate) checkAccess(pc *PlatformContext) mcp.Result {
+	// The init tool itself records initialization and is always allowed.
+	if pc.ToolName == g.initTool {
+		g.RecordInit(pc.SessionID)
+		return nil
+	}
+
+	// Exempt tools bypass the gate.
+	if g.IsExempt(pc.ToolName) {
+		return nil
+	}
+
+	// Initialized sessions proceed normally.
+	if g.IsInitialized(pc.SessionID) {
+		return nil
+	}
+
+	// Gate violation: session not initialized.
+	count := g.IncrementGateCount()
+	slog.Warn("session gate: tool called before platform_info",
+		"tool", pc.ToolName,
+		"session_id", pc.SessionID,
+		"user_id", pc.UserID,
+		"total_violations", count,
+	)
+	return createSessionGateError(g.initTool, pc.ToolName)
+}
+
+// createSessionGateError builds a SETUP_REQUIRED error result.
+func createSessionGateError(initTool, blockedTool string) mcp.Result {
+	msg := fmt.Sprintf(
+		"SETUP_REQUIRED: You must call %s before using %s (or any other tool). "+
+			"%s contains critical agent instructions for query routing, operational rules, "+
+			"and platform capabilities. Call %s first, then retry your request.",
+		initTool, blockedTool, initTool, initTool,
+	)
+
+	result := &mcp.CallToolResult{}
+	result.SetError(&PlatformError{
+		Category: ErrCategorySetupRequired,
+		Message:  msg,
+	})
+	return result
+}

--- a/pkg/middleware/mcp_session_gate_test.go
+++ b/pkg/middleware/mcp_session_gate_test.go
@@ -1,0 +1,428 @@
+package middleware
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test constants for session gate tests.
+const (
+	gateTestToolDatahubSearch  = "datahub_search"
+	gateTestToolListConns      = "list_connections"
+	gateTestToolPlatformInfo   = "platform_info"
+	gateTestToolReadResource   = "read_resource"
+	gateTestToolTrinoQuery     = "trino_query"
+	gateTestToolSomeFutureTool = "some_future_tool"
+)
+
+func TestNewSessionGate(t *testing.T) {
+	t.Run("init tool always exempt", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{
+			InitTool: gateTestToolPlatformInfo,
+		})
+		assert.True(t, gate.IsExempt(gateTestToolPlatformInfo))
+	})
+
+	t.Run("custom exempt tools", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{
+			InitTool:    gateTestToolPlatformInfo,
+			ExemptTools: []string{gateTestToolListConns, gateTestToolReadResource},
+		})
+		assert.True(t, gate.IsExempt(gateTestToolPlatformInfo))
+		assert.True(t, gate.IsExempt(gateTestToolListConns))
+		assert.True(t, gate.IsExempt(gateTestToolReadResource))
+		assert.False(t, gate.IsExempt(gateTestToolDatahubSearch))
+	})
+
+	t.Run("default TTL", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{InitTool: gateTestToolPlatformInfo})
+		assert.Equal(t, defaultGateSessionTTL*time.Minute, gate.sessionTTL)
+	})
+
+	t.Run("custom TTL", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{
+			InitTool:   gateTestToolPlatformInfo,
+			SessionTTL: 1 * time.Hour,
+		})
+		assert.Equal(t, 1*time.Hour, gate.sessionTTL)
+	})
+}
+
+func TestSessionGate_RecordAndCheck(t *testing.T) {
+	gate := NewSessionGate(SessionGateConfig{
+		InitTool:   gateTestToolPlatformInfo,
+		SessionTTL: defaultGateSessionTTL * time.Minute,
+	})
+
+	assert.False(t, gate.IsInitialized("s1"))
+
+	gate.RecordInit("s1")
+	assert.True(t, gate.IsInitialized("s1"))
+	assert.False(t, gate.IsInitialized("s2"), "sessions should be isolated")
+}
+
+func TestSessionGate_TTLExpiration(t *testing.T) {
+	gate := NewSessionGate(SessionGateConfig{
+		InitTool:   gateTestToolPlatformInfo,
+		SessionTTL: 50 * time.Millisecond,
+	})
+
+	gate.RecordInit("s1")
+	require.True(t, gate.IsInitialized("s1"))
+
+	time.Sleep(60 * time.Millisecond)
+	assert.False(t, gate.IsInitialized("s1"), "expired session should not be initialized")
+}
+
+func TestSessionGate_Cleanup(t *testing.T) {
+	gate := NewSessionGate(SessionGateConfig{
+		InitTool:   gateTestToolPlatformInfo,
+		SessionTTL: 50 * time.Millisecond,
+	})
+
+	gate.RecordInit("s1")
+	gate.RecordInit("s2")
+	require.True(t, gate.IsInitialized("s1"))
+
+	time.Sleep(60 * time.Millisecond)
+	gate.cleanup()
+
+	_, _, active := gate.Stats()
+	assert.Equal(t, int64(0), active, "all expired sessions should be cleaned up")
+}
+
+func TestSessionGate_StartCleanupAndStop(t *testing.T) {
+	gate := NewSessionGate(SessionGateConfig{
+		InitTool:   gateTestToolPlatformInfo,
+		SessionTTL: 10 * time.Millisecond,
+	})
+	gate.StartCleanup(10 * time.Millisecond)
+
+	gate.RecordInit("s-bg")
+	time.Sleep(50 * time.Millisecond)
+
+	// Stop should not panic
+	gate.Stop()
+
+	assert.False(t, gate.IsInitialized("s-bg"))
+}
+
+func TestSessionGate_Stats(t *testing.T) {
+	gate := NewSessionGate(SessionGateConfig{
+		InitTool:   gateTestToolPlatformInfo,
+		SessionTTL: defaultGateSessionTTL * time.Minute,
+	})
+
+	gate.RecordInit("s1")
+	gate.IncrementGateCount()
+	gate.IncrementGateCount()
+
+	violations, retries, active := gate.Stats()
+	assert.Equal(t, int64(2), violations)
+	assert.Equal(t, int64(0), retries)
+	assert.Equal(t, int64(1), active)
+
+	// Recording init for existing session counts as retry
+	gate.RecordInit("s1")
+	_, retries, _ = gate.Stats()
+	assert.Equal(t, int64(1), retries)
+}
+
+func TestSessionGate_ConcurrentAccess(t *testing.T) {
+	gate := NewSessionGate(SessionGateConfig{
+		InitTool:   gateTestToolPlatformInfo,
+		SessionTTL: defaultGateSessionTTL * time.Minute,
+	})
+
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			sid := "session-concurrent"
+			if n%3 == 0 {
+				gate.RecordInit(sid)
+			}
+			_ = gate.IsInitialized(sid)
+			_ = gate.IsExempt(gateTestToolPlatformInfo)
+			gate.IncrementGateCount()
+		}(i)
+	}
+	wg.Wait()
+
+	// No panics = success; verify state is readable
+	assert.True(t, gate.IsInitialized("session-concurrent"))
+}
+
+func TestMCPSessionGateMiddleware(t *testing.T) {
+	successResult := &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
+	}
+
+	t.Run("non-tools/call passes through", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{InitTool: gateTestToolPlatformInfo})
+		mw := MCPSessionGateMiddleware(gate)
+
+		nextCalled := false
+		handler := mw(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			nextCalled = true
+			return &mcp.ListResourcesResult{}, nil
+		})
+
+		result, err := handler(context.Background(), "resources/list", nil)
+		require.NoError(t, err)
+		assert.True(t, nextCalled)
+		assert.NotNil(t, result)
+	})
+
+	t.Run("no platform context passes through", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{InitTool: gateTestToolPlatformInfo})
+		mw := MCPSessionGateMiddleware(gate)
+
+		nextCalled := false
+		handler := mw(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			nextCalled = true
+			return successResult, nil
+		})
+
+		result, err := handler(context.Background(), methodToolsCall, nil)
+		require.NoError(t, err)
+		assert.True(t, nextCalled)
+		assert.NotNil(t, result)
+	})
+
+	t.Run("init tool call records and proceeds", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{InitTool: gateTestToolPlatformInfo})
+		mw := MCPSessionGateMiddleware(gate)
+
+		nextCalled := false
+		handler := mw(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			nextCalled = true
+			return successResult, nil
+		})
+
+		pc := NewPlatformContext("test-req")
+		pc.ToolName = gateTestToolPlatformInfo
+		pc.SessionID = "s1"
+		ctx := WithPlatformContext(context.Background(), pc)
+
+		result, err := handler(ctx, methodToolsCall, nil)
+		require.NoError(t, err)
+		assert.True(t, nextCalled)
+		assert.True(t, gate.IsInitialized("s1"))
+		assert.NotNil(t, result)
+	})
+
+	t.Run("exempt tool bypasses gate", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{
+			InitTool:    gateTestToolPlatformInfo,
+			ExemptTools: []string{gateTestToolListConns},
+		})
+		mw := MCPSessionGateMiddleware(gate)
+
+		nextCalled := false
+		handler := mw(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			nextCalled = true
+			return successResult, nil
+		})
+
+		pc := NewPlatformContext("test-req")
+		pc.ToolName = gateTestToolListConns
+		pc.SessionID = "s1"
+		ctx := WithPlatformContext(context.Background(), pc)
+
+		result, err := handler(ctx, methodToolsCall, nil)
+		require.NoError(t, err)
+		assert.True(t, nextCalled)
+		assert.NotNil(t, result)
+	})
+
+	t.Run("non-exempt tool before init is gated", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{InitTool: gateTestToolPlatformInfo})
+		mw := MCPSessionGateMiddleware(gate)
+
+		nextCalled := false
+		handler := mw(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			nextCalled = true
+			return successResult, nil
+		})
+
+		pc := NewPlatformContext("test-req")
+		pc.ToolName = gateTestToolDatahubSearch
+		pc.SessionID = "s1"
+		ctx := WithPlatformContext(context.Background(), pc)
+
+		result, err := handler(ctx, methodToolsCall, nil)
+		require.NoError(t, err)
+		assert.False(t, nextCalled, "handler should not be called when gated")
+
+		callResult, ok := result.(*mcp.CallToolResult)
+		require.True(t, ok)
+		require.NotNil(t, callResult.GetError())
+		assert.Contains(t, callResult.GetError().Error(), "SETUP_REQUIRED")
+		assert.Contains(t, callResult.GetError().Error(), gateTestToolPlatformInfo)
+		assert.Contains(t, callResult.GetError().Error(), gateTestToolDatahubSearch)
+	})
+
+	t.Run("non-exempt tool after init proceeds", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{InitTool: gateTestToolPlatformInfo})
+		gate.RecordInit("s1")
+
+		mw := MCPSessionGateMiddleware(gate)
+
+		nextCalled := false
+		handler := mw(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			nextCalled = true
+			return successResult, nil
+		})
+
+		pc := NewPlatformContext("test-req")
+		pc.ToolName = gateTestToolDatahubSearch
+		pc.SessionID = "s1"
+		ctx := WithPlatformContext(context.Background(), pc)
+
+		result, err := handler(ctx, methodToolsCall, nil)
+		require.NoError(t, err)
+		assert.True(t, nextCalled)
+		assert.Equal(t, successResult, result)
+	})
+
+	t.Run("gating increments violation count", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{InitTool: gateTestToolPlatformInfo})
+		mw := MCPSessionGateMiddleware(gate)
+
+		handler := mw(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			return successResult, nil
+		})
+
+		for i := range 3 {
+			pc := NewPlatformContext("test-req")
+			pc.ToolName = gateTestToolTrinoQuery
+			pc.SessionID = "s1"
+			ctx := WithPlatformContext(context.Background(), pc)
+
+			_, err := handler(ctx, methodToolsCall, nil)
+			require.NoError(t, err)
+
+			violations, _, _ := gate.Stats()
+			assert.Equal(t, int64(i+1), violations)
+		}
+	})
+
+	t.Run("different sessions gated independently", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{InitTool: gateTestToolPlatformInfo})
+		gate.RecordInit("s1")
+
+		mw := MCPSessionGateMiddleware(gate)
+
+		handler := mw(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			return successResult, nil
+		})
+
+		// s1 initialized - should proceed
+		pc1 := NewPlatformContext("test-req-1")
+		pc1.ToolName = gateTestToolDatahubSearch
+		pc1.SessionID = "s1"
+		ctx1 := WithPlatformContext(context.Background(), pc1)
+
+		result, err := handler(ctx1, methodToolsCall, nil)
+		require.NoError(t, err)
+		assert.Equal(t, successResult, result)
+
+		// s2 not initialized - should be gated
+		pc2 := NewPlatformContext("test-req-2")
+		pc2.ToolName = gateTestToolDatahubSearch
+		pc2.SessionID = "s2"
+		ctx2 := WithPlatformContext(context.Background(), pc2)
+
+		result, err = handler(ctx2, methodToolsCall, nil)
+		require.NoError(t, err)
+		callResult, ok := result.(*mcp.CallToolResult)
+		require.True(t, ok)
+		require.NotNil(t, callResult.GetError())
+		assert.Contains(t, callResult.GetError().Error(), "SETUP_REQUIRED")
+	})
+
+	t.Run("new tools automatically gated", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{InitTool: gateTestToolPlatformInfo})
+		mw := MCPSessionGateMiddleware(gate)
+
+		handler := mw(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+			return successResult, nil
+		})
+
+		// A hypothetical new tool should be gated without changes
+		pc := NewPlatformContext("test-req")
+		pc.ToolName = gateTestToolSomeFutureTool
+		pc.SessionID = "s1"
+		ctx := WithPlatformContext(context.Background(), pc)
+
+		result, err := handler(ctx, methodToolsCall, nil)
+		require.NoError(t, err)
+		callResult, ok := result.(*mcp.CallToolResult)
+		require.True(t, ok)
+		require.NotNil(t, callResult.GetError())
+		assert.Contains(t, callResult.GetError().Error(), "SETUP_REQUIRED")
+	})
+}
+
+func TestCreateSessionGateError(t *testing.T) {
+	result := createSessionGateError(gateTestToolPlatformInfo, gateTestToolTrinoQuery)
+	callResult, ok := result.(*mcp.CallToolResult)
+	require.True(t, ok)
+
+	getErr := callResult.GetError()
+	require.NotNil(t, getErr)
+	assert.Contains(t, getErr.Error(), "SETUP_REQUIRED")
+	assert.Contains(t, getErr.Error(), gateTestToolPlatformInfo)
+	assert.Contains(t, getErr.Error(), gateTestToolTrinoQuery)
+	assert.Contains(t, getErr.Error(), "query routing")
+
+	// Verify error category
+	cat := ErrorCategory(getErr)
+	assert.Equal(t, ErrCategorySetupRequired, cat)
+}
+
+func TestCheckAccess(t *testing.T) {
+	t.Run("init tool records and returns nil", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{InitTool: gateTestToolPlatformInfo})
+		pc := &PlatformContext{ToolName: gateTestToolPlatformInfo, SessionID: "s1"}
+		result := gate.checkAccess(pc)
+		assert.Nil(t, result)
+		assert.True(t, gate.IsInitialized("s1"))
+	})
+
+	t.Run("exempt tool returns nil without init", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{
+			InitTool:    gateTestToolPlatformInfo,
+			ExemptTools: []string{gateTestToolListConns},
+		})
+		pc := &PlatformContext{ToolName: gateTestToolListConns, SessionID: "s1"}
+		result := gate.checkAccess(pc)
+		assert.Nil(t, result)
+	})
+
+	t.Run("initialized session returns nil", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{InitTool: gateTestToolPlatformInfo})
+		gate.RecordInit("s1")
+		pc := &PlatformContext{ToolName: gateTestToolDatahubSearch, SessionID: "s1"}
+		result := gate.checkAccess(pc)
+		assert.Nil(t, result)
+	})
+
+	t.Run("uninitialized session returns error", func(t *testing.T) {
+		gate := NewSessionGate(SessionGateConfig{InitTool: gateTestToolPlatformInfo})
+		pc := &PlatformContext{ToolName: gateTestToolDatahubSearch, SessionID: "s1"}
+		result := gate.checkAccess(pc)
+		require.NotNil(t, result)
+		callResult, ok := result.(*mcp.CallToolResult)
+		require.True(t, ok)
+		assert.Contains(t, callResult.GetError().Error(), "SETUP_REQUIRED")
+	})
+}

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -77,6 +77,7 @@ type Config struct {
 	Icons         IconsConfig         `yaml:"icons"`
 	Elicitation   ElicitationConfig   `yaml:"elicitation"`
 	Workflow      WorkflowConfig      `yaml:"workflow"`
+	SessionGate   SessionGateConfig   `yaml:"session_gate"`
 }
 
 // AdminConfig configures the admin REST API.
@@ -594,6 +595,19 @@ type EscalationConfig struct {
 // defaultEscalationAfterWarnings is the default number of warnings before escalation.
 const defaultEscalationAfterWarnings = 3
 
+// SessionGateConfig configures the session initialization gate that requires
+// agents to call platform_info before using any other tool.
+type SessionGateConfig struct {
+	// Enabled activates the session initialization gate.
+	Enabled bool `yaml:"enabled"`
+
+	// InitTool is the tool that initializes the session (default: "platform_info").
+	InitTool string `yaml:"init_tool"`
+
+	// ExemptTools lists tool names that bypass the gate (e.g., "list_connections").
+	ExemptTools []string `yaml:"exempt_tools"`
+}
+
 // SessionsConfig configures session externalization.
 type SessionsConfig struct {
 	// Store selects the session storage backend: "memory" (default) or "database".
@@ -684,12 +698,23 @@ func applyDefaults(cfg *Config) {
 	applyAdminDefaults(cfg)
 	applyElicitationDefaults(cfg)
 	applyWorkflowDefaults(cfg)
+	applySessionGateDefaults(cfg)
 }
 
 // applyElicitationDefaults sets defaults for elicitation config.
 func applyElicitationDefaults(cfg *Config) {
 	if cfg.Elicitation.CostEstimation.RowThreshold == 0 {
 		cfg.Elicitation.CostEstimation.RowThreshold = defaultElicitRowThreshold
+	}
+}
+
+// defaultInitTool is the tool that initializes a session.
+const defaultInitTool = "platform_info"
+
+// applySessionGateDefaults sets defaults for session gate config.
+func applySessionGateDefaults(cfg *Config) {
+	if cfg.SessionGate.InitTool == "" {
+		cfg.SessionGate.InitTool = defaultInitTool
 	}
 }
 

--- a/pkg/platform/info_tool.go
+++ b/pkg/platform/info_tool.go
@@ -130,15 +130,19 @@ func (p *Platform) buildInfoToolTitle() string {
 
 // buildInfoToolDescription builds a dynamic tool description based on configuration.
 func (p *Platform) buildInfoToolDescription() string {
-	base := "Get information about this MCP data platform"
+	base := "MANDATORY first call in every session. "
 	if p.config.Server.Name != "" && p.config.Server.Name != "mcp-data-platform" {
-		base = fmt.Sprintf("Get information about %s", p.config.Server.Name)
+		base += fmt.Sprintf("Get information about %s", p.config.Server.Name)
+	} else {
+		base += "Get information about this MCP data platform"
 	}
 	if len(p.config.Server.Tags) > 0 {
 		base += fmt.Sprintf(" (%s)", strings.Join(p.config.Server.Tags, ", "))
 	}
 	return base + ", including its purpose, available toolkits, and enabled features. " +
-		"Call this first to understand what data and capabilities are available."
+		"This tool MUST be called before any other tool (datahub_search, trino_query, " +
+		"trino_describe_table, s3_list_objects, etc.). Skipping it causes incorrect query " +
+		"routing, operational rule violations, and degraded output quality."
 }
 
 // collectToolkits returns the list of enabled toolkit names and any

--- a/pkg/platform/info_tool_test.go
+++ b/pkg/platform/info_tool_test.go
@@ -231,6 +231,7 @@ func TestBuildInfoToolDescription(t *testing.T) {
 				Name: "mcp-data-platform",
 			},
 			wantContains: []string{
+				"MANDATORY first call",
 				"Get information about this MCP data platform",
 				"including its purpose",
 			},
@@ -241,7 +242,9 @@ func TestBuildInfoToolDescription(t *testing.T) {
 				Name: "ACME Data Platform",
 			},
 			wantContains: []string{
+				"MANDATORY first call",
 				"Get information about ACME Data Platform",
+				"MUST be called before any other tool",
 			},
 		},
 		{
@@ -251,6 +254,7 @@ func TestBuildInfoToolDescription(t *testing.T) {
 				Tags: []string{"analytics", "sales"},
 			},
 			wantContains: []string{
+				"MANDATORY first call",
 				"Get information about ACME Data Platform",
 				"(analytics, sales)",
 			},
@@ -263,6 +267,29 @@ func TestBuildInfoToolDescription(t *testing.T) {
 			},
 			wantContains: []string{
 				"Get information about ACME Data Platform",
+			},
+		},
+		{
+			name: "mentions consequences of skipping",
+			serverConfig: ServerConfig{
+				Name: "mcp-data-platform",
+			},
+			wantContains: []string{
+				"incorrect query routing",
+				"operational rule violations",
+				"degraded output quality",
+			},
+		},
+		{
+			name: "mentions specific tools that must not precede it",
+			serverConfig: ServerConfig{
+				Name: "mcp-data-platform",
+			},
+			wantContains: []string{
+				"datahub_search",
+				"trino_query",
+				"trino_describe_table",
+				"s3_list_objects",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Closes #164

LLM agents skip `platform_info` at session start and jump directly to data tools like `datahub_search` or `trino_query`, missing critical operational instructions. This PR adds both soft (description-level) and hard (middleware-level) enforcement to ensure `platform_info` is always called first.

### Requirement 1: Strengthen tool description
- `platform_info` description now leads with **"MANDATORY first call in every session"**
- Explicitly names tools that must not precede it (`datahub_search`, `trino_query`, `trino_describe_table`, `s3_list_objects`)
- States consequences of skipping: incorrect query routing, operational rule violations, degraded output quality

### Requirement 3: Session gating middleware (`MCPSessionGateMiddleware`)
- New `SessionGate` struct tracks which sessions have called the init tool
- Middleware intercepts all `tools/call` requests and returns a `SETUP_REQUIRED` error if the session hasn't called `platform_info` yet
- The init tool itself and configurable exempt tools (e.g., `list_connections`) bypass the gate
- TTL-based session expiration prevents memory leaks on long-lived servers
- Background cleanup goroutine evicts expired sessions
- Gating violations are logged with session ID, tool name, user ID, and cumulative violation count
- New tools added to the platform are automatically gated — no per-tool code changes needed

### Requirement 2: Fail-fast from other tools
Implemented as part of Requirement 3 — the middleware is the enforcement mechanism. Any non-exempt tool called before `platform_info` receives:
```
SETUP_REQUIRED: You must call platform_info before using datahub_search (or any other tool).
platform_info contains critical agent instructions for query routing, operational rules,
and platform capabilities. Call platform_info first, then retry your request.
```

### Configuration
```yaml
session_gate:
  enabled: true
  init_tool: platform_info        # default
  exempt_tools:
    - list_connections
    - read_resource
```

### Middleware chain positioning
```
Icons → Descriptions → Visibility → Apps → Auth/Authz → Session Gate → Audit → Rules → Logging → Enrichment → handler
```
The session gate sits **inner to Auth/Authz** (so `PlatformContext` with session ID and tool name is available) and **outer to Audit** (so gated calls don't produce audit events).

## Files changed

| File | Change |
|------|--------|
| `pkg/middleware/mcp_session_gate.go` | New session gate middleware and `SessionGate` tracker |
| `pkg/middleware/mcp_session_gate_test.go` | Comprehensive tests (100% coverage on all middleware functions) |
| `pkg/platform/config.go` | `SessionGateConfig` type and defaults |
| `pkg/platform/config_test.go` | Config loading and defaults tests |
| `pkg/platform/info_tool.go` | Strengthened tool description |
| `pkg/platform/info_tool_test.go` | Updated description assertions |
| `pkg/platform/platform.go` | Middleware wiring, init, shutdown, complexity refactor |

## Test plan

- [x] `platform_info` description contains "MANDATORY" and names blocked tools
- [x] Calling `datahub_search` before `platform_info` returns `SETUP_REQUIRED` error
- [x] After calling `platform_info`, all subsequent tools proceed normally
- [x] Exempt tools bypass the gate without `platform_info`
- [x] Session state expires via TTL (tested with 50ms TTL)
- [x] Gating violations increment counter and are logged
- [x] New/unknown tools are automatically gated
- [x] Different sessions are gated independently
- [x] Concurrent access is safe (race detection passes)
- [x] Background cleanup evicts expired sessions
- [x] Error includes correct category (`setup_required`) for audit
- [x] `golangci-lint` passes with zero issues
- [x] `gosec` and `govulncheck` pass with zero findings
- [x] Total coverage: 92.7%