### PR TITLE
feat: upgrade mcp-trino v1.1.0 + mcp-datahub v1.1.1 — consolidate browse tools

### DIFF
--- a/admin-ui/src/mocks/data/audit.ts
+++ b/admin-ui/src/mocks/data/audit.ts
@@ -76,8 +76,7 @@ const toolDefs: ToolDef[] = [
   // acme-warehouse (trino) — 35% of traffic
   { name: "trino_query", connection: "acme-warehouse", kind: "trino", toolkit: "acme-warehouse", weight: 22 },
   { name: "trino_describe_table", connection: "acme-warehouse", kind: "trino", toolkit: "acme-warehouse", weight: 7 },
-  { name: "trino_list_tables", connection: "acme-warehouse", kind: "trino", toolkit: "acme-warehouse", weight: 3 },
-  { name: "trino_list_schemas", connection: "acme-warehouse", kind: "trino", toolkit: "acme-warehouse", weight: 2 },
+  { name: "trino_browse", connection: "acme-warehouse", kind: "trino", toolkit: "acme-warehouse", weight: 5 },
   { name: "trino_explain", connection: "acme-warehouse", kind: "trino", toolkit: "acme-warehouse", weight: 1 },
   // acme-staging (trino) — 5% of traffic
   { name: "trino_query", connection: "acme-staging", kind: "trino", toolkit: "acme-staging", weight: 4 },
@@ -87,7 +86,7 @@ const toolDefs: ToolDef[] = [
   { name: "datahub_get_entity", connection: "acme-catalog", kind: "datahub", toolkit: "acme-catalog", weight: 6 },
   { name: "datahub_get_schema", connection: "acme-catalog", kind: "datahub", toolkit: "acme-catalog", weight: 3 },
   { name: "datahub_get_lineage", connection: "acme-catalog", kind: "datahub", toolkit: "acme-catalog", weight: 2 },
-  { name: "datahub_get_column_lineage", connection: "acme-catalog", kind: "datahub", toolkit: "acme-catalog", weight: 1 },
+  { name: "datahub_browse", connection: "acme-catalog", kind: "datahub", toolkit: "acme-catalog", weight: 1 },
   // acme-catalog-staging (datahub) — 3% of traffic
   { name: "datahub_search", connection: "acme-catalog-staging", kind: "datahub", toolkit: "acme-catalog-staging", weight: 2 },
   { name: "datahub_get_entity", connection: "acme-catalog-staging", kind: "datahub", toolkit: "acme-catalog-staging", weight: 1 },
@@ -174,12 +173,8 @@ function toolParameters(tool: ToolDef): Record<string, unknown> {
         schema: seededItem(trinoSchemas),
         table: seededItem(trinoTables),
       };
-    case "trino_list_tables":
+    case "trino_browse":
       return { catalog: seededItem(trinoCatalogs), schema: seededItem(trinoSchemas) };
-    case "trino_list_schemas":
-      return { catalog: seededItem(trinoCatalogs) };
-    case "trino_list_catalogs":
-      return {};
     case "trino_explain":
       return {
         sql: `SELECT region, SUM(revenue) FROM ${seededItem(trinoSchemas)}.${seededItem(trinoTables)} GROUP BY region`,
@@ -196,8 +191,8 @@ function toolParameters(tool: ToolDef): Record<string, unknown> {
         direction: seededItem(["upstream", "downstream"]),
         depth: seededItem([1, 2, 3]),
       };
-    case "datahub_get_column_lineage":
-      return { urn: `urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.analytics.${seededItem(trinoTables)},PROD)` };
+    case "datahub_browse":
+      return { type: seededItem(["tags", "domains", "data_products"]) };
     case "s3_list_objects":
       return { bucket: seededItem(s3Buckets), prefix: seededItem(s3Prefixes) };
     case "s3_get_object":
@@ -245,14 +240,12 @@ function toolDuration(tool: ToolDef): number {
     case "trino_query": return seededInt(45, 2800);
     case "trino_describe_table": return seededInt(20, 250);
     case "trino_explain": return seededInt(30, 400);
-    case "trino_list_tables": return seededInt(10, 80);
-    case "trino_list_schemas": return seededInt(8, 50);
-    case "trino_list_catalogs": return seededInt(5, 30);
+    case "trino_browse": return seededInt(5, 80);
     case "datahub_search": return seededInt(25, 180);
     case "datahub_get_entity": return seededInt(30, 200);
     case "datahub_get_schema": return seededInt(25, 150);
     case "datahub_get_lineage": return seededInt(40, 350);
-    case "datahub_get_column_lineage": return seededInt(50, 400);
+    case "datahub_browse": return seededInt(10, 100);
     case "s3_list_objects": return seededInt(15, 100);
     case "s3_get_object": return seededInt(20, 500);
     case "s3_list_buckets": return seededInt(8, 40);
@@ -361,7 +354,7 @@ export const mockToolBreakdown: BreakdownEntry[] = [
   { dimension: "s3_list_objects", count: 362, success_rate: 0.994, avg_duration_ms: 42.1 },
   { dimension: "s3_get_object", count: 338, success_rate: 0.953, avg_duration_ms: 156.8 },
   { dimension: "datahub_get_schema", count: 241, success_rate: 0.988, avg_duration_ms: 62.5 },
-  { dimension: "trino_list_tables", count: 193, success_rate: 1.0, avg_duration_ms: 28.3 },
+  { dimension: "trino_browse", count: 193, success_rate: 1.0, avg_duration_ms: 28.3 },
 ];
 
 export const mockUserBreakdown: BreakdownEntry[] = [

--- a/admin-ui/src/mocks/data/system.ts
+++ b/admin-ui/src/mocks/data/system.ts
@@ -31,9 +31,7 @@ export const mockTools: ToolInfo[] = [
   // acme-warehouse (trino) — production data warehouse
   { name: "trino_query", toolkit: "acme-warehouse", kind: "trino", connection: "acme-warehouse" },
   { name: "trino_describe_table", toolkit: "acme-warehouse", kind: "trino", connection: "acme-warehouse" },
-  { name: "trino_list_catalogs", toolkit: "acme-warehouse", kind: "trino", connection: "acme-warehouse" },
-  { name: "trino_list_schemas", toolkit: "acme-warehouse", kind: "trino", connection: "acme-warehouse" },
-  { name: "trino_list_tables", toolkit: "acme-warehouse", kind: "trino", connection: "acme-warehouse" },
+  { name: "trino_browse", toolkit: "acme-warehouse", kind: "trino", connection: "acme-warehouse" },
   { name: "trino_explain", toolkit: "acme-warehouse", kind: "trino", connection: "acme-warehouse" },
   // acme-staging (trino) — staging environment
   { name: "trino_query", toolkit: "acme-staging", kind: "trino", connection: "acme-staging" },
@@ -43,7 +41,7 @@ export const mockTools: ToolInfo[] = [
   { name: "datahub_get_entity", toolkit: "acme-catalog", kind: "datahub", connection: "acme-catalog" },
   { name: "datahub_get_schema", toolkit: "acme-catalog", kind: "datahub", connection: "acme-catalog" },
   { name: "datahub_get_lineage", toolkit: "acme-catalog", kind: "datahub", connection: "acme-catalog" },
-  { name: "datahub_get_column_lineage", toolkit: "acme-catalog", kind: "datahub", connection: "acme-catalog" },
+  { name: "datahub_browse", toolkit: "acme-catalog", kind: "datahub", connection: "acme-catalog" },
   // acme-catalog-staging (datahub) — staging catalog
   { name: "datahub_search", toolkit: "acme-catalog-staging", kind: "datahub", connection: "acme-catalog-staging" },
   { name: "datahub_get_entity", toolkit: "acme-catalog-staging", kind: "datahub", connection: "acme-catalog-staging" },
@@ -61,7 +59,7 @@ export const mockConnections: ConnectionInfo[] = [
     kind: "trino",
     name: "acme-warehouse",
     connection: "acme-warehouse",
-    tools: ["trino_query", "trino_describe_table", "trino_list_catalogs", "trino_list_schemas", "trino_list_tables", "trino_explain"],
+    tools: ["trino_query", "trino_describe_table", "trino_browse", "trino_explain"],
     hidden_tools: ["trino_explain"],
   },
   {
@@ -75,7 +73,7 @@ export const mockConnections: ConnectionInfo[] = [
     kind: "datahub",
     name: "acme-catalog",
     connection: "acme-catalog",
-    tools: ["datahub_search", "datahub_get_entity", "datahub_get_schema", "datahub_get_lineage", "datahub_get_column_lineage"],
+    tools: ["datahub_search", "datahub_get_entity", "datahub_get_schema", "datahub_get_lineage", "datahub_browse"],
     hidden_tools: [],
   },
   {

--- a/admin-ui/src/mocks/data/tools.ts
+++ b/admin-ui/src/mocks/data/tools.ts
@@ -80,53 +80,26 @@ export const mockToolSchemas: Record<string, ToolSchema> = {
       },
     },
   },
-  trino_list_catalogs: {
-    name: "trino_list_catalogs",
+  trino_browse: {
+    name: "trino_browse",
     kind: "trino",
     description:
-      "List all available catalogs in the Trino cluster. Catalogs are the top-level containers for schemas and tables.",
+      "Browse Trino catalogs, schemas, and tables. Omit all parameters to list catalogs; provide catalog to list schemas; provide catalog and schema to list tables.",
     parameters: {
       type: "object",
       required: [],
-      properties: {},
-    },
-  },
-  trino_list_schemas: {
-    name: "trino_list_schemas",
-    kind: "trino",
-    description:
-      "List all schemas in a catalog. Schemas are containers for tables within a catalog.",
-    parameters: {
-      type: "object",
-      required: ["catalog"],
       properties: {
         catalog: {
           type: "string",
-          description: "The catalog to list schemas from",
-        },
-      },
-    },
-  },
-  trino_list_tables: {
-    name: "trino_list_tables",
-    kind: "trino",
-    description:
-      "List all tables in a schema. Optionally filter by a LIKE pattern.",
-    parameters: {
-      type: "object",
-      required: ["catalog", "schema"],
-      properties: {
-        catalog: {
-          type: "string",
-          description: "The catalog containing the schema",
+          description: "Catalog name. Omit to list all catalogs.",
         },
         schema: {
           type: "string",
-          description: "The schema to list tables from",
+          description: "Schema name. Requires catalog. Omit to list schemas.",
         },
         pattern: {
           type: "string",
-          description: "Optional LIKE pattern to filter table names",
+          description: "LIKE pattern to filter tables (only when listing tables)",
         },
       },
     },
@@ -253,19 +226,23 @@ export const mockToolSchemas: Record<string, ToolSchema> = {
       },
     },
   },
-  datahub_get_column_lineage: {
-    name: "datahub_get_column_lineage",
+  datahub_browse: {
+    name: "datahub_browse",
     kind: "datahub",
     description:
-      "Get fine-grained column-level lineage for a dataset. Returns mappings showing how downstream columns are derived from upstream columns. Useful for understanding data transformations at the field level.",
+      "Browse the DataHub catalog: list tags, domains, and data products in a single tool. Specify the type parameter to choose what to browse.",
     parameters: {
       type: "object",
-      required: ["urn"],
+      required: ["type"],
       properties: {
-        urn: {
+        type: {
           type: "string",
-          description: "The DataHub URN of the dataset",
-          format: "urn",
+          description: "What to browse",
+          enum: ["tags", "domains", "data_products"],
+        },
+        filter: {
+          type: "string",
+          description: "Optional filter string (for tags)",
         },
       },
     },
@@ -347,33 +324,8 @@ export function generateMockResult(
       return trinoQueryResult(params, duration);
     case "trino_explain":
       return trinoExplainResult(params, duration);
-    case "trino_list_catalogs":
-      return textResult(
-        JSON.stringify(
-          ["acme_warehouse", "iceberg", "system", "hive", "memory"],
-          null,
-          2,
-        ),
-        duration,
-      );
-    case "trino_list_schemas":
-      return textResult(
-        JSON.stringify(
-          [
-            "sales",
-            "inventory",
-            "finance",
-            "analytics",
-            "staging",
-            "information_schema",
-          ],
-          null,
-          2,
-        ),
-        duration,
-      );
-    case "trino_list_tables":
-      return trinoListTablesResult(duration);
+    case "trino_browse":
+      return trinoBrowseResult(params, duration);
     case "trino_describe_table":
       return trinoDescribeResult(params, duration);
     case "datahub_search":
@@ -384,8 +336,8 @@ export function generateMockResult(
       return datahubSchemaResult(duration);
     case "datahub_get_lineage":
       return datahubLineageResult(params, duration);
-    case "datahub_get_column_lineage":
-      return datahubColumnLineageResult(duration);
+    case "datahub_browse":
+      return datahubBrowseResult(params, duration);
     case "s3_list_buckets":
       return s3ListBucketsResult(duration);
     case "s3_list_objects":
@@ -594,20 +546,47 @@ function trinoExplainResult(
   return textResult(text, duration, [trinoSemanticEnrichment("daily_sales")]);
 }
 
-function trinoListTablesResult(duration: number): ToolCallResponse {
-  const tables = [
-    { name: "daily_sales", type: "TABLE" },
-    { name: "store_transactions", type: "TABLE" },
-    { name: "inventory_levels", type: "TABLE" },
-    { name: "product_catalog", type: "TABLE" },
-    { name: "customer_segments", type: "TABLE" },
-    { name: "regional_performance", type: "VIEW" },
-    { name: "supply_chain_orders", type: "TABLE" },
-    { name: "price_adjustments", type: "TABLE" },
-    { name: "return_rates", type: "VIEW" },
-    { name: "employee_schedules", type: "TABLE" },
-  ];
-  return textResult(JSON.stringify(tables, null, 2), duration);
+function trinoBrowseResult(
+  params: Record<string, unknown>,
+  duration: number,
+): ToolCallResponse {
+  const catalog = params.catalog as string | undefined;
+  const schema = params.schema as string | undefined;
+
+  if (catalog && schema) {
+    // List tables
+    const tables = [
+      { name: "daily_sales", type: "TABLE" },
+      { name: "store_transactions", type: "TABLE" },
+      { name: "inventory_levels", type: "TABLE" },
+      { name: "product_catalog", type: "TABLE" },
+      { name: "customer_segments", type: "TABLE" },
+      { name: "regional_performance", type: "VIEW" },
+      { name: "supply_chain_orders", type: "TABLE" },
+      { name: "price_adjustments", type: "TABLE" },
+      { name: "return_rates", type: "VIEW" },
+      { name: "employee_schedules", type: "TABLE" },
+    ];
+    return textResult(JSON.stringify(tables, null, 2), duration);
+  }
+  if (catalog) {
+    // List schemas
+    return textResult(
+      JSON.stringify(
+        ["sales", "inventory", "finance", "analytics", "staging", "information_schema"],
+        null, 2,
+      ),
+      duration,
+    );
+  }
+  // List catalogs
+  return textResult(
+    JSON.stringify(
+      ["acme_warehouse", "iceberg", "system", "hive", "memory"],
+      null, 2,
+    ),
+    duration,
+  );
 }
 
 function trinoDescribeResult(
@@ -804,42 +783,34 @@ function datahubLineageResult(
   return textResult(JSON.stringify(lineage, null, 2), duration);
 }
 
-function datahubColumnLineageResult(duration: number): ToolCallResponse {
-  const lineage = {
-    mappings: [
-      {
-        downstream_column: "revenue",
-        upstream_columns: [
-          { dataset: "staging.raw_pos_events", column: "item_total", transform: "SUM(item_total)" },
-        ],
-      },
-      {
-        downstream_column: "units_sold",
-        upstream_columns: [
-          { dataset: "staging.raw_pos_events", column: "quantity", transform: "SUM(quantity)" },
-        ],
-      },
-      {
-        downstream_column: "store_id",
-        upstream_columns: [
-          { dataset: "staging.raw_pos_events", column: "store_id", transform: "PASSTHROUGH" },
-        ],
-      },
-      {
-        downstream_column: "region",
-        upstream_columns: [
-          { dataset: "staging.store_master", column: "region_name", transform: "LOOKUP(store_id)" },
-        ],
-      },
-      {
-        downstream_column: "avg_ticket",
-        upstream_columns: [
-          { dataset: "staging.raw_pos_events", column: "item_total", transform: "AVG(item_total) GROUP BY txn_id" },
-        ],
-      },
-    ],
-  };
-  return textResult(JSON.stringify(lineage, null, 2), duration);
+function datahubBrowseResult(
+  params: Record<string, unknown>,
+  duration: number,
+): ToolCallResponse {
+  const browseType = String(params.type ?? "tags");
+
+  switch (browseType) {
+    case "domains":
+      return textResult(JSON.stringify([
+        { name: "Retail Analytics", urn: "urn:li:domain:retail-analytics", description: "Sales, transactions, and customer data" },
+        { name: "Inventory Management", urn: "urn:li:domain:inventory", description: "Stock levels, supply chain, and warehousing" },
+        { name: "Finance", urn: "urn:li:domain:finance", description: "Revenue, margins, and financial reporting" },
+      ], null, 2), duration);
+    case "data_products":
+      return textResult(JSON.stringify([
+        { name: "Daily Sales Report", urn: "urn:li:dataProduct:daily-sales", datasets: 3, domain: "Retail Analytics" },
+        { name: "Inventory Dashboard", urn: "urn:li:dataProduct:inventory-dashboard", datasets: 4, domain: "Inventory Management" },
+      ], null, 2), duration);
+    default: // tags
+      return textResult(JSON.stringify([
+        { name: "certified", count: 12 },
+        { name: "pii", count: 5 },
+        { name: "pii-free", count: 18 },
+        { name: "tier-1", count: 8 },
+        { name: "raw", count: 14 },
+        { name: "real-time", count: 3 },
+      ], null, 2), duration);
+  }
 }
 
 function s3ListBucketsResult(duration: number): ToolCallResponse {

--- a/admin-ui/src/pages/home/HomePage.tsx
+++ b/admin-ui/src/pages/home/HomePage.tsx
@@ -220,7 +220,7 @@ function HelpTab({ onNavigate }: { onNavigate: (path: string) => void }) {
                   SQL query execution, schema exploration, catalog browsing
                 </td>
                 <td className="px-3 py-2 font-mono text-xs">
-                  trino_query, trino_describe_table, trino_list_catalogs
+                  trino_query, trino_describe_table, trino_browse
                 </td>
               </tr>
               <tr className="border-b">

--- a/admin-ui/src/pages/personas/PersonasPage.tsx
+++ b/admin-ui/src/pages/personas/PersonasPage.tsx
@@ -775,7 +775,7 @@ function HelpTab() {
               <tr className="border-b">
                 <td className="px-3 py-2 font-mono text-xs">trino_*</td>
                 <td className="px-3 py-2 text-xs">
-                  trino_query, trino_describe_table, trino_list_catalogs, etc.
+                  trino_query, trino_describe_table, trino_browse, etc.
                 </td>
               </tr>
               <tr className="border-b">

--- a/admin-ui/src/pages/tools/ToolsPage.tsx
+++ b/admin-ui/src/pages/tools/ToolsPage.tsx
@@ -969,18 +969,17 @@ function ToolsHelpTab() {
               <tr className="border-b">
                 <td className="px-3 py-2 font-medium">Trino</td>
                 <td className="px-3 py-2 text-xs">
-                  trino_query, trino_describe_table, trino_list_catalogs,
-                  trino_list_schemas, trino_list_tables, trino_explain
+                  trino_query, trino_describe_table, trino_browse,
+                  trino_explain, trino_execute
                 </td>
               </tr>
               <tr className="border-b">
                 <td className="px-3 py-2 font-medium">DataHub</td>
                 <td className="px-3 py-2 text-xs">
                   datahub_search, datahub_get_entity, datahub_get_schema,
-                  datahub_get_lineage, datahub_get_column_lineage,
+                  datahub_get_lineage, datahub_browse,
                   datahub_get_glossary_term, datahub_get_queries,
-                  datahub_get_data_product, datahub_list_data_products,
-                  datahub_list_domains, datahub_list_tags
+                  datahub_get_data_product
                 </td>
               </tr>
               <tr>

--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -93,7 +93,7 @@ personas:
       allow:
         - "datahub_search"
         - "datahub_get_entity"
-        - "datahub_list_*"
+        - "datahub_browse"
       deny: []
     prompts:
       system_prefix: |

--- a/dev/platform.yaml
+++ b/dev/platform.yaml
@@ -79,7 +79,7 @@ personas:
       allow:
         - "trino_query"
         - "trino_describe_table"
-        - "trino_list_*"
+        - "trino_browse"
         - "datahub_search"
         - "datahub_get_entity"
         - "datahub_get_schema"

--- a/dev/seed.sql
+++ b/dev/seed.sql
@@ -129,7 +129,7 @@ FROM
     SELECT tool_name, toolkit_kind, toolkit_name, connection FROM (VALUES
       ('trino_query',              'trino',   'acme-warehouse',        'acme-warehouse',         22),
       ('trino_describe_table',     'trino',   'acme-warehouse',        'acme-warehouse',          7),
-      ('trino_list_tables',        'trino',   'acme-warehouse',        'acme-warehouse',          3),
+      ('trino_browse',             'trino',   'acme-warehouse',        'acme-warehouse',          3),
       ('datahub_search',           'datahub', 'acme-catalog',          'acme-catalog',           12),
       ('datahub_get_entity',       'datahub', 'acme-catalog',          'acme-catalog',            6),
       ('datahub_get_schema',       'datahub', 'acme-catalog',          'acme-catalog',            3),

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -160,7 +160,7 @@ personas:
       display_name: "Data Analyst"
       roles: ["dp_analyst"]
       tools:
-        allow: ["trino_query", "trino_list_*", "trino_describe_*", "datahub_*"]
+        allow: ["trino_query", "trino_browse", "trino_describe_*", "trino_list_connections", "datahub_*"]
         deny: ["*_delete_*", "*_drop_*", "*_put_*"]
 
     # Tier 3: Data engineers with write access
@@ -386,8 +386,9 @@ personas:
           - "datahub_*"
           - "trino_query:marketing"      # Explicit cluster access
           - "trino_query:sales"
-          - "trino_list_*"
+          - "trino_browse"
           - "trino_describe_*"
+          - "trino_list_connections"
         deny:
           - "trino_query:finance"        # No finance access
           - "*_delete_*"

--- a/docs/personas/tool-filtering.md
+++ b/docs/personas/tool-filtering.md
@@ -41,7 +41,7 @@ graph TD
 |---------|---------|
 | `*` | Everything |
 | `trino_*` | trino_query, trino_execute, trino_explain, trino_browse, etc. |
-| `*_list_*` | s3_list_buckets, s3_list_objects, datahub_list_connections, etc. |
+| `*_list_*` | s3_list_buckets, s3_list_objects, trino_list_connections, etc. (does **not** match `trino_browse` or `datahub_browse`) |
 | `datahub_get_*` | datahub_get_entity, datahub_get_schema, etc. |
 | `s3_*` | All S3 tools |
 | `trino_query` | Exact match only |
@@ -65,8 +65,9 @@ tools:
   allow:
     - "trino_query"
     - "trino_explain"
-    - "trino_list_*"
+    - "trino_browse"
     - "trino_describe_*"
+    - "trino_list_connections"
     - "datahub_*"
     - "s3_list_*"
     - "s3_get_*"
@@ -83,8 +84,9 @@ tools:
 tools:
   allow:
     - "datahub_*"
-    - "trino_list_*"
+    - "trino_browse"
     - "trino_describe_*"
+    - "trino_list_connections"
   deny:
     - "trino_query"
     - "trino_execute"
@@ -188,8 +190,9 @@ data_steward:
   tools:
     allow:
       - "datahub_*"
-      - "trino_list_*"
+      - "trino_browse"
       - "trino_describe_*"
+      - "trino_list_connections"
     deny:
       - "trino_query"
       - "trino_execute"
@@ -217,8 +220,8 @@ viewer:
     allow:
       - "datahub_search"
       - "datahub_get_entity"
-      - "datahub_list_*"
-      - "trino_list_*"
+      - "datahub_browse"
+      - "trino_browse"
     deny:
       - "trino_query"
       - "trino_execute"
@@ -257,7 +260,8 @@ filter := persona.NewToolFilter(persona.ToolRules{
     Deny:  []string{"trino_query"},
 })
 
-filter.Allows("trino_browse")        // true
+filter.Allows("trino_browse")         // true
+filter.Allows("trino_describe_table") // true
 filter.Allows("trino_query")         // false
 filter.Allows("datahub_search")      // false
 ```

--- a/docs/reference/tools-api.md
+++ b/docs/reference/tools-api.md
@@ -343,18 +343,19 @@ Get dataset schema.
 
 ### datahub_get_lineage
 
-Get data lineage.
+Get upstream or downstream lineage for an entity. Set `level=column` for column-level lineage showing which upstream columns feed each downstream column. Default (`dataset`) returns dataset-level relationships with direction and depth control.
 
 **Parameters:**
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `urn` | string | Yes | - | Entity URN |
-| `direction` | string | No | `downstream` | `upstream` or `downstream` |
-| `depth` | integer | No | 3 | Maximum traversal depth |
+| `level` | string | No | `dataset` | Granularity: `dataset` or `column` |
+| `direction` | string | No | `downstream` | `upstream` or `downstream` (dataset level only) |
+| `depth` | integer | No | 3 | Maximum traversal depth, max 5 (dataset level only) |
 | `connection` | string | No | first configured | DataHub connection name |
 
-**Response Schema:**
+**Response Schema (dataset level):**
 
 ```json
 {
@@ -373,6 +374,28 @@ Get data lineage.
       "source": "urn:li:dataset:orders",
       "target": "urn:li:dataset:daily_orders_agg",
       "type": "TRANSFORMED"
+    }
+  ]
+}
+```
+
+**Response Schema (column level):**
+
+```json
+{
+  "root": "urn:li:dataset:...",
+  "column_lineage": [
+    {
+      "downstream": {
+        "urn": "urn:li:dataset:daily_orders_agg",
+        "column": "total_revenue"
+      },
+      "upstreams": [
+        {
+          "urn": "urn:li:dataset:orders",
+          "column": "total_amount"
+        }
+      ]
     }
   ]
 }

--- a/docs/server/multi-provider.md
+++ b/docs/server/multi-provider.md
@@ -200,9 +200,10 @@ personas:
       roles: ["staging"]
       tools:
         allow:
-          - "trino_query"       # Can query
-          - "trino_list_*"      # Can explore schema
-          - "trino_describe_*"  # Can describe tables
+          - "trino_query"           # Can query
+          - "trino_browse"          # Can explore catalogs/schemas/tables
+          - "trino_describe_*"      # Can describe tables
+          - "trino_list_connections" # Can list connections
         deny:
           - "trino_explain"     # Cannot see execution plans
 ```

--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,9 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
-	github.com/txn2/mcp-datahub v1.0.3
+	github.com/txn2/mcp-datahub v1.1.1
 	github.com/txn2/mcp-s3 v1.0.0
-	github.com/txn2/mcp-trino v1.0.0
+	github.com/txn2/mcp-trino v1.1.0
 	github.com/yosida95/uritemplate/v3 v3.0.2
 	github.com/yuin/goldmark v1.7.16
 	golang.org/x/crypto v0.48.0

--- a/go.sum
+++ b/go.sum
@@ -274,12 +274,12 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v1.0.3 h1:REOnVtRqNkIPRA0vRzLnTEo9qAwz/30g7tUKWtdoB74=
-github.com/txn2/mcp-datahub v1.0.3/go.mod h1:4RMSmUYrcoGwlmmJBLuiGPbz9kqT5dqZ65eKaMhqDX0=
+github.com/txn2/mcp-datahub v1.1.1 h1:dZcBC9buSV7XKCCHmIamf0SLl7pIilVZLo0HsgUIfIU=
+github.com/txn2/mcp-datahub v1.1.1/go.mod h1:4RMSmUYrcoGwlmmJBLuiGPbz9kqT5dqZ65eKaMhqDX0=
 github.com/txn2/mcp-s3 v1.0.0 h1:0772X3H7bAJPqDtuvDNlZTGEK2m1egInfuqQL/Jlq8Y=
 github.com/txn2/mcp-s3 v1.0.0/go.mod h1:hQc0xBl0t/afEgFmrOSKH3OW9uyKdeliFknQwfAzqG0=
-github.com/txn2/mcp-trino v1.0.0 h1:mrVIT4Bq+2ryL1WyCaD8arVanV/AI16bAcfZDGUDzxQ=
-github.com/txn2/mcp-trino v1.0.0/go.mod h1:Chpbs4zPxgwSMxYxTThd9ux+FfLQXqE5XX06VSuC/6I=
+github.com/txn2/mcp-trino v1.1.0 h1:5/cSIIzciTT/cV1p8enM+4k4SI+0OcK5uFwcQhOBWhk=
+github.com/txn2/mcp-trino v1.1.0/go.mod h1:Chpbs4zPxgwSMxYxTThd9ux+FfLQXqE5XX06VSuC/6I=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/pkg/middleware/session_workflow.go
+++ b/pkg/middleware/session_workflow.go
@@ -11,13 +11,10 @@ var DefaultDiscoveryTools = []string{
 	"datahub_get_entity",
 	"datahub_get_schema",
 	"datahub_get_lineage",
-	"datahub_get_column_lineage",
 	"datahub_get_queries",
+	"datahub_browse",
 	"datahub_get_glossary_term",
 	"datahub_get_data_product",
-	"datahub_list_data_products",
-	"datahub_list_domains",
-	"datahub_list_tags",
 }
 
 // DefaultQueryTools lists the tool names that are gated by discovery.

--- a/pkg/middleware/session_workflow_test.go
+++ b/pkg/middleware/session_workflow_test.go
@@ -150,14 +150,11 @@ func TestDefaultDiscoveryTools(t *testing.T) {
 	assert.Contains(t, DefaultDiscoveryTools, "datahub_get_entity")
 	assert.Contains(t, DefaultDiscoveryTools, "datahub_get_schema")
 	assert.Contains(t, DefaultDiscoveryTools, "datahub_get_lineage")
-	assert.Contains(t, DefaultDiscoveryTools, "datahub_get_column_lineage")
 	assert.Contains(t, DefaultDiscoveryTools, "datahub_get_queries")
+	assert.Contains(t, DefaultDiscoveryTools, "datahub_browse")
 	assert.Contains(t, DefaultDiscoveryTools, "datahub_get_glossary_term")
 	assert.Contains(t, DefaultDiscoveryTools, "datahub_get_data_product")
-	assert.Contains(t, DefaultDiscoveryTools, "datahub_list_data_products")
-	assert.Contains(t, DefaultDiscoveryTools, "datahub_list_domains")
-	assert.Contains(t, DefaultDiscoveryTools, "datahub_list_tags")
-	assert.Len(t, DefaultDiscoveryTools, 11)
+	assert.Len(t, DefaultDiscoveryTools, 8)
 }
 
 func TestDefaultQueryTools(t *testing.T) {

--- a/pkg/toolkits/datahub/toolkit.go
+++ b/pkg/toolkits/datahub/toolkit.go
@@ -209,12 +209,9 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 			dhtools.ToolGetEntity,
 			dhtools.ToolGetSchema,
 			dhtools.ToolGetLineage,
-			dhtools.ToolGetColumnLineage,
 			dhtools.ToolGetQueries,
+			dhtools.ToolBrowse,
 			dhtools.ToolGetGlossaryTerm,
-			dhtools.ToolListTags,
-			dhtools.ToolListDomains,
-			dhtools.ToolListDataProducts,
 			dhtools.ToolGetDataProduct,
 		)
 	}
@@ -227,12 +224,9 @@ func (*Toolkit) Tools() []string {
 		"datahub_get_entity",
 		"datahub_get_schema",
 		"datahub_get_lineage",
-		"datahub_get_column_lineage",
 		"datahub_get_queries",
+		"datahub_browse",
 		"datahub_get_glossary_term",
-		"datahub_list_tags",
-		"datahub_list_domains",
-		"datahub_list_data_products",
 		"datahub_get_data_product",
 	}
 }

--- a/pkg/toolkits/datahub/toolkit_test.go
+++ b/pkg/toolkits/datahub/toolkit_test.go
@@ -277,12 +277,9 @@ func TestToolkit_Tools(t *testing.T) {
 		"datahub_get_entity",
 		"datahub_get_schema",
 		"datahub_get_lineage",
-		"datahub_get_column_lineage",
 		"datahub_get_queries",
+		"datahub_browse",
 		"datahub_get_glossary_term",
-		"datahub_list_tags",
-		"datahub_list_domains",
-		"datahub_list_data_products",
 		"datahub_get_data_product",
 	}
 

--- a/pkg/toolkits/trino/connection_required_test.go
+++ b/pkg/toolkits/trino/connection_required_test.go
@@ -92,17 +92,17 @@ func TestConnectionRequiredMiddleware_Before(t *testing.T) {
 		}
 	})
 
-	t.Run("rejects list_catalogs without connection", func(t *testing.T) {
-		tc := trinotools.NewToolContext(trinotools.ToolListCatalogs, trinotools.ListCatalogsInput{})
+	t.Run("rejects browse without connection", func(t *testing.T) {
+		tc := trinotools.NewToolContext(trinotools.ToolBrowse, trinotools.BrowseInput{})
 
 		_, err := mw.Before(context.Background(), tc)
 		if err == nil {
-			t.Fatal("expected error for missing connection on list_catalogs")
+			t.Fatal("expected error for missing connection on browse")
 		}
 	})
 
-	t.Run("passes list_schemas with connection", func(t *testing.T) {
-		tc := trinotools.NewToolContext(trinotools.ToolListSchemas, trinotools.ListSchemasInput{
+	t.Run("passes browse with connection", func(t *testing.T) {
+		tc := trinotools.NewToolContext(trinotools.ToolBrowse, trinotools.BrowseInput{
 			Catalog:    "hive",
 			Connection: "elasticsearch",
 		})

--- a/pkg/toolkits/trino/toolkit.go
+++ b/pkg/toolkits/trino/toolkit.go
@@ -435,9 +435,7 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 			trinotools.ToolQuery,
 			trinotools.ToolExecute,
 			trinotools.ToolExplain,
-			trinotools.ToolListCatalogs,
-			trinotools.ToolListSchemas,
-			trinotools.ToolListTables,
+			trinotools.ToolBrowse,
 			trinotools.ToolDescribeTable,
 		)
 	}
@@ -449,9 +447,7 @@ func (*Toolkit) Tools() []string {
 		"trino_query",
 		"trino_execute",
 		"trino_explain",
-		"trino_list_catalogs",
-		"trino_list_schemas",
-		"trino_list_tables",
+		"trino_browse",
 		"trino_describe_table",
 	}
 }

--- a/pkg/toolkits/trino/toolkit_test.go
+++ b/pkg/toolkits/trino/toolkit_test.go
@@ -309,9 +309,7 @@ func TestToolkit_Tools(t *testing.T) {
 		"trino_query",
 		"trino_execute",
 		"trino_explain",
-		"trino_list_catalogs",
-		"trino_list_schemas",
-		"trino_list_tables",
+		"trino_browse",
 		"trino_describe_table",
 	}
 
@@ -692,8 +690,8 @@ func TestNewMulti(t *testing.T) {
 		}
 
 		tools := tk.Tools()
-		if len(tools) != 7 { //nolint:mnd // 7 trino tools
-			t.Errorf("expected 7 tools, got %d", len(tools))
+		if len(tools) != 5 { //nolint:mnd // 5 trino tools
+			t.Errorf("expected 5 tools, got %d", len(tools))
 		}
 	})
 


### PR DESCRIPTION
## Summary

Upgrades upstream dependencies that consolidate navigation/browse tools, reducing the platform's total tool count by 7.

- **mcp-trino** v1.0.0 → v1.1.0: `trino_list_catalogs`, `trino_list_schemas`, `trino_list_tables` → single `trino_browse` tool
- **mcp-datahub** v1.0.3 → v1.1.1: `datahub_list_tags`, `datahub_list_domains`, `datahub_list_data_products` → `datahub_browse`; `datahub_get_column_lineage` merged into `datahub_get_lineage` with `level=column` parameter

**Net reduction: -7 tools** (3 trino + 4 datahub)

Closes Phase 5 of #169.

## Changes

### Go source (4 files)
- **`pkg/toolkits/trino/toolkit.go`** — RegisterTools and Tools() updated (8→6 tools registered, tool list 7→5)
- **`pkg/toolkits/datahub/toolkit.go`** — RegisterTools and Tools() updated (11→8 tools registered)
- **`pkg/middleware/session_workflow.go`** — DefaultDiscoveryTools reduced from 11→8 entries

### Tests (4 files)
- **`pkg/toolkits/trino/toolkit_test.go`** — expected tools list and count updated
- **`pkg/toolkits/trino/connection_required_test.go`** — `ToolListCatalogs`/`ToolListSchemas` → `ToolBrowse` with `BrowseInput`
- **`pkg/toolkits/datahub/toolkit_test.go`** — expected tools list and count updated
- **`pkg/middleware/session_workflow_test.go`** — assertions updated (11→8 discovery tools)

### Configuration (3 files)
- **`dev/platform.yaml`** — inventory-analyst persona: `trino_list_*` → `trino_browse` (wildcard would not match)
- **`configs/platform.yaml`** — executive persona: `datahub_list_*` → `datahub_browse`
- **`dev/seed.sql`** — audit seed data: `trino_list_tables` → `trino_browse`

### Admin UI (6 files)
- **`admin-ui/src/mocks/data/tools.ts`** — replaced tool schemas/handlers for removed tools with `trino_browse` and `datahub_browse`
- **`admin-ui/src/mocks/data/system.ts`** — updated toolkit tool lists
- **`admin-ui/src/mocks/data/audit.ts`** — updated mock audit tool references
- **`admin-ui/src/pages/{home,tools,personas}/*.tsx`** — updated help text example tool names

### Documentation (4 files)
- **`docs/reference/tools-api.md`** — new `trino_browse` and `datahub_browse` API docs
- **`docs/personas/tool-filtering.md`** — updated tool listings, added note about `*_list_*` patterns not matching browse tools
- **`docs/examples/index.md`** — updated example persona configs
- **`docs/server/multi-provider.md`** — updated tool references

## Notes

- Enrichment middleware uses prefix-based dispatch (`strings.HasPrefix(toolName, "trino_")`) — no changes needed
- Wildcard persona filters `trino_*` and `datahub_*` still work, but `*_list_*` patterns will **not** match the new browse tools — documented in tool-filtering.md

## Test plan

- [x] `go test -race ./...` — all tests pass
- [x] `make verify` — full CI suite passes (fmt, lint, security, coverage ≥80%, mutation ≥60%)
- [ ] CI passes on this PR
- [ ] Verify `trino_browse` and `datahub_browse` work end-to-end against a live instance