### PR TITLE
fix: managed resources fall back to default S3 connection

### DIFF
--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1138,7 +1138,7 @@ func (p *Platform) initManagedResources() error {
 	}
 
 	slog.Info("managed resources enabled",
-		"s3_connection", p.config.Resources.Managed.S3Connection,
+		"s3_connection", p.managedResourceS3Connection(),
 		"s3_bucket", p.config.Resources.Managed.S3Bucket,
 		"uri_scheme", p.managedResourceURIScheme(),
 	)
@@ -1157,13 +1157,18 @@ func (p *Platform) managedResourceURIScheme() string {
 // resources. Returns the explicit config value if set, otherwise falls back
 // to the default/first S3 toolkit instance.
 func (p *Platform) managedResourceS3Connection() string {
-	if name := p.config.Resources.Managed.S3Connection; name != "" {
+	name := p.config.Resources.Managed.S3Connection
+	if name != "" {
 		return name
 	}
+	// No explicit s3_connection — resolve the default S3 toolkit instance
+	// so managed resources automatically use an available S3 backend.
 	cfg := p.getS3Config("")
 	if cfg == nil {
+		slog.Debug("managed resources: no S3 toolkit available for default resolution")
 		return ""
 	}
+	slog.Debug("managed resources: using default S3 connection", "s3_connection", cfg.ConnectionName)
 	return cfg.ConnectionName
 }
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1111,9 +1111,8 @@ func (p *Platform) initManagedResources() error {
 
 	p.resourceStore = resource.NewPostgresStore(p.db)
 
-	// Create S3 client from referenced connection.
-	if p.config.Resources.Managed.S3Connection != "" {
-		connName := p.config.Resources.Managed.S3Connection
+	// Create S3 client from referenced or default S3 connection.
+	if connName := p.managedResourceS3Connection(); connName != "" {
 		s3Cfg := p.getS3Config(connName)
 		if s3Cfg == nil {
 			return fmt.Errorf("resource s3 connection %q not found in toolkits config", connName)
@@ -1152,6 +1151,20 @@ func (p *Platform) managedResourceURIScheme() string {
 		return s
 	}
 	return resource.DefaultURIScheme
+}
+
+// managedResourceS3Connection returns the S3 connection name for managed
+// resources. Returns the explicit config value if set, otherwise falls back
+// to the default/first S3 toolkit instance.
+func (p *Platform) managedResourceS3Connection() string {
+	if name := p.config.Resources.Managed.S3Connection; name != "" {
+		return name
+	}
+	cfg := p.getS3Config("")
+	if cfg == nil {
+		return ""
+	}
+	return cfg.ConnectionName
 }
 
 // ResourceStore returns the managed resource store (nil if not enabled).

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -4343,6 +4343,46 @@ func TestAPIKeyStoreAccessor(t *testing.T) {
 	}
 }
 
+func TestResolvedResourceS3Connection(t *testing.T) {
+	t.Run("explicit connection returned", func(t *testing.T) {
+		p := &Platform{config: &Config{
+			Resources: ResourcesConfig{
+				Managed: ManagedResourcesCfg{S3Connection: "my-s3"},
+			},
+		}}
+		if got := p.managedResourceS3Connection(); got != "my-s3" {
+			t.Errorf("got %q, want my-s3", got)
+		}
+	})
+
+	t.Run("falls back to default S3 instance", func(t *testing.T) {
+		p := &Platform{config: &Config{
+			Toolkits: map[string]any{
+				"s3": map[string]any{
+					"instances": map[string]any{
+						"primary": map[string]any{
+							"endpoint":        "http://localhost:9000",
+							"access_key_id":   "key",
+							"secret_key":      "secret",
+							"connection_name": "primary",
+						},
+					},
+				},
+			},
+		}}
+		if got := p.managedResourceS3Connection(); got != "primary" {
+			t.Errorf("got %q, want primary", got)
+		}
+	})
+
+	t.Run("empty when no S3 toolkit", func(t *testing.T) {
+		p := &Platform{config: &Config{}}
+		if got := p.managedResourceS3Connection(); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
 func TestNotifyResourceListChanged(t *testing.T) {
 	t.Run("nil server does not panic", func(_ *testing.T) {
 		p := &Platform{}


### PR DESCRIPTION
## Summary

When `resources.managed.s3_connection` is not configured, managed resources disabled blob storage entirely — `resources/read` returned "not found" even though the resource metadata existed in the database and an S3 toolkit was available.

Managed resources are enabled by default when a database is available. If an S3 toolkit is configured (for portal, DataHub, or any other purpose), managed resources should use it automatically without requiring a separate `s3_connection` config entry.

### Fix

Added `managedResourceS3Connection()` which returns the explicit `s3_connection` if set, otherwise falls back to the default/first S3 toolkit instance via `getS3Config("")`. This follows the same pattern as `managedResourceURIScheme()` and the instance resolution in `getInstanceConfig`.

### Files changed

- **`pkg/platform/platform.go`** — `initManagedResources` calls `managedResourceS3Connection()` instead of reading the raw config field directly. New `managedResourceS3Connection()` method resolves the default.
- **`pkg/platform/platform_test.go`** — Tests for explicit connection, default fallback, and no-S3 cases.

## Test plan

- [x] Explicit `s3_connection` returned as-is
- [x] Empty `s3_connection` falls back to default S3 instance
- [x] No S3 toolkit configured returns empty (blob storage disabled gracefully)
- [x] `make verify` passes