### PR TITLE
feat: add collection CRUD actions to manage_artifact tool

### DIFF
--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1049,15 +1049,16 @@ func (p *Platform) initPortal() error {
 
 	// Create and register toolkit
 	tk := portalkit.New(portalkit.Config{
-		Name:           "default",
-		AssetStore:     p.portalAssetStore,
-		ShareStore:     p.portalShareStore,
-		VersionStore:   p.portalVersionStore,
-		S3Client:       s3Client,
-		S3Bucket:       p.config.Portal.S3Bucket,
-		S3Prefix:       p.config.Portal.S3Prefix,
-		BaseURL:        p.config.Portal.PublicBaseURL,
-		MaxContentSize: p.config.Portal.MaxContentSize,
+		Name:            "default",
+		AssetStore:      p.portalAssetStore,
+		ShareStore:      p.portalShareStore,
+		VersionStore:    p.portalVersionStore,
+		CollectionStore: p.portalCollectionStore,
+		S3Client:        s3Client,
+		S3Bucket:        p.config.Portal.S3Bucket,
+		S3Prefix:        p.config.Portal.S3Prefix,
+		BaseURL:         p.config.Portal.PublicBaseURL,
+		MaxContentSize:  p.config.Portal.MaxContentSize,
 	})
 
 	if err := p.toolkitRegistry.Register(tk); err != nil {

--- a/pkg/portal/public.go
+++ b/pkg/portal/public.go
@@ -87,12 +87,14 @@ func (h *Handler) publicView(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	h.renderAssetViewer(w, asset, data, share)
+	h.renderAssetViewer(w, r, asset, data, share)
 }
 
 // renderAssetViewer renders the public_viewer.html template for an asset.
 // Used by both single-asset public shares and collection item views.
-func (h *Handler) renderAssetViewer(w http.ResponseWriter, asset *Asset, data []byte, share *Share) {
+// When the request includes ?embedded=1, chrome (header, notice, info modal)
+// is suppressed so the viewer can be loaded in an iframe without double headers.
+func (h *Handler) renderAssetViewer(w http.ResponseWriter, r *http.Request, asset *Asset, data []byte, share *Share) {
 	contentJSON, _ := json.Marshal(map[string]any{ // #nosec G104 -- string/[]string map marshaling cannot fail
 		"contentType": asset.ContentType,
 		"content":     string(data),
@@ -141,6 +143,7 @@ func (h *Handler) renderAssetViewer(w http.ResponseWriter, asset *Asset, data []
 		"ExpiresAtISO":       expiresAtISO,
 		"HideExpiration":     share.HideExpiration,
 		"NoticeText":         share.NoticeText,
+		"Embedded":           r.URL.Query().Get("embedded") == "1",
 	})
 }
 
@@ -352,7 +355,7 @@ func (h *Handler) publicCollectionItemView(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Render with the exact same template and data as a single-asset public view.
-	h.renderAssetViewer(w, asset, data, share)
+	h.renderAssetViewer(w, r, asset, data, share)
 }
 
 // publicCollectionItemThumbnail serves an asset's thumbnail within a public collection share.

--- a/pkg/portal/templates/public_collection_viewer.html
+++ b/pkg/portal/templates/public_collection_viewer.html
@@ -207,7 +207,7 @@ main{max-width:960px;margin:0 auto;padding:32px 24px}
     // Load the full asset viewer (same page as single-asset public shares) in an iframe.
     var iframe = document.createElement('iframe');
     iframe.style.cssText = 'width:100%;height:100%;border:none';
-    iframe.src = '/portal/view/' + token + '/items/' + assetId + '/view';
+    iframe.src = '/portal/view/' + token + '/items/' + assetId + '/view?embedded=1';
     body.innerHTML = '';
     body.appendChild(iframe);
   };

--- a/pkg/portal/templates/public_viewer.html
+++ b/pkg/portal/templates/public_viewer.html
@@ -279,6 +279,8 @@
     </script>
 </head>
 <body>
+    {{if .Embedded}}<style>body{margin:0;padding:0} .content{height:100vh}</style>{{end}}
+    {{if not .Embedded}}
     <div class="header">
         {{if or .ImplementorName .ImplementorLogoSVG}}
         <div class="brand brand-implementor">
@@ -318,6 +320,7 @@
         {{if .NoticeText}}<span>{{.NoticeText}}</span>{{end}}
     </div>
     {{end}}
+    {{end}}
     <div class="content">
         <style>{{.ContentViewerCSS}}</style>
         <div id="content-root">
@@ -326,6 +329,7 @@
         <script type="application/json" id="content-data">{{.ContentJSON}}</script>
         <script>{{.ContentViewerJS}}</script>
     </div>
+    {{if not .Embedded}}
     <div class="modal-overlay" id="info-modal" hidden>
         <div class="modal-card">
             <h2>About this asset</h2>
@@ -410,5 +414,6 @@
         });
     })();
     </script>
+    {{end}}
 </body>
 </html>

--- a/pkg/toolkits/portal/collection_handlers.go
+++ b/pkg/toolkits/portal/collection_handlers.go
@@ -9,12 +9,30 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/portal"
 )
 
