### PR TITLE
fix: align parent and iframe CSP for JSX public viewer

### DIFF
--- a/pkg/portal/public.go
+++ b/pkg/portal/public.go
@@ -183,9 +183,11 @@ func publicCSP(contentType string) string {
 	if strings.Contains(strings.ToLower(contentType), "jsx") {
 		return "default-src 'none'; " +
 			"frame-src blob: data:; " +
-			"script-src 'unsafe-inline'; " +
-			"style-src 'unsafe-inline'; " +
-			"img-src data:;"
+			"script-src 'unsafe-eval' 'unsafe-inline' blob: https://esm.sh; " +
+			"style-src 'unsafe-inline' https://fonts.googleapis.com; " +
+			"img-src data: blob:; " +
+			"font-src data: https://fonts.gstatic.com; " +
+			"connect-src https://esm.sh https://fonts.googleapis.com https://fonts.gstatic.com;"
 	}
 	return "default-src 'none'; style-src 'unsafe-inline'; img-src data:;"
 }
@@ -200,7 +202,7 @@ var jsxSrcdocTpl = template.Must(template.New("jsx").Parse(`<!DOCTYPE html>
 <html>
 <head>
 <meta charset="UTF-8">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-eval' 'unsafe-inline' https://esm.sh; style-src 'unsafe-inline' https://fonts.googleapis.com; img-src data: blob:; font-src data: https://fonts.gstatic.com; connect-src https://esm.sh https://fonts.googleapis.com https://fonts.gstatic.com;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-eval' 'unsafe-inline' blob: https://esm.sh; style-src 'unsafe-inline' https://fonts.googleapis.com; img-src data: blob:; font-src data: https://fonts.gstatic.com; connect-src https://esm.sh https://fonts.googleapis.com https://fonts.gstatic.com;">
 <script type="importmap">
 {
   "imports": {

--- a/pkg/portal/public_test.go
+++ b/pkg/portal/public_test.go
@@ -271,7 +271,11 @@ func TestSanitizeSVGStripsStyleAttr(t *testing.T) {
 func TestPublicCSP(t *testing.T) {
 	csp := publicCSP("text/jsx")
 	assert.Contains(t, csp, "frame-src blob:")
-	assert.Contains(t, csp, "script-src 'unsafe-inline'")
+	assert.Contains(t, csp, "script-src 'unsafe-eval' 'unsafe-inline' blob: https://esm.sh")
+	assert.Contains(t, csp, "connect-src https://esm.sh")
+	assert.Contains(t, csp, "font-src data: https://fonts.gstatic.com")
+	assert.Contains(t, csp, "style-src 'unsafe-inline' https://fonts.googleapis.com")
+	assert.Contains(t, csp, "img-src data: blob:")
 
 	csp2 := publicCSP("text/html")
 	assert.NotContains(t, csp2, "frame-src")
@@ -286,6 +290,9 @@ func TestJsxIframe(t *testing.T) {
 	assert.Contains(t, result, "importmap")
 	assert.Contains(t, result, "esm.sh/sucrase")
 	assert.Contains(t, result, "esm.sh/react@19")
+	// blob: must be in script-src so the dynamic import of the transformed-code blob works.
+	// The CSP is inside a meta tag within the srcdoc attribute, so quotes are HTML-escaped.
+	assert.Contains(t, result, "script-src &#39;unsafe-eval&#39; &#39;unsafe-inline&#39; blob: https://esm.sh")
 }
 
 func TestJsxIframeSpecialChars(t *testing.T) {


### PR DESCRIPTION
## Summary

JSX public view links (`/portal/view/{token}`) are broken in production — the browser throws `TypeError: Failed to fetch dynamically imported module: https://esm.sh/sucrase@3?bundle` and the component never renders.

**Root cause:** Per the [CSP3 spec (section "inherit CSP")](https://www.w3.org/TR/CSP3/#security-inherit-csp), `srcdoc` iframes inherit the parent page's CSP headers. The effective CSP is the **intersection** of the parent's CSP header and the iframe's own `<meta>` CSP. The parent's `publicCSP()` was far more restrictive than the iframe's meta CSP, so the intersection blocked:

1. **`script-src`** — parent only allowed `'unsafe-inline'`, missing `https://esm.sh` (blocks Sucrase/React module loading), `'unsafe-eval'` (blocks Sucrase transform), and `blob:` (blocks dynamic import of the transformed code blob)
2. **`style-src`** — parent missing `https://fonts.googleapis.com`
3. **`connect-src`** — parent had no `connect-src` directive (blocks fetch to esm.sh)
4. **`font-src`** — parent had no `font-src` directive (blocks Google Fonts)

## Changes

- **`publicCSP()`** (`pkg/portal/public.go:182-191`) — Expanded the JSX branch to include all directives the iframe needs, so the CSP intersection doesn't block anything:
  - `script-src`: added `'unsafe-eval'`, `blob:`, `https://esm.sh`
  - `style-src`: added `https://fonts.googleapis.com`
  - `img-src`: added `blob:`
  - Added `font-src`, `connect-src` directives

- **Iframe meta CSP** (`pkg/portal/public.go:205`) — Added `blob:` to `script-src`. The public viewer transforms JSX at runtime inside the iframe (unlike the authenticated `JsxRenderer.tsx` which inlines transformed code), creates a blob URL from the result, and does `await import(blobUrl)`. Without `blob:` in script-src, that dynamic import is silently blocked by CSP even after Sucrase loads.

- **Tests** (`pkg/portal/public_test.go`) — Updated `TestPublicCSP` and `TestJsxIframe` to verify all required CSP directives including `blob:` in script-src.

## Why `blob:` in `script-src` matters

The public viewer's JSX execution flow differs from the authenticated `JsxRenderer.tsx`:

| Step | Authenticated (JsxRenderer.tsx) | Public viewer (public.go) |
|------|------|------|
| Transform | Sucrase runs client-side via bundled npm package | Sucrase loaded at runtime from esm.sh inside the iframe |
| Code injection | Transformed JS inlined directly in HTML | Transformed JS wrapped in a `Blob`, imported via `import(blobUrl)` |
| CSP implication | No `blob:` needed in `script-src` | `blob:` required in `script-src` for `import()` to succeed |

## Test plan

- [x] `go test -race ./pkg/portal/...` passes
- [x] `make verify` passes (full CI suite: fmt, test, lint, security, coverage, CodeQL, GoReleaser)
- [ ] Deploy and visit a JSX public view URL — component renders, esm.sh modules load, no CSP errors in console