### PR TITLE
fix: resolve platform admin from persona config instead of hard-coded role names

### DIFF
--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -613,7 +613,24 @@ func buildResourceClaims(user *portal.User, pr *persona.Registry, adminPersona s
 			}
 		}
 	}
+	claims.AdminOfPersonas = extractPersonaAdminRoles(user.Roles)
 	return claims
+}
+
+// personaAdminInfix is the role substring that marks a persona-admin grant.
+// Roles may carry an arbitrary prefix (e.g., "dp_persona-admin:finance").
+const personaAdminInfix = "persona-admin:"
+
+// extractPersonaAdminRoles extracts persona names from roles containing
+// the "persona-admin:" pattern, tolerating any prefix.
+func extractPersonaAdminRoles(roles []string) []string {
+	var out []string
+	for _, r := range roles {
+		if _, name, ok := strings.Cut(r, personaAdminInfix); ok && name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 // matchesAnyRole checks if any persona role matches any user role.

--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -573,25 +573,13 @@ func mountResourcesAPI(mux *http.ServeMux, p *platform.Platform) {
 	portalAuth := portal.NewAuthenticator(p.Authenticator(), portalAuthOpts...)
 
 	pr := p.PersonaRegistry()
+	adminPersona := p.Config().Admin.Persona
 	extractClaims := func(r *http.Request) (*resource.Claims, error) {
 		user, err := portalAuth.Authenticate(r)
 		if err != nil || user == nil {
 			return nil, fmt.Errorf("authentication required")
 		}
-		claims := &resource.Claims{
-			Sub:   user.UserID,
-			Email: user.Email,
-			Roles: user.Roles,
-		}
-		// Resolve all persona memberships.
-		if pr != nil {
-			for _, per := range pr.All() {
-				if matchesAnyRole(per.Roles, user.Roles) {
-					claims.Personas = append(claims.Personas, per.Name)
-				}
-			}
-		}
-		return claims, nil
+		return buildResourceClaims(user, pr, adminPersona), nil
 	}
 
 	deps := resource.Deps{
@@ -605,6 +593,27 @@ func mountResourcesAPI(mux *http.ServeMux, p *platform.Platform) {
 	mux.Handle("/api/v1/resources/", handler)
 	mux.Handle("/api/v1/resources", handler)
 	log.Println("Managed resources API enabled on /api/v1/resources")
+}
+
+// buildResourceClaims creates resource Claims from an authenticated user,
+// resolving persona memberships and admin status from the persona registry.
+func buildResourceClaims(user *portal.User, pr *persona.Registry, adminPersona string) *resource.Claims {
+	claims := &resource.Claims{
+		Sub:   user.UserID,
+		Email: user.Email,
+		Roles: user.Roles,
+	}
+	if pr != nil {
+		for _, per := range pr.All() {
+			if matchesAnyRole(per.Roles, user.Roles) {
+				claims.Personas = append(claims.Personas, per.Name)
+				if per.Name == adminPersona {
+					claims.IsAdmin = true
+				}
+			}
+		}
+	}
+	return claims
 }
 
 // matchesAnyRole checks if any persona role matches any user role.

--- a/cmd/mcp-data-platform/main_test.go
+++ b/cmd/mcp-data-platform/main_test.go
@@ -1166,4 +1166,53 @@ func TestBuildResourceClaims(t *testing.T) {
 			t.Errorf("expected 2 personas, got %v", claims.Personas)
 		}
 	})
+
+	t.Run("persona-admin roles populate AdminOfPersonas", func(t *testing.T) {
+		user := &portal.User{
+			UserID: "u5",
+			Email:  "pa@example.com",
+			Roles:  []string{"dp_persona-admin:finance", "dp_analyst"},
+		}
+		claims := buildResourceClaims(user, reg, "admin")
+		if !slices.Contains(claims.AdminOfPersonas, "finance") {
+			t.Errorf("expected finance in AdminOfPersonas, got %v", claims.AdminOfPersonas)
+		}
+	})
+}
+
+func TestExtractPersonaAdminRoles(t *testing.T) {
+	t.Run("unprefixed role", func(t *testing.T) {
+		got := extractPersonaAdminRoles([]string{"persona-admin:finance"})
+		if len(got) != 1 || got[0] != "finance" {
+			t.Errorf("got %v, want [finance]", got)
+		}
+	})
+
+	t.Run("prefixed role", func(t *testing.T) {
+		got := extractPersonaAdminRoles([]string{"dp_persona-admin:engineering"})
+		if len(got) != 1 || got[0] != "engineering" {
+			t.Errorf("got %v, want [engineering]", got)
+		}
+	})
+
+	t.Run("multiple persona-admin roles", func(t *testing.T) {
+		got := extractPersonaAdminRoles([]string{"dp_persona-admin:finance", "dp_persona-admin:ops", "dp_analyst"})
+		if len(got) != 2 {
+			t.Errorf("got %v, want 2 entries", got)
+		}
+	})
+
+	t.Run("no persona-admin roles", func(t *testing.T) {
+		got := extractPersonaAdminRoles([]string{"dp_admin", "dp_analyst"})
+		if len(got) != 0 {
+			t.Errorf("got %v, want empty", got)
+		}
+	})
+
+	t.Run("empty persona name ignored", func(t *testing.T) {
+		got := extractPersonaAdminRoles([]string{"persona-admin:"})
+		if len(got) != 0 {
+			t.Errorf("got %v, want empty for trailing colon", got)
+		}
+	})
 }

--- a/cmd/mcp-data-platform/main_test.go
+++ b/cmd/mcp-data-platform/main_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -15,7 +16,9 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/txn2/mcp-data-platform/pkg/health"
+	"github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
+	"github.com/txn2/mcp-data-platform/pkg/portal"
 	"github.com/txn2/mcp-data-platform/pkg/session"
 )
 
