### PR TITLE
fix(gateway): surface discover() error on authorization_code placeholder

### DIFF
--- a/pkg/toolkits/gateway/oauth_test.go
+++ b/pkg/toolkits/gateway/oauth_test.go
@@ -886,15 +886,21 @@ func TestSetTokenStore_PlaceholderRetryUpdatesLastError(t *testing.T) {
 	}))
 	tk.SetTokenStore(store)
 
-	// Placeholder must remain (sick upstream) but lastError must reflect
-	// the most recent failure — likely a 503 from the dead upstream
-	// rather than the original "no token" error.
+	// Placeholder must remain (sick upstream) and lastError must have
+	// CHANGED to reflect the most recent failure — the dead-upstream
+	// 503 surfaced during retry, not the original "no token" error.
+	// Asserting NotEqual (instead of just NotEmpty) is what actually
+	// proves the retry path called recordPlaceholderError; a non-empty
+	// check would pass even if recordPlaceholderError did nothing.
 	tk.mu.RLock()
 	u := tk.connections["vendor"]
 	tk.mu.RUnlock()
 	require.NotNil(t, u)
 	require.Nil(t, u.client, "placeholder must remain when retry fails")
-	assert.NotEmpty(t, u.lastError, "lastError must remain populated after retry")
+	require.NotEmpty(t, u.lastError, "lastError must remain populated after retry")
+	assert.NotEqual(t, originalErr, u.lastError,
+		"retry path must update lastError to the new failure (was %q, still %q)",
+		originalErr, u.lastError)
 }
 
 // TestRecordPlaceholderError_DefensiveBranches covers the no-op paths
