### PR TITLE
fix: public viewer iframe gap by making wrapper div a flex container

### DIFF
--- a/cmd/preview-content-viewer/main.go
+++ b/cmd/preview-content-viewer/main.go
@@ -30,8 +30,9 @@ body{font-family:system-ui,-apple-system,sans-serif;background:var(--bg);color:v
 .header h1{font-size:16px;font-weight:600;flex:1}
 .badge{font-size:11px;background:var(--badge-bg);color:var(--badge-text);padding:2px 8px;border-radius:10px}
 .theme-toggle{background:none;border:1px solid var(--page-border);border-radius:6px;padding:4px 8px;cursor:pointer;color:var(--text-muted)}
-.content{box-sizing:border-box;width:100%;padding:16px;flex:1;display:flex;flex-direction:column}
-.content iframe{flex:1;min-height:60vh;height:auto !important}
+.content{box-sizing:border-box;width:100%;padding:16px;flex:1;display:flex;flex-direction:column;overflow:hidden}
+.content>div{flex:1;display:flex;flex-direction:column}
+.content iframe{flex:1;min-height:60vh;width:100%;height:auto !important;display:block}
 nav{box-sizing:border-box;display:flex;gap:8px;padding:12px 24px;background:var(--bg-surface);border-bottom:1px solid var(--page-border);flex-shrink:0}
 nav a{color:var(--text-muted);text-decoration:none;padding:4px 12px;border-radius:6px;font-size:13px}
 nav a:hover{background:var(--toggle-hover)}

--- a/pkg/portal/templates/public_viewer.html
+++ b/pkg/portal/templates/public_viewer.html
@@ -167,11 +167,19 @@
             flex: 1;
             display: flex;
             flex-direction: column;
+            overflow: hidden;
+        }
+        .content > div {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
         }
         .content iframe {
             flex: 1;
             min-height: 60vh;
+            width: 100%;
             height: auto !important;
+            display: block;
         }
     </style>
     <script>


### PR DESCRIPTION
## Summary

- The wrapper `div` inside `.content` defaulted to `flex: 0 1 auto`, so it did not stretch to fill `.content`. The iframe's `flex: 1` had no effect because its parent was not a flex container.
- Added `.content > div { flex: 1; display: flex; flex-direction: column; }` so the wrapper stretches and the iframe expands to fill remaining viewport space.
- Applied same fix to `cmd/preview-content-viewer/main.go`.

## Test plan

- [ ] `make verify` passes
- [ ] `go run ./cmd/preview-content-viewer` — open `/?type=jsx` and `/?type=html` in dark mode, confirm no gap below iframe
- [ ] Verify `/?type=markdown` prose rendering is unaffected