### PR TITLE
fix: authenticate users for MCP resources/list and resources/read

### DIFF
--- a/pkg/middleware/mcp_resources.go
+++ b/pkg/middleware/mcp_resources.go
@@ -39,6 +39,8 @@ type ManagedResourceConfig struct {
 	S3Bucket         string
 	URIScheme        string
 	PersonasForRoles PersonasForRoles // resolves roles → persona names
+	Authenticator    Authenticator    // authenticates users for resources/list and resources/read
+	AdminPersona     string           // persona name that grants platform admin
 }
 
 // MCPManagedResourceMiddleware intercepts resources/list and resources/read
@@ -68,8 +70,9 @@ func handleManagedList(ctx context.Context, next mcp.MethodHandler, method strin
 		return result, err
 	}
 
-	// Require auth context — skip injecting managed resources for unauthenticated callers.
-	pc := GetPlatformContext(ctx)
+	// Get auth context — try PlatformContext first (set by MCPToolCallMiddleware
+	// for tools/call), then authenticate directly for resources/list.
+	pc := getOrAuthenticatePC(ctx, req, cfg)
 	if pc == nil {
 		return result, nil
 	}
@@ -137,7 +140,7 @@ func handleManagedRead(ctx context.Context, next mcp.MethodHandler, method strin
 	}
 
 	// Permission check — require authentication for managed resources.
-	pc := GetPlatformContext(ctx)
+	pc := getOrAuthenticatePC(ctx, req, cfg)
 	if pc == nil {
 		// No auth context — fall through to SDK handler.
 		return next(ctx, method, req)
@@ -210,6 +213,41 @@ func claimsFromPC(pc *PlatformContext, cfg ManagedResourceConfig) resource.Claim
 	claims.IsAdmin = pc.IsAdmin
 	claims.AdminOfPersonas = extractPersonaAdminRoles(pc.Roles)
 	return claims
+}
+
+// getOrAuthenticatePC returns the PlatformContext from the context if available
+// (set by MCPToolCallMiddleware for tools/call), or authenticates the user
+// directly for resources/list and resources/read methods. Returns nil if
+// authentication fails or no authenticator is configured.
+func getOrAuthenticatePC(ctx context.Context, req mcp.Request, cfg ManagedResourceConfig) *PlatformContext {
+	if pc := GetPlatformContext(ctx); pc != nil {
+		return pc
+	}
+	if cfg.Authenticator == nil {
+		return nil
+	}
+	// Bridge auth token from per-request headers (Streamable HTTP).
+	if req != nil {
+		ctx = bridgeAuthToken(ctx, req)
+	}
+	userInfo, err := cfg.Authenticator.Authenticate(ctx)
+	if err != nil || userInfo == nil {
+		return nil
+	}
+	pc := &PlatformContext{
+		UserID:    userInfo.UserID,
+		UserEmail: userInfo.Email,
+		Roles:     userInfo.Roles,
+	}
+	// Resolve persona for admin status.
+	if cfg.PersonasForRoles != nil {
+		personas := cfg.PersonasForRoles(userInfo.Roles)
+		if len(personas) > 0 {
+			pc.PersonaName = personas[0]
+		}
+		pc.IsAdmin = cfg.AdminPersona != "" && slices.Contains(personas, cfg.AdminPersona)
+	}
+	return pc
 }
 
 // personaAdminInfix is the role substring that marks a persona-admin grant.

--- a/pkg/middleware/mcp_resources_test.go
+++ b/pkg/middleware/mcp_resources_test.go
@@ -174,6 +174,89 @@ func TestClaimsFromPC(t *testing.T) {
 	}
 }
 
