### PR TITLE
fix: public viewer markdown scroll and source editor position retention

### DIFF
--- a/pkg/portal/templates/public_viewer.html
+++ b/pkg/portal/templates/public_viewer.html
@@ -167,7 +167,7 @@
             flex: 1;
             display: flex;
             flex-direction: column;
-            overflow: hidden;
+            overflow: auto;
         }
         .content > div {
             flex: 1;

--- a/ui/src/components/AssetViewer.tsx
+++ b/ui/src/components/AssetViewer.tsx
@@ -254,17 +254,22 @@ export function AssetViewer({
         )}
 
         {content !== undefined ? (
-          viewMode === "source" && canEditSource ? (
-            <Suspense fallback={<LoadingIndicator />}>
-              <SourceEditor
-                content={editedContent}
-                contentType={asset.content_type}
-                onChange={(v) => { setEditedContent(v); setDirty(true); }}
-              />
-            </Suspense>
-          ) : (
-            <ContentRenderer contentType={asset.content_type} content={hasChanges ? editedContent : (content as string)} />
-          )
+          <>
+            {canEditSource && (
+              <div style={{ display: viewMode === "source" ? undefined : "none" }}>
+                <Suspense fallback={<LoadingIndicator />}>
+                  <SourceEditor
+                    content={editedContent}
+                    contentType={asset.content_type}
+                    onChange={(v) => { setEditedContent(v); setDirty(true); }}
+                  />
+                </Suspense>
+              </div>
+            )}
+            {(viewMode !== "source" || !canEditSource) && (
+              <ContentRenderer contentType={asset.content_type} content={hasChanges ? editedContent : (content as string)} />
+            )}
+          </>
         ) : (
           <LoadingIndicator />
         )}


### PR DESCRIPTION
## Summary

- **Public viewer**: change `overflow: hidden` → `overflow: auto` on `.content` container so markdown and other non-iframe content can scroll (regression from #228-#230)
- **Source editor**: keep `SourceEditor` mounted but hidden via CSS (`display: none`) when switching to Preview mode, preserving CodeMirror scroll position, cursor, selections, and undo history across tab switches

## Test plan

- [ ] Open a shared markdown asset via public viewer link — verify content scrolls
- [ ] Open an asset in the asset viewer, switch to Source, scroll down and place cursor mid-file
- [ ] Switch to Preview, then back to Source — verify cursor and scroll position are preserved
- [ ] Verify undo history survives a round-trip (type in Source, switch to Preview, switch back, Ctrl+Z)
- [ ] `make verify` passes
- [ ] `npm run build` passes