### PR TITLE
fix(gateway): surface OAuth Connect button and friendly Test errors

### DIFF
--- a/pkg/admin/gateway_handler.go
+++ b/pkg/admin/gateway_handler.go
@@ -132,32 +132,12 @@ type testGatewayConnectionResponse struct {
 // @Router       /admin/gateway/connections/{name}/test [post]
 func (h *Handler) testGatewayConnection(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue(pathKeyName)
-
-	var req testGatewayConnectionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	cfg, ok := h.parseTestConnectionConfig(w, r, name)
+	if !ok {
 		return
 	}
-	if req.Config == nil {
-		req.Config = map[string]any{}
-	}
-
-	// Merge redacted credentials from the stored row if any sensitive field
-	// came in as "[REDACTED]".
-	if hasRedactedValues(req.Config) && h.deps.ConnectionStore != nil {
-		existing, err := h.deps.ConnectionStore.Get(r.Context(), gatewaykit.Kind, name)
-		if err == nil && existing != nil {
-			req.Config = mergeRedactedFields(req.Config, existing.Config)
-		}
-	}
-
-	cfg, err := gatewaykit.ParseConfig(req.Config)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+	if h.shortCircuitUnauthorizedAuthCode(w, name, cfg) {
 		return
-	}
-	if cfg.ConnectionName == "" {
-		cfg.ConnectionName = name
 	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), cfg.ConnectTimeout)
@@ -175,6 +155,70 @@ func (h *Handler) testGatewayConnection(w http.ResponseWriter, r *http.Request) 
 		Healthy: true,
 		Tools:   tools,
 	})
+}
+
+// parseTestConnectionConfig decodes the request body, merges any redacted
+// fields from the stored row, parses the config, and applies defaults.
+// Writes the appropriate HTTP error and returns ok=false on any failure path.
+func (h *Handler) parseTestConnectionConfig(w http.ResponseWriter, r *http.Request, name string) (gatewaykit.Config, bool) {
+	var req testGatewayConnectionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return gatewaykit.Config{}, false
+	}
+	if req.Config == nil {
+		req.Config = map[string]any{}
+	}
+	if hasRedactedValues(req.Config) && h.deps.ConnectionStore != nil {
+		existing, err := h.deps.ConnectionStore.Get(r.Context(), gatewaykit.Kind, name)
+		if err == nil && existing != nil {
+			req.Config = mergeRedactedFields(req.Config, existing.Config)
+		}
+	}
+	cfg, err := gatewaykit.ParseConfig(req.Config)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return gatewaykit.Config{}, false
+	}
+	if cfg.ConnectionName == "" {
+		cfg.ConnectionName = name
+	}
+	return cfg, true
+}
+
+// shortCircuitUnauthorizedAuthCode handles the special case where a Test
+// click hits an authorization_code OAuth connection with no stored token.
+// Probe would fail with a cryptic upstream error; instead we return a
+// clear 200 message pointing the operator at the Connect button. Returns
+// true when it wrote a response (caller must stop).
+func (h *Handler) shortCircuitUnauthorizedAuthCode(w http.ResponseWriter, name string, cfg gatewaykit.Config) bool {
+	if cfg.AuthMode != gatewaykit.AuthModeOAuth ||
+		cfg.OAuth.Grant != gatewaykit.OAuthGrantAuthorizationCode ||
+		h.connectionHasOAuthToken(name) {
+		return false
+	}
+	writeJSON(w, http.StatusOK, testGatewayConnectionResponse{
+		Healthy: false,
+		Error:   "Not connected: this OAuth connection needs browser sign-in before it can be tested. Use the Connect button in the OAuth status panel to authorize, then test again.",
+	})
+	return true
+}
+
+// connectionHasOAuthToken reports whether the live gateway toolkit has an
+// authorized OAuth token for the named connection. Used by the test
+// endpoint to short-circuit authorization_code connections that cannot be
+// probed without a stored token. Returns false when no toolkit is wired,
+// the connection is not registered, or the toolkit reports needs_reauth.
+func (h *Handler) connectionHasOAuthToken(name string) bool {
+	tk := h.findGatewayToolkit()
+	if tk == nil {
+		return false
+	}
+	status := tk.Status(name)
+	if status == nil || status.OAuth == nil {
+		return false
+	}
+	return !status.OAuth.NeedsReauth
 }
 
 // refreshGatewayConnectionResponse reports the post-refresh tool set.