@@ -1089,6 +1092,78 @@ func TestMcpappsBrandName(t *testing.T) {
 		got := mcpappsBrandName(p)
 		if got != "" {
 			t.Errorf("mcpappsBrandName() = %q, want empty", got)
+		}
+	})
+}
+
+func TestBuildResourceClaims(t *testing.T) {
+	reg := persona.NewRegistry()
+	_ = reg.Register(&persona.Persona{
+		Name:  "admin",
+		Roles: []string{"dp_admin"},
+	})
+	_ = reg.Register(&persona.Persona{
+		Name:  "analyst",
+		Roles: []string{"dp_analyst"},
+	})
+
+	t.Run("prefixed admin role resolves IsAdmin via persona", func(t *testing.T) {
+		user := &portal.User{
+			UserID: "u1",
+			Email:  "admin@example.com",
+			Roles:  []string{"dp_admin"},
+		}
+		claims := buildResourceClaims(user, reg, "admin")
+		if !claims.IsAdmin {
+			t.Error("expected IsAdmin=true for user with dp_admin role mapped to admin persona")
+		}
+		if !slices.Contains(claims.Personas, "admin") {
+			t.Errorf("expected admin in Personas, got %v", claims.Personas)
+		}
+	})
+
+	t.Run("non-admin role does not set IsAdmin", func(t *testing.T) {
+		user := &portal.User{
+			UserID: "u2",
+			Email:  "analyst@example.com",
+			Roles:  []string{"dp_analyst"},
+		}
+		claims := buildResourceClaims(user, reg, "admin")
+		if claims.IsAdmin {
+			t.Error("expected IsAdmin=false for non-admin user")
+		}
+		if !slices.Contains(claims.Personas, "analyst") {
+			t.Errorf("expected analyst in Personas, got %v", claims.Personas)
+		}
+	})
+
+	t.Run("nil registry skips persona resolution", func(t *testing.T) {
+		user := &portal.User{
+			UserID: "u3",
+			Email:  "u3@example.com",
+			Roles:  []string{"dp_admin"},
+		}
+		claims := buildResourceClaims(user, nil, "admin")
+		if claims.IsAdmin {
+			t.Error("expected IsAdmin=false when registry is nil")
+		}
+		if len(claims.Personas) != 0 {
+			t.Errorf("expected no personas, got %v", claims.Personas)
+		}
+	})
+
+	t.Run("user with multiple roles gets all matching personas", func(t *testing.T) {
+		user := &portal.User{
+			UserID: "u4",
+			Email:  "multi@example.com",
+			Roles:  []string{"dp_admin", "dp_analyst"},
+		}
+		claims := buildResourceClaims(user, reg, "admin")
+		if !claims.IsAdmin {
+			t.Error("expected IsAdmin=true")
+		}
+		if len(claims.Personas) != 2 {
+			t.Errorf("expected 2 personas, got %v", claims.Personas)
 		}
 	})
 }

--- a/cmd/mcp-data-platform/streamable_test.go
+++ b/cmd/mcp-data-platform/streamable_test.go
@@ -165,7 +165,7 @@ func TestStreamableHTTP_ToolCall_WithFullMiddleware(t *testing.T) {
 
 	// Add middleware in innermost-first order (last added = outermost = runs first)
 	// The production order is: enrichment → rules → audit → auth/authz → apps metadata
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, "http"))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, middleware.ToolCallConfig{Transport: "http", AdminPersona: "admin"}))
 
 	streamHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
 	handler := httpauth.MCPAuthGateway("")(streamHandler)
@@ -309,7 +309,7 @@ func TestStreamableHTTP_OAuthJWT_WithRoles(t *testing.T) {
 	})
 
 	authenticator, authorizer := buildProductionMiddleware(t, signingKey, issuer)
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, "http"))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, middleware.ToolCallConfig{Transport: "http", AdminPersona: "admin"}))
 
 	streamHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
 	handler := httpauth.MCPAuthGateway("")(streamHandler)
@@ -377,7 +377,7 @@ func TestStreamableHTTP_OAuthJWT_NoRoles_DeniedByPersona(t *testing.T) {
 	})
 
 	authenticator, authorizer := buildProductionMiddleware(t, signingKey, issuer)
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, "http"))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, middleware.ToolCallConfig{Transport: "http", AdminPersona: "admin"}))
 
 	streamHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
 	handler := httpauth.MCPAuthGateway("")(streamHandler)

