### PR TITLE
fix: zero-fill timeseries chart gaps for sparse activity data

### DIFF
--- a/pkg/audit/postgres/metrics.go
+++ b/pkg/audit/postgres/metrics.go
@@ -81,6 +81,8 @@ func (s *Store) Timeseries(ctx context.Context, filter audit.TimeseriesFilter) (
 	if buckets == nil {
 		buckets = []audit.TimeseriesBucket{}
 	}
+
+	buckets = audit.ZeroFill(buckets, start, end, filter.Resolution)
 	return buckets, nil
 }
 

--- a/pkg/audit/postgres/metrics_test.go
+++ b/pkg/audit/postgres/metrics_test.go
@@ -21,30 +21,43 @@ func TestTimeseries_Success(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	store := New(db, Config{})
-	now := time.Now()
-	start := now.Add(-24 * time.Hour)
+	// Use fixed times so zero-fill produces a predictable number of buckets.
+	start := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC) // 4h range → 5 buckets
 
 	rows := sqlmock.NewRows([]string{"bucket", "count", "success_count", "error_count", "avg_duration_ms"}).
-		AddRow(now.Truncate(time.Hour), 10, 8, 2, 42.5).
-		AddRow(now.Truncate(time.Hour).Add(time.Hour), 5, 5, 0, 30.0)
+		AddRow(time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC), 10, 8, 2, 42.5).
+		AddRow(time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC), 5, 5, 0, 30.0)
 
 	mock.ExpectQuery("SELECT").
-		WithArgs(start, now).
+		WithArgs(start, end).
 		WillReturnRows(rows)
 
 	result, err := store.Timeseries(context.Background(), audit.TimeseriesFilter{
 		Resolution: audit.ResolutionHour,
 		StartTime:  &start,
-		EndTime:    &now,
+		EndTime:    &end,
 	})
 
 	require.NoError(t, err)
-	require.Len(t, result, 2)
+	require.Len(t, result, 5) // zero-filled: 10:00, 11:00, 12:00, 13:00, 14:00
+
+	// First bucket has data.
 	assert.Equal(t, 10, result[0].Count)
 	assert.Equal(t, 8, result[0].SuccessCount)
 	assert.Equal(t, 2, result[0].ErrorCount)
 	assert.InDelta(t, 42.5, result[0].AvgDurationMS, 0.01)
-	assert.Equal(t, 5, result[1].Count)
+
+	// Second bucket is zero-filled.
+	assert.Equal(t, 0, result[1].Count)
+
+	// Third bucket has data.
+	assert.Equal(t, 5, result[2].Count)
+
+	// Remaining buckets are zero-filled.
+	assert.Equal(t, 0, result[3].Count)
+	assert.Equal(t, 0, result[4].Count)
+
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -66,17 +79,27 @@ func TestTimeseries_EmptyResult(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	store := New(db, Config{})
+	// Use fixed 1h range with hour resolution so zero-fill produces exactly 2 buckets.
+	start := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 6, 15, 11, 0, 0, 0, time.UTC)
 
 	rows := sqlmock.NewRows([]string{"bucket", "count", "success_count", "error_count", "avg_duration_ms"})
-	mock.ExpectQuery("SELECT").WillReturnRows(rows)
+	mock.ExpectQuery("SELECT").
+		WithArgs(start, end).
+		WillReturnRows(rows)
 
 	result, err := store.Timeseries(context.Background(), audit.TimeseriesFilter{
-		Resolution: audit.ResolutionDay,
+		Resolution: audit.ResolutionHour,
+		StartTime:  &start,
+		EndTime:    &end,
 	})
 
 	require.NoError(t, err)
