### PR TITLE
fix: auto-inject portal logo into platform-info MCP app

### DIFF
--- a/apps/platform-info/index.html
+++ b/apps/platform-info/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Platform Info</title>
-    <script id="app-config" type="application/json">{"brand_name":"","logo_svg":"","brand_url":""}</script>
+    <script id="app-config" type="application/json">{"brand_name":"","logo_svg":"","logo_url":"","brand_url":""}</script>
     <style>
         :root {
             --bg: #0d1117;
@@ -122,6 +122,7 @@
             display: flex; align-items: center; justify-content: center;
         }
         .logo svg { width: 53px; height: 53px; display: block; }
+        .logo img { width: 53px; height: 53px; display: block; object-fit: contain; }
         .logo a {
             display: flex; align-items: center; justify-content: center;
             color: inherit; text-decoration: none;
@@ -710,15 +711,26 @@
     function renderInfo(d) {
         var brandUrl  = CFG.brand_url  || '';
         var brandName = CFG.brand_name || 'MCP Data Platform';
-        var logoSvg   = CFG.logo_svg   || DEFAULT_LOGO;
+        var logoSvg   = CFG.logo_svg   || '';
+        var logoUrl   = CFG.logo_url   || '';
+
+        // Build logo markup: prefer inline SVG, fall back to URL image, then default icon.
+        var logoMarkup;
+        if (logoSvg) {
+            logoMarkup = logoSvg;
+        } else if (logoUrl) {
+            logoMarkup = '<img src="' + esc(logoUrl) + '" alt="' + esc(brandName) + '">';
+        } else {
+            logoMarkup = DEFAULT_LOGO;
+        }
 
         // Logo — wrapped in link if brand_url is set
         var logoEl = document.getElementById('logo');
         if (brandUrl) {
             logoEl.innerHTML = '<a href="' + esc(brandUrl) + '" target="_blank" rel="noopener noreferrer">'
-                + logoSvg + '</a>';
+                + logoMarkup + '</a>';
         } else {
-            logoEl.innerHTML = logoSvg;
+            logoEl.innerHTML = logoMarkup;
         }
 
         // Brand name — wrapped in link if brand_url is set

--- a/pkg/middleware/mcp.go
+++ b/pkg/middleware/mcp.go
@@ -23,6 +23,9 @@ const (
 
 	// methodToolsCall is the MCP method name for tool invocations.
 	methodToolsCall = "tools/call"
+
+	// logKeyTool is the slog key for tool name in log messages.
+	logKeyTool = "tool"
 )
 
 // Error categories for structured error handling and audit queries.
@@ -189,7 +192,7 @@ func authenticateAndAuthorize(
 	userInfo := GetPreAuthenticatedUser(ctx)
 	if userInfo != nil {
 		slog.Debug("using pre-authenticated user",
-			"tool", params.toolName,
+			logKeyTool, params.toolName,
 			"user_id", userInfo.UserID,
 			"auth_type", userInfo.AuthType,
 		)
@@ -198,7 +201,7 @@ func authenticateAndAuthorize(
 		userInfo, err = params.authenticator.Authenticate(ctx)
 		if err != nil {
 			slog.Warn("tool call authentication failed",
-				"tool", params.toolName,
+				logKeyTool, params.toolName,
 				"request_id", params.pc.RequestID,
 				"error", err.Error(),
 			)
@@ -219,7 +222,7 @@ func authenticateAndAuthorize(
 	if !authorized {
 		params.pc.AuthzError = reason
 		slog.Warn("tool call authorization denied",
-			"tool", params.toolName,
+			logKeyTool, params.toolName,
 			"user_id", params.pc.UserID,
 			"email", params.pc.UserEmail,
 			"roles", params.pc.Roles,

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -948,6 +948,9 @@ func (p *Platform) registerBuiltinPlatformInfo() error {
 		}
 	}
 
+	// Auto-inject portal logo when the operator hasn't set one explicitly.
+	app.Config = p.injectPortalLogo(app.Config)
+
 	if app.AssetsPath != "" {
 		if err := app.ValidateAssets(); err != nil {
 			return fmt.Errorf("app %s: %w", builtinPlatformInfoName, err)
@@ -960,6 +963,27 @@ func (p *Platform) registerBuiltinPlatformInfo() error {
 
 	slog.Info("registered MCP app", "app", builtinPlatformInfoName, "resource_uri", app.ResourceURI)
 	return nil
+}
+
+// injectPortalLogo auto-populates the logo_url field in the platform-info
+// app config from portal.logo when the operator hasn't set logo_svg or
+// logo_url explicitly. This avoids requiring operators to duplicate their
+// portal logo configuration in the mcpapps config.
+func (p *Platform) injectPortalLogo(cfg any) any {
+	portalLogo := p.config.Portal.Logo
+	if portalLogo == "" {
+		return cfg
+	}
+
+	m, ok := cfg.(map[string]any)
+	if !ok {
+		m = make(map[string]any)
+	}
+	if m["logo_svg"] != nil || m["logo_url"] != nil {
+		return m
+	}
+	m["logo_url"] = portalLogo
+	return m
 }
 
 // registerMCPApp creates, validates, and registers a single MCP app.

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -3689,6 +3689,69 @@ func TestNew_WorkflowGatingEnabled(t *testing.T) {
 	}
 }
 
+func mustMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", v)
+	}
+	return m
+}
+
+func TestInjectPortalLogo(t *testing.T) {
+	t.Run("injects logo_url from portal.logo", func(t *testing.T) {
+		p := &Platform{config: &Config{
+			Portal: PortalConfig{Logo: "https://example.com/logo.svg"},
+		}}
+		cfg := map[string]any{"brand_name": "Test"}
+		m := mustMap(t, p.injectPortalLogo(cfg))
+		if m["logo_url"] != "https://example.com/logo.svg" {
+			t.Errorf("logo_url = %v, want %q", m["logo_url"], "https://example.com/logo.svg")
+		}
+	})
+
+	t.Run("does not overwrite explicit logo_svg", func(t *testing.T) {
+		p := &Platform{config: &Config{
+			Portal: PortalConfig{Logo: "https://example.com/logo.svg"},
+		}}
+		cfg := map[string]any{"logo_svg": "<svg>custom</svg>"}
+		m := mustMap(t, p.injectPortalLogo(cfg))
+		if m["logo_url"] != nil {
+			t.Errorf("logo_url should be nil when logo_svg is set, got %v", m["logo_url"])
+		}
+	})
+
+	t.Run("does not overwrite explicit logo_url", func(t *testing.T) {
+		p := &Platform{config: &Config{
+			Portal: PortalConfig{Logo: "https://example.com/logo.svg"},
+		}}
+		cfg := map[string]any{"logo_url": "https://other.com/logo.png"}
+		m := mustMap(t, p.injectPortalLogo(cfg))
+		if m["logo_url"] != "https://other.com/logo.png" {
+			t.Errorf("logo_url = %v, want %q", m["logo_url"], "https://other.com/logo.png")
+		}
+	})
+
+	t.Run("no-op when portal logo is empty", func(t *testing.T) {
+		p := &Platform{config: &Config{}}
+		cfg := map[string]any{"brand_name": "Test"}
+		m := mustMap(t, p.injectPortalLogo(cfg))
+		if m["logo_url"] != nil {
+			t.Errorf("logo_url should be nil when portal logo is empty, got %v", m["logo_url"])
+		}
+	})
+
+	t.Run("creates map when config is nil", func(t *testing.T) {
+		p := &Platform{config: &Config{
+			Portal: PortalConfig{Logo: "https://example.com/logo.svg"},
+		}}
+		m := mustMap(t, p.injectPortalLogo(nil))
+		if m["logo_url"] != "https://example.com/logo.svg" {
+			t.Errorf("logo_url = %v, want %q", m["logo_url"], "https://example.com/logo.svg")
+		}
+	})
+}
+
 func TestNew_WorkflowGatingDisabled(t *testing.T) {
 	cfg := &Config{
 		Server:   ServerConfig{Name: testServerName},


### PR DESCRIPTION
## Summary

- **Platform-info MCP app shows default graph icon instead of operator logo.** `registerBuiltinPlatformInfo` passes the operator's `mcpapps.apps.platform-info.config` verbatim to the embedded HTML. The HTML renders `CFG.logo_svg || DEFAULT_LOGO`, but operators typically configure their logo via `portal.logo` (a URL), not by duplicating an inline SVG into `mcpapps.apps.platform-info.config.logo_svg`. The result: the portal, admin UI, and login page all show the correct logo, but the platform-info MCP app falls back to the default data-graph icon.

### Root cause

No bridging between `portal.logo` and the platform-info app config. The two config paths were completely disconnected:

```
portal.logo: "https://example.com/logo.svg"     ← used by portal/admin UI
mcpapps.apps.platform-info.config.logo_svg: ""   ← used by platform-info app (empty → default icon)
```

### Fix

#### Auto-inject portal logo (`pkg/platform/platform.go`)

New `injectPortalLogo()` method called at the end of `registerBuiltinPlatformInfo`. When the operator hasn't explicitly set `logo_svg` or `logo_url` in the app config, it auto-populates `logo_url` from `portal.logo`. This means any deployment that already has `portal.logo` configured gets the correct logo in the platform-info app with zero config changes.

Precedence chain (highest to lowest):
1. `mcpapps.apps.platform-info.config.logo_svg` — inline SVG markup (explicit override)
2. `mcpapps.apps.platform-info.config.logo_url` — image URL (explicit override)
3. `portal.logo` — auto-injected as `logo_url` (new behavior)
4. Default data-graph icon (built into HTML)

#### URL logo support (`apps/platform-info/index.html`)

The HTML previously only supported `logo_svg` (inline SVG markup). Added `logo_url` support that renders with `<img>` tag, including `object-fit: contain` styling to handle various aspect ratios. The logo markup selection is now:

```js
if (logoSvg) { logoMarkup = logoSvg; }
else if (logoUrl) { logoMarkup = '<img src="...">'; }
else { logoMarkup = DEFAULT_LOGO; }
```

#### Lint fix (`pkg/middleware/mcp.go`)

Extracted repeated `"tool"` slog key string literal (4 occurrences) to `logKeyTool` constant, fixing a pre-existing `revive/add-constant` lint finding.

## Test plan

- [x] `TestInjectPortalLogo/injects_logo_url_from_portal.logo` — portal.logo auto-injected as logo_url
- [x] `TestInjectPortalLogo/does_not_overwrite_explicit_logo_svg` — explicit logo_svg preserved, no logo_url added
- [x] `TestInjectPortalLogo/does_not_overwrite_explicit_logo_url` — explicit logo_url preserved unchanged
- [x] `TestInjectPortalLogo/no-op_when_portal_logo_is_empty` — no injection when portal.logo is unset
- [x] `TestInjectPortalLogo/creates_map_when_config_is_nil` — handles nil config (no mcpapps config block)
- [x] `injectPortalLogo` — 100% coverage
- [x] `make verify` — all checks pass (fmt, test, lint, security, coverage, dead-code, mutate, release-check)
- [ ] Deploy and verify platform-info app shows portal logo via `<img>` tag