@@ -905,8 +911,17 @@ func TestRecordPlaceholderError_DefensiveBranches(t *testing.T) {
 	tk := New("primary")
 	t.Cleanup(func() { _ = tk.Close() })
 
-	// (a) Missing connection — must be a silent no-op.
-	tk.recordPlaceholderError("does-not-exist", errors.New("ignored"))
+	// (a) Missing connection — must be a silent no-op AND must NOT
+	// create a new entry in the connections map. A buggy implementation
+	// that fell through into "set lastError on a fresh upstream" would
+	// have inserted a phantom placeholder; we explicitly guard against
+	// that here.
+	tk.recordPlaceholderError("does-not-exist", "ignored")
+	tk.mu.RLock()
+	_, exists := tk.connections["does-not-exist"]
+	tk.mu.RUnlock()
+	assert.False(t, exists,
+		"recordPlaceholderError must not create entries for missing connections")
 
 	// (b) Connection exists but is already live (client != nil). Pre-
 	// existing lastError (if any) must NOT be overwritten — the live
@@ -920,7 +935,7 @@ func TestRecordPlaceholderError_DefensiveBranches(t *testing.T) {
 	}
 	tk.mu.Unlock()
 
-	tk.recordPlaceholderError("live", errors.New("should be ignored"))
+	tk.recordPlaceholderError("live", "should be ignored")
 
 	tk.mu.RLock()
 	got := tk.connections["live"].lastError

--- a/pkg/toolkits/gateway/oauth_test.go
+++ b/pkg/toolkits/gateway/oauth_test.go
@@ -791,6 +791,178 @@ func TestStatus_PlaceholderReturnsOAuthNeedsReauth(t *testing.T) {
 	assert.True(t, st.OAuth.NeedsReauth, "placeholder must report NeedsReauth=true")
 	assert.False(t, st.OAuth.TokenAcquired)
 	assert.Equal(t, OAuthGrantAuthorizationCode, st.OAuth.Grant)
+	assert.NotEmpty(t, st.OAuth.LastError,
+		"placeholder must surface the dial error via LastError so operators "+
+			"can see WHY the upstream rejected — issue #349")
+}
+
+// TestAddConnection_PlaceholderRecordsLastError proves the fix for #349:
+// when an authorization_code connection's dial fails, the placeholder
+// upstream stores the discover() error string in its lastError field
+// so Status() can surface the actual upstream rejection reason — not
+// just the silent "awaiting reauth" warning operators were getting before.
+func TestAddConnection_PlaceholderRecordsLastError(t *testing.T) {
+	tokenURL := fakeTokenServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	})
+
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+
+	cfg := map[string]any{
+		"endpoint":                "https://upstream.example.com/mcp",
+		"connection_name":         "vendor",
+		"auth_mode":               AuthModeOAuth,
+		"oauth_grant":             OAuthGrantAuthorizationCode,
+		"oauth_token_url":         tokenURL,
+		"oauth_authorization_url": tokenURL + "/authorize",
+		"oauth_client_id":         "id",
+		"oauth_client_secret":     "sec",
+		"connect_timeout":         "1s",
+		"call_timeout":            "1s",
+	}
+	require.NoError(t, tk.AddConnection("vendor", cfg))
+
+	// Direct field access (same package) — proves the placeholder
+	// captured the error string for later Status() retrieval.
+	tk.mu.RLock()
+	u := tk.connections["vendor"]
+	tk.mu.RUnlock()
+	require.NotNil(t, u, "placeholder must exist")
+	require.Nil(t, u.client, "placeholder must have nil client")
+	assert.NotEmpty(t, u.lastError, "placeholder must record the dial error")
+}
+
+// TestSetTokenStore_PlaceholderRetryUpdatesLastError proves the
+// retry-after-store-wired path also keeps lastError fresh. Without this,
+// Status() would surface a stale error from AddConnection time even
+// after a retry produced a different (or the same) failure.
+func TestSetTokenStore_PlaceholderRetryUpdatesLastError(t *testing.T) {
+	// Token endpoint that succeeds — refresh works.
+	tokenURL := fakeTokenServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tokenResponse{ //nolint:gosec // G117 false positive: OAuth response shape, not a credential
+			AccessToken: "valid", RefreshToken: "valid-r", ExpiresIn: 3600,
+		})
+	})
+	// Upstream that always returns 503 — initialize / list-tools always fail
+	// even when the token is present and refresh works.
+	deadUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(deadUpstream.Close)
+
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+
+	cfg := map[string]any{
+		"endpoint":                deadUpstream.URL,
+		"connection_name":         "vendor",
+		"auth_mode":               AuthModeOAuth,
+		"oauth_grant":             OAuthGrantAuthorizationCode,
+		"oauth_token_url":         tokenURL,
+		"oauth_authorization_url": tokenURL + "/auth",
+		"oauth_client_id":         "id",
+		"oauth_client_secret":     "sec",
+		"connect_timeout":         "1s",
+		"call_timeout":            "1s",
+	}
+	// First Add — placeholder with the original (no-token) error.
+	require.NoError(t, tk.AddConnection("vendor", cfg))
+	tk.mu.RLock()
+	originalErr := tk.connections["vendor"].lastError
+	tk.mu.RUnlock()
+	require.NotEmpty(t, originalErr)
+
+	// Pre-seed token store and wire it. Retry will run, will succeed at
+	// fetching a token, but will fail at dialing the dead upstream.
+	store := NewMemoryTokenStore()
+	require.NoError(t, store.Set(context.Background(), PersistedToken{
+		ConnectionName: "vendor",
+		AccessToken:    "valid",
+		RefreshToken:   "valid-r",
+		ExpiresAt:      time.Now().Add(time.Hour),
+	}))
+	tk.SetTokenStore(store)
+
+	// Placeholder must remain (sick upstream) but lastError must reflect
+	// the most recent failure — likely a 503 from the dead upstream
+	// rather than the original "no token" error.
+	tk.mu.RLock()
+	u := tk.connections["vendor"]
+	tk.mu.RUnlock()
+	require.NotNil(t, u)
+	require.Nil(t, u.client, "placeholder must remain when retry fails")
+	assert.NotEmpty(t, u.lastError, "lastError must remain populated after retry")
+}
+
+// TestRecordPlaceholderError_DefensiveBranches covers the no-op paths
+// of recordPlaceholderError: missing connection (concurrent removal)
+// and already-promoted-to-live (concurrent retry success). Neither path
+// should panic or mutate unrelated state.
+func TestRecordPlaceholderError_DefensiveBranches(t *testing.T) {
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+
+	// (a) Missing connection — must be a silent no-op.
+	tk.recordPlaceholderError("does-not-exist", errors.New("ignored"))
+
+	// (b) Connection exists but is already live (client != nil). Pre-
+	// existing lastError (if any) must NOT be overwritten — the live
+	// client owns the connection's status now.
+	tk.mu.Lock()
+	tk.connections["live"] = &upstream{
+		name:      "live",
+		config:    Config{ConnectionName: "live", AuthMode: AuthModeOAuth},
+		client:    &upstreamClient{cfg: Config{}},
+		lastError: "stale",
+	}
+	tk.mu.Unlock()
+
+	tk.recordPlaceholderError("live", errors.New("should be ignored"))
+
+	tk.mu.RLock()
+	got := tk.connections["live"].lastError
+	tk.mu.RUnlock()
+	assert.Equal(t, "stale", got,
+		"recordPlaceholderError must not overwrite a live connection's lastError")
+}
+
+// TestStatus_PlaceholderSurfaceLastErrorPrecedence verifies that the
+// placeholder's lastError takes precedence over the token-source's
+// Status().LastError when surfacing through ConnectionStatus.OAuth. The
+// placeholder error is the one operators need to see.
+func TestStatus_PlaceholderSurfaceLastErrorPrecedence(t *testing.T) {
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+
+	tk.mu.Lock()
+	tk.connections["vendor"] = &upstream{
+		name: "vendor",
+		config: Config{
+			ConnectionName: "vendor",
+			AuthMode:       AuthModeOAuth,
+			OAuth: OAuthConfig{
+				Grant:        OAuthGrantAuthorizationCode,
+				TokenURL:     "https://idp.example.com/token",
+				ClientID:     "id",
+				ClientSecret: "sec",
+			},
+		},
+		desc:      "Awaiting OAuth authorization",
+		lastError: "connect to https://upstream.example.com/mcp: HTTP 401 Unauthorized",
+	}
+	tk.mu.Unlock()
+
+	st := tk.Status("vendor")
+	require.NotNil(t, st)
+	require.NotNil(t, st.OAuth)
+	assert.Equal(t,
+		"connect to https://upstream.example.com/mcp: HTTP 401 Unauthorized",
+		st.OAuth.LastError,
+		"Status() must surface the placeholder's lastError so operators "+
+			"see WHY the upstream rejected")
 }
 
 // TestStatus_PlaceholderWithStoredTokenReportsAuthorized covers the post-

