### PR TITLE
fix: bump mcp-datahub v1.4.2 → v1.4.3 for structured property value serialization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.40.0
-	github.com/txn2/mcp-datahub v1.4.2
+	github.com/txn2/mcp-datahub v1.4.3
 	github.com/txn2/mcp-s3 v1.0.0
 	github.com/txn2/mcp-trino v1.1.0
 	github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v1.4.2 h1:HR8bOeCfb7v8Iq9e8c9xf3FwJ5rjYROUo5Jn2TA+Xyc=
-github.com/txn2/mcp-datahub v1.4.2/go.mod h1:uktl1c12qQwInw0XIS03jxYusLOFj8h5UO3+YBThzTI=
+github.com/txn2/mcp-datahub v1.4.3 h1:jGoJ0mMUCiYTfcCrVNMgrEmk/0KH1kuor3/3Wnj9WZ4=
+github.com/txn2/mcp-datahub v1.4.3/go.mod h1:uktl1c12qQwInw0XIS03jxYusLOFj8h5UO3+YBThzTI=
 github.com/txn2/mcp-s3 v1.0.0 h1:0772X3H7bAJPqDtuvDNlZTGEK2m1egInfuqQL/Jlq8Y=
 github.com/txn2/mcp-s3 v1.0.0/go.mod h1:hQc0xBl0t/afEgFmrOSKH3OW9uyKdeliFknQwfAzqG0=
 github.com/txn2/mcp-trino v1.1.0 h1:5/cSIIzciTT/cV1p8enM+4k4SI+0OcK5uFwcQhOBWhk=


### PR DESCRIPTION
## Summary

Bumps `txn2/mcp-datahub` from v1.4.2 to [v1.4.3](https://github.com/txn2/mcp-datahub/releases/tag/v1.4.3), fixing the last known `set_structured_property` failure. Pure dependency bump — no platform code changes.

### Dependency Update

| Dependency | Previous | New |
|---|---|---|
| `txn2/mcp-datahub` | v1.4.2 | v1.4.3 |

---

## Bug Fixed (upstream)

### `set_structured_property` — "Expected type 'Map' but was 'String'"

The upstream `UpsertStructuredProperties` mutation passed raw values (e.g., `"2 years"`, `30`) directly in the `values` array. DataHub's GraphQL API expects typed value objects (`{"stringValue": "..."}` or `{"numberValue": ...}`).

v1.4.3 adds a `toTypedPropertyValue` helper that wraps each raw Go value in the appropriate typed map before building the GraphQL mutation variables.

**Before:** `set_structured_property` failed on all value types with a GraphQL type mismatch error.
**After:** String, numeric, and other value types are correctly serialized.

## Test plan

- [x] `go test -race ./...` — all pass, no mock changes needed
- [ ] Manual: `set_structured_property` with string value (e.g., `"2 years"`)
- [ ] Manual: `set_structured_property` with numeric value (e.g., `90`)
- [ ] Manual: `set_structured_property` with JSON array (e.g., `[90, "PII"]`)