### PR TITLE
fix: markdown thumbnail race condition — MutationObserver

### DIFF
--- a/ui/src/components/ThumbnailGenerator.tsx
+++ b/ui/src/components/ThumbnailGenerator.tsx
@@ -194,9 +194,26 @@ function DomCapture({
   }, [assetId, onCaptured, onFailed]);
 
   useEffect(() => {
-    // Wait for render to complete
-    const timer = setTimeout(doCapture, 500);
-    return () => clearTimeout(timer);
+    const el = containerRef.current;
+    if (!el) return;
+
+    // If content is already rendered (SVG via dangerouslySetInnerHTML), capture
+    // after one animation frame so layout settles.
+    if (el.querySelector("svg, p, h1, h2, h3, li, pre, blockquote, table")) {
+      const raf = requestAnimationFrame(() => void doCapture());
+      return () => cancelAnimationFrame(raf);
+    }
+
+    // Otherwise wait for ReactMarkdown to render child nodes.
+    const observer = new MutationObserver(() => {
+      if (el.querySelector("p, h1, h2, h3, li, pre, blockquote, table")) {
+        observer.disconnect();
+        // One more frame to let layout settle after the DOM mutation.
+        requestAnimationFrame(() => void doCapture());
+      }
+    });
+    observer.observe(el, { childList: true, subtree: true });
+    return () => observer.disconnect();
   }, [doCapture]);
 
   // Timeout: if capture hasn't completed, give up

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -679,6 +679,15 @@ export const handlers = [
     return HttpResponse.json(portalAssets[idx]);
   }),
 
+  http.put(`${ADMIN_BASE}/assets/:id/thumbnail`, ({ params }) => {
+    const asset = portalAssets.find((a) => a.id === params.id && !a.deleted_at);
+    if (!asset) {
+      return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+    }
+    asset.thumbnail_s3_key = `thumbnails/${asset.id}.png`;
+    return new HttpResponse(null, { status: 204 });
+  }),
+
   http.delete(`${ADMIN_BASE}/assets/:id`, ({ params }) => {
     const idx = portalAssets.findIndex(
       (a) => a.id === params.id && !a.deleted_at,
@@ -805,6 +814,15 @@ export const handlers = [
       portalAssets[idx]!.tags = body.tags as string[];
     portalAssets[idx]!.updated_at = new Date().toISOString();
     return HttpResponse.json(portalAssets[idx]);
+  }),
+
+  http.put(`${PORTAL_BASE}/assets/:id/thumbnail`, ({ params }) => {
+    const asset = portalAssets.find((a) => a.id === params.id && !a.deleted_at);
+    if (!asset) {
+      return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+    }
+    asset.thumbnail_s3_key = `thumbnails/${asset.id}.png`;
+    return new HttpResponse(null, { status: 204 });
   }),
 
   http.delete(`${PORTAL_BASE}/assets/:id`, ({ params }) => {


### PR DESCRIPTION
## Summary

- **Replace racy `setTimeout(500ms)` with `MutationObserver`**: `DomCapture` used an arbitrary 500ms delay before capturing, which was a race condition — if ReactMarkdown hadn't finished rendering, the capture produced a blank PNG. Now waits for actual rendered elements (`p`, `h1`–`h3`, `li`, `pre`, `blockquote`, `table`) to appear in the DOM, then captures after one `requestAnimationFrame` for layout to settle.
- **SVG fast path**: Content set synchronously via `dangerouslySetInnerHTML` is caught by an initial element check before the observer is attached — no unnecessary observation.
- **Mock thumbnail endpoints**: Added `PUT /assets/:id/thumbnail` handlers to MSW so thumbnail capture can be tested end-to-end in dev mode.

## Verified in browser

- Started dev server with `VITE_MSW=true`
- Navigated to My Assets, opened markdown assets (Weekly Inventory Report, Data Quality Summary)
- Confirmed `toPng` produces valid 11.8KB PNG blob from the DomCapture container
- Confirmed `thumbnail_s3_key` is set after capture completes
- Confirmed save-triggered regeneration works (edit source, save, thumbnail re-captured)
- Zero console errors on asset detail page

## Test plan

- [ ] `VITE_MSW=true npm run dev` → My Assets page → markdown assets get thumbnails
- [ ] Open a markdown asset → Source → edit → Save → thumbnail regenerates
- [ ] SVG assets still capture correctly
- [ ] `npm run build` passes