### PR TITLE
feat: branded two-zone header for public viewer

### DIFF
--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -498,6 +498,15 @@ func mountPortalAPI(mux *http.ServeMux, p *platform.Platform) {
 		}
 	}
 
+	// Platform brand (far right): prefer mcpapps platform-info config, then portal title.
+	brandName := mcpappsBrandName(p)
+	if brandName == "" {
+		brandName = p.Config().Portal.Title
+	}
+	if brandName == "" {
+		brandName = p.Config().Server.Name
+	}
+
 	deps := portal.Deps{
 		AssetStore:    p.PortalAssetStore(),
 		ShareStore:    p.PortalShareStore(),
@@ -508,8 +517,14 @@ func mountPortalAPI(mux *http.ServeMux, p *platform.Platform) {
 			RequestsPerMinute: p.Config().Portal.RateLimit.RequestsPerMinute,
 			BurstSize:         p.Config().Portal.RateLimit.BurstSize,
 		},
-		OIDCEnabled: p.BrowserSessionFlow() != nil,
-		AdminRoles:  adminRoles,
+		OIDCEnabled:        p.BrowserSessionFlow() != nil,
+		AdminRoles:         adminRoles,
+		BrandName:          brandName,
+		BrandLogoSVG:       p.BrandLogoSVG(),
+		BrandURL:           p.BrandURL(),
+		ImplementorName:    p.Config().Portal.Implementor.Name,
+		ImplementorLogoSVG: p.ResolveImplementorLogo(),
+		ImplementorURL:     p.Config().Portal.Implementor.URL,
 	}
 
 	wirePortalOptionalDeps(&deps, p)
@@ -518,6 +533,17 @@ func mountPortalAPI(mux *http.ServeMux, p *platform.Platform) {
 	mux.Handle("/api/v1/portal/", handler)
 	mux.Handle("/portal/view/", handler)
 	log.Println("Portal API enabled on /api/v1/portal/")
+}
+
+// mcpappsBrandName extracts brand_name from the mcpapps platform-info config,
+// or returns empty string if not configured.
+func mcpappsBrandName(p *platform.Platform) string {
+	appCfg, ok := p.Config().MCPApps.Apps["platform-info"]
+	if !ok {
+		return ""
+	}
+	name, _ := appCfg.Config["brand_name"].(string)
+	return name
 }
 
 // wirePortalOptionalDeps populates optional portal dependencies (audit, knowledge, persona).

--- a/cmd/mcp-data-platform/main_test.go
+++ b/cmd/mcp-data-platform/main_test.go
@@ -1017,3 +1017,55 @@ func TestMountPortalUI_NoAssets(t *testing.T) {
 	mux := http.NewServeMux()
 	mountPortalUI(mux, p, false) // no assets available
 }
+
+func TestMcpappsBrandName(t *testing.T) {
+	t.Run("returns brand_name from mcpapps config", func(t *testing.T) {
+		p := newTestPlatform(t, &platform.Config{
+			Server: platform.ServerConfig{Name: "test"},
+			MCPApps: platform.MCPAppsConfig{
+				Apps: map[string]platform.AppConfig{
+					"platform-info": {
+						Config: map[string]any{"brand_name": "Plexara"},
+					},
+				},
+			},
+		})
+		defer func() { _ = p.Close() }()
+
+		got := mcpappsBrandName(p)
+		if got != "Plexara" {
+			t.Errorf("mcpappsBrandName() = %q, want %q", got, "Plexara")
+		}
+	})
+
+	t.Run("returns empty when no platform-info app", func(t *testing.T) {
+		p := newTestPlatform(t, &platform.Config{
+			Server: platform.ServerConfig{Name: "test"},
+		})
+		defer func() { _ = p.Close() }()
+
+		got := mcpappsBrandName(p)
+		if got != "" {
+			t.Errorf("mcpappsBrandName() = %q, want empty", got)
+		}
+	})
+
+	t.Run("returns empty when brand_name not in config", func(t *testing.T) {
+		p := newTestPlatform(t, &platform.Config{
+			Server: platform.ServerConfig{Name: "test"},
+			MCPApps: platform.MCPAppsConfig{
+				Apps: map[string]platform.AppConfig{
+					"platform-info": {
+						Config: map[string]any{"other_key": "value"},
+					},
+				},
+			},
+		})
+		defer func() { _ = p.Close() }()
+
+		got := mcpappsBrandName(p)
+		if got != "" {
+			t.Errorf("mcpappsBrandName() = %q, want empty", got)
+		}
+	})
+}

