### PR TITLE
feat: portal UX improvements

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useAuthStore } from "@/stores/auth";
 import { LoginForm } from "@/components/LoginForm";
 import { AppShell } from "@/components/layout/AppShell";
+import { LoadingIndicator } from "@/components/LoadingIndicator";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -25,7 +26,7 @@ function AuthGate() {
   if (loading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="text-sm text-muted-foreground">Loading...</div>
+        <LoadingIndicator />
       </div>
     );
   }

--- a/ui/src/components/LoadingIndicator.tsx
+++ b/ui/src/components/LoadingIndicator.tsx
@@ -1,0 +1,34 @@
+import { useBranding } from "@/api/portal/hooks";
+import { useThemeStore } from "@/stores/theme";
+
+export function LoadingIndicator() {
+  const { data: branding } = useBranding();
+  const theme = useThemeStore((s) => s.theme);
+  const isDark =
+    theme === "dark" ||
+    (theme === "system" &&
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+  const base = import.meta.env.BASE_URL;
+  const defaultLogo = isDark
+    ? `${base}images/activity-svgrepo-com-white.svg`
+    : `${base}images/activity-svgrepo-com.svg`;
+  const logo = isDark
+    ? branding?.portal_logo_dark || branding?.portal_logo || defaultLogo
+    : branding?.portal_logo_light || branding?.portal_logo || defaultLogo;
+
+  return (
+    <div className="flex min-h-[200px] flex-col items-center justify-center gap-3">
+      <img
+        src={logo}
+        alt=""
+        className="h-16 w-16 animate-pulse-brand"
+        onError={(e) => {
+          (e.target as HTMLImageElement).style.display = "none";
+        }}
+      />
+      <p className="text-sm text-muted-foreground">Loading...</p>
+    </div>
+  );
+}

--- a/ui/src/components/ProvenancePanel.tsx
+++ b/ui/src/components/ProvenancePanel.tsx
@@ -1,11 +1,223 @@
-import type { Provenance } from "@/api/portal/types";
+import { useState } from "react";
+import {
+  Database,
+  Search,
+  FileText,
+  Info,
+  Link2,
+  Terminal,
+  type LucideIcon,
+} from "lucide-react";
+import * as Dialog from "@radix-ui/react-dialog";
+import type { Provenance, ProvenanceToolCall } from "@/api/portal/types";
 
 interface Props {
   provenance: Provenance;
 }
 
+interface ToolMeta {
+  label: string;
+  icon: LucideIcon;
+}
+
+const TOOL_LABELS: Record<string, ToolMeta> = {
+  trino_query: { label: "SQL Query", icon: Database },
+  trino_execute: { label: "SQL Execute", icon: Database },
+  trino_describe_table: { label: "Describe Table", icon: Database },
+  trino_list_tables: { label: "List Tables", icon: Database },
+  trino_list_schemas: { label: "List Schemas", icon: Database },
+  trino_list_catalogs: { label: "List Catalogs", icon: Database },
+  trino_explain: { label: "Query Plan", icon: Database },
+  datahub_search: { label: "Catalog Search", icon: Search },
+  datahub_get_schema: { label: "Schema Lookup", icon: FileText },
+  datahub_get_entity: { label: "Entity Details", icon: Info },
+  datahub_get_lineage: { label: "Lineage", icon: Link2 },
+  datahub_get_column_lineage: { label: "Column Lineage", icon: Link2 },
+  datahub_get_queries: { label: "Saved Queries", icon: FileText },
+  datahub_get_data_product: { label: "Data Product", icon: Info },
+  datahub_get_glossary_term: { label: "Glossary Term", icon: FileText },
+  datahub_list_data_products: { label: "Data Products", icon: Search },
+  datahub_list_domains: { label: "Domains", icon: Search },
+  datahub_list_tags: { label: "Tags", icon: Search },
+  platform_info: { label: "Platform Info", icon: Info },
+  s3_list_objects: { label: "List Files", icon: FileText },
+  s3_get_object: { label: "Get File", icon: FileText },
+  s3_list_buckets: { label: "List Buckets", icon: FileText },
+};
+
+function getToolMeta(toolName: string): ToolMeta {
+  return TOOL_LABELS[toolName] ?? { label: toolName, icon: Terminal };
+}
+
+/** Extract a human-readable summary from the raw summary JSON string. */
+function extractSummary(call: ProvenanceToolCall): string | null {
+  const raw = call.summary;
+  if (!raw) return null;
+
+  // Try to parse as JSON to extract useful fields
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === "string") return parsed;
+
+    // SQL queries
+    if (parsed.sql) {
+      const sql = String(parsed.sql).trim();
+      return sql.length > 120 ? sql.slice(0, 120) + "..." : sql;
+    }
+
+    // Search queries
+    if (parsed.query) return `"${parsed.query}"`;
+
+    // URN-based lookups
+    if (parsed.urn) return String(parsed.urn);
+
+    // Table operations
+    if (parsed.table) {
+      const parts = [parsed.catalog, parsed.schema, parsed.table].filter(Boolean);
+      return parts.join(".");
+    }
+
+    // Bucket/key for S3
+    if (parsed.bucket) {
+      return parsed.key ? `${parsed.bucket}/${parsed.key}` : parsed.bucket;
+    }
+
+    // Fall back to first string value
+    const firstStr = Object.values(parsed).find((v) => typeof v === "string");
+    if (firstStr) return String(firstStr);
+  } catch {
+    // Not JSON — use as-is if short enough
+    if (raw.length <= 150) return raw;
+    return raw.slice(0, 147) + "...";
+  }
+
+  return null;
+}
+
+/** Pretty-print the raw summary for the detail modal. */
+function formatDetail(summary: string | undefined): string {
+  if (!summary) return "(no parameters)";
+  try {
+    return JSON.stringify(JSON.parse(summary), null, 2);
+  } catch {
+    return summary;
+  }
+}
+
+function relativeTime(timestamp: string): string {
+  const now = Date.now();
+  const then = new Date(timestamp).getTime();
+  const diff = Math.max(0, now - then);
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function ProvenanceCard({
+  call,
+  onClick,
+}: {
+  call: ProvenanceToolCall;
+  onClick: () => void;
+}) {
+  const meta = getToolMeta(call.tool_name);
+  const Icon = meta.icon;
+  const summary = extractSummary(call);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full text-left rounded-md border bg-background p-3 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <div className="flex items-start gap-2.5">
+        <div className="mt-0.5 rounded bg-muted p-1.5">
+          <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-sm font-medium">{meta.label}</span>
+            <span
+              className="shrink-0 text-[11px] text-muted-foreground"
+              title={new Date(call.timestamp).toLocaleString()}
+            >
+              {relativeTime(call.timestamp)}
+            </span>
+          </div>
+          {summary && (
+            <p className="mt-0.5 truncate text-xs text-muted-foreground font-mono">
+              {summary}
+            </p>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function DetailModal({
+  call,
+  open,
+  onOpenChange,
+}: {
+  call: ProvenanceToolCall | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  if (!call) return null;
+  const meta = getToolMeta(call.tool_name);
+  const Icon = meta.icon;
+  const detail = formatDetail(call.summary);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/40" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-lg border bg-card p-6 shadow-lg focus:outline-none">
+          <Dialog.Title className="flex items-center gap-2 text-base font-semibold">
+            <Icon className="h-4 w-4 text-muted-foreground" />
+            {meta.label}
+          </Dialog.Title>
+          <Dialog.Description className="mt-1 text-xs text-muted-foreground">
+            {call.tool_name} &middot; {new Date(call.timestamp).toLocaleString()}
+          </Dialog.Description>
+
+          <div className="mt-4">
+            <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+              {call.tool_name.startsWith("trino_") && detail.includes("SELECT")
+                ? "SQL Query"
+                : "Parameters"}
+            </p>
+            <pre className="max-h-72 overflow-auto rounded-md bg-muted p-3 text-xs font-mono whitespace-pre-wrap break-words">
+              {detail}
+            </pre>
+          </div>
+
+          <div className="mt-4 flex justify-end">
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                className="rounded-md bg-secondary px-3 py-1.5 text-sm font-medium text-secondary-foreground hover:bg-secondary/80"
+              >
+                Close
+              </button>
+            </Dialog.Close>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
 export function ProvenancePanel({ provenance }: Props) {
   const calls = provenance.tool_calls ?? [];
+  const [selected, setSelected] = useState<ProvenanceToolCall | null>(null);
+
   if (calls.length === 0) {
     return (
       <p className="text-sm text-muted-foreground">No provenance data available.</p>
@@ -14,25 +226,30 @@ export function ProvenancePanel({ provenance }: Props) {
 
   return (
     <div className="space-y-3">
-      <h3 className="text-sm font-medium">Provenance</h3>
-      <div className="relative pl-4 border-l-2 border-primary/20 space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium">Provenance</h3>
+        <span className="text-xs text-muted-foreground">
+          {calls.length} {calls.length === 1 ? "call" : "calls"}
+        </span>
+      </div>
+
+      <div className="space-y-2">
         {calls.map((call, i) => (
-          <div key={i} className="relative">
-            <div className="absolute -left-[calc(0.5rem+1px)] top-1.5 h-2 w-2 rounded-full bg-primary" />
-            <div className="text-sm">
-              <span className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">
-                {call.tool_name}
-              </span>
-              {call.summary && (
-                <p className="text-muted-foreground mt-0.5">{call.summary}</p>
-              )}
-              <p className="text-xs text-muted-foreground mt-0.5">
-                {new Date(call.timestamp).toLocaleString()}
-              </p>
-            </div>
-          </div>
+          <ProvenanceCard
+            key={i}
+            call={call}
+            onClick={() => setSelected(call)}
+          />
         ))}
       </div>
+
+      <DetailModal
+        call={selected}
+        open={selected !== null}
+        onOpenChange={(open) => {
+          if (!open) setSelected(null);
+        }}
+      />
     </div>
   );
 }

--- a/ui/src/components/layout/AppShell.tsx
+++ b/ui/src/components/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Sidebar } from "./Sidebar";
 import { Header } from "./Header";
 import { useAuthStore } from "@/stores/auth";
@@ -26,6 +26,8 @@ const pageTitles: Record<string, string> = {
   "/admin/personas": "Personas",
 };
 
+const SIDEBAR_STORAGE_KEY = "sidebar-collapsed";
+
 /** Vite base path — must match vite.config.ts `base`. */
 const BASE = import.meta.env.BASE_URL.replace(/\/+$/, "");
 
@@ -37,6 +39,11 @@ function readPath(): string {
     : pathname;
   if (hash) route += hash;
   return route;
+}
+
+function isAssetRoute(path: string): boolean {
+  const route = path.split("#")[0] ?? "";
+  return /^\/assets\/.+$/.test(route);
 }
 
 function AccessDenied() {
@@ -52,6 +59,37 @@ function AccessDenied() {
 export function AppShell() {
   const [currentPath, setCurrentPath] = useState(readPath);
   const isAdmin = useAuthStore((s) => s.isAdmin());
+
+  // Sidebar collapsed state: auto-collapse on asset deep-link, otherwise restore from localStorage
+  const initialPath = useRef(readPath()).current;
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+    if (isAssetRoute(initialPath)) return true;
+    return localStorage.getItem(SIDEBAR_STORAGE_KEY) === "true";
+  });
+  // Track whether we auto-collapsed so we can restore on navigation away
+  const autoCollapsed = useRef(isAssetRoute(initialPath));
+
+  const toggleSidebar = useCallback(() => {
+    setSidebarCollapsed((prev) => {
+      const next = !prev;
+      localStorage.setItem(SIDEBAR_STORAGE_KEY, String(next));
+      autoCollapsed.current = false; // user explicitly toggled
+      return next;
+    });
+  }, []);
+
+  // Auto-collapse when entering asset routes, restore when leaving
+  useEffect(() => {
+    const onAsset = isAssetRoute(currentPath);
+    if (onAsset && !sidebarCollapsed) {
+      setSidebarCollapsed(true);
+      autoCollapsed.current = true;
+    } else if (!onAsset && autoCollapsed.current && sidebarCollapsed) {
+      const stored = localStorage.getItem(SIDEBAR_STORAGE_KEY) === "true";
+      setSidebarCollapsed(stored);
+      autoCollapsed.current = false;
+    }
+  }, [currentPath, sidebarCollapsed]);
 
   const navigate = useCallback((path: string) => {
     setCurrentPath(path);
@@ -83,7 +121,12 @@ export function AppShell() {
 
   return (
     <div className="flex h-screen">
-      <Sidebar currentPath={currentPath} onNavigate={navigate} />
+      <Sidebar
+        currentPath={currentPath}
+        onNavigate={navigate}
+        collapsed={sidebarCollapsed}
+        onToggleCollapse={toggleSidebar}
+      />
       <div className="flex flex-1 flex-col overflow-hidden">
         <Header title={title} />
         <main className="flex-1 overflow-auto bg-muted/40 p-6">

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -9,6 +9,8 @@ import {
   LogOut,
   LayoutGrid,
   Share2,
+  ChevronsLeft,
+  ChevronsRight,
 } from "lucide-react";
 import { useAuthStore } from "@/stores/auth";
 import { useThemeStore } from "@/stores/theme";
@@ -17,6 +19,8 @@ import { useBranding } from "@/api/portal/hooks";
 interface Props {
   currentPath: string;
   onNavigate: (path: string) => void;
+  collapsed: boolean;
+  onToggleCollapse: () => void;
 }
 
 const portalNavItems = [
@@ -32,7 +36,7 @@ const adminNavItems = [
   { path: "/admin/personas", label: "Personas", icon: Users },
 ];
 
-export function Sidebar({ currentPath, onNavigate }: Props) {
+export function Sidebar({ currentPath, onNavigate, collapsed, onToggleCollapse }: Props) {
   const logout = useAuthStore((s) => s.logout);
   const isAdmin = useAuthStore((s) => s.isAdmin());
   const { data: branding } = useBranding();
@@ -66,14 +70,18 @@ export function Sidebar({ currentPath, onNavigate }: Props) {
   const route = currentPath.split("#")[0] ?? "/";
 
   function isActive(itemPath: string) {
-    // Exact match for root paths, startsWith for /admin sub-routes
     if (itemPath === "/" || itemPath === "/shared") return route === itemPath;
     return route === itemPath || route.startsWith(itemPath + "/");
   }
 
   return (
-    <aside className="flex h-screen w-[var(--sidebar-width)] flex-col border-r bg-card">
-      <div className="flex h-14 items-center gap-2 border-b px-4">
+    <aside
+      className={cn(
+        "flex h-screen flex-col border-r bg-card transition-[width] duration-200 overflow-hidden",
+        collapsed ? "w-[var(--sidebar-width-collapsed)]" : "w-[var(--sidebar-width)]",
+      )}
+    >
+      <div className={cn("flex h-14 items-center border-b shrink-0", collapsed ? "justify-center px-2" : "gap-2 px-4")}>
         {portalLogo && (
           <img
             src={portalLogo}
@@ -84,63 +92,85 @@ export function Sidebar({ currentPath, onNavigate }: Props) {
             }}
           />
         )}
-        <span className="text-sm font-semibold truncate">{portalTitle}</span>
+        {!collapsed && (
+          <span className="text-sm font-semibold truncate">{portalTitle}</span>
+        )}
       </div>
 
       <nav className="flex-1 space-y-1 overflow-auto p-2">
-        {/* Portal section — everyone */}
         {portalNavItems.map((item) => (
           <button
             key={item.path}
             type="button"
             onClick={() => onNavigate(item.path)}
+            title={collapsed ? item.label : undefined}
             className={cn(
-              "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+              "flex w-full items-center rounded-md text-sm font-medium transition-colors",
+              collapsed ? "justify-center px-2 py-2" : "gap-3 px-3 py-2",
               isActive(item.path)
                 ? "bg-primary/10 text-primary"
                 : "text-muted-foreground hover:bg-muted hover:text-foreground",
             )}
           >
-            <item.icon className="h-4 w-4" />
-            {item.label}
+            <item.icon className="h-4 w-4 shrink-0" />
+            {!collapsed && item.label}
           </button>
         ))}
 
-        {/* Admin section — admins only */}
         {isAdmin && (
           <>
             <div className="my-2 border-t" />
-            <p className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-              Admin
-            </p>
+            {!collapsed && (
+              <p className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                Admin
+              </p>
+            )}
             {adminNavItems.map((item) => (
               <button
                 key={item.path}
                 type="button"
                 onClick={() => onNavigate(item.path)}
+                title={collapsed ? item.label : undefined}
                 className={cn(
-                  "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                  "flex w-full items-center rounded-md text-sm font-medium transition-colors",
+                  collapsed ? "justify-center px-2 py-2" : "gap-3 px-3 py-2",
                   isActive(item.path)
                     ? "bg-primary/10 text-primary"
                     : "text-muted-foreground hover:bg-muted hover:text-foreground",
                 )}
               >
-                <item.icon className="h-4 w-4" />
-                {item.label}
+                <item.icon className="h-4 w-4 shrink-0" />
+                {!collapsed && item.label}
               </button>
             ))}
           </>
         )}
       </nav>
 
-      <div className="border-t p-2">
+      <div className="border-t p-2 space-y-1">
+        <button
+          type="button"
+          onClick={onToggleCollapse}
+          title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          className={cn(
+            "flex w-full items-center rounded-md text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+            collapsed ? "justify-center px-2 py-2" : "gap-3 px-3 py-2",
+          )}
+        >
+          {collapsed ? <ChevronsRight className="h-4 w-4" /> : <ChevronsLeft className="h-4 w-4" />}
+          {!collapsed && "Collapse"}
+        </button>
         <button
           type="button"
           onClick={logout}
-          className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          title={collapsed ? "Sign Out" : undefined}
+          className={cn(
+            "flex w-full items-center rounded-md text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+            collapsed ? "justify-center px-2 py-2" : "gap-3 px-3 py-2",
+          )}
         >
-          <LogOut className="h-4 w-4" />
-          Sign Out
+          <LogOut className="h-4 w-4 shrink-0" />
+          {!collapsed && "Sign Out"}
         </button>
       </div>
     </aside>

--- a/ui/src/components/renderers/HtmlRenderer.tsx
+++ b/ui/src/components/renderers/HtmlRenderer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from "react";
 
 export function HtmlRenderer({ content }: { content: string }) {
   const blobUrl = useMemo(() => {
-    const blob = new Blob([content], { type: "text/html" });
+    const blob = new Blob([content], { type: "text/html;charset=utf-8" });
     return URL.createObjectURL(blob);
   }, [content]);
 

--- a/ui/src/components/renderers/JsxRenderer.tsx
+++ b/ui/src/components/renderers/JsxRenderer.tsx
@@ -115,9 +115,9 @@ export function JsxRenderer({ content }: { content: string }) {
       // If Sucrase fails, show the error in the iframe via textContent (safe).
       const errMsg =
         e instanceof Error ? e.message : "JSX transform failed";
-      const html = `<!DOCTYPE html><html><body><pre id="e" style="${ERROR_STYLE}"></pre>
+      const html = `<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body><pre id="e" style="${ERROR_STYLE}"></pre>
 <script>document.getElementById('e').textContent=${JSON.stringify(errMsg)};</script></body></html>`;
-      return URL.createObjectURL(new Blob([html], { type: "text/html" }));
+      return URL.createObjectURL(new Blob([html], { type: "text/html;charset=utf-8" }));
     }
 
     if (hasMountCode(content)) {
@@ -126,6 +126,7 @@ export function JsxRenderer({ content }: { content: string }) {
       const html = `<!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="${CSP}">
   <script type="importmap">${IMPORT_MAP}</script>
   <style>
@@ -147,7 +148,7 @@ ${transformed}
   </script>
 </body>
 </html>`;
-      return URL.createObjectURL(new Blob([html], { type: "text/html" }));
+      return URL.createObjectURL(new Blob([html], { type: "text/html;charset=utf-8" }));
     }
 
     // Auto-mount path: detect component name and render it.
@@ -159,6 +160,7 @@ ${transformed}
     const html = `<!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="${CSP}">
   <script type="importmap">${IMPORT_MAP}</script>
   <style>
@@ -190,7 +192,7 @@ try {
   </script>
 </body>
 </html>`;
-    return URL.createObjectURL(new Blob([html], { type: "text/html" }));
+    return URL.createObjectURL(new Blob([html], { type: "text/html;charset=utf-8" }));
   }, [content]);
 
   useEffect(() => {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -63,6 +63,15 @@
   }
 }
 
+@keyframes pulse-brand {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(0.95); }
+}
+
+.animate-pulse-brand {
+  animation: pulse-brand 2s ease-in-out infinite;
+}
+
 @theme inline {
   --color-background: hsl(var(--background));
   --color-foreground: hsl(var(--foreground));

--- a/ui/src/pages/viewer/AssetViewerPage.tsx
+++ b/ui/src/pages/viewer/AssetViewerPage.tsx
@@ -4,6 +4,7 @@ import { useAsset, useAssetContent, useUpdateAsset, useDeleteAsset } from "@/api
 import { ContentRenderer } from "@/components/renderers/ContentRenderer";
 import { ProvenancePanel } from "@/components/ProvenancePanel";
 import { ShareDialog } from "@/components/ShareDialog";
+import { LoadingIndicator } from "@/components/LoadingIndicator";
 import { formatBytes } from "@/lib/format";
 
 interface Props {
@@ -17,18 +18,14 @@ export function AssetViewerPage({ assetId, onNavigate }: Props) {
   const updateAsset = useUpdateAsset();
   const deleteAsset = useDeleteAsset();
   const [shareOpen, setShareOpen] = useState(false);
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
   const [editing, setEditing] = useState(false);
   const [editName, setEditName] = useState("");
   const [editDesc, setEditDesc] = useState("");
   const [editTags, setEditTags] = useState("");
 
   if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-12 text-muted-foreground">
-        Loading...
-      </div>
-    );
+    return <LoadingIndicator />;
   }
 
   if (!asset) {
@@ -105,9 +102,7 @@ export function AssetViewerPage({ assetId, onNavigate }: Props) {
         {content !== undefined ? (
           <ContentRenderer contentType={asset.content_type} content={content} />
         ) : (
-          <div className="flex items-center justify-center py-12 text-muted-foreground">
-            Loading content...
-          </div>
+          <LoadingIndicator />
         )}
       </div>
 


### PR DESCRIPTION
## Summary

Five portal UX improvements addressing issues observed in production:

- **Fix emoji/unicode rendering in iframes** — Blob URLs created without charset caused browsers to default to Latin-1, rendering multi-byte UTF-8 characters as mojibake (e.g. "ÐŸ"Š" instead of emoji). Added `<meta charset="UTF-8">` and `charset=utf-8` Blob MIME types to all iframe HTML templates.
- **Branded loading indicator** — Replaced plain "Loading..." text with a pulsating platform logo using the existing branding hook, shown during auth check, asset loading, and content loading states.
- **Collapsible left sidebar** — Sidebar toggles between full width (16rem) and icon-only mode (4rem) with a 200ms CSS transition. Collapsed state persists to localStorage. Icons get `title` tooltips when text labels are hidden.
- **Auto-collapse sidebars on dashboard deep-link** — When navigating directly to `/assets/:id`, both the left sidebar and the right details panel start collapsed to maximize content space. The left sidebar auto-restores when navigating away (unless the user explicitly toggled it).
- **Provenance panel redesign** — Replaced the raw timeline with a card-based layout featuring tool-specific icons, human-friendly labels (e.g. `trino_query` → "SQL Query"), smart summary extraction (shows SQL snippets, search terms, table paths instead of raw JSON), relative timestamps, and a click-to-open detail modal with pretty-printed parameters.

## Files Changed

| File | Change |
|------|--------|
| `ui/src/components/renderers/JsxRenderer.tsx` | Add `<meta charset="UTF-8">` to 3 HTML templates, `charset=utf-8` to 3 Blob types |
| `ui/src/components/renderers/HtmlRenderer.tsx` | Add `charset=utf-8` to Blob type |
| `ui/src/components/LoadingIndicator.tsx` | **New** — branded pulsating loader component |
| `ui/src/index.css` | Add `pulse-brand` keyframes and `.animate-pulse-brand` utility |
| `ui/src/components/layout/Sidebar.tsx` | Add `collapsed`/`onToggleCollapse` props, icon-only mode, collapse button |
| `ui/src/components/layout/AppShell.tsx` | Sidebar state management, localStorage persistence, auto-collapse on asset routes |
| `ui/src/components/ProvenancePanel.tsx` | Full redesign — card layout, 22 tool label mappings, summary extraction, detail modal |
| `ui/src/pages/viewer/AssetViewerPage.tsx` | Use `LoadingIndicator`, default right sidebar to closed |
| `ui/src/App.tsx` | Use `LoadingIndicator` for auth loading state |

## Provenance Tool Mappings

| Tool | Label | Icon |
|------|-------|------|
| `trino_query` | SQL Query | Database |
| `trino_execute` | SQL Execute | Database |
| `trino_describe_table` | Describe Table | Database |
| `datahub_search` | Catalog Search | Search |
| `datahub_get_schema` | Schema Lookup | FileText |
| `datahub_get_entity` | Entity Details | Info |
| `datahub_get_lineage` | Lineage | Link2 |
| `platform_info` | Platform Info | Info |
| `s3_*` | List Files / Get File / List Buckets | FileText |
| _(unknown)_ | Raw tool name | Terminal |

## Test Plan

- [ ] Open portal, navigate to a saved dashboard with emoji in title/tabs — confirm emoji renders correctly (no mojibake)
- [ ] Refresh the portal — verify branded loading indicator with pulsating logo appears
- [ ] Click sidebar collapse button (double chevron) — verify smooth 200ms transition to icon-only mode with tooltips
- [ ] Refresh page — verify sidebar collapse state persists from localStorage
- [ ] Direct-link to a dashboard URL (`/assets/:id`) — verify left sidebar starts collapsed and right details panel is closed
- [ ] Navigate back to My Assets — verify left sidebar restores to previous state
- [ ] Open an asset with provenance data — verify card layout with icons, labels, and relative timestamps
- [ ] Click a provenance card — verify detail modal opens with pretty-printed parameters
- [ ] Verify `npm run build` passes with no TypeScript errors