### PR TITLE
fix: invalidate version queries after content save

### DIFF
--- a/ui/src/api/admin/hooks.ts
+++ b/ui/src/api/admin/hooks.ts
@@ -487,6 +487,7 @@ export function useAdminUpdateAssetContent() {
       queryClient.invalidateQueries({ queryKey: ["admin", "asset-content"] });
       queryClient.invalidateQueries({ queryKey: ["admin", "asset"] });
       queryClient.invalidateQueries({ queryKey: ["admin", "assets"] });
+      queryClient.invalidateQueries({ queryKey: ["admin", "asset-versions"] });
     },
   });
 }

--- a/ui/src/api/portal/hooks.ts
+++ b/ui/src/api/portal/hooks.ts
@@ -158,6 +158,7 @@ export function useUpdateAssetContent() {
       void qc.invalidateQueries({ queryKey: ["asset-content"] });
       void qc.invalidateQueries({ queryKey: ["asset"] });
       void qc.invalidateQueries({ queryKey: ["assets"] });
+      void qc.invalidateQueries({ queryKey: ["asset-versions"] });
     },
   });
 }


### PR DESCRIPTION
## Summary

- Content update mutations (`useUpdateAssetContent`, `useAdminUpdateAssetContent`) were not invalidating the `asset-versions` query key, so the version dropdown stayed stale after saving until page refresh

## Test plan

- [ ] Edit asset content → Save → version dropdown immediately shows the new version without page refresh
- [ ] Same behavior in admin asset viewer