--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -319,6 +319,10 @@ tuning:
 #   public_base_url: "https://portal.example.com"
 #   s3_connection: data_lake                                   # S3 toolkit instance for artifact storage
 #   s3_bucket: portal-assets                                   # bucket for artifact storage
+#   implementor:                                               # optional implementor brand (far-left header zone)
+#     name: "ACME Corp"
+#     logo: "https://acme.com/logo.svg"
+#     url: "https://acme.com"
 
 # Admin REST API
 # admin:

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -113,7 +113,16 @@ type PortalConfig struct {
 	S3Prefix       string                `yaml:"s3_prefix"`        // key prefix within the bucket
 	PublicBaseURL  string                `yaml:"public_base_url"`  // base URL for portal links (e.g., "https://portal.example.com")
 	MaxContentSize int                   `yaml:"max_content_size"` // max artifact size in bytes (default: 10MB)
+	Implementor    ImplementorConfig     `yaml:"implementor"`      // optional implementor brand (far-left header zone)
 	RateLimit      PortalRateLimitConfig `yaml:"rate_limit"`
+}
+
+// ImplementorConfig configures the optional implementor brand shown in the
+// far-left zone of the public viewer header (e.g., "ACME Corp").
+type ImplementorConfig struct {
+	Name string `yaml:"name"` // display name (e.g., "ACME Corp")
+	Logo string `yaml:"logo"` // URL to logo SVG (fetched at startup for inline rendering)
+	URL  string `yaml:"url"`  // link URL (e.g., "https://acme.com")
 }
 
 // PortalRateLimitConfig configures rate limiting for the public portal viewer.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -125,10 +125,13 @@ type Platform struct {
 	knowledgeDataHubWriter  knowledgekit.DataHubWriter
 
 	// Portal stores (exposed for REST API in Phase 3)
-	portalAssetStore  portal.AssetStore
-	portalShareStore  portal.ShareStore
-	portalS3Client    portal.S3Client
-	provenanceTracker *middleware.ProvenanceTracker
+	portalAssetStore        portal.AssetStore
+	portalShareStore        portal.ShareStore
+	portalS3Client          portal.S3Client
+	provenanceTracker       *middleware.ProvenanceTracker
+	resolvedBrandLogoSVG    string // cached SVG from portal.logo or mcpapps config
+	resolvedBrandURL        string // cached brand_url from mcpapps platform-info config
+	resolvedImplementorLogo string // cached SVG fetched from portal.implementor.logo
 
 	// Workflow gating
 	workflowTracker *middleware.SessionWorkflowTracker