+func TestGetOrAuthenticatePC(t *testing.T) {
+	t.Run("returns existing PlatformContext", func(t *testing.T) {
+		existing := &PlatformContext{UserID: "existing"}
+		ctx := context.WithValue(context.Background(), platformContextKey, existing)
+		got := getOrAuthenticatePC(ctx, nil, ManagedResourceConfig{})
+		if got != existing {
+			t.Error("should return existing PlatformContext")
+		}
+	})
+
+	t.Run("authenticates when no PlatformContext", func(t *testing.T) {
+		auth := &mockManagedAuth{
+			user: &UserInfo{UserID: "u1", Email: "u1@example.com", Roles: []string{"dp_admin"}},
+		}
+		cfg := ManagedResourceConfig{
+			Authenticator:    auth,
+			AdminPersona:     "admin",
+			PersonasForRoles: func(_ []string) []string { return []string{"admin"} },
+		}
+		// Pass a request so bridgeAuthToken is exercised.
+		req := &mcp.ServerRequest[*mcp.ReadResourceParams]{
+			Params: &mcp.ReadResourceParams{URI: "mcp://global/test/file.txt"},
+		}
+		got := getOrAuthenticatePC(context.Background(), req, cfg)
+		if got == nil {
+			t.Fatal("expected non-nil PlatformContext")
+		}
+		if got.UserID != "u1" {
+			t.Errorf("UserID = %q, want u1", got.UserID)
+		}
+		if !got.IsAdmin {
+			t.Error("expected IsAdmin=true for admin persona")
+		}
+	})
+
+	t.Run("returns nil when auth fails", func(t *testing.T) {
+		auth := &mockManagedAuth{err: fmt.Errorf("unauthorized")}
+		cfg := ManagedResourceConfig{Authenticator: auth}
+		got := getOrAuthenticatePC(context.Background(), nil, cfg)
+		if got != nil {
+			t.Error("expected nil when auth fails")
+		}
+	})
+
+	t.Run("returns nil when no authenticator", func(t *testing.T) {
+		got := getOrAuthenticatePC(context.Background(), nil, ManagedResourceConfig{})
+		if got != nil {
+			t.Error("expected nil when no authenticator configured")
+		}
+	})
+
+	t.Run("non-admin persona does not set IsAdmin", func(t *testing.T) {
+		auth := &mockManagedAuth{
+			user: &UserInfo{UserID: "u2", Roles: []string{"dp_analyst"}},
+		}
+		cfg := ManagedResourceConfig{
+			Authenticator:    auth,
+			AdminPersona:     "admin",
+			PersonasForRoles: func(_ []string) []string { return []string{"analyst"} },
+		}
+		got := getOrAuthenticatePC(context.Background(), nil, cfg)
+		if got == nil {
+			t.Fatal("expected non-nil PlatformContext")
+		}
+		if got.IsAdmin {
+			t.Error("expected IsAdmin=false for non-admin persona")
+		}
+		if got.PersonaName != "analyst" {
+			t.Errorf("PersonaName = %q, want analyst", got.PersonaName)
+		}
+	})
+}
+
+// mockManagedAuth is a minimal Authenticator for resource middleware tests.
+type mockManagedAuth struct {
+	user *UserInfo
+	err  error
+}
+
+func (m *mockManagedAuth) Authenticate(_ context.Context) (*UserInfo, error) {
+	return m.user, m.err
+}
+
 // --- handleManagedList tests ---
 
 func TestMCPManagedResourceMiddleware_ListAppendsManaged(t *testing.T) {

--- a/pkg/middleware/mcp_resources_test.go
+++ b/pkg/middleware/mcp_resources_test.go
@@ -322,6 +322,108 @@ func TestMCPManagedResourceMiddleware_ListAppendsManaged(t *testing.T) {
 	}
 }
 
