### PR TITLE
feat: unified local dev harness with hot-reload and seed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ ui/dist/
 ui/dist-content-viewer/
 ui/.vite/
 ui/test-results/
+ui/src/api/generated/
 
 # Root node_modules (if any)
 node_modules/

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ GOLINT := golangci-lint
 	frontend-install frontend-build frontend-build-content-viewer \
 	frontend-dev frontend-mock frontend-test \
 	e2e-up e2e-down e2e-seed e2e-test e2e e2e-logs e2e-clean \
-	dev-up dev-down preview-apps preview-platform-info
+	dev dev-up dev-down mock-check \
+	preview-apps preview-platform-info
 
 ## all: Build and test
 all: build test lint
@@ -444,6 +445,22 @@ dev-down:
 	@echo "Stopping ACME dev environment..."
 	$(DEV_COMPOSE) down -v
 	@echo "ACME dev environment stopped."
+
+## dev: Start full dev environment with hot-reload (Docker + Go + Vite)
+## Runs pre-flight checks (Docker, air, ports), starts services sequentially,
+## waits for health, seeds data on first run, and reports clear status.
+dev:
+	@bash dev/start.sh
+
+## mock-check: Verify MSW mocks conform to Swagger spec types
+mock-check: swagger
+	@echo "Generating TypeScript types from Swagger spec..."
+	cd $(UI_DIR) && npm run generate-api-types
+	@echo "Type-checking mocks against generated types..."
+	cd $(UI_DIR) && npx tsc --noEmit
+	@echo "Running mock conformance tests..."
+	cd $(UI_DIR) && npx vitest run src/mocks/conformance.test.ts
+	@echo "Mock conformance check passed."
 
 ## preview-apps: Serve MCP apps locally at http://localhost:8000/test-harness.html (no server needed)
 preview-apps:

--- a/dev/.air.toml
+++ b/dev/.air.toml
@@ -1,0 +1,21 @@
+root = "."
+tmp_dir = "build/air"
+
+[build]
+  bin = "./build/air/mcp-data-platform"
+  args_bin = ["--config", "dev/platform.yaml"]
+  cmd = "go build -o ./build/air/mcp-data-platform ./cmd/mcp-data-platform"
+  delay = 500
+  exclude_dir = ["ui", "build", "dist", "node_modules", "dev", "test", "apps", "docs", ".git", "internal/apidocs", "internal/ui/dist", "internal/contentviewer/dist"]
+  exclude_regex = ["_test\\.go$"]
+  include_ext = ["go", "yaml"]
+  include_file = ["dev/platform.yaml"]
+  kill_delay = 500
+  send_interrupt = true
+  stop_on_error = false
+
+[log]
+  time = true
+
+[misc]
+  clean_on_exit = true

--- a/dev/README.md
+++ b/dev/README.md
@@ -2,57 +2,86 @@
 
 Local development environment for the portal UI, pre-configured with ACME Corporation retail data (national retailer, 1,000 stores, 12 users, 6 personas).
 
-## Quick Start: MSW Mode (No Backend)
+## Quick Start: Full-Stack with Hot-Reload
 
-The fastest way to see the portal UI with realistic data. No Docker, no database, no Go server.
-
-```bash
-cd ui
-npm install
-VITE_MSW=true npm run dev
-```
-
-Open <http://localhost:5173/portal/> — you'll see the portal with:
-
-- 12 ACME users across 6 personas (admin, data-engineer, inventory-analyst, regional-director, finance-executive, store-manager)
-- 20 tools across 6 connections (2 Trino, 2 DataHub, 2 S3)
-- 200 audit events with business-hours weighting and realistic parameters
-- Deterministic data (seeded PRNG) — same screenshots every time
-
-## Full-Stack Mode (Real API)
-
-For testing against real backend API endpoints with PostgreSQL.
+One command starts everything: Docker services, Go server with hot-reload, and Vite UI dev server.
 
 ### Prerequisites
 
-- Docker (for PostgreSQL)
+- Docker (for PostgreSQL + SeaweedFS)
 - Go 1.23+
