### PR TITLE
feat: render knowledge/memory content as markdown in portal

### DIFF
--- a/pkg/toolkits/knowledge/schemas.go
+++ b/pkg/toolkits/knowledge/schemas.go
@@ -19,7 +19,7 @@ var captureInsightSchema = json.RawMessage(`{
     },
     "insight_text": {
       "type": "string",
-      "description": "The insight content (10-4000 characters)",
+      "description": "The insight content (10-4000 characters). Supports markdown: use backticks for column/table names, bullet lists for multi-point observations, code blocks for SQL.",
       "minLength": 10,
       "maxLength": 4000
     },

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -1218,7 +1218,8 @@ Do NOT capture insights for:
 - Suggest concrete actions (add_tag, update_description) when applicable
 - Set confidence to "high" only when the user is clearly authoritative
 - For agent discoveries, set confidence based on evidence strength: "high" if verified by querying, "medium" if inferred from patterns, "low" if speculative
-- Capture the insight promptly while context is fresh`
+- Capture the insight promptly while context is fresh
+- Use markdown formatting when it aids clarity: backticks for ` + "`column_name`" + ` and ` + "`table_name`" + `, bullet lists for multi-point insights, fenced code blocks for SQL examples. Plain text is fine for simple observations.`
 
 // Verify interface compliance.
 var _ interface {

--- a/pkg/toolkits/memory/schemas.go
+++ b/pkg/toolkits/memory/schemas.go
@@ -14,7 +14,7 @@ var memoryManageSchema = json.RawMessage(`{
     },
     "content": {
       "type": "string",
-      "description": "Memory content text. Required for 'remember'. Min 10, max 4000 characters."
+      "description": "Memory content text. Required for 'remember'. Min 10, max 4000 characters. Supports markdown: use backticks for column/table names, bullet lists for multi-point observations, code blocks for SQL."
     },
     "id": {
       "type": "string",

--- a/ui/src/components/renderers/MarkdownRenderer.tsx
+++ b/ui/src/components/renderers/MarkdownRenderer.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Components } from "react-markdown";
 import mermaid from "mermaid";
+import DOMPurify from "dompurify";
 
 /** Detect whether the document is currently in dark mode. */
 function isDark(): boolean {
@@ -72,7 +73,7 @@ function MermaidBlock({ content }: { content: string }) {
       .render(id, content)
       .then(({ svg }) => {
         if (!cancelled && ref.current) {
-          ref.current.innerHTML = svg;
+          ref.current.innerHTML = DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true } });
           setError(null);
         }
       })
@@ -94,7 +95,7 @@ function MermaidBlock({ content }: { content: string }) {
       mermaid
         .render(id + "t", content)
         .then(({ svg }) => {
-          if (ref.current) ref.current.innerHTML = svg;
+          if (ref.current) ref.current.innerHTML = DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true } });
         })
         .catch(() => {});
     });
@@ -126,7 +127,7 @@ function MermaidBlock({ content }: { content: string }) {
   );
 }
 
