### PR TITLE
fix: GoReleaser before hook missing content viewer build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ before:
   hooks:
     - go mod download
     - go mod verify
-    - bash -c "if [ -f ui/package.json ]; then cd ui && npm ci && npm run build && rm -rf ../internal/ui/dist/* && cp -r dist/* ../internal/ui/dist/ && rm -f ../internal/ui/dist/mockServiceWorker.js; fi"
+    - bash -c "if [ -f ui/package.json ]; then cd ui && npm ci && npm run build && rm -rf ../internal/ui/dist/* && cp -r dist/* ../internal/ui/dist/ && rm -f ../internal/ui/dist/mockServiceWorker.js && npx vite build --config vite.content-viewer.config.ts && mkdir -p ../internal/contentviewer/dist && cp dist-content-viewer/content-viewer.js ../internal/contentviewer/dist/ && SPA_CSS=$(find dist/assets -maxdepth 1 -name '*.css' -print -quit) && cp \"$SPA_CSS\" ../internal/contentviewer/dist/content-viewer.css; fi"
 
 builds:
   - id: mcp-data-platform


### PR DESCRIPTION
## Summary

- The GoReleaser before hook built the SPA and copied it to `internal/ui/dist/`, but never built the content viewer IIFE bundle or copied the SPA CSS to `internal/contentviewer/dist/`. The Go binary embedded an empty directory, so `contentviewer.JS` and `contentviewer.CSS` were empty strings at runtime — the public viewer showed "Loading..." permanently with no rendered content.

## Changes

**`.goreleaser.yml`** — Extended the existing bash before hook to also:
1. Run `npx vite build --config vite.content-viewer.config.ts` (builds the IIFE JS bundle)
2. Copy `content-viewer.js` to `internal/contentviewer/dist/`
3. Find the SPA CSS output and copy it as `content-viewer.css` to `internal/contentviewer/dist/`

This mirrors what `make frontend-build` does after the SPA build step.

## Test plan

- [ ] `goreleaser check` passes (validated locally)
- [ ] `goreleaser release --snapshot --clean --skip=publish,sign,sbom` produces a binary where `contentviewer.JS` and `contentviewer.CSS` are non-empty
- [ ] Public viewer at `/portal/view/<token>` renders markdown instead of showing "Loading..."