--- a/pkg/middleware/context.go
+++ b/pkg/middleware/context.go
@@ -44,6 +44,7 @@ type PlatformContext struct {
 
 	// Authorization
 	Authorized bool
+	IsAdmin    bool // user belongs to the platform's admin persona
 	AuthzError string
 
 	// Transport metadata

--- a/pkg/middleware/mcp.go
+++ b/pkg/middleware/mcp.go
@@ -47,6 +47,13 @@ func (e *PlatformError) Error() string { return e.Message }
 // ErrorCategory implements CategorizedError.
 func (e *PlatformError) ErrorCategory() string { return e.Category }
 
+// ToolCallConfig holds configuration for MCPToolCallMiddleware.
+type ToolCallConfig struct {
+	Transport       string                  // "stdio" or "http"
+	AdminPersona    string                  // persona name that grants platform admin
+	WorkflowTracker *SessionWorkflowTracker // optional workflow tracker
+}
+
 // MCPToolCallMiddleware creates MCP protocol-level middleware that intercepts
 // tools/call requests and enforces authentication and authorization.
 //
@@ -59,13 +66,9 @@ func (e *PlatformError) ErrorCategory() string { return e.Category }
 // 5. Runs authorization to check if the user can access the tool
 // 6. Either proceeds with the call or returns an access denied error
 //
-// The transport parameter identifies the server transport ("stdio" or "http").
 // The toolkitLookup parameter is optional; if nil, toolkit metadata won't be populated.
-func MCPToolCallMiddleware(authenticator Authenticator, authorizer Authorizer, toolkitLookup ToolkitLookup, transport string, workflowTracker ...*SessionWorkflowTracker) mcp.Middleware {
-	var tracker *SessionWorkflowTracker
-	if len(workflowTracker) > 0 {
-		tracker = workflowTracker[0]
-	}
+func MCPToolCallMiddleware(authenticator Authenticator, authorizer Authorizer, toolkitLookup ToolkitLookup, cfg ToolCallConfig) mcp.Middleware {
+	tracker := cfg.WorkflowTracker
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
 			// Only intercept tools/call requests
@@ -90,7 +93,7 @@ func MCPToolCallMiddleware(authenticator Authenticator, authorizer Authorizer, t
 					pc.SessionID = awareID
 				}
 			}
-			pc.Transport = transport
+			pc.Transport = cfg.Transport
 			pc.Source = "mcp"
 			ctx = buildToolCallContext(ctx, req, pc, toolkitLookup, toolName)
 
@@ -100,6 +103,7 @@ func MCPToolCallMiddleware(authenticator Authenticator, authorizer Authorizer, t
 				authorizer:      authorizer,
 				pc:              pc,
 				toolName:        toolName,
+				adminPersona:    cfg.AdminPersona,
 				workflowTracker: tracker,
 			})
 		}
@@ -177,6 +181,7 @@ type authParams struct {
 	authorizer      Authorizer
 	pc              *PlatformContext
 	toolName        string
+	adminPersona    string
 	workflowTracker *SessionWorkflowTracker
 }
 
@@ -219,6 +224,7 @@ func authenticateAndAuthorize(
 	authorized, personaName, reason := params.authorizer.IsAuthorized(ctx, params.pc.UserID, params.pc.Roles, params.toolName, params.pc.Connection)
 	params.pc.Authorized = authorized
 	params.pc.PersonaName = personaName
+	params.pc.IsAdmin = personaName != "" && personaName == params.adminPersona
 	if !authorized {
 		params.pc.AuthzError = reason
 		slog.Warn("tool call authorization denied",

--- a/pkg/middleware/mcp_resources.go
+++ b/pkg/middleware/mcp_resources.go
@@ -207,6 +207,7 @@ func claimsFromPC(pc *PlatformContext, cfg ManagedResourceConfig) resource.Claim
 	} else if pc.PersonaName != "" {
 		claims.Personas = []string{pc.PersonaName}
 	}
+	claims.IsAdmin = pc.IsAdmin
 	return claims
 }
 

--- a/pkg/middleware/mcp_resources.go
+++ b/pkg/middleware/mcp_resources.go
@@ -208,7 +208,23 @@ func claimsFromPC(pc *PlatformContext, cfg ManagedResourceConfig) resource.Claim
 		claims.Personas = []string{pc.PersonaName}
 	}
 	claims.IsAdmin = pc.IsAdmin
+	claims.AdminOfPersonas = extractPersonaAdminRoles(pc.Roles)
 	return claims
