### PR TITLE
feat: CSV download button + public viewer info modal

### DIFF
--- a/pkg/portal/public.go
+++ b/pkg/portal/public.go
@@ -76,9 +76,14 @@ func (h *Handler) publicView(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	contentJSON, _ := json.Marshal(map[string]string{ // #nosec G104 -- string map marshaling cannot fail
+	contentJSON, _ := json.Marshal(map[string]any{ // #nosec G104 -- string/[]string map marshaling cannot fail
 		"contentType": asset.ContentType,
 		"content":     string(data),
+		"name":        asset.Name,
+		"description": asset.Description,
+		"tags":        asset.Tags,
+		"createdAt":   asset.CreatedAt.UTC().Format(time.RFC3339),
+		"updatedAt":   asset.UpdatedAt.UTC().Format(time.RFC3339),
 	})
 
 	csp := publicCSP()
@@ -102,6 +107,10 @@ func (h *Handler) publicView(w http.ResponseWriter, r *http.Request) {
 	_ = viewerTemplate.Execute(w, map[string]any{
 		"Name":               asset.Name,
 		"ContentType":        asset.ContentType,
+		"Description":        asset.Description,
+		"Tags":               asset.Tags,
+		"CreatedAtISO":       asset.CreatedAt.UTC().Format(time.RFC3339),
+		"UpdatedAtISO":       asset.UpdatedAt.UTC().Format(time.RFC3339),
 		"ContentJSON":        template.JS(contentJSON),        // #nosec G203 -- json.Marshal escapes <, >, & as \uXXXX; safe inside <script type="application/json">
 		"ContentViewerJS":    template.JS(contentviewer.JS),   // #nosec G203 -- build artifact embedded at compile time, not user input
 		"ContentViewerCSS":   template.CSS(contentviewer.CSS), // #nosec G203 -- build artifact embedded at compile time, not user input

--- a/pkg/portal/templates/public_viewer.html
+++ b/pkg/portal/templates/public_viewer.html
@@ -181,6 +181,92 @@
             height: auto !important;
             display: block;
         }
+        .info-toggle {
+            background: none;
+            border: 1px solid var(--page-border);
+            border-radius: 6px;
+            padding: 4px 6px;
+            cursor: pointer;
+            color: var(--text-muted);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-shrink: 0;
+            transition: background 0.15s;
+        }
+        .info-toggle:hover { background: var(--toggle-hover); }
+        .info-toggle svg { width: 16px; height: 16px; }
+        .modal-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(0,0,0,0.45);
+            z-index: 100;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .modal-overlay[hidden] { display: none; }
+        .modal-card {
+            background: var(--bg-surface);
+            border: 1px solid var(--page-border);
+            border-radius: 12px;
+            box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+            max-width: 420px;
+            width: calc(100% - 32px);
+            padding: 24px;
+        }
+        .modal-card h2 {
+            font-size: 15px;
+            font-weight: 600;
+            margin: 0 0 16px 0;
+        }
+        .modal-card .desc {
+            font-size: 13px;
+            color: var(--text-muted);
+            margin: 0 0 16px 0;
+            line-height: 1.5;
+        }
+        .modal-card dl {
+            margin: 0 0 16px 0;
+            font-size: 13px;
+        }
+        .modal-card dt {
+            color: var(--text-muted);
+            font-size: 11px;
+            font-weight: 500;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            margin-top: 10px;
+        }
+        .modal-card dt:first-child { margin-top: 0; }
+        .modal-card dd {
+            margin: 2px 0 0 0;
+            color: var(--text);
+        }
+        .modal-tags {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin: 0;
+        }
+        .modal-tags .badge {
+            font-size: 11px;
+        }
+        .modal-close {
+            display: block;
+            width: 100%;
+            padding: 8px;
+            border: 1px solid var(--page-border);
+            border-radius: 6px;
+            background: var(--bg);
+            color: var(--text);
+            font-size: 13px;
+            font-weight: 500;
+            cursor: pointer;
+            text-align: center;
+            transition: background 0.15s;
+        }
+        .modal-close:hover { background: var(--toggle-hover); }
     </style>
     <script>
     (function() {
@@ -207,6 +293,9 @@
             <h1>{{.Name}}</h1>
             <span class="badge">{{.ContentType}}</span>
         </div>
+        <button class="info-toggle" id="info-toggle" aria-label="Asset info" title="Asset info">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+        </button>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
             <svg id="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
             <svg id="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
@@ -235,6 +324,24 @@
         </div>
         <script type="application/json" id="content-data">{{.ContentJSON}}</script>
         <script>{{.ContentViewerJS}}</script>
+    </div>
+    <div class="modal-overlay" id="info-modal" hidden>
+        <div class="modal-card">
+            <h2>About this asset</h2>
+            {{if .Description}}<p class="desc">{{.Description}}</p>{{end}}
+            <dl>
+                <dt>Created</dt>
+                <dd id="info-created"></dd>
+                <dt>Updated</dt>
+                <dd id="info-updated"></dd>
+            </dl>
+            {{if .Tags}}
+            <div class="modal-tags" style="margin-bottom:16px">
+                {{range .Tags}}<span class="badge">{{.}}</span>{{end}}
+            </div>
+            {{end}}
+            <button class="modal-close" id="info-close">Close</button>
+        </div>
     </div>
     <script>
     (function() {
@@ -275,6 +382,31 @@
                 expiryEl.textContent = "soon";
             }
         }
+
+        // Info modal
+        var infoModal = document.getElementById("info-modal");
+        var infoBtn = document.getElementById("info-toggle");
+        var infoClose = document.getElementById("info-close");
+
+        // Format dates
+        var createdEl = document.getElementById("info-created");
+        var updatedEl = document.getElementById("info-updated");
+        var createdISO = "{{.CreatedAtISO}}";
+        var updatedISO = "{{.UpdatedAtISO}}";
+        if (createdEl && createdISO) createdEl.textContent = new Date(createdISO).toLocaleString();
+        if (updatedEl && updatedISO) updatedEl.textContent = new Date(updatedISO).toLocaleString();
+
+        function showInfo() { infoModal.hidden = false; }
+        function hideInfo() { infoModal.hidden = true; }
+
+        infoBtn.addEventListener("click", showInfo);
+        infoClose.addEventListener("click", hideInfo);
+        infoModal.addEventListener("click", function(e) {
+            if (e.target === infoModal) hideInfo();
+        });
+        document.addEventListener("keydown", function(e) {
+            if (e.key === "Escape" && !infoModal.hidden) hideInfo();
+        });
     })();
     </script>
 </body>

--- a/ui/src/components/AssetViewer.tsx
+++ b/ui/src/components/AssetViewer.tsx
@@ -276,7 +276,7 @@ export function AssetViewer({
               </div>
             )}
             {(viewMode !== "source" || !canEditSource) && (
-              <ContentRenderer contentType={asset.content_type} content={hasChanges ? editedContent : (content as string)} />
+              <ContentRenderer contentType={asset.content_type} content={hasChanges ? editedContent : (content as string)} fileName={asset.name} />
             )}
           </>
         ) : (

--- a/ui/src/components/renderers/ContentRenderer.tsx
+++ b/ui/src/components/renderers/ContentRenderer.tsx
@@ -7,9 +7,10 @@ import { CsvRenderer } from "./CsvRenderer";
 interface Props {
   contentType: string;
   content: string;
+  fileName?: string;
 }
 
-export function ContentRenderer({ contentType, content }: Props) {
+export function ContentRenderer({ contentType, content, fileName }: Props) {
   const ct = contentType.toLowerCase();
 
   if (ct.includes("jsx") || ct.includes("react")) {
@@ -25,7 +26,7 @@ export function ContentRenderer({ contentType, content }: Props) {
     return <HtmlRenderer content={content} />;
   }
   if (ct.includes("csv")) {
-    return <CsvRenderer content={content} />;
+    return <CsvRenderer content={content} fileName={fileName} />;
   }
 
   // Fallback: plain text

--- a/ui/src/components/renderers/CsvRenderer.tsx
+++ b/ui/src/components/renderers/CsvRenderer.tsx
@@ -1,9 +1,10 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 import Papa from "papaparse";
-import { ChevronUp, ChevronDown, Search } from "lucide-react";
+import { ChevronUp, ChevronDown, Search, Download } from "lucide-react";
 
 interface Props {
   content: string;
+  fileName?: string;
 }
 
 const MAX_DISPLAY_ROWS = 500;
@@ -12,7 +13,7 @@ function isNumeric(val: unknown): val is number {
   return typeof val === "number" && !isNaN(val);
 }
 
-export function CsvRenderer({ content }: Props) {
+export function CsvRenderer({ content, fileName = "data.csv" }: Props) {
   const [sortColumn, setSortColumn] = useState<string | null>(null);
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
   const [filterText, setFilterText] = useState("");
@@ -64,6 +65,18 @@ export function CsvRenderer({ content }: Props) {
     }
   }
 
+  const handleDownload = useCallback(() => {
+    const blob = new Blob([content], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, [content, fileName]);
+
   if (columns.length === 0) {
     return (
       <pre className="rounded-lg border bg-card p-6 text-sm overflow-auto whitespace-pre-wrap">
@@ -74,16 +87,27 @@ export function CsvRenderer({ content }: Props) {
 
   return (
     <div className="space-y-3">
-      {/* Search */}
-      <div className="relative max-w-sm">
-        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-        <input
-          type="text"
-          value={filterText}
-          onChange={(e) => setFilterText(e.target.value)}
-          placeholder="Search all columns..."
-          className="w-full rounded-md border bg-background pl-9 pr-3 py-2 text-sm outline-none ring-ring focus:ring-2"
-        />
+      {/* Search + Download */}
+      <div className="flex items-center justify-between gap-3">
+        <div className="relative max-w-sm flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            type="text"
+            value={filterText}
+            onChange={(e) => setFilterText(e.target.value)}
+            placeholder="Search all columns..."
+            className="w-full rounded-md border bg-background pl-9 pr-3 py-2 text-sm outline-none ring-ring focus:ring-2"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={handleDownload}
+          className="flex items-center gap-1.5 rounded-md border px-3 py-2 text-sm font-medium hover:bg-accent shrink-0"
+          title="Download CSV"
+        >
+          <Download className="h-4 w-4" />
+          Download
+        </button>
       </div>
 
       {/* Table */}

--- a/ui/src/content-viewer-entry.tsx
+++ b/ui/src/content-viewer-entry.tsx
@@ -4,11 +4,11 @@ import { ContentRenderer } from "./components/renderers/ContentRenderer";
 // Read content from embedded JSON (injected by Go template).
 const dataEl = document.getElementById("content-data");
 if (dataEl) {
-  const { contentType, content } = JSON.parse(dataEl.textContent!);
+  const { contentType, content, name } = JSON.parse(dataEl.textContent!);
   const root = document.getElementById("content-root");
   if (root) {
     createRoot(root).render(
-      <ContentRenderer contentType={contentType} content={content} />,
+      <ContentRenderer contentType={contentType} content={content} fileName={name} />,
     );
   }
 }


### PR DESCRIPTION
## Summary

Two UX improvements for the asset portal:

- **CSV Download Button**: Adds a "Download" button to the CSV table view header, positioned to the right of the search input. Clicking it creates a Blob from the raw CSV content and triggers a browser download with the correct asset filename. The `fileName` prop is threaded from `AssetViewer` → `ContentRenderer` → `CsvRenderer`, and the asset name is included in the public viewer's `content-data` JSON so shared links also use the real filename (falls back to `data.csv` if unavailable).

- **Public Viewer Info Modal**: Adds an info button (ℹ circle icon) to the public viewer header bar, between the asset title area and the theme toggle. Clicking it opens a modal displaying asset metadata: description (if present), creation and update dates (locale-formatted via JS `toLocaleString()`), and tags (as pill badges). The modal closes on button click, overlay click, or Escape key. Styling matches the existing public viewer design system (CSS variables, border/surface colors, badge styles).

## Changes

### Backend (`pkg/portal/public.go`)
- Added `Description`, `Tags`, `CreatedAtISO`, `UpdatedAtISO` to the template data map
- Added `name`, `description`, `tags`, `createdAt`, `updatedAt` to the `contentJSON` payload (used by the content viewer React bundle)
- Changed `contentJSON` map type from `map[string]string` to `map[string]any` to accommodate `[]string` tags

### Template (`pkg/portal/templates/public_viewer.html`)
- Added CSS for `.info-toggle` button, `.modal-overlay`, `.modal-card`, `.modal-tags`, `.modal-close`
- Added info button SVG icon in header
- Added modal markup with conditional `{{if .Description}}` and `{{if .Tags}}` guards
- Added JS to toggle modal, format ISO dates to locale strings, handle Escape key

### Frontend
- **`CsvRenderer.tsx`**: Added `fileName` prop (default `"data.csv"`), `Download` icon button in a flex row with the search input, `handleDownload` using Blob + object URL
- **`ContentRenderer.tsx`**: Added optional `fileName` prop, passed through to `CsvRenderer`
- **`AssetViewer.tsx`**: Passes `fileName={asset.name}` to `ContentRenderer`
- **`content-viewer-entry.tsx`**: Extracts `name` from the content-data JSON and passes it as `fileName`

## Test plan

- [x] `go test -race ./...` passes (existing public view tests cover template rendering with new fields)
- [x] `npm run build` and content viewer bundle build succeed
- [ ] Open a CSV asset in the portal → verify Download button appears right of search, downloads file with correct asset name
- [ ] Open a public share link for a CSV asset → verify Download button uses the asset name
- [ ] Open a public share link → verify info button (ℹ) appears in the header
- [ ] Click info button → modal shows description, created/updated dates, and tags
- [ ] Modal closes on Close button, overlay click, and Escape key
- [ ] Verify modal handles missing description and empty tags gracefully (sections hidden)
- [ ] Verify light/dark theme applies correctly to info modal