### PR TITLE
fix: address server bugs found during deep testing

### DIFF
--- a/pkg/admin/knowledge_test.go
+++ b/pkg/admin/knowledge_test.go
@@ -429,12 +429,12 @@ func TestUpdateInsightStatus(t *testing.T) {
 	t.Run("invalid status transition returns 409", func(t *testing.T) {
 		insight := &knowledge.Insight{
 			ID:     "ins-789",
-			Status: knowledge.StatusApproved, // approved -> rejected is not valid
+			Status: knowledge.StatusRejected, // rejected is terminal — cannot approve
 		}
 		store := &mockInsightStore{getResult: insight}
 		kh := NewKnowledgeHandler(store, nil, nil)
 
-		body := `{"status":"rejected"}`
+		body := `{"status":"approved"}`
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/v1/admin/knowledge/insights/ins-789/status", strings.NewReader(body))
 		req.SetPathValue("id", "ins-789")
 		w := httptest.NewRecorder()

--- a/pkg/middleware/semantic.go
+++ b/pkg/middleware/semantic.go
@@ -712,12 +712,14 @@ func (e *semanticEnricher) enrichDataHubResult(
 ) (*mcp.CallToolResult, error) {
 	provider := e.queryProvider
 
-	// Extract URNs from result content
-	urns := extractURNsFromResult(result)
+	// Extract URNs from result content, keeping only dataset URNs.
+	// Non-dataset URNs (domains, tags, queries, owners) cannot be
+	// resolved to queryable tables and would produce spurious errors.
+	urns := filterDatasetURNs(extractURNsFromResult(result))
 
 	// Also extract URN from request (for tools like datahub_get_schema that take urn param)
 	if reqURN := extractURNFromRequest(request); reqURN != "" {
-		if !slices.Contains(urns, reqURN) {
+		if isDatasetURN(reqURN) && !slices.Contains(urns, reqURN) {
 			urns = append(urns, reqURN)
 		}
 	}
@@ -995,6 +997,25 @@ func splitTableName(name string) []string {
 		}
 	}
 	return result
+}
+
+// datasetURNPrefix identifies dataset URNs in DataHub's URN scheme.
+const datasetURNPrefix = "urn:li:dataset:"
+
+// isDatasetURN returns true if the URN represents a dataset entity.
+func isDatasetURN(urn string) bool {
+	return strings.HasPrefix(urn, datasetURNPrefix)
+}
+
+// filterDatasetURNs returns only dataset URNs from the input slice.
+func filterDatasetURNs(urns []string) []string {
+	filtered := make([]string, 0, len(urns))
+	for _, urn := range urns {
+		if isDatasetURN(urn) {
+			filtered = append(filtered, urn)
+		}
+	}
+	return filtered
 }
 
 // extractURNsFromResult extracts URNs from result content.

--- a/pkg/middleware/semantic_test.go
+++ b/pkg/middleware/semantic_test.go
@@ -423,6 +423,58 @@ func TestExtractURNsFromMap(t *testing.T) {
 	}
 }
 
+func TestIsDatasetURN(t *testing.T) {
+	tests := []struct {
+		urn  string
+		want bool
+	}{
+		{"urn:li:dataset:(urn:li:dataPlatform:trino,warehouse.public.orders,PROD)", true},
+		{"urn:li:dataset:simple", true},
+		{"urn:li:domain:sales", false},
+		{"urn:li:tag:PII", false},
+		{"urn:li:query:85695abc", false},
+		{"urn:li:corpuser:admin", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.urn, func(t *testing.T) {
+			if got := isDatasetURN(tt.urn); got != tt.want {
+				t.Errorf("isDatasetURN(%q) = %v, want %v", tt.urn, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterDatasetURNs(t *testing.T) {
+	input := []string{
+		"urn:li:dataset:(urn:li:dataPlatform:trino,warehouse.public.orders,PROD)",
+		"urn:li:domain:sales",
+		"urn:li:tag:PII",
+		"urn:li:dataset:(urn:li:dataPlatform:trino,warehouse.public.customers,PROD)",
+		"urn:li:query:85695abc",
+	}
+	got := filterDatasetURNs(input)
+	want := []string{
+		"urn:li:dataset:(urn:li:dataPlatform:trino,warehouse.public.orders,PROD)",
+		"urn:li:dataset:(urn:li:dataPlatform:trino,warehouse.public.customers,PROD)",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("filterDatasetURNs returned %d URNs, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("filterDatasetURNs[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFilterDatasetURNsEmpty(t *testing.T) {
+	got := filterDatasetURNs(nil)
+	if len(got) != 0 {
+		t.Errorf("filterDatasetURNs(nil) returned %d URNs, want 0", len(got))
+	}
+}
+
 func TestAppendSemanticContext(t *testing.T) {
 	t.Run("nil context", func(t *testing.T) {
 		result := NewToolResultText("original")

--- a/pkg/platform/connection_source.go
+++ b/pkg/platform/connection_source.go
@@ -47,8 +47,13 @@ func NewConnectionSourceMap() *ConnectionSourceMap {
 }
 
 // Add registers a connection's DataHub source mapping.
+// If the same connection (kind+name) already exists, the old entry is
+// replaced so that bySourceName never contains duplicates.
 func (m *ConnectionSourceMap) Add(src ConnectionSource) {
 	key := src.Kind + "/" + src.Name
+	if _, exists := m.byConnection[key]; exists {
+		m.Remove(src.Kind, src.Name)
+	}
 	m.byConnection[key] = &src
 	m.bySourceName[src.DataHubSourceName] = append(m.bySourceName[src.DataHubSourceName], &src)
 }

--- a/pkg/platform/connection_source_test.go
+++ b/pkg/platform/connection_source_test.go
@@ -179,6 +179,17 @@ func TestDefaultSourceNameForKind(t *testing.T) {
 	assert.Equal(t, "", defaultSourceNameForKind(""))
 }
 
+func TestConnectionSourceMap_AddDeduplicates(t *testing.T) {
+	m := NewConnectionSourceMap()
+	src := ConnectionSource{Kind: "trino", Name: "prod", DataHubSourceName: "trino"}
+	m.Add(src)
+	m.Add(src) // add same connection again
+
+	conns := m.ConnectionsForURN("urn:li:dataset:(urn:li:dataPlatform:trino,catalog.schema.table,PROD)")
+	assert.Len(t, conns, 1, "duplicate Add should not create duplicate entries")
+	assert.Equal(t, "prod", conns[0].Name)
+}
+
 func TestConnectionSourceMap_Nil(t *testing.T) {
 	var m *ConnectionSourceMap
 

--- a/pkg/platform/prompt_tool.go
+++ b/pkg/platform/prompt_tool.go
@@ -12,6 +12,12 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/prompt"
 )
 
+const (
+	promptErrGet    = "failed to get prompt"
+	promptLogKey    = "name"
+	promptLogKeyErr = "error"
+)
+
 // platformPromptCreator adapts the prompt store and platform for the
 // knowledge toolkit's PromptCreator interface.
 type platformPromptCreator struct {
@@ -57,7 +63,9 @@ func (p *Platform) registerPromptTool() {
 		Title: "Manage Prompts",
 		Description: "Create, update, delete, list, or get prompts. " +
 			"Non-admin users can manage their own personal prompts. " +
-			"Admins can manage prompts at all scope levels (global, persona, personal).",
+			"Admins can manage prompts at all scope levels (global, persona, personal). " +
+			"This tool manages database-stored prompts only; static prompts from server " +
+			"configuration are not listed or editable here.",
 		InputSchema: managePromptSchema(),
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, input managePromptInput) (*mcp.CallToolResult, any, error) {
 		return p.handleManagePrompt(ctx, input)
@@ -104,6 +112,11 @@ func (p *Platform) handlePromptCreate(ctx context.Context, input managePromptInp
 		return promptErrorResult("only admins can create global or persona-scoped prompts"), nil, nil
 	}
 
+	personas := input.Personas
+	if personas == nil {
+		personas = []string{}
+	}
+
 	pr := &prompt.Prompt{
 		Name:        input.Name,
 		DisplayName: input.DisplayName,
@@ -112,14 +125,15 @@ func (p *Platform) handlePromptCreate(ctx context.Context, input managePromptInp
 		Arguments:   input.Arguments,
 		Category:    input.Category,
 		Scope:       scope,
-		Personas:    input.Personas,
+		Personas:    personas,
 		OwnerEmail:  email,
 		Source:      prompt.SourceOperator,
 		Enabled:     true,
 	}
 
 	if err := p.promptStore.Create(ctx, pr); err != nil {
-		return promptErrorResult(fmt.Sprintf("failed to create prompt: %v", err)), nil, nil
+		slog.Error("failed to create prompt", promptLogKey, input.Name, promptLogKeyErr, err)
+		return promptErrorResult("failed to create prompt"), nil, nil
 	}
 
 	p.RegisterRuntimePrompt(pr)
@@ -139,7 +153,8 @@ func (p *Platform) handlePromptUpdate(ctx context.Context, input managePromptInp
 
 	existing, err := p.promptStore.Get(ctx, input.Name)
 	if err != nil {
-		return promptErrorResult(fmt.Sprintf("failed to get prompt: %v", err)), nil, nil
+		slog.Error(promptErrGet, promptLogKey, input.Name, promptLogKeyErr, err)
+		return promptErrorResult(promptErrGet), nil, nil
 	}
 	if existing == nil {
 		return promptErrorResult(fmt.Sprintf("prompt %q not found", input.Name)), nil, nil
@@ -160,7 +175,8 @@ func (p *Platform) handlePromptUpdate(ctx context.Context, input managePromptInp
 	}
 
 	if err := p.promptStore.Update(ctx, existing); err != nil {
-		return promptErrorResult(fmt.Sprintf("failed to update prompt: %v", err)), nil, nil
+		slog.Error("failed to update prompt", promptLogKey, input.Name, promptLogKeyErr, err)
+		return promptErrorResult("failed to update prompt"), nil, nil
 	}
 
 	// Re-register with updated content
@@ -211,7 +227,8 @@ func (p *Platform) handlePromptDelete(ctx context.Context, input managePromptInp
 
 	existing, err := p.promptStore.Get(ctx, input.Name)
 	if err != nil {
-		return promptErrorResult(fmt.Sprintf("failed to get prompt: %v", err)), nil, nil
+		slog.Error(promptErrGet, promptLogKey, input.Name, promptLogKeyErr, err)
+		return promptErrorResult(promptErrGet), nil, nil
 	}
 	if existing == nil {
 		return promptErrorResult(fmt.Sprintf("prompt %q not found", input.Name)), nil, nil
@@ -228,7 +245,8 @@ func (p *Platform) handlePromptDelete(ctx context.Context, input managePromptInp
 	}
 
 	if err := p.promptStore.Delete(ctx, input.Name); err != nil {
-		return promptErrorResult(fmt.Sprintf("failed to delete prompt: %v", err)), nil, nil
+		slog.Error("failed to delete prompt", promptLogKey, input.Name, promptLogKeyErr, err)
+		return promptErrorResult("failed to delete prompt"), nil, nil
 	}
 
 	p.UnregisterRuntimePrompt(input.Name)
@@ -263,7 +281,8 @@ func (p *Platform) handlePromptList(ctx context.Context, input managePromptInput
 
 	prompts, err := p.promptStore.List(ctx, filter)
 	if err != nil {
-		return promptErrorResult(fmt.Sprintf("failed to list prompts: %v", err)), nil, nil
+		slog.Error("failed to list prompts", promptLogKeyErr, err)
+		return promptErrorResult("failed to list prompts"), nil, nil
 	}
 
 	// For non-admins without an explicit scope, also include global and persona-scoped prompts.
@@ -313,7 +332,8 @@ func (p *Platform) handlePromptGet(ctx context.Context, input managePromptInput)
 
 	pr, err := p.promptStore.Get(ctx, input.Name)
 	if err != nil {
-		return promptErrorResult(fmt.Sprintf("failed to get prompt: %v", err)), nil, nil
+		slog.Error(promptErrGet, promptLogKey, input.Name, promptLogKeyErr, err)
+		return promptErrorResult(promptErrGet), nil, nil
 	}
 	if pr == nil {
 		return promptErrorResult(fmt.Sprintf("prompt %q not found", input.Name)), nil, nil
@@ -428,7 +448,7 @@ func managePromptSchema() any {
 			"personas": map[string]any{
 				schemaKeyType:        "array",
 				"items":              map[string]any{schemaKeyType: schemaValString},
-				schemaKeyDescription: "Personas this prompt is assigned to (when scope is 'persona')",
+				schemaKeyDescription: "Personas this prompt is assigned to. Defaults to empty list if omitted.",
 			},
 			"search": map[string]any{
 				schemaKeyType:        schemaValString,

--- a/pkg/platform/prompt_tool_test.go
+++ b/pkg/platform/prompt_tool_test.go
@@ -19,6 +19,10 @@ import (
 type mockPlatformPromptStore struct {
 	prompts   map[string]*prompt.Prompt
 	createErr error
+	getErr    error
+	updateErr error
+	deleteErr error
+	listErr   error
 }
 
 func newMockPlatformPromptStore() *mockPlatformPromptStore {
@@ -35,6 +39,9 @@ func (m *mockPlatformPromptStore) Create(_ context.Context, p *prompt.Prompt) er
 }
 
 func (m *mockPlatformPromptStore) Get(_ context.Context, name string) (*prompt.Prompt, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
 	p := m.prompts[name]
 	return p, nil //nolint:nilnil // interface contract
 }
@@ -49,11 +56,17 @@ func (m *mockPlatformPromptStore) GetByID(_ context.Context, id string) (*prompt
 }
 
 func (m *mockPlatformPromptStore) Update(_ context.Context, p *prompt.Prompt) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
 	m.prompts[p.Name] = p
 	return nil
 }
 
 func (m *mockPlatformPromptStore) Delete(_ context.Context, name string) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
 	delete(m.prompts, name)
 	return nil
 }
@@ -68,7 +81,10 @@ func (m *mockPlatformPromptStore) DeleteByID(_ context.Context, id string) error
 	return nil
 }
 
-func (m *mockPlatformPromptStore) List(_ context.Context, f prompt.ListFilter) ([]prompt.Prompt, error) {
+func (m *mockPlatformPromptStore) List(_ context.Context, f prompt.ListFilter) ([]prompt.Prompt, error) { //nolint:revive // interface impl
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
 	var result []prompt.Prompt
 	for _, p := range m.prompts {
 		if f.Scope != "" && p.Scope != f.Scope {
@@ -190,6 +206,29 @@ func TestHandlePromptCreate_NonAdminPersonalOK(t *testing.T) {
 	assert.Equal(t, "user@example.com", store.prompts["my-personal"].OwnerEmail)
 }
 
+func TestHandlePromptCreate_NilPersonasDefaultsToEmpty(t *testing.T) {
+	p, store := newTestPlatformWithPromptStore()
+	r, _, _ := p.handlePromptCreate(adminCtx(), managePromptInput{
+		Name: "no-personas", Content: "content", Scope: "personal",
+		// Personas intentionally omitted (nil)
+	})
+	assert.False(t, r.IsError)
+	assert.Equal(t, []string{}, store.prompts["no-personas"].Personas)
+}
+
+func TestHandlePromptCreate_StoreErrorDoesNotLeakDetails(t *testing.T) {
+	p, store := newTestPlatformWithPromptStore()
+	store.createErr = fmt.Errorf("pq: null value in column \"personas\" violates not-null constraint (23502)")
+	r, _, _ := p.handlePromptCreate(adminCtx(), managePromptInput{
+		Name: "test", Content: "content",
+	})
+	assert.True(t, r.IsError)
+	text := resultText(r)
+	assert.Contains(t, text, "failed to create prompt")
+	assert.NotContains(t, text, "pq:")
+	assert.NotContains(t, text, "23502")
+}
+
 func TestHandlePromptCreate_StoreError(t *testing.T) {
 	p, store := newTestPlatformWithPromptStore()
 	store.createErr = fmt.Errorf("db down")
@@ -258,6 +297,29 @@ func TestHandlePromptUpdate_ScopeChangeByNonAdmin(t *testing.T) {
 	assert.Contains(t, resultText(r), "only admins")
 }
 
+func TestHandlePromptUpdate_StoreGetError(t *testing.T) {
+	p, store := newTestPlatformWithPromptStore()
+	store.getErr = fmt.Errorf("pq: connection refused")
+	r, _, _ := p.handlePromptUpdate(adminCtx(), managePromptInput{Name: "test", Content: "c"})
+	assert.True(t, r.IsError)
+	text := resultText(r)
+	assert.Contains(t, text, "failed to get prompt")
+	assert.NotContains(t, text, "pq:")
+}
+
+func TestHandlePromptUpdate_StoreUpdateError(t *testing.T) {
+	p, store := newTestPlatformWithPromptStore()
+	store.prompts["test"] = &prompt.Prompt{
+		ID: "id-1", Name: "test", Scope: prompt.ScopeGlobal,
+	}
+	store.updateErr = fmt.Errorf("pq: disk full")
+	r, _, _ := p.handlePromptUpdate(adminCtx(), managePromptInput{Name: "test", Content: "c"})
+	assert.True(t, r.IsError)
+	text := resultText(r)
+	assert.Contains(t, text, "failed to update prompt")
+	assert.NotContains(t, text, "pq:")
+}
+
 // --- handlePromptDelete ---
 
 func TestHandlePromptDelete_Success(t *testing.T) {
@@ -285,6 +347,29 @@ func TestHandlePromptDelete_NonAdminDeniedNonPersonal(t *testing.T) {
 	r, _, _ := p.handlePromptDelete(userCtx("user@example.com", "analyst"), managePromptInput{Name: "global"})
 	assert.True(t, r.IsError)
 	assert.Contains(t, resultText(r), "non-admins")
+}
+
+func TestHandlePromptDelete_StoreGetError(t *testing.T) {
+	p, store := newTestPlatformWithPromptStore()
+	store.getErr = fmt.Errorf("pq: timeout")
+	r, _, _ := p.handlePromptDelete(adminCtx(), managePromptInput{Name: "test"})
+	assert.True(t, r.IsError)
+	text := resultText(r)
+	assert.Contains(t, text, "failed to get prompt")
+	assert.NotContains(t, text, "pq:")
+}
+
+func TestHandlePromptDelete_StoreDeleteError(t *testing.T) {
+	p, store := newTestPlatformWithPromptStore()
+	store.prompts["test"] = &prompt.Prompt{
+		ID: "id-1", Name: "test", Scope: prompt.ScopeGlobal,
+	}
+	store.deleteErr = fmt.Errorf("pq: constraint violation")
+	r, _, _ := p.handlePromptDelete(adminCtx(), managePromptInput{Name: "test"})
+	assert.True(t, r.IsError)
+	text := resultText(r)
+	assert.Contains(t, text, "failed to delete prompt")
+	assert.NotContains(t, text, "pq:")
 }
 
 // --- handlePromptList ---
@@ -337,6 +422,16 @@ func TestHandlePromptList_NonAdminWithScope(t *testing.T) {
 	assert.Equal(t, 1, count) // only global
 }
 
+func TestHandlePromptList_StoreError(t *testing.T) {
+	p, store := newTestPlatformWithPromptStore()
+	store.listErr = fmt.Errorf("pq: too many connections")
+	r, _, _ := p.handlePromptList(adminCtx(), managePromptInput{Command: "list"})
+	assert.True(t, r.IsError)
+	text := resultText(r)
+	assert.Contains(t, text, "failed to list prompts")
+	assert.NotContains(t, text, "pq:")
+}
+
 // --- handlePromptGet ---
 
 func TestHandlePromptGet_Found(t *testing.T) {
@@ -364,6 +459,16 @@ func TestHandlePromptGet_NonAdminDeniedOtherPersonal(t *testing.T) {
 	r, _, _ := p.handlePromptGet(userCtx("alice@example.com", "engineer"), managePromptInput{Name: "secret"})
 	assert.True(t, r.IsError)
 	assert.Contains(t, resultText(r), "your own")
+}
+
+func TestHandlePromptGet_StoreError(t *testing.T) {
+	p, store := newTestPlatformWithPromptStore()
+	store.getErr = fmt.Errorf("pq: connection reset")
+	r, _, _ := p.handlePromptGet(adminCtx(), managePromptInput{Name: "test"})
+	assert.True(t, r.IsError)
+	text := resultText(r)
+	assert.Contains(t, text, "failed to get prompt")
+	assert.NotContains(t, text, "pq:")
 }
 
 // --- applyPromptUpdates ---

--- a/pkg/portal/store.go
+++ b/pkg/portal/store.go
@@ -73,10 +73,8 @@ func (s *postgresAssetStore) Insert(ctx context.Context, asset Asset) error { //
 		return fmt.Errorf("marshaling provenance: %w", err)
 	}
 
+	// Zero is the correct initial value — CreateVersion increments it to 1.
 	currentVersion := asset.CurrentVersion
-	if currentVersion <= 0 {
-		currentVersion = 1
-	}
 
 	query := `
 		INSERT INTO portal_assets

--- a/pkg/portal/store_test.go
+++ b/pkg/portal/store_test.go
@@ -40,7 +40,7 @@ func TestPostgresAssetStoreInsert(t *testing.T) {
 		WithArgs(
 			asset.ID, asset.OwnerID, asset.OwnerEmail, asset.Name, asset.Description,
 			asset.ContentType, asset.S3Bucket, asset.S3Key, asset.SizeBytes,
-			sqlmock.AnyArg(), sqlmock.AnyArg(), asset.SessionID, 1,
+			sqlmock.AnyArg(), sqlmock.AnyArg(), asset.SessionID, 0,
 		).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -200,7 +200,8 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 				"For update_context_document, target is the document ID, detail is the new content, query_sql is the new title, query_description is the category. " +
 				"For remove_context_document, target is the document ID. " +
 				"add_context_document/update_context_document work on datasets, glossaryTerms, glossaryNodes, and containers. " +
-				"Structured properties, incidents, and context documents require DataHub 1.4.x.",
+				"Structured properties, incidents, and context documents require DataHub 1.4.x. " +
+				"Insight lifecycle: pending → approved/rejected/superseded; approved → applied/rejected; applied → rolled_back.",
 			InputSchema: applyKnowledgeSchema,
 		}, t.handleApplyKnowledge)
 	}

--- a/pkg/toolkits/knowledge/types.go
+++ b/pkg/toolkits/knowledge/types.go
@@ -283,7 +283,8 @@ var validTransitions = map[string]map[string]bool{
 		StatusSuperseded: true,
 	},
 	StatusApproved: {
-		StatusApplied: true,
+		StatusApplied:  true,
+		StatusRejected: true,
 	},
 	StatusApplied: {
 		StatusRolledBack: true,

--- a/pkg/toolkits/knowledge/types_test.go
+++ b/pkg/toolkits/knowledge/types_test.go
@@ -264,7 +264,7 @@ func TestValidateStatusTransition(t *testing.T) {
 
 		// Invalid transitions from approved
 		{name: "approved to pending", from: StatusApproved, to: StatusPending, wantErr: true},
-		{name: "approved to rejected", from: StatusApproved, to: StatusRejected, wantErr: true},
+		{name: "approved to rejected", from: StatusApproved, to: StatusRejected, wantErr: false},
 		{name: "approved to approved", from: StatusApproved, to: StatusApproved, wantErr: true},
 		{name: "approved to rolled_back", from: StatusApproved, to: StatusRolledBack, wantErr: true},
 		{name: "approved to superseded", from: StatusApproved, to: StatusSuperseded, wantErr: true},

--- a/pkg/toolkits/portal/toolkit.go
+++ b/pkg/toolkits/portal/toolkit.go
@@ -180,7 +180,9 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 		Description: "Manages saved artifacts and collections. " +
 			"Asset actions: list, get, update, delete, list_versions, revert. " +
 			"Collection actions: create_collection, list_collections, get_collection, " +
-			"update_collection, delete_collection, set_sections.",
+			"update_collection, delete_collection, set_sections. " +
+			"Note: 'list' returns full metadata including provenance for each asset. " +
+			"Use 'get' with a specific asset_id for content retrieval.",
 		InputSchema: manageArtifactSchema,
 	}, t.handleManageArtifact)
 

--- a/pkg/toolkits/trino/connection_required.go
+++ b/pkg/toolkits/trino/connection_required.go
@@ -51,6 +51,12 @@ func (m *ConnectionRequiredMiddleware) Before(ctx context.Context, tc *trinotool
 		return ctx, nil
 	}
 
+	// When a default connection exists, allow pass-through.
+	// The handler's Manager.Client("") resolves to the default.
+	if m.hasDefault() {
+		return ctx, nil
+	}
+
 	return ctx, fmt.Errorf("multiple Trino connections are configured — you must specify the 'connection' parameter.\n\n%s",
 		m.formatAvailableConnections())
 }
@@ -63,6 +69,16 @@ func (*ConnectionRequiredMiddleware) After(
 	handlerErr error,
 ) (*mcp.CallToolResult, error) {
 	return result, handlerErr
+}
+
+// hasDefault returns true if any connection is marked as default.
+func (m *ConnectionRequiredMiddleware) hasDefault() bool {
+	for _, c := range m.connections {
+		if c.IsDefault {
+			return true
+		}
+	}
+	return false
 }
 
 // extractConnectionFromInput extracts the Connection field from a tool input

--- a/pkg/toolkits/trino/connection_required_test.go
+++ b/pkg/toolkits/trino/connection_required_test.go
@@ -28,31 +28,14 @@ func TestConnectionRequiredMiddleware_Before(t *testing.T) {
 		}
 	})
 
-	t.Run("rejects when connection is empty", func(t *testing.T) {
+	t.Run("passes when connection is empty and default exists", func(t *testing.T) {
 		tc := trinotools.NewToolContext(trinotools.ToolQuery, trinotools.QueryInput{
 			SQL: "SELECT 1",
 		})
 
 		_, err := mw.Before(context.Background(), tc)
-		if err == nil {
-			t.Fatal("expected error for missing connection")
-		}
-
-		errMsg := err.Error()
-		if !strings.Contains(errMsg, "multiple Trino connections") {
-			t.Errorf("error should mention multiple connections, got: %s", errMsg)
-		}
-		if !strings.Contains(errMsg, trinoTestWarehouse) {
-			t.Errorf("error should list warehouse, got: %s", errMsg)
-		}
-		if !strings.Contains(errMsg, "elasticsearch") {
-			t.Errorf("error should list elasticsearch, got: %s", errMsg)
-		}
-		if !strings.Contains(errMsg, "Data warehouse for analytics") {
-			t.Errorf("error should include descriptions, got: %s", errMsg)
-		}
-		if !strings.Contains(errMsg, "(default)") {
-			t.Errorf("error should mark default connection, got: %s", errMsg)
+		if err != nil {
+			t.Errorf("expected pass-through when default exists, got: %v", err)
 		}
 	})
 
@@ -79,7 +62,7 @@ func TestConnectionRequiredMiddleware_Before(t *testing.T) {
 		}
 	})
 
-	t.Run("rejects describe_table without connection", func(t *testing.T) {
+	t.Run("passes describe_table without connection when default exists", func(t *testing.T) {
 		tc := trinotools.NewToolContext(trinotools.ToolDescribeTable, trinotools.DescribeTableInput{
 			Catalog: "hive",
 			Schema:  "default",
@@ -87,17 +70,17 @@ func TestConnectionRequiredMiddleware_Before(t *testing.T) {
 		})
 
 		_, err := mw.Before(context.Background(), tc)
-		if err == nil {
-			t.Fatal("expected error for missing connection on describe_table")
+		if err != nil {
+			t.Errorf("expected pass-through when default exists, got: %v", err)
 		}
 	})
 
-	t.Run("rejects browse without connection", func(t *testing.T) {
+	t.Run("passes browse without connection when default exists", func(t *testing.T) {
 		tc := trinotools.NewToolContext(trinotools.ToolBrowse, trinotools.BrowseInput{})
 
 		_, err := mw.Before(context.Background(), tc)
-		if err == nil {
-			t.Fatal("expected error for missing connection on browse")
+		if err != nil {
+			t.Errorf("expected pass-through when default exists, got: %v", err)
 		}
 	})
 
@@ -112,6 +95,37 @@ func TestConnectionRequiredMiddleware_Before(t *testing.T) {
 			t.Errorf("expected no error, got: %v", err)
 		}
 	})
+}
+
+func TestConnectionRequiredMiddleware_NoDefault(t *testing.T) {
+	noDefaultConns := []ConnectionDescription{
+		{Name: trinoTestWarehouse, Description: "Data warehouse for analytics", IsDefault: false},
+		{Name: "elasticsearch", Description: "Elasticsearch for sales data", IsDefault: false},
+		{Name: "cassandra", Description: "", IsDefault: false},
+	}
+	mw := NewConnectionRequiredMiddleware(noDefaultConns)
+
+	t.Run("rejects when connection is empty and no default", func(t *testing.T) {
+		tc := trinotools.NewToolContext(trinotools.ToolQuery, trinotools.QueryInput{
+			SQL: "SELECT 1",
+		})
+
+		_, err := mw.Before(context.Background(), tc)
+		if err == nil {
+			t.Fatal("expected error for missing connection without default")
+		}
+
+		errMsg := err.Error()
+		if !strings.Contains(errMsg, "multiple Trino connections") {
+			t.Errorf("error should mention multiple connections, got: %s", errMsg)
+		}
+		if !strings.Contains(errMsg, trinoTestWarehouse) {
+			t.Errorf("error should list warehouse, got: %s", errMsg)
+		}
+		if !strings.Contains(errMsg, "elasticsearch") {
+			t.Errorf("error should list elasticsearch, got: %s", errMsg)
+		}
+	})
 
 	t.Run("connection without description in error", func(t *testing.T) {
 		_, err := mw.Before(context.Background(), trinotools.NewToolContext(
@@ -120,9 +134,37 @@ func TestConnectionRequiredMiddleware_Before(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error")
 		}
-		// cassandra has no description, should just show the name
 		if !strings.Contains(err.Error(), "cassandra") {
 			t.Errorf("error should list cassandra, got: %s", err.Error())
+		}
+	})
+}
+
+func TestConnectionRequiredMiddleware_HasDefault(t *testing.T) {
+	t.Run("returns true when default exists", func(t *testing.T) {
+		mw := NewConnectionRequiredMiddleware([]ConnectionDescription{
+			{Name: "a", IsDefault: false},
+			{Name: "b", IsDefault: true},
+		})
+		if !mw.hasDefault() {
+			t.Error("expected hasDefault() = true")
+		}
+	})
+
+	t.Run("returns false when no default", func(t *testing.T) {
+		mw := NewConnectionRequiredMiddleware([]ConnectionDescription{
+			{Name: "a", IsDefault: false},
+			{Name: "b", IsDefault: false},
+		})
+		if mw.hasDefault() {
+			t.Error("expected hasDefault() = false")
+		}
+	})
+
+	t.Run("returns false for empty connections", func(t *testing.T) {
+		mw := NewConnectionRequiredMiddleware(nil)
+		if mw.hasDefault() {
+			t.Error("expected hasDefault() = false for nil connections")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fixes 6 server bugs and 4 tool description gaps identified during deep testing of a production deployment (server v1.55.9, admin persona, dual Trino connections).

## Bug fixes

### B5: Artifact version off-by-one
- **File:** `pkg/portal/store.go`
- Asset was inserted with `current_version = 1`, then `CreateVersion` read that value and created version `1 + 1 = 2`. Changed default to `0` so the first `CreateVersion` correctly produces version 1.

### B1: `manage_prompt create` leaks raw DB errors and requires `personas` for non-persona scopes
- **File:** `pkg/platform/prompt_tool.go`
- Nil `personas` input now defaults to `[]string{}` before insertion, preventing a `pq: null value in column "personas" violates not-null constraint` error.
- All DB errors across create/update/delete/list/get handlers are now logged server-side via `slog.Error` and returned to the client as clean messages without driver-specific details (no `pq:` prefix, no SQLSTATE codes).

### B2: `query_context` resolves non-dataset URNs as tables
- **File:** `pkg/middleware/semantic.go`
- `extractURNsFromResult` was recursively extracting ALL URNs (domains, tags, queries, owners) and passing them to `GetTableAvailability`, which returned spurious `"invalid dataset URN"` errors in every response.
- Added `filterDatasetURNs` to keep only `urn:li:dataset:` prefixed URNs before building query context.

### B3: `available_connections` returns duplicates
- **File:** `pkg/platform/connection_source.go`
- `ConnectionSourceMap.Add` now removes any existing entry with the same `kind/name` key before appending, preventing duplicate connection names in `query_context.available_connections`.

### D1: `connection` required even when a default exists
- **File:** `pkg/toolkits/trino/connection_required.go`
- When `connection` param is empty and a default connection is configured, the middleware now passes through instead of erroring. The handler's `Manager.Client("")` already resolves to the default.
- Added `hasDefault()` method to check for a default connection.

### D2: No revoke path for approved insights
- **File:** `pkg/toolkits/knowledge/types.go`
- Added `StatusRejected` to the `StatusApproved` transitions, allowing `approved → rejected` for revoking erroneous approvals. Updated the admin API test to use `rejected → approved` (a genuinely invalid transition) instead.

## Tool description improvements

- **T3 (`manage_prompt`):** States that only database-stored prompts are managed; static prompts from server configuration are not listed or editable.
- **T4 (`manage_artifact`):** Notes that `list` returns full metadata including provenance per asset.
- **T5 (`apply_knowledge`):** Documents the insight lifecycle state machine: `pending → approved/rejected/superseded; approved → applied/rejected; applied → rolled_back`.
- **T7 (`manage_prompt` personas field):** Clarifies the field defaults to an empty list if omitted.

## Out of scope

Issues in external dependencies or requiring product decisions were excluded:
- B4 (matched_fields empty value) — DataHub GraphQL returns empty, not a server bug
- B7 (tag not idempotent) — mcp-datahub library
- B8 (opaque OpenSearch error) — mcp-trino library
- B6 (S3 key layout migration) — needs product decision
- D3 (provenance in list API) — needs product decision
- D4 (union static + DB prompts) — needs product decision
- D5 (resource links message) — generated by MCP host
- D6 (multi-word search) — DataHub search behavior

## Test plan

- [x] `make verify` passes (fmt, test, lint, security, coverage, dead-code, mutation, release-check)
- [x] Patch coverage 88.5% (threshold: 80%)
- [x] All new functions (`isDatasetURN`, `filterDatasetURNs`, `hasDefault`) at 100% coverage
- [x] New error-path tests for all `manage_prompt` handlers verify no driver error leakage
- [x] Updated existing tests for D1 (default connection passthrough) and D2 (approved→rejected now valid)
- [ ] Live verification against a deployment with dual Trino connections
- [ ] Verify `save_artifact` followed by `manage_artifact list_versions` shows `version: 1`
- [ ] Verify `manage_prompt create` with omitted `personas` succeeds without error
- [ ] Verify `datahub_search` responses no longer contain spurious non-dataset URN errors in `query_context`