+}
+
+// personaAdminInfix is the role substring that marks a persona-admin grant.
+const personaAdminInfix = "persona-admin:"
+
+// extractPersonaAdminRoles extracts persona names from roles containing
+// the "persona-admin:" pattern, tolerating any prefix (e.g., "dp_persona-admin:finance").
+func extractPersonaAdminRoles(roles []string) []string {
+	var out []string
+	for _, r := range roles {
+		if _, name, ok := strings.Cut(r, personaAdminInfix); ok && name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 // extractResourceURI extracts the URI from a resources/read request.

--- a/pkg/middleware/mcp_resources_test.go
+++ b/pkg/middleware/mcp_resources_test.go
@@ -150,6 +150,21 @@ func TestClaimsFromPC(t *testing.T) {
 	if len(claims.Personas) != 2 {
 		t.Errorf("Personas = %v, want [a b]", claims.Personas)
 	}
+
+	// IsAdmin propagated from PlatformContext.
+	pc.IsAdmin = true
+	cfg.PersonasForRoles = nil
+	claims = claimsFromPC(pc, cfg)
+	if !claims.IsAdmin {
+		t.Error("expected IsAdmin=true when PlatformContext.IsAdmin is true")
+	}
+
+	// IsAdmin=false propagated.
+	pc.IsAdmin = false
+	claims = claimsFromPC(pc, cfg)
+	if claims.IsAdmin {
+		t.Error("expected IsAdmin=false when PlatformContext.IsAdmin is false")
+	}
 }
 
 // --- handleManagedList tests ---

--- a/pkg/middleware/mcp_resources_test.go
+++ b/pkg/middleware/mcp_resources_test.go
@@ -165,6 +165,13 @@ func TestClaimsFromPC(t *testing.T) {
 	if claims.IsAdmin {
 		t.Error("expected IsAdmin=false when PlatformContext.IsAdmin is false")
 	}
+
+	// AdminOfPersonas extracted from prefixed roles.
+	pc.Roles = []string{"dp_persona-admin:finance", "dp_analyst"}
+	claims = claimsFromPC(pc, cfg)
+	if len(claims.AdminOfPersonas) != 1 || claims.AdminOfPersonas[0] != "finance" {
+		t.Errorf("AdminOfPersonas = %v, want [finance]", claims.AdminOfPersonas)
+	}
 }
 
 // --- handleManagedList tests ---

--- a/pkg/middleware/mcp_test.go
+++ b/pkg/middleware/mcp_test.go
@@ -84,7 +84,7 @@ func TestMCPToolCallMiddleware_AuthenticationFailure(t *testing.T) {
 	}
 	authorizer := &mcpTestAuthorizer{authorized: true}
 
-	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, mcpTestStdio)
+	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
 
 	next := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
 		t.Fatal("next should not be called on auth failure")
@@ -122,7 +122,7 @@ func TestMCPToolCallMiddleware_AuthorizationFailure(t *testing.T) {
 		reason:      "tool not allowed for persona",
 	}
 
-	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, mcpTestStdio)
+	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
 
 	next := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
 		t.Fatal("next should not be called on authz failure")
@@ -168,7 +168,7 @@ func TestMCPToolCallMiddleware_Success(t *testing.T) {
 	}
 	authorizer := &mcpTestAuthorizer{authorized: true, personaName: mcpTestPersona}
 
-	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, mcpTestStdio)
+	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
 
 	expectedResult := &mcp.CallToolResult{
 		Content: []mcp.Content{
@@ -228,7 +228,7 @@ func TestMCPToolCallMiddleware_NonToolsCallPassthrough(t *testing.T) {
 	}
 	authorizer := &mcpTestAuthorizer{authorized: false}
 
-	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, mcpTestStdio)
+	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
 
 	expectedResult := &mcp.CallToolResult{
 		Content: []mcp.Content{
@@ -267,7 +267,7 @@ func TestMCPToolCallMiddleware_MissingToolName(t *testing.T) {
 	}
 	authorizer := &mcpTestAuthorizer{authorized: true}
 
-	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, mcpTestStdio)
+	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
 
 	next := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
 		t.Fatal("next should not be called with missing tool name")
@@ -298,7 +298,7 @@ func TestMCPToolCallMiddleware_NilParams(t *testing.T) {
 	}
 	authorizer := &mcpTestAuthorizer{authorized: true}
 
-	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, mcpTestStdio)
+	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
 
 	next := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
 		t.Fatal("next should not be called with nil params")
@@ -331,7 +331,7 @@ func TestMCPToolCallMiddleware_WrongParamsType(t *testing.T) {
 	}
 	authorizer := &mcpTestAuthorizer{authorized: true}
 
-	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, mcpTestStdio)
+	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
 
 	next := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
 		t.Fatal("next should not be called with wrong params type")
@@ -377,7 +377,7 @@ func TestMCPToolCallMiddleware_ToolkitLookup(t *testing.T) {
 		found:      true,
 	}
 
