### PR TITLE
feat: apply_knowledge supports non-dataset entities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
-	github.com/txn2/mcp-datahub v1.1.1
+	github.com/txn2/mcp-datahub v1.2.0
 	github.com/txn2/mcp-s3 v1.0.0
 	github.com/txn2/mcp-trino v1.1.0
 	github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v1.1.1 h1:dZcBC9buSV7XKCCHmIamf0SLl7pIilVZLo0HsgUIfIU=
-github.com/txn2/mcp-datahub v1.1.1/go.mod h1:4RMSmUYrcoGwlmmJBLuiGPbz9kqT5dqZ65eKaMhqDX0=
+github.com/txn2/mcp-datahub v1.2.0 h1:7ua4DUvCzt4EIY9fDOrIMvufqMeGtsjbvb9/xIbRHwc=
+github.com/txn2/mcp-datahub v1.2.0/go.mod h1:uktl1c12qQwInw0XIS03jxYusLOFj8h5UO3+YBThzTI=
 github.com/txn2/mcp-s3 v1.0.0 h1:0772X3H7bAJPqDtuvDNlZTGEK2m1egInfuqQL/Jlq8Y=
 github.com/txn2/mcp-s3 v1.0.0/go.mod h1:hQc0xBl0t/afEgFmrOSKH3OW9uyKdeliFknQwfAzqG0=
 github.com/txn2/mcp-trino v1.1.0 h1:5/cSIIzciTT/cV1p8enM+4k4SI+0OcK5uFwcQhOBWhk=

--- a/pkg/toolkits/knowledge/entity_type.go
+++ b/pkg/toolkits/knowledge/entity_type.go
@@ -1,0 +1,129 @@
+package knowledge
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	dhclient "github.com/txn2/mcp-datahub/pkg/client"
+)
+
+// entityTypeDataset is the DataHub entity type string for datasets.
+const entityTypeDataset = "dataset"
+
+// entityTypeFromURN extracts the entity type from a DataHub URN.
+// For example, "urn:li:dataset:(...)" returns "dataset".
+func entityTypeFromURN(urn string) (string, error) {
+	parsed, err := dhclient.ParseURN(urn)
+	if err != nil {
+		return "", fmt.Errorf("invalid URN %q: %w", urn, err)
+	}
+	return parsed.EntityType, nil
+}
+
+// datasetOnlyOperations are change types that only work on dataset entities.
+var datasetOnlyOperations = map[actionType]bool{
+	actionAddCuratedQuery: true,
+}
+
+// supportedOpsForType returns the list of supported operations for a given entity type.
+// All entity types support tag, glossary term, documentation, and quality issue operations.
+// Only datasets support column descriptions and curated queries.
+// update_description is supported for the 10 entity types handled by mcp-datahub.
+func supportedOpsForType(entityType string) []string {
+	ops := []string{
+		"add_tag", "remove_tag", "add_glossary_term",
+		"add_documentation", "flag_quality_issue",
+	}
+
+	if descriptionSupportedTypes[entityType] {
+		ops = append([]string{"update_description"}, ops...)
+	}
+
+	if entityType == entityTypeDataset {
+		ops = append(ops, "add_curated_query")
+	}
+
+	return ops
+}
+
+// descriptionSupportedTypes are entity types that support update_description.
+// This matches the upstream mcp-datahub descriptionAspectMap.
+var descriptionSupportedTypes = map[string]bool{
+	"dataset":      true,
+	"dashboard":    true,
+	"chart":        true,
+	"dataFlow":     true,
+	"dataJob":      true,
+	"container":    true,
+	"dataProduct":  true,
+	"domain":       true,
+	"glossaryTerm": true,
+	"glossaryNode": true,
+}
+
+// validateEntityTypeForChange checks whether a change type is supported for the
+// given entity URN. Returns a user-friendly error message when incompatible.
+func validateEntityTypeForChange(urn string, c ApplyChange) error {
+	entityType, err := entityTypeFromURN(urn)
+	if err != nil {
+		return err
+	}
+
+	// Column-level descriptions are dataset-only (schema metadata is a dataset concept).
+	if c.ChangeType == string(actionUpdateDescription) {
+		if _, isColumn := parseColumnTarget(c.Target); isColumn {
+			if entityType != "dataset" {
+				return fmt.Errorf(
+					"column-level update_description is only supported for datasets, not %s entities. "+
+						"Supported operations for %s: %s",
+					entityType, entityType, strings.Join(supportedOpsForType(entityType), ", "),
+				)
+			}
+			return nil
+		}
+	}
+
+	// Dataset-only operations.
+	if datasetOnlyOperations[actionType(c.ChangeType)] && entityType != "dataset" {
+		return fmt.Errorf(
+			"%s is only supported for datasets, not %s entities. "+
+				"Supported operations for %s: %s",
+			c.ChangeType, entityType, entityType, strings.Join(supportedOpsForType(entityType), ", "),
+		)
+	}
+
+	return nil
+}
+
+// wrapUnsupportedEntityTypeError checks if an error is an ErrUnsupportedEntityType
+// from the upstream mcp-datahub library and wraps it with a user-friendly message.
+func wrapUnsupportedEntityTypeError(err error, urn string) error {
+	if err == nil {
+		return nil
+	}
+
+	if !errors.Is(err, dhclient.ErrUnsupportedEntityType) {
+		return err
+	}
+
+	entityType, parseErr := entityTypeFromURN(urn)
+	if parseErr != nil {
+		return err // Fall back to original error if URN parsing fails
+	}
+
+	return fmt.Errorf(
+		"update_description is not supported for %s entities. "+
+			"Supported operations for %s: %s",
+		entityType, entityType, strings.Join(supportedOpsForType(entityType), ", "),
+	)
+}
+
+// wrapDescriptionError converts ErrUnsupportedEntityType into a user-friendly message,
+// and falls back to a generic "description update" wrapper for all other errors.
+func wrapDescriptionError(err error, urn string) error {
+	if errors.Is(err, dhclient.ErrUnsupportedEntityType) {
+		return wrapUnsupportedEntityTypeError(err, urn)
+	}
+	return fmt.Errorf("description update: %w", err)
+}

