### PR TITLE
fix: save dialog UX, version header for all users

### DIFF
--- a/pkg/admin/system.go
+++ b/pkg/admin/system.go
@@ -86,6 +86,7 @@ func (h *Handler) getSystemInfo(w http.ResponseWriter, _ *http.Request) {
 // publicBrandingResponse is returned by the unauthenticated branding endpoint.
 type publicBrandingResponse struct {
 	Name            string `json:"name"`
+	Version         string `json:"version"`
 	PortalTitle     string `json:"portal_title"`
 	PortalLogo      string `json:"portal_logo"`
 	PortalLogoLight string `json:"portal_logo_light"`
@@ -96,7 +97,9 @@ type publicBrandingResponse struct {
 // getPublicBranding handles GET /api/v1/admin/public/branding.
 // This endpoint is unauthenticated and returns only non-sensitive display info.
 func (h *Handler) getPublicBranding(w http.ResponseWriter, _ *http.Request) {
-	resp := publicBrandingResponse{}
+	resp := publicBrandingResponse{
+		Version: mcpserver.Version,
+	}
 	if h.deps.Config != nil {
 		resp.Name = h.deps.Config.Server.Name
 		resp.PortalTitle = h.deps.Config.Portal.Title

--- a/pkg/admin/system_test.go
+++ b/pkg/admin/system_test.go
@@ -142,13 +142,14 @@ func TestGetPublicBranding(t *testing.T) {
 		var body publicBrandingResponse
 		require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
 		assert.Equal(t, "acme-platform", body.Name)
+		assert.NotEmpty(t, body.Version)
 		assert.Equal(t, "ACME Admin", body.PortalTitle)
 		assert.Equal(t, "https://cdn.example.com/acme-logo.svg", body.PortalLogo)
 		assert.Equal(t, "https://cdn.example.com/acme-light.svg", body.PortalLogoLight)
 		assert.Equal(t, "https://cdn.example.com/acme-dark.svg", body.PortalLogoDark)
 	})
 
-	t.Run("returns empty when no config", func(t *testing.T) {
+	t.Run("returns version even without config", func(t *testing.T) {
 		h := NewHandler(Deps{}, nil)
 
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/admin/public/branding", http.NoBody)
@@ -160,6 +161,7 @@ func TestGetPublicBranding(t *testing.T) {
 		require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
 		assert.Empty(t, body.Name)
 		assert.Empty(t, body.PortalTitle)
+		assert.NotEmpty(t, body.Version)
 	})
 
 	t.Run("bypasses auth middleware", func(t *testing.T) {

--- a/ui/src/api/portal/hooks.ts
+++ b/ui/src/api/portal/hooks.ts
@@ -20,6 +20,7 @@ import type {
 
 export interface Branding {
   name: string;
+  version: string;
   portal_title: string;
   portal_logo: string;
   portal_logo_light: string;

--- a/ui/src/api/portal/types.ts
+++ b/ui/src/api/portal/types.ts
@@ -95,6 +95,7 @@ export interface ShareResponse {
 
 export interface Branding {
   name: string;
+  version: string;
   portal_title: string;
   portal_logo: string;
   portal_logo_light: string;

--- a/ui/src/components/AssetViewer.tsx
+++ b/ui/src/components/AssetViewer.tsx
@@ -124,6 +124,8 @@ export function AssetViewer({
           setSharedSaveWarningOpen(false);
           setChangeSummaryOpen(false);
           setChangeSummary("");
+          setViewMode("preview");
+          onSelectVersion?.(null);
           if (isThumbnailSupported(asset.content_type)) {
             setThumbnailStale(true);
           }
@@ -639,6 +641,9 @@ export function AssetViewer({
           />
           <div className="relative rounded-lg border bg-card p-6 shadow-lg max-w-sm w-full mx-4 space-y-4">
             <h3 className="text-sm font-semibold">What changed?</h3>
+            <p className="text-xs text-muted-foreground">
+              Saving will create a new version v{(asset.current_version ?? 0) + 1}.
+            </p>
             <textarea
               value={changeSummary}
               onChange={(e) => setChangeSummary(e.target.value)}
@@ -650,11 +655,10 @@ export function AssetViewer({
             <div className="flex justify-end gap-2">
               <button
                 type="button"
-                onClick={() => doSaveContent("")}
-                disabled={contentUpdateMutation?.isPending}
-                className="rounded-md bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground hover:bg-secondary/80 disabled:opacity-50"
+                onClick={() => setChangeSummaryOpen(false)}
+                className="rounded-md bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground hover:bg-secondary/80"
               >
-                Skip
+                Cancel
               </button>
               <button
                 type="button"

--- a/ui/src/components/layout/Header.tsx
+++ b/ui/src/components/layout/Header.tsx
@@ -1,6 +1,5 @@
 import { useThemeStore } from "@/stores/theme";
-import { useAuthStore } from "@/stores/auth";
-import { useSystemInfo } from "@/api/admin/hooks";
+import { useBranding } from "@/api/portal/hooks";
 import { Sun, Moon, Monitor } from "lucide-react";
 
 interface Props {
@@ -15,22 +14,15 @@ const themeOptions = [
 
 export function Header({ title }: Props) {
   const { theme, setTheme } = useThemeStore();
-  const isAdmin = useAuthStore((s) => s.isAdmin());
-  const { data: systemInfo } = useSystemInfo(isAdmin);
-  const version = systemInfo?.version ?? "dev";
-  const tooltip = systemInfo
-    ? `${systemInfo.version}\nCommit: ${systemInfo.commit}\nBuilt: ${systemInfo.build_date}`
-    : "";
+  const { data: branding } = useBranding();
+  const version = branding?.version;
 
   return (
     <header className="flex h-14 items-center justify-between border-b bg-card px-6">
       <h1 className="text-lg font-semibold">{title}</h1>
       <div className="flex items-center gap-3">
-        {isAdmin && systemInfo && (
-          <span
-            className="text-xs text-muted-foreground"
-            title={tooltip}
-          >
+        {version && (
+          <span className="text-xs text-muted-foreground">
             v{version}
           </span>
         )}

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -225,6 +225,7 @@ export const handlers = [
   http.get(`${ADMIN_BASE}/public/branding`, () =>
     HttpResponse.json({
       name: mockSystemInfo.name,
+      version: mockSystemInfo.version,
       portal_title: mockSystemInfo.portal_title,
       portal_logo: mockSystemInfo.portal_logo,
       portal_logo_light: mockSystemInfo.portal_logo_light,


### PR DESCRIPTION
## Summary

- **Change summary dialog**: Shows "Saving will create a new version vN" so users know a version will be created before confirming
- **Post-save behavior**: Switches back to preview mode and resets the version dropdown to current after a successful save
- **Cancel button**: Renamed "Skip" to "Cancel" — dismisses the dialog without saving (Skip implied saving without a summary, which was confusing)
- **Version in header for all users**: Added `version` to the public branding endpoint so non-admin users also see the platform version in the header

## Test plan

- [ ] `go test -race ./...` — all pass
- [ ] `golangci-lint run ./...` — no issues
- [ ] `npx tsc --noEmit` in `ui/` — compiles clean
- [ ] Edit asset → Save → dialog shows "Saving will create a new version vN" with correct version number
- [ ] Enter summary → Save → view switches to preview, version dropdown shows new current version
- [ ] Click Cancel in dialog → dialog closes, no save occurs, editor state preserved
- [ ] Log in as non-admin user → header shows platform version badge
- [ ] Log in as admin user → header still shows platform version badge