### PR TITLE
fix: extract resource URI via type assertion instead of json.Marshal

### DIFF
--- a/pkg/middleware/mcp_resources.go
+++ b/pkg/middleware/mcp_resources.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -328,19 +327,14 @@ func extractPersonaAdminRoles(roles []string) []string {
 
 // extractResourceURI extracts the URI from a resources/read request.
 func extractResourceURI(req mcp.Request) (string, error) {
-	raw, err := json.Marshal(req)
-	if err != nil {
-		return "", fmt.Errorf("marshaling request: %w", err)
+	if req == nil {
+		return "", fmt.Errorf("nil request")
 	}
-	var wrapper struct {
-		Params struct {
-			URI string `json:"uri"`
-		} `json:"params"`
+	params, ok := req.GetParams().(*mcp.ReadResourceParams)
+	if !ok || params == nil {
+		return "", fmt.Errorf("unexpected params type: %T", req.GetParams())
 	}
-	if err := json.Unmarshal(raw, &wrapper); err != nil {
-		return "", fmt.Errorf("unmarshaling request: %w", err)
-	}
-	return wrapper.Params.URI, nil
+	return params.URI, nil
 }
 
 // isTextMIME returns true for MIME types that should be returned as inline text.

--- a/pkg/middleware/mcp_resources_test.go
+++ b/pkg/middleware/mcp_resources_test.go
@@ -107,6 +107,21 @@ func TestExtractResourceURI(t *testing.T) {
 	}
 }
 
+func TestExtractResourceURI_NilRequest(t *testing.T) {
+	_, err := extractResourceURI(nil)
+	if err == nil {
+		t.Error("expected error for nil request")
+	}
+}
+
+func TestExtractResourceURI_WrongParamsType(t *testing.T) {
+	req := &mcp.ServerRequest[*mcp.ListResourcesParams]{Params: &mcp.ListResourcesParams{}}
+	_, err := extractResourceURI(req)
+	if err == nil {
+		t.Error("expected error for wrong params type")
+	}
+}
+
 func TestScopesFromPlatformContext(t *testing.T) {
 	pc := &PlatformContext{
 		UserID:      "user-1",

--- a/pkg/resource/handler.go
+++ b/pkg/resource/handler.go
@@ -49,7 +49,7 @@ type Handler struct {
 // notifyCreate registers a newly created resource with MCP clients.
 func (h *Handler) notifyCreate(res *Resource) {
 	if h.deps.OnCreate != nil {
-		slog.Debug("resource handler: notifying create", "resource_id", res.ID) //nolint:gosec // ID is server-generated, not user input
+		slog.Debug("resource handler: notifying create", "resource_id", res.ID) // #nosec G706 -- ID is server-generated, not user input
 		h.deps.OnCreate(res)
 	}
 }


### PR DESCRIPTION
## Summary

`extractResourceURI` used `json.Marshal` on the MCP request to extract the URI. This failed because the `ServerRequest` struct contains function fields (`func(mcp.CloseSSEStreamArgs)`) that cannot be serialized. Every `resources/read` request fell through the middleware to the SDK's fallback handler.

### Root cause

Diagnosed via production logs (v1.55.8):
```
managed resources read: URI extraction failed, falling through
error: marshaling request: json: unsupported type: func(mcp.CloseSSEStreamArgs)
```

### Fix

Replace `json.Marshal`/`Unmarshal` with `req.GetParams().(*mcp.ReadResourceParams)` — a direct type assertion to the SDK's typed params struct. This is how the SDK itself accesses request parameters.

### Verified

- Local e2e test: `resources/read` returns content from S3 mock, middleware handles the read (no fallback handler invocation)
- Production logs confirmed `resources/list` returns all 7 resources (3 static + 4 managed) with correct auth and scope filtering
- `make verify` passes

## Test plan

- [x] `extractResourceURI` returns URI from valid `ReadResourceRequest`
- [x] `extractResourceURI` returns error for nil request
- [x] `extractResourceURI` returns error for wrong params type
- [x] Local e2e: `resources/read` serves content through middleware
- [x] `make verify` passes