### PR TITLE
fix: use unknown cast in MyAssetsPage test mocks for tsc strict compat

### DIFF
--- a/ui/src/pages/assets/MyAssetsPage.test.tsx
+++ b/ui/src/pages/assets/MyAssetsPage.test.tsx
@@ -49,7 +49,7 @@ describe("MyAssetsPage: title does not overlap share icons", () => {
         },
       },
       isLoading: false,
-    } as ReturnType<typeof useAssets>);
+    } as unknown as ReturnType<typeof useAssets>);
 
     render(<MyAssetsPage onNavigate={vi.fn()} />, { wrapper });
 
@@ -89,7 +89,7 @@ describe("MyAssetsPage: title does not overlap share icons", () => {
         },
       },
       isLoading: false,
-    } as ReturnType<typeof useAssets>);
+    } as unknown as ReturnType<typeof useAssets>);
 
     render(<MyAssetsPage onNavigate={vi.fn()} />, { wrapper });
 
@@ -115,7 +115,7 @@ describe("MyAssetsPage: title does not overlap share icons", () => {
         },
       },
       isLoading: false,
-    } as ReturnType<typeof useAssets>);
+    } as unknown as ReturnType<typeof useAssets>);
 
     render(<MyAssetsPage onNavigate={vi.fn()} />, { wrapper });
 
@@ -139,7 +139,7 @@ describe("MyAssetsPage: title does not overlap share icons", () => {
         share_summaries: {},
       },
       isLoading: false,
-    } as ReturnType<typeof useAssets>);
+    } as unknown as ReturnType<typeof useAssets>);
 
     render(<MyAssetsPage onNavigate={vi.fn()} />, { wrapper });
 


### PR DESCRIPTION
## Summary
- Fixes v0.37.5 release failure caused by `tsc -b` rejecting partial `UseQueryResult` mock casts
- Changes `as ReturnType<typeof useAssets>` to `as unknown as ReturnType<typeof useAssets>` in 4 test mock sites

## Test plan
- [x] `tsc -b` compiles clean
- [x] `vitest run` — all 24 tests pass