--- a/pkg/toolkits/knowledge/entity_type_test.go
+++ b/pkg/toolkits/knowledge/entity_type_test.go
@@ -1,0 +1,306 @@
+package knowledge
+
+import (
+	"errors"
+	"testing"
+
+	dhclient "github.com/txn2/mcp-datahub/pkg/client"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntityTypeFromURN(t *testing.T) {
+	tests := []struct {
+		name       string
+		urn        string
+		wantType   string
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name:     "dataset",
+			urn:      "urn:li:dataset:(urn:li:dataPlatform:trino,test.table,PROD)",
+			wantType: "dataset",
+		},
+		{
+			name:     "domain",
+			urn:      "urn:li:domain:sales",
+			wantType: "domain",
+		},
+		{
+			name:     "glossaryTerm",
+			urn:      "urn:li:glossaryTerm:Revenue",
+			wantType: "glossaryTerm",
+		},
+		{
+			name:     "dataProduct",
+			urn:      "urn:li:dataProduct:analytics",
+			wantType: "dataProduct",
+		},
+		{
+			name:     "dashboard",
+			urn:      "urn:li:dashboard:(looker,abc123)",
+			wantType: "dashboard",
+		},
+		{
+			name:     "tag",
+			urn:      "urn:li:tag:pii",
+			wantType: "tag",
+		},
+		{
+			name:       "invalid URN",
+			urn:        "not-a-urn",
+			wantErr:    true,
+			errContain: "invalid URN",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := entityTypeFromURN(tc.urn)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContain)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantType, got)
+		})
+	}
+}
+
+func TestValidateEntityTypeForChange(t *testing.T) {
+	datasetURN := "urn:li:dataset:(urn:li:dataPlatform:trino,test.table,PROD)"
+	domainURN := "urn:li:domain:sales"
+	glossaryURN := "urn:li:glossaryTerm:Revenue"
+	dataProductURN := "urn:li:dataProduct:analytics"
+	tagURN := "urn:li:tag:pii"
+
+	tests := []struct {
+		name       string
+		urn        string
+		change     ApplyChange
+		wantErr    bool
+		errContain string
+	}{
+		// update_description on various entity types
+		{
+			name:   "update_description on dataset",
+			urn:    datasetURN,
+			change: ApplyChange{ChangeType: "update_description", Detail: "desc"},
+		},
+		{
+			name:   "update_description on domain",
+			urn:    domainURN,
+			change: ApplyChange{ChangeType: "update_description", Detail: "desc"},
+		},
+		{
+			name:   "update_description on glossaryTerm",
+			urn:    glossaryURN,
+			change: ApplyChange{ChangeType: "update_description", Detail: "desc"},
+		},
+		{
+			name:   "update_description on dataProduct",
+			urn:    dataProductURN,
+			change: ApplyChange{ChangeType: "update_description", Detail: "desc"},
+		},
+
+		// Column-level descriptions: dataset only
+		{
+			name:   "column description on dataset",
+			urn:    datasetURN,
+			change: ApplyChange{ChangeType: "update_description", Target: "column:customer_id", Detail: "desc"},
+		},
+		{
+			name:       "column description on domain",
+			urn:        domainURN,
+			change:     ApplyChange{ChangeType: "update_description", Target: "column:name", Detail: "desc"},
+			wantErr:    true,
+			errContain: "column-level update_description is only supported for datasets",
+		},
+		{
+			name:       "column description on glossaryTerm",
+			urn:        glossaryURN,
+			change:     ApplyChange{ChangeType: "update_description", Target: "column:name", Detail: "desc"},
+			wantErr:    true,
+			errContain: "column-level update_description is only supported for datasets",
+		},
+
+		// add_curated_query: dataset only
+		{
+			name:   "curated query on dataset",
+			urn:    datasetURN,
+			change: ApplyChange{ChangeType: "add_curated_query", Detail: "My Query", QuerySQL: "SELECT 1"},
+		},
+		{
+			name:       "curated query on domain",
+			urn:        domainURN,
+			change:     ApplyChange{ChangeType: "add_curated_query", Detail: "My Query", QuerySQL: "SELECT 1"},
+			wantErr:    true,
+			errContain: "add_curated_query is only supported for datasets",
+		},
+		{
+			name:       "curated query on glossaryTerm",
+			urn:        glossaryURN,
+			change:     ApplyChange{ChangeType: "add_curated_query", Detail: "My Query", QuerySQL: "SELECT 1"},
+			wantErr:    true,
+			errContain: "add_curated_query is only supported for datasets",
+		},
+
+		// Operations that work on all entity types
+		{
+			name:   "add_tag on domain",
+			urn:    domainURN,
+			change: ApplyChange{ChangeType: "add_tag", Detail: "important"},
+		},
+		{
+			name:   "remove_tag on glossaryTerm",
+			urn:    glossaryURN,
+			change: ApplyChange{ChangeType: "remove_tag", Detail: "deprecated"},
+		},
+		{
+			name:   "add_glossary_term on dataProduct",
+			urn:    dataProductURN,
+			change: ApplyChange{ChangeType: "add_glossary_term", Detail: "revenue"},
+		},
+		{
+			name:   "add_documentation on domain",
+			urn:    domainURN,
+			change: ApplyChange{ChangeType: "add_documentation", Target: "https://docs.example.com", Detail: "docs"},
+		},
+		{
+			name:   "flag_quality_issue on domain",
+			urn:    domainURN,
+			change: ApplyChange{ChangeType: "flag_quality_issue", Detail: "stale data"},
+		},
+
+		// Error messages include supported operations
+		{
+			name:       "curated query error lists supported ops",
+			urn:        domainURN,
+			change:     ApplyChange{ChangeType: "add_curated_query", Detail: "q", QuerySQL: "SELECT 1"},
+			wantErr:    true,
+			errContain: "Supported operations for domain",
+		},
+		{
+			name:       "column desc error lists supported ops for tag entity",
+			urn:        tagURN,
+			change:     ApplyChange{ChangeType: "update_description", Target: "column:name", Detail: "desc"},
+			wantErr:    true,
+			errContain: "Supported operations for tag",
+		},
+
+		// Invalid URN
+		{
+			name:       "invalid URN",
+			urn:        "not-a-urn",
+			change:     ApplyChange{ChangeType: "add_tag", Detail: "tag1"},
+			wantErr:    true,
+			errContain: "invalid URN",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateEntityTypeForChange(tc.urn, tc.change)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContain)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestSupportedOpsForType(t *testing.T) {
+	tests := []struct {
+		entityType   string
+		wantContains []string
+		wantMissing  []string
+	}{
+		{
+			entityType:   "dataset",
+			wantContains: []string{"update_description", "add_tag", "remove_tag", "add_glossary_term", "add_documentation", "flag_quality_issue", "add_curated_query"},
+		},
+		{
+			entityType:   "domain",
+			wantContains: []string{"update_description", "add_tag", "remove_tag", "add_glossary_term", "add_documentation", "flag_quality_issue"},
+			wantMissing:  []string{"add_curated_query"},
+		},
+		{
+			entityType:   "tag",
+			wantContains: []string{"add_tag", "remove_tag", "add_glossary_term"},
+			wantMissing:  []string{"update_description", "add_curated_query"},
+		},
+		{
+			entityType:   "glossaryTerm",
+			wantContains: []string{"update_description", "add_tag"},
+			wantMissing:  []string{"add_curated_query"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.entityType, func(t *testing.T) {
+			ops := supportedOpsForType(tc.entityType)
+			for _, want := range tc.wantContains {
+				assert.Contains(t, ops, want)
+			}
+			for _, notWant := range tc.wantMissing {
+				assert.NotContains(t, ops, notWant)
+			}
+		})
+	}
+}
+
+func TestWrapDescriptionError(t *testing.T) {
+	t.Run("wraps unsupported entity type", func(t *testing.T) {
+		err := dhclient.ErrUnsupportedEntityType
+		got := wrapDescriptionError(err, "urn:li:tag:pii")
+		require.Error(t, got)
+		assert.Contains(t, got.Error(), "update_description is not supported for tag entities")
+	})
+
+	t.Run("wraps generic error", func(t *testing.T) {
+		err := errors.New("network timeout")
+		got := wrapDescriptionError(err, "urn:li:dataset:(urn:li:dataPlatform:trino,x,PROD)")
+		require.Error(t, got)
+		assert.Contains(t, got.Error(), "description update:")
+		assert.Contains(t, got.Error(), "network timeout")
+	})
+}
+
+func TestWrapUnsupportedEntityTypeError(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		assert.Nil(t, wrapUnsupportedEntityTypeError(nil, "urn:li:tag:pii"))
+	})
+
+	t.Run("non-sentinel error passes through", func(t *testing.T) {
+		orig := errors.New("network timeout")
+		got := wrapUnsupportedEntityTypeError(orig, "urn:li:dataset:(urn:li:dataPlatform:trino,x,PROD)")
+		assert.Equal(t, orig, got)
+	})
+
+	t.Run("wraps ErrUnsupportedEntityType with entity info", func(t *testing.T) {
+		orig := dhclient.ErrUnsupportedEntityType
+		got := wrapUnsupportedEntityTypeError(orig, "urn:li:tag:pii")
+		require.Error(t, got)
+		assert.Contains(t, got.Error(), "update_description is not supported for tag entities")
+		assert.Contains(t, got.Error(), "Supported operations for tag")
+		// Should NOT be the same error object (wrapped)
+		assert.NotEqual(t, orig, got)
+	})
+
+	t.Run("wrapped ErrUnsupportedEntityType", func(t *testing.T) {
+		wrapped := errors.Join(dhclient.ErrUnsupportedEntityType, errors.New("extra context"))
+		got := wrapUnsupportedEntityTypeError(wrapped, "urn:li:tag:pii")
+		assert.Contains(t, got.Error(), "update_description is not supported for tag entities")
+	})
+
+	t.Run("invalid URN falls back to original error", func(t *testing.T) {
+		orig := dhclient.ErrUnsupportedEntityType
+		got := wrapUnsupportedEntityTypeError(orig, "not-a-urn")
+		assert.Equal(t, orig, got)
+	})
+}

--- a/pkg/toolkits/knowledge/schemas.go
+++ b/pkg/toolkits/knowledge/schemas.go
@@ -115,11 +115,11 @@ var applyKnowledgeSchema = json.RawMessage(`{
         "properties": {
           "change_type": {
             "type": "string",
-            "description": "Type of catalog change. Valid values: update_description, add_tag, remove_tag, add_glossary_term, flag_quality_issue, add_documentation, add_curated_query"
+            "description": "Type of catalog change. Valid values: update_description, add_tag, remove_tag, add_glossary_term, flag_quality_issue, add_documentation, add_curated_query. update_description supports datasets, dashboards, charts, dataFlows, dataJobs, containers, dataProducts, domains, glossaryTerms, glossaryNodes. Column-level descriptions and add_curated_query are dataset-only."
           },
           "target": {
             "type": "string",
-            "description": "Where to apply the change. Use 'column:<fieldPath>' for column-level descriptions (e.g., 'column:location_type_id'). For add_documentation, this is the URL. For remove_tag, this is ignored. Leave empty for dataset-level updates"
+            "description": "Where to apply the change. Use 'column:<fieldPath>' for column-level descriptions (e.g., 'column:location_type_id', dataset-only). For add_documentation, this is the URL. For remove_tag, this is ignored. Leave empty for entity-level updates"
           },
           "detail": {
             "type": "string",

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -145,7 +145,11 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 			Description: "Reviews, synthesizes, and applies captured insights to the data catalog. Admin-only. " +
 				"Actions: bulk_review, review, synthesize, apply, approve, reject. " +
 				"Change types: update_description, add_tag, remove_tag, add_glossary_term, flag_quality_issue, add_documentation, add_curated_query. " +
-				"For update_description, use target 'column:<fieldPath>' for column-level (e.g., 'column:location_type_id'), omit for dataset-level. " +
+				"For update_description, use target 'column:<fieldPath>' for column-level (e.g., 'column:location_type_id'), omit for entity-level. " +
+				"update_description works on datasets, dashboards, charts, dataFlows, dataJobs, containers, dataProducts, domains, glossaryTerms, and glossaryNodes. " +
+				"Column-level descriptions (column:<fieldPath>) are dataset-only. " +
+				"add_tag, remove_tag, add_glossary_term, add_documentation, and flag_quality_issue work on all entity types. " +
+				"add_curated_query is dataset-only. " +
 				"For add_tag/remove_tag, detail is the tag name or URN (e.g., 'pii' or 'urn:li:tag:pii'). " +
 				"flag_quality_issue adds a fixed 'QualityIssue' tag; the detail text is stored as context in the knowledge store. " +
 				"For add_documentation, target is the URL, detail is the link description. " +
@@ -486,6 +490,13 @@ const columnTargetPrefix = "column:"
 // executeChanges applies changes to DataHub, rolling back on failure.
 // Returns a list of URNs created by add_curated_query changes.
 func (t *Toolkit) executeChanges(ctx context.Context, urn string, changes []ApplyChange) ([]string, error) {
+	// Pre-flight: validate entity type compatibility for all changes before executing any.
+	for i, c := range changes {
+		if err := validateEntityTypeForChange(urn, c); err != nil {
+			return nil, fmt.Errorf("change %d of %d rejected: %w", i+1, len(changes), err)
+		}
+	}
+
 	var createdURNs []string
 	for i, c := range changes {
 		queryURN, err := t.dispatchChange(ctx, urn, c)
@@ -562,7 +573,8 @@ func (t *Toolkit) executeUpdateDescription(ctx context.Context, urn string, c Ap
 		return nil
 	}
 	if err := t.datahubWriter.UpdateDescription(ctx, urn, c.Detail); err != nil {
-		return fmt.Errorf("description update: %w", err)
+		// Wrap ErrUnsupportedEntityType with a user-friendly message.
+		return wrapDescriptionError(err, urn)
 	}
 	return nil
 }

--- a/pkg/toolkits/knowledge/toolkit_test.go
+++ b/pkg/toolkits/knowledge/toolkit_test.go
@@ -2843,3 +2843,170 @@ func TestExecuteChanges_DocumentationParamMapping(t *testing.T) {
 	// Second arg is description (from detail)
 	assert.Equal(t, "Revenue documentation", call.Arg2)
 }
+
+// ---------------------------------------------------------------------------
+// Non-dataset entity support (issue #180)
+// ---------------------------------------------------------------------------
+
+func TestHandleApply_UpdateDescriptionOnDomain(t *testing.T) {
+	store := &fullSpyStore{}
+	csStore := &spyChangesetStore{}
+	writer := &spyWriter{}
+	tk := newApplyToolkit(t, store, csStore, writer)
+
+	input := applyKnowledgeInput{
+		Action:    "apply",
+		EntityURN: "urn:li:domain:sales",
+		Changes:   []ApplyChange{{ChangeType: "update_description", Detail: "Sales domain"}},
+	}
+
+	result, _, callErr := tk.handleApplyKnowledge(context.Background(), nil, input)
+	require.Nil(t, callErr)
+	require.False(t, result.IsError, "update_description should work on domains: %v", result.Content)
+
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "UpdateDescription", writer.WriteCalls[0].Method)
+	assert.Equal(t, "urn:li:domain:sales", writer.WriteCalls[0].URN)
+}
+
+func TestHandleApply_UpdateDescriptionOnGlossaryTerm(t *testing.T) {
+	store := &fullSpyStore{}
+	csStore := &spyChangesetStore{}
+	writer := &spyWriter{}
+	tk := newApplyToolkit(t, store, csStore, writer)
+
+	input := applyKnowledgeInput{
+		Action:    "apply",
+		EntityURN: "urn:li:glossaryTerm:Revenue",
+		Changes:   []ApplyChange{{ChangeType: "update_description", Detail: "Revenue is..."}},
+	}
+
+	result, _, callErr := tk.handleApplyKnowledge(context.Background(), nil, input)
+	require.Nil(t, callErr)
+	require.False(t, result.IsError, "update_description should work on glossary terms: %v", result.Content)
+
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "UpdateDescription", writer.WriteCalls[0].Method)
+	assert.Equal(t, "urn:li:glossaryTerm:Revenue", writer.WriteCalls[0].URN)
+}
+
+func TestHandleApply_UpdateDescriptionOnDataProduct(t *testing.T) {
+	store := &fullSpyStore{}
+	csStore := &spyChangesetStore{}
+	writer := &spyWriter{}
+	tk := newApplyToolkit(t, store, csStore, writer)
+
+	input := applyKnowledgeInput{
+		Action:    "apply",
+		EntityURN: "urn:li:dataProduct:analytics",
+		Changes:   []ApplyChange{{ChangeType: "update_description", Detail: "Analytics product"}},
+	}
+
+	result, _, callErr := tk.handleApplyKnowledge(context.Background(), nil, input)
+	require.Nil(t, callErr)
+	require.False(t, result.IsError, "update_description should work on data products: %v", result.Content)
+
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "UpdateDescription", writer.WriteCalls[0].Method)
+	assert.Equal(t, "urn:li:dataProduct:analytics", writer.WriteCalls[0].URN)
+}
+
+func TestHandleApply_ColumnDescOnNonDatasetRejected(t *testing.T) {
+	store := &fullSpyStore{}
+	csStore := &spyChangesetStore{}
+	writer := &spyWriter{}
+	tk := newApplyToolkit(t, store, csStore, writer)
+
+	input := applyKnowledgeInput{
+		Action:    "apply",
+		EntityURN: "urn:li:domain:sales",
+		Changes:   []ApplyChange{{ChangeType: "update_description", Target: "column:name", Detail: "desc"}},
+	}
+
+	result, _, callErr := tk.handleApplyKnowledge(context.Background(), nil, input)
+	require.Nil(t, callErr)
+	assert.True(t, result.IsError, "column description on domain should fail")
+
+	m := parseJSONResult(t, result)
+	errMsg, _ := m["error"].(string)
+	assert.Contains(t, errMsg, "column-level update_description is only supported for datasets")
+	assert.Contains(t, errMsg, "Supported operations for domain")
+
+	// No writes should have been attempted
+	assert.Empty(t, writer.WriteCalls)
+}
+
+func TestHandleApply_CuratedQueryOnNonDatasetRejected(t *testing.T) {
+	store := &fullSpyStore{}
+	csStore := &spyChangesetStore{}
+	writer := &spyWriter{}
+	tk := newApplyToolkit(t, store, csStore, writer)
+
+	input := applyKnowledgeInput{
+		Action:    "apply",
+		EntityURN: "urn:li:glossaryTerm:Revenue",
+		Changes:   []ApplyChange{{ChangeType: "add_curated_query", Detail: "Query", QuerySQL: "SELECT 1"}},
+	}
+
+	result, _, callErr := tk.handleApplyKnowledge(context.Background(), nil, input)
+	require.Nil(t, callErr)
+	assert.True(t, result.IsError, "curated query on glossary term should fail")
+
+	m := parseJSONResult(t, result)
+	errMsg, _ := m["error"].(string)
+	assert.Contains(t, errMsg, "add_curated_query is only supported for datasets")
+	assert.Contains(t, errMsg, "Supported operations for glossaryTerm")
+
+	// No writes should have been attempted
+	assert.Empty(t, writer.WriteCalls)
+}
+
+func TestHandleApply_AddTagOnNonDatasetSucceeds(t *testing.T) {
+	store := &fullSpyStore{}
+	csStore := &spyChangesetStore{}
+	writer := &spyWriter{}
+	tk := newApplyToolkit(t, store, csStore, writer)
+
+	input := applyKnowledgeInput{
+		Action:    "apply",
+		EntityURN: "urn:li:domain:sales",
+		Changes: []ApplyChange{
+			{ChangeType: "add_tag", Detail: "important"},
+			{ChangeType: "remove_tag", Detail: "deprecated"},
+			{ChangeType: "add_glossary_term", Detail: "Revenue"},
+			{ChangeType: "add_documentation", Target: "https://docs.example.com", Detail: "docs"},
+			{ChangeType: "flag_quality_issue", Detail: "stale metadata"},
+		},
+	}
+
+	result, _, callErr := tk.handleApplyKnowledge(context.Background(), nil, input)
+	require.Nil(t, callErr)
+	require.False(t, result.IsError, "tag/glossary/doc/quality ops should work on domains: %v", result.Content)
+
+	assert.Len(t, writer.WriteCalls, 5)
+}
+
+func TestHandleApply_MixedChangesRejectsBeforeExecution(t *testing.T) {
+	store := &fullSpyStore{}
+	csStore := &spyChangesetStore{}
+	writer := &spyWriter{}
+	tk := newApplyToolkit(t, store, csStore, writer)
+
+	// First change is valid, second is not (curated query on domain)
+	input := applyKnowledgeInput{
+		Action:    "apply",
+		EntityURN: "urn:li:domain:sales",
+		Changes: []ApplyChange{
+			{ChangeType: "add_tag", Detail: "tag1"},
+			{ChangeType: "add_curated_query", Detail: "Query", QuerySQL: "SELECT 1"},
+		},
+	}
+
+	result, _, callErr := tk.handleApplyKnowledge(context.Background(), nil, input)
+	require.Nil(t, callErr)
+	assert.True(t, result.IsError, "should reject entire batch when one change is incompatible")
+
+	// Pre-flight validation should prevent ANY writes
+	assert.Empty(t, writer.WriteCalls, "no writes should occur when pre-flight validation fails")
+	assert.Empty(t, csStore.Changesets, "no changeset should be recorded")
+}


### PR DESCRIPTION
## Summary

Closes #180.

- **Upgrade mcp-datahub v1.1.1 → v1.2.0** — brings entity-type-aware `UpdateDescription` that resolves the correct aspect name per entity type (dataset, dashboard, domain, glossaryTerm, etc.), unblocking txn2/mcp-datahub#85
- **Pre-flight entity type validation** — before executing any writes, `executeChanges` validates every change against the target URN's entity type. Incompatible operations (e.g., `add_curated_query` on a domain) reject the entire batch before any DataHub writes occur
- **User-friendly error messages** — when an operation is unsupported for an entity type, the error lists the operations that *are* supported (e.g., `"add_curated_query is only supported for datasets, not domain entities. Supported operations for domain: update_description, add_tag, remove_tag, add_glossary_term, add_documentation, flag_quality_issue"`)
- **Upstream error wrapping** — catches `ErrUnsupportedEntityType` from mcp-datahub and wraps it with the same actionable message format
- **Tool description + schema updates** — clarify which operations work on which entity types so LLM clients know upfront

### Entity type support matrix

| Operation | Supported Entity Types |
|-----------|----------------------|
| `update_description` | dataset, dashboard, chart, dataFlow, dataJob, container, dataProduct, domain, glossaryTerm, glossaryNode |
| `update_description` with `column:<field>` | dataset only |
| `add_tag` / `remove_tag` | all |
| `add_glossary_term` | all |
| `add_documentation` | all |
| `flag_quality_issue` | all |
| `add_curated_query` | dataset only |

### New files

- `pkg/toolkits/knowledge/entity_type.go` — URN entity type extraction, compatibility validation, supported-ops lookup, error wrapping
- `pkg/toolkits/knowledge/entity_type_test.go` — unit tests for all validation paths (18 table-driven cases + error wrapping tests)

### Modified files

- `pkg/toolkits/knowledge/toolkit.go` — pre-flight validation in `executeChanges`, upstream error wrapping in `executeUpdateDescription`, updated tool description
- `pkg/toolkits/knowledge/schemas.go` — schema descriptions document entity type support
- `pkg/toolkits/knowledge/toolkit_test.go` — 7 end-to-end tests through `handleApplyKnowledge`: domain/glossaryTerm/dataProduct descriptions, column desc rejection, curated query rejection, all-ops-on-domain success, mixed-batch pre-flight rejection

## Test plan

- [x] `update_description` on domain URN succeeds
- [x] `update_description` on glossaryTerm URN succeeds
- [x] `update_description` on dataProduct URN succeeds
- [x] `column:` target on non-dataset URN returns actionable error
- [x] `add_curated_query` on non-dataset URN returns actionable error
- [x] `add_tag`, `remove_tag`, `add_glossary_term`, `add_documentation`, `flag_quality_issue` all succeed on domain URN
- [x] Mixed batch with one incompatible change rejects entire batch before any writes
- [x] All new functions at 100% coverage
- [x] All existing tests pass (`go test -race ./...`)
- [x] Lint, security, and coverage gates pass (`make fmt test lint security coverage-report`)