-	middleware := MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, mcpTestStdio)
+	middleware := MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
 
 	expectedResult := &mcp.CallToolResult{
 		Content: []mcp.Content{
@@ -441,7 +441,7 @@ func TestMCPToolCallMiddleware_ToolkitLookupNotFound(t *testing.T) {
 		found: false, // Tool not found in any toolkit
 	}
 
-	middleware := MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, mcpTestStdio)
+	middleware := MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
 
 	expectedResult := &mcp.CallToolResult{
 		Content: []mcp.Content{
@@ -570,7 +570,7 @@ func TestMCPToolCallMiddleware_SessionIDPopulated(t *testing.T) {
 	}
 	authorizer := &mcpTestAuthorizer{authorized: true, personaName: mcpTestPersona}
 
-	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, mcpTestStdio)
+	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
 
 	next := func(ctx context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
 		pc := GetPlatformContext(ctx)
@@ -614,7 +614,7 @@ func TestMCPToolCallMiddleware_AuthBridgeFromRequestExtra(t *testing.T) {
 	}
 	authorizer := &mcpTestAuthorizer{authorized: true, personaName: "admin"}
 
-	mw := MCPToolCallMiddleware(authenticator, authorizer, nil, mcpTestStdio)
+	mw := MCPToolCallMiddleware(authenticator, authorizer, nil, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
 
 	next := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
 		return &mcp.CallToolResult{
@@ -912,7 +912,7 @@ func TestMCPToolCallMiddleware_ConnectionOverride(t *testing.T) {
 		found:      true,
 	}
 
-	middleware := MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, mcpTestStdio)
+	middleware := MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
 
 	t.Run("connection arg overrides toolkit default", func(t *testing.T) {
 		next := func(ctx context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
@@ -980,7 +980,7 @@ func TestMCPToolCallMiddleware_AwareSessionIDFallback(t *testing.T) {
 	}
 	authorizer := &mcpTestAuthorizer{authorized: true, personaName: mcpTestPersona}
 
-	mw := MCPToolCallMiddleware(authenticator, authorizer, nil, "http")
+	mw := MCPToolCallMiddleware(authenticator, authorizer, nil, ToolCallConfig{Transport: "http", AdminPersona: "admin"})
 
 	t.Run("uses AwareHandler session ID when SDK returns default", func(t *testing.T) {
 		next := func(ctx context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
@@ -1049,7 +1049,7 @@ func TestMCPToolCallMiddleware_PreAuthenticatedUser(t *testing.T) {
 	}
 	authorizer := &mcpTestAuthorizer{authorized: true, personaName: mcpTestPersona}
 
-	mw := MCPToolCallMiddleware(authenticator, authorizer, nil, mcpTestStdio)
+	mw := MCPToolCallMiddleware(authenticator, authorizer, nil, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
 
 	next := func(ctx context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
 		pc := GetPlatformContext(ctx)
@@ -1107,7 +1107,7 @@ func TestMCPToolCallMiddleware_PreAuthenticatedUser_AuthzDenied(t *testing.T) {
 		reason:      "tool not allowed",
 	}
 
-	mw := MCPToolCallMiddleware(authenticator, authorizer, nil, mcpTestStdio)
+	mw := MCPToolCallMiddleware(authenticator, authorizer, nil, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
 
 	next := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
 		t.Fatal("next should not be called on authz failure")

--- a/pkg/middleware/middleware_chain_test.go
+++ b/pkg/middleware/middleware_chain_test.go
@@ -261,7 +261,7 @@ func TestMiddlewareChain_AuditReceivesPlatformContext(t *testing.T) {
 	// MCPAuditMiddleware is added FIRST (innermost).
 	// MCPToolCallMiddleware is added SECOND (outermost — runs first).
 	server.AddReceivingMiddleware(middleware.MCPAuditMiddleware(auditStore))
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, chainTestStdio))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, middleware.ToolCallConfig{Transport: chainTestStdio, AdminPersona: "admin"}))
 
 	// Connect client
 	ctx := context.Background()
@@ -341,7 +341,7 @@ func TestMiddlewareChain_WrongOrder_AuditGetsNilContext(t *testing.T) {
 
 	// WRONG ORDER: auth first (innermost), audit second (outermost).
 	// This is what the code did before the fix.
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, chainTestStdio))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, middleware.ToolCallConfig{Transport: chainTestStdio, AdminPersona: "admin"}))
 	server.AddReceivingMiddleware(middleware.MCPAuditMiddleware(auditStore))
 
 	ctx := context.Background()
@@ -493,7 +493,7 @@ func TestMiddlewareChain_EnrichmentAddsSemanticContext(t *testing.T) {
 		semProvider, nil, nil,
 		middleware.EnrichmentConfig{EnrichTrinoResults: true}, nil,
 	))
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, chainTestStdio))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, middleware.ToolCallConfig{Transport: chainTestStdio, AdminPersona: "admin"}))
 
 	ctx := context.Background()
 	session, err := connectClientServer(ctx, server)
@@ -588,7 +588,7 @@ func TestMiddlewareChain_EnrichmentAddsQueryContext(t *testing.T) {
 		nil, queryProv, nil,
 		middleware.EnrichmentConfig{EnrichDataHubResults: true}, nil,
 	))
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, chainTestStdio))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, middleware.ToolCallConfig{Transport: chainTestStdio, AdminPersona: "admin"}))
 
 	ctx := context.Background()
 	session, err := connectClientServer(ctx, server)
@@ -655,7 +655,7 @@ func TestMiddlewareChain_DefaultDenyPersona(t *testing.T) {
 	})
 
 	// Only auth middleware (outermost)
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, chainTestStdio))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, middleware.ToolCallConfig{Transport: chainTestStdio, AdminPersona: "admin"}))
 
 	ctx := context.Background()
 	session, err := connectClientServer(ctx, server)
@@ -750,7 +750,7 @@ func TestMiddlewareChain_FullStack(t *testing.T) {
 	// 3. Audit
 	server.AddReceivingMiddleware(middleware.MCPAuditMiddleware(auditStore))
 	// 4. Auth/Authz (outermost)
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, chainTestStdio))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, middleware.ToolCallConfig{Transport: chainTestStdio, AdminPersona: "admin"}))
 
 	ctx := context.Background()
 	session, err := connectClientServer(ctx, server)
@@ -821,7 +821,7 @@ func TestMiddlewareChain_AuditResponseSize(t *testing.T) {
 
 	// Middleware: audit (innermost), auth (outermost)
 	server.AddReceivingMiddleware(middleware.MCPAuditMiddleware(auditStore))
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, chainTestStdio))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, middleware.ToolCallConfig{Transport: chainTestStdio, AdminPersona: "admin"}))
 
 	ctx := context.Background()
 	session, err := connectClientServer(ctx, server)