--- a/pkg/admin/gateway_handler_test.go
+++ b/pkg/admin/gateway_handler_test.go
@@ -365,6 +365,89 @@ func TestGetGatewayConnectionStatus_ReturnsStatus(t *testing.T) {
 	assert.Nil(t, status.OAuth)
 }
 
+// TestConnectionHasOAuthToken_NoToolkitReturnsFalse covers the early-out
+// path where the gateway toolkit isn't registered at all (e.g. config-mode
+// deployments). The check must conservatively report "no token" so the
+// short-circuit message still tells the operator how to proceed.
+func TestConnectionHasOAuthToken_NoToolkitReturnsFalse(t *testing.T) {
+	reg := &mockToolkitRegistry{rawToolkits: []registry.Toolkit{}}
+	h := NewHandler(Deps{
+		Config:          testConfig(),
+		ConnectionStore: &mockConnectionStore{},
+		ToolkitRegistry: reg,
+		ConfigStore:     &mockConfigStore{mode: "database"},
+	}, nil)
+	assert.False(t, h.connectionHasOAuthToken("anything"))
+}
+
+// TestConnectionHasOAuthToken_UnknownConnectionReturnsFalse covers the case
+// where the toolkit exists but the named connection has not been added —
+// Status() returns nil and we must report "no token".
+func TestConnectionHasOAuthToken_UnknownConnectionReturnsFalse(t *testing.T) {
+	h, _ := gatewayHandlerDeps(t, &mockConnectionStore{})
+	assert.False(t, h.connectionHasOAuthToken("does-not-exist"))
+}
+
+// TestConnectionHasOAuthToken_NonOAuthConnectionReturnsFalse covers a
+// bearer/api_key/none connection: Status returns OAuth=nil and we treat
+// that as "not authorized" for the purposes of the test short-circuit.
+func TestConnectionHasOAuthToken_NonOAuthConnectionReturnsFalse(t *testing.T) {
+	url := upstreamMCP(t)
+	h, tk := gatewayHandlerDeps(t, &mockConnectionStore{})
+	require.NoError(t, tk.AddConnection("plain", map[string]any{
+		"endpoint":        url,
+		"connection_name": "plain",
+		"connect_timeout": "3s",
+		"call_timeout":    "3s",
+	}))
+	assert.False(t, h.connectionHasOAuthToken("plain"))
+}
+
+// TestTestGatewayConnection_AuthCodeUnauthorizedReturnsFriendlyMessage
+// proves the admin UX fix: a Test-connection click on an OAuth
+// authorization_code connection that has no stored token must return a
+// 200 with a clear "click Connect first" message instead of letting the
+// upstream dial fail with a cryptic OAuth error.
+func TestTestGatewayConnection_AuthCodeUnauthorizedReturnsFriendlyMessage(t *testing.T) {
+	cfg := map[string]any{
+		"endpoint":                "https://upstream.example.com/mcp",
+		"connection_name":         "vendor",
+		"auth_mode":               gatewaykit.AuthModeOAuth,
+		"oauth_grant":             gatewaykit.OAuthGrantAuthorizationCode,
+		"oauth_token_url":         "https://idp.example.com/token",
+		"oauth_authorization_url": "https://idp.example.com/authorize",
+		"oauth_client_id":         "id",
+		"oauth_client_secret":     "sec",
+		"connect_timeout":         "1s",
+		"call_timeout":            "1s",
+	}
+	store := &mockConnectionStore{
+		getResult: &platform.ConnectionInstance{
+			Kind: gatewaykit.Kind, Name: "vendor", Config: cfg,
+		},
+	}
+	h, tk := gatewayHandlerDeps(t, store)
+	// Mirror the post-save state: AddConnection records a placeholder
+	// because dial fails (no token yet).
+	require.NoError(t, tk.AddConnection("vendor", cfg))
+
+	body, _ := json.Marshal(testGatewayConnectionRequest{Config: cfg})
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/api/v1/admin/gateway/connections/vendor/test",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code,
+		"unauthorized authcode is a domain-level outcome, not an HTTP failure")
+	var resp testGatewayConnectionResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.False(t, resp.Healthy)
+	assert.Contains(t, resp.Error, "Connect",
+		"error message must point the operator at the Connect button")
+	assert.Empty(t, resp.Tools)
+}
+
 func TestReacquireGatewayOAuth_NotFound(t *testing.T) {
 	h, _ := gatewayHandlerDeps(t, &mockConnectionStore{})
 	req := httptest.NewRequestWithContext(context.Background(),

--- a/pkg/toolkits/gateway/oauth_test.go
+++ b/pkg/toolkits/gateway/oauth_test.go
@@ -750,6 +750,103 @@ func TestReacquireOAuthToken_UnhealthyClientError(t *testing.T) {
 	}
 }
 
+// TestStatus_PlaceholderReturnsOAuthNeedsReauth proves the admin UI fix
+// for the "Connect button missing" bug: when an authorization_code OAuth
+// connection has been saved but never authorized, AddConnection records
+// a placeholder upstream with client == nil. Status() must still surface
+// the OAuth field — populated as NeedsReauth=true — so the admin UI can
+// render the Connect button.
+func TestStatus_PlaceholderReturnsOAuthNeedsReauth(t *testing.T) {
+	// Token endpoint that always 401s, simulating the "no refresh token
+	// yet, browser sign-in required" state. AddConnection's discover()
+	// fails, the toolkit creates a placeholder, and Status() must report
+	// the placeholder as needs_reauth so the UI knows to prompt Connect.
+	tokenURL := fakeTokenServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+
+	cfg := map[string]any{
+		"endpoint":                "https://upstream.example.com/mcp",
+		"connection_name":         "vendor",
+		"auth_mode":               AuthModeOAuth,
+		"oauth_grant":             OAuthGrantAuthorizationCode,
+		"oauth_token_url":         tokenURL,
+		"oauth_authorization_url": tokenURL + "/authorize",
+		"oauth_client_id":         "id",
+		"oauth_client_secret":     "sec",
+		"connect_timeout":         "1s",
+		"call_timeout":            "1s",
+	}
+	require.NoError(t, tk.AddConnection("vendor", cfg))
+
+	st := tk.Status("vendor")
+	require.NotNil(t, st, "Status must return a snapshot for the placeholder")
+	assert.False(t, st.Healthy, "placeholder is not healthy (no live client)")
+	assert.Equal(t, AuthModeOAuth, st.AuthMode)
+	require.NotNil(t, st.OAuth,
+		"OAuth field must be populated for placeholders so the admin UI can show Connect")
+	assert.True(t, st.OAuth.NeedsReauth, "placeholder must report NeedsReauth=true")
+	assert.False(t, st.OAuth.TokenAcquired)
+	assert.Equal(t, OAuthGrantAuthorizationCode, st.OAuth.Grant)
+}
+
+// TestStatus_PlaceholderWithStoredTokenReportsAuthorized covers the post-
+// restart case: the token store has a valid token, AddConnection's dial
+// fails because the upstream is unreachable, so a placeholder is kept.
+// Status() must reflect that the operator has already authorized (so the
+// UI does NOT push them through Connect again) — only the upstream is
+// sick.
+func TestStatus_PlaceholderWithStoredTokenReportsAuthorized(t *testing.T) {
+	tokenURL := fakeTokenServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"a","refresh_token":"r","expires_in":3600}`))
+	})
+	deadUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(deadUpstream.Close)
+
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+
+	store := NewMemoryTokenStore()
+	require.NoError(t, store.Set(context.Background(), PersistedToken{
+		ConnectionName:  "vendor",
+		AccessToken:     "stored-acc",
+		RefreshToken:    "stored-ref",
+		ExpiresAt:       time.Now().Add(time.Hour),
+		AuthenticatedBy: "admin@example.com",
+		AuthenticatedAt: time.Now().UTC(),
+	}))
+	tk.SetTokenStore(store)
+
+	cfg := map[string]any{
+		"endpoint":                deadUpstream.URL,
+		"connection_name":         "vendor",
+		"auth_mode":               AuthModeOAuth,
+		"oauth_grant":             OAuthGrantAuthorizationCode,
+		"oauth_token_url":         tokenURL,
+		"oauth_authorization_url": tokenURL + "/auth",
+		"oauth_client_id":         "id",
+		"oauth_client_secret":     "sec",
+		"connect_timeout":         "1s",
+		"call_timeout":            "1s",
+	}
+	// Dial will fail because deadUpstream returns 503; placeholder retained.
+	require.NoError(t, tk.AddConnection("vendor", cfg))
+
+	st := tk.Status("vendor")
+	require.NotNil(t, st)
+	require.NotNil(t, st.OAuth, "OAuth status must surface even when upstream is unreachable")
+	assert.False(t, st.OAuth.NeedsReauth,
+		"already authorized — UI should not push Connect again")
+	assert.True(t, st.OAuth.HasRefreshToken)
+	assert.Equal(t, "admin@example.com", st.OAuth.AuthenticatedBy)
+}
+
 func TestStatus_OAuthFieldsPopulated(t *testing.T) {
 	tokenURL := fakeTokenServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/toolkits/gateway/toolkit.go
+++ b/pkg/toolkits/gateway/toolkit.go
@@ -392,6 +392,13 @@ type ConnectionStatus struct {
 
 // Status returns a status snapshot for the named connection. Returns nil
 // when the connection is not registered.
+//
+// For oauth connections the OAuth field is always populated when present:
+// for live clients it reflects the live token source's state; for awaiting-
+// reauth placeholders (client == nil) it is synthesized from the persisted
+// token store so the admin UI can render the Connect button or show the
+// "authorized but upstream unreachable" state without needing a successful
+// upstream dial.
 func (t *Toolkit) Status(name string) *ConnectionStatus {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -405,8 +412,17 @@ func (t *Toolkit) Status(name string) *ConnectionStatus {
 		AuthMode: u.config.AuthMode,
 		Tools:    append([]string(nil), u.toolNames...),
 	}
-	if u.client != nil && u.client.oauth != nil {
+	switch {
+	case u.client != nil && u.client.oauth != nil:
 		s := u.client.oauth.Status()
+		cs.OAuth = &s
+	case u.config.AuthMode == AuthModeOAuth:
+		// Placeholder for an oauth connection with no live client (e.g.
+		// authorization_code awaiting first Connect, or a dial failure
+		// post-restart). Build a status view from the persisted store so
+		// the admin UI can drive the next step.
+		src := newOAuthTokenSource(u.config.OAuth, name, t.tokenStore)
+		s := src.Status()
 		cs.OAuth = &s
 	}
 	return cs

--- a/ui/src/api/admin/client.test.ts
+++ b/ui/src/api/admin/client.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { useAuthStore } from "@/stores/auth";
+
+// apiFetch is not exported on its own; we exercise it through the public
+// `apiFetch` symbol re-exported by the module. The alternative — exposing
+// a separate test entry — would leak test concerns into production code.
+async function loadApiFetch() {
+  const mod = await import("./client");
+  return mod.apiFetch;
+}
+
+describe("apiFetch error handling", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    // Keep the auth store predictable so the request shape doesn't depend
+    // on whatever the previous test left behind.
+    useAuthStore.setState({ apiKey: "test-key", authMethod: "apikey" });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function mockResponse(status: number, body: unknown): void {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  }
+
+  it("surfaces body.error when body.detail is missing (gateway test endpoint shape)", async () => {
+    // The gateway test-connection endpoint returns 502 with
+    // {healthy:false, error: "..."} — the previous client only read
+    // body.detail and lost the actual upstream message, leaving the
+    // operator with a generic 'Bad Gateway' / 'Failed' indicator.
+    mockResponse(502, { healthy: false, error: "oauth: token endpoint returned 401: invalid_client" });
+    const apiFetch = await loadApiFetch();
+    await expect(apiFetch("/gateway/connections/vendor/test", { method: "POST" }))
+      .rejects.toMatchObject({
+        status: 502,
+        message: "oauth: token endpoint returned 401: invalid_client",
+      });
+  });
+
+  it("falls back to body.message when neither detail nor error is set", async () => {
+    mockResponse(500, { message: "internal failure detail" });
+    const apiFetch = await loadApiFetch();
+    await expect(apiFetch("/anything"))
+      .rejects.toMatchObject({ status: 500, message: "internal failure detail" });
+  });
+
+  it("prefers body.detail when present (problemDetail-shaped responses)", async () => {
+    mockResponse(404, { detail: "not found", error: "ignored", message: "ignored" });
+    const apiFetch = await loadApiFetch();
+    await expect(apiFetch("/x"))
+      .rejects.toMatchObject({ status: 404, message: "not found" });
+  });
+
+  it("falls back to statusText when the body has no diagnostic fields", async () => {
+    mockResponse(503, {});
+    const apiFetch = await loadApiFetch();
+    // Response.statusText reflects the second arg's `statusText`. When
+    // omitted, jsdom's Response leaves it empty; our fallback handles
+    // either case — the failure message must just be non-empty.
+    await expect(apiFetch("/x")).rejects.toMatchObject({ status: 503 });
+  });
+});

--- a/ui/src/api/admin/client.ts
+++ b/ui/src/api/admin/client.ts
@@ -30,8 +30,12 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   });
 
   if (!res.ok) {
-    const body = await res.json().catch(() => ({ detail: res.statusText }));
-    throw new ApiError(res.status, body.detail || res.statusText);
+    const body = await res.json().catch(() => ({} as Record<string, unknown>));
+    const detail = (typeof body.detail === "string" && body.detail)
+      || (typeof body.error === "string" && body.error)
+      || (typeof body.message === "string" && body.message)
+      || res.statusText;
+    throw new ApiError(res.status, detail);
   }
 
   return res.json() as Promise<T>;


### PR DESCRIPTION
## Summary

The MCP gateway's OAuth `authorization_code` flow was effectively unusable from the admin UI. Saving the form did not produce a Connect button — even though the help text promised one — and clicking **Test connection** returned a generic "Failed" with no actionable diagnostic. This PR fixes both, plus a wider client-side bug that was hiding error messages across the entire admin API surface.

## Root cause

### Bug 1 — Connect button never rendered

`Toolkit.Status()` (`pkg/toolkits/gateway/toolkit.go`) only populated the `OAuth` field when `client != nil`. But on the very first save of an `authorization_code` connection there is no live client — `AddConnection` records an "awaiting reauth" placeholder upstream, because the platform cannot dial without a stored token. With `OAuth: null`, the admin UI's `OAuthStatusCard` (`ui/src/pages/settings/GatewayActions.tsx:168`) early-returns to `null`, so the entire status panel — including the Connect button — silently disappears. The form text said *"After saving the connection, click Connect to authorize"* but there was nowhere to click.

### Bug 2 — generic "Failed" on Test connection

Two compounding issues:

1. `testGatewayConnection` calls `gatewaykit.Probe`, which always passes `nil` for the token store (one-shot dial, never persists). For an unauthorized `authorization_code` connection that means the dial fails on whatever cryptic error the upstream IdP returns — frequently a 401 on the token endpoint with no useful body.
2. The admin API client (`ui/src/api/admin/client.ts`) extracted only `body.detail` from non-OK responses. The gateway test endpoint returns `{healthy: false, error: "..."}` — different shape — so even the cryptic upstream message was discarded and the operator saw an empty "Failed" indicator.

## Fixes

| File | Change |
|---|---|
| `pkg/toolkits/gateway/toolkit.go` | `Status()` synthesizes the `OAuth` field from the persisted token store when the connection is a placeholder. `NeedsReauth=true` when no stored token; `false` when one exists but the upstream is just unreachable. The admin UI now renders Connect for the first case and "authorized but upstream sick" for the second. |
| `pkg/admin/gateway_handler.go` | `testGatewayConnection` short-circuits unauthorized `authorization_code` connections with HTTP 200 + a clear *"Not connected: this OAuth connection needs browser sign-in… Use the Connect button…"* message instead of bubbling up the upstream dial failure. Refactored into `parseTestConnectionConfig`, `shortCircuitUnauthorizedAuthCode`, and `connectionHasOAuthToken` helpers to stay under the project's cyclo ≤ 10. |
| `ui/src/api/admin/client.ts` | `apiFetch` error extraction now falls back through `detail → error → message → statusText`. Endpoint-shaped error responses across the admin API now surface a useful diagnostic instead of being silently dropped. |

## What you'll see in the UI now

After saving an `authorization_code` connection (e.g. the screenshot from the bug report — Keycloak realm `mcp-test`):

1. **OAuth status panel renders** below Test/Refresh buttons with `Token: not yet acquired`, `Refresh token: none`, `Grant: authorization_code`.
2. **Blue Connect button** is visible alongside an amber *"Not connected. Click Connect to authorize…"* notice.
3. Clicking **Test connection** shows the friendly *"Not connected… Use the Connect button"* message instead of "Failed".
4. Clicking **Connect** opens the upstream `/authorize` URL in a new tab. After sign-in, the platform exchanges the code, persists the tokens, and the panel flips to `Token: acquired` with **Reconnect** and **Refresh now** controls.

## Tests

All new code has direct unit coverage. Patch coverage for this PR is **100%** (43/43 changed lines on `pkg/admin/gateway_handler.go`).

**Go**:
- `TestStatus_PlaceholderReturnsOAuthNeedsReauth` — proves the placeholder Status surfaces `NeedsReauth=true`
- `TestStatus_PlaceholderWithStoredTokenReportsAuthorized` — proves a placeholder with a persisted token reports authorized (not `NeedsReauth`), so the UI doesn't push Connect again after a transient upstream outage
- `TestTestGatewayConnection_AuthCodeUnauthorizedReturnsFriendlyMessage` — proves the test endpoint returns 200 + Connect-prompt message
- Three branch tests for `connectionHasOAuthToken` (no toolkit, unknown connection, non-OAuth connection)

**TypeScript** (`ui/src/api/admin/client.test.ts`, new file):
- `surfaces body.error when body.detail is missing` — gateway test endpoint shape
- `falls back to body.message` when neither `detail` nor `error` is set
- `prefers body.detail when present` — `problemDetail`-shaped responses still work
- `falls back to statusText` when the body has no diagnostic fields

## Verification

- `make fmt test lint coverage-report patch-coverage` — clean
- `make security` — clean against pinned `gosec v2.22.0`. (Local `gosec 2.26.1` flags 3 G710 open-redirect findings, but they exist on `main` too — pre-existing, not introduced here.)
- New Go tests pass under `-race`
- Vitest passes for the new `client.test.ts`

## Test plan

- [ ] `make dev` brings up the local stack with `dev-mcp-mock` providing OAuth on `:9180` and MCP on `:9181`
- [ ] In the admin UI, add a new MCP connection: endpoint `http://localhost:9181/mcp`, auth_mode `oauth`, grant `authorization_code`, authorization URL `http://localhost:9180/authorize`, token URL `http://localhost:9180/token`, any client_id/secret, scope `openid profile email`
- [ ] After Save: OAuth status panel is visible, Connect button is rendered, "Not connected" notice is shown
- [ ] Click Test connection → friendly "click Connect" message (not "Failed")
- [ ] Click Connect → new tab opens, mock immediately redirects back through `/api/v1/admin/oauth/callback`, status flips to `token_acquired`
- [ ] Click Test connection → "Discovered N tools" with `dev-mock__echo`, `dev-mock__add`, `dev-mock__now`
- [ ] Click Refresh now → forces `grant_type=refresh_token` exchange, `last_refreshed_at` updates
- [ ] Verify against the live Keycloak `mcp-test` realm at `https://iam.plexara.io` once deployed