### PR TITLE
fix: notify MCP clients when managed resources change via REST API

### DIFF
--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -587,6 +587,7 @@ func mountResourcesAPI(mux *http.ServeMux, p *platform.Platform) {
 		S3Client:  p.ResourceS3Client(),
 		S3Bucket:  p.Config().Resources.Managed.S3Bucket,
 		URIScheme: p.Config().Resources.Managed.URIScheme,
+		NotifyFn:  p.NotifyResourceListChanged,
 	}
 
 	handler := resource.NewHandler(deps, extractClaims, nil)

--- a/pkg/middleware/mcp_resources.go
+++ b/pkg/middleware/mcp_resources.go
@@ -39,6 +39,8 @@ type ManagedResourceConfig struct {
 	S3Bucket         string
 	URIScheme        string
 	PersonasForRoles PersonasForRoles // resolves roles → persona names
+	Authenticator    Authenticator    // authenticates users for resources/list and resources/read
+	AdminPersona     string           // persona name that grants platform admin
 }
 
 // MCPManagedResourceMiddleware intercepts resources/list and resources/read
@@ -68,8 +70,9 @@ func handleManagedList(ctx context.Context, next mcp.MethodHandler, method strin
 		return result, err
 	}
 
-	// Require auth context — skip injecting managed resources for unauthenticated callers.
-	pc := GetPlatformContext(ctx)
+	// Get auth context — try PlatformContext first (set by MCPToolCallMiddleware
+	// for tools/call), then authenticate directly for resources/list.
+	pc := getOrAuthenticatePC(ctx, req, cfg)
 	if pc == nil {
 		return result, nil
 	}
@@ -137,7 +140,7 @@ func handleManagedRead(ctx context.Context, next mcp.MethodHandler, method strin
 	}
 
 	// Permission check — require authentication for managed resources.
-	pc := GetPlatformContext(ctx)
+	pc := getOrAuthenticatePC(ctx, req, cfg)
 	if pc == nil {
 		// No auth context — fall through to SDK handler.
 		return next(ctx, method, req)
@@ -210,6 +213,41 @@ func claimsFromPC(pc *PlatformContext, cfg ManagedResourceConfig) resource.Claim
 	claims.IsAdmin = pc.IsAdmin
 	claims.AdminOfPersonas = extractPersonaAdminRoles(pc.Roles)
 	return claims
+}
+
+// getOrAuthenticatePC returns the PlatformContext from the context if available
+// (set by MCPToolCallMiddleware for tools/call), or authenticates the user
+// directly for resources/list and resources/read methods. Returns nil if
+// authentication fails or no authenticator is configured.
+func getOrAuthenticatePC(ctx context.Context, req mcp.Request, cfg ManagedResourceConfig) *PlatformContext {
+	if pc := GetPlatformContext(ctx); pc != nil {
+		return pc
+	}
+	if cfg.Authenticator == nil {
+		return nil
+	}
+	// Bridge auth token from per-request headers (Streamable HTTP).
+	if req != nil {
+		ctx = bridgeAuthToken(ctx, req)
+	}
+	userInfo, err := cfg.Authenticator.Authenticate(ctx)
+	if err != nil || userInfo == nil {
+		return nil
+	}
+	pc := &PlatformContext{
+		UserID:    userInfo.UserID,
+		UserEmail: userInfo.Email,
+		Roles:     userInfo.Roles,
+	}
+	// Resolve persona for admin status.
+	if cfg.PersonasForRoles != nil {
+		personas := cfg.PersonasForRoles(userInfo.Roles)
+		if len(personas) > 0 {
+			pc.PersonaName = personas[0]
+		}
+		pc.IsAdmin = cfg.AdminPersona != "" && slices.Contains(personas, cfg.AdminPersona)
+	}
+	return pc
 }
 
 // personaAdminInfix is the role substring that marks a persona-admin grant.

--- a/pkg/middleware/mcp_resources_test.go
+++ b/pkg/middleware/mcp_resources_test.go
@@ -174,6 +174,89 @@ func TestClaimsFromPC(t *testing.T) {
 	}
 }
 