-export function MarkdownRenderer({ content, bare }: { content: string; bare?: boolean }) {
+export function MarkdownRenderer({ content, bare }: { content: string | null | undefined; bare?: boolean }) {
   const components: Components = {
     code: useCallback(
       // react-markdown passes `node` (hast AST) — destructure it out so it
@@ -158,8 +159,10 @@ export function MarkdownRenderer({ content, bare }: { content: string; bare?: bo
     ),
   };
 
+  if (!content) return null;
+
   return (
-    <div className={`prose prose-sm max-w-none dark:prose-invert ${bare ? "" : "rounded-lg border bg-card p-6"}`}>
+    <div className={`prose prose-sm max-w-none dark:prose-invert [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 ${bare ? "" : "rounded-lg border bg-card p-6"}`}>
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
         {content}
       </ReactMarkdown>

--- a/ui/src/pages/knowledge/KnowledgePage.tsx
+++ b/ui/src/pages/knowledge/KnowledgePage.tsx
@@ -14,6 +14,7 @@ import { StatCard } from "@/components/cards/StatCard";
 import { StatusBadge } from "@/components/cards/StatusBadge";
 import type { Insight, Changeset, MemoryRecord } from "@/api/admin/types";
 import { formatUser } from "@/lib/formatUser";
+import { MarkdownRenderer } from "@/components/renderers/MarkdownRenderer";
 import {
   PieChart,
   Pie,
@@ -843,9 +844,9 @@ function InsightDrawer({
           {/* Full insight text */}
           <div>
             <p className="mb-1 text-xs text-muted-foreground">Insight</p>
-            <p className="rounded bg-muted p-3 text-sm">
-              {insight.insight_text}
-            </p>
+            <div className="rounded bg-muted p-3">
+              <MarkdownRenderer content={insight.insight_text} bare />
+            </div>
           </div>
 
           {/* Entity URNs */}
@@ -1375,9 +1376,9 @@ function MemoryDrawer({
           {/* Full content */}
           <div>
             <p className="mb-1 text-xs text-muted-foreground">Content</p>
-            <p className="rounded bg-muted p-3 text-sm whitespace-pre-wrap">
-              {record.content}
-            </p>
+            <div className="rounded bg-muted p-3">
+              <MarkdownRenderer content={record.content} bare />
+            </div>
           </div>
 
           {/* Entity URNs */}

--- a/ui/src/pages/knowledge/MyKnowledgePage.tsx
+++ b/ui/src/pages/knowledge/MyKnowledgePage.tsx
@@ -8,6 +8,7 @@ import {
 import { StatCard } from "@/components/cards/StatCard";
 import { Lightbulb, ChevronLeft, ChevronRight } from "lucide-react";
 import type { Insight, MemoryRecord } from "@/api/portal/types";
+import { MarkdownRenderer } from "@/components/renderers/MarkdownRenderer";
 import { formatEntityUrn } from "@/lib/formatEntityUrn";
 
 const STATUS_BADGES: Record<string, { label: string; cls: string }> = {
@@ -98,7 +99,7 @@ function InsightCard({ insight }: { insight: Insight }) {
           {new Date(insight.created_at).toLocaleDateString()}
         </span>
       </div>
-      <p className="text-sm leading-relaxed">{insight.insight_text}</p>
+      <MarkdownRenderer content={insight.insight_text} bare />
       {insight.entity_urns.length > 0 && (
         <div className="flex flex-wrap gap-1">
           {insight.entity_urns.map((urn) => (
@@ -141,7 +142,7 @@ function MemoryCard({ record }: { record: MemoryRecord }) {
           {new Date(record.created_at).toLocaleDateString()}
         </span>
       </div>
-      <p className="text-sm leading-relaxed">{record.content}</p>
+      <MarkdownRenderer content={record.content} bare />
       {record.entity_urns && record.entity_urns.length > 0 && (
         <div className="flex flex-wrap gap-1">
           {record.entity_urns.map((urn) => (


### PR DESCRIPTION
## Summary

- Render insight and memory content through the existing `MarkdownRenderer` component (with `bare` mode) in both user (`MyKnowledgePage`) and admin (`KnowledgePage`) detail views
- Update `capture_insight` and `memory_manage` tool field descriptions and the knowledge capture prompt to encourage markdown formatting (backticks, bullet lists, code blocks)
- Table cell previews remain plain text since they are truncated

No schema or migration changes — plain text renders identically through react-markdown.

## Test plan

- [ ] Verify `make verify` passes (Go tests, lint, coverage, mutation)
- [ ] Verify `cd ui && npm run build` succeeds
- [ ] Check existing plain-text insights render unchanged in portal
- [ ] Create a new insight with markdown (bold, bullets, backtick code) and verify it renders properly in both user and admin views