### PR TITLE
feat: persona-based tools/list filtering + connection UI polish

### DIFF
--- a/pkg/middleware/mcp_visibility.go
+++ b/pkg/middleware/mcp_visibility.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -14,27 +15,44 @@ const (
 	methodPromptsList            = "prompts/list"
 )
 
+// ToolVisibilityConfig configures tool visibility filtering for tools/list responses.
+type ToolVisibilityConfig struct {
+	// GlobalAllow/GlobalDeny are static glob patterns from the config file.
+	GlobalAllow []string
+	GlobalDeny  []string
+
+	// Authenticator resolves the caller's identity from the request context.
+	Authenticator Authenticator
+
+	// IsToolAllowedForPersona checks whether a tool is allowed for a persona.
+	// Takes (personaName, toolName) and returns true if allowed.
+	// If nil, persona-based filtering is skipped.
+	IsToolAllowedForPersona func(ctx context.Context, roles []string, toolName string) bool
+}
+
 // MCPToolVisibilityMiddleware creates MCP protocol-level middleware that filters
-// tools/list responses based on allow/deny glob patterns. This reduces token
-// usage in LLM clients by hiding tools that are not needed for a deployment.
+// tools/list responses. It applies two layers of filtering:
 //
-// This is a visibility filter, not a security boundary — persona auth continues
-// to gate tools/call independently.
-func MCPToolVisibilityMiddleware(allow, deny []string) mcp.Middleware {
+//  1. Global allow/deny patterns from config (static, applies to all users)
+//  2. Persona-based filtering (dynamic, based on the authenticated user's persona)
+//
+// The persona filter ensures agents only see tools they're authorized to use,
+// reducing token waste and preventing confusion from inaccessible tools.
+func MCPToolVisibilityMiddleware(cfg ToolVisibilityConfig) mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
 			result, err := next(ctx, method, req)
 			if err != nil {
 				return result, err
 			}
-			return filterToolVisibility(allow, deny, method, result)
+			return filterToolVisibility(ctx, cfg, method, result)
 		}
 	}
 }
 
 // filterToolVisibility filters tools from a tools/list response based on
