### PR TITLE
fix: prevent non-admin users from getting session expired after SSO login

### DIFF
--- a/ui/src/api/admin/client.ts
+++ b/ui/src/api/admin/client.ts
@@ -30,9 +30,6 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   });
 
   if (!res.ok) {
-    if (res.status === 401) {
-      useAuthStore.getState().expireSession();
-    }
     const body = await res.json().catch(() => ({ detail: res.statusText }));
     throw new ApiError(res.status, body.detail || res.statusText);
   }

--- a/ui/src/api/admin/hooks.ts
+++ b/ui/src/api/admin/hooks.ts
@@ -36,11 +36,12 @@ import type { Asset } from "@/api/portal/types";
 // Refresh interval for auto-updating queries (30 seconds)
 const REFETCH_INTERVAL = 30_000;
 
-export function useSystemInfo() {
+export function useSystemInfo(enabled = true) {
   return useQuery({
     queryKey: ["system", "info"],
     queryFn: () => apiFetch<SystemInfo>("/system/info"),
     refetchInterval: REFETCH_INTERVAL,
+    enabled,
   });
 }
 

--- a/ui/src/components/layout/Header.tsx
+++ b/ui/src/components/layout/Header.tsx
@@ -16,7 +16,7 @@ const themeOptions = [
 export function Header({ title }: Props) {
   const { theme, setTheme } = useThemeStore();
   const isAdmin = useAuthStore((s) => s.isAdmin());
-  const { data: systemInfo } = useSystemInfo();
+  const { data: systemInfo } = useSystemInfo(isAdmin);
   const version = systemInfo?.version ?? "dev";
   const tooltip = systemInfo
     ? `${systemInfo.version}\nCommit: ${systemInfo.commit}\nBuilt: ${systemInfo.build_date}`


### PR DESCRIPTION
## Problem

Non-admin users (e.g. those with the `dp_analyst` role) are immediately logged out after a successful SSO login. The sequence:

1. User completes OIDC login — callback succeeds, session cookie is set, redirect to `/portal/` has no error
2. `AppShell` renders → `Header` component mounts
3. `Header` unconditionally calls `useSystemInfo()`, which hits `GET /api/v1/admin/system/info`
4. The admin middleware checks the user's persona — `dp_analyst` resolves to `"analyst"`, not `"admin"` — so the server returns **401**
5. The admin API client (`client.ts:34`) catches the 401 and calls `expireSession()`, destroying the perfectly valid session
6. User sees "Your session has expired. Please sign in again."

The version badge in the header is already gated by `isAdmin` (line 29), so non-admin users would never see the result anyway — but the data-fetching hook fired unconditionally.

## Root Cause

Two issues compounding:

1. **Unconditional data fetching** — `useSystemInfo()` fires for every user, regardless of role
2. **Overly aggressive 401 handling** — the admin API client treated all 401 responses as session expiration, but 401 from admin endpoints means "you're not an admin", not "your session is invalid"

## Fix

### 1. Gate `useSystemInfo()` on admin status (`Header.tsx`)

```diff
- const { data: systemInfo } = useSystemInfo();
+ const { data: systemInfo } = useSystemInfo(isAdmin);
```

Non-admin users never call the admin system info endpoint.

### 2. Add `enabled` parameter to `useSystemInfo` hook (`hooks.ts`)

```diff
- export function useSystemInfo() {
+ export function useSystemInfo(enabled = true) {
    return useQuery({
      queryKey: ["system", "info"],
      queryFn: () => apiFetch<SystemInfo>("/system/info"),
      refetchInterval: REFETCH_INTERVAL,
+     enabled,
    });
  }
```

Uses React Query's built-in `enabled` option to skip the query entirely when `false`.

### 3. Remove `expireSession()` from admin client (defense in depth) (`client.ts`)

```diff
  if (!res.ok) {
-   if (res.status === 401) {
-     useAuthStore.getState().expireSession();
-   }
    const body = await res.json().catch(() => ({ detail: res.statusText }));
    throw new ApiError(res.status, body.detail || res.statusText);
  }
```

The admin client should not expire sessions on 401. A 401 from `/api/v1/admin/*` means "insufficient privileges", not "session invalid". The portal client already handles true session expiration independently.

## Impact

- **Non-admin users**: Can now use the portal without being immediately logged out
- **Admin users**: No change — `useSystemInfo(true)` behaves identically to the previous `useSystemInfo()`
- **Admin pages**: If a non-admin somehow navigates to an admin page, admin API calls will throw `ApiError` with status 401 (which the admin pages already handle) instead of silently destroying the session

## Test Plan

- [ ] Log in as a non-admin user (e.g. `dp_analyst` role) — portal loads without "session expired"
- [ ] Log in as an admin user — version badge still appears in header
- [ ] Verify browser Network tab shows no 401 responses for non-admin users on initial load
- [ ] Verify admin pages still work correctly for admin users
- [ ] `cd ui && npm run build` passes cleanly