### PR TITLE
deps: upgrade txn2/mcp-datahub v1.6.0 → v1.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.41.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.41.0
-	github.com/txn2/mcp-datahub v1.6.0
+	github.com/txn2/mcp-datahub v1.7.0
 	github.com/txn2/mcp-s3 v1.0.0
 	github.com/txn2/mcp-trino v1.1.0
 	github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9R
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v1.6.0 h1:4WgG24LfCxVd1zGntTbEeEMjNmASnASdsBHrXrZul9Q=
-github.com/txn2/mcp-datahub v1.6.0/go.mod h1:+GPUNirzhGDEUGiSsebuxToLriUygkugHkwDYrFiDKY=
+github.com/txn2/mcp-datahub v1.7.0 h1:19vGJ1yOXle9OFcFG/A2z1MHQhzh9nFfInb0LlCn1Rw=
+github.com/txn2/mcp-datahub v1.7.0/go.mod h1:+GPUNirzhGDEUGiSsebuxToLriUygkugHkwDYrFiDKY=
 github.com/txn2/mcp-s3 v1.0.0 h1:0772X3H7bAJPqDtuvDNlZTGEK2m1egInfuqQL/Jlq8Y=
 github.com/txn2/mcp-s3 v1.0.0/go.mod h1:hQc0xBl0t/afEgFmrOSKH3OW9uyKdeliFknQwfAzqG0=
 github.com/txn2/mcp-trino v1.1.0 h1:5/cSIIzciTT/cV1p8enM+4k4SI+0OcK5uFwcQhOBWhk=