-	assert.Empty(t, result)
-	assert.NotNil(t, result) // must return empty slice, not nil
+	assert.NotNil(t, result) // must return non-nil slice
+	// Zero-fill produces 2 zero-valued buckets (10:00, 11:00).
+	require.Len(t, result, 2)
+	assert.Equal(t, 0, result[0].Count)
+	assert.Equal(t, 0, result[1].Count)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -437,25 +460,30 @@ func TestTimeseries_WithUserID(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	store := New(db, Config{})
-	now := time.Now()
-	start := now.Add(-24 * time.Hour)
+	// Use fixed 3h range for predictable zero-fill output.
+	start := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
 
 	rows := sqlmock.NewRows([]string{"bucket", "count", "success_count", "error_count", "avg_duration_ms"}).
-		AddRow(now.Truncate(time.Hour), 3, 3, 0, 15.0)
+		AddRow(time.Date(2025, 6, 15, 11, 0, 0, 0, time.UTC), 3, 3, 0, 15.0)
 	mock.ExpectQuery("SELECT").
-		WithArgs(start, now, "user-42").
+		WithArgs(start, end, "user-42").
 		WillReturnRows(rows)
 
 	result, err := store.Timeseries(context.Background(), audit.TimeseriesFilter{
 		Resolution: audit.ResolutionHour,
 		StartTime:  &start,
-		EndTime:    &now,
+		EndTime:    &end,
 		UserID:     "user-42",
 	})
 
 	require.NoError(t, err)
-	require.Len(t, result, 1)
-	assert.Equal(t, 3, result[0].Count)
+	require.Len(t, result, 3) // zero-filled: 10:00, 11:00, 12:00
+
+	// Data is in the second bucket.
+	assert.Equal(t, 0, result[0].Count)
+	assert.Equal(t, 3, result[1].Count)
+	assert.Equal(t, 0, result[2].Count)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/pkg/audit/zerofill.go
+++ b/pkg/audit/zerofill.go
@@ -1,0 +1,68 @@
+package audit
+
+import "time"
+
+// hoursPerDay is the number of hours in a day.
+const hoursPerDay = 24
+
+// ZeroFill expands a sparse set of timeseries buckets into a complete
+// series covering [start, end] at the given resolution. Missing buckets
+// are filled with zero values.
+func ZeroFill(buckets []TimeseriesBucket, start, end time.Time, resolution Resolution) []TimeseriesBucket {
+	interval := resolutionInterval(resolution)
+	if interval == 0 {
+		return buckets
+	}
+
+	// Build lookup map from existing buckets (keyed by truncated time).
+	existing := make(map[int64]TimeseriesBucket, len(buckets))
+	for _, b := range buckets {
+		existing[b.Bucket.Unix()] = b
+	}
+
+	// Generate complete series.
+	truncStart := truncateTime(start, resolution)
+	truncEnd := truncateTime(end, resolution)
+
+	var result []TimeseriesBucket
+	for t := truncStart; !t.After(truncEnd); t = t.Add(interval) {
+		if b, ok := existing[t.Unix()]; ok {
+			result = append(result, b)
+		} else {
+			result = append(result, TimeseriesBucket{Bucket: t})
+		}
+	}
+
+	if result == nil {
+		return []TimeseriesBucket{}
+	}
+	return result
+}
+
+// resolutionInterval maps a Resolution to its corresponding time.Duration.
+func resolutionInterval(r Resolution) time.Duration {
+	switch r {
+	case ResolutionMinute:
+		return time.Minute
+	case ResolutionHour:
+		return time.Hour
+	case ResolutionDay:
+		return hoursPerDay * time.Hour
+	default:
+		return 0
+	}
+}
+
+// truncateTime truncates a time to the bucket boundary for the given resolution.
+func truncateTime(t time.Time, r Resolution) time.Time {
+	switch r {
+	case ResolutionMinute:
+		return t.Truncate(time.Minute)
+	case ResolutionHour:
+		return t.Truncate(time.Hour)
+	case ResolutionDay:
+		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	default:
+		return t
+	}
+}

--- a/pkg/audit/zerofill_test.go
+++ b/pkg/audit/zerofill_test.go
@@ -1,0 +1,195 @@
+package audit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestZeroFill(t *testing.T) {
+	base := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		buckets    []TimeseriesBucket
+		start      time.Time
+		end        time.Time
+		resolution Resolution
+		wantLen    int
+		wantNonZ   int // expected number of non-zero Count buckets
+	}{
+		{
+			name: "fills gaps in sparse data",
+			buckets: []TimeseriesBucket{
+				{Bucket: base, Count: 5, SuccessCount: 4, ErrorCount: 1},
+				{Bucket: base.Add(2 * time.Hour), Count: 3, SuccessCount: 3},
+				{Bucket: base.Add(4 * time.Hour), Count: 1, SuccessCount: 1},
+			},
+			start:      base,
+			end:        base.Add(4 * time.Hour),
+			resolution: ResolutionHour,
+			wantLen:    5, // hours 0,1,2,3,4
+			wantNonZ:   3,
+		},
+		{
+			name:       "empty input returns full zero series",
+			buckets:    nil,
+			start:      base,
+			end:        base.Add(3 * time.Hour),
+			resolution: ResolutionHour,
+			wantLen:    4, // hours 0,1,2,3
+			wantNonZ:   0,
+		},
+		{
+			name: "all populated returns unchanged length",
+			buckets: []TimeseriesBucket{
+				{Bucket: base, Count: 1},
+				{Bucket: base.Add(time.Hour), Count: 2},
+				{Bucket: base.Add(2 * time.Hour), Count: 3},
+			},
+			start:      base,
+			end:        base.Add(2 * time.Hour),
+			resolution: ResolutionHour,
+			wantLen:    3,
+			wantNonZ:   3,
+		},
+		{
+			name: "single data point in 24h range",
+			buckets: []TimeseriesBucket{
+				{Bucket: base.Add(12 * time.Hour), Count: 7, SuccessCount: 7},
+			},
+			start:      base,
+			end:        base.Add(23 * time.Hour),
+			resolution: ResolutionHour,
+			wantLen:    24, // hours 0..23
+			wantNonZ:   1,
+		},
+		{
+			name: "minute resolution",
+			buckets: []TimeseriesBucket{
+				{Bucket: base, Count: 2},
+				{Bucket: base.Add(4 * time.Minute), Count: 1},
+			},
+			start:      base,
+			end:        base.Add(4 * time.Minute),
+			resolution: ResolutionMinute,
+			wantLen:    5, // minutes 0,1,2,3,4
+			wantNonZ:   2,
+		},
+		{
+			name: "day resolution",
+			buckets: []TimeseriesBucket{
+				{Bucket: time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC), Count: 10},
+				{Bucket: time.Date(2025, 6, 17, 0, 0, 0, 0, time.UTC), Count: 5},
+			},
+			start:      time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC),
+			end:        time.Date(2025, 6, 18, 0, 0, 0, 0, time.UTC),
+			resolution: ResolutionDay,
+			wantLen:    4, // days 15,16,17,18
+			wantNonZ:   2,
+		},
+		{
+			name:       "start equals end returns single bucket",
+			buckets:    nil,
+			start:      base,
+			end:        base,
+			resolution: ResolutionHour,
+			wantLen:    1,
+			wantNonZ:   0,
+		},
+		{
+			name:       "start within bucket truncates to boundary",
+			buckets:    nil,
+			start:      base.Add(30 * time.Minute),             // 10:30
+			end:        base.Add(2*time.Hour + 30*time.Minute), // 12:30
+			resolution: ResolutionHour,
+			wantLen:    3, // 10:00, 11:00, 12:00
+			wantNonZ:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ZeroFill(tt.buckets, tt.start, tt.end, tt.resolution)
+			require.Len(t, result, tt.wantLen)
+
+			nonZero := 0
+			for _, b := range result {
+				if b.Count > 0 {
+					nonZero++
+				}
+			}
+			assert.Equal(t, tt.wantNonZ, nonZero)
+
+			// Verify ordering is ascending.
+			for i := 1; i < len(result); i++ {
+				assert.True(t, result[i].Bucket.After(result[i-1].Bucket),
+					"bucket %d (%v) should be after bucket %d (%v)",
+					i, result[i].Bucket, i-1, result[i-1].Bucket)
+			}
+		})
+	}
+}
+
+func TestZeroFill_PreservesOriginalData(t *testing.T) {
+	base := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+	buckets := []TimeseriesBucket{
+		{Bucket: base, Count: 5, SuccessCount: 4, ErrorCount: 1, AvgDurationMS: 42.5},
+	}
+
+	result := ZeroFill(buckets, base, base.Add(2*time.Hour), ResolutionHour)
+	require.Len(t, result, 3)
+
+	// Original data preserved.
+	assert.Equal(t, 5, result[0].Count)
+	assert.Equal(t, 4, result[0].SuccessCount)
+	assert.Equal(t, 1, result[0].ErrorCount)
+	assert.InDelta(t, 42.5, result[0].AvgDurationMS, 0.01)
+
+	// Zero-filled buckets.
+	assert.Equal(t, 0, result[1].Count)
+	assert.Equal(t, 0, result[2].Count)
+}
+
+func TestZeroFill_InvalidResolution(t *testing.T) {
+	base := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+	buckets := []TimeseriesBucket{{Bucket: base, Count: 1}}
+
+	result := ZeroFill(buckets, base, base.Add(time.Hour), Resolution("invalid"))
+	assert.Equal(t, buckets, result)
+}
+
+func TestResolutionInterval(t *testing.T) {
+	assert.Equal(t, time.Minute, resolutionInterval(ResolutionMinute))
+	assert.Equal(t, time.Hour, resolutionInterval(ResolutionHour))
+	assert.Equal(t, 24*time.Hour, resolutionInterval(ResolutionDay))
+	assert.Equal(t, time.Duration(0), resolutionInterval(Resolution("invalid")))
+}
+
+func TestTruncateTime(t *testing.T) {
+	ts := time.Date(2025, 6, 15, 14, 35, 42, 123456789, time.UTC)
+
+	assert.Equal(t,
+		time.Date(2025, 6, 15, 14, 35, 0, 0, time.UTC),
+		truncateTime(ts, ResolutionMinute))
+
+	assert.Equal(t,
+		time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC),
+		truncateTime(ts, ResolutionHour))
+
+	assert.Equal(t,
+		time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC),
+		truncateTime(ts, ResolutionDay))
+
+	// Invalid resolution returns time unchanged.
+	assert.Equal(t, ts, truncateTime(ts, Resolution("invalid")))
+}
+
+func TestZeroFill_EmptySliceNotNil(t *testing.T) {
+	base := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+	// End before start after truncation → could produce empty result.
+	result := ZeroFill(nil, base, base, ResolutionHour)
+	assert.NotNil(t, result)
+}

