### PR TITLE
fix: resolve default S3 instance name for managed resources

### DIFF
--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1163,13 +1163,31 @@ func (p *Platform) managedResourceS3Connection() string {
 	}
 	// No explicit s3_connection — resolve the default S3 toolkit instance
 	// so managed resources automatically use an available S3 backend.
-	cfg := p.getS3Config("")
-	if cfg == nil {
+	resolved := p.resolveDefaultS3Instance()
+	if resolved == "" {
 		slog.Debug("managed resources: no S3 toolkit available for default resolution")
 		return ""
 	}
-	slog.Debug("managed resources: using default S3 connection", "s3_connection", cfg.ConnectionName)
-	return cfg.ConnectionName
+	slog.Debug("managed resources: using default S3 connection", "s3_connection", resolved)
+	return resolved
+}
+
+// resolveDefaultS3Instance returns the name of the default/first S3 toolkit
+// instance, or "" if no S3 toolkit is configured.
+func (p *Platform) resolveDefaultS3Instance() string {
+	toolkitsCfg, ok := p.config.Toolkits["s3"]
+	if !ok {
+		return ""
+	}
+	kindCfg, ok := toolkitsCfg.(map[string]any)
+	if !ok {
+		return ""
+	}
+	instances, ok := kindCfg[cfgKeyInstances].(map[string]any)
+	if !ok {
+		return ""
+	}
+	return resolveDefaultInstance(kindCfg, instances)
 }
 
 // ResourceStore returns the managed resource store (nil if not enabled).

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -4360,24 +4360,77 @@ func TestResolvedResourceS3Connection(t *testing.T) {
 			Toolkits: map[string]any{
 				"s3": map[string]any{
 					"instances": map[string]any{
-						"primary": map[string]any{
-							"endpoint":        "http://localhost:9000",
-							"access_key_id":   "key",
-							"secret_key":      "secret",
-							"connection_name": "primary",
+						"acme": map[string]any{
+							"endpoint":      "http://localhost:9000",
+							"access_key_id": "key",
+							"secret_key":    "secret",
 						},
 					},
 				},
 			},
 		}}
-		if got := p.managedResourceS3Connection(); got != "primary" {
-			t.Errorf("got %q, want primary", got)
+		if got := p.managedResourceS3Connection(); got != "acme" {
+			t.Errorf("got %q, want acme", got)
 		}
 	})
 
 	t.Run("empty when no S3 toolkit", func(t *testing.T) {
 		p := &Platform{config: &Config{}}
 		if got := p.managedResourceS3Connection(); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+func TestResolveDefaultS3Instance(t *testing.T) {
+	t.Run("returns instance name", func(t *testing.T) {
+		p := &Platform{config: &Config{
+			Toolkits: map[string]any{
+				"s3": map[string]any{
+					"instances": map[string]any{
+						"mys3": map[string]any{"endpoint": "http://localhost:9000"},
+					},
+				},
+			},
+		}}
+		if got := p.resolveDefaultS3Instance(); got != "mys3" {
+			t.Errorf("got %q, want mys3", got)
+		}
+	})
+
+	t.Run("returns configured default", func(t *testing.T) {
+		p := &Platform{config: &Config{
+			Toolkits: map[string]any{
+				"s3": map[string]any{
+					"default": "second",
+					"instances": map[string]any{
+						"first":  map[string]any{"endpoint": "http://a:9000"},
+						"second": map[string]any{"endpoint": "http://b:9000"},
+					},
+				},
+			},
+		}}
+		if got := p.resolveDefaultS3Instance(); got != "second" {
+			t.Errorf("got %q, want second", got)
+		}
+	})
+
+	t.Run("empty when no S3 toolkit", func(t *testing.T) {
+		p := &Platform{config: &Config{}}
+		if got := p.resolveDefaultS3Instance(); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("empty when instances not a map", func(t *testing.T) {
+		p := &Platform{config: &Config{
+			Toolkits: map[string]any{
+				"s3": map[string]any{
+					"instances": "invalid",
+				},
+			},
+		}}
+		if got := p.resolveDefaultS3Instance(); got != "" {
 			t.Errorf("got %q, want empty", got)
 		}
 	})


### PR DESCRIPTION
## Summary

`managedResourceS3Connection()` called `getS3Config("")` which internally resolved the default S3 instance but returned `ConnectionName=""` — the fallback `cfg.ConnectionName = instanceName` used the empty string that was passed in. This meant the method returned `""`, the S3 client was never created, and managed resources blob storage was silently disabled even when an S3 toolkit was available.

### Root cause

`getS3Config(instanceName)` resolves the default instance internally via `getInstanceConfig`, but the resolved instance name is not returned to the caller. When `instanceName=""`, the `ConnectionName` fallback sets it to `""`.

### Fix

Added `resolveDefaultS3Instance()` which resolves the instance name directly from the S3 toolkits config map, returning the actual key (e.g., `"acme"`). `managedResourceS3Connection()` uses this resolved name instead of passing `""` to `getS3Config`. The info log now shows the resolved connection name.

### Verified against ACME demo config

The test mirrors the exact ACME deployment config: S3 instance named `"acme"` with `default: acme`, no `connection_name` field in the instance config. The test confirms `managedResourceS3Connection()` returns `"acme"`.

## Test plan

- [x] `managedResourceS3Connection` returns explicit config when set
- [x] `managedResourceS3Connection` falls back to default S3 instance by map key name
- [x] `managedResourceS3Connection` returns empty when no S3 toolkit exists
- [x] `resolveDefaultS3Instance` returns instance name from config map
- [x] `resolveDefaultS3Instance` respects configured `default` field
- [x] `resolveDefaultS3Instance` returns empty for missing/invalid config
- [x] `make verify` passes