### PR TITLE
fix: platform-info Copy button copies to clipboard with permissions fix

### DIFF
--- a/apps/platform-info/index.html
+++ b/apps/platform-info/index.html
@@ -1203,22 +1203,35 @@ if(__exports != exports)module.exports = exports;return module.exports}));
                 text += ' (' + parts.join(', ') + ')';
             }
         }
-        if (navigator.clipboard && navigator.clipboard.writeText) {
-            navigator.clipboard.writeText(text);
-        } else {
-            var ta = document.createElement('textarea');
-            ta.value = text;
-            document.body.appendChild(ta);
-            ta.select();
-            document.execCommand('copy');
-            document.body.removeChild(ta);
+
+        function onSuccess() {
+            btn.textContent = 'Copied!';
+            btn.classList.add('copied');
+            setTimeout(function() {
+                btn.textContent = 'Copy';
+                btn.classList.remove('copied');
+            }, 2000);
         }
-        btn.textContent = 'Copied!';
-        btn.classList.add('copied');
-        setTimeout(function() {
-            btn.textContent = 'Copy';
-            btn.classList.remove('copied');
-        }, 2000);
+
+        function fallbackCopy() {
+            try {
+                var ta = document.createElement('textarea');
+                ta.value = text;
+                ta.style.position = 'fixed';
+                ta.style.opacity = '0';
+                document.body.appendChild(ta);
+                ta.select();
+                var ok = document.execCommand('copy');
+                document.body.removeChild(ta);
+                if (ok) { onSuccess(); }
+            } catch (e) { /* fallback also failed */ }
+        }
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(onSuccess).catch(fallbackCopy);
+        } else {
+            fallbackCopy();
+        }
     }
 
     function showErr(msg) {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -940,6 +940,11 @@ func (p *Platform) registerBuiltinPlatformInfo() error {
 		Content:     subFS,
 		EntryPoint:  "index.html",
 		ResourceURI: "ui://platform-info",
+		CSP: &mcpapps.CSPConfig{
+			Permissions: &mcpapps.PermissionsConfig{
+				ClipboardWrite: &struct{}{},
+			},
+		},
 	}
 
 	// Merge operator config (branding) if present.


### PR DESCRIPTION
## Summary
- Add `clipboard-write` CSP permission to the built-in platform-info app so the Clipboard API works inside sandboxed MCP App iframes
- Fix `copyPrompt()` to handle the async `navigator.clipboard.writeText()` Promise — "Copied!" feedback now only shows after confirmed success
- Add `execCommand('copy')` fallback with proper error handling when the Clipboard API is unavailable or rejected

## Test plan
- [ ] `make verify` passes (confirmed locally)
- [ ] Open platform-info MCP App in Claude Desktop, go to Prompts tab, click Copy — text is actually in clipboard
- [ ] Verify the app resource response includes `permissions.clipboardWrite` in metadata