+func TestGetOrAuthenticatePC(t *testing.T) {
+	t.Run("returns existing PlatformContext", func(t *testing.T) {
+		existing := &PlatformContext{UserID: "existing"}
+		ctx := context.WithValue(context.Background(), platformContextKey, existing)
+		got := getOrAuthenticatePC(ctx, nil, ManagedResourceConfig{})
+		if got != existing {
+			t.Error("should return existing PlatformContext")
+		}
+	})
+
+	t.Run("authenticates when no PlatformContext", func(t *testing.T) {
+		auth := &mockManagedAuth{
+			user: &UserInfo{UserID: "u1", Email: "u1@example.com", Roles: []string{"dp_admin"}},
+		}
+		cfg := ManagedResourceConfig{
+			Authenticator:    auth,
+			AdminPersona:     "admin",
+			PersonasForRoles: func(_ []string) []string { return []string{"admin"} },
+		}
+		// Pass a request so bridgeAuthToken is exercised.
+		req := &mcp.ServerRequest[*mcp.ReadResourceParams]{
+			Params: &mcp.ReadResourceParams{URI: "mcp://global/test/file.txt"},
+		}
+		got := getOrAuthenticatePC(context.Background(), req, cfg)
+		if got == nil {
+			t.Fatal("expected non-nil PlatformContext")
+		}
+		if got.UserID != "u1" {
+			t.Errorf("UserID = %q, want u1", got.UserID)
+		}
+		if !got.IsAdmin {
+			t.Error("expected IsAdmin=true for admin persona")
+		}
+	})
+
+	t.Run("returns nil when auth fails", func(t *testing.T) {
+		auth := &mockManagedAuth{err: fmt.Errorf("unauthorized")}
+		cfg := ManagedResourceConfig{Authenticator: auth}
+		got := getOrAuthenticatePC(context.Background(), nil, cfg)
+		if got != nil {
+			t.Error("expected nil when auth fails")
+		}
+	})
+
+	t.Run("returns nil when no authenticator", func(t *testing.T) {
+		got := getOrAuthenticatePC(context.Background(), nil, ManagedResourceConfig{})
+		if got != nil {
+			t.Error("expected nil when no authenticator configured")
+		}
+	})
+
+	t.Run("non-admin persona does not set IsAdmin", func(t *testing.T) {
+		auth := &mockManagedAuth{
+			user: &UserInfo{UserID: "u2", Roles: []string{"dp_analyst"}},
+		}
+		cfg := ManagedResourceConfig{
+			Authenticator:    auth,
+			AdminPersona:     "admin",
+			PersonasForRoles: func(_ []string) []string { return []string{"analyst"} },
+		}
+		got := getOrAuthenticatePC(context.Background(), nil, cfg)
+		if got == nil {
+			t.Fatal("expected non-nil PlatformContext")
+		}
+		if got.IsAdmin {
+			t.Error("expected IsAdmin=false for non-admin persona")
+		}
+		if got.PersonaName != "analyst" {
+			t.Errorf("PersonaName = %q, want analyst", got.PersonaName)
+		}
+	})
+}
+
+// mockManagedAuth is a minimal Authenticator for resource middleware tests.
+type mockManagedAuth struct {
+	user *UserInfo
+	err  error
+}
+
+func (m *mockManagedAuth) Authenticate(_ context.Context) (*UserInfo, error) {
+	return m.user, m.err
+}
+
 // --- handleManagedList tests ---
 
 func TestMCPManagedResourceMiddleware_ListAppendsManaged(t *testing.T) {

--- a/pkg/middleware/mcp_resources_test.go
+++ b/pkg/middleware/mcp_resources_test.go
@@ -322,6 +322,108 @@ func TestMCPManagedResourceMiddleware_ListAppendsManaged(t *testing.T) {
 	}
 }
 
