### PR TITLE
feat: broadcast tool list changes to connected MCP clients

### DIFF
--- a/pkg/platform/export_adapters_test.go
+++ b/pkg/platform/export_adapters_test.go
@@ -5,10 +5,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/txn2/mcp-data-platform/pkg/portal"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
 	trinokit "github.com/txn2/mcp-data-platform/pkg/toolkits/trino"
 )
 
@@ -218,6 +221,241 @@ func TestParseExportConfigDefaults(t *testing.T) {
 	cfg := p.parseExportConfig()
 	// Zero values — applyExportDefaults fills them in later
 	assert.Equal(t, 0, cfg.MaxRows)
+}
+
+func TestWireTrinoExport_ToolAppearsInToolList(t *testing.T) {
+	// This is the integration test that proves trino_export actually registers
+	// when portal + trino are both configured.
+
+	// Create a real trino toolkit
+	tk, err := trinokit.New("test", trinokit.Config{
+		Host: "localhost",
+		User: "test",
+	})
+	require.NoError(t, err)
+	defer tk.Close() //nolint:errcheck // test cleanup
+
+	// Verify trino_export is NOT in the tool list before wiring
+	assert.NotContains(t, tk.Tools(), "trino_export")
+
+	// Create a platform with portal stores and wire export
+	p := &Platform{
+		config: &Config{
+			Portal: PortalConfig{
+				S3Bucket: "test-bucket",
+				S3Prefix: "exports",
+			},
+		},
+		portalAssetStore:   portal.NewNoopAssetStore(),
+		portalVersionStore: portal.NewNoopVersionStore(),
+		portalShareStore:   portal.NewNoopShareStore(),
+		portalS3Client:     &noopS3Client{},
+		toolkitRegistry:    newTestRegistry(tk),
+	}
+
+	p.wireTrinoExport()
+
+	// Verify trino_export IS in the tool list after wiring
+	assert.Contains(t, tk.Tools(), "trino_export")
+
+	// Verify it registers on an MCP server
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1"}, nil)
+	tk.RegisterTools(server)
+}
+
+// noopS3Client implements portal.S3Client for testing.
+type noopS3Client struct{}
+
+func (*noopS3Client) PutObject(_ context.Context, _, _ string, _ []byte, _ string) error {
+	return nil
+}
+
+func (*noopS3Client) GetObject(_ context.Context, _, _ string) (data []byte, contentType string, err error) { //nolint:gocritic // named for clarity
+	return nil, "", nil
+}
+func (*noopS3Client) DeleteObject(_ context.Context, _, _ string) error { return nil }
+func (*noopS3Client) Close() error                                      { return nil }
+
+// newTestRegistry creates a registry with a single toolkit.
+func newTestRegistry(tk *trinokit.Toolkit) *registry.Registry {
+	r := registry.NewRegistry()
+	_ = r.Register(tk) //nolint:errcheck // test setup
+	return r
+}
+
+func TestWireTrinoExport_WithMultiConnectionToolkit(t *testing.T) {
+	// Mirror the real deployment: multi-connection trino created via NewMulti
+	multiTk, err := trinokit.NewMulti(trinokit.MultiConfig{
+		DefaultConnection: "acme",
+		Instances: map[string]trinokit.Config{
+			"acme": {Host: "localhost", User: "test", Port: 8080},
+		},
+	})
+	require.NoError(t, err)
+	defer multiTk.Close() //nolint:errcheck // test cleanup
+
+	assert.NotContains(t, multiTk.Tools(), "trino_export")
+
+	p := &Platform{
+		config: &Config{
+			Portal: PortalConfig{
+				S3Bucket: "portal-assets",
+				S3Prefix: "artifacts",
+			},
+		},
+		portalAssetStore:   portal.NewNoopAssetStore(),
+		portalVersionStore: portal.NewNoopVersionStore(),
+		portalShareStore:   portal.NewNoopShareStore(),
+		portalS3Client:     &noopS3Client{},
+		toolkitRegistry:    newTestRegistry(multiTk),
+	}
+
+	p.wireTrinoExport()
+
+	assert.Contains(t, multiTk.Tools(), "trino_export",
+		"trino_export must appear in tool list when portal+trino are both configured")
+}
+
+func TestWireTrinoExport_SkipsWhenExplicitlyDisabled(t *testing.T) {
+	tk, err := trinokit.New("test", trinokit.Config{Host: "localhost", User: "test"})
+	require.NoError(t, err)
+	defer tk.Close() //nolint:errcheck // test cleanup
+
+	disabled := false
+	p := &Platform{
+		config: &Config{
+			Portal: PortalConfig{
+				Export:   PortalExportConfig{Enabled: &disabled},
+				S3Bucket: "b",
+			},
+		},
+		portalAssetStore:   portal.NewNoopAssetStore(),
+		portalVersionStore: portal.NewNoopVersionStore(),
+		portalShareStore:   portal.NewNoopShareStore(),
+		portalS3Client:     &noopS3Client{},
+		toolkitRegistry:    newTestRegistry(tk),
+	}
+
+	p.wireTrinoExport()
+	assert.NotContains(t, tk.Tools(), "trino_export")
+}
+
+func TestWireTrinoExport_SkipsWhenNoPortalS3(t *testing.T) {
+	tk, err := trinokit.New("test", trinokit.Config{Host: "localhost", User: "test"})
+	require.NoError(t, err)
+	defer tk.Close() //nolint:errcheck // test cleanup
+
+	p := &Platform{
+		config:           &Config{},
+		portalAssetStore: portal.NewNoopAssetStore(),
+		// portalS3Client is nil — no S3 configured
+		toolkitRegistry: newTestRegistry(tk),
+	}
+
+	p.wireTrinoExport()
+
+	// trino_export should NOT appear because S3 is missing
+	assert.NotContains(t, tk.Tools(), "trino_export")
+}
+
+func TestWireTrinoExport_SkipsWhenNoTrino(_ *testing.T) {
+	p := &Platform{
+		config:             &Config{Portal: PortalConfig{S3Bucket: "b"}},
+		portalAssetStore:   portal.NewNoopAssetStore(),
+		portalVersionStore: portal.NewNoopVersionStore(),
+		portalShareStore:   portal.NewNoopShareStore(),
+		portalS3Client:     &noopS3Client{},
+		toolkitRegistry:    registry.NewRegistry(), // empty — no trino
+	}
+
+	p.wireTrinoExport()
+	// No panic, no error — just silently skips
+}
+
+func TestTrinoExportRegistersViaFullPlatformInit(t *testing.T) {
+	// This test mirrors the real deployment: toolkit registry has trino,
+	// portal has S3 + database. Exercises initPortal → wireTrinoExport
+	// with a real toolkit registry (same path as the production code).
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	// Build the toolkit registry with trino + s3 (same as initRegistries)
+	reg := registry.NewRegistry()
+	registry.RegisterBuiltinFactories(reg)
+	loader := registry.NewLoader(reg)
+	err = loader.LoadFromMap(map[string]any{
+		"trino": map[string]any{
+			"enabled": true,
+			"instances": map[string]any{
+				"test": map[string]any{
+					"host": "localhost",
+					"user": "test",
+					"port": 8080,
+				},
+			},
+			"default": "test",
+		},
+		"s3": map[string]any{
+			"enabled": true,
+			"instances": map[string]any{
+				"test": map[string]any{
+					"endpoint":   "http://localhost:9000",
+					"region":     "us-east-1",
+					"access_key": "test",
+					"secret_key": "test",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Verify trino loaded
+	trinoToolkits := reg.GetByKind("trino")
+	require.NotEmpty(t, trinoToolkits, "trino toolkit should be in registry")
+
+	// Build platform with db + registry + portal config (same state as after initRegistries + initDatabase)
+	p := &Platform{
+		config: &Config{
+			Toolkits: map[string]any{
+				"s3": map[string]any{
+					"enabled": true,
+					"instances": map[string]any{
+						"test": map[string]any{
+							"endpoint":          "http://localhost:9000",
+							"region":            "us-east-1",
+							"access_key_id":     "test",
+							"secret_access_key": "test",
+						},
+					},
+				},
+			},
+			Portal: PortalConfig{
+				S3Connection: "test",
+				S3Bucket:     "portal-assets",
+				S3Prefix:     "artifacts",
+			},
+		},
+		db:              db,
+		toolkitRegistry: reg,
+	}
+
+	// Run initPortal — this creates stores and calls wireTrinoExport
+	err = p.initPortal()
+	require.NoError(t, err)
+
+	// Check trino_export appeared
+	var exportTools []string
+	for _, tk := range reg.GetByKind("trino") {
+		exportTools = append(exportTools, tk.Tools()...)
+	}
+
+	assert.Contains(t, exportTools, "trino_export",
+		"trino_export must appear after initPortal when db + trino + s3 are configured. Tools found: %v", exportTools)
+
+	// Also verify it registers on the MCP server (simulating Start → RegisterAllTools)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1"}, nil)
+	reg.RegisterAllTools(server)
 }
 
 func TestConvertProvenanceCalls(t *testing.T) {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1114,14 +1114,17 @@ func (p *Platform) createPortalS3Client() (portal.S3Client, error) {
 // wireTrinoExport injects portal dependencies into Trino toolkits for trino_export.
 func (p *Platform) wireTrinoExport() {
 	if isExplicitlyDisabled(p.config.Portal.Export.Enabled) {
+		slog.Debug("trino_export: disabled by config")
 		return
 	}
 	if p.portalS3Client == nil || p.portalAssetStore == nil {
+		slog.Debug("trino_export: portal S3 or asset store not configured, skipping")
 		return
 	}
 
 	trinoToolkits := p.toolkitRegistry.GetByKind("trino")
 	if len(trinoToolkits) == 0 {
+		slog.Debug("trino_export: no trino toolkits registered, skipping")
 		return
 	}
 
@@ -1951,7 +1954,7 @@ func convertIconDefs(defs map[string]IconDef) map[string]middleware.IconConfig {
 func (p *Platform) buildServerCapabilities() *mcp.ServerCapabilities {
 	caps := &mcp.ServerCapabilities{
 		// Tools are always available — every platform deployment has at least platform_info.
-		Tools: &mcp.ToolCapabilities{},
+		Tools: &mcp.ToolCapabilities{ListChanged: true},
 		// Logging is always available for client logging support.
 		Logging: &mcp.LoggingCapabilities{},
 	}


### PR DESCRIPTION
## Summary

- Set `ToolCapabilities.ListChanged` to `true` so the server sends `notifications/tools/list_changed` to connected clients whenever the tool list changes
- Add debug logging to `wireTrinoExport` for diagnosing tool registration during startup
- Add integration tests verifying `trino_export` registers correctly through the full `initPortal` path (single-connection, multi-connection, explicitly disabled, no S3, no trino)

## Test plan

- [ ] `make verify` passes
- [ ] Deploy to live instance, reconnect MCP client, verify new tools appear without manual disconnect/reconnect