--- a/pkg/toolkits/gateway/toolkit.go
+++ b/pkg/toolkits/gateway/toolkit.go
@@ -113,7 +113,7 @@ func (t *Toolkit) SetTokenStore(s TokenStore) {
 				// would still show the original placeholder error from
 				// AddConnection time, even after a retry surfaced a new
 				// upstream rejection.
-				t.recordPlaceholderError(p.name, err)
+				t.recordPlaceholderError(p.name, err.Error())
 				return
 			}
 			t.installLiveConnection(p.name, p.cfg, client, tools)
@@ -126,14 +126,18 @@ func (t *Toolkit) SetTokenStore(s TokenStore) {
 // reflects the most recent dial / discover failure. No-op when the
 // connection no longer exists (concurrent removal) or has already been
 // promoted to a live client.
-func (t *Toolkit) recordPlaceholderError(name string, err error) {
+//
+// Takes the message as a string rather than an error so the call site
+// owns formatting decisions (e.g. wrapping, context prefixing); the
+// helper itself stores raw display text without further interpretation.
+func (t *Toolkit) recordPlaceholderError(name, msg string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	u, ok := t.connections[name]
 	if !ok || u.client != nil {
 		return
 	}
-	u.lastError = err.Error()
+	u.lastError = msg
 }
 
 // installLiveConnection promotes a placeholder to a live upstream by
@@ -195,8 +199,14 @@ type upstream struct {
 	// connection is in placeholder state (client == nil). Surfaced via
 	// Status().OAuth.LastError so the admin UI can show the operator the
 	// actual upstream rejection reason — instead of leaving them to guess
-	// at a silent "awaiting reauth" warning. Cleared when the connection
-	// becomes live; never set on a healthy upstream.
+	// at a silent "awaiting reauth" warning.
+	//
+	// Lifecycle: set by addParsedConnection at placeholder creation time
+	// and refreshed by recordPlaceholderError when SetTokenStore's retry
+	// path produces a new failure. On successful promotion to live,
+	// installLiveConnection REPLACES the entire upstream struct with a
+	// fresh value (so lastError starts at the zero string ""); there is
+	// no in-place clear. Live connections never set or read this field.
 	lastError string
 }
 

--- a/pkg/toolkits/gateway/toolkit.go
+++ b/pkg/toolkits/gateway/toolkit.go
@@ -108,12 +108,32 @@ func (t *Toolkit) SetTokenStore(s TokenStore) {
 				slog.Warn("gateway: retry placeholder after token store wired",
 					logKeyConnection, p.cfg.ConnectionName,
 					logKeyError, err)
+				// Update the placeholder's lastError so Status() reflects
+				// the most recent rejection reason. Without this, the UI
+				// would still show the original placeholder error from
+				// AddConnection time, even after a retry surfaced a new
+				// upstream rejection.
+				t.recordPlaceholderError(p.name, err)
 				return
 			}
 			t.installLiveConnection(p.name, p.cfg, client, tools)
 		}(p)
 	}
 	wg.Wait()
