### PR TITLE
fix: correct postMessage origin check for thumbnail capture

### DIFF
--- a/ui/src/components/ThumbnailGenerator.tsx
+++ b/ui/src/components/ThumbnailGenerator.tsx
@@ -98,8 +98,8 @@ function IframeCapture({
 
   useEffect(() => {
     function handleMessage(e: MessageEvent) {
-      // blob: iframes have origin "null" — reject messages from other origins
-      if (e.origin !== "null") return;
+      // With allow-same-origin, blob: iframes inherit the parent's origin
+      if (e.origin !== window.location.origin) return;
       if (e.data?.type !== "thumbnail-ready") return;
       void doCapture();
     }


### PR DESCRIPTION
## Summary

- Fix thumbnail generation broken since v1.40.0 (#232): the iframe sandbox was changed to `allow-same-origin` (needed for `html2canvas` to access `contentDocument`), but the `postMessage` origin check still expected `"null"`. With `allow-same-origin`, blob: iframes inherit the parent's origin, so every `thumbnail-ready` message was silently rejected and no thumbnails were ever generated.

## Test plan

- [ ] Deploy and verify thumbnails generate for HTML/JSX assets
- [ ] Verify thumbnails generate for Markdown and SVG assets
- [ ] Verify queue advances on failure (timeout fires after 15s)
- [ ] `npm run build` passes