+// collectionDeletedMsg is returned when an operation targets a soft-deleted collection.
+const collectionDeletedMsg = "collection has been deleted"
+
+// validationMsgFmt formats a validation error for MCP error responses.
+const validationMsgFmt = "validation: %s"
+
+// getActiveCollection fetches a collection and rejects soft-deleted ones.
+func (t *Toolkit) getActiveCollection(ctx context.Context, id string) (*portal.Collection, *mcp.CallToolResult) {
+	coll, err := t.collectionStore.Get(ctx, id)
+	if err != nil {
+		return nil, errorResult("collection not found: " + err.Error())
+	}
+	if coll.DeletedAt != nil {
+		return nil, errorResult(collectionDeletedMsg)
+	}
+	return coll, nil
+}
+
 func (t *Toolkit) handleCreateCollection(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
 	if err := portal.ValidateCollectionName(input.Name); err != nil {
-		return errorResult(fmt.Errorf(validationFmt, err).Error()), nil, nil
+		return errorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil
 	}
 	if err := portal.ValidateCollectionDescription(input.Description); err != nil {
-		return errorResult(fmt.Errorf(validationFmt, err).Error()), nil, nil
+		return errorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil
 	}
 
 	ownerID := resolveOwnerID(ctx)
@@ -40,10 +58,13 @@ func (t *Toolkit) handleCreateCollection(ctx context.Context, input manageArtifa
 	if len(input.Sections) > 0 {
 		sections, err := convertSections(input.Sections)
 		if err != nil {
-			return errorResult(fmt.Errorf(validationFmt, err).Error()), nil, nil //nolint:nilerr // MCP protocol
+			return errorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil //nolint:nilerr // MCP protocol
 		}
 		if err := t.collectionStore.SetSections(ctx, collID, sections); err != nil {
-			return errorResult("failed to set sections: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+			// Include collection_id so the agent can retry set_sections on the orphaned collection.
+			return errorResult(fmt.Sprintf(
+				"collection %s created but failed to set sections: %s", collID, err.Error(),
+			)), nil, nil //nolint:nilerr // MCP protocol
 		}
 	}
 
@@ -80,18 +101,16 @@ func (t *Toolkit) handleListCollections(ctx context.Context, input manageArtifac
 	})
 }
 
+// handleGetCollection retrieves a collection by ID. No ownership check — read
+// access is intentionally broader than write, matching the asset get behavior.
 func (t *Toolkit) handleGetCollection(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
 	if input.CollectionID == "" {
 		return errorResult("collection_id is required for get_collection action"), nil, nil
 	}
 
-	coll, err := t.collectionStore.Get(ctx, input.CollectionID)
-	if err != nil {
-		return errorResult("collection not found: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
-	}
-
-	if coll.DeletedAt != nil {
-		return errorResult("collection has been deleted"), nil, nil
+	coll, errResult := t.getActiveCollection(ctx, input.CollectionID)
+	if errResult != nil {
+		return errResult, nil, nil
 	}
 
 	return jsonResult(coll)
@@ -102,9 +121,9 @@ func (t *Toolkit) handleUpdateCollection(ctx context.Context, input manageArtifa
 		return errorResult("collection_id is required for update_collection action"), nil, nil
 	}
 
-	coll, err := t.collectionStore.Get(ctx, input.CollectionID)
-	if err != nil {
-		return errorResult("collection not found: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	coll, errResult := t.getActiveCollection(ctx, input.CollectionID)
+	if errResult != nil {
+		return errResult, nil, nil
 	}
 
 	ownerID := resolveOwnerID(ctx)
@@ -122,20 +141,22 @@ func (t *Toolkit) handleUpdateCollection(ctx context.Context, input manageArtifa
 	}
 
 	if err := portal.ValidateCollectionName(name); err != nil {
-		return errorResult(fmt.Errorf(validationFmt, err).Error()), nil, nil
+		return errorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil
 	}
 	if err := portal.ValidateCollectionDescription(desc); err != nil {
-		return errorResult(fmt.Errorf(validationFmt, err).Error()), nil, nil
+		return errorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil
 	}
 
 	if err := t.collectionStore.Update(ctx, input.CollectionID, name, desc); err != nil {
 		return errorResult("failed to update collection: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
 	}
 
-	return jsonResult(map[string]any{
-		"collection_id": input.CollectionID,
-		"message":       "Collection updated successfully.",
-	})
+	updated, err := t.collectionStore.Get(ctx, input.CollectionID)
+	if err != nil {
+		return errorResult("updated but failed to retrieve collection: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	return jsonResult(updated)
 }
 
 func (t *Toolkit) handleDeleteCollection(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
@@ -143,9 +164,9 @@ func (t *Toolkit) handleDeleteCollection(ctx context.Context, input manageArtifa
 		return errorResult("collection_id is required for delete_collection action"), nil, nil
 	}
 
-	coll, err := t.collectionStore.Get(ctx, input.CollectionID)
-	if err != nil {
-		return errorResult("collection not found: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	coll, errResult := t.getActiveCollection(ctx, input.CollectionID)
+	if errResult != nil {
+		return errResult, nil, nil
 	}
 
 	ownerID := resolveOwnerID(ctx)
@@ -168,9 +189,9 @@ func (t *Toolkit) handleSetSections(ctx context.Context, input manageArtifactInp
 		return errorResult("collection_id is required for set_sections action"), nil, nil
 	}
 
-	coll, err := t.collectionStore.Get(ctx, input.CollectionID)
-	if err != nil {
-		return errorResult("collection not found: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	coll, errResult := t.getActiveCollection(ctx, input.CollectionID)
+	if errResult != nil {
+		return errResult, nil, nil
 	}
 
 	ownerID := resolveOwnerID(ctx)
@@ -180,7 +201,7 @@ func (t *Toolkit) handleSetSections(ctx context.Context, input manageArtifactInp
 
 	sections, err := convertSections(input.Sections)
 	if err != nil {
-		return errorResult(fmt.Errorf(validationFmt, err).Error()), nil, nil //nolint:nilerr // MCP protocol
+		return errorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil //nolint:nilerr // MCP protocol
 	}
 
 	if err := t.collectionStore.SetSections(ctx, input.CollectionID, sections); err != nil {

--- a/pkg/toolkits/portal/collection_handlers.go
+++ b/pkg/toolkits/portal/collection_handlers.go
@@ -1,0 +1,229 @@
+package portal
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/portal"
+)
+
+func (t *Toolkit) handleCreateCollection(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+	if err := portal.ValidateCollectionName(input.Name); err != nil {
+		return errorResult(fmt.Errorf(validationFmt, err).Error()), nil, nil
+	}
+	if err := portal.ValidateCollectionDescription(input.Description); err != nil {
+		return errorResult(fmt.Errorf(validationFmt, err).Error()), nil, nil
+	}
+
+	ownerID := resolveOwnerID(ctx)
+	ownerEmail := resolveOwnerEmail(ctx)
+
+	collID, err := generateID()
+	if err != nil {
+		return errorResult("internal error generating collection ID"), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	coll := portal.Collection{
+		ID:          collID,
+		OwnerID:     ownerID,
+		OwnerEmail:  ownerEmail,
+		Name:        input.Name,
+		Description: input.Description,
+	}
+
+	if err := t.collectionStore.Insert(ctx, coll); err != nil {
+		return errorResult("failed to create collection: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	if len(input.Sections) > 0 {
+		sections, err := convertSections(input.Sections)
+		if err != nil {
+			return errorResult(fmt.Errorf(validationFmt, err).Error()), nil, nil //nolint:nilerr // MCP protocol
+		}
+		if err := t.collectionStore.SetSections(ctx, collID, sections); err != nil {
+			return errorResult("failed to set sections: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		}
+	}
+
+	result := map[string]any{
+		"collection_id": collID,
+		"message":       "Collection created successfully.",
+	}
+	if t.baseURL != "" {
+		result["portal_url"] = t.baseURL + "/portal/collections/" + collID
+	}
+	return jsonResult(result)
+}
+
+func (t *Toolkit) handleListCollections(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+	ownerID := resolveOwnerID(ctx)
+
+	collections, total, err := t.collectionStore.List(ctx, portal.CollectionFilter{
+		OwnerID: ownerID,
+		Search:  input.Search,
+		Limit:   input.Limit,
+		Offset:  input.Offset,
+	})
+	if err != nil {
+		return errorResult("failed to list collections: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	if collections == nil {
+		collections = []portal.Collection{}
+	}
+
+	return jsonResult(map[string]any{
+		"collections": collections,
+		"total":       total,
+	})
+}
+
+func (t *Toolkit) handleGetCollection(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+	if input.CollectionID == "" {
+		return errorResult("collection_id is required for get_collection action"), nil, nil
+	}
+
+	coll, err := t.collectionStore.Get(ctx, input.CollectionID)
+	if err != nil {
+		return errorResult("collection not found: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	if coll.DeletedAt != nil {
+		return errorResult("collection has been deleted"), nil, nil
+	}
+
+	return jsonResult(coll)
+}
+
+func (t *Toolkit) handleUpdateCollection(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+	if input.CollectionID == "" {
+		return errorResult("collection_id is required for update_collection action"), nil, nil
+	}
+
+	coll, err := t.collectionStore.Get(ctx, input.CollectionID)
+	if err != nil {
+		return errorResult("collection not found: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	ownerID := resolveOwnerID(ctx)
+	if coll.OwnerID != ownerID {
+		return errorResult("you can only update your own collections"), nil, nil
+	}
+
+	name := coll.Name
+	if input.Name != "" {
+		name = input.Name
+	}
+	desc := coll.Description
+	if input.Description != "" {
+		desc = input.Description
+	}
+
+	if err := portal.ValidateCollectionName(name); err != nil {
+		return errorResult(fmt.Errorf(validationFmt, err).Error()), nil, nil
+	}
+	if err := portal.ValidateCollectionDescription(desc); err != nil {
+		return errorResult(fmt.Errorf(validationFmt, err).Error()), nil, nil
+	}
+
+	if err := t.collectionStore.Update(ctx, input.CollectionID, name, desc); err != nil {
+		return errorResult("failed to update collection: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	return jsonResult(map[string]any{
+		"collection_id": input.CollectionID,
+		"message":       "Collection updated successfully.",
+	})
+}
+
+func (t *Toolkit) handleDeleteCollection(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+	if input.CollectionID == "" {
+		return errorResult("collection_id is required for delete_collection action"), nil, nil
+	}
+
+	coll, err := t.collectionStore.Get(ctx, input.CollectionID)
+	if err != nil {
+		return errorResult("collection not found: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	ownerID := resolveOwnerID(ctx)
+	if coll.OwnerID != ownerID {
+		return errorResult("you can only delete your own collections"), nil, nil
+	}
+
+	if err := t.collectionStore.SoftDelete(ctx, input.CollectionID); err != nil {
+		return errorResult("failed to delete collection: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	return jsonResult(map[string]any{
+		"collection_id": input.CollectionID,
+		"message":       "Collection deleted successfully.",
+	})
+}
+
+func (t *Toolkit) handleSetSections(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+	if input.CollectionID == "" {
+		return errorResult("collection_id is required for set_sections action"), nil, nil
+	}
+
+	coll, err := t.collectionStore.Get(ctx, input.CollectionID)
+	if err != nil {
+		return errorResult("collection not found: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	ownerID := resolveOwnerID(ctx)
+	if coll.OwnerID != ownerID {
+		return errorResult("you can only modify your own collections"), nil, nil
+	}
+
+	sections, err := convertSections(input.Sections)
+	if err != nil {
+		return errorResult(fmt.Errorf(validationFmt, err).Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	if err := t.collectionStore.SetSections(ctx, input.CollectionID, sections); err != nil {
+		return errorResult("failed to set sections: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	updated, err := t.collectionStore.Get(ctx, input.CollectionID)
+	if err != nil {
+		return errorResult("sections updated but failed to retrieve collection: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	return jsonResult(updated)
+}
+
+// convertSections transforms MCP input sections into portal CollectionSection
+// values with generated IDs, validating each section and item.
+func convertSections(inputs []sectionInput) ([]portal.CollectionSection, error) {
+	sections := make([]portal.CollectionSection, len(inputs))
+	for i, s := range inputs {
+		items := make([]portal.CollectionItem, len(s.Items))
+		for j, item := range s.Items {
+			if item.AssetID == "" {
+				return nil, fmt.Errorf("section %d, item %d: asset_id is required", i, j)
+			}
+			itemID, err := generateID()
+			if err != nil {
+				return nil, fmt.Errorf("generating item ID: %w", err)
+			}
+			items[j] = portal.CollectionItem{ID: itemID, AssetID: item.AssetID}
+		}
+		secID, err := generateID()
+		if err != nil {
+			return nil, fmt.Errorf("generating section ID: %w", err)
+		}
+		sections[i] = portal.CollectionSection{
+			ID:          secID,
+			Title:       s.Title,
+			Description: s.Description,
+			Items:       items,
+		}
+	}
+	if err := portal.ValidateSections(sections); err != nil {
+		return nil, fmt.Errorf("validating sections: %w", err)
+	}
+	return sections, nil
+}

--- a/pkg/toolkits/portal/collection_handlers_test.go
+++ b/pkg/toolkits/portal/collection_handlers_test.go
@@ -1,0 +1,688 @@
+package portal
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/portal"
+)
+
+// inMemoryCollectionStore implements portal.CollectionStore for testing.
+type inMemoryCollectionStore struct {
+	collections map[string]portal.Collection
+	sections    map[string][]portal.CollectionSection // keyed by collection ID
+	insertErr   error
+	updateErr   error
+	deleteErr   error
+	setSectErr  error
+}
+
+func newInMemoryCollectionStore() *inMemoryCollectionStore {
+	return &inMemoryCollectionStore{
+		collections: make(map[string]portal.Collection),
+		sections:    make(map[string][]portal.CollectionSection),
+	}
+}
+
+func (s *inMemoryCollectionStore) Insert(_ context.Context, c portal.Collection) error {
+	if s.insertErr != nil {
+		return s.insertErr
+	}
+	s.collections[c.ID] = c
+	return nil
+}
+
+func (s *inMemoryCollectionStore) Get(_ context.Context, id string) (*portal.Collection, error) {
+	c, ok := s.collections[id]
+	if !ok {
+		return nil, notFoundError{}
+	}
+	c.Sections = s.sections[id]
+	return &c, nil
+}
+
+func (s *inMemoryCollectionStore) List(_ context.Context, filter portal.CollectionFilter) ([]portal.Collection, int, error) {
+	var result []portal.Collection
+	for _, c := range s.collections {
+		if c.DeletedAt != nil {
+			continue
+		}
+		if filter.OwnerID != "" && c.OwnerID != filter.OwnerID {
+			continue
+		}
+		result = append(result, c)
+	}
+	return result, len(result), nil
+}
+
+func (s *inMemoryCollectionStore) Update(_ context.Context, id, name, description string) error {
+	if s.updateErr != nil {
+		return s.updateErr
+	}
+	c, ok := s.collections[id]
+	if !ok || c.DeletedAt != nil {
+		return notFoundError{}
+	}
+	c.Name = name
+	c.Description = description
+	s.collections[id] = c
+	return nil
+}
+
+func (s *inMemoryCollectionStore) UpdateConfig(_ context.Context, id string, config portal.CollectionConfig) error {
+	c, ok := s.collections[id]
+	if !ok {
+		return notFoundError{}
+	}
+	c.Config = config
+	s.collections[id] = c
+	return nil
+}
+
+func (s *inMemoryCollectionStore) UpdateThumbnail(_ context.Context, id, thumbnailS3Key string) error {
+	c, ok := s.collections[id]
+	if !ok {
+		return notFoundError{}
+	}
+	c.ThumbnailS3Key = thumbnailS3Key
+	s.collections[id] = c
+	return nil
+}
+
+func (s *inMemoryCollectionStore) SoftDelete(_ context.Context, id string) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	c, ok := s.collections[id]
+	if !ok || c.DeletedAt != nil {
+		return notFoundError{}
+	}
+	now := time.Now()
+	c.DeletedAt = &now
+	s.collections[id] = c
+	return nil
+}
+
+func (s *inMemoryCollectionStore) SetSections(_ context.Context, collectionID string, sections []portal.CollectionSection) error {
+	if s.setSectErr != nil {
+		return s.setSectErr
+	}
+	s.sections[collectionID] = sections
+	return nil
+}
+
+var _ portal.CollectionStore = (*inMemoryCollectionStore)(nil)
+
+func userCtx(userID, email string) context.Context { //nolint:unparam // test helper, values vary by intent
+	return middleware.WithPlatformContext(context.Background(), &middleware.PlatformContext{
+		UserID:    userID,
+		UserEmail: email,
+	})
+}
+
+func toolkitWithCollections(cs *inMemoryCollectionStore) *Toolkit {
+	return New(Config{
+		Name:            "test",
+		CollectionStore: cs,
+		S3Bucket:        "bucket",
+		BaseURL:         "http://example.com",
+	})
+}
+
+func extractJSON(t *testing.T, result *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &out))
+	return out
+}
+
+func extractError(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	return tc.Text
+}
+
+// --- create_collection tests ---
+
+func TestCreateCollection_Success(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action:      "create_collection",
+		Name:        "My Collection",
+		Description: "A test collection",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	out := extractJSON(t, result)
+	assert.NotEmpty(t, out["collection_id"])
+	assert.Equal(t, "Collection created successfully.", out["message"])
+	assert.Contains(t, out["portal_url"], out["collection_id"])
+
+	// Verify stored
+	collID := out["collection_id"].(string) //nolint:errcheck // test assertion
+	coll, getErr := cs.Get(context.Background(), collID)
+	require.NoError(t, getErr)
+	assert.Equal(t, "user1", coll.OwnerID)
+	assert.Equal(t, "user1@example.com", coll.OwnerEmail)
+	assert.Equal(t, "My Collection", coll.Name)
+}
+
+func TestCreateCollection_WithSections(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "create_collection",
+		Name:   "With Sections",
+		Sections: []sectionInput{
+			{
+				Title: "Section 1",
+				Items: []itemInput{{AssetID: "asset-a"}, {AssetID: "asset-b"}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	out := extractJSON(t, result)
+	collID := out["collection_id"].(string) //nolint:errcheck // test assertion
+
+	sections := cs.sections[collID]
+	require.Len(t, sections, 1)
+	assert.Equal(t, "Section 1", sections[0].Title)
+	require.Len(t, sections[0].Items, 2)
+	assert.Equal(t, "asset-a", sections[0].Items[0].AssetID)
+}
+
+func TestCreateCollection_MissingName(t *testing.T) {
+	tk := toolkitWithCollections(newInMemoryCollectionStore())
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "create_collection",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "name is required")
+}
+
+func TestCreateCollection_InsertError(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.insertErr = notFoundError{}
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "create_collection",
+		Name:   "Failing",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "failed to create collection")
+}
+
+func TestCreateCollection_SetSectionsError(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.setSectErr = notFoundError{}
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action:   "create_collection",
+		Name:     "Failing Sections",
+		Sections: []sectionInput{{Title: "S1", Items: []itemInput{{AssetID: "a1"}}}},
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "failed to set sections")
+}
+
+func TestCreateCollection_InvalidSections(t *testing.T) {
+	tk := toolkitWithCollections(newInMemoryCollectionStore())
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action:   "create_collection",
+		Name:     "Bad Sections",
+		Sections: []sectionInput{{Title: "S1", Items: []itemInput{{AssetID: ""}}}},
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "asset_id is required")
+}
+
+// --- list_collections tests ---
+
+func TestListCollections_Success(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{ID: "c1", OwnerID: "user1", Name: "Coll 1"}
+	cs.collections["c2"] = portal.Collection{ID: "c2", OwnerID: "user1", Name: "Coll 2"}
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "list_collections",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	out := extractJSON(t, result)
+	collections := out["collections"].([]any) //nolint:errcheck // test assertion
+	assert.Len(t, collections, 2)
+	assert.Equal(t, float64(2), out["total"])
+}
+
+func TestListCollections_Empty(t *testing.T) {
+	tk := toolkitWithCollections(newInMemoryCollectionStore())
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "list_collections",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	out := extractJSON(t, result)
+	collections := out["collections"].([]any) //nolint:errcheck // test assertion
+	assert.Len(t, collections, 0)             // empty array, not nil
+}
+
+func TestListCollections_FiltersByOwner(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{ID: "c1", OwnerID: "user1", Name: "Mine"}
+	cs.collections["c2"] = portal.Collection{ID: "c2", OwnerID: "user2", Name: "Theirs"}
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "list_collections",
+	})
+	require.NoError(t, err)
+
+	out := extractJSON(t, result)
+	assert.Equal(t, float64(1), out["total"])
+}
+
+// --- get_collection tests ---
+
+func TestGetCollection_Success(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user1", Name: "Test Coll",
+	}
+	cs.sections["c1"] = []portal.CollectionSection{
+		{ID: "s1", Title: "Section One", Items: []portal.CollectionItem{{ID: "i1", AssetID: "a1"}}},
+	}
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "get_collection", CollectionID: "c1",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	out := extractJSON(t, result)
+	assert.Equal(t, "Test Coll", out["name"])
+	sections := out["sections"].([]any) //nolint:errcheck // test assertion
+	assert.Len(t, sections, 1)
+}
+
+func TestGetCollection_MissingID(t *testing.T) {
+	tk := toolkitWithCollections(newInMemoryCollectionStore())
+
+	result, _, err := tk.handleManageArtifact(context.Background(), nil, manageArtifactInput{
+		Action: "get_collection",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "collection_id is required")
+}
+
+func TestGetCollection_NotFound(t *testing.T) {
+	tk := toolkitWithCollections(newInMemoryCollectionStore())
+
+	result, _, err := tk.handleManageArtifact(context.Background(), nil, manageArtifactInput{
+		Action: "get_collection", CollectionID: "nonexistent",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "collection not found")
+}
+
+func TestGetCollection_Deleted(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	now := time.Now()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user1", Name: "Deleted", DeletedAt: &now,
+	}
+	tk := toolkitWithCollections(cs)
+
+	result, _, err := tk.handleManageArtifact(context.Background(), nil, manageArtifactInput{
+		Action: "get_collection", CollectionID: "c1",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "collection has been deleted")
+}
+
+// --- update_collection tests ---
+
+func TestUpdateCollection_Success(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user1", Name: "Old Name", Description: "Old Desc",
+	}
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "update_collection", CollectionID: "c1", Name: "New Name",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	out := extractJSON(t, result)
+	assert.Equal(t, "Collection updated successfully.", out["message"])
+
+	// Verify name changed, description carried forward
+	coll, _ := cs.Get(context.Background(), "c1")
+	assert.Equal(t, "New Name", coll.Name)
+	assert.Equal(t, "Old Desc", coll.Description)
+}
+
+func TestUpdateCollection_MissingID(t *testing.T) {
+	tk := toolkitWithCollections(newInMemoryCollectionStore())
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "update_collection",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "collection_id is required")
+}
+
+func TestUpdateCollection_WrongOwner(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user2", Name: "Theirs",
+	}
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "update_collection", CollectionID: "c1", Name: "Stolen",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "you can only update your own collections")
+}
+
+func TestUpdateCollection_NotFound(t *testing.T) {
+	tk := toolkitWithCollections(newInMemoryCollectionStore())
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "update_collection", CollectionID: "nonexistent", Name: "X",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "collection not found")
+}
+
+// --- delete_collection tests ---
+
+func TestDeleteCollection_Success(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user1", Name: "To Delete",
+	}
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "delete_collection", CollectionID: "c1",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	out := extractJSON(t, result)
+	assert.Equal(t, "Collection deleted successfully.", out["message"])
+
+	coll := cs.collections["c1"]
+	assert.NotNil(t, coll.DeletedAt)
+}
+
+func TestDeleteCollection_MissingID(t *testing.T) {
+	tk := toolkitWithCollections(newInMemoryCollectionStore())
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "delete_collection",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "collection_id is required")
+}
+
+func TestDeleteCollection_WrongOwner(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user2", Name: "Theirs",
+	}
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "delete_collection", CollectionID: "c1",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "you can only delete your own collections")
+}
+
+func TestDeleteCollection_StoreError(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user1", Name: "Failing",
+	}
+	cs.deleteErr = notFoundError{}
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "delete_collection", CollectionID: "c1",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "failed to delete collection")
+}
+
+// --- set_sections tests ---
+
+func TestSetSections_Success(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user1", Name: "My Coll",
+	}
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action:       "set_sections",
+		CollectionID: "c1",
+		Sections: []sectionInput{
+			{Title: "Charts", Items: []itemInput{{AssetID: "a1"}}},
+			{Title: "Reports", Description: "Monthly reports", Items: []itemInput{{AssetID: "a2"}, {AssetID: "a3"}}},
+		},
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	out := extractJSON(t, result)
+	assert.Equal(t, "My Coll", out["name"])
+
+	sections := cs.sections["c1"]
+	require.Len(t, sections, 2)
+	assert.Equal(t, "Charts", sections[0].Title)
+	assert.Len(t, sections[0].Items, 1)
+	assert.Equal(t, "Reports", sections[1].Title)
+	assert.Len(t, sections[1].Items, 2)
+}
+
+func TestSetSections_ClearSections(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user1", Name: "My Coll",
+	}
+	cs.sections["c1"] = []portal.CollectionSection{{ID: "old", Title: "Old"}}
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action:       "set_sections",
+		CollectionID: "c1",
+		Sections:     []sectionInput{},
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	assert.Len(t, cs.sections["c1"], 0)
+}
+
+func TestSetSections_MissingID(t *testing.T) {
+	tk := toolkitWithCollections(newInMemoryCollectionStore())
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "set_sections",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "collection_id is required")
+}
+
+func TestSetSections_WrongOwner(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user2", Name: "Theirs",
+	}
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action:       "set_sections",
+		CollectionID: "c1",
+		Sections:     []sectionInput{{Title: "S1", Items: []itemInput{{AssetID: "a1"}}}},
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "you can only modify your own collections")
+}
+
+func TestSetSections_InvalidSection(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user1", Name: "My Coll",
+	}
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action:       "set_sections",
+		CollectionID: "c1",
+		Sections:     []sectionInput{{Title: "S1", Items: []itemInput{{AssetID: ""}}}},
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "asset_id is required")
+}
+
+func TestSetSections_StoreError(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user1", Name: "My Coll",
+	}
+	cs.setSectErr = notFoundError{}
+	tk := toolkitWithCollections(cs)
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action:       "set_sections",
+		CollectionID: "c1",
+		Sections:     []sectionInput{{Title: "S1", Items: []itemInput{{AssetID: "a1"}}}},
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "failed to set sections")
+}
+
+// --- convertSections tests ---
+
+func TestConvertSections_Valid(t *testing.T) {
+	inputs := []sectionInput{
+		{Title: "S1", Description: "Desc", Items: []itemInput{{AssetID: "a1"}, {AssetID: "a2"}}},
+		{Title: "S2", Items: []itemInput{{AssetID: "a3"}}},
+	}
+
+	sections, err := convertSections(inputs)
+	require.NoError(t, err)
+	require.Len(t, sections, 2)
+	assert.NotEmpty(t, sections[0].ID)
+	assert.Equal(t, "S1", sections[0].Title)
+	assert.Equal(t, "Desc", sections[0].Description)
+	require.Len(t, sections[0].Items, 2)
+	assert.NotEmpty(t, sections[0].Items[0].ID)
+	assert.Equal(t, "a1", sections[0].Items[0].AssetID)
+}
+
+func TestConvertSections_EmptyAssetID(t *testing.T) {
+	_, err := convertSections([]sectionInput{
+		{Title: "S1", Items: []itemInput{{AssetID: ""}}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "asset_id is required")
+}
+
+func TestConvertSections_EmptyInput(t *testing.T) {
+	sections, err := convertSections([]sectionInput{})
+	require.NoError(t, err)
+	assert.Len(t, sections, 0)
+}
+
+func TestCreateCollection_NoBaseURL(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	tk := New(Config{
+		Name:            "test",
+		CollectionStore: cs,
+		S3Bucket:        "bucket",
+	})
+	ctx := userCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "create_collection",
+		Name:   "No URL",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	out := extractJSON(t, result)
+	_, hasURL := out["portal_url"]
+	assert.False(t, hasURL)
+}

--- a/pkg/toolkits/portal/collection_handlers_test.go
+++ b/pkg/toolkits/portal/collection_handlers_test.go
@@ -3,6 +3,7 @@ package portal
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -22,6 +23,7 @@ type inMemoryCollectionStore struct {
 	updateErr   error
 	deleteErr   error
 	setSectErr  error
+	listErr     error
 }
 
 func newInMemoryCollectionStore() *inMemoryCollectionStore {
@@ -49,6 +51,9 @@ func (s *inMemoryCollectionStore) Get(_ context.Context, id string) (*portal.Col
 }
 
 func (s *inMemoryCollectionStore) List(_ context.Context, filter portal.CollectionFilter) ([]portal.Collection, int, error) {
+	if s.listErr != nil {
+		return nil, 0, s.listErr
+	}
 	var result []portal.Collection
 	for _, c := range s.collections {
 		if c.DeletedAt != nil {
@@ -120,7 +125,7 @@ func (s *inMemoryCollectionStore) SetSections(_ context.Context, collectionID st
 
 var _ portal.CollectionStore = (*inMemoryCollectionStore)(nil)
 
-func userCtx(userID, email string) context.Context { //nolint:unparam // test helper, values vary by intent
+func collCtx(userID, email string) context.Context {
 	return middleware.WithPlatformContext(context.Background(), &middleware.PlatformContext{
 		UserID:    userID,
 		UserEmail: email,
@@ -138,7 +143,7 @@ func toolkitWithCollections(cs *inMemoryCollectionStore) *Toolkit {
 
 func extractJSON(t *testing.T, result *mcp.CallToolResult) map[string]any {
 	t.Helper()
-	tc, ok := result.Content[0].(*mcp.TextContent)
+	tc, ok := result.Content[0].(*mcp.TextContent) //nolint:errcheck // test assertion
 	require.True(t, ok)
 	var out map[string]any
 	require.NoError(t, json.Unmarshal([]byte(tc.Text), &out))
@@ -147,7 +152,7 @@ func extractJSON(t *testing.T, result *mcp.CallToolResult) map[string]any {
 
 func extractError(t *testing.T, result *mcp.CallToolResult) string {
 	t.Helper()
-	tc, ok := result.Content[0].(*mcp.TextContent)
+	tc, ok := result.Content[0].(*mcp.TextContent) //nolint:errcheck // test assertion
 	require.True(t, ok)
 	return tc.Text
 }
@@ -157,7 +162,7 @@ func extractError(t *testing.T, result *mcp.CallToolResult) string {
 func TestCreateCollection_Success(t *testing.T) {
 	cs := newInMemoryCollectionStore()
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action:      "create_collection",
@@ -184,7 +189,7 @@ func TestCreateCollection_Success(t *testing.T) {
 func TestCreateCollection_WithSections(t *testing.T) {
 	cs := newInMemoryCollectionStore()
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "create_collection",
@@ -211,7 +216,7 @@ func TestCreateCollection_WithSections(t *testing.T) {
 
 func TestCreateCollection_MissingName(t *testing.T) {
 	tk := toolkitWithCollections(newInMemoryCollectionStore())
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "create_collection",
@@ -225,7 +230,7 @@ func TestCreateCollection_InsertError(t *testing.T) {
 	cs := newInMemoryCollectionStore()
 	cs.insertErr = notFoundError{}
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "create_collection",
@@ -238,9 +243,9 @@ func TestCreateCollection_InsertError(t *testing.T) {
 
 func TestCreateCollection_SetSectionsError(t *testing.T) {
 	cs := newInMemoryCollectionStore()
-	cs.setSectErr = notFoundError{}
+	cs.setSectErr = errors.New("db timeout")
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action:   "create_collection",
@@ -249,12 +254,15 @@ func TestCreateCollection_SetSectionsError(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, result.IsError)
-	assert.Contains(t, extractError(t, result), "failed to set sections")
+
+	errText := extractError(t, result)
+	// Error must include collection_id so agent can retry set_sections
+	assert.Contains(t, errText, "created but failed to set sections")
 }
 
 func TestCreateCollection_InvalidSections(t *testing.T) {
 	tk := toolkitWithCollections(newInMemoryCollectionStore())
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action:   "create_collection",
@@ -266,6 +274,27 @@ func TestCreateCollection_InvalidSections(t *testing.T) {
 	assert.Contains(t, extractError(t, result), "asset_id is required")
 }
 
+func TestCreateCollection_NoBaseURL(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	tk := New(Config{
+		Name:            "test",
+		CollectionStore: cs,
+		S3Bucket:        "bucket",
+	})
+	ctx := collCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "create_collection",
+		Name:   "No URL",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	out := extractJSON(t, result)
+	_, hasURL := out["portal_url"]
+	assert.False(t, hasURL)
+}
+
 // --- list_collections tests ---
 
 func TestListCollections_Success(t *testing.T) {
@@ -273,7 +302,7 @@ func TestListCollections_Success(t *testing.T) {
 	cs.collections["c1"] = portal.Collection{ID: "c1", OwnerID: "user1", Name: "Coll 1"}
 	cs.collections["c2"] = portal.Collection{ID: "c2", OwnerID: "user1", Name: "Coll 2"}
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "list_collections",
@@ -289,7 +318,7 @@ func TestListCollections_Success(t *testing.T) {
 
 func TestListCollections_Empty(t *testing.T) {
 	tk := toolkitWithCollections(newInMemoryCollectionStore())
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "list_collections",
@@ -307,7 +336,7 @@ func TestListCollections_FiltersByOwner(t *testing.T) {
 	cs.collections["c1"] = portal.Collection{ID: "c1", OwnerID: "user1", Name: "Mine"}
 	cs.collections["c2"] = portal.Collection{ID: "c2", OwnerID: "user2", Name: "Theirs"}
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "list_collections",
@@ -316,6 +345,20 @@ func TestListCollections_FiltersByOwner(t *testing.T) {
 
 	out := extractJSON(t, result)
 	assert.Equal(t, float64(1), out["total"])
+}
+
+func TestListCollections_StoreError(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.listErr = errors.New("db connection lost")
+	tk := toolkitWithCollections(cs)
+	ctx := collCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "list_collections",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "failed to list collections")
 }
 
 // --- get_collection tests ---
@@ -329,7 +372,7 @@ func TestGetCollection_Success(t *testing.T) {
 		{ID: "s1", Title: "Section One", Items: []portal.CollectionItem{{ID: "i1", AssetID: "a1"}}},
 	}
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "get_collection", CollectionID: "c1",
@@ -389,7 +432,7 @@ func TestUpdateCollection_Success(t *testing.T) {
 		ID: "c1", OwnerID: "user1", Name: "Old Name", Description: "Old Desc",
 	}
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "update_collection", CollectionID: "c1", Name: "New Name",
@@ -397,18 +440,34 @@ func TestUpdateCollection_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, result.IsError)
 
+	// Returns full collection object
 	out := extractJSON(t, result)
-	assert.Equal(t, "Collection updated successfully.", out["message"])
+	assert.Equal(t, "New Name", out["name"])
+	assert.Equal(t, "Old Desc", out["description"])
+}
 
-	// Verify name changed, description carried forward
-	coll, _ := cs.Get(context.Background(), "c1")
-	assert.Equal(t, "New Name", coll.Name)
-	assert.Equal(t, "Old Desc", coll.Description)
+func TestUpdateCollection_DescriptionOnly(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user1", Name: "Keep This", Description: "Old Desc",
+	}
+	tk := toolkitWithCollections(cs)
+	ctx := collCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "update_collection", CollectionID: "c1", Description: "New Desc",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	out := extractJSON(t, result)
+	assert.Equal(t, "Keep This", out["name"])
+	assert.Equal(t, "New Desc", out["description"])
 }
 
 func TestUpdateCollection_MissingID(t *testing.T) {
 	tk := toolkitWithCollections(newInMemoryCollectionStore())
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "update_collection",
@@ -421,10 +480,10 @@ func TestUpdateCollection_MissingID(t *testing.T) {
 func TestUpdateCollection_WrongOwner(t *testing.T) {
 	cs := newInMemoryCollectionStore()
 	cs.collections["c1"] = portal.Collection{
-		ID: "c1", OwnerID: "user2", Name: "Theirs",
+		ID: "c1", OwnerID: "owner-xyz", Name: "Theirs",
 	}
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("attacker", "attacker@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "update_collection", CollectionID: "c1", Name: "Stolen",
@@ -436,7 +495,7 @@ func TestUpdateCollection_WrongOwner(t *testing.T) {
 
 func TestUpdateCollection_NotFound(t *testing.T) {
 	tk := toolkitWithCollections(newInMemoryCollectionStore())
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "update_collection", CollectionID: "nonexistent", Name: "X",
@@ -444,6 +503,40 @@ func TestUpdateCollection_NotFound(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, result.IsError)
 	assert.Contains(t, extractError(t, result), "collection not found")
+}
+
+func TestUpdateCollection_Deleted(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	now := time.Now()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user1", Name: "Gone", DeletedAt: &now,
+	}
+	tk := toolkitWithCollections(cs)
+	ctx := collCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "update_collection", CollectionID: "c1", Name: "Revive?",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "collection has been deleted")
+}
+
+func TestUpdateCollection_StoreError(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user1", Name: "Current",
+	}
+	cs.updateErr = errors.New("db timeout")
+	tk := toolkitWithCollections(cs)
+	ctx := collCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "update_collection", CollectionID: "c1", Name: "Attempt",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "failed to update collection")
 }
 
 // --- delete_collection tests ---
@@ -454,7 +547,7 @@ func TestDeleteCollection_Success(t *testing.T) {
 		ID: "c1", OwnerID: "user1", Name: "To Delete",
 	}
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "delete_collection", CollectionID: "c1",
@@ -471,7 +564,7 @@ func TestDeleteCollection_Success(t *testing.T) {
 
 func TestDeleteCollection_MissingID(t *testing.T) {
 	tk := toolkitWithCollections(newInMemoryCollectionStore())
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "delete_collection",
@@ -484,10 +577,10 @@ func TestDeleteCollection_MissingID(t *testing.T) {
 func TestDeleteCollection_WrongOwner(t *testing.T) {
 	cs := newInMemoryCollectionStore()
 	cs.collections["c1"] = portal.Collection{
-		ID: "c1", OwnerID: "user2", Name: "Theirs",
+		ID: "c1", OwnerID: "owner-xyz", Name: "Theirs",
 	}
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("attacker", "attacker@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "delete_collection", CollectionID: "c1",
@@ -497,6 +590,23 @@ func TestDeleteCollection_WrongOwner(t *testing.T) {
 	assert.Contains(t, extractError(t, result), "you can only delete your own collections")
 }
 
+func TestDeleteCollection_Deleted(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	now := time.Now()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user1", Name: "Already Gone", DeletedAt: &now,
+	}
+	tk := toolkitWithCollections(cs)
+	ctx := collCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "delete_collection", CollectionID: "c1",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "collection has been deleted")
+}
+
 func TestDeleteCollection_StoreError(t *testing.T) {
 	cs := newInMemoryCollectionStore()
 	cs.collections["c1"] = portal.Collection{
@@ -504,7 +614,7 @@ func TestDeleteCollection_StoreError(t *testing.T) {
 	}
 	cs.deleteErr = notFoundError{}
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "delete_collection", CollectionID: "c1",
@@ -522,7 +632,7 @@ func TestSetSections_Success(t *testing.T) {
 		ID: "c1", OwnerID: "user1", Name: "My Coll",
 	}
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action:       "set_sections",
@@ -553,7 +663,7 @@ func TestSetSections_ClearSections(t *testing.T) {
 	}
 	cs.sections["c1"] = []portal.CollectionSection{{ID: "old", Title: "Old"}}
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action:       "set_sections",
@@ -568,7 +678,7 @@ func TestSetSections_ClearSections(t *testing.T) {
 
 func TestSetSections_MissingID(t *testing.T) {
 	tk := toolkitWithCollections(newInMemoryCollectionStore())
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action: "set_sections",
@@ -581,10 +691,10 @@ func TestSetSections_MissingID(t *testing.T) {
 func TestSetSections_WrongOwner(t *testing.T) {
 	cs := newInMemoryCollectionStore()
 	cs.collections["c1"] = portal.Collection{
-		ID: "c1", OwnerID: "user2", Name: "Theirs",
+		ID: "c1", OwnerID: "owner-xyz", Name: "Theirs",
 	}
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("attacker", "attacker@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action:       "set_sections",
@@ -596,13 +706,32 @@ func TestSetSections_WrongOwner(t *testing.T) {
 	assert.Contains(t, extractError(t, result), "you can only modify your own collections")
 }
 
+func TestSetSections_Deleted(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	now := time.Now()
+	cs.collections["c1"] = portal.Collection{
+		ID: "c1", OwnerID: "user1", Name: "Gone", DeletedAt: &now,
+	}
+	tk := toolkitWithCollections(cs)
+	ctx := collCtx("user1", "user1@example.com")
+
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action:       "set_sections",
+		CollectionID: "c1",
+		Sections:     []sectionInput{{Title: "S1", Items: []itemInput{{AssetID: "a1"}}}},
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractError(t, result), "collection has been deleted")
+}
+
 func TestSetSections_InvalidSection(t *testing.T) {
 	cs := newInMemoryCollectionStore()
 	cs.collections["c1"] = portal.Collection{
 		ID: "c1", OwnerID: "user1", Name: "My Coll",
 	}
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action:       "set_sections",
@@ -621,7 +750,7 @@ func TestSetSections_StoreError(t *testing.T) {
 	}
 	cs.setSectErr = notFoundError{}
 	tk := toolkitWithCollections(cs)
-	ctx := userCtx("user1", "user1@example.com")
+	ctx := collCtx("user1", "user1@example.com")
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
 		Action:       "set_sections",
@@ -666,23 +795,37 @@ func TestConvertSections_EmptyInput(t *testing.T) {
 	assert.Len(t, sections, 0)
 }
 
-func TestCreateCollection_NoBaseURL(t *testing.T) {
+// --- getActiveCollection tests ---
+
+func TestGetActiveCollection_NotFound(t *testing.T) {
 	cs := newInMemoryCollectionStore()
-	tk := New(Config{
-		Name:            "test",
-		CollectionStore: cs,
-		S3Bucket:        "bucket",
-	})
-	ctx := userCtx("user1", "user1@example.com")
+	tk := toolkitWithCollections(cs)
 
-	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
-		Action: "create_collection",
-		Name:   "No URL",
-	})
-	require.NoError(t, err)
-	assert.False(t, result.IsError)
+	coll, errResult := tk.getActiveCollection(context.Background(), "missing")
+	assert.Nil(t, coll)
+	assert.NotNil(t, errResult)
+	assert.True(t, errResult.IsError)
+}
 
-	out := extractJSON(t, result)
-	_, hasURL := out["portal_url"]
-	assert.False(t, hasURL)
+func TestGetActiveCollection_Deleted(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	now := time.Now()
+	cs.collections["c1"] = portal.Collection{ID: "c1", DeletedAt: &now}
+	tk := toolkitWithCollections(cs)
+
+	coll, errResult := tk.getActiveCollection(context.Background(), "c1")
+	assert.Nil(t, coll)
+	assert.NotNil(t, errResult)
+	assert.Contains(t, extractError(&testing.T{}, errResult), "collection has been deleted")
+}
+
+func TestGetActiveCollection_Success(t *testing.T) {
+	cs := newInMemoryCollectionStore()
+	cs.collections["c1"] = portal.Collection{ID: "c1", Name: "Active"}
+	tk := toolkitWithCollections(cs)
+
+	coll, errResult := tk.getActiveCollection(context.Background(), "c1")
+	assert.NotNil(t, coll)
+	assert.Nil(t, errResult)
+	assert.Equal(t, "Active", coll.Name)
 }

--- a/pkg/toolkits/portal/schemas.go
+++ b/pkg/toolkits/portal/schemas.go
@@ -43,7 +43,7 @@ var manageArtifactSchema = json.RawMessage(`{
   "properties": {
     "action": {
       "type": "string",
-      "description": "Action to perform. Valid values: list, get, update, delete, list_versions, revert"
+      "description": "Action to perform. Asset actions: list, get, update, delete, list_versions, revert. Collection actions: create_collection, list_collections, get_collection, update_collection, delete_collection, set_sections"
     },
     "asset_id": {
       "type": "string",
@@ -55,11 +55,11 @@ var manageArtifactSchema = json.RawMessage(`{
     },
     "name": {
       "type": "string",
-      "description": "New name (for update action)"
+      "description": "Name (for update, create_collection, update_collection)"
     },
     "description": {
       "type": "string",
-      "description": "New description (for update action)"
+      "description": "Description (for update, create_collection, update_collection)"
     },
     "tags": {
       "type": "array",
@@ -73,11 +73,57 @@ var manageArtifactSchema = json.RawMessage(`{
     },
     "limit": {
       "type": "integer",
-      "description": "Max results for list/list_versions actions (default 50, max 200)"
+      "description": "Max results for list/list_versions/list_collections (default 50, max 200)"
     },
     "version": {
       "type": "integer",
       "description": "Version number (required for revert action)"
+    },
+    "collection_id": {
+      "type": "string",
+      "description": "Collection ID (required for get_collection, update_collection, delete_collection, set_sections)"
+    },
+    "search": {
+      "type": "string",
+      "description": "Search term for list_collections"
+    },
+    "offset": {
+      "type": "integer",
+      "description": "Offset for paginated results (list_collections)"
+    },
+    "sections": {
+      "type": "array",
+      "description": "Sections with asset references (for create_collection and set_sections)",
+      "items": {
+        "type": "object",
+        "required": ["title", "items"],
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Section title"
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional section description"
+          },
+          "items": {
+            "type": "array",
+            "description": "Assets in this section",
+            "items": {
+              "type": "object",
+              "required": ["asset_id"],
+              "additionalProperties": false,
+              "properties": {
+                "asset_id": {
+                  "type": "string",
+                  "description": "ID of the asset to include"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }`)

--- a/pkg/toolkits/portal/toolkit.go
+++ b/pkg/toolkits/portal/toolkit.go
@@ -111,6 +111,7 @@ type Toolkit struct {
 	s3Prefix        string
 	baseURL         string
 	maxContentSize  int
+	actions         map[string]manageActionHandler
 
 	semanticProvider semantic.Provider
 	queryProvider    query.Provider
@@ -134,7 +135,7 @@ func New(cfg Config) *Toolkit {
 	if collectionStore == nil {
 		collectionStore = portal.NewNoopCollectionStore()
 	}
-	return &Toolkit{
+	tk := &Toolkit{
 		name:            cfg.Name,
 		assetStore:      assetStore,
 		shareStore:      shareStore,
@@ -146,6 +147,8 @@ func New(cfg Config) *Toolkit {
 		baseURL:         cfg.BaseURL,
 		maxContentSize:  cfg.MaxContentSize,
 	}
+	tk.actions = tk.buildActions()
+	return tk
 }
 
 // Kind returns the toolkit kind.
@@ -348,8 +351,8 @@ func (t *Toolkit) handleSaveArtifact(ctx context.Context, _ *mcp.CallToolRequest
 // manageActionHandler is a function that handles a manage_artifact action.
 type manageActionHandler func(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error)
 
-// manageActions returns the action dispatch table for manage_artifact.
-func (t *Toolkit) manageActions() map[string]manageActionHandler {
+// buildActions constructs the action dispatch table, called once during New().
+func (t *Toolkit) buildActions() map[string]manageActionHandler {
 	return map[string]manageActionHandler{
 		"list":              t.handleList,
 		"get":               t.handleGet,
@@ -368,7 +371,7 @@ func (t *Toolkit) manageActions() map[string]manageActionHandler {
 
 // handleManageArtifact dispatches to the appropriate action handler.
 func (t *Toolkit) handleManageArtifact(ctx context.Context, _ *mcp.CallToolRequest, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
-	handler, ok := t.manageActions()[input.Action]
+	handler, ok := t.actions[input.Action]
 	if !ok {
 		return errorResult(fmt.Sprintf(
 			"invalid action %q: must be one of: list, get, update, delete, list_versions, revert, "+

--- a/pkg/toolkits/portal/toolkit.go
+++ b/pkg/toolkits/portal/toolkit.go
@@ -49,15 +49,31 @@ type saveArtifactInput struct {
 
 // manageArtifactInput defines the input for manage_artifact.
 type manageArtifactInput struct {
-	Action      string   `json:"action"`
-	AssetID     string   `json:"asset_id,omitempty"`
-	Content     string   `json:"content,omitempty"`
-	Name        string   `json:"name,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Tags        []string `json:"tags,omitempty"`
-	ContentType string   `json:"content_type,omitempty"`
-	Limit       int      `json:"limit,omitempty"`
-	Version     int      `json:"version,omitempty"`
+	Action       string         `json:"action"`
+	AssetID      string         `json:"asset_id,omitempty"`
+	Content      string         `json:"content,omitempty"`
+	Name         string         `json:"name,omitempty"`
+	Description  string         `json:"description,omitempty"`
+	Tags         []string       `json:"tags,omitempty"`
+	ContentType  string         `json:"content_type,omitempty"`
+	Limit        int            `json:"limit,omitempty"`
+	Version      int            `json:"version,omitempty"`
+	CollectionID string         `json:"collection_id,omitempty"`
+	Sections     []sectionInput `json:"sections,omitempty"`
+	Search       string         `json:"search,omitempty"`
+	Offset       int            `json:"offset,omitempty"`
+}
+
+// sectionInput defines a collection section in MCP tool input.
+type sectionInput struct {
+	Title       string      `json:"title"`
+	Description string      `json:"description,omitempty"`
+	Items       []itemInput `json:"items"`
+}
+
+// itemInput defines a collection item in MCP tool input.
+type itemInput struct {
+	AssetID string `json:"asset_id"`
 }
 
 // saveArtifactOutput is the success response for save_artifact.
@@ -71,28 +87,30 @@ type saveArtifactOutput struct {
 
 // Config holds configuration for creating a portal toolkit.
 type Config struct {
-	Name           string
-	AssetStore     portal.AssetStore
-	ShareStore     portal.ShareStore
-	VersionStore   portal.VersionStore
-	S3Client       portal.S3Client
-	S3Bucket       string
-	S3Prefix       string
-	BaseURL        string
-	MaxContentSize int // max artifact content size in bytes (0 = no limit)
+	Name            string
+	AssetStore      portal.AssetStore
+	ShareStore      portal.ShareStore
+	VersionStore    portal.VersionStore
+	CollectionStore portal.CollectionStore
+	S3Client        portal.S3Client
+	S3Bucket        string
+	S3Prefix        string
+	BaseURL         string
+	MaxContentSize  int // max artifact content size in bytes (0 = no limit)
 }
 
 // Toolkit implements the portal artifact toolkit.
 type Toolkit struct {
-	name           string
-	assetStore     portal.AssetStore
-	shareStore     portal.ShareStore
-	versionStore   portal.VersionStore
-	s3Client       portal.S3Client
-	s3Bucket       string
-	s3Prefix       string
-	baseURL        string
-	maxContentSize int
+	name            string
+	assetStore      portal.AssetStore
+	shareStore      portal.ShareStore
+	versionStore    portal.VersionStore
+	collectionStore portal.CollectionStore
+	s3Client        portal.S3Client
+	s3Bucket        string
+	s3Prefix        string
+	baseURL         string
+	maxContentSize  int
 
 	semanticProvider semantic.Provider
 	queryProvider    query.Provider
@@ -112,16 +130,21 @@ func New(cfg Config) *Toolkit {
 	if versionStore == nil {
 		versionStore = portal.NewNoopVersionStore()
 	}
+	collectionStore := cfg.CollectionStore
+	if collectionStore == nil {
+		collectionStore = portal.NewNoopCollectionStore()
+	}
 	return &Toolkit{
-		name:           cfg.Name,
-		assetStore:     assetStore,
-		shareStore:     shareStore,
-		versionStore:   versionStore,
-		s3Client:       cfg.S3Client,
-		s3Bucket:       cfg.S3Bucket,
-		s3Prefix:       cfg.S3Prefix,
-		baseURL:        cfg.BaseURL,
-		maxContentSize: cfg.MaxContentSize,
+		name:            cfg.Name,
+		assetStore:      assetStore,
+		shareStore:      shareStore,
+		versionStore:    versionStore,
+		collectionStore: collectionStore,
+		s3Client:        cfg.S3Client,
+		s3Bucket:        cfg.S3Bucket,
+		s3Prefix:        cfg.S3Prefix,
+		baseURL:         cfg.BaseURL,
+		maxContentSize:  cfg.MaxContentSize,
 	}
 }
 
@@ -151,10 +174,10 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:  manageToolName,
 		Title: "Manage Artifact",
-		Description: "Lists, retrieves, updates, or deletes saved artifacts. " +
-			"Actions: list (show user's artifacts), get (metadata + content), " +
-			"update (change name/description/tags/content), delete (soft-delete), " +
-			"list_versions (show version history), revert (revert to a previous version).",
+		Description: "Manages saved artifacts and collections. " +
+			"Asset actions: list, get, update, delete, list_versions, revert. " +
+			"Collection actions: create_collection, list_collections, get_collection, " +
+			"update_collection, delete_collection, set_sections.",
 		InputSchema: manageArtifactSchema,
 	}, t.handleManageArtifact)
 
@@ -322,24 +345,37 @@ func (t *Toolkit) handleSaveArtifact(ctx context.Context, _ *mcp.CallToolRequest
 	return jsonResult(t.buildSaveOutput(assetID, prov))
 }
 
-// handleManageArtifact dispatches to list/get/update/delete.
-func (t *Toolkit) handleManageArtifact(ctx context.Context, _ *mcp.CallToolRequest, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
-	switch input.Action {
-	case "list":
-		return t.handleList(ctx, input)
-	case "get":
-		return t.handleGet(ctx, input)
-	case "update":
-		return t.handleUpdate(ctx, input)
-	case "delete":
-		return t.handleDelete(ctx, input)
-	case "list_versions":
-		return t.handleListVersions(ctx, input)
-	case "revert":
-		return t.handleRevert(ctx, input)
-	default:
-		return errorResult(fmt.Sprintf("invalid action %q: must be one of: list, get, update, delete, list_versions, revert", input.Action)), nil, nil
+// manageActionHandler is a function that handles a manage_artifact action.
+type manageActionHandler func(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error)
+
+// manageActions returns the action dispatch table for manage_artifact.
+func (t *Toolkit) manageActions() map[string]manageActionHandler {
+	return map[string]manageActionHandler{
+		"list":              t.handleList,
+		"get":               t.handleGet,
+		"update":            t.handleUpdate,
+		"delete":            t.handleDelete,
+		"list_versions":     t.handleListVersions,
+		"revert":            t.handleRevert,
+		"create_collection": t.handleCreateCollection,
+		"list_collections":  t.handleListCollections,
+		"get_collection":    t.handleGetCollection,
+		"update_collection": t.handleUpdateCollection,
+		"delete_collection": t.handleDeleteCollection,
+		"set_sections":      t.handleSetSections,
 	}
+}
+
+// handleManageArtifact dispatches to the appropriate action handler.
+func (t *Toolkit) handleManageArtifact(ctx context.Context, _ *mcp.CallToolRequest, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+	handler, ok := t.manageActions()[input.Action]
+	if !ok {
+		return errorResult(fmt.Sprintf(
+			"invalid action %q: must be one of: list, get, update, delete, list_versions, revert, "+
+				"create_collection, list_collections, get_collection, update_collection, delete_collection, set_sections",
+			input.Action)), nil, nil
+	}
+	return handler(ctx, input)
 }
 
 func (t *Toolkit) handleList(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {


### PR DESCRIPTION
## Summary

Extends the existing `manage_artifact` MCP tool with six collection actions so agents can create and organize collections **without adding a new tool**. The platform already had full collection support (database schema, Go types, `CollectionStore`, HTTP API) but it was not exposed via MCP — this PR closes that gap.

### What changed

- **Wired `CollectionStore` into portal toolkit** — added to `Config`/`Toolkit` structs with noop fallback, passed from `platform.go` where it was already instantiated but unused by the toolkit
- **Extended `manage_artifact` schema** with new properties: `collection_id`, `sections` (nested array of section objects with items), `search`, `offset`
- **Added six new actions** to the existing action dispatch:
  | Action | Description |
  |--------|-------------|
  | `create_collection` | Create a collection with name, description, and optional sections with asset references |
  | `list_collections` | List user's collections with search and pagination |
  | `get_collection` | Retrieve a collection with its sections and items (includes denormalized asset metadata) |
  | `update_collection` | Update name/description (carries forward unchanged fields) |
  | `delete_collection` | Soft-delete a collection |
  | `set_sections` | Replace sections atomically — the primary organizational tool for arranging assets into ordered groups |
- **Refactored action dispatch** from switch/case to map-based lookup to stay within cyclomatic complexity limit (was 13, now 2)
- All handlers enforce **ownership checks** for mutating operations and reuse existing validators (`ValidateCollectionName`, `ValidateSectionTitle`, `ValidateSections`, etc.)

### Files changed

| File | Change |
|------|--------|
| `pkg/platform/platform.go` | Wire `CollectionStore` into `portalkit.Config` |
| `pkg/toolkits/portal/toolkit.go` | Config/Toolkit fields, input struct extension, map-based dispatch, updated tool description |
| `pkg/toolkits/portal/schemas.go` | Extended JSON schema with collection properties |
| `pkg/toolkits/portal/collection_handlers.go` | **New** — 6 handlers + `convertSections` helper |
| `pkg/toolkits/portal/collection_handlers_test.go` | **New** — 27 tests with in-memory `CollectionStore` double |

### Design decisions

- **Zero new tools**: All collection operations go through the existing `manage_artifact` action dispatch, keeping the agent's tool surface minimal
- **Reuses all existing infrastructure**: `CollectionStore` interface, `postgresCollectionStore`, portal types, validators — no new database migrations or storage code needed
- **Map-based dispatch**: Replaces the 12-case switch with a `map[string]manageActionHandler` lookup, reducing `handleManageArtifact` cyclomatic complexity from 13 to 2
- **`generateID()` over UUID**: Consistent with the toolkit's existing hex-based ID generation (HTTP handlers use UUID separately)
- **Two-step create**: `create_collection` calls `Insert` then optionally `SetSections` — not atomic, but acceptable since the user can retry `set_sections` independently

## Test plan

- [x] All 27 new tests pass (`go test -race ./pkg/toolkits/portal/...`)
- [x] All new functions have >80% coverage (range: 81%–100%)
- [x] Full test suite passes (`go test -race ./...` — 40 packages, zero failures)
- [x] Linter clean (`golangci-lint run ./...` — 0 issues)
- [ ] `make verify` full suite (blocked locally by stale `swag` binary path, not related to this change)
- [ ] Manual verification: deploy and test collection CRUD via MCP client