### PR TITLE
fix: bump mcp-datahub v1.4.0 → v1.4.1 for apply_knowledge write fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
-	github.com/txn2/mcp-datahub v1.4.0
+	github.com/txn2/mcp-datahub v1.4.1
 	github.com/txn2/mcp-s3 v1.0.0
 	github.com/txn2/mcp-trino v1.1.0
 	github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v1.4.0 h1:meNQp++jq3thX22zJU9VA1Wui2NS9uDCYtgTKAF+CSQ=
-github.com/txn2/mcp-datahub v1.4.0/go.mod h1:uktl1c12qQwInw0XIS03jxYusLOFj8h5UO3+YBThzTI=
+github.com/txn2/mcp-datahub v1.4.1 h1:TQW09kvFRhoxobGs1Bgv+IftVZoYcavE0uyzTu/PP7w=
+github.com/txn2/mcp-datahub v1.4.1/go.mod h1:uktl1c12qQwInw0XIS03jxYusLOFj8h5UO3+YBThzTI=
 github.com/txn2/mcp-s3 v1.0.0 h1:0772X3H7bAJPqDtuvDNlZTGEK2m1egInfuqQL/Jlq8Y=
 github.com/txn2/mcp-s3 v1.0.0/go.mod h1:hQc0xBl0t/afEgFmrOSKH3OW9uyKdeliFknQwfAzqG0=
 github.com/txn2/mcp-trino v1.1.0 h1:5/cSIIzciTT/cV1p8enM+4k4SI+0OcK5uFwcQhOBWhk=

--- a/pkg/semantic/datahub/adapter.go
+++ b/pkg/semantic/datahub/adapter.go
@@ -418,7 +418,14 @@ func (a *Adapter) logInjectionAttempts(entity *types.Entity) {
 		}
 	}
 
-	// Check structured property display names and string values (DataHub 1.4.x)
+	a.logInjectionAttemptsV14(entity)
+}
+
+// logInjectionAttemptsV14 checks DataHub 1.4.x fields for prompt injection attempts.
+func (a *Adapter) logInjectionAttemptsV14(entity *types.Entity) {
+	logger := semantic.DefaultInjectionLogger
+
+	// Check structured property display names and string values
 	for i, sp := range entity.StructuredProperties {
 		if sp.Definition != nil {
 			logger.DetectAndLog(a.sanitizer, entity.URN, fmt.Sprintf("structuredProperties[%d].displayName", i), sp.Definition.DisplayName)
@@ -430,7 +437,7 @@ func (a *Adapter) logInjectionAttempts(entity *types.Entity) {
 		}
 	}
 
-	// Check incident titles and descriptions (DataHub 1.4.x)
+	// Check incident titles and descriptions
 	if entity.ActiveIncidents != nil {
 		for i, inc := range entity.ActiveIncidents.Incidents {
 			logger.DetectAndLog(a.sanitizer, entity.URN, fmt.Sprintf("incidents[%d].title", i), inc.Title)

--- a/pkg/toolkits/knowledge/datahub_client_writer_test.go
+++ b/pkg/toolkits/knowledge/datahub_client_writer_test.go
@@ -383,7 +383,7 @@ func TestDataHubClientWriter_UpsertStructuredProperties(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		resp := graphQLResponse{
-			Data: json.RawMessage(`{"upsertStructuredProperties": true}`),
+			Data: json.RawMessage(`{"upsertStructuredProperties": {"properties": [{"structuredProperty": {"urn": "urn:li:structuredProperty:io.acryl.privacy.retentionTime"}}]}}`),
 		}
 		_ = json.NewEncoder(w).Encode(resp)
 	}))
@@ -421,7 +421,7 @@ func TestDataHubClientWriter_RemoveStructuredProperty(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		resp := graphQLResponse{
-			Data: json.RawMessage(`{"removeStructuredProperties": true}`),
+			Data: json.RawMessage(`{"removeStructuredProperties": {"properties": []}}`),
 		}
 		_ = json.NewEncoder(w).Encode(resp)
 	}))


### PR DESCRIPTION
## Summary

Bumps `txn2/mcp-datahub` from v1.4.0 to [v1.4.1](https://github.com/txn2/mcp-datahub/releases/tag/v1.4.1), fixing three `apply_knowledge` bugs discovered during live testing against a DataHub 1.4.x instance.

**+14 lines, -7 lines across 4 files**

---

## Bugs Fixed (upstream)

### 1. `raise_incident` — "At least 1 resource urn must be defined"

The upstream `RaiseIncident` mutation sent `resourceUrns` as an array of `{"urn":"..."}` objects. DataHub 1.4.x expects `resourceUrn` — a singular `String!` field. The platform-side code correctly passed `entity_urn` through as `ResourceURNs: []string{entityURN}`, but the upstream client serialized it incorrectly.

### 2. `set_structured_property` — GraphQL `SubselectionRequired`

The upstream `UpsertStructuredProperties` and `RemoveStructuredProperties` mutations were missing a required GraphQL selection set. DataHub returns `StructuredProperties!` (a non-scalar type) which requires field selection. The platform-side mock responses in `datahub_client_writer_test.go` returned `true` (boolean), masking the issue in tests. Updated mocks to match the v1.4.1 struct response format.

### 3. `update_description` / `add_tag` on non-dataset entities — "unsupported entity type"

The upstream client's `descriptionAspectMap` excluded `domain` and `glossaryTerm`, and `globalTagsSupportedTypes` / `glossaryTermsSupportedTypes` excluded `domain`, `glossaryTerm`, and `glossaryNode`. The platform's `entity_type.go` already listed these as supported (correctly anticipating the upstream fix), so no platform-side validation changes were needed.

---

## Platform-side Changes

| File | Change |
|------|--------|
| `go.mod` / `go.sum` | `txn2/mcp-datahub` v1.4.0 → v1.4.1 |
| `pkg/toolkits/knowledge/datahub_client_writer_test.go` | Updated mock GraphQL responses for `UpsertStructuredProperties` and `RemoveStructuredProperties` to match v1.4.1 struct response format (was boolean) |
| `pkg/semantic/datahub/adapter.go` | Split `logInjectionAttempts` (cognitive complexity 18) into `logInjectionAttempts` + `logInjectionAttemptsV14` to fix gocognit lint violation (threshold: 15) |

## Test plan

- [x] `go test -race ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues (complexity violation fixed)
- [x] Coverage: `logInjectionAttempts` 100%, `logInjectionAttemptsV14` 90.9%
- [ ] Manual: `raise_incident` on a dataset → incident URN returned
- [ ] Manual: `set_structured_property` on a dataset → property set
- [ ] Manual: `update_description` on `urn:li:domain:*` → description updated
- [ ] Manual: `add_tag` on `urn:li:domain:*` → tag added
- [ ] Manual: `update_description` on `urn:li:glossaryTerm:*` → description updated