### PR TITLE
fix: public viewer full-width layout and implementor logo sizing

### DIFF
--- a/pkg/portal/public_test.go
+++ b/pkg/portal/public_test.go
@@ -54,8 +54,8 @@ func TestPublicViewSuccess(t *testing.T) {
 	assert.Contains(t, body, defaultLogoSVG)
 	assert.Contains(t, body, `brand-platform`)
 
-	// No implementor on left by default
-	assert.NotContains(t, body, `brand-implementor`)
+	// No implementor on left by default (CSS has the class name, but no HTML element uses it)
+	assert.NotContains(t, body, `class="brand brand-implementor"`)
 
 	// Dark mode toggle is present
 	assert.Contains(t, body, `id="theme-toggle"`)

--- a/pkg/portal/templates/public_viewer.html
+++ b/pkg/portal/templates/public_viewer.html
@@ -69,6 +69,14 @@
             width: 24px;
             height: 24px;
         }
+        .brand-implementor .brand-logo {
+            width: auto;
+            height: 28px;
+        }
+        .brand-implementor .brand-logo svg {
+            width: auto;
+            height: 28px;
+        }
         .brand-name {
             font-size: 13px;
             font-weight: 500;
@@ -128,10 +136,8 @@
             line-height: 1.4;
         }
         .content {
-            max-width: 1200px;
             width: 100%;
-            margin: 0 auto;
-            padding: 24px;
+            padding: 16px;
             flex: 1;
             display: flex;
             flex-direction: column;

--- a/ui/src/components/ShareDialog.tsx
+++ b/ui/src/components/ShareDialog.tsx
@@ -31,15 +31,17 @@ export function ShareDialog({ assetId, open, onOpenChange }: Props) {
   const [email, setEmail] = useState("");
   const [copied, setCopied] = useState<string | null>(null);
   const [showOptions, setShowOptions] = useState(false);
-  const [hideExpiration, setHideExpiration] = useState(false);
-  const [noticeText, setNoticeText] = useState("");
+  const [showExpiration, setShowExpiration] = useState(true);
+  const [noticeText, setNoticeText] = useState(
+    "Proprietary & Confidential. Only share with authorized viewers.",
+  );
 
   function handleCreatePublicLink() {
     createShare.mutate({
       assetId,
       expires_in: ttl,
-      ...(hideExpiration && { hide_expiration: true }),
-      ...(noticeText.trim() && { notice_text: noticeText.trim() }),
+      ...(!showExpiration && { hide_expiration: true }),
+      notice_text: noticeText.trim(),
     });
   }
 
@@ -117,11 +119,11 @@ export function ShareDialog({ assetId, open, onOpenChange }: Props) {
                 <label className="flex items-center gap-2 text-sm">
                   <input
                     type="checkbox"
-                    checked={hideExpiration}
-                    onChange={(e) => setHideExpiration(e.target.checked)}
+                    checked={showExpiration}
+                    onChange={(e) => setShowExpiration(e.target.checked)}
                     className="rounded border-input"
                   />
-                  Hide expiration notice
+                  Show expiration notice
                 </label>
                 <div>
                   <label className="text-sm text-muted-foreground" htmlFor="notice-text">
@@ -130,11 +132,14 @@ export function ShareDialog({ assetId, open, onOpenChange }: Props) {
                   <input
                     id="notice-text"
                     type="text"
-                    placeholder="Custom notice shown on the public page"
+                    placeholder="Leave empty to hide the notice"
                     value={noticeText}
                     onChange={(e) => setNoticeText(e.target.value)}
                     className="mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm outline-none ring-ring focus:ring-2"
                   />
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Clear to hide notice bar entirely.
+                  </p>
                 </div>
               </div>
             )}

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -846,8 +846,8 @@ export const handlers = [
         revoked: false,
         access_count: 0,
         created_at: new Date().toISOString(),
-        hide_expiration: body.hide_expiration ? true : undefined,
-        notice_text: body.notice_text ? String(body.notice_text) : undefined,
+        hide_expiration: body.hide_expiration === true,
+        notice_text: typeof body.notice_text === "string" ? body.notice_text : undefined,
       };
 
       if (!portalShares[assetId]) portalShares[assetId] = [];


### PR DESCRIPTION
## Summary

- Remove `max-width: 1200px` from `.content` in the public viewer template so dashboards render full-width, matching the internal viewer layout
- Scale implementor logos proportionally (`height: 28px; width: auto`) instead of forcing 24x24px, making text-based logos readable
- Flip share dialog defaults: "Show expiration" checked by default, notice text pre-filled with the default confidentiality message

## Test plan

- [ ] `go test -race ./pkg/portal/...` passes
- [ ] `cd ui && npx tsc --noEmit` passes
- [ ] Public viewer renders dashboard content full-width (5 KPI cards across, side-by-side charts)
- [ ] Implementor logos with text scale proportionally in the header
- [ ] Share dialog shows sensible defaults without requiring manual input