@@ -938,7 +938,7 @@ func newDedupTestServer(t *testing.T, mode middleware.DedupMode, cache *middlewa
 		},
 		nil,
 	))
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, chainTestStdio))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, middleware.ToolCallConfig{Transport: chainTestStdio, AdminPersona: "admin"}))
 
 	return server
 }
@@ -1289,7 +1289,7 @@ func TestMiddlewareChain_EnrichmentAppliedInAudit(t *testing.T) {
 	// 2. Audit
 	server.AddReceivingMiddleware(middleware.MCPAuditMiddleware(auditStore))
 	// 3. Auth/Authz (outermost)
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, chainTestStdio))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, middleware.ToolCallConfig{Transport: chainTestStdio, AdminPersona: "admin"}))
 
 	ctx := context.Background()
 	session, err := connectClientServer(ctx, server)
@@ -1451,7 +1451,7 @@ func newHTTPDedupTestSession(t *testing.T, includeQueryTool bool) httpDedupTestR
 		},
 		nil,
 	))
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, "http"))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, middleware.ToolCallConfig{Transport: "http", AdminPersona: "admin"}))
 
 	// Start a real HTTP server with Streamable HTTP transport
 	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
@@ -1595,7 +1595,7 @@ func TestMiddlewareChain_SessionDedup_StreamableHTTP_Stateless(t *testing.T) {
 		},
 		nil,
 	))
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, "http"))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, middleware.ToolCallConfig{Transport: "http", AdminPersona: "admin"}))
 
 	// Stateless mode: each request creates a new temporary session
 	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
@@ -1717,7 +1717,7 @@ func TestMiddlewareChain_SessionDedup_SSE(t *testing.T) {
 		},
 		nil,
 	))
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, chainTestStdio))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, toolkitLookup, middleware.ToolCallConfig{Transport: chainTestStdio, AdminPersona: "admin"}))
 
 	// SSE handler
 	sseHandler := mcp.NewSSEHandler(func(*http.Request) *mcp.Server {
@@ -1951,7 +1951,7 @@ func TestWorkflowGating_NoDiscovery(t *testing.T) {
 		},
 	}
 	server.AddReceivingMiddleware(middleware.MCPRuleEnforcementMiddleware(ruleCfg))
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, chainTestStdio, tracker))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, middleware.ToolCallConfig{Transport: chainTestStdio, AdminPersona: "admin", WorkflowTracker: tracker}))
 
 	ctx := context.Background()
 	session, err := connectClientServer(ctx, server)
@@ -2010,7 +2010,7 @@ func TestWorkflowGating_WithDiscovery(t *testing.T) {
 		},
 	}
 	server.AddReceivingMiddleware(middleware.MCPRuleEnforcementMiddleware(ruleCfg))
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, chainTestStdio, tracker))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, middleware.ToolCallConfig{Transport: chainTestStdio, AdminPersona: "admin", WorkflowTracker: tracker}))
 
 	ctx := context.Background()
 	session, err := connectClientServer(ctx, server)
@@ -2068,7 +2068,7 @@ func TestWorkflowGating_Escalation(t *testing.T) {
 		},
 	}
 	server.AddReceivingMiddleware(middleware.MCPRuleEnforcementMiddleware(ruleCfg))
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, chainTestStdio, tracker))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, middleware.ToolCallConfig{Transport: chainTestStdio, AdminPersona: "admin", WorkflowTracker: tracker}))
 
 	ctx := context.Background()
 	session, err := connectClientServer(ctx, server)
@@ -2172,7 +2172,7 @@ func TestWorkflowGating_BackwardCompat(t *testing.T) {
 	// No workflow tracker — static fallback
 	ruleCfg := middleware.RuleEnforcementConfig{Engine: ruleEngine}
 	server.AddReceivingMiddleware(middleware.MCPRuleEnforcementMiddleware(ruleCfg))
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, chainTestStdio))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, middleware.ToolCallConfig{Transport: chainTestStdio, AdminPersona: "admin"}))
 
 	ctx := context.Background()
 	session, err := connectClientServer(ctx, server)
@@ -2254,7 +2254,7 @@ func TestMiddlewareChain_AwareHandler_ProvenanceSessionID(t *testing.T) {
 	// 1. Provenance (innermost) — records tool calls, harvests on save_artifact
 	// 2. Auth (outermost) — creates PlatformContext with session ID
 	server.AddReceivingMiddleware(middleware.MCPProvenanceMiddleware(tracker, saveToolName))
-	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, "http"))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, middleware.ToolCallConfig{Transport: "http", AdminPersona: "admin"}))
 
 	// Stateless Streamable HTTP handler — no SDK-managed sessions.
 	streamableHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1471,7 +1471,11 @@ func (p *Platform) finalizeSetup() {
 	// users, creates PlatformContext. Must be outer to Audit so PlatformContext
 	// is available in the ctx that Audit receives.
 	p.mcpServer.AddReceivingMiddleware(
-		middleware.MCPToolCallMiddleware(p.authenticator, p.authorizer, p.toolkitRegistry, p.config.Server.Transport, p.workflowTracker),
+		middleware.MCPToolCallMiddleware(p.authenticator, p.authorizer, p.toolkitRegistry, middleware.ToolCallConfig{
+			Transport:       p.config.Server.Transport,
+			AdminPersona:    p.config.Admin.Persona,
+			WorkflowTracker: p.workflowTracker,
+		}),
 	)
 
 	// 7. MCP Apps metadata - injects _meta.ui into tools/list

--- a/pkg/resource/handler_test.go
+++ b/pkg/resource/handler_test.go
@@ -127,6 +127,7 @@ func testClaims() *Claims {
 		Email:    "user@example.com",
 		Personas: []string{"analyst"},
 		Roles:    []string{"admin"},
+		IsAdmin:  true,
 	}
 }
 

