### PR TITLE
fix: admin tool call auth bypass and asset viewer content flash

### DIFF
--- a/pkg/admin/tools.go
+++ b/pkg/admin/tools.go
@@ -211,18 +211,20 @@ func extractContentBlocks(mcpContent []mcp.Content) []toolContentBlock {
 func (h *Handler) connectInternalSession(r *http.Request) (*mcp.ClientSession, func(), error) {
 	t1, t2 := mcp.NewInMemoryTransports()
 
-	// Inject the admin's auth token into the server connection context so
-	// the MCP auth middleware can authenticate the internal call.
+	// Inject auth credentials into the server connection context so the MCP
+	// auth middleware can authenticate the internal call.
 	ctx := r.Context()
 	if token := extractToken(r); token != "" {
+		// API key or Bearer token from request headers.
 		ctx = middleware.WithToken(ctx, token)
 	} else if h.deps.BrowserAuth != nil {
-		// Fall back to the OIDC id_token stored in the browser session cookie.
-		// Note: the id_token may expire before the session cookie (IdP TTL is
-		// typically shorter than the 8h session TTL). In that case the MCP auth
-		// middleware will reject the call and the user must re-authenticate.
-		if idToken := h.deps.BrowserAuth.ExtractIDToken(r); idToken != "" {
-			ctx = middleware.WithToken(ctx, idToken)
+		// The admin HTTP middleware already validated the session cookie.
+		// Pass the authenticated user identity directly so the MCP auth
+		// middleware skips token validation. This avoids re-validating the
+		// raw id_token which may have expired (IdP TTL is typically shorter
+		// than the browser session TTL).
+		if info, err := h.deps.BrowserAuth.AuthenticateHTTP(r); err == nil && info != nil {
+			ctx = middleware.WithPreAuthenticatedUser(ctx, info)
 		}
 	}
 

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
@@ -31,12 +32,17 @@ func NewChainedAuthenticator(cfg ChainedAuthConfig, authenticators ...middleware
 func (c *ChainedAuthenticator) Authenticate(ctx context.Context) (*middleware.UserInfo, error) {
 	var lastErr error
 
-	for _, auth := range c.authenticators {
+	for i, auth := range c.authenticators {
 		userInfo, err := auth.Authenticate(ctx)
 		if err == nil && userInfo != nil {
 			return userInfo, nil
 		}
 		if err != nil {
+			slog.Debug("chained auth: authenticator rejected",
+				"index", i,
+				"type", fmt.Sprintf("%T", auth),
+				"error", err.Error(),
+			)
 			lastErr = err
 		}
 	}

--- a/pkg/middleware/context.go
+++ b/pkg/middleware/context.go
@@ -19,6 +19,7 @@ type contextKey int
 const (
 	platformContextKey contextKey = iota
 	tokenContextKey
+	preAuthUserKey
 )
 
 // PlatformContext holds platform-specific context for a request.
@@ -103,6 +104,23 @@ func GetToken(ctx context.Context) string {
 		return token
 	}
 	return ""
+}
+
+// WithPreAuthenticatedUser adds a pre-authenticated user to the context.
+// When present, the MCP auth middleware skips token validation and uses
+// this user info directly. This is used by the admin API when the HTTP
+// middleware has already authenticated the user (e.g. via browser session
+// cookie) and the OIDC id_token may have expired.
+func WithPreAuthenticatedUser(ctx context.Context, info *UserInfo) context.Context {
+	return context.WithValue(ctx, preAuthUserKey, info)
+}
+
+// GetPreAuthenticatedUser retrieves a pre-authenticated user from the context.
+func GetPreAuthenticatedUser(ctx context.Context) *UserInfo {
+	if info, ok := ctx.Value(preAuthUserKey).(*UserInfo); ok {
+		return info
+	}
+	return nil
 }
 
 // WithServerSession adds a ServerSession to the context.

--- a/pkg/middleware/context_test.go
+++ b/pkg/middleware/context_test.go
@@ -93,6 +93,38 @@ func TestTokenContext(t *testing.T) {
 	})
 }
 
+func TestPreAuthenticatedUserContext(t *testing.T) {
+	t.Run("round-trip", func(t *testing.T) {
+		info := &UserInfo{
+			UserID:   "user-123",
+			Email:    "user@example.com",
+			Roles:    []string{"admin"},
+			AuthType: "browser_session",
+		}
+		ctx := WithPreAuthenticatedUser(context.Background(), info)
+		got := GetPreAuthenticatedUser(ctx)
+		if got == nil {
+			t.Fatal("GetPreAuthenticatedUser() returned nil")
+		}
+		if got.UserID != "user-123" {
+			t.Errorf("UserID = %q, want %q", got.UserID, "user-123")
+		}
+		if got.Email != "user@example.com" {
+			t.Errorf("Email = %q, want %q", got.Email, "user@example.com")
+		}
+		if got.AuthType != "browser_session" {
+			t.Errorf("AuthType = %q, want %q", got.AuthType, "browser_session")
+		}
+	})
+
+	t.Run("not set returns nil", func(t *testing.T) {
+		got := GetPreAuthenticatedUser(context.Background())
+		if got != nil {
+			t.Error("GetPreAuthenticatedUser() expected nil for empty context")
+		}
+	})
+}
+
 func TestServerSessionContext(t *testing.T) {
 	t.Run("round-trip", func(t *testing.T) {
 		// We can't construct a real ServerSession (private fields), but we can

--- a/pkg/middleware/mcp.go
+++ b/pkg/middleware/mcp.go
@@ -184,14 +184,26 @@ func authenticateAndAuthorize(
 	next mcp.MethodHandler,
 	params authParams,
 ) (mcp.Result, error) {
-	userInfo, err := params.authenticator.Authenticate(ctx)
-	if err != nil {
-		slog.Warn("tool call authentication failed",
+	// Check for pre-authenticated user first (e.g. admin tool calls where
+	// the HTTP middleware already validated the browser session cookie).
+	userInfo := GetPreAuthenticatedUser(ctx)
+	if userInfo != nil {
+		slog.Debug("using pre-authenticated user",
 			"tool", params.toolName,
-			"request_id", params.pc.RequestID,
-			"error", err.Error(),
+			"user_id", userInfo.UserID,
+			"auth_type", userInfo.AuthType,
 		)
-		return createCategorizedErrorResult(ErrCategoryAuth, "authentication failed: "+err.Error()), nil
+	} else {
+		var err error
+		userInfo, err = params.authenticator.Authenticate(ctx)
+		if err != nil {
+			slog.Warn("tool call authentication failed",
+				"tool", params.toolName,
+				"request_id", params.pc.RequestID,
+				"error", err.Error(),
+			)
+			return createCategorizedErrorResult(ErrCategoryAuth, "authentication failed: "+err.Error()), nil
+		}
 	}
 
 	if userInfo != nil {

--- a/pkg/middleware/mcp_test.go
+++ b/pkg/middleware/mcp_test.go
@@ -1040,3 +1040,100 @@ func TestMCPToolCallMiddleware_AwareSessionIDFallback(t *testing.T) {
 		}
 	})
 }
+
+func TestMCPToolCallMiddleware_PreAuthenticatedUser(t *testing.T) {
+	// The authenticator should NOT be called when a pre-authenticated user
+	// is present in the context — this verifies the bypass path.
+	authenticator := &mcpTestAuthenticator{
+		err: errors.New("should not be called"),
+	}
+	authorizer := &mcpTestAuthorizer{authorized: true, personaName: mcpTestPersona}
+
+	mw := MCPToolCallMiddleware(authenticator, authorizer, nil, mcpTestStdio)
+
+	next := func(ctx context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		pc := GetPlatformContext(ctx)
+		if pc == nil {
+			t.Fatal(mcpTestPCExpected)
+		}
+		if pc.UserID != "preauth-user" {
+			t.Errorf("UserID = %q, want %q", pc.UserID, "preauth-user")
+		}
+		if pc.UserEmail != "preauth@example.com" {
+			t.Errorf("UserEmail = %q, want %q", pc.UserEmail, "preauth@example.com")
+		}
+		if !pc.Authorized {
+			t.Error("expected Authorized to be true")
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
+		}, nil
+	}
+
+	handler := mw(next)
+	req := newMCPTestRequest(mcpTestToolName)
+
+	// Inject a pre-authenticated user into the context.
+	preAuth := &UserInfo{
+		UserID:   "preauth-user",
+		Email:    "preauth@example.com",
+		Roles:    []string{mcpTestPersona},
+		AuthType: "browser_session",
+	}
+	ctx := WithPreAuthenticatedUser(context.Background(), preAuth)
+
+	result, err := handler(ctx, mcpTestMethod, req)
+	if err != nil {
+		t.Fatalf(mcpTestErrFmt, err)
+	}
+
+	toolResult, ok := result.(*mcp.CallToolResult)
+	if !ok {
+		t.Fatalf(mcpTestResultFmt, result)
+	}
+	if toolResult.IsError {
+		t.Error("expected IsError to be false")
+	}
+}
+
+func TestMCPToolCallMiddleware_PreAuthenticatedUser_AuthzDenied(t *testing.T) {
+	// Pre-authenticated user still goes through authorization.
+	authenticator := &mcpTestAuthenticator{
+		err: errors.New("should not be called"),
+	}
+	authorizer := &mcpTestAuthorizer{
+		authorized:  false,
+		personaName: "viewer",
+		reason:      "tool not allowed",
+	}
+
+	mw := MCPToolCallMiddleware(authenticator, authorizer, nil, mcpTestStdio)
+
+	next := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		t.Fatal("next should not be called on authz failure")
+		return nil, nil //nolint:nilnil // unreachable
+	}
+
+	handler := mw(next)
+	req := newMCPTestRequest(mcpTestToolName)
+
+	preAuth := &UserInfo{
+		UserID:   "preauth-user",
+		Roles:    []string{"viewer"},
+		AuthType: "browser_session",
+	}
+	ctx := WithPreAuthenticatedUser(context.Background(), preAuth)
+
+	result, err := handler(ctx, mcpTestMethod, req)
+	if err != nil {
+		t.Fatalf(mcpTestErrFmt, err)
+	}
+
+	toolResult, ok := result.(*mcp.CallToolResult)
+	if !ok {
+		t.Fatalf(mcpTestResultFmt, result)
+	}
+	if !toolResult.IsError {
+		t.Error("expected IsError to be true for denied pre-auth user")
+	}
+}

--- a/ui/src/components/AssetViewer.tsx
+++ b/ui/src/components/AssetViewer.tsx
@@ -64,17 +64,19 @@ export function AssetViewer({
 
   const [viewMode, setViewMode] = useState<ViewMode>("preview");
   const [editedContent, setEditedContent] = useState<string>("");
+  const [dirty, setDirty] = useState(false);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saved" | "error">("idle");
 
   const canEditSource = !!contentUpdateMutation && !!asset && isTextContent(asset.content_type);
   const contentStr = typeof content === "string" ? content : "";
-  const hasChanges = editedContent !== contentStr;
+  const hasChanges = dirty && editedContent !== contentStr;
 
   // Only sync editedContent when the server content changes (initial load or post-save refetch),
   // NOT on tab switches — so unsaved edits survive Preview/Source toggling.
   useEffect(() => {
     if (content !== undefined) {
       setEditedContent(contentStr);
+      setDirty(false);
       setSaveStatus("idle");
     }
   }, [contentStr]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -257,7 +259,7 @@ export function AssetViewer({
               <SourceEditor
                 content={editedContent}
                 contentType={asset.content_type}
-                onChange={setEditedContent}
+                onChange={(v) => { setEditedContent(v); setDirty(true); }}
               />
             </Suspense>
           ) : (


### PR DESCRIPTION
## Summary

- **Admin tool calls fail with "authentication failed: invalid API key"** when using browser session auth (Tools > Explore page). `connectInternalSession` was re-extracting the raw OIDC id_token from the session cookie and forcing it through the full MCP auth chain (OAuth JWT → OIDC → API Key). The OIDC authenticator could reject the token (e.g. expired id_token, JWKS cache stale), but `ChainedAuthenticator` only reports the *last* error — the unhelpful "invalid API key" from the API key authenticator. The admin HTTP middleware had already validated the session cookie, making this re-validation redundant and fragile.
- **Asset viewer shows "No component found" error** on first render of JSX/TSX assets. The `hasChanges` flag (`editedContent !== contentStr`) evaluated `true` during the initial render because `editedContent` initializes as `""` while `contentStr` has the loaded content. This passed empty content to `ContentRenderer` → `JsxRenderer`, which couldn't find a component name in an empty string.

## Changes

### Admin tool call pre-authentication (`pkg/admin/tools.go`)
Instead of extracting the raw id_token and pushing it through token validation, `connectInternalSession` now calls `BrowserAuth.AuthenticateHTTP(r)` to get the already-validated `UserInfo` and passes it via `WithPreAuthenticatedUser()`. This completely decouples admin tool calls from id_token lifetime — the session cookie validity is the only thing that matters.

### MCP auth middleware pre-auth check (`pkg/middleware/mcp.go`)
`authenticateAndAuthorize` now checks for a pre-authenticated user in the context before running the auth chain. When present, it skips token validation and proceeds directly to authorization. This preserves the full authorization check (persona/role-based tool filtering) while eliminating the fragile token re-validation.

### Pre-authenticated user context (`pkg/middleware/context.go`)
Added `WithPreAuthenticatedUser` / `GetPreAuthenticatedUser` context helpers using a dedicated context key. This is a clean, type-safe mechanism for passing already-authenticated identity through the MCP middleware chain.

### ChainedAuthenticator debug logging (`pkg/auth/middleware.go`)
Added per-authenticator `slog.Debug` logging that records the index, type, and error for each rejected authenticator. Previously, only the last error was kept — making it impossible to diagnose which authenticator in the chain actually had the relevant failure.

### Asset viewer dirty flag (`ui/src/components/AssetViewer.tsx`)
Added a `dirty` state flag that is only set `true` when the user actually edits content in the SourceEditor. `hasChanges` now requires `dirty && editedContent !== contentStr`, preventing the false-positive on initial render. The flag resets when server content syncs (initial load or post-save refetch).

## Test plan

- [x] `TestPreAuthenticatedUserContext` — round-trip and nil-context tests for the new context helpers
- [x] `TestMCPToolCallMiddleware_PreAuthenticatedUser` — pre-auth user bypasses auth chain, populates PlatformContext correctly, proceeds to tool handler
- [x] `TestMCPToolCallMiddleware_PreAuthenticatedUser_AuthzDenied` — pre-auth user still goes through authorization; denied users get error result
- [x] All existing middleware, auth, and admin tests pass
- [x] Full `go test -race ./...` passes
- [ ] Deploy and verify Tools > Explore works with browser session auth
- [ ] Deploy and verify JSX/TSX assets render without flash error on first load