### PR TITLE
build(deps): bump mcp-datahub v1.8.0 → v1.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/testcontainers/testcontainers-go v0.41.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.41.0
-	github.com/txn2/mcp-datahub v1.8.0
+	github.com/txn2/mcp-datahub v1.8.1
 	github.com/txn2/mcp-s3 v1.1.0
 	github.com/txn2/mcp-trino v1.2.0
 	github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9R
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v1.8.0 h1:G6Hg/tVIl/drkjOG3DrY8/htm2so+oSiLFNJN4HrD54=
-github.com/txn2/mcp-datahub v1.8.0/go.mod h1:+GPUNirzhGDEUGiSsebuxToLriUygkugHkwDYrFiDKY=
+github.com/txn2/mcp-datahub v1.8.1 h1:nQGpL5UC7nXR1Gm6LqMOwgv6bRRsnFYWO5G3VvdG5/I=
+github.com/txn2/mcp-datahub v1.8.1/go.mod h1:+GPUNirzhGDEUGiSsebuxToLriUygkugHkwDYrFiDKY=
 github.com/txn2/mcp-s3 v1.1.0 h1:fncD3bMXdRlUUVcjc3j4lBBD0wuOzudSJkotdRNrKrA=
 github.com/txn2/mcp-s3 v1.1.0/go.mod h1:8ZB3tEZvEan+9cBqvnaMoCYbkhW0TzDuW2cesNYkEH4=
 github.com/txn2/mcp-trino v1.2.0 h1:XImkDJpahNT+2SHxCO97ZT4GEJBoH8Cr1eVeeX4oIRw=


### PR DESCRIPTION
## Summary

- Bumps `mcp-datahub` from v1.8.0 to [v1.8.1](https://github.com/txn2/mcp-datahub/releases/tag/v1.8.1)
- Fixes `datahub_search` returning `"entities": null` instead of `"entities": []` on zero results, which caused MCP OutputSchema validation failures

No platform-side code changes — fix is entirely in the upstream library.

## Test plan

- [x] Compiles cleanly
- [x] `go test ./pkg/semantic/...` passes