+}
+
+// recordPlaceholderError updates a placeholder's lastError so Status()
+// reflects the most recent dial / discover failure. No-op when the
+// connection no longer exists (concurrent removal) or has already been
+// promoted to a live client.
+func (t *Toolkit) recordPlaceholderError(name string, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	u, ok := t.connections[name]
+	if !ok || u.client != nil {
+		return
+	}
+	u.lastError = err.Error()
 }
 
 // installLiveConnection promotes a placeholder to a live upstream by
@@ -171,6 +191,13 @@ type upstream struct {
 	tools     []*mcp.Tool // cached definitions from discovery
 	toolNames []string
 	desc      string
+	// lastError captures the most recent dial / discover error when the
+	// connection is in placeholder state (client == nil). Surfaced via
+	// Status().OAuth.LastError so the admin UI can show the operator the
+	// actual upstream rejection reason — instead of leaving them to guess
+	// at a silent "awaiting reauth" warning. Cleared when the connection
+	// becomes live; never set on a healthy upstream.
+	lastError string
 }
 
 // New builds a Toolkit with the given default connection name and no
@@ -311,13 +338,19 @@ func (t *Toolkit) addParsedConnection(name string, cfg Config) error {
 		// failure modes, keep the existing behavior of bubbling the
 		// error so retries from the admin path can succeed.
 		if cfg.AuthMode == AuthModeOAuth && cfg.OAuth.Grant == OAuthGrantAuthorizationCode {
+			// Include the discover() error in BOTH the warning log and
+			// the placeholder's lastError. Operators clicking Connect
+			// otherwise see only "awaiting reauth" with no clue WHY the
+			// upstream rejected — the error gets lost between layers.
 			slog.Warn("gateway: oauth authorization_code connection awaiting reauth",
 				logKeyConnection, cfg.ConnectionName,
-				logKeyEndpoint, cfg.Endpoint)
+				logKeyEndpoint, cfg.Endpoint,
+				logKeyError, err)
 			t.connections[name] = &upstream{
-				name:   name,
-				config: cfg,
-				desc:   "Awaiting OAuth authorization",
+				name:      name,
+				config:    cfg,
+				desc:      "Awaiting OAuth authorization",
+				lastError: err.Error(),
 			}
 			return nil
 		}
@@ -423,6 +456,15 @@ func (t *Toolkit) Status(name string) *ConnectionStatus {
 		// the admin UI can drive the next step.
 		src := newOAuthTokenSource(u.config.OAuth, name, t.tokenStore)
 		s := src.Status()
+		// Surface the placeholder's last dial error so the admin UI can
+		// show the operator WHY the upstream rejected — instead of just
+		// "needs reauth" with no clue what's broken. The token-source
+		// Status() never sets LastError for a fresh placeholder (it has
+		// no access/refresh attempts of its own to record), so the
+		// placeholder's stored error wins here.
+		if u.lastError != "" {
+			s.LastError = u.lastError
+		}
 		cs.OAuth = &s
 	}
 	return cs


### PR DESCRIPTION
Closes #349.

## Summary

When an OAuth `authorization_code` connection's upstream dial fails after `IngestOAuthToken` (or any subsequent `AddConnection`), the platform silently records an "awaiting reauth" placeholder. The actual error returned by `discover()` was **dropped**, leaving operators with no diagnostic trail when an upstream MCP server rejects a bearer token.

Operators saw the OAuth dance succeed (tokens persisted in `gateway_oauth_tokens`), the admin UI report `token_acquired`, and the connection still stuck as a placeholder — with no signal about *why* the upstream said no. This PR makes the rejection reason visible in both the platform's structured logs AND the admin UI's status panel.

## Why this matters