@@ -981,23 +984,40 @@ func (p *Platform) registerBuiltinPlatformInfo() error {
 // explicitly. When the logo is an SVG URL, it is fetched and inlined as
 // logo_svg so the logo renders in sandboxed contexts (MCP App iframes)
 // that block external resource loading.
+//
+// Also caches brand_url from the app config for use by BrandURL().
 func (p *Platform) injectPortalLogo(cfg any) any {
-	portalLogo := p.config.Portal.Logo
-	if portalLogo == "" {
-		return cfg
-	}
-
 	m, ok := cfg.(map[string]any)
 	if !ok {
 		m = make(map[string]any)
 	}
-	if m["logo_svg"] != nil || m["logo_url"] != nil {
+
+	// Cache brand_url from the mcpapps platform-info config.
+	if brandURL, _ := m["brand_url"].(string); brandURL != "" {
+		p.resolvedBrandURL = brandURL
+	}
+
+	portalLogo := p.config.Portal.Logo
+	if portalLogo == "" {
+		// Still cache logo_svg if present in the app config.
+		if svg, _ := m["logo_svg"].(string); svg != "" {
+			p.resolvedBrandLogoSVG = svg
+		}
+		return m
+	}
+
+	if svg, _ := m["logo_svg"].(string); svg != "" {
+		p.resolvedBrandLogoSVG = svg
+		return m
+	}
+	if m["logo_url"] != nil {
 		return m
 	}
 
 	// Fetch SVG content for inline rendering; fall back to URL on failure.
 	if svg, err := fetchLogoSVG(portalLogo); err == nil {
 		m["logo_svg"] = svg
+		p.resolvedBrandLogoSVG = svg
 	} else {
 		slog.Debug("portal logo fetch failed, using URL", "url", portalLogo, "err", err)
 		m["logo_url"] = portalLogo
@@ -1704,6 +1724,39 @@ func (p *Platform) PortalShareStore() portal.ShareStore {
 // PortalS3Client returns the portal S3 client, or nil if portal is disabled.
 func (p *Platform) PortalS3Client() portal.S3Client {
 	return p.portalS3Client
+}
+
+// BrandLogoSVG returns the resolved brand logo SVG content (from portal.logo
+// or mcpapps platform-info config), or empty string if none is configured.
+func (p *Platform) BrandLogoSVG() string {
+	return p.resolvedBrandLogoSVG
+}
+
+// BrandURL returns the resolved brand URL from the mcpapps platform-info
+// config (brand_url), or empty string if not configured.
+func (p *Platform) BrandURL() string {
+	return p.resolvedBrandURL
+}
+
+// ResolveImplementorLogo fetches the implementor logo SVG from the URL
+// configured in portal.implementor.logo. The result is cached so subsequent
+// calls return the same value without another HTTP request. Returns empty
+// string if no logo URL is configured or the fetch fails.
+func (p *Platform) ResolveImplementorLogo() string {
+	logoURL := p.config.Portal.Implementor.Logo
+	if logoURL == "" {
+		return ""
+	}
+	if p.resolvedImplementorLogo != "" {
+		return p.resolvedImplementorLogo
+	}
+	svg, err := fetchLogoSVG(logoURL)
+	if err != nil {
+		slog.Debug("implementor logo fetch failed", "url", logoURL, "err", err)
+		return ""
+	}
+	p.resolvedImplementorLogo = svg
+	return svg
 }
 
 // BrowserSessionFlow returns the OIDC login flow, or nil if browser sessions are disabled.

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -3870,6 +3870,101 @@ func TestFetchLogoSVG(t *testing.T) {
 	})
 }
 
+func TestBrandURL(t *testing.T) {
+	t.Run("returns empty when not set", func(t *testing.T) {
+		p := &Platform{config: &Config{}}
+		if got := p.BrandURL(); got != "" {
+			t.Errorf("BrandURL() = %q, want empty", got)
+		}
+	})
+
+	t.Run("returns cached value from injectPortalLogo", func(t *testing.T) {
+		p := &Platform{config: &Config{}}
+		cfg := map[string]any{"brand_url": "https://example.com"}
+		_ = p.injectPortalLogo(cfg)
+		if got := p.BrandURL(); got != "https://example.com" {
+			t.Errorf("BrandURL() = %q, want %q", got, "https://example.com")
+		}
+	})
+}
+
+func TestInjectPortalLogo_CachesBrandURL(t *testing.T) {
+	t.Run("caches brand_url from config", func(t *testing.T) {
+		p := &Platform{config: &Config{}}
+		cfg := map[string]any{"brand_url": "https://platform.io"}
+		_ = p.injectPortalLogo(cfg)
+		if p.resolvedBrandURL != "https://platform.io" {
+			t.Errorf("resolvedBrandURL = %q, want %q", p.resolvedBrandURL, "https://platform.io")
+		}
+	})
+
+	t.Run("caches brand_url even without portal logo", func(t *testing.T) {
+		p := &Platform{config: &Config{}} // no Portal.Logo
+		cfg := map[string]any{"brand_url": "https://noportallogo.io", "logo_svg": "<svg/>"}
+		_ = p.injectPortalLogo(cfg)
+		if p.resolvedBrandURL != "https://noportallogo.io" {
+			t.Errorf("resolvedBrandURL = %q, want %q", p.resolvedBrandURL, "https://noportallogo.io")
+		}
+		// Also verify logo_svg was cached even without portal.Logo
+		if p.resolvedBrandLogoSVG != "<svg/>" {
+			t.Errorf("resolvedBrandLogoSVG = %q, want %q", p.resolvedBrandLogoSVG, "<svg/>")
+		}
+	})
+
+	t.Run("does not set brand_url when absent", func(t *testing.T) {
+		p := &Platform{config: &Config{}}
+		cfg := map[string]any{"brand_name": "Test"}
+		_ = p.injectPortalLogo(cfg)
+		if p.resolvedBrandURL != "" {
+			t.Errorf("resolvedBrandURL = %q, want empty", p.resolvedBrandURL)
+		}
+	})
+}
+
+func TestResolveImplementorLogo(t *testing.T) {
+	svgContent := `<svg viewBox="0 0 32 32"><rect width="32" height="32"/></svg>`
+
+	t.Run("fetches and caches SVG", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "image/svg+xml")
+			_, _ = w.Write([]byte(svgContent))
+		}))
+		defer srv.Close()
+
+		p := &Platform{config: &Config{
+			Portal: PortalConfig{Implementor: ImplementorConfig{Logo: srv.URL + "/impl.svg"}},
+		}}
+
+		got := p.ResolveImplementorLogo()
+		if got != svgContent {
+			t.Errorf("ResolveImplementorLogo() = %q, want %q", got, svgContent)
+		}
+
+		// Second call should return cached value (no HTTP request)
+		srv.Close()
+		got2 := p.ResolveImplementorLogo()
+		if got2 != svgContent {
+			t.Errorf("cached ResolveImplementorLogo() = %q, want %q", got2, svgContent)
+		}
+	})
+
+	t.Run("returns empty when logo URL is empty", func(t *testing.T) {
+		p := &Platform{config: &Config{}}
+		if got := p.ResolveImplementorLogo(); got != "" {
+			t.Errorf("ResolveImplementorLogo() = %q, want empty", got)
+		}
+	})
+
+	t.Run("returns empty on fetch failure", func(t *testing.T) {
+		p := &Platform{config: &Config{
+			Portal: PortalConfig{Implementor: ImplementorConfig{Logo: "http://127.0.0.1:1/unreachable.svg"}},
+		}}
+		if got := p.ResolveImplementorLogo(); got != "" {
+			t.Errorf("ResolveImplementorLogo() = %q, want empty on fetch failure", got)
+		}
+	})
+}
+
 func TestNew_WorkflowGatingDisabled(t *testing.T) {
 	cfg := &Config{
 		Server:   ServerConfig{Name: testServerName},

--- a/pkg/portal/handler.go
+++ b/pkg/portal/handler.go
@@ -63,6 +63,15 @@ type Deps struct {
 	AuditMetrics    AuditMetrics
 	InsightStore    InsightReader
 	PersonaResolver PersonaResolver
+	// Platform brand (far right of public viewer header)
+	BrandName    string // display name (default: "MCP Data Platform")
+	BrandLogoSVG string // inline SVG for header logo (empty = default icon)
+	BrandURL     string // link URL (e.g., "https://plexara.io"); empty = no link
+
+	// Implementor brand (far left of public viewer header, optional)
+	ImplementorName    string // display name (e.g., "ACME Corp"); empty = hidden
+	ImplementorLogoSVG string // inline SVG; empty = hidden
+	ImplementorURL     string // link URL; empty = no link
 }
 
 // Handler provides portal REST API endpoints.

--- a/pkg/portal/public.go
+++ b/pkg/portal/public.go
@@ -21,6 +21,26 @@ import (
 // share access counters after the HTTP response has been sent.
 const incrementAccessTimeout = 5 * time.Second
 
+// defaultLogoSVG is the MCP Data Platform logo used in the public viewer header
+// when no brand logo is configured. Matches the platform-info app's default icon.
+//
+//nolint:lll // SVG markup
+const defaultLogoSVG = `<svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">` +
+	`<circle cx="20" cy="20" r="4.5" fill="currentColor" opacity=".95"/>` +
+	`<circle cx="6"  cy="11" r="3"   fill="currentColor" opacity=".65"/>` +
+	`<circle cx="34" cy="11" r="3"   fill="currentColor" opacity=".65"/>` +
+	`<circle cx="6"  cy="29" r="3"   fill="currentColor" opacity=".45"/>` +
+	`<circle cx="34" cy="29" r="3"   fill="currentColor" opacity=".45"/>` +
+	`<circle cx="20" cy="4"  r="2.2" fill="currentColor" opacity=".55"/>` +
+	`<circle cx="20" cy="36" r="2.2" fill="currentColor" opacity=".35"/>` +
+	`<line x1="20" y1="20" x2="6"  y2="11" stroke="currentColor" stroke-width="1.4" opacity=".3"/>` +
+	`<line x1="20" y1="20" x2="34" y2="11" stroke="currentColor" stroke-width="1.4" opacity=".3"/>` +
+	`<line x1="20" y1="20" x2="6"  y2="29" stroke="currentColor" stroke-width="1.4" opacity=".22"/>` +
+	`<line x1="20" y1="20" x2="34" y2="29" stroke="currentColor" stroke-width="1.4" opacity=".22"/>` +
+	`<line x1="20" y1="20" x2="20" y2="4"  stroke="currentColor" stroke-width="1.4" opacity=".28"/>` +
+	`<line x1="20" y1="20" x2="20" y2="36" stroke="currentColor" stroke-width="1.4" opacity=".18"/>` +
+	`</svg>`
+
 //go:embed templates/public_viewer.html
 var templateFS embed.FS
 
@@ -70,10 +90,26 @@ func (h *Handler) publicView(w http.ResponseWriter, r *http.Request) {
 	csp := publicCSP(asset.ContentType)
 	w.Header().Set("Content-Security-Policy", csp)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	brandName := h.deps.BrandName
+	if brandName == "" {
+		brandName = "MCP Data Platform"
+	}
+	brandLogo := h.deps.BrandLogoSVG
+	if brandLogo == "" {
+		brandLogo = defaultLogoSVG
+	}
+
 	_ = viewerTemplate.Execute(w, map[string]any{
-		"Name":        asset.Name,
-		"ContentType": asset.ContentType,
-		"Content":     template.HTML(rendered), // #nosec G203 -- content is sanitized by renderContent
+		"Name":               asset.Name,
+		"ContentType":        asset.ContentType,
+		"Content":            template.HTML(rendered), // #nosec G203 -- content is sanitized by renderContent
+		"BrandName":          brandName,
+		"BrandLogoSVG":       template.HTML(brandLogo), // #nosec G203 -- operator-provided SVG from config, not user input
+		"BrandURL":           h.deps.BrandURL,
+		"ImplementorName":    h.deps.ImplementorName,
+		"ImplementorLogoSVG": template.HTML(h.deps.ImplementorLogoSVG), // #nosec G203 -- operator-provided SVG from config
+		"ImplementorURL":     h.deps.ImplementorURL,
 	})
 }
 
@@ -189,7 +225,7 @@ func publicCSP(contentType string) string {
 			"font-src data: https://fonts.gstatic.com; " +
 			"connect-src https://esm.sh https://fonts.googleapis.com https://fonts.gstatic.com;"
 	}
-	return "default-src 'none'; style-src 'unsafe-inline'; img-src data:;"
+	return "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:;"
 }
 
 // jsxSrcdocTpl is parsed once at init. It renders the JSX viewer HTML

--- a/pkg/portal/public_test.go
+++ b/pkg/portal/public_test.go
@@ -40,6 +40,143 @@ func TestPublicViewSuccess(t *testing.T) {
 	// CSP header must be set on public view responses (plain text uses default CSP).
 	csp := w.Header().Get("Content-Security-Policy")
 	assert.NotEmpty(t, csp)
+
+	// Default brand on right: logo + "MCP Data Platform"
+	body := w.Body.String()
+	assert.Contains(t, body, "MCP Data Platform")
+	assert.Contains(t, body, `class="brand-logo"`)
+	assert.Contains(t, body, defaultLogoSVG)
+	assert.Contains(t, body, `brand-platform`)
+
+	// No implementor on left by default
+	assert.NotContains(t, body, `brand-implementor`)
+}
+
+func TestPublicViewCustomBrand(t *testing.T) {
+	now := time.Now()
+	share := &Share{ID: "s1", AssetID: "a1", Token: "tok1", Revoked: false}
+	asset := &Asset{
+		ID: "a1", OwnerID: "u1", Name: "Report", ContentType: "text/plain",
+		Tags: []string{}, CreatedAt: now, UpdatedAt: now,
+	}
+
+	customLogo := `<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>`
+	implLogo := `<svg viewBox="0 0 32 32"><rect width="32" height="32"/></svg>`
+	h := NewHandler(Deps{
+		AssetStore:         &mockAssetStore{getAsset: asset},
+		ShareStore:         &mockShareStore{getByTokenRes: share},
+		S3Client:           &mockS3Client{getData: []byte("data"), getCT: "text/plain"},
+		S3Bucket:           "test",
+		BrandName:          "Plexara",
+		BrandLogoSVG:       customLogo,
+		BrandURL:           "https://plexara.io",
+		ImplementorName:    "ACME Corp",
+		ImplementorLogoSVG: implLogo,
+		ImplementorURL:     "https://acme.com",
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/portal/view/tok1", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+
+	// Right side: custom platform brand
+	assert.Contains(t, body, "Plexara")
+	assert.Contains(t, body, customLogo)
+	assert.NotContains(t, body, defaultLogoSVG)
+	assert.Contains(t, body, `href="https://plexara.io"`)
+
+	// Left side: implementor
+	assert.Contains(t, body, "ACME Corp")
+	assert.Contains(t, body, implLogo)
+	assert.Contains(t, body, `href="https://acme.com"`)
+	assert.Contains(t, body, `brand-implementor`)
+}
+
+func TestPublicViewImplementorOnly(t *testing.T) {
+	now := time.Now()
+	share := &Share{ID: "s1", AssetID: "a1", Token: "tok1", Revoked: false}
+	asset := &Asset{
+		ID: "a1", OwnerID: "u1", Name: "Report", ContentType: "text/plain",
+		Tags: []string{}, CreatedAt: now, UpdatedAt: now,
+	}
+
+	h := NewHandler(Deps{
+		AssetStore:      &mockAssetStore{getAsset: asset},
+		ShareStore:      &mockShareStore{getByTokenRes: share},
+		S3Client:        &mockS3Client{getData: []byte("data"), getCT: "text/plain"},
+		S3Bucket:        "test",
+		ImplementorName: "ACME Corp",
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/portal/view/tok1", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+
+	// Left side: implementor name shown (no logo, no link)
+	assert.Contains(t, body, "ACME Corp")
+	assert.Contains(t, body, `brand-implementor`)
+
+	// Right side: default platform brand
+	assert.Contains(t, body, "MCP Data Platform")
+	assert.Contains(t, body, defaultLogoSVG)
+	assert.Contains(t, body, `brand-platform`)
+}
+
+func TestPublicViewBrandLinks(t *testing.T) {
+	now := time.Now()
+	share := &Share{ID: "s1", AssetID: "a1", Token: "tok1", Revoked: false}
+	asset := &Asset{
+		ID: "a1", OwnerID: "u1", Name: "Report", ContentType: "text/plain",
+		Tags: []string{}, CreatedAt: now, UpdatedAt: now,
+	}
+
+	t.Run("with URLs", func(t *testing.T) {
+		h := NewHandler(Deps{
+			AssetStore:      &mockAssetStore{getAsset: asset},
+			ShareStore:      &mockShareStore{getByTokenRes: share},
+			S3Client:        &mockS3Client{getData: []byte("data"), getCT: "text/plain"},
+			S3Bucket:        "test",
+			BrandURL:        "https://platform.io",
+			ImplementorName: "Impl",
+			ImplementorURL:  "https://impl.com",
+		}, nil)
+
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/portal/view/tok1", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		body := w.Body.String()
+		assert.Contains(t, body, `href="https://platform.io"`)
+		assert.Contains(t, body, `href="https://impl.com"`)
+	})
+
+	t.Run("without URLs", func(t *testing.T) {
+		h := NewHandler(Deps{
+			AssetStore:      &mockAssetStore{getAsset: asset},
+			ShareStore:      &mockShareStore{getByTokenRes: share},
+			S3Client:        &mockS3Client{getData: []byte("data"), getCT: "text/plain"},
+			S3Bucket:        "test",
+			ImplementorName: "Impl",
+		}, nil)
+
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/portal/view/tok1", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		body := w.Body.String()
+		// No <a> links should be present for brands without URLs
+		assert.NotContains(t, body, `href="https://platform.io"`)
+		assert.NotContains(t, body, `href="https://impl.com"`)
+		// But brand names should still render
+		assert.Contains(t, body, "MCP Data Platform")
+		assert.Contains(t, body, "Impl")
+	})
 }
 
 func TestPublicViewTokenNotFound(t *testing.T) {
@@ -280,6 +417,12 @@ func TestPublicCSP(t *testing.T) {
 	csp2 := publicCSP("text/html")
 	assert.NotContains(t, csp2, "frame-src")
 	assert.Contains(t, csp2, "default-src 'none'")
+	assert.Contains(t, csp2, "script-src 'unsafe-inline'")
+	assert.Contains(t, csp2, "style-src 'unsafe-inline'")
+	assert.Contains(t, csp2, "img-src data: blob:")
+	assert.Contains(t, csp2, "font-src data:")
+	assert.NotContains(t, csp2, "'unsafe-eval'")
+	assert.NotContains(t, csp2, "connect-src")
 }
 
 // --- jsxIframe ---
@@ -300,6 +443,14 @@ func TestJsxIframeSpecialChars(t *testing.T) {
 	assert.Contains(t, result, `sandbox="allow-scripts"`)
 	// Content is JSON-encoded then HTML-escaped, so it's safely embedded.
 	assert.NotContains(t, result, `<div title=`)
+}
+
+// --- defaultLogoSVG ---
+
+func TestDefaultLogoSVG(t *testing.T) {
+	assert.Contains(t, defaultLogoSVG, "<svg")
+	assert.Contains(t, defaultLogoSVG, "</svg>")
+	assert.Contains(t, defaultLogoSVG, "viewBox")
 }
 
 // --- sandboxedIframe ---

--- a/pkg/portal/templates/public_viewer.html
+++ b/pkg/portal/templates/public_viewer.html
@@ -19,9 +19,55 @@
             align-items: center;
             gap: 12px;
         }
-        .header h1 {
+        .brand {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            color: #374151;
+            flex-shrink: 0;
+        }
+        .brand a {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            color: inherit;
+            text-decoration: none;
+        }
+        .brand a:hover { opacity: 0.8; }
+        .brand-logo {
+            width: 24px;
+            height: 24px;
+            display: flex;
+            align-items: center;
+        }
+        .brand-logo svg {
+            width: 24px;
+            height: 24px;
+        }
+        .brand-name {
+            font-size: 13px;
+            font-weight: 500;
+            color: #6b7280;
+        }
+        .separator {
+            width: 1px;
+            height: 20px;
+            background: #e5e5e5;
+            flex-shrink: 0;
+        }
+        .header-center {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            flex: 1;
+            min-width: 0;
+        }
+        .header-center h1 {
             font-size: 16px;
             font-weight: 600;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
         .badge {
             font-size: 11px;
@@ -29,6 +75,7 @@
             color: #374151;
             padding: 2px 8px;
             border-radius: 10px;
+            flex-shrink: 0;
         }
         .content {
             max-width: 1200px;
@@ -55,8 +102,26 @@
 </head>
 <body>
     <div class="header">
-        <h1>{{.Name}}</h1>
-        <span class="badge">{{.ContentType}}</span>
+        {{if or .ImplementorName .ImplementorLogoSVG}}
+        <div class="brand brand-implementor">
+            {{if .ImplementorURL}}<a href="{{.ImplementorURL}}" target="_blank" rel="noopener noreferrer">{{end}}
+            {{if .ImplementorLogoSVG}}<div class="brand-logo">{{.ImplementorLogoSVG}}</div>{{end}}
+            {{if .ImplementorName}}<span class="brand-name">{{.ImplementorName}}</span>{{end}}
+            {{if .ImplementorURL}}</a>{{end}}
+        </div>
+        <div class="separator"></div>
+        {{end}}
+        <div class="header-center">
+            <h1>{{.Name}}</h1>
+            <span class="badge">{{.ContentType}}</span>
+        </div>
+        <div class="separator"></div>
+        <div class="brand brand-platform">
+            {{if .BrandURL}}<a href="{{.BrandURL}}" target="_blank" rel="noopener noreferrer">{{end}}
+            <div class="brand-logo">{{.BrandLogoSVG}}</div>
+            <span class="brand-name">{{.BrandName}}</span>
+            {{if .BrandURL}}</a>{{end}}
+        </div>
     </div>
     <div class="content">
         {{.Content}}


### PR DESCRIPTION
## Summary

- Add two-zone branded header to the public viewer (`/portal/view/:token`): **implementor** (far left, optional) and **platform brand** (far right, always shown)
- Implementor zone renders only when `portal.implementor.name` or `logo` is configured; both zones support clickable links via URL fields
- Platform brand name/URL resolved from `mcpapps.apps.platform-info.config.brand_name`/`brand_url`, with fallback to `portal.title` then `server.name`

## Test plan

- [x] `TestPublicViewSuccess` — default platform brand on right, no implementor on left
- [x] `TestPublicViewCustomBrand` — both zones render with custom logos, names, and links
- [x] `TestPublicViewImplementorOnly` — implementor name without logo, default platform brand
- [x] `TestPublicViewBrandLinks` — `<a href>` wrapping present/absent based on URL config
- [x] `TestBrandURL`, `TestResolveImplementorLogo`, `TestInjectPortalLogo_CachesBrandURL` — platform getters and caching
- [x] `TestMcpappsBrandName` — mcpapps config extraction
- [x] All new functions at 100% coverage
- [x] `make verify` passes (fmt, lint, race, coverage, security, mutation, release)