### PR TITLE
fix: trino_export S3 key portability and name sanitization

### DIFF
--- a/pkg/toolkits/trino/export.go
+++ b/pkg/toolkits/trino/export.go
@@ -245,8 +245,8 @@ func (t *Toolkit) registerExportTool(s *mcp.Server) {
 		Description: "Export query results directly to a portal asset file (CSV, JSON, Markdown, or text). " +
 			"Use ONLY after you have validated the query shape with trino_query using a small LIMIT. " +
 			"Do NOT use this for data exploration. " +
-			"Returns asset metadata (ID, URL, row count, size) — the data is NOT returned through this response. " +
-			"NAMING: keep `name` short and portable — ASCII letters, digits, spaces, hyphens, and dots. " +
+			"Returns asset metadata (ID, URL, row count, size); the data is NOT returned through this response. " +
+			"NAMING: keep `name` short and portable, using only ASCII letters, digits, spaces, hyphens, and dots. " +
 			"Avoid em/en dashes, smart quotes, ellipses, and other Unicode punctuation; they will be normalized to ASCII. " +
 			"The name doubles as the download filename.",
 		InputSchema: exportInputSchema(),
@@ -730,14 +730,30 @@ func sanitizeExportName(name string) string {
 }
 
 // isZeroWidth reports whether r is a zero-width or invisible formatting rune
-// that should be stripped from display names.
+// that should be stripped from display names. Covers zero-width spacing
+// chars, directional marks and embedding controls, invisible math operators,
+// and Unicode variation selectors.
 func isZeroWidth(r rune) bool {
 	switch r {
 	case '\u200B', // zero-width space
 		'\u200C', // zero-width non-joiner
 		'\u200D', // zero-width joiner
+		'\u200E', // left-to-right mark
+		'\u200F', // right-to-left mark
 		'\u2060', // word joiner
+		'\u2061', // function application
+		'\u2062', // invisible times
+		'\u2063', // invisible separator
+		'\u2064', // invisible plus
 		'\uFEFF': // BOM / zero-width no-break space
+		return true
+	}
+	// Bidi embedding/override controls (U+202A..U+202E).
+	if r >= '\u202A' && r <= '\u202E' {
+		return true
+	}
+	// Variation selectors (U+FE00..U+FE0F).
+	if r >= '\uFE00' && r <= '\uFE0F' {
 		return true
 	}
 	return false
@@ -747,20 +763,28 @@ func isZeroWidth(r rune) bool {
 // as an S3 object key segment. Subjects from OIDC or API keys may contain
 // ':', '@', '/', or other characters that produce non-portable keys (rejected
 // by stricter object stores like MinIO). All non-[A-Za-z0-9._-] characters
-// are replaced with '_'.
+// are replaced with '_'. An all-dots result ('.', '..', '...', etc.) is
+// replaced with '_' so path.Clean cannot interpret the segment as path
+// navigation and escape the configured prefix.
 func sanitizeUserIDPath(userID string) string {
 	if userID == "" {
 		return "_"
 	}
-	return userIDPathSafe.ReplaceAllString(userID, "_")
+	cleaned := userIDPathSafe.ReplaceAllString(userID, "_")
+	if strings.Trim(cleaned, ".") == "" {
+		return "_"
+	}
+	return cleaned
 }
 
 // buildExportS3Key composes the S3 object key for an exported asset, ensuring
 // the result is portable across S3-compatible backends. path.Join collapses
-// redundant slashes (e.g., when prefix has a trailing '/'), and the user ID
-// segment is sanitized to remove characters that some backends reject.
+// redundant slashes (e.g., when prefix has a trailing '/'), the user ID
+// segment is sanitized to remove characters that some backends reject, and
+// any leading '/' is trimmed because MinIO rejects keys that start with '/'.
 func buildExportS3Key(prefix, userID, assetID, extension string) string {
-	return path.Join(prefix, sanitizeUserIDPath(userID), assetID, "content"+extension)
+	key := path.Join(prefix, sanitizeUserIDPath(userID), assetID, "content"+extension)
+	return strings.TrimPrefix(key, "/")
 }
 
 // generateExportID generates a cryptographically random hex ID.

--- a/pkg/toolkits/trino/export.go
+++ b/pkg/toolkits/trino/export.go
@@ -7,9 +7,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"path"
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	trinoclient "github.com/txn2/mcp-trino/pkg/client"
@@ -53,6 +55,33 @@ const (
 
 // exportTagPattern validates lowercase kebab-case tags.
 var exportTagPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// userIDPathSafe matches characters allowed in a path segment without escaping.
+var userIDPathSafe = regexp.MustCompile(`[^A-Za-z0-9._-]`)
+
+// repeatedWhitespace collapses consecutive whitespace.
+var repeatedWhitespace = regexp.MustCompile(`\s+`)
+
+// nameCharReplacements maps Unicode punctuation that breaks downstream consumers
+// (Content-Disposition headers, filename heuristics, some object stores) to
+// portable ASCII equivalents.
+var nameCharReplacements = map[rune]string{
+	'—': "-",   // em dash
+	'–': "-",   // en dash
+	'‒': "-",   // figure dash
+	'―': "-",   // horizontal bar
+	'−': "-",   // minus sign
+	'‘': "'",   // left single quote
+	'’': "'",   // right single quote
+	'‚': "'",   // single low-9 quote
+	'‛': "'",   // single high-reversed-9 quote
+	'“': `"`,   // left double quote
+	'”': `"`,   // right double quote
+	'„': `"`,   // double low-9 quote
+	'‟': `"`,   // double high-reversed-9 quote
+	'…': "...", // ellipsis
+	' ': " ",   // non-breaking space
+}
 
 // ExportAssetStore is the subset of portal.AssetStore needed by trino_export.
 // Defined here to avoid import cycles (portal → registry → trino).
@@ -216,7 +245,10 @@ func (t *Toolkit) registerExportTool(s *mcp.Server) {
 		Description: "Export query results directly to a portal asset file (CSV, JSON, Markdown, or text). " +
 			"Use ONLY after you have validated the query shape with trino_query using a small LIMIT. " +
 			"Do NOT use this for data exploration. " +
-			"Returns asset metadata (ID, URL, row count, size) — the data is NOT returned through this response.",
+			"Returns asset metadata (ID, URL, row count, size) — the data is NOT returned through this response. " +
+			"NAMING: keep `name` short and portable — ASCII letters, digits, spaces, hyphens, and dots. " +
+			"Avoid em/en dashes, smart quotes, ellipses, and other Unicode punctuation; they will be normalized to ASCII. " +
+			"The name doubles as the download filename.",
 		InputSchema: exportInputSchema(),
 		Annotations: &mcp.ToolAnnotations{
 			ReadOnlyHint: false,
@@ -252,6 +284,7 @@ func (*Toolkit) validateAndPrepare(ctx context.Context, req *mcp.CallToolRequest
 	if err != nil {
 		return exportInput{}, nil, exportError(err.Error())
 	}
+	input.Name = sanitizeExportName(input.Name)
 	if err := validateExportInput(input, deps.Config); err != nil {
 		return exportInput{}, nil, exportError(err.Error())
 	}
@@ -316,7 +349,7 @@ func (t *Toolkit) executeAndPersist(ctx context.Context, deps *ExportDeps, input
 		return exportError(fmt.Sprintf("generating asset ID: %v", err)), nil
 	}
 
-	s3Key := fmt.Sprintf("%s/%s/%s/content%s", deps.S3Prefix, uc.UserID, assetID, formatter.FileExtension())
+	s3Key := buildExportS3Key(deps.S3Prefix, uc.UserID, assetID, formatter.FileExtension())
 
 	if err := deps.S3Client.PutObject(ctx, deps.S3Bucket, s3Key, formatted, formatter.ContentType()); err != nil {
 		return exportError(fmt.Sprintf("S3 upload failed: %v", err)), nil
@@ -668,6 +701,68 @@ func validateExportTags(tags []string) error {
 	return nil
 }
 
+// sanitizeExportName normalizes a user-supplied asset name into a portable
+// display string. It replaces Unicode punctuation that breaks
+// Content-Disposition headers and downstream filename heuristics with ASCII
+// equivalents, strips control and zero-width characters, and collapses
+// runs of whitespace. The result preserves readability — letters, digits,
+// spaces, and ASCII punctuation are kept as-is.
+func sanitizeExportName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		if replacement, ok := nameCharReplacements[r]; ok {
+			b.WriteString(replacement)
+			continue
+		}
+		if unicode.IsControl(r) || isZeroWidth(r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+
+	return strings.TrimSpace(repeatedWhitespace.ReplaceAllString(b.String(), " "))
+}
+
+// isZeroWidth reports whether r is a zero-width or invisible formatting rune
+// that should be stripped from display names.
+func isZeroWidth(r rune) bool {
+	switch r {
+	case '\u200B', // zero-width space
+		'\u200C', // zero-width non-joiner
+		'\u200D', // zero-width joiner
+		'\u2060', // word joiner
+		'\uFEFF': // BOM / zero-width no-break space
+		return true
+	}
+	return false
+}
+
+// sanitizeUserIDPath returns a path-safe representation of a user ID for use
+// as an S3 object key segment. Subjects from OIDC or API keys may contain
+// ':', '@', '/', or other characters that produce non-portable keys (rejected
+// by stricter object stores like MinIO). All non-[A-Za-z0-9._-] characters
+// are replaced with '_'.
+func sanitizeUserIDPath(userID string) string {
+	if userID == "" {
+		return "_"
+	}
+	return userIDPathSafe.ReplaceAllString(userID, "_")
+}
+
+// buildExportS3Key composes the S3 object key for an exported asset, ensuring
+// the result is portable across S3-compatible backends. path.Join collapses
+// redundant slashes (e.g., when prefix has a trailing '/'), and the user ID
+// segment is sanitized to remove characters that some backends reject.
+func buildExportS3Key(prefix, userID, assetID, extension string) string {
+	return path.Join(prefix, sanitizeUserIDPath(userID), assetID, "content"+extension)
+}
+
 // generateExportID generates a cryptographically random hex ID.
 func generateExportID() (string, error) {
 	b := make([]byte, exportIDLength)
@@ -729,8 +824,10 @@ func exportInputSchema() map[string]any {
 			},
 			"name": map[string]any{
 				schemaKeyType: schemaTypeString,
-				schemaKeyDesc: "Display name for the exported asset.",
-				"maxLength":   maxExportNameLength,
+				schemaKeyDesc: "Display name for the exported asset; also used as the download filename. " +
+					"Use ASCII letters, digits, spaces, hyphens, and dots. " +
+					"Em/en dashes, smart quotes, ellipses, and other Unicode punctuation are auto-normalized to ASCII.",
+				"maxLength": maxExportNameLength,
 			},
 			"description": map[string]any{
 				schemaKeyType: schemaTypeString,

--- a/pkg/toolkits/trino/export_test.go
+++ b/pkg/toolkits/trino/export_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -1017,6 +1018,11 @@ func TestSanitizeUserIDPath(t *testing.T) {
 		{"backslash", "DOMAIN\\user", "DOMAIN_user"},
 		{"unicode", "f\u00f6\u00f6", "f__"},
 		{"mixed", "anonymous (api)", "anonymous__api_"},
+		{"single dot", ".", "_"},
+		{"double dot", "..", "_"},
+		{"triple dot", "...", "_"},
+		{"all dots six", "......", "_"},
+		{"dot among letters preserved", "a.b", "a.b"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1074,12 +1080,37 @@ func TestBuildExportS3Key(t *testing.T) {
 			extension: ".md",
 			want:      "tenants/acme/exports/u1/id1/content.md",
 		},
+		{
+			name:      "leading slash on prefix is trimmed",
+			prefix:    "/artifacts/",
+			userID:    "u1",
+			assetID:   "abc",
+			extension: ".csv",
+			want:      "artifacts/u1/abc/content.csv",
+		},
+		{
+			name:      "dotdot user id cannot escape prefix",
+			prefix:    "artifacts/",
+			userID:    "..",
+			assetID:   "abc",
+			extension: ".csv",
+			want:      "artifacts/_/abc/content.csv",
+		},
+		{
+			name:      "dot user id cannot collapse segment",
+			prefix:    "artifacts/",
+			userID:    ".",
+			assetID:   "abc",
+			extension: ".csv",
+			want:      "artifacts/_/abc/content.csv",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := buildExportS3Key(tt.prefix, tt.userID, tt.assetID, tt.extension)
 			assert.Equal(t, tt.want, got)
 			assert.NotContains(t, got, "//", "S3 key must not contain consecutive slashes")
+			assert.False(t, strings.HasPrefix(got, "/"), "S3 key must not start with /")
 		})
 	}
 }
@@ -1096,9 +1127,8 @@ func TestValidateAndPrepare_NameSanitization(t *testing.T) {
 		"name":   "Q1\u2014\u201cSales\u201d Report\u2026",
 	})
 
-	input, uc, errResult := tk.validateAndPrepare(context.Background(), req, tk.exportDeps)
+	input, _, errResult := tk.validateAndPrepare(context.Background(), req, tk.exportDeps)
 	require.Nil(t, errResult, "validation should succeed")
-	require.NotNil(t, uc)
 	assert.Equal(t, "Q1-\"Sales\" Report...", input.Name, "name should be sanitized to ASCII")
 }
 
@@ -1118,5 +1148,24 @@ func TestValidateAndPrepare_NameSanitizedToEmpty(t *testing.T) {
 	_, _, errResult := tk.validateAndPrepare(context.Background(), req, tk.exportDeps)
 	require.NotNil(t, errResult, "validation should fail when name sanitizes to empty")
 	assert.True(t, errResult.IsError)
-	assertResultContains(t, errResult, "name is required")
+	assertResultContains(t, errResult, "name")
+}
+
+func TestValidateAndPrepare_SanitizationExpansionExceedsCap(t *testing.T) {
+	// 100 ellipsis runes (1 char each) sanitize to 300 ASCII chars (3 each),
+	// which exceeds maxExportNameLength (255). validateExportInput runs after
+	// sanitization and must still catch the over-cap result.
+	tk := newTestExportToolkit(&mockExportAssetStore{}, &mockExportVersionStore{}, &mockExportS3Client{})
+
+	name := strings.Repeat("\u2026", 100)
+	req := buildExportRequest(map[string]any{
+		"sql":    "SELECT 1",
+		"format": "csv",
+		"name":   name,
+	})
+
+	_, _, errResult := tk.validateAndPrepare(context.Background(), req, tk.exportDeps)
+	require.NotNil(t, errResult, "validation should catch over-cap name after sanitization expansion")
+	assert.True(t, errResult.IsError)
+	assertResultContains(t, errResult, "exceeds")
 }

--- a/pkg/toolkits/trino/export_test.go
+++ b/pkg/toolkits/trino/export_test.go
@@ -966,3 +966,157 @@ func assertResultContains(t *testing.T, result *mcp.CallToolResult, substr strin
 	}
 	assert.Contains(t, tc.Text, substr)
 }
+
+func TestSanitizeExportName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain ascii", "Loyalty Customers by DBA", "Loyalty Customers by DBA"},
+		{"em dash", "Q1 \u2014 Sales Report", "Q1 - Sales Report"},
+		{"en dash", "2024\u20132025 Trend", "2024-2025 Trend"},
+		{"figure dash", "Page\u20122", "Page-2"},
+		{"horizontal bar", "Section\u2015A", "Section-A"},
+		{"minus sign", "Delta\u22125", "Delta-5"},
+		{"smart double quotes", "\u201cHello\u201d", "\"Hello\""},
+		{"smart single quotes", "It\u2019s great", "It's great"},
+		{"low double quote", "\u201eGerman\u201c style", "\"German\" style"},
+		{"ellipsis", "Loading\u2026", "Loading..."},
+		{"non-breaking space", "Hello\u00a0World", "Hello World"},
+		{"zero-width space stripped", "A\u200BB", "AB"},
+		{"BOM stripped", "\ufeffReport", "Report"},
+		{"control chars stripped", "Line1\x00Line2", "Line1Line2"},
+		{"trim whitespace", "  spaced  ", "spaced"},
+		{"collapse whitespace", "many   spaces", "many spaces"},
+		{"empty input", "", ""},
+		{"only whitespace", "   \t\n", ""},
+		{"mixed real-world", "Q1\u2014\u201cSales\u201d Report\u2026", "Q1-\"Sales\" Report..."},
+		{"preserves dots and underscores", "report_v1.2.csv", "report_v1.2.csv"},
+		{"preserves digits", "2024 Q1 Report", "2024 Q1 Report"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sanitizeExportName(tt.in))
+		})
+	}
+}
+
+func TestSanitizeUserIDPath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty becomes underscore", "", "_"},
+		{"plain alphanumeric", "user-123", "user-123"},
+		{"uuid", "550e8400-e29b-41d4-a716-446655440000", "550e8400-e29b-41d4-a716-446655440000"},
+		{"apikey colon", "apikey:admin", "apikey_admin"},
+		{"email", "alice@example.com", "alice_example.com"},
+		{"slash injection", "user/../etc", "user_.._etc"},
+		{"backslash", "DOMAIN\\user", "DOMAIN_user"},
+		{"unicode", "f\u00f6\u00f6", "f__"},
+		{"mixed", "anonymous (api)", "anonymous__api_"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sanitizeUserIDPath(tt.in))
+		})
+	}
+}
+
+func TestBuildExportS3Key(t *testing.T) {
+	tests := []struct {
+		name      string
+		prefix    string
+		userID    string
+		assetID   string
+		extension string
+		want      string
+	}{
+		{
+			name:      "default trailing-slash prefix is normalized",
+			prefix:    "artifacts/",
+			userID:    "user-123",
+			assetID:   "abc",
+			extension: ".csv",
+			want:      "artifacts/user-123/abc/content.csv",
+		},
+		{
+			name:      "no trailing slash on prefix",
+			prefix:    "artifacts",
+			userID:    "user-123",
+			assetID:   "abc",
+			extension: ".csv",
+			want:      "artifacts/user-123/abc/content.csv",
+		},
+		{
+			name:      "apikey user id is sanitized",
+			prefix:    "exports",
+			userID:    "apikey:admin",
+			assetID:   "abc",
+			extension: ".json",
+			want:      "exports/apikey_admin/abc/content.json",
+		},
+		{
+			name:      "empty user id falls back to underscore",
+			prefix:    "exports",
+			userID:    "",
+			assetID:   "abc",
+			extension: ".csv",
+			want:      "exports/_/abc/content.csv",
+		},
+		{
+			name:      "nested prefix",
+			prefix:    "tenants/acme/exports/",
+			userID:    "u1",
+			assetID:   "id1",
+			extension: ".md",
+			want:      "tenants/acme/exports/u1/id1/content.md",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildExportS3Key(tt.prefix, tt.userID, tt.assetID, tt.extension)
+			assert.Equal(t, tt.want, got)
+			assert.NotContains(t, got, "//", "S3 key must not contain consecutive slashes")
+		})
+	}
+}
+
+func TestValidateAndPrepare_NameSanitization(t *testing.T) {
+	assetStore := &mockExportAssetStore{}
+	versionStore := &mockExportVersionStore{}
+	s3Client := &mockExportS3Client{}
+	tk := newTestExportToolkit(assetStore, versionStore, s3Client)
+
+	req := buildExportRequest(map[string]any{
+		"sql":    "SELECT 1",
+		"format": "csv",
+		"name":   "Q1\u2014\u201cSales\u201d Report\u2026",
+	})
+
+	input, uc, errResult := tk.validateAndPrepare(context.Background(), req, tk.exportDeps)
+	require.Nil(t, errResult, "validation should succeed")
+	require.NotNil(t, uc)
+	assert.Equal(t, "Q1-\"Sales\" Report...", input.Name, "name should be sanitized to ASCII")
+}
+
+func TestValidateAndPrepare_NameSanitizedToEmpty(t *testing.T) {
+	assetStore := &mockExportAssetStore{}
+	versionStore := &mockExportVersionStore{}
+	s3Client := &mockExportS3Client{}
+	tk := newTestExportToolkit(assetStore, versionStore, s3Client)
+
+	// A name made up entirely of zero-width and control chars sanitizes to "".
+	req := buildExportRequest(map[string]any{
+		"sql":    "SELECT 1",
+		"format": "csv",
+		"name":   "\u200B\u200C\u200D",
+	})
+
+	_, _, errResult := tk.validateAndPrepare(context.Background(), req, tk.exportDeps)
+	require.NotNil(t, errResult, "validation should fail when name sanitizes to empty")
+	assert.True(t, errResult.IsError)
+	assertResultContains(t, errResult, "name is required")
+}