-// allow/deny patterns. Non-tools/list methods pass through unchanged.
-func filterToolVisibility(allow, deny []string, method string, result mcp.Result) (mcp.Result, error) {
+// global patterns and persona rules. Non-tools/list methods pass through unchanged.
+func filterToolVisibility(ctx context.Context, cfg ToolVisibilityConfig, method string, result mcp.Result) (mcp.Result, error) {
 	if method != methodToolsList {
 		return result, nil
 	}
@@ -44,15 +62,51 @@ func filterToolVisibility(allow, deny []string, method string, result mcp.Result
 		return result, nil
 	}
 
-	filtered := make([]*mcp.Tool, 0, len(listResult.Tools))
-	for _, tool := range listResult.Tools {
-		if IsToolVisible(tool.Name, allow, deny) {
-			filtered = append(filtered, tool)
-		}
-	}
-	listResult.Tools = filtered
+	roles := resolveRolesIfNeeded(ctx, cfg)
+	listResult.Tools = filterTools(ctx, listResult.Tools, cfg, roles)
 
 	return listResult, nil
+}
+
+// filterTools applies global and persona-based filtering to a tool list.
+func filterTools(ctx context.Context, tools []*mcp.Tool, cfg ToolVisibilityConfig, roles []string) []*mcp.Tool {
+	filtered := make([]*mcp.Tool, 0, len(tools))
+	for _, tool := range tools {
+		if !IsToolVisible(tool.Name, cfg.GlobalAllow, cfg.GlobalDeny) {
+			continue
+		}
+		if roles != nil && cfg.IsToolAllowedForPersona != nil {
+			if !cfg.IsToolAllowedForPersona(ctx, roles, tool.Name) {
+				continue
+			}
+		}
+		filtered = append(filtered, tool)
+	}
+	return filtered
+}
+
+// resolveRolesIfNeeded resolves the caller's roles when persona filtering is configured.
+func resolveRolesIfNeeded(ctx context.Context, cfg ToolVisibilityConfig) []string {
+	if cfg.Authenticator == nil || cfg.IsToolAllowedForPersona == nil {
+		return nil
+	}
+	return resolveCallerRoles(ctx, cfg.Authenticator)
+}
+
+// resolveCallerRoles extracts the caller's roles from the request context.
+func resolveCallerRoles(ctx context.Context, authenticator Authenticator) []string {
+	// Try pre-authenticated user first (set by HTTP-level auth middleware).
+	if userInfo := GetPreAuthenticatedUser(ctx); userInfo != nil {
+		return userInfo.Roles
+	}
+
+	// Fall back to authenticating from the context (e.g. token in headers).
+	userInfo, err := authenticator.Authenticate(ctx)
+	if err != nil || userInfo == nil {
+		slog.Debug("visibility: no authenticated user for tools/list filtering")
+		return nil
+	}
+	return userInfo.Roles
 }
 
 // IsToolVisible determines whether a tool should appear in tools/list based on

--- a/pkg/middleware/mcp_visibility_test.go
+++ b/pkg/middleware/mcp_visibility_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsToolVisible(t *testing.T) {
@@ -158,7 +160,7 @@ func TestFilterToolVisibility(t *testing.T) {
 
 	t.Run("non tools/list passthrough", func(t *testing.T) {
 		result := &mcp.CallToolResult{}
-		got, err := filterToolVisibility([]string{"trino_*"}, nil, "tools/call", result)
+		got, err := filterToolVisibility(context.Background(), ToolVisibilityConfig{GlobalAllow: []string{"trino_*"}}, "tools/call", result)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -168,7 +170,7 @@ func TestFilterToolVisibility(t *testing.T) {
 	})
 
 	t.Run("nil result passthrough", func(t *testing.T) {
-		got, err := filterToolVisibility([]string{"trino_*"}, nil, "tools/list", nil)
+		got, err := filterToolVisibility(context.Background(), ToolVisibilityConfig{GlobalAllow: []string{"trino_*"}}, "tools/list", nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -179,7 +181,7 @@ func TestFilterToolVisibility(t *testing.T) {
 
 	t.Run("non ListToolsResult type passthrough", func(t *testing.T) {
 		result := &mcp.CallToolResult{}
-		got, err := filterToolVisibility([]string{"trino_*"}, nil, "tools/list", result)
+		got, err := filterToolVisibility(context.Background(), ToolVisibilityConfig{GlobalAllow: []string{"trino_*"}}, "tools/list", result)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -190,7 +192,7 @@ func TestFilterToolVisibility(t *testing.T) {
 
 	t.Run("empty tools list", func(t *testing.T) {
 		result := &mcp.ListToolsResult{Tools: []*mcp.Tool{}}
-		got, err := filterToolVisibility([]string{"trino_*"}, nil, "tools/list", result)
+		got, err := filterToolVisibility(context.Background(), ToolVisibilityConfig{GlobalAllow: []string{"trino_*"}}, "tools/list", result)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -204,7 +206,7 @@ func TestFilterToolVisibility(t *testing.T) {
 		result := &mcp.ListToolsResult{
 			Tools: makeTools(testAuditToolName, "trino_describe_table", "datahub_search", "s3_list_objects"),
 		}
-		got, err := filterToolVisibility([]string{"trino_*"}, nil, "tools/list", result)
+		got, err := filterToolVisibility(context.Background(), ToolVisibilityConfig{GlobalAllow: []string{"trino_*"}}, "tools/list", result)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -222,7 +224,7 @@ func TestFilterToolVisibility(t *testing.T) {
 		result := &mcp.ListToolsResult{
 			Tools: makeTools(testAuditToolName, "s3_delete_object", "datahub_search"),
 		}
-		got, err := filterToolVisibility(nil, []string{"s3_delete_*"}, "tools/list", result)
+		got, err := filterToolVisibility(context.Background(), ToolVisibilityConfig{GlobalDeny: []string{"s3_delete_*"}}, "tools/list", result)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -240,7 +242,7 @@ func TestFilterToolVisibility(t *testing.T) {
 		result := &mcp.ListToolsResult{
 			Tools: makeTools(testAuditToolName, "trino_delete_table", "datahub_search", "s3_list_objects"),
 		}
-		got, err := filterToolVisibility([]string{"trino_*"}, []string{"*_delete_*"}, "tools/list", result)
+		got, err := filterToolVisibility(context.Background(), ToolVisibilityConfig{GlobalAllow: []string{"trino_*"}, GlobalDeny: []string{"*_delete_*"}}, "tools/list", result)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -270,7 +272,7 @@ func TestMCPToolVisibilityMiddleware(t *testing.T) {
 		return &mcp.CallToolResult{}, nil
 	}
 
-	mw := MCPToolVisibilityMiddleware([]string{"trino_*"}, nil)
+	mw := MCPToolVisibilityMiddleware(ToolVisibilityConfig{GlobalAllow: []string{"trino_*"}})
 	handler := mw(baseHandler)
 
 	t.Run("filters tools/list", func(t *testing.T) {
@@ -298,11 +300,110 @@ func TestMCPToolVisibilityMiddleware(t *testing.T) {
 		errHandler := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
 			return nil, context.Canceled
 		}
-		errMW := MCPToolVisibilityMiddleware([]string{"trino_*"}, nil)
+		errMW := MCPToolVisibilityMiddleware(ToolVisibilityConfig{GlobalAllow: []string{"trino_*"}})
 		h := errMW(errHandler)
 		_, err := h(context.Background(), "tools/list", nil)
 		if !errors.Is(err, context.Canceled) {
 			t.Errorf("expected context.Canceled, got %v", err)
 		}
+	})
+}
+
+func TestFilterToolVisibility_PersonaFiltering(t *testing.T) {
+	t.Run("persona denies tools not in allow list", func(t *testing.T) {
+		result := &mcp.ListToolsResult{
+			Tools: []*mcp.Tool{
+				{Name: "trino_query"},
+				{Name: "datahub_search"},
+				{Name: "s3_list_objects"},
+			},
+		}
+
+		cfg := ToolVisibilityConfig{
+			Authenticator: &NoopAuthenticator{},
+			IsToolAllowedForPersona: func(_ context.Context, _ []string, toolName string) bool {
+				return toolName == "trino_query"
+			},
+		}
+
+		ctx := WithPreAuthenticatedUser(context.Background(), &UserInfo{
+			UserID: "test-user",
+			Roles:  []string{"analyst"},
+		})
+
+		got, err := filterToolVisibility(ctx, cfg, "tools/list", result)
+		require.NoError(t, err)
+		listResult, ok := got.(*mcp.ListToolsResult)
+		require.True(t, ok)
+		assert.Len(t, listResult.Tools, 1)
+		assert.Equal(t, "trino_query", listResult.Tools[0].Name)
+	})
+
+	t.Run("no persona filter passes all tools", func(t *testing.T) {
+		result := &mcp.ListToolsResult{
+			Tools: []*mcp.Tool{
+				{Name: "trino_query"},
+				{Name: "s3_list_objects"},
+			},
+		}
+
+		cfg := ToolVisibilityConfig{}
+
+		got, err := filterToolVisibility(context.Background(), cfg, "tools/list", result)
+		require.NoError(t, err)
+		listResult, ok := got.(*mcp.ListToolsResult)
+		require.True(t, ok)
+		assert.Len(t, listResult.Tools, 2)
+	})
+
+	t.Run("global and persona filters stack", func(t *testing.T) {
+		result := &mcp.ListToolsResult{
+			Tools: []*mcp.Tool{
+				{Name: "trino_query"},
+				{Name: "trino_delete"},
+				{Name: "s3_list_objects"},
+			},
+		}
+
+		cfg := ToolVisibilityConfig{
+			GlobalDeny:    []string{"*_delete*"},
+			Authenticator: &NoopAuthenticator{},
+			IsToolAllowedForPersona: func(_ context.Context, _ []string, toolName string) bool {
+				return toolName != "s3_list_objects"
+			},
+		}
+
+		ctx := WithPreAuthenticatedUser(context.Background(), &UserInfo{
+			UserID: "test", Roles: []string{"analyst"},
+		})
+
+		got, err := filterToolVisibility(ctx, cfg, "tools/list", result)
+		require.NoError(t, err)
+		listResult, ok := got.(*mcp.ListToolsResult)
+		require.True(t, ok)
+		assert.Len(t, listResult.Tools, 1)
+		assert.Equal(t, "trino_query", listResult.Tools[0].Name)
+	})
+
+	t.Run("unauthenticated user skips persona filter", func(t *testing.T) {
+		result := &mcp.ListToolsResult{
+			Tools: []*mcp.Tool{
+				{Name: "trino_query"},
+				{Name: "s3_list_objects"},
+			},
+		}
+
+		cfg := ToolVisibilityConfig{
+			IsToolAllowedForPersona: func(_ context.Context, _ []string, _ string) bool {
+				return false
+			},
+		}
+
+		// No pre-authenticated user, no authenticator — persona filter should be skipped
+		got, err := filterToolVisibility(context.Background(), cfg, "tools/list", result)
+		require.NoError(t, err)
+		listResult, ok := got.(*mcp.ListToolsResult)
+		require.True(t, ok)
+		assert.Len(t, listResult.Tools, 2)
 	})
 }

--- a/pkg/middleware/middleware_chain_test.go
+++ b/pkg/middleware/middleware_chain_test.go
@@ -1799,7 +1799,7 @@ func TestMiddlewareChain_ToolVisibility(t *testing.T) {
 	}
 
 	// Add visibility middleware: allow only trino_* tools
-	server.AddReceivingMiddleware(middleware.MCPToolVisibilityMiddleware([]string{"trino_*"}, nil))
+	server.AddReceivingMiddleware(middleware.MCPToolVisibilityMiddleware(middleware.ToolVisibilityConfig{GlobalAllow: []string{"trino_*"}}))
 
 	ctx := context.Background()
 	session, err := connectClientServer(ctx, server)
@@ -1850,7 +1850,7 @@ func TestMiddlewareChain_ToolVisibility_DenyOnly(t *testing.T) {
 	}
 
 	// Deny s3_delete_* only
-	server.AddReceivingMiddleware(middleware.MCPToolVisibilityMiddleware(nil, []string{"s3_delete_*"}))
+	server.AddReceivingMiddleware(middleware.MCPToolVisibilityMiddleware(middleware.ToolVisibilityConfig{GlobalDeny: []string{"s3_delete_*"}}))
 
 	ctx := context.Background()
 	session, err := connectClientServer(ctx, server)
@@ -1901,7 +1901,7 @@ func TestMiddlewareChain_ToolVisibility_NoPatterns(t *testing.T) {
 	}
 
 	// No patterns — middleware still registered but should be no-op
-	server.AddReceivingMiddleware(middleware.MCPToolVisibilityMiddleware(nil, nil))
+	server.AddReceivingMiddleware(middleware.MCPToolVisibilityMiddleware(middleware.ToolVisibilityConfig{}))
 
 	ctx := context.Background()
 	session, err := connectClientServer(ctx, server)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1289,14 +1289,26 @@ func (p *Platform) addMCPAppsMiddleware() {
 	p.mcpAppsRegistry.RegisterResources(p.mcpServer)
 }
 
-// addToolVisibilityMiddleware registers tool visibility filtering middleware
-// when allow/deny patterns are configured.
+// addToolVisibilityMiddleware registers tool visibility filtering middleware.
+// Applies both global allow/deny patterns and persona-based tool filtering
+// so agents only see tools they're authorized to use.
 func (p *Platform) addToolVisibilityMiddleware() {
-	if len(p.config.Tools.Allow) == 0 && len(p.config.Tools.Deny) == 0 {
-		return
+	cfg := middleware.ToolVisibilityConfig{
+		GlobalAllow:   p.config.Tools.Allow,
+		GlobalDeny:    p.config.Tools.Deny,
+		Authenticator: p.authenticator,
 	}
+
+	// Wire persona-based filtering via the authorizer.
+	if p.authorizer != nil {
+		cfg.IsToolAllowedForPersona = func(ctx context.Context, roles []string, toolName string) bool {
+			allowed, _, _ := p.authorizer.IsAuthorized(ctx, "", roles, toolName, "")
+			return allowed
+		}
+	}
+
 	p.mcpServer.AddReceivingMiddleware(
-		middleware.MCPToolVisibilityMiddleware(p.config.Tools.Allow, p.config.Tools.Deny),
+		middleware.MCPToolVisibilityMiddleware(cfg),
 	)
 }
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -422,6 +422,12 @@
         "lodash-es": "4.17.23"
       }
     },
+    "node_modules/@chevrotain/cst-dts-gen/node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
+    },
     "node_modules/@chevrotain/gast": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
@@ -431,6 +437,12 @@
         "@chevrotain/types": "11.1.2",
         "lodash-es": "4.17.23"
       }
+    },
+    "node_modules/@chevrotain/gast/node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
     },
     "node_modules/@chevrotain/regexp-to-ast": {
       "version": "11.1.2",
@@ -1717,9 +1729,9 @@
       "license": "MIT"
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.1.tgz",
-      "integrity": "sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
       "license": "MIT",
       "dependencies": {
         "langium": "^4.0.0"
@@ -4125,9 +4137,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4596,9 +4608,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4814,6 +4826,12 @@
       "peerDependencies": {
         "chevrotain": "^11.0.0"
       }
+    },
+    "node_modules/chevrotain/node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -7062,9 +7080,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -7448,14 +7466,14 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.13.0.tgz",
-      "integrity": "sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.0.1",
+        "@mermaid-js/parser": "^1.1.0",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
         "cytoscape": "^3.33.1",

--- a/ui/src/pages/settings/ConnectionsPanel.tsx
+++ b/ui/src/pages/settings/ConnectionsPanel.tsx
@@ -163,10 +163,9 @@ export function ConnectionsPanel() {
                         <span className={cn(
                           "shrink-0 rounded px-1 py-0 text-[9px] font-medium",
                           c.source === "file" ? "bg-muted text-muted-foreground" :
-                          c.source === "database" ? "bg-primary/10 text-primary" :
-                          "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+                          "bg-primary/10 text-primary",
                         )}>
-                          {c.source === "both" ? "file+db" : c.source}
+                          {c.source === "file" ? "file" : "database"}
                         </span>
                       </div>
                       {c.description && (
@@ -295,6 +294,11 @@ function ConnectionViewer({
           {connection.description && (
             <p className="mt-1 text-sm text-muted-foreground">{connection.description}</p>
           )}
+          {connection.source === "both" && (
+            <p className="mt-1 text-[10px] text-muted-foreground">
+              This connection is managed in the database. A fallback version also exists in the config file and can be removed once database management is confirmed.
+            </p>
+          )}
         </div>
         {!isReadOnly && (
           <div className="flex gap-2">
@@ -346,7 +350,11 @@ function ConnectionViewer({
           <div className="rounded-md border divide-y">
             {configEntries.map(([key, value]) => {
               const sensitive = isSensitive(key);
-              const displayValue = sensitive && !showSensitive ? "********" : String(value);
+              const displayValue = sensitive && !showSensitive
+                ? "********"
+                : typeof value === "object" && value !== null
+                  ? JSON.stringify(value)
+                  : String(value);
               return (
                 <div key={key} className="flex items-center gap-4 px-4 py-2">
                   <span className="text-xs font-mono text-muted-foreground w-48 shrink-0 truncate">


### PR DESCRIPTION
## Summary

Agents now only see tools they're authorized to use. Previously, `tools/list` returned all registered tools regardless of persona — the agent would see tools it couldn't call, wasting tokens and causing confusion. Now the visibility middleware resolves the caller's persona from the session context and filters `tools/list` to only include tools the persona's allow/deny rules permit.

Also fixes three connection UI issues reported in production.

## Persona-based tools/list filtering

The `MCPToolVisibilityMiddleware` now applies two layers of filtering:

1. **Global allow/deny patterns** (from `tools` config) — static, applies to all users
2. **Persona tool rules** (from persona `tools.allow`/`tools.deny`) — dynamic, based on the authenticated user's resolved persona

The middleware resolves the caller's identity via `GetPreAuthenticatedUser(ctx)` (set by HTTP-level auth on session establishment) or falls back to `Authenticator.Authenticate(ctx)`. The caller's roles are then checked against each tool using the persona authorizer.

If no user is authenticated (e.g. during initial capability negotiation before auth), the persona filter is skipped and all tools pass — the `tools/call` auth gate still enforces access.

### Files changed

- `pkg/middleware/mcp_visibility.go` — `ToolVisibilityConfig` struct replaces bare `allow, deny` params; adds `Authenticator` and `IsToolAllowedForPersona` function fields; `filterToolVisibility` applies both layers
- `pkg/platform/platform.go` — `addToolVisibilityMiddleware` wires the persona authorizer via closure
- `pkg/middleware/mcp_visibility_test.go` — updated for new signature + 4 new persona filtering tests (deny, passthrough, stacking, unauthenticated)
- `pkg/middleware/middleware_chain_test.go` — updated for new signature

## Connection UI fixes

- **`[object Object]`** — nested config values (e.g. `elicitation` object) now render as JSON in the connection viewer instead of `[object Object]`
- **Source label** — connections that exist in both file and database now show as "database" instead of the confusing "file+db" label, since the DB version is the authority
- **File fallback note** — the viewer shows an explanatory note when a DB-managed connection also has a config file fallback: "This connection is managed in the database. A fallback version also exists in the config file and can be removed once database management is confirmed."

### Files changed

- `ui/src/pages/settings/ConnectionsPanel.tsx` — object rendering, label fix, fallback note

## Test plan

- [ ] Connect as a non-admin persona (e.g. analyst) — `tools/list` should only return tools matching the persona's allow rules
- [ ] Connect as admin — `tools/list` should return all tools
- [ ] Verify global `tools.deny` still hides tools from all personas
- [ ] View a connection with nested config (e.g. elicitation object) — should show JSON, not `[object Object]`
- [ ] View a connection that exists in both file and DB — should show "database" badge and fallback note