### PR TITLE
docs: add datahub write tool specs to tools-api.md

### DIFF
--- a/docs/reference/tools-api.md
+++ b/docs/reference/tools-api.md
@@ -575,6 +575,121 @@ List configured DataHub connections.
 
 ---
 
+### datahub_create
+
+Create a new entity or resource in DataHub. Uses the `what` discriminator to select the entity type. Only available when `read_only: false`.
+
+Annotated with `DestructiveHint: false`, `IdempotentHint: false`, `OpenWorldHint: true`.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `what` | string | Yes | - | Entity type to create (see table below) |
+| `name` | string | Varies | - | Entity name (required for most types) |
+| `connection` | string | No | first configured | DataHub connection name |
+
+Additional parameters vary by `what` value — see the [mcp-datahub documentation](https://github.com/txn2/mcp-datahub) for full parameter details per entity type.
+
+| `what` | Creates | Key fields |
+|--------|---------|------------|
+| `tag` | Tag | `name` |
+| `domain` | Domain | `name` |
+| `glossary_term` | Glossary term | `name` |
+| `data_product` | Data product | `name`, `domain_urn` |
+| `document` | Context document (1.4.x+) | `name` |
+| `application` | Application | `name` |
+| `query` | Saved query | `value` (SQL) |
+| `incident` | Incident | `name`, `incident_type`, `entity_urns` |
+| `structured_property` | Structured property | `qualified_name`, `value_type`, `entity_types` |
+| `data_contract` | Data contract | `dataset_urns` |
+
+**Response Schema:**
+
+```json
+{
+  "urn": "urn:li:tag:new-tag",
+  "message": "Created tag 'new-tag'"
+}
+```
+
+---
+
+### datahub_update
+
+Update metadata on an existing DataHub entity. Uses the `what` discriminator to select what to update, with an optional `action` for add/remove operations. Only available when `read_only: false`.
+
+Annotated with `DestructiveHint: false`, `IdempotentHint: true`, `OpenWorldHint: true`.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `what` | string | Yes | - | What to update (see table below) |
+| `urn` | string | Varies | - | Entity URN to update |
+| `action` | string | Varies | - | `add` or `remove` (required for tags, glossary terms, links, owners) |
+| `connection` | string | No | first configured | DataHub connection name |
+
+Additional parameters vary by `what` value — see the [mcp-datahub documentation](https://github.com/txn2/mcp-datahub) for full parameter details.
+
+| `what` | `action` | Description |
+|--------|----------|-------------|
+| `description` | — | Set entity description |
+| `column_description` | — | Set schema field description |
+| `tag` | add/remove | Add or remove a tag |
+| `glossary_term` | add/remove | Add or remove a glossary term |
+| `link` | add/remove | Add or remove a link |
+| `owner` | add/remove | Add or remove an owner |
+| `domain` | set/remove | Set or remove domain assignment |
+| `structured_properties` | set/remove | Set or remove structured property values |
+| `structured_property` | — | Update a structured property definition |
+| `incident_status` | — | Update incident status |
+| `incident` | — | Update incident details |
+| `query` | — | Update query properties |
+| `document_contents` | — | Update document title/text (1.4.x+) |
+| `document_status` | — | Update document status (1.4.x+) |
+| `document_related_entities` | — | Update document related entities (1.4.x+) |
+| `document_sub_type` | — | Update document sub-type (1.4.x+) |
+| `data_contract` | — | Upsert a data contract |
+
+**Response Schema:**
+
+```json
+{
+  "urn": "urn:li:dataset:...",
+  "message": "Updated description on urn:li:dataset:..."
+}
+```
+
+---
+
+### datahub_delete
+
+Delete an entity or resource from DataHub. Uses the `what` discriminator to select the entity type. Only available when `read_only: false`.
+
+Annotated with `DestructiveHint: true`, `IdempotentHint: true`, `OpenWorldHint: true`.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `what` | string | Yes | - | Entity type to delete (see below) |
+| `urn` | string | Yes | - | Entity URN to delete |
+| `connection` | string | No | first configured | DataHub connection name |
+
+Supported `what` values: `query`, `tag`, `domain`, `glossary_entity`, `data_product`, `application`, `document`, `structured_property`.
+
+**Response Schema:**
+
+```json
+{
+  "urn": "urn:li:tag:old-tag",
+  "message": "Deleted tag 'old-tag'"
+}
+```
+
+---
+
 ## S3 Tools
 
 ### s3_list_buckets


### PR DESCRIPTION
## Summary

- Adds complete API specifications for `datahub_create`, `datahub_update`, and `datahub_delete` to `docs/reference/tools-api.md`, which was the only documentation file missing these entries after the v1.5.0 CRUD tool consolidation (#263)
- Includes parameter tables, `what` discriminator tables, response schemas, and MCP tool annotations, matching the style of existing tool entries

## Test plan

- [ ] Verify rendered markdown displays correctly on GitHub