+// TestMCPManagedResourceMiddleware_ListAuthenticatesFallback verifies the
+// production path where resources/list is called WITHOUT a pre-set
+// PlatformContext. The middleware must authenticate the user directly
+// via the configured Authenticator and return managed resources.
+func TestMCPManagedResourceMiddleware_ListAuthenticatesFallback(t *testing.T) {
+	store := newMockResourceStore()
+	store.resources["r1"] = &resource.Resource{
+		ID:          "r1",
+		Scope:       resource.ScopeGlobal,
+		URI:         "mcp://global/samples/test.csv",
+		DisplayName: "Test CSV",
+		Description: "A test CSV file.",
+		MIMEType:    "text/csv",
+	}
+
+	cfg := ManagedResourceConfig{
+		Store:     store,
+		URIScheme: "mcp",
+		Authenticator: &mockManagedAuth{
+			user: &UserInfo{UserID: "u1", Email: "u1@example.com", Roles: []string{"dp_admin"}},
+		},
+		AdminPersona:     "admin",
+		PersonasForRoles: func(_ []string) []string { return []string{"admin"} },
+	}
+
+	staticResource := &mcp.Resource{URI: "file:///static.txt", Name: "Static"}
+	next := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return &mcp.ListResourcesResult{Resources: []*mcp.Resource{staticResource}}, nil
+	}
+
+	mw := MCPManagedResourceMiddleware(cfg)
+	handler := mw(next)
+
+	// NO PlatformContext in context — forces the authentication fallback.
+	req := &mcp.ServerRequest[*mcp.ListResourcesParams]{Params: &mcp.ListResourcesParams{}}
+	result, err := handler(context.Background(), methodListResources, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	listResult, ok := result.(*mcp.ListResourcesResult)
+	if !ok {
+		t.Fatalf("result type = %T, want *mcp.ListResourcesResult", result)
+	}
+
+	if len(listResult.Resources) != 2 {
+		t.Errorf("expected 2 resources (1 static + 1 managed), got %d", len(listResult.Resources))
+		for i, r := range listResult.Resources {
+			t.Logf("  [%d] URI=%s Name=%s", i, r.URI, r.Name)
+		}
+	}
+
+	if len(listResult.Resources) >= 2 {
+		managed := listResult.Resources[1]
+		if managed.URI != "mcp://global/samples/test.csv" {
+			t.Errorf("managed URI = %q, want mcp://global/samples/test.csv", managed.URI)
+		}
+	}
+}
+
+// TestMCPManagedResourceMiddleware_ListNoAuthReturnsStaticOnly verifies that
+// when no Authenticator is configured and no PlatformContext exists, the
+// middleware returns only static resources without error.
+func TestMCPManagedResourceMiddleware_ListNoAuthReturnsStaticOnly(t *testing.T) {
+	store := newMockResourceStore()
+	store.resources["r1"] = &resource.Resource{
+		ID:    "r1",
+		Scope: resource.ScopeGlobal,
+		URI:   "mcp://global/samples/test.csv",
+	}
+
+	cfg := ManagedResourceConfig{
+		Store:     store,
+		URIScheme: "mcp",
+		// No Authenticator — simulates stdio transport without auth.
+	}
+
+	staticResource := &mcp.Resource{URI: "file:///static.txt", Name: "Static"}
+	next := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return &mcp.ListResourcesResult{Resources: []*mcp.Resource{staticResource}}, nil
+	}
+
+	mw := MCPManagedResourceMiddleware(cfg)
+	handler := mw(next)
+
+	// No PlatformContext, no Authenticator.
+	result, err := handler(context.Background(), methodListResources, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	listResult, ok := result.(*mcp.ListResourcesResult)
+	if !ok {
+		t.Fatalf("result type = %T, want *mcp.ListResourcesResult", result)
+	}
+
+	// Should have only the static resource — managed resources not injected.
+	if len(listResult.Resources) != 1 {
+		t.Errorf("expected 1 static resource, got %d", len(listResult.Resources))
+	}
+}
+
 func TestMCPManagedResourceMiddleware_ListNoManaged(t *testing.T) {
 	store := newMockResourceStore() // empty store
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1497,10 +1497,12 @@ func (p *Platform) addManagedResourceMiddleware() {
 		return
 	}
 	cfg := middleware.ManagedResourceConfig{
-		Store:     p.resourceStore,
-		S3Client:  p.resourceS3Client,
-		S3Bucket:  p.config.Resources.Managed.S3Bucket,
-		URIScheme: p.managedResourceURIScheme(),
+		Store:         p.resourceStore,
+		S3Client:      p.resourceS3Client,
+		S3Bucket:      p.config.Resources.Managed.S3Bucket,
+		URIScheme:     p.managedResourceURIScheme(),
+		Authenticator: p.authenticator,
+		AdminPersona:  p.config.Admin.Persona,
 	}
 	// Resolve all persona memberships from roles.
 	if p.personaRegistry != nil {


### PR DESCRIPTION
## Summary

Managed resources uploaded via the REST API were not visible through the MCP resources primitive (`resources/list` and `resources/read`).

### Root cause

`MCPManagedResourceMiddleware` checked `GetPlatformContext(ctx)` for authentication, but `PlatformContext` is only set by `MCPToolCallMiddleware` which only intercepts `tools/call` requests. The `resources/list` and `resources/read` MCP methods never go through that middleware, so `PlatformContext` was always nil and the middleware silently returned only the static resources.

### Fix

Added `getOrAuthenticatePC` which checks for an existing `PlatformContext` first (for the case where a `tools/call` triggers a resource read internally), then falls back to authenticating the user directly using the platform's `Authenticator`. This makes the managed resources middleware self-sufficient for auth — it doesn't depend on another middleware having run first.

`ManagedResourceConfig` now carries:
- `Authenticator` — the same authenticator used by the tools/call pipeline
- `AdminPersona` — for resolving `IsAdmin` on the authenticated user

Both are wired from `addManagedResourceMiddleware` in `platform.go`.

### What this enables

After this fix, the full round-trip works:
1. Upload a resource via `POST /api/v1/resources` (REST API)
2. See it in `resources/list` via MCP (filtered by the caller's visible scopes)
3. Read its content via `resources/read` with the `mcp://` URI scheme

## Test plan

- [x] `getOrAuthenticatePC` returns existing PlatformContext when available
- [x] `getOrAuthenticatePC` authenticates and builds PlatformContext when none exists
- [x] `getOrAuthenticatePC` resolves admin persona and sets IsAdmin
- [x] `getOrAuthenticatePC` returns nil when auth fails
- [x] `getOrAuthenticatePC` returns nil when no authenticator configured
- [x] Non-admin persona does not set IsAdmin
- [x] All new functions at 100% coverage
- [x] `make verify` passes