### PR TITLE
fix: batch column description updates in apply_knowledge

### DIFF
--- a/pkg/admin/knowledge_test.go
+++ b/pkg/admin/knowledge_test.go
@@ -207,6 +207,10 @@ func (*mockDataHubWriter) UpdateColumnDescription(_ context.Context, _, _, _ str
 	return nil
 }
 
+func (*mockDataHubWriter) UpdateColumnDescriptionBatch(_ context.Context, _ string, _ map[string]string) error {
+	return nil
+}
+
 func (*mockDataHubWriter) CreateCuratedQuery(_ context.Context, _, _, _, _ string) (string, error) {
 	return "", nil
 }

--- a/pkg/toolkits/knowledge/datahub_client_writer.go
+++ b/pkg/toolkits/knowledge/datahub_client_writer.go
@@ -1,8 +1,14 @@
 package knowledge
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
 
 	dhclient "github.com/txn2/mcp-datahub/pkg/client"
 	"github.com/txn2/mcp-datahub/pkg/types"
@@ -63,6 +69,210 @@ func (w *DataHubClientWriter) UpdateColumnDescription(ctx context.Context, urn, 
 		return fmt.Errorf("updating column description for %s.%s: %w", urn, fieldPath, err)
 	}
 	return nil
+}
+
+// UpdateColumnDescriptionBatch sets descriptions for multiple columns in a single
+// read-modify-write cycle. This avoids the stale-read bug where back-to-back single
+// UpdateColumnDescription calls lose all but the last column due to DataHub's
+// eventual consistency.
+func (w *DataHubClientWriter) UpdateColumnDescriptionBatch(ctx context.Context, urn string, columns map[string]string) error {
+	if len(columns) == 0 {
+		return nil
+	}
+	// For a single column, delegate to the standard method.
+	if len(columns) == 1 {
+		for fp, desc := range columns {
+			return w.UpdateColumnDescription(ctx, urn, fp, desc)
+		}
+	}
+	// Batch: read the current schema, apply all changes, write once.
+	parsed, err := dhclient.ParseURN(urn)
+	if err != nil {
+		return fmt.Errorf("batch column description: invalid URN: %w", err)
+	}
+	schema, err := w.readEditableSchema(ctx, parsed.EntityType, urn)
+	if err != nil {
+		return fmt.Errorf("batch column description: read schema: %w", err)
+	}
+	for fieldPath, desc := range columns {
+		found := false
+		for i := range schema.EditableSchemaFieldInfo {
+			if schema.EditableSchemaFieldInfo[i].FieldPath == fieldPath {
+				schema.EditableSchemaFieldInfo[i].Description = desc
+				found = true
+				break
+			}
+		}
+		if !found {
+			schema.EditableSchemaFieldInfo = append(schema.EditableSchemaFieldInfo, editableFieldInfo{
+				FieldPath:   fieldPath,
+				Description: desc,
+			})
+		}
+	}
+	return w.postIngestProposal(ctx, parsed.EntityType, urn, "editableSchemaMetadata", schema)
+}
+
+// editableSchemaAspect mirrors the upstream unexported type for batch operations.
+type editableSchemaAspect struct {
+	EditableSchemaFieldInfo []editableFieldInfo `json:"editableSchemaFieldInfo"`
+}
+
+// editableFieldInfo mirrors the upstream unexported type for batch operations.
+type editableFieldInfo struct {
+	FieldPath     string          `json:"fieldPath"`
+	Description   string          `json:"description,omitempty"`
+	GlobalTags    json.RawMessage `json:"globalTags,omitempty"`
+	GlossaryTerms json.RawMessage `json:"glossaryTerms,omitempty"`
+}
+
+// readEditableSchema reads the current editableSchemaMetadata aspect via REST.
+func (w *DataHubClientWriter) readEditableSchema(ctx context.Context, entityType, urn string) (*editableSchemaAspect, error) {
+	body, statusCode, err := w.doRESTGet(ctx, w.aspectGetURL(entityType, urn, "editableSchemaMetadata"))
+	if err != nil {
+		return nil, fmt.Errorf("rest get aspect: %w", err)
+	}
+	if statusCode == http.StatusNotFound {
+		return &editableSchemaAspect{}, nil
+	}
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("rest get status %d: %s", statusCode, truncateBody(body))
+	}
+	return parseEditableSchema(body)
+}
+
+// parseEditableSchema unmarshals the REST response body into an editableSchemaAspect.
+func parseEditableSchema(body []byte) (*editableSchemaAspect, error) {
+	var aspectResp struct {
+		Value json.RawMessage `json:"value"`
+	}
+	if err := json.Unmarshal(body, &aspectResp); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+	if len(aspectResp.Value) == 0 || string(bytes.TrimSpace(aspectResp.Value)) == "null" {
+		return &editableSchemaAspect{}, nil
+	}
+	var schema editableSchemaAspect
+	if err := json.Unmarshal(aspectResp.Value, &schema); err != nil {
+		return nil, fmt.Errorf("unmarshal schema: %w", err)
+	}
+	return &schema, nil
+}
+
+// aspectGetURL builds the REST URL for reading an aspect.
+func (w *DataHubClientWriter) aspectGetURL(entityType, urn, aspectName string) string {
+	cfg := w.client.Config()
+	base := strings.TrimSuffix(cfg.URL, "/api/graphql")
+	if cfg.APIVersion == dhclient.APIVersionV3 {
+		return fmt.Sprintf("%s/openapi/v3/entity/%s/%s/%s",
+			base, entityType, url.PathEscape(urn), aspectName)
+	}
+	return fmt.Sprintf("%s/aspects/%s?aspect=%s&version=0", base, urn, aspectName)
+}
+
+// doRESTGet performs an authenticated GET request and returns the body and status code.
+func (w *DataHubClientWriter) doRESTGet(ctx context.Context, reqURL string) (body []byte, statusCode int, err error) {
+	cfg := w.client.Config()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+	if err != nil {
+		return nil, 0, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	if cfg.APIVersion != dhclient.APIVersionV3 {
+		req.Header.Set("X-RestLi-Protocol-Version", "2.0.0")
+	}
+
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // URL from configured endpoint
+	if err != nil {
+		return nil, 0, fmt.Errorf("http get: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("read response: %w", err)
+	}
+	return body, resp.StatusCode, nil
+}
+
+// postIngestProposal writes an aspect via the DataHub REST API.
+func (w *DataHubClientWriter) postIngestProposal(ctx context.Context, entityType, urn, aspectName string, aspect any) error {
+	cfg := w.client.Config()
+	base := strings.TrimSuffix(cfg.URL, "/api/graphql")
+
+	var reqURL string
+	var jsonBody []byte
+	var err error
+
+	if cfg.APIVersion == dhclient.APIVersionV3 {
+		reqURL = fmt.Sprintf("%s/openapi/v3/entity/%s/%s/%s",
+			base, entityType, url.PathEscape(urn), aspectName)
+		jsonBody, err = json.Marshal(struct {
+			Value any `json:"value"`
+		}{Value: aspect})
+	} else {
+		reqURL = fmt.Sprintf("%s/aspects?action=ingestProposal", base)
+		aspectJSON, marshalErr := json.Marshal(aspect)
+		if marshalErr != nil {
+			return fmt.Errorf("marshal aspect: %w", marshalErr)
+		}
+		proposal := struct {
+			Proposal struct {
+				EntityType string `json:"entityType"`
+				EntityURN  string `json:"entityUrn"`
+				ChangeType string `json:"changeType"`
+				AspectName string `json:"aspectName"`
+				Aspect     struct {
+					Value       string `json:"value"`
+					ContentType string `json:"contentType"`
+				} `json:"aspect"`
+			} `json:"proposal"`
+		}{}
+		proposal.Proposal.EntityType = entityType
+		proposal.Proposal.EntityURN = urn
+		proposal.Proposal.ChangeType = "UPSERT"
+		proposal.Proposal.AspectName = aspectName
+		proposal.Proposal.Aspect.Value = string(aspectJSON)
+		proposal.Proposal.Aspect.ContentType = "application/json"
+		jsonBody, err = json.Marshal(proposal)
+	}
+	if err != nil {
+		return fmt.Errorf("marshal proposal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+	if cfg.APIVersion != dhclient.APIVersionV3 {
+		req.Header.Set("X-RestLi-Protocol-Version", "2.0.0")
+	}
+
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // URL from configured endpoint
+	if err != nil {
+		return fmt.Errorf("rest post aspect: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("rest post status %d: %s", resp.StatusCode, truncateBody(body))
+	}
+	return nil
+}
+
+const maxBodyTruncate = 200
+
+func truncateBody(b []byte) string {
+	if len(b) <= maxBodyTruncate {
+		return string(b)
+	}
+	return string(b[:maxBodyTruncate]) + "..."
 }
 
 // AddTag adds a tag to an entity.

--- a/pkg/toolkits/knowledge/datahub_client_writer_test.go
+++ b/pkg/toolkits/knowledge/datahub_client_writer_test.go
@@ -324,6 +324,231 @@ func TestDataHubClientWriter_UpdateColumnDescription_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "updating column description")
 }
 
+func TestDataHubClientWriter_UpdateColumnDescriptionBatch_MultipleColumns(t *testing.T) {
+	var postedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			// Return existing schema with one field already present.
+			resp := struct {
+				Value json.RawMessage `json:"value"`
+			}{
+				Value: json.RawMessage(`{"editableSchemaFieldInfo":[{"fieldPath":"existing","description":"old desc"}]}`),
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		// Capture the POST body.
+		postedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.UpdateColumnDescriptionBatch(context.Background(), testURN, map[string]string{
+		"email": "Email address",
+		"name":  "Full name",
+	})
+	require.NoError(t, err)
+
+	// Verify the POST body contains all three fields (existing + 2 new).
+	require.NotEmpty(t, postedBody)
+	body := string(postedBody)
+	assert.Contains(t, body, "existing")
+	assert.Contains(t, body, "email")
+	assert.Contains(t, body, "name")
+	assert.Contains(t, body, "Email address")
+	assert.Contains(t, body, "Full name")
+}
+
+func TestDataHubClientWriter_UpdateColumnDescriptionBatch_SingleColumn(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.UpdateColumnDescriptionBatch(context.Background(), testURN, map[string]string{
+		"email": "Updated email description",
+	})
+	require.NoError(t, err)
+	// Single column delegates to UpdateColumnDescription (upstream).
+}
+
+func TestDataHubClientWriter_UpdateColumnDescriptionBatch_EmptyMap(t *testing.T) {
+	writer := NewDataHubClientWriter(newTestClient(t, "http://unused"))
+	err := writer.UpdateColumnDescriptionBatch(context.Background(), testURN, map[string]string{})
+	require.NoError(t, err)
+}
+
+func TestDataHubClientWriter_UpdateColumnDescriptionBatch_InvalidURN(t *testing.T) {
+	writer := NewDataHubClientWriter(newTestClient(t, "http://unused"))
+	err := writer.UpdateColumnDescriptionBatch(context.Background(), "not-a-urn", map[string]string{
+		"a": "1",
+		"b": "2",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid URN")
+}
+
+func TestDataHubClientWriter_UpdateColumnDescriptionBatch_ReadError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("server error"))
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.UpdateColumnDescriptionBatch(context.Background(), testURN, map[string]string{
+		"a": "1",
+		"b": "2",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "read schema")
+}
+
+func TestDataHubClientWriter_UpdateColumnDescriptionBatch_WriteError(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if r.Method == http.MethodGet {
+			// Successful read.
+			resp := struct {
+				Value json.RawMessage `json:"value"`
+			}{
+				Value: json.RawMessage(`{"editableSchemaFieldInfo":[]}`),
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		// POST fails.
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("write failed"))
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.UpdateColumnDescriptionBatch(context.Background(), testURN, map[string]string{
+		"a": "1",
+		"b": "2",
+	})
+	assert.Error(t, err)
+}
+
+func TestDataHubClientWriter_UpdateColumnDescriptionBatch_NoExistingAspect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.UpdateColumnDescriptionBatch(context.Background(), testURN, map[string]string{
+		"col_a": "Description A",
+		"col_b": "Description B",
+	})
+	require.NoError(t, err)
+}
+
+func TestDataHubClientWriter_UpdateColumnDescriptionBatch_NullAspectValue(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			resp := struct {
+				Value json.RawMessage `json:"value"`
+			}{
+				Value: json.RawMessage(`null`),
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.UpdateColumnDescriptionBatch(context.Background(), testURN, map[string]string{
+		"col_a": "Description A",
+		"col_b": "Description B",
+	})
+	require.NoError(t, err)
+}
+
+func TestParseEditableSchema(t *testing.T) {
+	body := `{"value":{"editableSchemaFieldInfo":[{"fieldPath":"email","description":"Email"}]}}`
+	schema, err := parseEditableSchema([]byte(body))
+	require.NoError(t, err)
+	require.Len(t, schema.EditableSchemaFieldInfo, 1)
+	assert.Equal(t, "email", schema.EditableSchemaFieldInfo[0].FieldPath)
+	assert.Equal(t, "Email", schema.EditableSchemaFieldInfo[0].Description)
+}
+
+func TestParseEditableSchema_NullValue(t *testing.T) {
+	body := `{"value":null}`
+	schema, err := parseEditableSchema([]byte(body))
+	require.NoError(t, err)
+	assert.Empty(t, schema.EditableSchemaFieldInfo)
+}
+
+func TestParseEditableSchema_EmptyValue(t *testing.T) {
+	body := `{"value":""}`
+	_, err := parseEditableSchema([]byte(body))
+	// Empty string is not valid JSON for the schema, should error.
+	assert.Error(t, err)
+}
+
+func TestParseEditableSchema_InvalidJSON(t *testing.T) {
+	_, err := parseEditableSchema([]byte(`not json`))
+	assert.Error(t, err)
+}
+
+func TestAspectGetURL_V1(t *testing.T) {
+	cfg := dhclient.DefaultConfig()
+	cfg.URL = "https://datahub.example.com/api/graphql"
+	cfg.Token = "test"
+	c, err := dhclient.New(cfg)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	writer := NewDataHubClientWriter(c)
+
+	got := writer.aspectGetURL("dataset", testURN, "editableSchemaMetadata")
+	assert.Contains(t, got, "/aspects/")
+	assert.Contains(t, got, "editableSchemaMetadata")
+}
+
+func TestAspectGetURL_V3(t *testing.T) {
+	cfg := dhclient.DefaultConfig()
+	cfg.URL = "https://datahub.example.com/api/graphql"
+	cfg.Token = "test"
+	cfg.APIVersion = dhclient.APIVersionV3
+	c, err := dhclient.New(cfg)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	writer := NewDataHubClientWriter(c)
+
+	got := writer.aspectGetURL("dataset", testURN, "editableSchemaMetadata")
+	assert.Contains(t, got, "/openapi/v3/entity/dataset/")
+	assert.Contains(t, got, "editableSchemaMetadata")
+}
+
+func TestTruncateBody(t *testing.T) {
+	short := []byte("short")
+	assert.Equal(t, "short", truncateBody(short))
+
+	long := []byte(strings.Repeat("x", 300))
+	result := truncateBody(long)
+	assert.Len(t, result, 203) // 200 + "..."
+	assert.True(t, strings.HasSuffix(result, "..."))
+}
+
 func TestDataHubClientWriter_CreateCuratedQuery(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/toolkits/knowledge/datahub_writer.go
+++ b/pkg/toolkits/knowledge/datahub_writer.go
@@ -11,6 +11,10 @@ type DataHubWriter interface {
 	GetCurrentMetadata(ctx context.Context, urn string) (*EntityMetadata, error)
 	UpdateDescription(ctx context.Context, urn string, description string) error
 	UpdateColumnDescription(ctx context.Context, urn string, fieldPath string, description string) error
+	// UpdateColumnDescriptionBatch sets descriptions for multiple columns in a single
+	// read-modify-write cycle, avoiding the stale-read bug where back-to-back single
+	// calls lose all but the last column.
+	UpdateColumnDescriptionBatch(ctx context.Context, urn string, columns map[string]string) error
 	AddTag(ctx context.Context, urn string, tag string) error
 	RemoveTag(ctx context.Context, urn string, tag string) error
 	AddGlossaryTerm(ctx context.Context, urn string, termURN string) error
@@ -47,6 +51,11 @@ func (*NoopDataHubWriter) UpdateDescription(_ context.Context, _, _ string) erro
 
 // UpdateColumnDescription is a no-op.
 func (*NoopDataHubWriter) UpdateColumnDescription(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+// UpdateColumnDescriptionBatch is a no-op.
+func (*NoopDataHubWriter) UpdateColumnDescriptionBatch(_ context.Context, _ string, _ map[string]string) error {
 	return nil
 }
 

--- a/pkg/toolkits/knowledge/datahub_writer_test.go
+++ b/pkg/toolkits/knowledge/datahub_writer_test.go
@@ -74,6 +74,15 @@ func TestNoopDataHubWriter_UpdateColumnDescription(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestNoopDataHubWriter_UpdateColumnDescriptionBatch(t *testing.T) {
+	writer := &NoopDataHubWriter{}
+	err := writer.UpdateColumnDescriptionBatch(context.Background(), testDatasetURN, map[string]string{
+		"email": "Email address",
+		"name":  "Full name",
+	})
+	assert.NoError(t, err)
+}
+
 func TestNoopDataHubWriter_CreateCuratedQuery(t *testing.T) {
 	writer := &NoopDataHubWriter{}
 	urn, err := writer.CreateCuratedQuery(context.Background(), testDatasetURN, "test query", "SELECT 1", "a test")

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -548,14 +548,52 @@ const columnTargetPrefix = "column:"
 
 // executeChanges applies changes to DataHub, rolling back on failure.
 // Returns a list of IDs/URNs created by changes (query URNs, document IDs, incident URNs).
+// Column description updates are batched into a single read-modify-write to avoid
+// the stale-read bug where back-to-back single calls lose all but the last column.
 func (t *Toolkit) executeChanges(ctx context.Context, urn string, changes []ApplyChange) ([]string, error) {
-	// Pre-flight: validate entity type compatibility for all changes before executing any.
-	for i, c := range changes {
-		if err := validateEntityTypeForChange(urn, c); err != nil {
-			return nil, fmt.Errorf("change %d of %d rejected: %w", i+1, len(changes), err)
+	if err := validateAllChanges(urn, changes); err != nil {
+		return nil, err
+	}
+
+	columnDescs, nonColumnChanges := partitionColumnChanges(changes)
+
+	if len(columnDescs) > 0 {
+		if err := t.datahubWriter.UpdateColumnDescriptionBatch(ctx, urn, columnDescs); err != nil {
+			return nil, fmt.Errorf("datahub write failed for column descriptions: %w", err)
 		}
 	}
 
+	return t.dispatchNonColumnChanges(ctx, urn, nonColumnChanges)
+}
+
+// validateAllChanges pre-checks entity type compatibility for all changes.
+func validateAllChanges(urn string, changes []ApplyChange) error {
+	for i, c := range changes {
+		if err := validateEntityTypeForChange(urn, c); err != nil {
+			return fmt.Errorf("change %d of %d rejected: %w", i+1, len(changes), err)
+		}
+	}
+	return nil
+}
+
+// partitionColumnChanges separates column description updates from other changes.
+func partitionColumnChanges(changes []ApplyChange) (map[string]string, []ApplyChange) {
+	columnDescs := make(map[string]string)
+	var other []ApplyChange
+	for _, c := range changes {
+		if c.ChangeType == string(actionUpdateDescription) {
+			if fieldPath, ok := parseColumnTarget(c.Target); ok {
+				columnDescs[fieldPath] = c.Detail
+				continue
+			}
+		}
+		other = append(other, c)
+	}
+	return columnDescs, other
+}
+
+// dispatchNonColumnChanges applies non-column changes individually.
+func (t *Toolkit) dispatchNonColumnChanges(ctx context.Context, urn string, changes []ApplyChange) ([]string, error) {
 	var createdURNs []string
 	for i, c := range changes {
 		queryURN, err := t.dispatchChange(ctx, urn, c)

--- a/pkg/toolkits/knowledge/toolkit_test.go
+++ b/pkg/toolkits/knowledge/toolkit_test.go
@@ -286,6 +286,15 @@ func (w *spyWriter) UpdateColumnDescription(_ context.Context, urn, fieldPath, d
 	return w.recordAndCheck("UpdateColumnDescription", urn, fieldPath, desc)
 }
 
+func (w *spyWriter) UpdateColumnDescriptionBatch(_ context.Context, urn string, columns map[string]string) error {
+	for fp, desc := range columns {
+		if err := w.recordAndCheck("UpdateColumnDescriptionBatch", urn, fp, desc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (w *spyWriter) AddTag(_ context.Context, urn, tag string) error {
 	return w.recordAndCheck("AddTag", urn, tag, "")
 }
@@ -2632,7 +2641,7 @@ func TestExecuteChanges_ColumnTarget(t *testing.T) {
 	require.Len(t, writer.WriteCalls, 1)
 
 	call := writer.WriteCalls[0]
-	assert.Equal(t, "UpdateColumnDescription", call.Method)
+	assert.Equal(t, "UpdateColumnDescriptionBatch", call.Method)
 	assert.Equal(t, testEntityURN, call.URN)
 	assert.Equal(t, "location_type_id", call.Arg1)
 	assert.Equal(t, "Type of location", call.Arg2)
@@ -2695,9 +2704,11 @@ func TestExecuteChanges_MixedColumnAndDataset(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, writer.WriteCalls, 3)
 
-	assert.Equal(t, "UpdateDescription", writer.WriteCalls[0].Method)
-	assert.Equal(t, "UpdateColumnDescription", writer.WriteCalls[1].Method)
-	assert.Equal(t, "email", writer.WriteCalls[1].Arg1)
+	// Column descriptions are batched and applied first.
+	assert.Equal(t, "UpdateColumnDescriptionBatch", writer.WriteCalls[0].Method)
+	assert.Equal(t, "email", writer.WriteCalls[0].Arg1)
+	// Then non-column changes in order.
+	assert.Equal(t, "UpdateDescription", writer.WriteCalls[1].Method)
 	assert.Equal(t, "AddTag", writer.WriteCalls[2].Method)
 	// Full URN should pass through unchanged (no double-prepend)
 	assert.Equal(t, "urn:li:tag:PII", writer.WriteCalls[2].Arg1)
@@ -2713,7 +2724,7 @@ func TestExecuteChanges_ColumnTargetError(t *testing.T) {
 
 	_, err := tk.executeChanges(context.Background(), testEntityURN, changes)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "column description update")
+	assert.Contains(t, err.Error(), "column descriptions")
 }
 
 func TestExecuteChanges_DatasetDescriptionError(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Fixes a data loss bug** where `apply_knowledge` with multiple `update_description` changes targeting different columns (e.g., `column:email`, `column:name`) would only persist the **last** column description, silently dropping all others
- Root cause: each `UpdateColumnDescription` call performs a read-modify-write on DataHub's `editableSchemaMetadata` aspect, but back-to-back calls read stale state before the previous write is indexed — the last write wins and overwrites all prior columns
- The fix batches all column description changes into a single read-modify-write cycle via a new `UpdateColumnDescriptionBatch` method that reads the schema once, applies all column changes in memory, and writes once

## What changed

**Interface** (`pkg/toolkits/knowledge/datahub_writer.go`):
- Added `UpdateColumnDescriptionBatch(ctx, urn string, columns map[string]string) error` to the `DataHubWriter` interface
- Added noop implementation

**Batch implementation** (`pkg/toolkits/knowledge/datahub_client_writer.go`):
- `UpdateColumnDescriptionBatch` reads the `editableSchemaMetadata` aspect via DataHub REST API, applies all column descriptions in memory, and writes the full aspect back in a single POST
- For single-column batches, delegates to the existing `UpdateColumnDescription` (no behavior change)
- Mirrors the upstream `mcp-datahub` REST protocol (v1 Rest.li and v3 OpenAPI) using the client's exported `Config()` for URL/token/API version — no upstream changes required
- Uses `json.RawMessage` for `globalTags` and `glossaryTerms` fields to preserve existing column metadata that isn't being modified

**Orchestration** (`pkg/toolkits/knowledge/toolkit.go`):
- `executeChanges` now partitions incoming changes: column description updates are collected into a `map[string]string` and applied via `UpdateColumnDescriptionBatch` before other changes are dispatched individually
- Extracted `validateAllChanges`, `partitionColumnChanges`, and `dispatchNonColumnChanges` helpers to keep cyclomatic/cognitive complexity within lint thresholds

## Reproduction

Before this fix, the following `apply_knowledge` call would only persist the description for `column:name`:

```json
{
  "action": "apply",
  "entity_urn": "urn:li:dataset:(...)",
  "changes": [
    {"change_type": "update_description", "target": "column:id", "detail": "Primary key"},
    {"change_type": "update_description", "target": "column:name", "detail": "Display name"},
    {"change_type": "update_description", "target": "column:email", "detail": "Email address"}
  ]
}
```

After this fix, all three column descriptions persist correctly.

## Test plan

- [x] `TestExecuteChanges_ColumnTarget` — single column description routed through batch method
- [x] `TestExecuteChanges_MixedColumnAndDataset` — column descriptions batched first, then entity-level description and tags applied in order
- [x] `TestExecuteChanges_ColumnTargetError` — batch failure propagates correctly
- [x] `TestNoopDataHubWriter_UpdateColumnDescriptionBatch` — noop returns nil
- [x] All existing knowledge toolkit tests pass (no regressions)
- [x] Full project test suite passes with race detection
- [x] 0 golangci-lint issues
- [ ] Manual verification: run `apply_knowledge` with 3+ column descriptions against a live DataHub instance and confirm all persist