--- a/pkg/browsersession/cookie.go
+++ b/pkg/browsersession/cookie.go
@@ -98,8 +98,9 @@ func extractSessionClaims(mc jwt.MapClaims) (*SessionClaims, error) {
 
 // SetCookie writes the session JWT as an HTTP-only cookie.
 func SetCookie(w http.ResponseWriter, cfg *CookieConfig, tokenString string) {
-	// nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure -- Secure is cfg-driven (defaults true, opt-out for local dev)
-	http.SetCookie(w, &http.Cookie{
+	// Secure is cfg-driven (defaults true, opt-out for local dev without TLS).
+	// nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
+	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- Secure is cfg-driven (defaults true, opt-out for local dev without TLS)
 		Name:     cfg.effectiveName(),
 		Value:    tokenString,
 		Domain:   cfg.Domain,
@@ -113,8 +114,8 @@ func SetCookie(w http.ResponseWriter, cfg *CookieConfig, tokenString string) {
 
 // ClearCookie removes the session cookie.
 func ClearCookie(w http.ResponseWriter, cfg *CookieConfig) {
-	// nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure -- Secure is cfg-driven (defaults true, opt-out for local dev)
-	http.SetCookie(w, &http.Cookie{
+	// nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
+	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- Secure is cfg-driven (defaults true, opt-out for local dev without TLS)
 		Name:     cfg.effectiveName(),
 		Value:    "",
 		Domain:   cfg.Domain,

--- a/pkg/browsersession/oidcflow.go
+++ b/pkg/browsersession/oidcflow.go
@@ -146,8 +146,8 @@ func (f *Flow) LoginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure -- Secure is cfg-driven (defaults true, opt-out for local dev)
-	http.SetCookie(w, &http.Cookie{
+	// nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
+	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- Secure is cfg-driven (defaults true, opt-out for local dev without TLS)
 		Name:     stateCookieName,
 		Value:    stateToken,
 		Path:     "/portal/auth/",
@@ -245,8 +245,8 @@ func (f *Flow) validateCallbackState(r *http.Request, state string) (string, err
 
 // clearStateCookie removes the temporary OIDC state cookie.
 func (f *Flow) clearStateCookie(w http.ResponseWriter) {
-	// nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure -- Secure is cfg-driven (defaults true, opt-out for local dev)
-	http.SetCookie(w, &http.Cookie{
+	// nosemgrep: go.lang.security.audit.net.cookie-missing-secure.cookie-missing-secure
+	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- Secure is cfg-driven (defaults true, opt-out for local dev without TLS)
 		Name:     stateCookieName,
 		Value:    "",
 		Path:     "/portal/auth/",

--- a/pkg/middleware/semantic_test.go
+++ b/pkg/middleware/semantic_test.go
@@ -3675,7 +3675,7 @@ func TestBuildTrinoSemanticContext_V14Fields(t *testing.T) {
 		DataContract: &semantic.DataContractStatus{
 			Status: "FAILING",
 			AssertionResults: []semantic.AssertionResult{
-				{Type: "FRESHNESS", ResultType: "FAILURE"},
+				{AssertionURN: "urn:li:assertion:freshness-1", Type: "FRESHNESS"},
 			},
 		},
 	}

--- a/pkg/semantic/datahub/adapter.go
+++ b/pkg/semantic/datahub/adapter.go
@@ -681,8 +681,8 @@ func convertDataContract(dc *types.DataContract) *semantic.DataContractStatus {
 		result.AssertionResults = make([]semantic.AssertionResult, len(dc.AssertionResults))
 		for i, ar := range dc.AssertionResults {
 			result.AssertionResults[i] = semantic.AssertionResult{
-				Type:       ar.Type,
-				ResultType: ar.ResultType,
+				AssertionURN: ar.AssertionURN,
+				Type:         ar.Type,
 			}
 		}
 	}

--- a/pkg/semantic/datahub/adapter_test.go
+++ b/pkg/semantic/datahub/adapter_test.go
@@ -1098,8 +1098,8 @@ func TestConvertDataContract(t *testing.T) {
 		input := &types.DataContract{
 			Status: "PASSING",
 			AssertionResults: []types.AssertionResult{
-				{Type: "FRESHNESS", ResultType: "SUCCESS"},
-				{Type: "SCHEMA", ResultType: "SUCCESS"},
+				{AssertionURN: "urn:li:assertion:freshness-1", Type: "FRESHNESS"},
+				{AssertionURN: "urn:li:assertion:schema-1", Type: "SCHEMA"},
 			},
 		}
 		result := convertDataContract(input)
@@ -1158,7 +1158,7 @@ func TestGetTableContext_WithV14Fields(t *testing.T) {
 				DataContract: &types.DataContract{
 					Status: "PASSING",
 					AssertionResults: []types.AssertionResult{
-						{Type: "FRESHNESS", ResultType: "SUCCESS"},
+						{AssertionURN: "urn:li:assertion:freshness-1", Type: "FRESHNESS"},
 					},
 				},
 			}, nil

--- a/pkg/semantic/types.go
+++ b/pkg/semantic/types.go
@@ -238,8 +238,8 @@ type DataContractStatus struct {
 	AssertionResults []AssertionResult `json:"assertion_results,omitempty"`
 }
 
-// AssertionResult represents a single assertion outcome within a data contract.
+// AssertionResult represents a single assertion reference within a data contract.
 type AssertionResult struct {
-	Type       string `json:"type"`        // FRESHNESS, SCHEMA, DATA_QUALITY
-	ResultType string `json:"result_type"` // SUCCESS, FAILURE
+	AssertionURN string `json:"assertion_urn,omitempty"` // URN identifying the assertion
+	Type         string `json:"type"`                    // FRESHNESS, SCHEMA, DATA_QUALITY
 }

--- a/pkg/semantic/types_test.go
+++ b/pkg/semantic/types_test.go
@@ -168,8 +168,8 @@ func TestDataContractStatus_JSON(t *testing.T) {
 	dc := DataContractStatus{
 		Status: "FAILING",
 		AssertionResults: []AssertionResult{
-			{Type: "FRESHNESS", ResultType: "FAILURE"},
-			{Type: "SCHEMA", ResultType: "SUCCESS"},
+			{AssertionURN: "urn:li:assertion:freshness-1", Type: "FRESHNESS"},
+			{AssertionURN: "urn:li:assertion:schema-1", Type: "SCHEMA"},
 		},
 	}
 	data, err := json.Marshal(dc)
@@ -186,7 +186,7 @@ func TestDataContractStatus_JSON(t *testing.T) {
 	if len(got.AssertionResults) != 2 {
 		t.Fatalf("AssertionResults len = %d, want 2", len(got.AssertionResults))
 	}
-	if got.AssertionResults[0].Type != "FRESHNESS" || got.AssertionResults[0].ResultType != "FAILURE" {
+	if got.AssertionResults[0].Type != "FRESHNESS" || got.AssertionResults[0].AssertionURN != "urn:li:assertion:freshness-1" {
 		t.Errorf("AssertionResults[0] mismatch: %+v", got.AssertionResults[0])
 	}
 }

--- a/ui/src/components/ThumbnailGenerator.tsx
+++ b/ui/src/components/ThumbnailGenerator.tsx
@@ -221,25 +221,27 @@ function DomCapture({
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
+    // Capture as non-null for the async closure (TS can't narrow across await).
+    const container: HTMLDivElement = el;
 
     async function renderMermaidAndCapture() {
       // Wait for ReactMarkdown to render child nodes
       await new Promise<void>((resolve) => {
-        if (el.querySelector("p, h1, h2, h3, li, pre, blockquote, table, svg")) {
+        if (container.querySelector("p, h1, h2, h3, li, pre, blockquote, table, svg")) {
           resolve();
           return;
         }
         const observer = new MutationObserver(() => {
-          if (el.querySelector("p, h1, h2, h3, li, pre, blockquote, table, svg")) {
+          if (container.querySelector("p, h1, h2, h3, li, pre, blockquote, table, svg")) {
             observer.disconnect();
             resolve();
           }
         });
-        observer.observe(el, { childList: true, subtree: true });
+        observer.observe(container, { childList: true, subtree: true });
       });
 
       // Render mermaid code blocks if present
-      const mermaidBlocks = el.querySelectorAll<HTMLElement>("code.language-mermaid");
+      const mermaidBlocks = container.querySelectorAll<HTMLElement>("code.language-mermaid");
       if (mermaidBlocks.length > 0) {
         mermaid.initialize({ startOnLoad: false, theme: "default", fontFamily: "system-ui, sans-serif" });
         for (let i = 0; i < mermaidBlocks.length; i++) {


### PR DESCRIPTION
## Summary

Upgrades [txn2/mcp-datahub](https://github.com/txn2/mcp-datahub) from v1.6.0 to [v1.7.0](https://github.com/txn2/mcp-datahub/releases/tag/v1.7.0).

### Breaking change in upstream types

`types.AssertionResult` was restructured in v1.7.0:

| Field | v1.6.0 | v1.7.0 |
|-------|--------|--------|
| `Type` | assertion category (FRESHNESS, SCHEMA, DATA_QUALITY) | unchanged |
| `ResultType` | outcome (SUCCESS, FAILURE) | **removed** |
| `AssertionURN` | — | **added** — URN identifying the assertion |

The `ResultType` field (pass/fail outcome) was removed from the assertion reference and replaced with `AssertionURN` (a pointer to the full assertion entity). This aligns with DataHub's model where the pass/fail status lives on the assertion run, not the contract reference.

### Changes

- **`pkg/semantic/types.go`**: `AssertionResult.ResultType` → `AssertionResult.AssertionURN`
- **`pkg/semantic/datahub/adapter.go`**: `convertDataContract` maps the new field
- **`pkg/semantic/types_test.go`**, **`pkg/semantic/datahub/adapter_test.go`**, **`pkg/middleware/semantic_test.go`**: all test fixtures updated
- **`pkg/browsersession/cookie.go`**, **`pkg/browsersession/oidcflow.go`**: added `#nosec G124` annotations to fix gosec findings on config-driven `Secure` cookie attribute (4 call sites)
- **`ui/src/components/ThumbnailGenerator.tsx`**: fixed TypeScript narrowing error in async closure (`el` → `container` non-null binding)

### Verification

`make verify` passes — full suite including tests, lint, security (gosec + govulncheck + semgrep + codeql), coverage, mutation testing, and GoReleaser dry-run.

## Test plan

- [ ] `make verify` passes
- [ ] `go test ./pkg/semantic/...` — assertion result type changes covered
- [ ] `go test ./pkg/middleware/...` — enrichment middleware test fixtures updated
- [ ] `gosec ./...` — zero findings (G124 suppressed with justification)
- [ ] E2E cross-injection tests pass (if DataHub available) — data contract enrichment uses new field