### PR DESCRIPTION
## Summary

`trino_export` was failing on MinIO with `XMinioInvalidObjectName: Object name contains unsupported characters` for any export, even with plain ASCII names like `"Loyalty Customers by DBA"`.

**Root cause:** `pkg/toolkits/trino/export.go` built the S3 key with `fmt.Sprintf("%s/%s/%s/content%s", deps.S3Prefix, ...)`. The default `S3Prefix` is `"artifacts/"` (trailing slash, `pkg/platform/config.go:135`), producing `artifacts//{userID}/{assetID}/content.csv`. MinIO rejects consecutive slashes; AWS S3 silently allows them. The portal toolkit gets this right via `path.Join` (`pkg/toolkits/portal/toolkit.go:480,672`).

### Changes

- **Fix the S3 key** — replace `fmt.Sprintf` with `path.Join`, which collapses redundant slashes. New helper `buildExportS3Key`.
- **Sanitize the user ID path segment** — `apikey:<name>` subjects (`pkg/auth/apikey.go:117`) and email-as-subject OIDC claims contain `:` / `@` / other chars some object stores reject. New helper `sanitizeUserIDPath` replaces non-`[A-Za-z0-9._-]` with `_`.
- **Sanitize the user-supplied asset `name`** — em/en dashes, smart quotes, ellipses, NBSP normalized to ASCII; control and zero-width chars stripped; whitespace collapsed. The name is the download filename (Content-Disposition, `pkg/portal/public.go:213`) and the portal display string. New helper `sanitizeExportName`.
- **Tool description + `name` schema** — explicit naming hint to the agent so the next call is clean to start with.