--- a/ui/src/components/charts/TimeseriesChart.tsx
+++ b/ui/src/components/charts/TimeseriesChart.tsx
@@ -38,6 +38,9 @@ export function TimeseriesChart({
 }: TimeseriesChartProps) {
   if (isLoading || !data) return <ChartSkeleton height={height} />;
 
+  const nonZeroCount = data.filter((d) => d.count > 0).length;
+  const showDots = nonZeroCount > 0 && nonZeroCount <= 10;
+
   return (
     <ResponsiveContainer width="100%" height={height}>
       <LineChart data={data}>
@@ -70,7 +73,7 @@ export function TimeseriesChart({
           dataKey="success_count"
           stroke="hsl(142, 76%, 36%)"
           strokeWidth={2}
-          dot={false}
+          dot={showDots ? { r: 3 } : false}
           name="Success"
         />
         <Line
@@ -78,7 +81,7 @@ export function TimeseriesChart({
           dataKey="error_count"
           stroke="hsl(0, 84%, 60%)"
           strokeWidth={2}
-          dot={false}
+          dot={showDots ? { r: 3 } : false}
           name="Errors"
         />
       </LineChart>


### PR DESCRIPTION
## Summary

- **Root cause**: The `Timeseries()` SQL query uses `GROUP BY date_trunc(resolution, timestamp)` which only returns non-empty buckets. With sparse usage (e.g., 2 tool calls in a 24h window), the chart collapsed to just the data points, losing all temporal context on the X-axis.
- **Fix**: Added a Go-side `ZeroFill` helper that expands sparse SQL results into a complete series covering `[start, end]` at the requested resolution, inserting zero-valued buckets for gaps. Called in the Postgres `Timeseries()` method after the query, so both the admin dashboard and portal activity charts are fixed.
- **Frontend**: When there are 10 or fewer non-zero data points, dots (`r: 3`) are shown on the lines so sparse spikes are visible against the zero baseline.

## Why Go-side instead of SQL `generate_series`

- Keeps existing squirrel-based SQL unchanged (less risk)
- Pure Go logic is trivially testable with table-driven tests
- Not PostgreSQL-specific — works with any store implementation

## Changes

| File | Change |
|------|--------|
| `pkg/audit/zerofill.go` | New: `ZeroFill`, `resolutionInterval`, `truncateTime` |
| `pkg/audit/zerofill_test.go` | New: 8 table-driven cases + data preservation, invalid resolution, helper unit tests |
| `pkg/audit/postgres/metrics.go` | Call `audit.ZeroFill()` after SQL query |
| `pkg/audit/postgres/metrics_test.go` | Updated 3 tests to use fixed times and verify zero-filled output |
| `ui/src/components/charts/TimeseriesChart.tsx` | Conditional dots on sparse data |

## Test plan

- [x] `make verify` passes (all gates: tests, lint, security, coverage, CodeQL, GoReleaser)
- [x] New `ZeroFill` function has 93.8% coverage, helpers at 100%
- [ ] Manual: start Vite dev server, switch to 1h preset — chart shows 60 minute-level buckets
- [ ] Manual: with 2 tool calls in same hour on 24h view — chart shows full 24-hour timeline with a single spike and visible dots, not a collapsed single data point
- [ ] Manual: admin dashboard shows same improvement for sparse activity