### PR TITLE
deps: upgrade txn2/mcp-datahub v1.7.0 → v1.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.41.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.41.0
-	github.com/txn2/mcp-datahub v1.7.0
+	github.com/txn2/mcp-datahub v1.7.1
 	github.com/txn2/mcp-s3 v1.0.0
 	github.com/txn2/mcp-trino v1.1.0
 	github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9R
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v1.7.0 h1:19vGJ1yOXle9OFcFG/A2z1MHQhzh9nFfInb0LlCn1Rw=
-github.com/txn2/mcp-datahub v1.7.0/go.mod h1:+GPUNirzhGDEUGiSsebuxToLriUygkugHkwDYrFiDKY=
+github.com/txn2/mcp-datahub v1.7.1 h1:at4KDlnbl8EPHY4k1roDdz86AVv4+8lZII3/Mnw4obE=
+github.com/txn2/mcp-datahub v1.7.1/go.mod h1:+GPUNirzhGDEUGiSsebuxToLriUygkugHkwDYrFiDKY=
 github.com/txn2/mcp-s3 v1.0.0 h1:0772X3H7bAJPqDtuvDNlZTGEK2m1egInfuqQL/Jlq8Y=
 github.com/txn2/mcp-s3 v1.0.0/go.mod h1:hQc0xBl0t/afEgFmrOSKH3OW9uyKdeliFknQwfAzqG0=
 github.com/txn2/mcp-trino v1.1.0 h1:5/cSIIzciTT/cV1p8enM+4k4SI+0OcK5uFwcQhOBWhk=


### PR DESCRIPTION
## Summary

- Bumps `txn2/mcp-datahub` from v1.7.0 to v1.7.1
- Context documents created via `apply_knowledge` (`add_context_document`) and `datahub_create` (`what=document`) now default to visible and published, eliminating the need for callers to manually set `global_context=true` and `status=PUBLISHED`

## Test plan

- [ ] Verify `apply_knowledge` with `add_context_document` produces a document visible in DataHub UI
- [ ] Verify `datahub_create what=document` without explicit `global_context`/`status` produces a visible, published document
- [ ] Verify explicit `global_context=false` or `status=UNPUBLISHED` still overrides the defaults