### PR TITLE
fix: markdown thumbnail blank capture

### DIFF
--- a/ui/src/components/ThumbnailGenerator.tsx
+++ b/ui/src/components/ThumbnailGenerator.tsx
@@ -215,14 +215,12 @@ function DomCapture({
       ref={containerRef}
       style={{
         position: "fixed",
-        left: 0,
-        top: 0,
+        left: -9999,
+        top: -9999,
         width: THUMB_WIDTH,
         height: THUMB_HEIGHT,
         overflow: "hidden",
         pointerEvents: "none",
-        visibility: "hidden",
-        zIndex: -1,
         background: "white",
         color: "black",
         fontSize: 12,


### PR DESCRIPTION
## Summary

- **Fix blank markdown thumbnails**: `DomCapture` used `visibility: hidden` to hide the off-screen render container, but `html-to-image` (`toPng`) clones the DOM node with computed styles intact — so the cloned content was also hidden, producing a blank/transparent PNG
- **Switch to off-screen positioning** (`left: -9999`): same pattern `IframeCapture` already uses, keeps the element rendered with layout but out of viewport

## Test plan

- [ ] Delete `thumbnail_s3_key` from a markdown asset (or create a new one)
- [ ] Visit My Assets — verify markdown asset gets a rendered prose thumbnail instead of blank/missing
- [ ] Verify SVG thumbnails still generate correctly (same `DomCapture` path)