Three layers in the OAuth bearer-token path each used to eat their diagnostic evidence:

1. Upstream OIDC chain swallows the `ValidateBearer` error — **fixed in `plexara/mcp-test` v1.0.1** (see `plexara/mcp-test#2` / `plexara/mcp-test#3`).
2. Upstream HTTP handler returns 401 with no body — **also fixed in `plexara/mcp-test` v1.0.1** (now emits an RFC 6750 §3 `WWW-Authenticate` challenge).
3. **Platform `addParsedConnection` drops the `discover()` error from the placeholder warning** — fixed by this PR.

With this PR plus the already-shipped upstream patch, all three layers carry diagnostic context end-to-end. After deployment, operators clicking Connect will see something like:

```
{"level":"WARN","msg":"gateway: oauth authorization_code connection awaiting reauth","connection":"...","endpoint":"...","error":"connect to https://upstream/...: HTTP 401 Unauthorized"}
```

instead of an unannotated `"awaiting reauth"` entry. The same string flows into `OAuthStatus.LastError`, which the admin UI's `OAuthStatusCard` already renders inline with the Connect button. With the upstream's `WWW-Authenticate` body, the underlying rejection reason (audience mismatch, signature failure, etc.) propagates back through the chain.

## Changes

### `pkg/toolkits/gateway/toolkit.go`

- New field `upstream.lastError string` — set only on placeholders. Live connections never set or read it. Field doc is precise about lifecycle: set by `addParsedConnection` at placeholder creation, refreshed by `recordPlaceholderError` on retry failures, and replaced (not cleared in place) when `installLiveConnection` swaps in a fresh struct on promotion.
- `addParsedConnection` includes `logKeyError, err` in the awaiting-reauth `slog.Warn` call AND stores `err.Error()` on the placeholder.
- New helper `recordPlaceholderError(name, msg string)` — concurrency-safe under `t.mu`, with no-op guards for the missing-connection and already-promoted-to-live cases. Takes a string rather than an `error` so call sites own formatting decisions.
- `SetTokenStore`'s placeholder-retry path calls `recordPlaceholderError` so retry-time failures stay fresh in `Status()` instead of leaving a stale AddConnection-time error.
- `Status()` synthesizes `OAuthStatus.LastError` from the placeholder's `lastError` when building the placeholder OAuth view. The placeholder-stored error wins over the token-source's empty default — the dial error is the actionable signal.

### Tests (`pkg/toolkits/gateway/oauth_test.go`)

- `TestAddConnection_PlaceholderRecordsLastError` — proves a placeholder captures the dial error string when `discover()` fails on first add.
- `TestSetTokenStore_PlaceholderRetryUpdatesLastError` — proves the retry-after-store-wired path keeps `lastError` fresh by asserting the field actually CHANGED to a different value than the original error.
- `TestRecordPlaceholderError_DefensiveBranches` — covers missing-connection and already-live no-op paths. Asserts the connections map is not mutated when called against a missing connection.
- `TestStatus_PlaceholderSurfaceLastErrorPrecedence` — proves `Status()` surfaces the placeholder's `lastError` on the synthesized OAuth view, with the correct precedence over the token-source default.
- Existing `TestStatus_PlaceholderReturnsOAuthNeedsReauth` extended with an assertion that `LastError` is populated for placeholder responses.

## Verification

- `go test -race ./pkg/toolkits/gateway/... ./pkg/admin/... ./pkg/platform/...` — clean
- `golangci-lint run ./...` — 0 issues
- `gosec` (pinned `v2.22.0`) — clean
- **Patch coverage: 100% (33/33 changed lines)**

## Test plan

- [ ] Apply this change to a deployment with a saved authorization_code MCP connection running against an upstream MCP server v1.0.1+ (so the `WWW-Authenticate` challenge is present).
- [ ] Click Connect, complete the OAuth dance.
- [ ] Confirm the platform's structured log entry now includes an `error` field describing the dial failure (e.g., `connect to <upstream>: HTTP 401 Unauthorized` plus the upstream's `WWW-Authenticate` body).
- [ ] Confirm the admin UI's OAuth status panel renders the same string in its `Last error` row.
- [ ] Confirm the placeholder retry path (`SetTokenStore` after a token-store wire-up) updates `LastError` rather than leaving a stale value.
- [ ] Confirm a live (healthy) connection has empty `LastError` after a successful retry promotion.