### Safety

Sanitization does not affect retrieval. Asset lookups are by `asset.ID` (random hex). S3 reads use the stored `asset.S3Key` written at upload time (`pkg/portal/handler.go:430,938,1023,1889`, `pkg/portal/public.go:243,271`). The user ID never participates in read-path key computation, so writes and reads stay symmetric.

## Test plan

- [x] `TestSanitizeExportName` — 21 cases covering em/en/figure/horizontal-bar dashes, minus sign, smart quotes (single, double, low-9), ellipsis, NBSP, zero-width space, BOM, control chars, whitespace handling, mixed real-world input.
- [x] `TestSanitizeUserIDPath` — 9 cases covering empty input, UUIDs, `apikey:admin`, email, slash injection (`user/../etc`), backslash, Unicode.
- [x] `TestBuildExportS3Key` — 5 cases; each asserts the output contains no `//` (regression guard for the original MinIO bug).
- [x] `TestValidateAndPrepare_NameSanitization` — integration: an em-dash + smart-quote + ellipsis name reaches `validateAndPrepare` and comes out ASCII.
- [x] `TestValidateAndPrepare_NameSanitizedToEmpty` — a name composed entirely of zero-width chars sanitizes to `""` and triggers the existing `name is required` validation.
- [x] `make verify` — full CI suite (fmt, race tests, lint, security, coverage, dead-code, mutation, release-check) passes locally.