### PR TITLE
fix: populate Content in toolkit PromptInfos

### DIFF
--- a/pkg/platform/prompts_test.go
+++ b/pkg/platform/prompts_test.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -556,6 +557,54 @@ func TestPromptMetadataCollection(t *testing.T) {
 	for _, info := range infos {
 		assert.NotEmpty(t, info.Category, "prompt %q should have a category", info.Name)
 		assert.NotEmpty(t, info.Content, "prompt %q should have content", info.Name)
+	}
+}
+
+func TestPromptContentInJSON(t *testing.T) {
+	reg := registry.NewRegistry()
+	_ = reg.Register(&mockToolkit{kind: "datahub", name: "primary"})
+
+	mcpServer := mcp.NewServer(&mcp.Implementation{
+		Name:    "test-server",
+		Version: "1.0.0",
+	}, nil)
+
+	p := &Platform{
+		mcpServer:       mcpServer,
+		toolkitRegistry: reg,
+		config: &Config{
+			Server: ServerConfig{
+				Description: "Test.",
+				Prompts: []PromptConfig{
+					{
+						Name:        "my-prompt",
+						Description: "My prompt",
+						Content:     "Do the thing about {topic}.",
+						Arguments: []PromptArgumentConfig{
+							{Name: "topic", Description: "The topic", Required: true},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p.registerPlatformPrompts()
+
+	infos := p.allPromptInfos()
+
+	data, err := json.Marshal(infos)
+	require.NoError(t, err)
+
+	jsonStr := string(data)
+	assert.Contains(t, jsonStr, `"content"`, "JSON output must include content field")
+	assert.Contains(t, jsonStr, "Do the thing about {topic}.", "JSON output must include prompt template text")
+
+	// Workflow prompts should also have content in the JSON
+	for _, info := range infos {
+		if info.Category == "workflow" {
+			assert.NotEmpty(t, info.Content, "workflow prompt %q must have content", info.Name)
+		}
 	}
 }
 

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -788,11 +788,13 @@ func (*Toolkit) PromptInfos() []registry.PromptInfo {
 			Name:        promptName,
 			Description: "Guidance on when and how to capture domain knowledge insights",
 			Category:    "toolkit",
+			Content:     knowledgeCapturePrompt,
 		},
 		{
 			Name:        userPromptName,
 			Description: "Record insights from this conversation for data catalog improvement",
 			Category:    "toolkit",
+			Content:     captureKnowledgePromptContent,
 		},
 	}
 }

--- a/pkg/toolkits/portal/toolkit.go
+++ b/pkg/toolkits/portal/toolkit.go
@@ -192,11 +192,13 @@ func (*Toolkit) PromptInfos() []registry.PromptInfo {
 			Name:        saveAssetPromptName,
 			Description: "Save an artifact from this conversation as a viewable, shareable asset",
 			Category:    "toolkit",
+			Content:     saveAssetPromptContent,
 		},
 		{
 			Name:        showAssetsPromptName,
 			Description: "Browse your saved artifacts and assets",
 			Category:    "toolkit",
+			Content:     showAssetsPromptContent,
 		},
 	}
 }


### PR DESCRIPTION
## Summary

- Portal and knowledge toolkit `PromptInfos()` methods returned structs without the `Content` field, even though content constants were defined right next to them
- The `platform_info` JSON response omitted `content` for toolkit prompts due to `omitempty`, so the UI "Show prompt template" toggle never appeared
- Add `Content` to both portal and knowledge toolkit `PromptInfos()` return values
- Add `TestPromptContentInJSON` that marshals prompt infos to JSON and asserts the `"content"` key is present

## Test plan

- [x] `make verify` passes
- [ ] Deploy and confirm "Show prompt template" toggle appears on all prompt cards (workflow + toolkit)
- [ ] Verify `platform_info` JSON includes `content` for portal and knowledge prompts