--- a/pkg/resource/permission.go
+++ b/pkg/resource/permission.go
@@ -8,6 +8,7 @@ type Claims struct {
 	Email    string   // user email
 	Personas []string // persona names the user belongs to
 	Roles    []string // e.g., "admin", "platform-admin", "persona-admin:finance"
+	IsAdmin  bool     // resolved by the caller from persona config (true when user belongs to the admin persona)
 }
 
 // CanWriteScope checks whether the caller has write permission for the given scope.
@@ -76,7 +77,9 @@ func VisibleScopes(c Claims) []ScopeFilter {
 }
 
 func isPlatformAdmin(c Claims) bool {
-	return slices.Contains(c.Roles, "admin") || slices.Contains(c.Roles, "platform-admin")
+	return c.IsAdmin ||
+		slices.Contains(c.Roles, "admin") ||
+		slices.Contains(c.Roles, "platform-admin")
 }
 
 func isPersonaAdmin(c Claims, personaName string) bool {

--- a/pkg/resource/permission.go
+++ b/pkg/resource/permission.go
@@ -4,11 +4,12 @@ import "slices"
 
 // Claims represents the identity information needed for resource permission checks.
 type Claims struct {
-	Sub      string   // Keycloak subject (user ID)
-	Email    string   // user email
-	Personas []string // persona names the user belongs to
-	Roles    []string // e.g., "admin", "platform-admin", "persona-admin:finance"
-	IsAdmin  bool     // resolved by the caller from persona config (true when user belongs to the admin persona)
+	Sub             string   // Keycloak subject (user ID)
+	Email           string   // user email
+	Personas        []string // persona names the user belongs to
+	Roles           []string // raw roles from auth (may have prefix, e.g., "dp_admin")
+	IsAdmin         bool     // resolved by the caller from persona config
+	AdminOfPersonas []string // persona names this user can admin (resolved by caller from role patterns)
 }
 
 // CanWriteScope checks whether the caller has write permission for the given scope.
@@ -86,5 +87,6 @@ func isPersonaAdmin(c Claims, personaName string) bool {
 	if isPlatformAdmin(c) {
 		return true
 	}
-	return slices.Contains(c.Roles, "persona-admin:"+personaName)
+	return slices.Contains(c.AdminOfPersonas, personaName) ||
+		slices.Contains(c.Roles, "persona-admin:"+personaName)
 }

--- a/pkg/resource/permission_test.go
+++ b/pkg/resource/permission_test.go
@@ -10,6 +10,8 @@ func TestCanWriteScope(t *testing.T) {
 	personaAdmin := Claims{Sub: "pa-1", Roles: []string{"persona-admin:finance"}}
 	// Simulates an API key or OIDC user with prefixed role dp_admin mapped to admin persona.
 	prefixedAdmin := Claims{Sub: "pa-2", Roles: []string{"dp_admin"}, IsAdmin: true}
+	// Simulates a persona admin with a prefixed role.
+	prefixedPersonaAdmin := Claims{Sub: "pa-3", Roles: []string{"dp_persona-admin:finance"}, AdminOfPersonas: []string{"finance"}}
 
 	tests := []struct {
 		name    string
@@ -28,6 +30,9 @@ func TestCanWriteScope(t *testing.T) {
 		{"prefixed role admin writes global via IsAdmin", prefixedAdmin, ScopeGlobal, "", true},
 		{"prefixed role admin writes persona via IsAdmin", prefixedAdmin, ScopePersona, "finance", true},
 		{"prefixed role admin writes user scope via IsAdmin", prefixedAdmin, ScopeUser, "other-user", true},
+		{"prefixed persona admin writes their persona", prefixedPersonaAdmin, ScopePersona, "finance", true},
+		{"prefixed persona admin cannot write other persona", prefixedPersonaAdmin, ScopePersona, "engineering", false},
+		{"prefixed persona admin cannot write global", prefixedPersonaAdmin, ScopeGlobal, "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -177,5 +182,12 @@ func TestIsPersonaAdmin(t *testing.T) {
 	}
 	if !isPersonaAdmin(Claims{Roles: []string{"admin"}}, "anything") {
 		t.Error("platform admin should be persona admin of any persona")
+	}
+	// AdminOfPersonas resolved by caller — works with prefixed roles.
+	if !isPersonaAdmin(Claims{Roles: []string{"dp_persona-admin:finance"}, AdminOfPersonas: []string{"finance"}}, "finance") {
+		t.Error("AdminOfPersonas should grant persona admin for prefixed roles")
+	}
+	if isPersonaAdmin(Claims{Roles: []string{"dp_persona-admin:finance"}, AdminOfPersonas: []string{"finance"}}, "engineering") {
+		t.Error("AdminOfPersonas for finance should not grant admin for engineering")
 	}
 }

--- a/pkg/resource/permission_test.go
+++ b/pkg/resource/permission_test.go
@@ -8,6 +8,8 @@ func TestCanWriteScope(t *testing.T) {
 	admin := Claims{Sub: "admin-1", Roles: []string{"admin"}}
 	user := Claims{Sub: "user-1", Roles: []string{"analyst"}}
 	personaAdmin := Claims{Sub: "pa-1", Roles: []string{"persona-admin:finance"}}
+	// Simulates an API key or OIDC user with prefixed role dp_admin mapped to admin persona.
+	prefixedAdmin := Claims{Sub: "pa-2", Roles: []string{"dp_admin"}, IsAdmin: true}
 
 	tests := []struct {
 		name    string
@@ -23,6 +25,9 @@ func TestCanWriteScope(t *testing.T) {
 		{"user cannot write other user scope", user, ScopeUser, "other", false},
 		{"persona admin writes their persona", personaAdmin, ScopePersona, "finance", true},
 		{"persona admin cannot write other persona", personaAdmin, ScopePersona, "engineering", false},
+		{"prefixed role admin writes global via IsAdmin", prefixedAdmin, ScopeGlobal, "", true},
+		{"prefixed role admin writes persona via IsAdmin", prefixedAdmin, ScopePersona, "finance", true},
+		{"prefixed role admin writes user scope via IsAdmin", prefixedAdmin, ScopeUser, "other-user", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -149,6 +154,17 @@ func TestIsPlatformAdmin(t *testing.T) {
 	}
 	if isPlatformAdmin(Claims{Roles: []string{"analyst"}}) {
 		t.Error("analyst should not be platform admin")
+	}
+	// IsAdmin flag set by caller based on persona resolution — works
+	// regardless of role name (e.g., dp_admin, custom_superuser).
+	if !isPlatformAdmin(Claims{Roles: []string{"dp_admin"}, IsAdmin: true}) {
+		t.Error("IsAdmin=true should be platform admin regardless of role name")
+	}
+	if !isPlatformAdmin(Claims{IsAdmin: true}) {
+		t.Error("IsAdmin=true with no roles should still be platform admin")
+	}
+	if isPlatformAdmin(Claims{Roles: []string{"dp_analyst"}, IsAdmin: false}) {
+		t.Error("IsAdmin=false with non-admin role should not be platform admin")
 	}
 }
 


### PR DESCRIPTION
## Summary

`isPlatformAdmin` in the resource permission system checked for literal role strings `"admin"` and `"platform-admin"`, which fails when roles carry an OIDC prefix (e.g., `dp_admin` from `role_prefix: "dp_"`). The persona mapper correctly resolved `dp_admin` → admin persona, but the resource permission system bypassed personas entirely. This meant API keys and OIDC users with prefixed admin roles could not write to global-scope managed resources.

The bug was masked by tests that only used literal `"admin"` roles.

### Root cause

The resource permission system (`pkg/resource/permission.go`) operated on raw role strings while the rest of the platform (tool access, MCP middleware) operated on resolved personas. Two different authorization models for the same user identity.

### Fix

Add `IsAdmin bool` to `resource.Claims` and `middleware.PlatformContext`. The callers who construct claims determine admin status by comparing the user's resolved persona against the platform's configured admin persona name (`Config.Admin.Persona`). The permission system checks this flag instead of hard-coding role or persona names.

**Data flow:**

1. **MCP path**: `MCPToolCallMiddleware` resolves the persona via the authorizer, compares against `cfg.AdminPersona`, sets `PlatformContext.IsAdmin`. The managed resources middleware reads `pc.IsAdmin` into `resource.Claims.IsAdmin`.

2. **REST API path**: `extractClaims` in `main.go` resolves personas via the registry, compares against `p.Config().Admin.Persona`, sets `Claims.IsAdmin`.

3. **Permission check**: `isPlatformAdmin` checks `c.IsAdmin` first, with existing `"admin"`/`"platform-admin"` role checks as backward-compatible fallback for deployments that assign roles directly without persona mapping.

### Additional cleanup

`MCPToolCallMiddleware` previously took 5 positional parameters plus a variadic. Adding `adminPersona` would have been a 6th, violating the `revive` argument-limit lint rule. Consolidated `transport`, `adminPersona`, and `workflowTracker` into a `ToolCallConfig` struct. All call sites (production and test) updated.

## Test plan

- [x] `isPlatformAdmin` returns true for `IsAdmin: true` regardless of role names
- [x] `isPlatformAdmin` returns true for `IsAdmin: true` with no roles at all
- [x] `isPlatformAdmin` returns false for `IsAdmin: false` with non-admin prefixed role
- [x] `CanWriteScope` grants global/persona/user write for `IsAdmin: true` with prefixed role `dp_admin`
- [x] `claimsFromPC` propagates `PlatformContext.IsAdmin` to `Claims.IsAdmin`
- [x] `buildResourceClaims` sets `IsAdmin: true` when resolved persona matches admin persona config
- [x] `buildResourceClaims` sets `IsAdmin: false` for non-admin persona
- [x] `buildResourceClaims` handles nil registry (no panic, no IsAdmin)
- [x] `buildResourceClaims` resolves multiple personas for multi-role users
- [x] All existing middleware chain integration tests pass with `ToolCallConfig` struct
- [x] 100% coverage on `isPlatformAdmin`, `claimsFromPC`, `buildResourceClaims`
- [x] `make verify` passes (fmt, test, lint, security, coverage, patch-coverage, mutation, release)