### PR TITLE
fix: sidebar expand, share view counts, and provenance filtering

### DIFF
--- a/ui/src/components/ProvenancePanel.tsx
+++ b/ui/src/components/ProvenancePanel.tsx
@@ -140,6 +140,22 @@ function ProvenanceCard({
   );
 }
 
+/** Extract the SQL string from a summary, or null if not a SQL call. */
+function extractSQL(call: ProvenanceToolCall): string | null {
+  if (!call.tool_name.startsWith("trino_")) return null;
+  if (!call.summary) return null;
+  try {
+    const parsed = JSON.parse(call.summary);
+    if (typeof parsed === "object" && parsed.sql) return String(parsed.sql);
+  } catch {
+    // Not JSON — check if raw text looks like SQL
+    if (/^\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|WITH|EXPLAIN)\b/i.test(call.summary)) {
+      return call.summary;
+    }
+  }
+  return null;
+}
+
 function DetailModal({
   call,
   open,
@@ -151,7 +167,8 @@ function DetailModal({
 }) {
   if (!call) return null;
   const Icon = getToolIcon(call.tool_name);
-  const detail = formatDetail(call.summary);
+  const sql = extractSQL(call);
+  const detail = sql ?? formatDetail(call.summary);
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -168,11 +185,9 @@ function DetailModal({
 
           <div className="mt-4">
             <p className="mb-1.5 text-xs font-medium text-muted-foreground">
-              {call.tool_name.startsWith("trino_") && detail.includes("SELECT")
-                ? "SQL Query"
-                : "Parameters"}
+              {sql ? "SQL Query" : "Parameters"}
             </p>
-            <pre className="max-h-72 overflow-auto rounded-md bg-muted p-3 text-xs font-mono whitespace-pre-wrap break-words">
+            <pre className="max-h-96 overflow-auto rounded-md bg-muted p-3 text-xs font-mono whitespace-pre-wrap break-words">
               {detail}
             </pre>
           </div>
@@ -196,6 +211,7 @@ function DetailModal({
 export function ProvenancePanel({ provenance }: Props) {
   const calls = provenance.tool_calls ?? [];
   const [selected, setSelected] = useState<ProvenanceToolCall | null>(null);
+  const [showAll, setShowAll] = useState(false);
 
   if (calls.length === 0) {
     return (
@@ -203,17 +219,22 @@ export function ProvenancePanel({ provenance }: Props) {
     );
   }
 
+  const trinoCalls = calls.filter((c) => c.tool_name.startsWith("trino_"));
+  const otherCalls = calls.filter((c) => !c.tool_name.startsWith("trino_"));
+  const visibleCalls = showAll ? calls : trinoCalls;
+
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-medium">Provenance</h3>
         <span className="text-xs text-muted-foreground">
-          {calls.length} {calls.length === 1 ? "call" : "calls"}
+          {trinoCalls.length} {trinoCalls.length === 1 ? "query" : "queries"}
+          {otherCalls.length > 0 && !showAll && ` + ${otherCalls.length} other`}
         </span>
       </div>
 
       <div className="space-y-2">
-        {calls.map((call, i) => (
+        {visibleCalls.map((call, i) => (
           <ProvenanceCard
             key={i}
             call={call}
@@ -221,6 +242,16 @@ export function ProvenancePanel({ provenance }: Props) {
           />
         ))}
       </div>
+
+      {otherCalls.length > 0 && (
+        <button
+          type="button"
+          onClick={() => setShowAll((v) => !v)}
+          className="w-full rounded-md border border-dashed py-1.5 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-colors"
+        >
+          {showAll ? "Show queries only" : `Show all ${calls.length} calls`}
+        </button>
+      )}
 
       <DetailModal
         call={selected}

--- a/ui/src/components/ShareDialog.tsx
+++ b/ui/src/components/ShareDialog.tsx
@@ -200,9 +200,11 @@ export function ShareDialog({ assetId, open, onOpenChange }: Props) {
                           Public Link
                         </span>
                       )}
-                      <span className="text-xs text-muted-foreground ml-2">
-                        ({share.access_count} views)
-                      </span>
+                      {!share.shared_with_user_id && !share.shared_with_email && share.access_count > 0 && (
+                        <span className="text-xs text-muted-foreground ml-2">
+                          ({share.access_count} {share.access_count === 1 ? "view" : "views"})
+                        </span>
+                      )}
                       <span className="text-xs text-muted-foreground ml-2">
                         {formatTimeRemaining(share.expires_at)}
                       </span>

--- a/ui/src/components/layout/AppShell.tsx
+++ b/ui/src/components/layout/AppShell.tsx
@@ -86,12 +86,17 @@ export function AppShell() {
   }, []);
 
   // Auto-collapse when entering asset routes, restore when leaving
+  const prevPath = useRef(currentPath);
   useEffect(() => {
+    if (prevPath.current === currentPath) return;
+    const wasOnAsset = isAssetRoute(prevPath.current);
     const onAsset = isAssetRoute(currentPath);
-    if (onAsset && !sidebarCollapsed) {
+    prevPath.current = currentPath;
+
+    if (onAsset && !wasOnAsset && !sidebarCollapsed) {
       setSidebarCollapsed(true);
       autoCollapsed.current = true;
-    } else if (!onAsset && autoCollapsed.current && sidebarCollapsed) {
+    } else if (!onAsset && wasOnAsset && autoCollapsed.current) {
       const stored = localStorage.getItem(SIDEBAR_STORAGE_KEY) === "true";
       setSidebarCollapsed(stored);
       autoCollapsed.current = false;


### PR DESCRIPTION
## Summary
- **Share view counts**: Hide misleading "(0 views)" on user-specific shares where access isn't tracked; only show count on public links with >0 views
- **Sidebar expand bug**: Fix expand button not working on asset routes — the auto-collapse `useEffect` was re-triggering on sidebar state changes, immediately re-collapsing; now only reacts to path transitions
- **Provenance filtering**: Show only Trino queries by default with a "Show all N calls" toggle to reveal other tool calls
- **Trino query modal**: Extract and display formatted SQL directly instead of raw JSON wrapper; increased modal max height for longer queries

## Test plan
- [ ] Share an asset with a user — verify no "(0 views)" is shown
- [ ] Create a public link, access it, then verify view count appears correctly
- [ ] Navigate to an asset viewer — sidebar should auto-collapse
- [ ] Click the expand arrows at the bottom of the collapsed sidebar — verify it stays expanded
- [ ] Navigate away from asset viewer — sidebar should restore to previous state
- [ ] View an asset with provenance — verify only Trino queries show by default
- [ ] Click "Show all" — verify all tool calls appear; click "Show queries only" to toggle back
- [ ] Click a Trino query in provenance — verify modal shows formatted SQL, not JSON wrapper