### PR TITLE
fix: bump mcp-datahub v1.4.1 → v1.4.2 for remaining write fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
-	github.com/txn2/mcp-datahub v1.4.1
+	github.com/txn2/mcp-datahub v1.4.2
 	github.com/txn2/mcp-s3 v1.0.0
 	github.com/txn2/mcp-trino v1.1.0
 	github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v1.4.1 h1:TQW09kvFRhoxobGs1Bgv+IftVZoYcavE0uyzTu/PP7w=
-github.com/txn2/mcp-datahub v1.4.1/go.mod h1:uktl1c12qQwInw0XIS03jxYusLOFj8h5UO3+YBThzTI=
+github.com/txn2/mcp-datahub v1.4.2 h1:HR8bOeCfb7v8Iq9e8c9xf3FwJ5rjYROUo5Jn2TA+Xyc=
+github.com/txn2/mcp-datahub v1.4.2/go.mod h1:uktl1c12qQwInw0XIS03jxYusLOFj8h5UO3+YBThzTI=
 github.com/txn2/mcp-s3 v1.0.0 h1:0772X3H7bAJPqDtuvDNlZTGEK2m1egInfuqQL/Jlq8Y=
 github.com/txn2/mcp-s3 v1.0.0/go.mod h1:hQc0xBl0t/afEgFmrOSKH3OW9uyKdeliFknQwfAzqG0=
 github.com/txn2/mcp-trino v1.1.0 h1:5/cSIIzciTT/cV1p8enM+4k4SI+0OcK5uFwcQhOBWhk=


### PR DESCRIPTION
## Summary

Bumps `txn2/mcp-datahub` from v1.4.1 to [v1.4.2](https://github.com/txn2/mcp-datahub/releases/tag/v1.4.2), fixing the four remaining `apply_knowledge` write failures from live testing. Pure dependency bump — no platform code changes.

### Dependency Update

| Dependency | Previous | New |
|---|---|---|
| `txn2/mcp-datahub` | v1.4.1 | v1.4.2 |

---

## Bugs Fixed (upstream)

### 1. `set_structured_property` — Wrong GraphQL field name

The mutation input used `propertyUrn` (REST API field name) instead of `structuredPropertyUrn` (GraphQL field name), causing `field name 'propertyUrn' is not defined for input object type 'StructuredPropertyInputParams'`.

### 2. `resolve_incident` — Wrong GraphQL input type

The mutation declared `$input: UpdateIncidentStatusInput!` but DataHub 1.4.x renamed the type to `IncidentStatusInput!`, causing a type mismatch validation error.

### 3. `update_description` on domain/glossaryTerm/glossaryNode — REST API rejects these aspects

The REST `ingestProposal` endpoint does not register `domainProperties`, `glossaryTermInfo`, or `glossaryNodeInfo` as writable aspects, returning 422 validation errors. v1.4.2 routes these entity types through the GraphQL `updateDescription` mutation instead.

### 4. `add_tag` / `remove_tag` on domain/glossaryTerm/glossaryNode — Same REST limitation

The REST API does not register `globalTags` as a writable aspect for these entity types. v1.4.2 routes them through GraphQL `addTag`/`removeTag`/`addTerm`/`removeTerm` mutations. All other entity types (dataset, dashboard, chart, etc.) continue using REST unchanged.

---

## URN Normalization Verification

Confirmed that structured property URN normalization happens **only** in the platform layer (`normalizeStructuredPropertyURN` in `toolkit.go:615-620`). The upstream client passes `PropertyURN` through as-is. No double-normalization issue.

## Test plan

- [x] `go test -race ./...` — all pass, no mock changes needed
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Manual: `set_structured_property` on a dataset
- [ ] Manual: `resolve_incident` on a dataset
- [ ] Manual: `update_description` on `urn:li:domain:*`
- [ ] Manual: `add_tag` on `urn:li:glossaryTerm:*`