### PR TITLE
feat: show prompt template content in platform-info UI

### DIFF
--- a/apps/platform-info/index.html
+++ b/apps/platform-info/index.html
@@ -714,6 +714,32 @@ if(__exports != exports)module.exports = exports;return module.exports}));
             border-color: var(--success);
         }
 
+        .prompt-template-toggle {
+            font-size: 11px;
+            color: var(--accent);
+            cursor: pointer;
+            margin-top: 4px;
+            user-select: none;
+        }
+        .prompt-template-toggle:hover { text-decoration: underline; }
+
+        .prompt-template {
+            margin-top: 8px;
+        }
+        .prompt-template pre {
+            font-family: var(--font-mono);
+            font-size: 11.5px;
+            line-height: 1.55;
+            color: var(--text-secondary);
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 10px 12px;
+            white-space: pre-wrap;
+            word-break: break-word;
+            margin: 0;
+        }
+
         .hidden { display: none !important; }
     </style>
 </head>
@@ -1173,6 +1199,12 @@ if(__exports != exports)module.exports = exports;return module.exports}));
                 }).join('')
                 + '</div>';
         }
+        var templateHtml = '';
+        if (p.content) {
+            templateHtml = '<div class="prompt-template-toggle" onclick="toggleTemplate(' + idx + ', this)">Show prompt template</div>'
+                + '<div class="prompt-template" id="prompt-tpl-' + idx + '" style="display:none">'
+                + '<pre>' + esc(p.content) + '</pre></div>';
+        }
         return '<div class="prompt-card">'
             + '<div class="prompt-card-header">'
             + '<div>'
@@ -1183,7 +1215,16 @@ if(__exports != exports)module.exports = exports;return module.exports}));
             + '</div>'
             + (p.description ? '<div class="prompt-card-desc">' + esc(p.description) + '</div>' : '')
             + argsHtml
+            + templateHtml
             + '</div>';
+    }
+
+    function toggleTemplate(idx, el) {
+        var tpl = document.getElementById('prompt-tpl-' + idx);
+        if (!tpl) { return; }
+        var hidden = tpl.style.display === 'none';
+        tpl.style.display = hidden ? 'block' : 'none';
+        el.textContent = hidden ? 'Hide prompt template' : 'Show prompt template';
     }
 
     function copyPrompt(idx, btn) {

--- a/pkg/platform/prompts.go
+++ b/pkg/platform/prompts.go
@@ -155,6 +155,7 @@ func (p *Platform) registerPromptWithCategory(cfg PromptConfig, category string)
 		Name:        cfg.Name,
 		Description: cfg.Description,
 		Category:    category,
+		Content:     cfg.Content,
 	}
 	for _, arg := range cfg.Arguments {
 		info.Arguments = append(info.Arguments, registry.PromptArgumentInfo{

--- a/pkg/platform/prompts_test.go
+++ b/pkg/platform/prompts_test.go
@@ -540,6 +540,7 @@ func TestPromptMetadataCollection(t *testing.T) {
 		}
 		customFound = true
 		assert.Equal(t, "A custom prompt", info.Description)
+		assert.Equal(t, "Do {thing}.", info.Content)
 		require.Len(t, info.Arguments, 1)
 		assert.Equal(t, "thing", info.Arguments[0].Name)
 		assert.True(t, info.Arguments[0].Required)
@@ -551,9 +552,10 @@ func TestPromptMetadataCollection(t *testing.T) {
 		assert.NotEqual(t, autoPromptName, info.Name, "platform-overview should not be in collected infos")
 	}
 
-	// Verify categories are set
+	// Verify categories and content are set
 	for _, info := range infos {
 		assert.NotEmpty(t, info.Category, "prompt %q should have a category", info.Name)
+		assert.NotEmpty(t, info.Content, "prompt %q should have content", info.Name)
 	}
 }
 

--- a/pkg/registry/toolkit.go
+++ b/pkg/registry/toolkit.go
@@ -49,6 +49,7 @@ type PromptInfo struct {
 	Name        string               `json:"name"`
 	Description string               `json:"description"`
 	Category    string               `json:"category,omitempty"`
+	Content     string               `json:"content,omitempty"`
 	Arguments   []PromptArgumentInfo `json:"arguments,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

- Add `Content` field to `PromptInfo` so the `platform_info` response includes the actual prompt template text
- Prompts tab now shows a collapsible "Show prompt template" toggle on each card, letting users inspect what each prompt instructs the AI to do
- Tests updated to verify `Content` is populated in collected prompt metadata

## Test plan

- [x] `make verify` passes (all checks green)
- [ ] Deploy and verify Prompts tab cards show "Show prompt template" toggle
- [ ] Clicking toggle reveals the prompt content; clicking again hides it
- [ ] Copy button still works as before
- [ ] `platform_info` JSON response includes `content` field in prompts array