+- [air](https://github.com/air-verse/air): `go install github.com/air-verse/air@latest`
+- psql (optional, for auto-seeding dev data)
 
 ### Start
 
 ```bash
-# 1. Start PostgreSQL
-make dev-up
-
-# 2. Start the Go server (runs migrations automatically)
-go run ./cmd/mcp-data-platform --config dev/platform.yaml
-
-# 3. (Optional) Seed with historical data
-psql -h localhost -U platform -d mcp_platform -f dev/seed.sql
-
-# 4. Start the portal UI dev server
-cd ui && npm run dev
+make dev
 ```
 
-Open <http://localhost:5173/portal/>
+This starts:
+
+| Service | URL / Port | Notes |
+|---------|-----------|-------|
+| PostgreSQL | `:5432` | Auto-migrated on startup |
+| SeaweedFS (S3) | `:9000` | Portal asset storage |
+| Go API server | `http://localhost:8080` | Hot-reloads on `.go` file changes via air |
+| Vite UI | `http://localhost:5173/portal/` | Hot module replacement |
+
+On first run, seed data (~5K audit events, 8 knowledge insights) is automatically loaded.
 
 **API Key**: `acme-dev-key-2024`
 
-### Stop
+Press **Ctrl-C** to stop all services.
+
+### Stop and Clean Up
 
 ```bash
-make dev-down
+make dev-down    # Stop Docker services and remove volumes
 ```
+
+## MSW Mode (No Backend)
+
+The fastest way to see the portal UI with realistic data. No Docker, no database, no Go server.
+
+```bash
+make frontend-mock
+```
+
+Open <http://localhost:5173/portal/> — you'll see the portal with:
+
+- 12 ACME users across 6 personas
+- 20 tools across 6 connections (2 Trino, 2 DataHub, 2 S3)
+- 200 audit events with business-hours weighting and realistic parameters
+- Deterministic data (seeded PRNG) — same screenshots every time
+
+## Advanced: Individual Services
+
+For running components individually (e.g., only Docker, only Vite):
+
+```bash
+# Docker services only
+make dev-up
+
+# Go server only (requires Docker services running)
+go run ./cmd/mcp-data-platform --config dev/platform.yaml
+
+# Vite UI only (requires Go server running)
+make frontend-dev
+
+# Seed data manually
+psql -h localhost -U platform -d mcp_platform -f dev/seed.sql
+```
+
+## Mock Conformance
+
+Verify that MSW mock data matches the Go API Swagger spec:
+
+```bash
+make mock-check
+```
+
+This generates TypeScript types from the Swagger spec and runs conformance tests against the mock data.
 
 ## ACME Data Model
 

--- a/dev/platform.yaml
+++ b/dev/platform.yaml
@@ -176,8 +176,8 @@ toolkits:
         enabled: true
         endpoint: "http://localhost:9000"
         region: "us-east-1"
-        access_key_id: "minioadmin"
-        secret_access_key: "minioadmin"
+        access_key_id: "dev-access-key"
+        secret_access_key: "dev-secret-key"
         force_path_style: true
 
 # Providers: noop (no external services)

--- a/dev/seaweedfs-s3.json
+++ b/dev/seaweedfs-s3.json
@@ -4,8 +4,8 @@
       "name": "admin",
       "credentials": [
         {
-          "accessKey": "minioadmin",
-          "secretKey": "minioadmin"
+          "accessKey": "dev-access-key",
+          "secretKey": "dev-secret-key"
         }
       ],
       "actions": ["Admin", "Read", "Write", "List", "Tagging"]

--- a/dev/seed-content/asset-001.html
+++ b/dev/seed-content/asset-001.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f8fafc; color: #1e293b; padding: 24px; }
+  h1 { font-size: 20px; font-weight: 600; margin-bottom: 4px; }
+  .subtitle { color: #64748b; font-size: 13px; margin-bottom: 20px; }
+  .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-bottom: 24px; }
+  .card { background: white; border-radius: 12px; padding: 20px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+  .card .label { font-size: 12px; color: #64748b; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card .value { font-size: 28px; font-weight: 700; margin-top: 4px; }
+  .card .change { font-size: 12px; margin-top: 4px; }
+  .up { color: #16a34a; }
+  .down { color: #dc2626; }
+  .chart-area { background: white; border-radius: 12px; padding: 20px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+  .chart-title { font-size: 14px; font-weight: 600; margin-bottom: 12px; }
+  .bar-chart { display: flex; align-items: flex-end; gap: 8px; height: 160px; }
+  .bar-group { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 4px; }
+  .bar { width: 100%; background: #3b82f6; border-radius: 4px 4px 0 0; min-height: 4px; transition: height 0.3s; }
+  .bar:hover { background: #2563eb; }
+  .bar-label { font-size: 10px; color: #64748b; }
+  .bar-value { font-size: 10px; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; margin-top: 24px; background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+  th { background: #f1f5f9; text-align: left; padding: 10px 16px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: #64748b; }
+  td { padding: 10px 16px; font-size: 13px; border-top: 1px solid #f1f5f9; }
+  tr:hover td { background: #f8fafc; }
+</style>
+</head>
+<body>
+<h1>Weekly Revenue Dashboard</h1>
+<p class="subtitle">Week of Mar 22 – Mar 28, 2026</p>
+<div class="grid">
+  <div class="card">
+    <div class="label">Total Revenue</div>
+    <div class="value">$2.4M</div>
+    <div class="change up">↑ 8.3% vs last week</div>
+  </div>
+  <div class="card">
+    <div class="label">Transactions</div>
+    <div class="value">48,291</div>
+    <div class="change up">↑ 3.1% vs last week</div>
+  </div>
+  <div class="card">
+    <div class="label">Avg Order Value</div>
+    <div class="value">$49.70</div>
+    <div class="change up">↑ 5.0% vs last week</div>
+  </div>
+</div>
+<div class="chart-area">
+  <div class="chart-title">Daily Revenue</div>
+  <div class="bar-chart">
+    <div class="bar-group"><div class="bar-value">$310K</div><div class="bar" style="height:78%"></div><div class="bar-label">Mon</div></div>
+    <div class="bar-group"><div class="bar-value">$345K</div><div class="bar" style="height:86%"></div><div class="bar-label">Tue</div></div>
+    <div class="bar-group"><div class="bar-value">$328K</div><div class="bar" style="height:82%"></div><div class="bar-label">Wed</div></div>
+    <div class="bar-group"><div class="bar-value">$362K</div><div class="bar" style="height:90%"></div><div class="bar-label">Thu</div></div>
+    <div class="bar-group"><div class="bar-value">$398K</div><div class="bar" style="height:100%"></div><div class="bar-label">Fri</div></div>
+    <div class="bar-group"><div class="bar-value">$380K</div><div class="bar" style="height:95%"></div><div class="bar-label">Sat</div></div>
+    <div class="bar-group"><div class="bar-value">$277K</div><div class="bar" style="height:69%"></div><div class="bar-label">Sun</div></div>
+  </div>
+</div>
+<table>
+  <thead><tr><th>Store</th><th>Revenue</th><th>Transactions</th><th>Avg Order</th><th>vs Last Week</th></tr></thead>
+  <tbody>
+    <tr><td>Downtown Flagship</td><td>$412,500</td><td>6,840</td><td>$60.31</td><td class="up">+12.4%</td></tr>
+    <tr><td>Mall of America</td><td>$385,200</td><td>7,120</td><td>$54.10</td><td class="up">+9.1%</td></tr>
+    <tr><td>Westfield Center</td><td>$298,700</td><td>5,480</td><td>$54.51</td><td class="up">+6.8%</td></tr>
+    <tr><td>Airport Terminal B</td><td>$276,400</td><td>4,920</td><td>$56.18</td><td class="down">-2.3%</td></tr>
+    <tr><td>University District</td><td>$245,100</td><td>5,890</td><td>$41.61</td><td class="up">+4.5%</td></tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/dev/seed-content/asset-002.csv
+++ b/dev/seed-content/asset-002.csv
@@ -1,0 +1,21 @@
+sku,product_name,category,current_stock,reorder_point,reorder_qty,stock_status,risk_score,last_restock,warehouse
+SKU-1001,Premium Wireless Headphones,Electronics,342,150,500,OK,0.12,2026-03-15,West
+SKU-1002,Organic Coffee Beans 1lb,Grocery,89,200,600,LOW,0.78,2026-03-10,Central
+SKU-1003,Running Shoes Pro X,Footwear,523,100,300,OK,0.05,2026-03-20,East
+SKU-1004,Stainless Steel Water Bottle,Home,1205,400,1000,OK,0.02,2026-03-18,West
+SKU-1005,Yoga Mat Premium,Sports,45,100,250,CRITICAL,0.92,2026-02-28,Central
+SKU-1006,Bluetooth Speaker Mini,Electronics,678,200,500,OK,0.08,2026-03-22,East
+SKU-1007,Protein Bar Variety 12pk,Grocery,156,300,800,LOW,0.65,2026-03-12,Central
+SKU-1008,Hiking Backpack 40L,Outdoor,234,80,200,OK,0.15,2026-03-19,West
+SKU-1009,LED Desk Lamp,Home,890,250,600,OK,0.04,2026-03-25,East
+SKU-1010,Thermal Jacket,Apparel,12,50,150,CRITICAL,0.95,2026-02-15,West
+SKU-1011,Wireless Charging Pad,Electronics,445,150,400,OK,0.10,2026-03-21,Central
+SKU-1012,Organic Green Tea 50ct,Grocery,267,200,500,OK,0.18,2026-03-17,East
+SKU-1013,Trail Running Shoes,Footwear,178,100,300,OK,0.22,2026-03-14,West
+SKU-1014,Cast Iron Skillet 12in,Home,356,120,300,OK,0.09,2026-03-23,Central
+SKU-1015,Resistance Band Set,Sports,67,100,250,LOW,0.71,2026-03-08,East
+SKU-1016,Noise Canceling Earbuds,Electronics,298,175,450,OK,0.16,2026-03-20,West
+SKU-1017,Almond Butter Organic,Grocery,34,150,400,CRITICAL,0.88,2026-03-01,Central
+SKU-1018,Winter Hiking Boots,Footwear,89,60,150,OK,0.25,2026-03-16,East
+SKU-1019,Smart Home Hub,Electronics,512,200,500,OK,0.07,2026-03-24,West
+SKU-1020,Camping Tent 4-Person,Outdoor,145,50,120,OK,0.13,2026-03-19,Central

--- a/dev/seed-content/asset-003.jsx
+++ b/dev/seed-content/asset-003.jsx
@@ -1,0 +1,57 @@
+function StoreComparison() {
+  const stores = [
+    { name: "Downtown Flagship", revenue: 412500, traffic: 12400, conversion: 55.2, trend: "up" },
+    { name: "Mall of America", revenue: 385200, traffic: 15800, conversion: 45.1, trend: "up" },
+    { name: "Westfield Center", revenue: 298700, traffic: 9200, conversion: 59.6, trend: "up" },
+    { name: "Airport Terminal B", revenue: 276400, traffic: 18300, conversion: 26.9, trend: "down" },
+    { name: "University District", revenue: 245100, traffic: 11500, conversion: 51.2, trend: "up" },
+    { name: "Harbor Mall", revenue: 234800, traffic: 8900, conversion: 52.8, trend: "flat" },
+    { name: "Tech Park Plaza", revenue: 221300, traffic: 7600, conversion: 64.8, trend: "up" },
+    { name: "Suburban Square", revenue: 198500, traffic: 6800, conversion: 58.4, trend: "down" },
+    { name: "Riverside Walk", revenue: 187200, traffic: 7200, conversion: 52.0, trend: "up" },
+    { name: "Market Street", revenue: 176900, traffic: 8100, conversion: 43.7, trend: "flat" },
+  ];
+
+  const maxRevenue = Math.max(...stores.map(s => s.revenue));
+
+  const fmt = (n) => "$" + (n / 1000).toFixed(0) + "K";
+  const trendIcon = (t) => t === "up" ? "↑" : t === "down" ? "↓" : "→";
+  const trendColor = (t) => t === "up" ? "#16a34a" : t === "down" ? "#dc2626" : "#64748b";
+
+  return (
+    <div style={{ fontFamily: "-apple-system, sans-serif", padding: 24, background: "#f8fafc", minHeight: "100%" }}>
+      <h2 style={{ fontSize: 18, fontWeight: 600, marginBottom: 4 }}>Store Performance Comparison</h2>
+      <p style={{ fontSize: 13, color: "#64748b", marginBottom: 20 }}>Top 10 stores — Week ending Mar 28, 2026</p>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {stores.map((store, i) => (
+          <div key={i} style={{ display: "flex", alignItems: "center", gap: 12, background: "white", borderRadius: 8, padding: "12px 16px", boxShadow: "0 1px 2px rgba(0,0,0,0.06)" }}>
+            <span style={{ width: 24, fontSize: 13, fontWeight: 600, color: "#64748b" }}>#{i + 1}</span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 14, fontWeight: 500, marginBottom: 4 }}>{store.name}</div>
+              <div style={{ height: 6, background: "#e2e8f0", borderRadius: 3, overflow: "hidden" }}>
+                <div style={{ height: "100%", width: `${(store.revenue / maxRevenue) * 100}%`, background: "#3b82f6", borderRadius: 3 }} />
+              </div>
+            </div>
+            <div style={{ textAlign: "right", minWidth: 80 }}>
+              <div style={{ fontSize: 14, fontWeight: 600 }}>{fmt(store.revenue)}</div>
+              <div style={{ fontSize: 11, color: "#64748b" }}>revenue</div>
+            </div>
+            <div style={{ textAlign: "right", minWidth: 60 }}>
+              <div style={{ fontSize: 14 }}>{(store.traffic / 1000).toFixed(1)}K</div>
+              <div style={{ fontSize: 11, color: "#64748b" }}>traffic</div>
+            </div>
+            <div style={{ textAlign: "right", minWidth: 50 }}>
+              <div style={{ fontSize: 14 }}>{store.conversion}%</div>
+              <div style={{ fontSize: 11, color: "#64748b" }}>conv.</div>
+            </div>
+            <span style={{ fontSize: 16, color: trendColor(store.trend), width: 20, textAlign: "center" }}>
+              {trendIcon(store.trend)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default StoreComparison;

--- a/dev/seed-content/asset-004.md
+++ b/dev/seed-content/asset-004.md
@@ -1,0 +1,76 @@
+# Data Pipeline Architecture
+
+## Overview
+
+ACME's data platform ingests from 6 source systems, processes through a multi-layer warehouse, and serves analytics through Trino and the semantic layer.
+
+## Pipeline Flow
+
+```mermaid
+graph LR
+    subgraph Sources
+        POS[POS Systems]
+        ERP[SAP ERP]
+        WEB[Web Analytics]
+        CRM[Salesforce CRM]
+        INV[Warehouse Mgmt]
+        ML[ML Pipeline]
+    end
+
+    subgraph Ingestion
+        KAF[Kafka]
+        CDC[Debezium CDC]
+    end
+
+    subgraph Processing
+        SP[Spark Jobs]
+        DBT[dbt Models]
+        ICE[Iceberg Tables]
+    end
+
+    subgraph Serving
+        TRI[Trino]
+        DH[DataHub]
+        S3[S3 Data Lake]
+    end
+
+    POS --> KAF
+    ERP --> CDC
+    WEB --> KAF
+    CRM --> CDC
+    INV --> CDC
+    ML --> S3
+
+    KAF --> SP
+    CDC --> SP
+    SP --> ICE
+    ICE --> DBT
+    DBT --> ICE
+
+    ICE --> TRI
+    ICE --> DH
+    ICE --> S3
+```
+
+## Key Schemas
+
+| Schema | Tables | Refresh | Owner |
+|--------|--------|---------|-------|
+| `retail` | daily_sales, store_transactions, price_adjustments | Hourly | Data Engineering |
+| `inventory` | inventory_levels, supply_chain_orders, current_stock (view) | 15 min | Data Engineering |
+| `analytics` | regional_performance, customer_segments | Daily (4am) | Analytics Team |
+| `finance` | revenue_summary, cost_centers, margin_analysis | Daily (6am) | Finance Team |
+
+## SLAs
+
+- **POS → Iceberg**: < 15 minutes (CDC via Debezium)
+- **ERP → Iceberg**: < 1 hour (batch CDC)
+- **dbt models**: Complete by 5:00 AM ET
+- **DataHub metadata sync**: < 30 minutes after schema change
+
+## Data Quality Rules
+
+1. `daily_sales.revenue` must be non-negative
+2. `inventory_levels.current_stock` must be ≥ 0
+3. `store_transactions` must have matching `daily_sales` aggregate within 0.1%
+4. No orphan records in `customer_segments` (FK to `regional_performance`)

--- a/dev/seed-content/asset-005.svg
+++ b/dev/seed-content/asset-005.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" font-family="-apple-system, BlinkMacSystemFont, sans-serif">
+  <defs>
+    <linearGradient id="g1" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#22c55e"/><stop offset="1" stop-color="#16a34a"/></linearGradient>
+    <linearGradient id="g2" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#3b82f6"/><stop offset="1" stop-color="#2563eb"/></linearGradient>
+    <linearGradient id="g3" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#f59e0b"/><stop offset="1" stop-color="#d97706"/></linearGradient>
+    <linearGradient id="g4" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#ef4444"/><stop offset="1" stop-color="#dc2626"/></linearGradient>
+    <linearGradient id="g5" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#8b5cf6"/><stop offset="1" stop-color="#7c3aed"/></linearGradient>
+  </defs>
+  <rect width="800" height="500" fill="#f8fafc" rx="8"/>
+  <text x="32" y="36" font-size="18" font-weight="600" fill="#1e293b">Regional Sales Heatmap</text>
+  <text x="32" y="56" font-size="12" fill="#64748b">Revenue by region and category — Q1 2026 ($K)</text>
+
+  <!-- Column headers -->
+  <text x="220" y="90" font-size="11" fill="#64748b" text-anchor="middle">Electronics</text>
+  <text x="340" y="90" font-size="11" fill="#64748b" text-anchor="middle">Grocery</text>
+  <text x="460" y="90" font-size="11" fill="#64748b" text-anchor="middle">Apparel</text>
+  <text x="580" y="90" font-size="11" fill="#64748b" text-anchor="middle">Home</text>
+  <text x="700" y="90" font-size="11" fill="#64748b" text-anchor="middle">Sports</text>
+
+  <!-- Row: Northeast -->
+  <text x="140" y="140" font-size="13" fill="#1e293b" text-anchor="end">Northeast</text>
+  <rect x="165" y="105" width="110" height="50" rx="6" fill="#16a34a" opacity="0.9"/><text x="220" y="135" font-size="14" fill="white" text-anchor="middle" font-weight="600">$842</text>
+  <rect x="285" y="105" width="110" height="50" rx="6" fill="#16a34a" opacity="0.7"/><text x="340" y="135" font-size="14" fill="white" text-anchor="middle" font-weight="600">$634</text>
+  <rect x="405" y="105" width="110" height="50" rx="6" fill="#3b82f6" opacity="0.8"/><text x="460" y="135" font-size="14" fill="white" text-anchor="middle" font-weight="600">$521</text>
+  <rect x="525" y="105" width="110" height="50" rx="6" fill="#3b82f6" opacity="0.6"/><text x="580" y="135" font-size="14" fill="white" text-anchor="middle" font-weight="600">$412</text>
+  <rect x="645" y="105" width="110" height="50" rx="6" fill="#f59e0b" opacity="0.7"/><text x="700" y="135" font-size="14" fill="white" text-anchor="middle" font-weight="600">$298</text>
+
+  <!-- Row: Southeast -->
+  <text x="140" y="210" font-size="13" fill="#1e293b" text-anchor="end">Southeast</text>
+  <rect x="165" y="175" width="110" height="50" rx="6" fill="#3b82f6" opacity="0.8"/><text x="220" y="205" font-size="14" fill="white" text-anchor="middle" font-weight="600">$567</text>
+  <rect x="285" y="175" width="110" height="50" rx="6" fill="#16a34a" opacity="0.85"/><text x="340" y="205" font-size="14" fill="white" text-anchor="middle" font-weight="600">$712</text>
+  <rect x="405" y="175" width="110" height="50" rx="6" fill="#3b82f6" opacity="0.7"/><text x="460" y="205" font-size="14" fill="white" text-anchor="middle" font-weight="600">$489</text>
+  <rect x="525" y="175" width="110" height="50" rx="6" fill="#f59e0b" opacity="0.6"/><text x="580" y="205" font-size="14" fill="white" text-anchor="middle" font-weight="600">$334</text>
+  <rect x="645" y="175" width="110" height="50" rx="6" fill="#f59e0b" opacity="0.8"/><text x="700" y="205" font-size="14" fill="white" text-anchor="middle" font-weight="600">$356</text>
+
+  <!-- Row: Midwest -->
+  <text x="140" y="280" font-size="13" fill="#1e293b" text-anchor="end">Midwest</text>
+  <rect x="165" y="245" width="110" height="50" rx="6" fill="#3b82f6" opacity="0.6"/><text x="220" y="275" font-size="14" fill="white" text-anchor="middle" font-weight="600">$445</text>
+  <rect x="285" y="245" width="110" height="50" rx="6" fill="#3b82f6" opacity="0.7"/><text x="340" y="275" font-size="14" fill="white" text-anchor="middle" font-weight="600">$523</text>
+  <rect x="405" y="245" width="110" height="50" rx="6" fill="#f59e0b" opacity="0.6"/><text x="460" y="275" font-size="14" fill="white" text-anchor="middle" font-weight="600">$312</text>
+  <rect x="525" y="245" width="110" height="50" rx="6" fill="#3b82f6" opacity="0.6"/><text x="580" y="275" font-size="14" fill="white" text-anchor="middle" font-weight="600">$401</text>
+  <rect x="645" y="245" width="110" height="50" rx="6" fill="#f59e0b" opacity="0.5"/><text x="700" y="275" font-size="14" fill="white" text-anchor="middle" font-weight="600">$245</text>
+
+  <!-- Row: West -->
+  <text x="140" y="350" font-size="13" fill="#1e293b" text-anchor="end">West</text>
+  <rect x="165" y="315" width="110" height="50" rx="6" fill="#16a34a" opacity="0.95"/><text x="220" y="345" font-size="14" fill="white" text-anchor="middle" font-weight="600">$923</text>
+  <rect x="285" y="315" width="110" height="50" rx="6" fill="#3b82f6" opacity="0.65"/><text x="340" y="345" font-size="14" fill="white" text-anchor="middle" font-weight="600">$478</text>
+  <rect x="405" y="315" width="110" height="50" rx="6" fill="#16a34a" opacity="0.75"/><text x="460" y="345" font-size="14" fill="white" text-anchor="middle" font-weight="600">$612</text>
+  <rect x="525" y="315" width="110" height="50" rx="6" fill="#3b82f6" opacity="0.75"/><text x="580" y="345" font-size="14" fill="white" text-anchor="middle" font-weight="600">$534</text>
+  <rect x="645" y="315" width="110" height="50" rx="6" fill="#3b82f6" opacity="0.7"/><text x="700" y="345" font-size="14" fill="white" text-anchor="middle" font-weight="600">$467</text>
+
+  <!-- Row: Southwest -->
+  <text x="140" y="420" font-size="13" fill="#1e293b" text-anchor="end">Southwest</text>
+  <rect x="165" y="385" width="110" height="50" rx="6" fill="#f59e0b" opacity="0.7"/><text x="220" y="415" font-size="14" fill="white" text-anchor="middle" font-weight="600">$378</text>
+  <rect x="285" y="385" width="110" height="50" rx="6" fill="#3b82f6" opacity="0.6"/><text x="340" y="415" font-size="14" fill="white" text-anchor="middle" font-weight="600">$445</text>
+  <rect x="405" y="385" width="110" height="50" rx="6" fill="#f59e0b" opacity="0.5"/><text x="460" y="415" font-size="14" fill="white" text-anchor="middle" font-weight="600">$267</text>
+  <rect x="525" y="385" width="110" height="50" rx="6" fill="#f59e0b" opacity="0.55"/><text x="580" y="415" font-size="14" fill="white" text-anchor="middle" font-weight="600">$289</text>
+  <rect x="645" y="385" width="110" height="50" rx="6" fill="#ef4444" opacity="0.6"/><text x="700" y="415" font-size="14" fill="white" text-anchor="middle" font-weight="600">$189</text>
+
+  <!-- Legend -->
+  <rect x="165" y="460" width="16" height="12" rx="2" fill="#16a34a"/><text x="186" y="471" font-size="10" fill="#64748b">$600K+</text>
+  <rect x="260" y="460" width="16" height="12" rx="2" fill="#3b82f6"/><text x="281" y="471" font-size="10" fill="#64748b">$400–599K</text>
+  <rect x="380" y="460" width="16" height="12" rx="2" fill="#f59e0b"/><text x="401" y="471" font-size="10" fill="#64748b">$200–399K</text>
+  <rect x="500" y="460" width="16" height="12" rx="2" fill="#ef4444"/><text x="521" y="471" font-size="10" fill="#64748b">&lt;$200K</text>
+</svg>

--- a/dev/seed-content/asset-006.html
+++ b/dev/seed-content/asset-006.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f8fafc; color: #1e293b; padding: 24px; }
+  h1 { font-size: 20px; font-weight: 600; margin-bottom: 4px; }
+  .subtitle { color: #64748b; font-size: 13px; margin-bottom: 20px; }
+  .grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 24px; }
+  .metric { background: white; border-radius: 10px; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+  .metric .label { font-size: 11px; color: #64748b; text-transform: uppercase; letter-spacing: 0.05em; }
+  .metric .value { font-size: 24px; font-weight: 700; margin-top: 2px; }
+  .metric .sub { font-size: 11px; margin-top: 2px; }
+  .up { color: #16a34a; } .down { color: #dc2626; } .flat { color: #64748b; }
+  .section { background: white; border-radius: 10px; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); margin-bottom: 16px; }
+  .section-title { font-size: 14px; font-weight: 600; margin-bottom: 12px; }
+  table { width: 100%; border-collapse: collapse; }
+  th { text-align: left; padding: 8px 12px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: #64748b; border-bottom: 2px solid #e2e8f0; }
+  td { padding: 8px 12px; font-size: 13px; border-bottom: 1px solid #f1f5f9; }
+  .bar-bg { height: 8px; background: #e2e8f0; border-radius: 4px; margin-top: 4px; }
+  .bar-fill { height: 100%; border-radius: 4px; }
+</style>
+</head>
+<body>
+<h1>Q3 Financial Summary</h1>
+<p class="subtitle">FY2026 Q3 (Oct 1 – Dec 31, 2025) — ACME Corporation</p>
+
+<div class="grid">
+  <div class="metric">
+    <div class="label">Revenue</div>
+    <div class="value">$28.4M</div>
+    <div class="sub up">↑ 11.2% YoY</div>
+  </div>
+  <div class="metric">
+    <div class="label">Gross Margin</div>
+    <div class="value">42.3%</div>
+    <div class="sub up">↑ 1.8pp YoY</div>
+  </div>
+  <div class="metric">
+    <div class="label">Operating Income</div>
+    <div class="value">$3.8M</div>
+    <div class="sub up">↑ 18.7% YoY</div>
+  </div>
+  <div class="metric">
+    <div class="label">Net Income</div>
+    <div class="value">$2.6M</div>
+    <div class="sub up">↑ 14.2% YoY</div>
+  </div>
+</div>
+
+<div class="section">
+  <div class="section-title">Revenue by Category</div>
+  <table>
+    <thead><tr><th>Category</th><th>Revenue</th><th>% of Total</th><th>YoY Change</th><th>Margin</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>Electronics</td><td>$9.2M</td>
+        <td><div class="bar-bg"><div class="bar-fill" style="width:32.4%;background:#3b82f6"></div></div>32.4%</td>
+        <td class="up">+15.3%</td><td>38.1%</td>
+      </tr>
+      <tr>
+        <td>Grocery</td><td>$7.8M</td>
+        <td><div class="bar-bg"><div class="bar-fill" style="width:27.5%;background:#22c55e"></div></div>27.5%</td>
+        <td class="up">+8.6%</td><td>31.2%</td>
+      </tr>
+      <tr>
+        <td>Apparel</td><td>$5.1M</td>
+        <td><div class="bar-bg"><div class="bar-fill" style="width:18%;background:#f59e0b"></div></div>18.0%</td>
+        <td class="up">+12.1%</td><td>52.4%</td>
+      </tr>
+      <tr>
+        <td>Home &amp; Living</td><td>$3.8M</td>
+        <td><div class="bar-bg"><div class="bar-fill" style="width:13.4%;background:#8b5cf6"></div></div>13.4%</td>
+        <td class="up">+6.2%</td><td>44.8%</td>
+      </tr>
+      <tr>
+        <td>Sports &amp; Outdoor</td><td>$2.5M</td>
+        <td><div class="bar-bg"><div class="bar-fill" style="width:8.8%;background:#ec4899"></div></div>8.8%</td>
+        <td class="down">-2.4%</td><td>46.3%</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="section">
+  <div class="section-title">Quarterly Trend (FY2026)</div>
+  <table>
+    <thead><tr><th>Quarter</th><th>Revenue</th><th>Gross Margin</th><th>Op. Income</th><th>Stores</th></tr></thead>
+    <tbody>
+      <tr><td>Q1 (Feb–Apr)</td><td>$24.1M</td><td>39.8%</td><td>$2.9M</td><td>985</td></tr>
+      <tr><td>Q2 (May–Jul)</td><td>$26.7M</td><td>41.1%</td><td>$3.4M</td><td>992</td></tr>
+      <tr><td><strong>Q3 (Oct–Dec)</strong></td><td><strong>$28.4M</strong></td><td><strong>42.3%</strong></td><td><strong>$3.8M</strong></td><td><strong>1,000</strong></td></tr>
+      <tr style="color:#94a3b8"><td>Q4 (Nov–Jan) est.</td><td>$31.2M</td><td>43.0%</td><td>$4.2M</td><td>1,008</td></tr>
+    </tbody>
+  </table>
+</div>
+</body>
+</html>

--- a/dev/seed-s3.sh
+++ b/dev/seed-s3.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Upload seed asset content to SeaweedFS and the portal API.
+# Called by start.sh after SQL seed completes.
+set -euo pipefail
+
+API="http://localhost:8080"
+API_KEY="acme-dev-key-2024"
+CONTENT_DIR="dev/seed-content"
+
+# Upload content via the portal API (handles S3 + version tracking)
+# Bucket must already exist (created by start.sh during Docker startup).
+upload() {
+  local id="$1" file="$2"
+  curl -sf -X PUT "$API/api/v1/portal/assets/$id/content" \
+    -H "X-API-Key: $API_KEY" \
+    --data-binary "@$file" > /dev/null
+}
+
+upload "asset-001" "$CONTENT_DIR/asset-001.html"
+upload "asset-002" "$CONTENT_DIR/asset-002.csv"
+upload "asset-003" "$CONTENT_DIR/asset-003.jsx"
+upload "asset-004" "$CONTENT_DIR/asset-004.md"
+upload "asset-005" "$CONTENT_DIR/asset-005.svg"
+upload "asset-006" "$CONTENT_DIR/asset-006.html"

--- a/dev/seed.sql
+++ b/dev/seed.sql
@@ -1,27 +1,28 @@
 -- ACME Corporation Seed Data
 --
 -- Run AFTER the Go server has started once (to create the schema via migrations).
--- Usage: psql -h localhost -U platform -d mcp_platform -f dev/seed.sql
+-- Usage: docker exec acme-dev-postgres psql -U platform -d mcp_platform -f /tmp/seed.sql
 --
--- This seeds ~5,000 audit events over the past 7 days, 8 knowledge insights,
--- and 2 knowledge changesets with ACME Corporation retail data.
+-- Seeds:
+--   ~5,000 audit events over the past 7 days
+--   8 knowledge insights in various states
+--   2 knowledge changesets (1 applied, 1 rolled back)
+--   6 portal assets with versions and shares
 
 -- ============================================================================
 -- Audit Events (~5,000 over 7 days)
 -- ============================================================================
 
--- Helper: weighted random selection via generate_series
--- Uses a deterministic approach with modular arithmetic for reproducibility.
-
 INSERT INTO audit_logs (
-  request_id, session_id, user_id, user_email, persona,
+  id, request_id, session_id, user_id, user_email, persona,
   tool_name, toolkit_kind, toolkit_name, connection,
   parameters, success, error_message,
   duration_ms, response_chars, request_chars, content_blocks,
   transport, source, enrichment_applied, authorized,
-  created_at
+  "timestamp", created_date
 )
 SELECT
+  'evt-' || lpad(n::text, 8, '0'),
   'req-' || lpad(n::text, 8, '0'),
   'sess-' || ((n % 50) + 100),
   u.email,
@@ -31,7 +32,6 @@ SELECT
   t.toolkit_kind,
   t.toolkit_name,
   t.connection,
-  -- Realistic parameters as JSONB
   CASE t.toolkit_kind
     WHEN 'trino' THEN jsonb_build_object(
       'catalog', (ARRAY['iceberg','hive','memory'])[1 + (n % 3)],
@@ -46,9 +46,7 @@ SELECT
       'prefix', (ARRAY['raw/2024/','processed/daily/','exports/regional/','ml/features/'])[1 + (n % 4)]
     )
   END,
-  -- 96.3% success rate
   (n % 27) != 0,
-  -- Error messages for failures
   CASE WHEN (n % 27) = 0 THEN
     CASE t.toolkit_kind
       WHEN 'trino' THEN (ARRAY[
@@ -70,41 +68,38 @@ SELECT
       ])[1 + (n % 3)]
     END
   ELSE '' END,
-  -- Duration varies by tool type
   CASE t.toolkit_kind
     WHEN 'trino' THEN 45 + (n * 7 % 2755)
     WHEN 'datahub' THEN 25 + (n * 3 % 325)
     WHEN 's3' THEN 15 + (n * 5 % 485)
   END,
-  200 + (n * 13 % 11800),  -- response_chars
-  50 + (n * 7 % 750),      -- request_chars
-  1 + (n % 5),             -- content_blocks
+  200 + (n * 13 % 11800),
+  50 + (n * 7 % 750),
+  1 + (n % 5),
   'http',
   'mcp',
-  (n % 5) != 0,            -- 80% enrichment rate
+  (n % 5) != 0,
   true,
-  -- Business-hours weighted timestamps over past 7 days
-  -- Peak at 9-11am and 2-4pm, minimal overnight
+  -- timestamp: business-hours weighted over past 7 days
   NOW() - (
-    -- Day offset (0-6 days ago)
     ((n % 7) || ' days')::interval
-    -- Hour offset: weighted toward business hours
     + (CASE
-        WHEN n % 20 < 1  THEN (n % 3)       -- 5%: midnight-2am
-        WHEN n % 20 < 2  THEN 6 + (n % 2)   -- 5%: 6-7am
-        WHEN n % 20 < 5  THEN 8 + (n % 2)   -- 15%: 8-9am
-        WHEN n % 20 < 9  THEN 9 + (n % 3)   -- 20%: 9-11am
-        WHEN n % 20 < 11 THEN 11 + (n % 2)  -- 10%: 11am-12pm
-        WHEN n % 20 < 15 THEN 13 + (n % 3)  -- 20%: 1-3pm
-        WHEN n % 20 < 18 THEN 14 + (n % 3)  -- 15%: 2-4pm
-        ELSE 17 + (n % 3)                    -- 10%: 5-7pm
+        WHEN n % 20 < 1  THEN (n % 3)
+        WHEN n % 20 < 2  THEN 6 + (n % 2)
+        WHEN n % 20 < 5  THEN 8 + (n % 2)
+        WHEN n % 20 < 9  THEN 9 + (n % 3)
+        WHEN n % 20 < 11 THEN 11 + (n % 2)
+        WHEN n % 20 < 15 THEN 13 + (n % 3)
+        WHEN n % 20 < 18 THEN 14 + (n % 3)
+        ELSE 17 + (n % 3)
       END || ' hours')::interval
     + ((n * 17 % 60) || ' minutes')::interval
     + ((n * 31 % 60) || ' seconds')::interval
-  )
+  ),
+  -- created_date: matches the date portion of timestamp
+  (NOW() - ((n % 7) || ' days')::interval)::date
 FROM
   generate_series(1, 5000) AS n,
-  -- Weighted user selection: data engineers are most active
   LATERAL (
     SELECT email, persona FROM (VALUES
       ('sarah.chen@example.com',       'admin',              8),
@@ -124,7 +119,6 @@ FROM
     OFFSET (n * 7 % 12)
     LIMIT 1
   ) AS u,
-  -- Weighted tool selection: trino_query is most common
   LATERAL (
     SELECT tool_name, toolkit_kind, toolkit_name, connection FROM (VALUES
       ('trino_query',              'trino',   'acme-warehouse',        'acme-warehouse',         22),
@@ -150,98 +144,97 @@ FROM
 -- ============================================================================
 
 INSERT INTO knowledge_insights (
+  id, session_id, captured_by, persona,
   category, insight_text, confidence, entity_urns, related_columns,
-  suggested_actions, status, review_notes, created_at
+  suggested_actions, status, reviewed_by, review_notes, applied_by, changeset_ref,
+  created_at
 ) VALUES
 (
+  'ins-001', 'sess-101', 'marcus.johnson@example.com', 'data-engineer',
   'business_context',
   'The daily_sales table in the retail schema is the primary source of truth for all revenue reporting. The revenue column uses post-discount, pre-tax amounts in USD.',
   'high',
-  ARRAY['urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)'],
+  '["urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)"]'::jsonb,
   '[{"urn": "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)", "column": "revenue", "relevance": "primary"}]'::jsonb,
   '[{"action_type": "update_description", "target": "iceberg.retail.daily_sales.revenue", "detail": "Post-discount, pre-tax revenue in USD"}]'::jsonb,
-  'approved',
-  'Verified with finance team - this is correct.',
+  'approved', 'sarah.chen@example.com', 'Verified with finance team - this is correct.', '', '',
   NOW() - interval '5 days'
 ),
 (
+  'ins-002', 'sess-102', 'rachel.thompson@example.com', 'inventory-analyst',
   'data_quality',
   'The inventory_levels table has NULL values in the reorder_point column for approximately 12% of SKUs, primarily in the seasonal-goods category.',
   'high',
-  ARRAY['urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.inventory.inventory_levels,PROD)'],
+  '["urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.inventory.inventory_levels,PROD)"]'::jsonb,
   '[{"urn": "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.inventory.inventory_levels,PROD)", "column": "reorder_point", "relevance": "primary"}]'::jsonb,
   '[{"action_type": "add_tag", "target": "iceberg.inventory.inventory_levels.reorder_point", "detail": "has_nulls_seasonal"}]'::jsonb,
-  'approved',
-  'Known issue - seasonal items have dynamic reorder points calculated separately.',
+  'approved', 'sarah.chen@example.com', 'Known issue - seasonal items have dynamic reorder points calculated separately.', '', '',
   NOW() - interval '4 days'
 ),
 (
-  'usage_tip',
+  'ins-003', 'sess-103', 'amanda.lee@example.com', 'data-engineer',
+  'usage_guidance',
   'When querying regional_performance, always filter by fiscal_quarter rather than calendar_quarter. ACME fiscal year starts February 1.',
   'high',
-  ARRAY['urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.analytics.regional_performance,PROD)'],
+  '["urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.analytics.regional_performance,PROD)"]'::jsonb,
   '[]'::jsonb,
   '[{"action_type": "update_description", "target": "iceberg.analytics.regional_performance", "detail": "Uses ACME fiscal calendar (FY starts Feb 1). Filter by fiscal_quarter for accurate period comparisons."}]'::jsonb,
-  'applied',
-  'Applied to DataHub description.',
+  'applied', 'sarah.chen@example.com', 'Applied to DataHub description.', 'sarah.chen@example.com', 'cs-001',
   NOW() - interval '3 days'
 ),
 (
+  'ins-004', 'sess-104', 'lisa.chang@example.com', 'data-engineer',
   'relationship',
   'The customer_segments table is refreshed daily from the ML pipeline and feeds into regional_performance via a nightly ETL job. Segments are based on 90-day purchase history.',
   'medium',
-  ARRAY[
-    'urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.analytics.customer_segments,PROD)',
-    'urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.analytics.regional_performance,PROD)'
-  ],
+  '["urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.analytics.customer_segments,PROD)", "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.analytics.regional_performance,PROD)"]'::jsonb,
   '[]'::jsonb,
   '[]'::jsonb,
-  'pending',
-  NULL,
+  'pending', '', '', '', '',
   NOW() - interval '2 days'
 ),
 (
+  'ins-005', 'sess-105', 'marcus.johnson@example.com', 'data-engineer',
   'correction',
   'The store_transactions.discount_pct column is stored as a decimal (0.15 = 15%), not as a percentage integer. Several downstream reports incorrectly multiply by 100.',
   'high',
-  ARRAY['urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.store_transactions,PROD)'],
+  '["urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.store_transactions,PROD)"]'::jsonb,
   '[{"urn": "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.store_transactions,PROD)", "column": "discount_pct", "relevance": "primary"}]'::jsonb,
   '[{"action_type": "update_description", "target": "iceberg.retail.store_transactions.discount_pct", "detail": "Decimal format: 0.15 means 15% discount. Do NOT multiply by 100."}]'::jsonb,
-  'pending',
-  NULL,
+  'pending', '', '', '', '',
   NOW() - interval '1 day'
 ),
 (
+  'ins-006', 'sess-106', 'rachel.thompson@example.com', 'inventory-analyst',
   'business_context',
   'Supply chain orders with status BACKORDER should be excluded from current inventory calculations. They represent items ordered but not yet received from vendors.',
   'high',
-  ARRAY['urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.inventory.supply_chain_orders,PROD)'],
+  '["urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.inventory.supply_chain_orders,PROD)"]'::jsonb,
   '[{"urn": "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.inventory.supply_chain_orders,PROD)", "column": "status", "relevance": "primary"}]'::jsonb,
   '[]'::jsonb,
-  'applied',
-  'Added as a data quality rule in the enrichment layer.',
+  'applied', 'sarah.chen@example.com', 'Added as a data quality rule in the enrichment layer.', 'sarah.chen@example.com', 'cs-002',
   NOW() - interval '6 days'
 ),
 (
+  'ins-007', 'sess-107', 'emily.watson@example.com', 'inventory-analyst',
   'data_quality',
   'The price_adjustments table contains duplicate entries for Black Friday 2024 promotions (Nov 29). Use DISTINCT on (store_id, sku, effective_date) to deduplicate.',
   'medium',
-  ARRAY['urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.price_adjustments,PROD)'],
+  '["urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.price_adjustments,PROD)"]'::jsonb,
   '[]'::jsonb,
   '[{"action_type": "add_tag", "target": "iceberg.retail.price_adjustments", "detail": "has_duplicates_bf2024"}]'::jsonb,
-  'rejected',
-  'Duplicates were intentional - separate promotional line items for stackable discounts.',
+  'rejected', 'sarah.chen@example.com', 'Duplicates were intentional - separate promotional line items for stackable discounts.', '', '',
   NOW() - interval '5 days'
 ),
 (
-  'usage_tip',
+  'ins-008', 'sess-108', 'amanda.lee@example.com', 'data-engineer',
+  'usage_guidance',
   'For real-time inventory queries, use the inventory.current_stock view instead of inventory_levels. The view joins with pending_receipts and in_transit tables for accurate on-hand counts.',
   'high',
-  ARRAY['urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.inventory.inventory_levels,PROD)'],
+  '["urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.inventory.inventory_levels,PROD)"]'::jsonb,
   '[]'::jsonb,
   '[]'::jsonb,
-  'pending',
-  NULL,
+  'pending', '', '', '', '',
   NOW() - interval '12 hours'
 );
 
@@ -250,23 +243,134 @@ INSERT INTO knowledge_insights (
 -- ============================================================================
 
 INSERT INTO knowledge_changesets (
-  insight_ids, changes, status, applied_by, applied_at, created_at
+  id, target_urn, change_type, previous_value, new_value,
+  source_insight_ids, approved_by, applied_by,
+  rolled_back, rolled_back_by,
+  created_at
 ) VALUES
 (
-  -- Applied changeset for the fiscal calendar insight
-  (SELECT ARRAY[id] FROM knowledge_insights WHERE insight_text LIKE '%fiscal_quarter%' LIMIT 1),
-  '[{"change_type": "update_description", "target": "iceberg.analytics.regional_performance", "detail": "Uses ACME fiscal calendar (FY starts Feb 1). Filter by fiscal_quarter for accurate period comparisons."}]'::jsonb,
-  'applied',
-  'sarah.chen@example.com',
-  NOW() - interval '3 days',
+  'cs-001',
+  'urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.analytics.regional_performance,PROD)',
+  'update_description',
+  '{"description": ""}'::jsonb,
+  '{"description": "Uses ACME fiscal calendar (FY starts Feb 1). Filter by fiscal_quarter for accurate period comparisons."}'::jsonb,
+  '["ins-003"]'::jsonb,
+  'sarah.chen@example.com', 'sarah.chen@example.com',
+  false, '',
   NOW() - interval '3 days'
 ),
 (
-  -- Rolled-back changeset for the supply chain insight
-  (SELECT ARRAY[id] FROM knowledge_insights WHERE insight_text LIKE '%BACKORDER%' LIMIT 1),
-  '[{"change_type": "add_tag", "target": "iceberg.inventory.supply_chain_orders", "detail": "exclude_backorders_from_inventory"}]'::jsonb,
-  'rolled_back',
-  'sarah.chen@example.com',
-  NOW() - interval '5 days',
+  'cs-002',
+  'urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.inventory.supply_chain_orders,PROD)',
+  'add_tag',
+  '{}'::jsonb,
+  '{"tag": "exclude_backorders_from_inventory"}'::jsonb,
+  '["ins-006"]'::jsonb,
+  'sarah.chen@example.com', 'sarah.chen@example.com',
+  true, 'sarah.chen@example.com',
   NOW() - interval '6 days'
+);
+
+-- ============================================================================
+-- Portal Assets (6 assets across different users and content types)
+-- ============================================================================
+
+INSERT INTO portal_assets (
+  id, owner_id, owner_email, name, description, content_type,
+  s3_bucket, s3_key, size_bytes, tags, provenance, session_id,
+  current_version, created_at, updated_at
+) VALUES
+(
+  'asset-001', 'apikey:admin', 'admin@apikey.local',
+  'Weekly Revenue Dashboard',
+  'Interactive dashboard showing revenue trends, top stores, and category breakdown for the current week.',
+  'text/html',
+  'portal-assets', 'portal/apikey:admin/asset-001/v1/content.html', 4280,
+  '["dashboard", "revenue", "weekly"]'::jsonb,
+  '{"tool": "save_artifact", "session_id": "sess-201"}'::jsonb,
+  'sess-201', 1,
+  NOW() - interval '6 days', NOW() - interval '6 days'
+),
+(
+  'asset-002', 'apikey:admin', 'admin@apikey.local',
+  'Inventory Health Report',
+  'CSV export of current inventory levels with reorder alerts and stock-out risk scores.',
+  'text/csv',
+  'portal-assets', 'portal/apikey:admin/asset-002/v1/content.csv', 15720,
+  '["inventory", "report", "csv"]'::jsonb,
+  '{"tool": "save_artifact", "session_id": "sess-202"}'::jsonb,
+  'sess-202', 1,
+  NOW() - interval '5 days', NOW() - interval '5 days'
+),
+(
+  'asset-003', 'apikey:admin', 'admin@apikey.local',
+  'Store Performance Comparison',
+  'Side-by-side comparison of top 10 stores by revenue, foot traffic, and conversion rate.',
+  'text/jsx',
+  'portal-assets', 'portal/apikey:admin/asset-003/v1/content.jsx', 6340,
+  '["stores", "comparison", "interactive"]'::jsonb,
+  '{"tool": "save_artifact", "session_id": "sess-203"}'::jsonb,
+  'sess-203', 1,
+  NOW() - interval '4 days', NOW() - interval '4 days'
+),
+(
+  'asset-004', 'apikey:admin', 'admin@apikey.local',
+  'Data Pipeline Architecture',
+  'Mermaid diagram showing the complete data flow from source systems through the warehouse to analytics.',
+  'text/markdown',
+  'portal-assets', 'portal/apikey:admin/asset-004/v1/content.md', 2890,
+  '["architecture", "documentation", "pipeline"]'::jsonb,
+  '{"tool": "save_artifact", "session_id": "sess-204"}'::jsonb,
+  'sess-204', 1,
+  NOW() - interval '3 days', NOW() - interval '3 days'
+),
+(
+  'asset-005', 'apikey:admin', 'admin@apikey.local',
+  'Regional Sales Heatmap',
+  'SVG heatmap visualization of sales performance by region and product category.',
+  'image/svg+xml',
+  'portal-assets', 'portal/apikey:admin/asset-005/v1/content.svg', 8150,
+  '["visualization", "sales", "regional"]'::jsonb,
+  '{"tool": "save_artifact", "session_id": "sess-205"}'::jsonb,
+  'sess-205', 1,
+  NOW() - interval '2 days', NOW() - interval '2 days'
+),
+(
+  'asset-006', 'apikey:admin', 'admin@apikey.local',
+  'Q3 Financial Summary',
+  'Quarterly financial summary with revenue, margins, and year-over-year comparisons.',
+  'text/html',
+  'portal-assets', 'portal/apikey:admin/asset-006/v1/content.html', 5420,
+  '["finance", "quarterly", "dashboard"]'::jsonb,
+  '{"tool": "save_artifact", "session_id": "sess-206"}'::jsonb,
+  'sess-206', 1,
+  NOW() - interval '1 day', NOW() - interval '1 day'
+);
+
+-- Asset versions (one per asset, matching the current_version=1)
+INSERT INTO portal_asset_versions (
+  id, asset_id, version, s3_key, s3_bucket, content_type, size_bytes,
+  created_by, change_summary, created_at
+) VALUES
+('ver-001', 'asset-001', 1, 'portal/apikey:admin/asset-001/v1/content.html', 'portal-assets', 'text/html',     4280, 'apikey:admin', 'Initial version', NOW() - interval '6 days'),
+('ver-002', 'asset-002', 1, 'portal/apikey:admin/asset-002/v1/content.csv',  'portal-assets', 'text/csv',     15720, 'apikey:admin', 'Initial version', NOW() - interval '5 days'),
+('ver-003', 'asset-003', 1, 'portal/apikey:admin/asset-003/v1/content.jsx',  'portal-assets', 'text/jsx',      6340, 'apikey:admin', 'Initial version', NOW() - interval '4 days'),
+('ver-004', 'asset-004', 1, 'portal/apikey:admin/asset-004/v1/content.md',   'portal-assets', 'text/markdown', 2890, 'apikey:admin', 'Initial version', NOW() - interval '3 days'),
+('ver-005', 'asset-005', 1, 'portal/apikey:admin/asset-005/v1/content.svg',  'portal-assets', 'image/svg+xml', 8150, 'apikey:admin', 'Initial version', NOW() - interval '2 days'),
+('ver-006', 'asset-006', 1, 'portal/apikey:admin/asset-006/v1/content.html', 'portal-assets', 'text/html',     5420, 'apikey:admin', 'Initial version', NOW() - interval '1 day');
+
+-- Shares (2 assets shared: one user share, one public link)
+INSERT INTO portal_shares (
+  id, asset_id, token, created_by, expires_at, created_at,
+  shared_with_user_id, shared_with_email, permission
+) VALUES
+(
+  'share-001', 'asset-001', 'tok-revenue-dash-public',
+  'apikey:admin', NOW() + interval '30 days', NOW() - interval '5 days',
+  NULL, NULL, 'viewer'
+),
+(
+  'share-002', 'asset-002', 'tok-inventory-marcus',
+  'apikey:admin', NULL, NOW() - interval '4 days',
+  'apikey:admin', 'marcus.johnson@example.com', 'viewer'
 );

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+# PIDs to clean up on exit
+PIDS=()
+cleanup() {
+  echo ""
+  echo -e "${YELLOW}Shutting down...${NC}"
+  for pid in "${PIDS[@]+"${PIDS[@]}"}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  docker compose -f dev/docker-compose.yml stop 2>/dev/null || true
+  wait 2>/dev/null || true
+  echo -e "${GREEN}Done.${NC}"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  echo -e "${RED}FAIL: $1${NC}" >&2
+  exit 1
+}
+
+ok() {
+  echo -e "  ${GREEN}✓${NC} $1"
+}
+
+info() {
+  echo -e "  ${CYAN}…${NC} $1"
+}
+
+# ─── Pre-flight checks ──────────────────────────────────────────────
+
+echo -e "${BOLD}Pre-flight checks${NC}"
+
+# Docker
+docker info > /dev/null 2>&1 || fail "Docker is not running. Start Docker Desktop and try again."
+ok "Docker is running"
+
+# Required tools
+which air > /dev/null 2>&1 || fail "air not found. Install: go install github.com/air-verse/air@latest"
+ok "air installed"
+
+# Node modules
+if [ ! -d ui/node_modules ]; then
+  info "Installing UI dependencies..."
+  (cd ui && npm ci --silent)
+fi
+ok "UI dependencies ready"
+
+# Port checks
+for port in 5432 8080 5173 9000; do
+  if lsof -i ":$port" -sTCP:LISTEN > /dev/null 2>&1; then
+    fail "Port $port is already in use. Run 'make dev-down' or stop the conflicting process."
+  fi
+done
+ok "Ports 5432, 8080, 5173, 9000 are free"
+
+echo ""
+
+# ─── Start Docker services ──────────────────────────────────────────
+
+echo -e "${BOLD}Starting Docker services${NC}"
+docker compose -f dev/docker-compose.yml up -d 2>&1 | grep -v "^$" | sed 's/^/  /'
+
+# Wait for PostgreSQL using docker exec (no psql dependency required)
+PG_CONTAINER="acme-dev-postgres"
+info "Waiting for PostgreSQL..."
+for i in $(seq 1 30); do
+  if docker exec "$PG_CONTAINER" pg_isready -U platform -d mcp_platform > /dev/null 2>&1; then
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    fail "PostgreSQL did not become ready within 30s"
+  fi
+  sleep 1
+done
+ok "PostgreSQL ready on :5432"
+
+# Wait for SeaweedFS (S3 returns 403 on GET /, so check for any HTTP response)
+info "Waiting for SeaweedFS..."
+for i in $(seq 1 30); do
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9000/ 2>/dev/null || echo "000")
+  if [ "$HTTP_CODE" != "000" ]; then
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    fail "SeaweedFS did not become ready within 30s"
+  fi
+  sleep 1
+done
+ok "SeaweedFS ready on :9000"
+
+# Create the portal-assets S3 bucket (requires aws CLI)
+if which aws > /dev/null 2>&1; then
+  info "Creating S3 bucket..."
+  for i in $(seq 1 30); do
+    if AWS_ACCESS_KEY_ID=dev-access-key AWS_SECRET_ACCESS_KEY=dev-secret-key \
+       aws --endpoint-url http://localhost:9000 s3 ls s3://portal-assets 2>/dev/null || \
+       AWS_ACCESS_KEY_ID=dev-access-key AWS_SECRET_ACCESS_KEY=dev-secret-key \
+       aws --endpoint-url http://localhost:9000 s3 mb s3://portal-assets 2>/dev/null; then
+      break
+    fi
+    if [ "$i" -eq 30 ]; then
+      fail "Could not create S3 bucket after 30s"
+    fi
+    sleep 1
+  done
+  ok "S3 bucket portal-assets ready"
+else
+  echo -e "  ${YELLOW}⚠${NC} aws CLI not found — S3 bucket not created. Install: brew install awscli"
+fi
+
+echo ""
+
+# ─── Start Go server with hot-reload ────────────────────────────────
+
+echo -e "${BOLD}Starting Go server (air)${NC}"
+AIR_LOG="/tmp/mcp-dev-air.log"
+air -c dev/.air.toml > "$AIR_LOG" 2>&1 &
+PIDS+=($!)
+
+# Wait for server health
+info "Building and starting server (this may take a moment on first run)..."
+for i in $(seq 1 60); do
+  if curl -sf http://localhost:8080/healthz > /dev/null 2>&1; then
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    echo -e "  ${RED}Air log (last 20 lines):${NC}"
+    tail -20 "$AIR_LOG" 2>/dev/null | sed 's/^/    /'
+    fail "Go server did not become healthy within 60s"
+  fi
+  sleep 1
+done
+ok "Go server ready on :8080"
+
+echo ""
+
+# ─── Seed data if needed ────────────────────────────────────────────
+
+# Use docker exec to query PostgreSQL (no psql dependency required)
+COUNT=$(docker exec "$PG_CONTAINER" psql -U platform -d mcp_platform -tAc \
+  "SELECT count(*) FROM audit_logs" 2>/dev/null | tr -d '[:space:]' || echo "0")
+
+if [ "$COUNT" = "0" ]; then
+  echo -e "${BOLD}Seeding development data${NC}"
+  # Seed PostgreSQL
+  docker cp dev/seed.sql "$PG_CONTAINER":/tmp/seed.sql
+  docker exec "$PG_CONTAINER" psql -U platform -d mcp_platform -f /tmp/seed.sql > /dev/null 2>&1
+  ok "Database seeded (audit events, knowledge insights, portal assets)"
+  # Upload asset content via the portal API
+  bash dev/seed-s3.sh
+  ok "Asset content uploaded to S3"
+else
+  ok "Seed data present ($COUNT audit events)"
+fi
+
+echo ""
+
+# ─── Start Vite dev server ──────────────────────────────────────────
+
+echo -e "${BOLD}Starting Vite UI${NC}"
+(cd ui && npm run dev -- --clearScreen false 2>&1) &
+PIDS+=($!)
+
+# Wait for Vite
+for i in $(seq 1 15); do
+  if curl -sf http://localhost:5173/portal/ > /dev/null 2>&1; then
+    break
+  fi
+  if [ "$i" -eq 15 ]; then
+    fail "Vite dev server did not start within 15s"
+  fi
+  sleep 1
+done
+ok "Vite UI ready on :5173"
+
+echo ""
+
+# ─── Ready ──────────────────────────────────────────────────────────
+
+echo -e "${BOLD}${GREEN}══════════════════════════════════════════${NC}"
+echo -e "${BOLD}${GREEN}  Development environment ready${NC}"
+echo -e "${BOLD}${GREEN}══════════════════════════════════════════${NC}"
+echo ""
+echo -e "  Portal UI:  ${CYAN}http://localhost:5173/portal/${NC}"
+echo -e "  Go API:     ${CYAN}http://localhost:8080${NC}"
+echo -e "  API Key:    ${CYAN}acme-dev-key-2024${NC}"
+echo ""
+echo -e "  Go files  → air rebuilds automatically"
+echo -e "  UI files  → Vite hot-reloads automatically"
+echo ""
+echo -e "  Press ${BOLD}Ctrl-C${NC} to stop all services."
+echo ""
+
+# Keep running until interrupted
+wait

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -27,6 +27,7 @@
         "dompurify": "^3.3.2",
         "html2canvas": "^1.4.1",
         "lucide-react": "^0.469.0",
+        "mermaid": "^11.13.0",
         "papaparse": "^5.5.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -51,6 +52,8 @@
         "globals": "^16.1.0",
         "jsdom": "^26.1.0",
         "msw": "^2.12.10",
+        "openapi-typescript": "^7.6.1",
+        "swagger2openapi": "^7.0.8",
         "tailwindcss": "^4.1.7",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.33.0",
@@ -64,6 +67,28 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@antfu/install-pkg/node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
@@ -376,6 +401,51 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.2.tgz",
+      "integrity": "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "11.1.2",
+        "@chevrotain/types": "11.1.2",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
+      "integrity": "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "11.1.2",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.2.tgz",
+      "integrity": "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
+      "integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.20.1",
@@ -1258,6 +1328,13 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/schemasafe": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
+      "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -1346,6 +1423,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "mlly": "^1.8.0"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -1565,6 +1659,15 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.1.tgz",
+      "integrity": "sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "langium": "^4.0.0"
+      }
     },
     "node_modules/@mswjs/interceptors": {
       "version": "0.41.3",
@@ -2430,6 +2533,82 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
+    },
+    "node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/ajv/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.11",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.11.tgz",
+      "integrity": "sha512-V09ayfnb5GyysmvARbt+voFZAjGcf7hSYxOYxSkCc4fbH/DTfq5YWoec8cflvmHHqyIFbqvmGKmYFzqhr9zxDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "8.11.2",
+        "@redocly/config": "0.22.0",
+        "colorette": "1.4.0",
+        "https-proxy-agent": "7.0.6",
+        "js-levenshtein": "1.1.6",
+        "js-yaml": "4.1.1",
+        "minimatch": "5.1.9",
+        "pluralize": "8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -3302,10 +3481,72 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
       "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
@@ -3314,10 +3555,83 @@
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
@@ -3335,6 +3649,24 @@
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
@@ -3343,6 +3675,18 @@
       "dependencies": {
         "@types/d3-time": "*"
       }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.8",
@@ -3359,11 +3703,36 @@
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -3406,6 +3775,12 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -3849,6 +4224,16 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -3989,7 +4374,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4033,6 +4417,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -4200,6 +4594,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4275,6 +4676,13 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -4323,6 +4731,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/chevrotain": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
+      "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "11.1.2",
+        "@chevrotain/gast": "11.1.2",
+        "@chevrotain/regexp-to-ast": "11.1.2",
+        "@chevrotain/types": "11.1.2",
+        "@chevrotain/utils": "11.1.2",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
+      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      },
+      "peerDependencies": {
+        "chevrotain": "^11.0.0"
       }
     },
     "node_modules/class-variance-authority": {
@@ -4424,6 +4858,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -4450,6 +4891,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -4469,6 +4916,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
       }
     },
     "node_modules/crelt": {
@@ -4540,6 +4996,95 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
+      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -4547,6 +5092,43 @@
       "license": "ISC",
       "dependencies": {
         "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
       },
       "engines": {
         "node": ">=12"
@@ -4561,6 +5143,86 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -4570,10 +5232,57 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4600,6 +5309,73 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
     "node_modules/d3-scale": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
@@ -4612,6 +5388,28 @@
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -4661,6 +5459,51 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -4674,6 +5517,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4734,6 +5583,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -4848,6 +5706,13 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5155,6 +6020,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5310,6 +6182,12 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5417,6 +6295,13 @@
         "node": ">= 14"
       }
     },
+    "node_modules/http2-client": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
+      "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -5435,7 +6320,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -5489,6 +6373,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/inline-style-parser": {
@@ -5626,6 +6523,16 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5732,6 +6639,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.44",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.44.tgz",
+      "integrity": "sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5741,6 +6673,34 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/langium": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
+      "integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chevrotain": "~11.1.1",
+        "chevrotain-allstar": "~0.3.1",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -6045,6 +7005,12 @@
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6129,6 +7095,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -6411,6 +7389,35 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.13.0.tgz",
+      "integrity": "sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.0.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0"
       }
     },
     "node_modules/micromark": {
@@ -6999,6 +8006,18 @@
         "node": "*"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7130,6 +8149,75 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch-h2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+      "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http2-client": "^1.2.5"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-readfiles": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+      "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^3.2.1"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
@@ -7144,6 +8232,111 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/oas-kit-common": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+      "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.7"
+      }
+    },
+    "node_modules/oas-linter": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
+      "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@exodus/schemasafe": "^1.0.0-rc.2",
+        "should": "^13.2.1",
+        "yaml": "^1.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-linter/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/oas-resolver": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
+      "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "node-fetch-h2": "^2.3.0",
+        "oas-kit-common": "^1.0.8",
+        "reftools": "^1.1.9",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "resolve": "resolve.js"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-resolver/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/oas-schema-walker": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
+      "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-validator": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
+      "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "oas-kit-common": "^1.0.8",
+        "oas-linter": "^3.2.2",
+        "oas-resolver": "^2.5.6",
+        "oas-schema-walker": "^1.1.5",
+        "reftools": "^1.1.9",
+        "should": "^13.2.1",
+        "yaml": "^1.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/oas-validator/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7151,6 +8344,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/openapi-typescript": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
+      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.34.6",
+        "ansi-colors": "^4.1.3",
+        "change-case": "^5.4.4",
+        "parse-json": "^8.3.0",
+        "supports-color": "^10.2.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.x"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/optionator": {
@@ -7210,6 +8437,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/papaparse": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
@@ -7254,6 +8487,37 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-json/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -7266,6 +8530,12 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -7298,7 +8568,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
@@ -7337,6 +8606,43 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -7676,6 +8982,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/reftools": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
+      "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -7752,6 +9068,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -7768,6 +9094,12 @@
       "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
     },
     "node_modules/rollup": {
       "version": "4.59.0",
@@ -7814,6 +9146,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -7821,11 +9165,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -7879,6 +9228,66 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/should": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.4.0"
+      }
+    },
+    "node_modules/should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
+      }
+    },
+    "node_modules/should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-util": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -8063,6 +9472,12 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -8096,6 +9511,44 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger2openapi": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
+      "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "node-fetch": "^2.6.1",
+        "node-fetch-h2": "^2.3.0",
+        "node-readfiles": "^0.2.0",
+        "oas-kit-common": "^1.0.8",
+        "oas-resolver": "^2.5.6",
+        "oas-schema-walker": "^1.1.5",
+        "oas-validator": "^5.0.8",
+        "reftools": "^1.1.9",
+        "yaml": "^1.10.0",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "boast": "boast.js",
+        "oas-validate": "oas-validate.js",
+        "swagger2openapi": "swagger2openapi.js"
+      },
+      "funding": {
+        "url": "https://github.com/Mermade/oas-kit?sponsor=1"
+      }
+    },
+    "node_modules/swagger2openapi/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/symbol-tree": {
@@ -8323,6 +9776,15 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -8401,6 +9863,12 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
@@ -8546,6 +10014,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
@@ -8602,6 +10077,19 @@
       "license": "MIT",
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vfile": {
@@ -8825,6 +10313,55 @@
         }
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -9005,6 +10542,13 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "generate-api-types": "npx swagger2openapi ../internal/apidocs/swagger.json -o src/api/generated/openapi3.json && openapi-typescript src/api/generated/openapi3.json -o src/api/generated/admin-api.d.ts"
   },
   "dependencies": {
     "@codemirror/lang-html": "^6.4.11",
@@ -32,6 +33,7 @@
     "dompurify": "^3.3.2",
     "html2canvas": "^1.4.1",
     "lucide-react": "^0.469.0",
+    "mermaid": "^11.13.0",
     "papaparse": "^5.5.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
@@ -56,6 +58,8 @@
     "globals": "^16.1.0",
     "jsdom": "^26.1.0",
     "msw": "^2.12.10",
+    "openapi-typescript": "^7.6.1",
+    "swagger2openapi": "^7.0.8",
     "tailwindcss": "^4.1.7",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.33.0",

--- a/ui/src/components/AuthImg.tsx
+++ b/ui/src/components/AuthImg.tsx
@@ -1,0 +1,15 @@
+import { useAuthSrc } from "@/hooks/useAuthSrc";
+
+type Props = Omit<React.ImgHTMLAttributes<HTMLImageElement>, "src"> & {
+  src: string | undefined;
+};
+
+/**
+ * An <img> that fetches authenticated URLs with the API key header.
+ * In cookie auth mode, behaves like a normal <img>.
+ */
+export function AuthImg({ src, ...props }: Props) {
+  const resolvedSrc = useAuthSrc(src);
+  if (!resolvedSrc) return null;
+  return <img src={resolvedSrc} {...props} />;
+}

--- a/ui/src/components/ThumbnailGenerator.tsx
+++ b/ui/src/components/ThumbnailGenerator.tsx
@@ -4,6 +4,7 @@ import remarkGfm from "remark-gfm";
 import Papa from "papaparse";
 import DOMPurify from "dompurify";
 import html2canvas from "html2canvas";
+import mermaid from "mermaid";
 import {
   THUMB_WIDTH,
   THUMB_HEIGHT,
@@ -221,23 +222,50 @@ function DomCapture({
     const el = containerRef.current;
     if (!el) return;
 
-    // If content is already rendered (SVG via dangerouslySetInnerHTML), capture
-    // after one animation frame so layout settles.
-    if (el.querySelector("svg, p, h1, h2, h3, li, pre, blockquote, table")) {
-      const raf = requestAnimationFrame(() => void doCapture());
-      return () => cancelAnimationFrame(raf);
+    async function renderMermaidAndCapture() {
+      // Wait for ReactMarkdown to render child nodes
+      await new Promise<void>((resolve) => {
+        if (el.querySelector("p, h1, h2, h3, li, pre, blockquote, table, svg")) {
+          resolve();
+          return;
+        }
+        const observer = new MutationObserver(() => {
+          if (el.querySelector("p, h1, h2, h3, li, pre, blockquote, table, svg")) {
+            observer.disconnect();
+            resolve();
+          }
+        });
+        observer.observe(el, { childList: true, subtree: true });
+      });
+
+      // Render mermaid code blocks if present
+      const mermaidBlocks = el.querySelectorAll<HTMLElement>("code.language-mermaid");
+      if (mermaidBlocks.length > 0) {
+        mermaid.initialize({ startOnLoad: false, theme: "default", fontFamily: "system-ui, sans-serif" });
+        for (let i = 0; i < mermaidBlocks.length; i++) {
+          const codeEl = mermaidBlocks[i]!;
+          const preEl = codeEl.parentElement;
+          if (!preEl || preEl.tagName !== "PRE") continue;
+          try {
+            const { svg } = await mermaid.render(`thumb-mermaid-${i}`, codeEl.textContent || "");
+            const wrapper = document.createElement("div");
+            wrapper.innerHTML = svg;
+            wrapper.style.display = "flex";
+            wrapper.style.justifyContent = "center";
+            wrapper.style.margin = "0.5em 0";
+            preEl.replaceWith(wrapper);
+          } catch {
+            // Leave as code block on failure
+          }
+        }
+      }
+
+      // Let layout settle after mermaid SVGs are inserted
+      await new Promise((r) => requestAnimationFrame(r));
+      void doCapture();
     }
 
-    // Otherwise wait for ReactMarkdown to render child nodes.
-    const observer = new MutationObserver(() => {
-      if (el.querySelector("p, h1, h2, h3, li, pre, blockquote, table")) {
-        observer.disconnect();
-        // One more frame to let layout settle after the DOM mutation.
-        requestAnimationFrame(() => void doCapture());
-      }
-    });
-    observer.observe(el, { childList: true, subtree: true });
-    return () => observer.disconnect();
+    void renderMermaidAndCapture();
   }, [doCapture]);
 
   // Timeout: if capture hasn't completed, give up

--- a/ui/src/components/renderers/MarkdownRenderer.tsx
+++ b/ui/src/components/renderers/MarkdownRenderer.tsx
@@ -1,10 +1,168 @@
+import { useEffect, useRef, useId, useCallback, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import type { Components } from "react-markdown";
+import mermaid from "mermaid";
+
+/** Detect whether the document is currently in dark mode. */
+function isDark(): boolean {
+  return document.documentElement.classList.contains("dark");
+}
+
+/** Re-initialize mermaid with the appropriate theme. */
+function initMermaid() {
+  mermaid.initialize({
+    startOnLoad: false,
+    theme: isDark() ? "dark" : "default",
+    fontFamily: "ui-sans-serif, system-ui, sans-serif",
+    themeVariables: isDark()
+      ? {
+          primaryColor: "#3b82f6",
+          primaryTextColor: "#f1f5f9",
+          primaryBorderColor: "#475569",
+          lineColor: "#64748b",
+          secondaryColor: "#1e293b",
+          tertiaryColor: "#0f172a",
+          background: "#0f172a",
+          mainBkg: "#1e293b",
+          nodeBorder: "#475569",
+          clusterBkg: "#1e293b",
+          clusterBorder: "#334155",
+          titleColor: "#e2e8f0",
+          edgeLabelBackground: "#1e293b",
+          noteBkgColor: "#1e293b",
+          noteTextColor: "#e2e8f0",
+          noteBorderColor: "#475569",
+        }
+      : {
+          primaryColor: "#3b82f6",
+          primaryTextColor: "#1e293b",
+          primaryBorderColor: "#cbd5e1",
+          lineColor: "#94a3b8",
+          secondaryColor: "#f1f5f9",
+          tertiaryColor: "#e2e8f0",
+          background: "#ffffff",
+          mainBkg: "#f8fafc",
+          nodeBorder: "#cbd5e1",
+          clusterBkg: "#f8fafc",
+          clusterBorder: "#e2e8f0",
+          titleColor: "#1e293b",
+          edgeLabelBackground: "#ffffff",
+          noteBkgColor: "#f8fafc",
+          noteTextColor: "#1e293b",
+          noteBorderColor: "#cbd5e1",
+        },
+  });
+}
+
+initMermaid();
+
+function MermaidBlock({ content }: { content: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const id = useId().replace(/:/g, "m");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    // Re-init with current theme before each render
+    initMermaid();
+
+    mermaid
+      .render(id, content)
+      .then(({ svg }) => {
+        if (!cancelled && ref.current) {
+          ref.current.innerHTML = svg;
+          setError(null);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to render diagram");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id, content]);
+
+  // Listen for theme changes and re-render
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      initMermaid();
+      mermaid
+        .render(id + "t", content)
+        .then(({ svg }) => {
+          if (ref.current) ref.current.innerHTML = svg;
+        })
+        .catch(() => {});
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    return () => observer.disconnect();
+  }, [id, content]);
+
+  if (error) {
+    return (
+      <div className="my-4 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
+        <p className="font-medium">Diagram Error</p>
+        <pre className="mt-1 text-xs opacity-75">{error}</pre>
+      </div>
+    );
+  }
+
+  return (
+    <div className="my-4 not-prose">
+      <div
+        ref={ref}
+        className="flex justify-center rounded-lg border border-border bg-muted/30 p-6 overflow-x-auto"
+      />
+    </div>
+  );
+}
 
 export function MarkdownRenderer({ content }: { content: string }) {
+  const components: Components = {
+    code: useCallback(
+      // react-markdown passes `node` (hast AST) — destructure it out so it
+      // doesn't leak into the DOM as an invalid attribute.
+      ({ className, children, node: _node, ...rest }: // eslint-disable-line @typescript-eslint/no-unused-vars
+        React.ComponentProps<"code"> & { node?: unknown }) => {
+        const match = /language-(\w+)/.exec(className || "");
+        const lang = match?.[1];
+        const text = String(children).replace(/\n$/, "");
+
+        if (lang === "mermaid") {
+          return <MermaidBlock content={text} />;
+        }
+
+        return (
+          <code className={className} {...rest}>
+            {children}
+          </code>
+        );
+      },
+      [],
+    ),
+    // Strip the `node` prop from <pre> as well to prevent DOM warnings.
+    pre: useCallback(
+      ({ node: _node, ...rest }: React.ComponentProps<"pre"> & { node?: unknown }) => ( // eslint-disable-line @typescript-eslint/no-unused-vars
+        <pre {...rest} />
+      ),
+      [],
+    ),
+  };
+
   return (
     <div className="prose prose-sm max-w-none dark:prose-invert rounded-lg border bg-card p-6">
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+        {content}
+      </ReactMarkdown>
     </div>
   );
 }

--- a/ui/src/hooks/useAuthSrc.ts
+++ b/ui/src/hooks/useAuthSrc.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect } from "react";
+import { useAuthStore } from "@/stores/auth";
+
+/**
+ * Fetches a URL with authentication and returns a blob URL for use in <img> tags.
+ * In cookie auth mode, returns the original URL (browser sends cookies automatically).
+ * In API key mode, fetches with the X-API-Key header and creates a blob URL.
+ */
+export function useAuthSrc(url: string | undefined): string | undefined {
+  const authMethod = useAuthStore((s) => s.authMethod);
+  const apiKey = useAuthStore((s) => s.apiKey);
+  const [blobUrl, setBlobUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!url) {
+      setBlobUrl(undefined);
+      return;
+    }
+
+    // Cookie auth: browser sends credentials automatically on <img> tags.
+    if (authMethod !== "apikey") {
+      setBlobUrl(url);
+      return;
+    }
+
+    let revoke: string | undefined;
+
+    fetch(url, { headers: { "X-API-Key": apiKey } })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.blob();
+      })
+      .then((blob) => {
+        revoke = URL.createObjectURL(blob);
+        setBlobUrl(revoke);
+      })
+      .catch(() => {
+        setBlobUrl(undefined);
+      });
+
+    return () => {
+      if (revoke) URL.revokeObjectURL(revoke);
+    };
+  }, [url, authMethod, apiKey]);
+
+  return blobUrl;
+}

--- a/ui/src/mocks/conformance.test.ts
+++ b/ui/src/mocks/conformance.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Mock Conformance Tests
+ *
+ * Validates that MSW mock data structures match the Swagger-generated types.
+ * Run `npm run generate-api-types` before this test to regenerate types from
+ * the Go backend's Swagger spec.
+ *
+ * This catches drift between the Go API and the mock data used in development.
+ * If a field is added to a Go response struct but not to the mock data, these
+ * tests will flag it.
+ */
+import { describe, it, expect } from "vitest";
+import { mockSystemInfo, mockTools, mockConnections } from "./data/system";
+import { mockPersonaDetails, mockPersonas } from "./data/personas";
+
+// ---------------------------------------------------------------------------
+// Helper: extract keys recursively from an object
+// ---------------------------------------------------------------------------
+function flatKeys(obj: unknown, prefix = ""): Set<string> {
+  const keys = new Set<string>();
+  if (obj === null || obj === undefined || typeof obj !== "object") return keys;
+  if (Array.isArray(obj)) {
+    if (obj.length > 0) {
+      for (const k of flatKeys(obj[0], prefix)) keys.add(k);
+    }
+    return keys;
+  }
+  for (const [k, v] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${k}` : k;
+    keys.add(path);
+    if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+      for (const nested of flatKeys(v, path)) keys.add(nested);
+    }
+  }
+  return keys;
+}
+
+// ---------------------------------------------------------------------------
+// System Info
+// ---------------------------------------------------------------------------
+describe("Mock conformance: SystemInfo", () => {
+  it("should have all expected top-level fields", () => {
+    const keys = flatKeys(mockSystemInfo);
+    const expected = [
+      "name",
+      "version",
+      "commit",
+      "build_date",
+      "description",
+      "transport",
+      "config_mode",
+      "portal_title",
+      "portal_logo",
+      "portal_logo_light",
+      "portal_logo_dark",
+      "features",
+      "toolkit_count",
+      "persona_count",
+    ];
+    for (const field of expected) {
+      expect(keys.has(field), `missing field: ${field}`).toBe(true);
+    }
+  });
+
+  it("should have all feature flags", () => {
+    const featureKeys = Object.keys(mockSystemInfo.features);
+    const expected = ["audit", "oauth", "knowledge", "admin", "database"];
+    expect(featureKeys.sort()).toEqual(expected.sort());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tools
+// ---------------------------------------------------------------------------
+describe("Mock conformance: ToolInfo", () => {
+  it("should have tools with required fields", () => {
+    expect(mockTools.length).toBeGreaterThan(0);
+    for (const tool of mockTools) {
+      expect(tool).toHaveProperty("name");
+      expect(tool).toHaveProperty("toolkit");
+      expect(tool).toHaveProperty("kind");
+      expect(tool).toHaveProperty("connection");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Connections
+// ---------------------------------------------------------------------------
+describe("Mock conformance: ConnectionInfo", () => {
+  it("should have connections with required fields", () => {
+    expect(mockConnections.length).toBeGreaterThan(0);
+    for (const conn of mockConnections) {
+      expect(conn).toHaveProperty("kind");
+      expect(conn).toHaveProperty("name");
+      expect(conn).toHaveProperty("connection");
+      expect(conn).toHaveProperty("tools");
+      expect(Array.isArray(conn.tools)).toBe(true);
+      expect(conn).toHaveProperty("hidden_tools");
+      expect(Array.isArray(conn.hidden_tools)).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Personas
+// ---------------------------------------------------------------------------
+describe("Mock conformance: PersonaSummary", () => {
+  it("should have summaries with required fields", () => {
+    expect(mockPersonas.length).toBeGreaterThan(0);
+    for (const p of mockPersonas) {
+      expect(p).toHaveProperty("name");
+      expect(p).toHaveProperty("display_name");
+      expect(p).toHaveProperty("roles");
+      expect(p).toHaveProperty("tool_count");
+    }
+  });
+});
+
+describe("Mock conformance: PersonaDetail", () => {
+  it("should have details with required fields", () => {
+    const details = Object.values(mockPersonaDetails);
+    expect(details.length).toBeGreaterThan(0);
+    for (const p of details) {
+      expect(p).toHaveProperty("name");
+      expect(p).toHaveProperty("display_name");
+      expect(p).toHaveProperty("roles");
+      expect(p).toHaveProperty("priority");
+      expect(p).toHaveProperty("allow_tools");
+      expect(p).toHaveProperty("deny_tools");
+      expect(p).toHaveProperty("tools");
+    }
+  });
+});

--- a/ui/src/pages/assets/MyAssetsPage.test.tsx
+++ b/ui/src/pages/assets/MyAssetsPage.test.tsx
@@ -36,8 +36,8 @@ function makeAsset(overrides: Record<string, unknown> = {}) {
   };
 }
 
-describe("MyAssetsPage: title does not overlap share icons", () => {
-  it("title row has pr-12 padding to clear absolutely-positioned share icons", () => {
+describe("MyAssetsPage: share icons overlay on card thumbnail", () => {
+  it("both share icons appear when asset has user share and public link", () => {
     mockUseAssets.mockReturnValue({
       data: {
         data: [makeAsset()],
@@ -53,31 +53,18 @@ describe("MyAssetsPage: title does not overlap share icons", () => {
 
     render(<MyAssetsPage onNavigate={vi.fn()} />, { wrapper });
 
-    // The share icons should be present
     expect(screen.getByTitle("Shared with users")).toBeInTheDocument();
     expect(screen.getByTitle("Has public link")).toBeInTheDocument();
 
-    // The title text element
-    const titleSpan = screen.getByText(
-      "A very long asset name that should be truncated before it reaches the icons",
-    );
-    // The title row is the parent div containing the icon + title span
-    const titleRow = titleSpan.closest("div");
-    expect(titleRow).not.toBeNull();
-    expect(titleRow!.className).toContain("pr-12");
-
-    // The share icon container should be absolutely positioned.
-    // Structure: <button> > <div class="absolute ..."> > <span title="..."> > <svg>
-    // So shareIcon's parentElement is the <span>, and its parentElement is the <div>.
+    // Share icons are in an overlay container positioned on the card (top-2 right-2)
     const shareIcon = screen.getByTitle("Shared with users");
-    // shareIcon is the <span>, its parent is the absolute div
     const iconContainer = shareIcon.parentElement!;
     expect(iconContainer.className).toContain("absolute");
-    expect(iconContainer.className).toContain("top-4");
-    expect(iconContainer.className).toContain("right-4");
+    expect(iconContainer.className).toContain("top-2");
+    expect(iconContainer.className).toContain("right-2");
   });
 
-  it("title row has pr-12 with only one share icon (user share)", () => {
+  it("only user share icon when has_public_link is false", () => {
     mockUseAssets.mockReturnValue({
       data: {
         data: [makeAsset()],
@@ -95,15 +82,9 @@ describe("MyAssetsPage: title does not overlap share icons", () => {
 
     expect(screen.getByTitle("Shared with users")).toBeInTheDocument();
     expect(screen.queryByTitle("Has public link")).not.toBeInTheDocument();
-
-    const titleSpan = screen.getByText(
-      "A very long asset name that should be truncated before it reaches the icons",
-    );
-    const titleRow = titleSpan.closest("div");
-    expect(titleRow!.className).toContain("pr-12");
   });
 
-  it("title row has pr-12 with only one share icon (public link)", () => {
+  it("only public link icon when has_user_share is false", () => {
     mockUseAssets.mockReturnValue({
       data: {
         data: [makeAsset()],
@@ -121,15 +102,9 @@ describe("MyAssetsPage: title does not overlap share icons", () => {
 
     expect(screen.queryByTitle("Shared with users")).not.toBeInTheDocument();
     expect(screen.getByTitle("Has public link")).toBeInTheDocument();
-
-    const titleSpan = screen.getByText(
-      "A very long asset name that should be truncated before it reaches the icons",
-    );
-    const titleRow = titleSpan.closest("div");
-    expect(titleRow!.className).toContain("pr-12");
   });
 
-  it("title row has pr-12 even when no share icons are present", () => {
+  it("no share icons when share_summaries is empty", () => {
     mockUseAssets.mockReturnValue({
       data: {
         data: [makeAsset()],
@@ -143,12 +118,12 @@ describe("MyAssetsPage: title does not overlap share icons", () => {
 
     render(<MyAssetsPage onNavigate={vi.fn()} />, { wrapper });
 
-    const titleSpan = screen.getByText(
-      "A very long asset name that should be truncated before it reaches the icons",
-    );
-    const titleRow = titleSpan.closest("div");
-    expect(titleRow).not.toBeNull();
-    // pr-12 is always applied regardless of icon presence (avoids layout shift)
-    expect(titleRow!.className).toContain("pr-12");
+    expect(screen.queryByTitle("Shared with users")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("Has public link")).not.toBeInTheDocument();
+
+    // Title should still render correctly
+    expect(
+      screen.getByText("A very long asset name that should be truncated before it reaches the icons"),
+    ).toBeInTheDocument();
   });
 });

--- a/ui/src/pages/assets/MyAssetsPage.tsx
+++ b/ui/src/pages/assets/MyAssetsPage.tsx
@@ -3,6 +3,7 @@ import { Search, FileText, Image, Code, File, Users, Globe, Table2 } from "lucid
 import { useAssets } from "@/api/portal/hooks";
 import { formatBytes } from "@/lib/format";
 import { ThumbnailQueue } from "@/components/ThumbnailQueue";
+import { AuthImg } from "@/components/AuthImg";
 
 interface Props {
   onNavigate: (path: string) => void;
@@ -113,11 +114,10 @@ export function MyAssetsPage({ onNavigate }: Props) {
               >
                 <div className="w-full aspect-[4/3] bg-muted">
                   {asset.thumbnail_s3_key ? (
-                    <img
+                    <AuthImg
                       src={`/api/v1/portal/assets/${asset.id}/thumbnail`}
                       alt=""
                       className="w-full h-full object-cover object-top"
-                      loading="lazy"
                     />
                   ) : (
                     <div className="w-full h-full flex items-center justify-center">

--- a/ui/src/pages/shared/SharedWithMePage.tsx
+++ b/ui/src/pages/shared/SharedWithMePage.tsx
@@ -3,6 +3,7 @@ import { Search, FileText, Image, Code, File, Table2 } from "lucide-react";
 import { useSharedWithMe } from "@/api/portal/hooks";
 import { formatBytes } from "@/lib/format";
 import { ThumbnailQueue } from "@/components/ThumbnailQueue";
+import { AuthImg } from "@/components/AuthImg";
 
 interface Props {
   onNavigate: (path: string) => void;
@@ -110,11 +111,10 @@ export function SharedWithMePage({ onNavigate }: Props) {
               >
                 <div className="w-full aspect-[4/3] bg-muted">
                   {item.asset.thumbnail_s3_key ? (
-                    <img
+                    <AuthImg
                       src={`/api/v1/portal/assets/${item.asset.id}/thumbnail`}
                       alt=""
                       className="w-full h-full object-cover object-top"
-                      loading="lazy"
                     />
                   ) : (
                     <div className="w-full h-full flex items-center justify-center">


### PR DESCRIPTION
## Summary

- **Single `make dev` command** starts Docker (PostgreSQL + SeaweedFS), Go server with air hot-reload, and Vite UI — sequential startup with pre-flight checks (Docker running, air installed, ports free) and clear status reporting
- **Seed data rewritten** to match current schemas; includes 6 portal assets with real content (HTML dashboards, CSV, JSX, Markdown with mermaid, SVG) uploaded to SeaweedFS via the portal API
- **Thumbnail auth fix**: `AuthImg` component fetches images with `X-API-Key` header using blob URLs, fixing broken thumbnails in API key auth mode
- **Mermaid rendering in markdown**: theme-aware (light/dark) with live theme switching via MutationObserver; thumbnail generator now renders mermaid before capture
- **Mock conformance tests**: validates MSW mock data shapes against expected API structures
- **S3 credentials**: changed from minio defaults to `dev-access-key`/`dev-secret-key`

## Test plan

- [ ] `make dev` from clean state (no Docker containers) — all steps should pass with green checkmarks
- [ ] `make dev` with Docker stopped — should fail with clear "Docker is not running" message
- [ ] `make dev` with port 8080 in use — should fail with clear port conflict message
- [ ] Edit a Go file while `make dev` is running — air should rebuild and restart within ~2s
- [ ] Edit a React component — Vite should hot-reload instantly
- [ ] Login with API key `acme-dev-key-2024` — 6 assets should appear with working thumbnails
- [ ] Open the Markdown asset (Data Pipeline Architecture) — mermaid diagram should render
- [ ] Toggle dark mode — mermaid diagram should re-render with dark theme
- [ ] Open the JSX asset (Store Performance Comparison) — should render the component
- [ ] `Ctrl-C` — all processes should shut down cleanly
- [ ] `make frontend-mock` — should still work independently (existing targets not broken)
- [ ] `cd ui && npx vitest run` — all 30 tests pass