### PR TITLE
fix: replace html-to-image with html2canvas for markdown thumbnails

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -24,7 +24,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dompurify": "^3.3.2",
-        "html-to-image": "^1.11.13",
         "html2canvas": "^1.4.1",
         "lucide-react": "^0.469.0",
         "react": "^19.1.0",
@@ -5360,12 +5359,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/html-to-image": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
-      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
-      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,7 +29,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.3.2",
-    "html-to-image": "^1.11.13",
     "html2canvas": "^1.4.1",
     "lucide-react": "^0.469.0",
     "react": "^19.1.0",

--- a/ui/src/components/ThumbnailGenerator.tsx
+++ b/ui/src/components/ThumbnailGenerator.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import DOMPurify from "dompurify";
+import html2canvas from "html2canvas";
 import {
   THUMB_WIDTH,
   THUMB_HEIGHT,
@@ -11,7 +12,6 @@ import {
   injectCaptureScript,
   buildJsxThumbnailHtml,
   captureIframe,
-  captureElement,
   uploadThumbnail,
 } from "@/lib/thumbnail";
 
@@ -157,7 +157,7 @@ function IframeCapture({
 }
 
 /**
- * Captures same-origin DOM content (Markdown/SVG) using html-to-image.
+ * Captures same-origin DOM content (Markdown/SVG) using html2canvas.
  */
 function DomCapture({
   assetId,
@@ -185,7 +185,15 @@ function DomCapture({
     if (capturedRef.current || !containerRef.current) return;
     capturedRef.current = true;
     try {
-      const blob = await captureElement(containerRef.current);
+      const canvas = await html2canvas(containerRef.current, {
+        width: THUMB_WIDTH,
+        height: THUMB_HEIGHT,
+        scale: 1,
+        logging: false,
+      });
+      const blob = await new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob((b) => (b ? resolve(b) : reject(new Error("toBlob returned null"))), "image/png");
+      });
       await uploadThumbnail(assetId, blob);
       onCaptured?.();
     } catch {

--- a/ui/src/lib/thumbnail.ts
+++ b/ui/src/lib/thumbnail.ts
@@ -1,4 +1,3 @@
-import { toPng } from "html-to-image";
 import html2canvas from "html2canvas";
 import { apiFetchRaw } from "@/api/portal/client";
 import { transformJsx, escapeScriptClose, findComponentName } from "@/components/renderers/JsxRenderer";
@@ -77,19 +76,6 @@ export async function captureIframe(iframe: HTMLIFrameElement): Promise<Blob> {
   });
 }
 
-/**
- * Capture a same-origin DOM element as a PNG blob using html-to-image.
- */
-export async function captureElement(element: HTMLElement): Promise<Blob> {
-  const dataUrl = await toPng(element, {
-    width: THUMB_WIDTH,
-    height: THUMB_HEIGHT,
-    canvasWidth: THUMB_WIDTH,
-    canvasHeight: THUMB_HEIGHT,
-  });
-  const res = await fetch(dataUrl);
-  return res.blob();
-}
 
 /**
  * Upload a PNG thumbnail blob for an asset.


### PR DESCRIPTION
## Summary

- **Root cause**: `html-to-image` (`toPng`) uses SVG `foreignObject` internally, which produces **fully transparent pixels** for off-screen elements. The existing markdown thumbnail in S3 on production is an 800x600 PNG with 0% opaque pixels — confirmed by fetching and analyzing the pixel data on the live site.
- **Fix**: Replace `toPng` with `html2canvas` (already used by `IframeCapture`) for `DomCapture`. Keep `left: -9999px` off-screen positioning.
- **Remove `html-to-image`** dependency entirely — no longer imported anywhere. Saves ~13KB from the production bundle.

## Why previous fixes failed

| Version | Attempted fix | Why it failed |
|---------|--------------|---------------|
| v1.40.2 | `visibility: hidden` → `left: -9999px` | Wrong diagnosis — `toPng` produces transparent pixels regardless of hiding method |
| v1.40.3 | Same as above (positioning only) | Same root cause — still using `toPng` |
| v1.40.4 | `setTimeout` → `MutationObserver` | Fixed a real race condition but the capture library itself was broken |

## Verified on production site

Tested all hiding strategies with both libraries on `mcp-demo.plexara.io`:

| Library | Positioning | Result |
|---------|------------|--------|
| `toPng` (html-to-image) | `left: -9999px` | **0% opaque** (transparent) |
| `html2canvas` | `opacity: 0` | 100% opaque, **0% content** (white rect) |
| `html2canvas` | `left: -9999px` | **100% opaque, 14.7% content** (text, tables, headings rendered) |
| `html2canvas` | visible on-screen | Identical to `left: -9999px` |

Screenshot of the captured thumbnail overlaid on the production asset viewer confirmed rendered markdown with title, metadata, Executive Summary, and table content.

## Changed files

- `ui/src/components/ThumbnailGenerator.tsx` — `DomCapture` uses `html2canvas` instead of `captureElement`/`toPng`
- `ui/src/lib/thumbnail.ts` — removed `captureElement` function and `html-to-image` import
- `ui/package.json` / `ui/package-lock.json` — removed `html-to-image` dependency

## Test plan

- [ ] Deploy and open a markdown asset — thumbnail should show rendered prose (not blank)
- [ ] Delete the existing blank thumbnail from S3 or edit+save the markdown to trigger regeneration
- [ ] SVG thumbnails still capture correctly (same `DomCapture` path)
- [ ] HTML/JSX thumbnails unaffected (`IframeCapture` path unchanged)
- [ ] `npm run build` passes