+// TestMCPManagedResourceMiddleware_ListAuthenticatesFallback verifies the
+// production path where resources/list is called WITHOUT a pre-set
+// PlatformContext. The middleware must authenticate the user directly
+// via the configured Authenticator and return managed resources.
+func TestMCPManagedResourceMiddleware_ListAuthenticatesFallback(t *testing.T) {
+	store := newMockResourceStore()
+	store.resources["r1"] = &resource.Resource{
+		ID:          "r1",
+		Scope:       resource.ScopeGlobal,
+		URI:         "mcp://global/samples/test.csv",
+		DisplayName: "Test CSV",
+		Description: "A test CSV file.",
+		MIMEType:    "text/csv",
+	}
+
+	cfg := ManagedResourceConfig{
+		Store:     store,
+		URIScheme: "mcp",
+		Authenticator: &mockManagedAuth{
+			user: &UserInfo{UserID: "u1", Email: "u1@example.com", Roles: []string{"dp_admin"}},
+		},
+		AdminPersona:     "admin",
+		PersonasForRoles: func(_ []string) []string { return []string{"admin"} },
+	}
+
+	staticResource := &mcp.Resource{URI: "file:///static.txt", Name: "Static"}
+	next := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return &mcp.ListResourcesResult{Resources: []*mcp.Resource{staticResource}}, nil
+	}
+
+	mw := MCPManagedResourceMiddleware(cfg)
+	handler := mw(next)
+
+	// NO PlatformContext in context — forces the authentication fallback.
+	req := &mcp.ServerRequest[*mcp.ListResourcesParams]{Params: &mcp.ListResourcesParams{}}
+	result, err := handler(context.Background(), methodListResources, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	listResult, ok := result.(*mcp.ListResourcesResult)
+	if !ok {
+		t.Fatalf("result type = %T, want *mcp.ListResourcesResult", result)
+	}
+
+	if len(listResult.Resources) != 2 {
+		t.Errorf("expected 2 resources (1 static + 1 managed), got %d", len(listResult.Resources))
+		for i, r := range listResult.Resources {
+			t.Logf("  [%d] URI=%s Name=%s", i, r.URI, r.Name)
+		}
+	}
+
+	if len(listResult.Resources) >= 2 {
+		managed := listResult.Resources[1]
+		if managed.URI != "mcp://global/samples/test.csv" {
+			t.Errorf("managed URI = %q, want mcp://global/samples/test.csv", managed.URI)
+		}
+	}
+}
+
+// TestMCPManagedResourceMiddleware_ListNoAuthReturnsStaticOnly verifies that
+// when no Authenticator is configured and no PlatformContext exists, the
+// middleware returns only static resources without error.
+func TestMCPManagedResourceMiddleware_ListNoAuthReturnsStaticOnly(t *testing.T) {
+	store := newMockResourceStore()
+	store.resources["r1"] = &resource.Resource{
+		ID:    "r1",
+		Scope: resource.ScopeGlobal,
+		URI:   "mcp://global/samples/test.csv",
+	}
+
+	cfg := ManagedResourceConfig{
+		Store:     store,
+		URIScheme: "mcp",
+		// No Authenticator — simulates stdio transport without auth.
+	}
+
+	staticResource := &mcp.Resource{URI: "file:///static.txt", Name: "Static"}
+	next := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return &mcp.ListResourcesResult{Resources: []*mcp.Resource{staticResource}}, nil
+	}
+
+	mw := MCPManagedResourceMiddleware(cfg)
+	handler := mw(next)
+
+	// No PlatformContext, no Authenticator.
+	result, err := handler(context.Background(), methodListResources, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	listResult, ok := result.(*mcp.ListResourcesResult)
+	if !ok {
+		t.Fatalf("result type = %T, want *mcp.ListResourcesResult", result)
+	}
+
+	// Should have only the static resource — managed resources not injected.
+	if len(listResult.Resources) != 1 {
+		t.Errorf("expected 1 static resource, got %d", len(listResult.Resources))
+	}
+}
+
 func TestMCPManagedResourceMiddleware_ListNoManaged(t *testing.T) {
 	store := newMockResourceStore() // empty store
 

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -76,6 +76,9 @@ type Config struct {
 	SessionGate   SessionGateConfig   `yaml:"session_gate"`
 }
 
+// defaultAdminPersona is the persona name that grants platform admin.
+const defaultAdminPersona = "admin"
+
 // AdminConfig configures the admin REST API.
 type AdminConfig struct {
 	Enabled    bool   `yaml:"enabled"`
@@ -887,7 +890,7 @@ func applyWorkflowDefaults(cfg *Config) {
 // applyAdminDefaults sets defaults for admin API config.
 func applyAdminDefaults(cfg *Config) {
 	if cfg.Admin.Persona == "" {
-		cfg.Admin.Persona = "admin"
+		cfg.Admin.Persona = defaultAdminPersona
 	}
 	if cfg.Admin.PathPrefix == "" {
 		cfg.Admin.PathPrefix = "/api/v1/admin"

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1497,10 +1497,12 @@ func (p *Platform) addManagedResourceMiddleware() {
 		return
 	}
 	cfg := middleware.ManagedResourceConfig{
-		Store:     p.resourceStore,
-		S3Client:  p.resourceS3Client,
-		S3Bucket:  p.config.Resources.Managed.S3Bucket,
-		URIScheme: p.managedResourceURIScheme(),
+		Store:         p.resourceStore,
+		S3Client:      p.resourceS3Client,
+		S3Bucket:      p.config.Resources.Managed.S3Bucket,
+		URIScheme:     p.managedResourceURIScheme(),
+		Authenticator: p.authenticator,
+		AdminPersona:  p.config.Admin.Persona,
 	}
 	// Resolve all persona memberships from roles.
 	if p.personaRegistry != nil {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1164,6 +1164,26 @@ func (p *Platform) ResourceS3Client() resource.S3Client {
 	return p.resourceS3Client
 }
 
+// sentinelResourceURI is a temporary resource used to trigger
+// notifications/resources/list_changed on the MCP server.
+const sentinelResourceURI = "mcp://internal/sentinel"
+
+// NotifyResourceListChanged signals all connected MCP clients to refresh
+// their cached resource list. Call this after REST API resource changes
+// (create, update, delete) so clients see the updated managed resources.
+func (p *Platform) NotifyResourceListChanged() {
+	if p.mcpServer == nil {
+		return
+	}
+	p.mcpServer.AddResource(&mcp.Resource{
+		URI:  sentinelResourceURI,
+		Name: "_sentinel",
+	}, func(context.Context, *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		return &mcp.ReadResourceResult{}, nil
+	})
+	p.mcpServer.RemoveResources(sentinelResourceURI)
+}
+
 // initMCPApps initializes MCP Apps support.
 func (p *Platform) initMCPApps() error {
 	if !p.config.MCPApps.IsEnabled() {

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -4342,3 +4342,16 @@ func TestAPIKeyStoreAccessor(t *testing.T) {
 		t.Error("APIKeyStore() should return the assigned store")
 	}
 }
+
+func TestNotifyResourceListChanged(t *testing.T) {
+	t.Run("nil server does not panic", func(_ *testing.T) {
+		p := &Platform{}
+		p.NotifyResourceListChanged() // should not panic
+	})
+
+	t.Run("triggers notification via sentinel", func(t *testing.T) {
+		p := newTestPlatform(t)
+		// Should not panic — adds and removes a sentinel resource.
+		p.NotifyResourceListChanged()
+	})
+}

--- a/pkg/resource/handler.go
+++ b/pkg/resource/handler.go
@@ -31,6 +31,7 @@ type Deps struct {
 	S3Client  S3Client
 	S3Bucket  string
 	URIScheme string // defaults to "mcp" if empty
+	NotifyFn  func() // called after create/update/delete to notify MCP clients
 }
 
 // ClaimsExtractor extracts resource Claims from an HTTP request.
@@ -42,6 +43,13 @@ type Handler struct {
 	mux       *http.ServeMux
 	deps      Deps
 	extractFn ClaimsExtractor
+}
+
+// notify calls the notification function if configured.
+func (h *Handler) notify() {
+	if h.deps.NotifyFn != nil {
+		h.deps.NotifyFn()
+	}
 }
 
 // NewHandler creates a resource handler with auth middleware.
@@ -221,6 +229,7 @@ func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, res)
+	h.notify()
 }
 
 // persistResource generates an ID, uploads to S3, inserts metadata, and returns the saved resource.
@@ -484,6 +493,7 @@ func (h *Handler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, updated)
+	h.notify()
 }
 
 // --- Delete ---
@@ -526,6 +536,7 @@ func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+	h.notify()
 }
 
 // conflictError signals a 409 Conflict (e.g. duplicate URI).

--- a/pkg/resource/handler_test.go
+++ b/pkg/resource/handler_test.go
@@ -255,6 +255,67 @@ func TestHandleCreate_Success(t *testing.T) {
 	}
 }
 
+func TestNotifyFn_CalledOnCreate(t *testing.T) {
+	store := newMockStore()
+	s3 := newMockS3()
+	notified := false
+	deps := Deps{
+		Store:     store,
+		S3Client:  s3,
+		S3Bucket:  "test-bucket",
+		URIScheme: "mcp",
+		NotifyFn:  func() { notified = true },
+	}
+	h := NewHandler(deps, okExtractor, nil)
+
+	fields := map[string]string{
+		"scope":        "global",
+		"category":     "samples",
+		"display_name": "Notify Test",
+		"description":  "Testing notify callback",
+	}
+	req := buildMultipartRequest(t, fields, []byte("data"), "test.txt")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !notified {
+		t.Error("expected NotifyFn to be called after create")
+	}
+}
+
+func TestNotifyFn_CalledOnDelete(t *testing.T) {
+	store := newMockStore()
+	store.resources["r1"] = &Resource{
+		ID: "r1", Scope: ScopeGlobal, UploaderSub: "user-123",
+		S3Key: "resources/global/r1/file.txt",
+	}
+	s3 := newMockS3()
+	s3.objects["resources/global/r1/file.txt"] = []byte("data")
+	notified := false
+	deps := Deps{
+		Store:     store,
+		S3Client:  s3,
+		S3Bucket:  "test-bucket",
+		URIScheme: "mcp",
+		NotifyFn:  func() { notified = true },
+	}
+	h := NewHandler(deps, okExtractor, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/v1/resources/r1", http.NoBody)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !notified {
+		t.Error("expected NotifyFn to be called after delete")
+	}
+}
+
 func TestHandleCreate_Unauthorized(t *testing.T) {
 	store := newMockStore()
 	s3 := newMockS3()


### PR DESCRIPTION
## Summary

Managed resources uploaded via the REST API were invisible to MCP clients because the MCP SDK client caches `resources/list` responses and only refreshes when the server sends a `notifications/resources/list_changed` notification. The REST API never triggered this notification.

### Root cause

The MCP SDK client calls `resources/list` once during session setup and caches the result. It only re-fetches when it receives `notifications/resources/list_changed` from the server. The server sends this notification when `Server.AddResource()` or `Server.RemoveResources()` is called — but managed resources are injected via middleware, not registered with the SDK, so no notification was ever sent.

### Fix

Added `NotifyResourceListChanged()` to `Platform` which triggers the notification by adding and immediately removing a sentinel resource. The SDK debounces notifications, so only one `notifications/resources/list_changed` is sent.

The resource REST API handler now calls this after successful create, update, and delete operations via a `NotifyFn` callback in `Deps`.

### Additional fixes in this PR

- `goconst` lint: extracted `defaultAdminPersona` constant for the `"admin"` string in `applyAdminDefaults`

## Test plan

- [x] `NotifyResourceListChanged` does not panic with nil server
- [x] `NotifyResourceListChanged` executes sentinel add/remove without error
- [x] `NotifyFn` called after successful resource create
- [x] `NotifyFn` called after successful resource delete
- [x] `NotifyFn` nil-safe (existing tests without NotifyFn still pass)
- [x] `make verify` passes