### PR TITLE
fix(tools): resolve three bugs from #340 master-detail redesign

### DIFF
--- a/pkg/admin/handler.go
+++ b/pkg/admin/handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -154,6 +155,17 @@ type Handler struct {
 	publicMux  *http.ServeMux
 	deps       Deps
 	authMiddle func(http.Handler) http.Handler
+	// toolsDenyMu serializes read-modify-write of the tools.deny config
+	// entry across concurrent setToolVisibility calls. Without it, two
+	// admins toggling visibility on different tools could each load the
+	// same starting list, modify their own copy, and the second writer
+	// overwrites the first — silently losing one of the changes (#343).
+	//
+	// In-process serialization is sufficient for single-replica
+	// deployments. Multi-replica deployments would additionally need a
+	// row-level DB lock or version-token CAS at the config_entries layer;
+	// that's a separate concern not addressed here.
+	toolsDenyMu sync.Mutex
 }
 
 // statusResponse is a generic status response.

--- a/pkg/admin/testhelpers_test.go
+++ b/pkg/admin/testhelpers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -259,6 +260,12 @@ var _ APIKeyManager = (*mockAPIKeyManager)(nil)
 // --- Mock ConfigStore ---
 
 type mockConfigStore struct {
+	// mu guards entries, changelog, and setCalls so the mock can be
+	// safely shared across goroutines in concurrency tests
+	// (e.g. the visibility-lock test for #343 bug 1). Single-goroutine
+	// tests pay no measurable cost — Mutex.Lock on uncontended use is
+	// a single CAS.
+	mu           sync.Mutex
 	mode         string
 	entries      map[string]*configstore.Entry
 	changelog    []configstore.ChangelogEntry
@@ -271,6 +278,8 @@ type mockConfigStore struct {
 }
 
 func (m *mockConfigStore) Get(_ context.Context, key string) (*configstore.Entry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.getErr != nil {
 		return nil, m.getErr
 	}
@@ -283,6 +292,8 @@ func (m *mockConfigStore) Get(_ context.Context, key string) (*configstore.Entry
 }
 
 func (m *mockConfigStore) Set(_ context.Context, key, value, _ string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.setCalls++
 	if m.setErr != nil {
 		return m.setErr
@@ -295,6 +306,8 @@ func (m *mockConfigStore) Set(_ context.Context, key, value, _ string) error {
 }
 
 func (m *mockConfigStore) Delete(_ context.Context, key, _ string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.deleteErr != nil {
 		return m.deleteErr
 	}
@@ -308,6 +321,8 @@ func (m *mockConfigStore) Delete(_ context.Context, key, _ string) error {
 }
 
 func (m *mockConfigStore) List(_ context.Context) ([]configstore.Entry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.listErr != nil {
 		return nil, m.listErr
 	}
@@ -319,6 +334,8 @@ func (m *mockConfigStore) List(_ context.Context) ([]configstore.Entry, error) {
 }
 
 func (m *mockConfigStore) Changelog(_ context.Context, _ int) ([]configstore.ChangelogEntry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.changelogErr != nil {
 		return nil, m.changelogErr
 	}

--- a/pkg/admin/tools_detail.go
+++ b/pkg/admin/tools_detail.go
@@ -335,6 +335,13 @@ func toolDescriptionConfigKey(toolName string) string {
 // kill-switch. The value stored in config_entries is a JSON-encoded
 // []string. Centralized so the live-config hot-reload path and the
 // admin UI agree.
+//
+// CONCURRENCY: any code path that mutates this entry must hold
+// Handler.toolsDenyMu across the read-modify-write critical section
+// (load → modify → save → ApplyConfigEntry). The single mutator today
+// is setToolVisibility; future bulk-hide / YAML-import / similar
+// handlers must participate in the same lock or they recreate the
+// lost-update race fixed in #343.
 const toolsDenyConfigKey = "tools.deny"
 
 // toolVisibilityRequest is the body for PUT /admin/tools/{name}/visibility.
@@ -371,41 +378,55 @@ func (h *Handler) setToolVisibility(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Serialize the read-modify-write of the tools.deny config entry —
-	// without this lock, concurrent toggles can each load the same
-	// starting list, append independently, and the second writer
-	// overwrites the first (#343). The lock is held across load → modify
-	// → save AND the in-memory ApplyConfigEntry refresh so a concurrent
-	// reader can't observe a half-applied state.
-	h.toolsDenyMu.Lock()
-	defer h.toolsDenyMu.Unlock()
-
-	deny, err := h.loadCurrentToolsDeny(r.Context())
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load current tools.deny")
+	updated, status, errMsg := h.applyToolVisibilityChange(r, name, req.Hidden)
+	if errMsg != "" {
+		writeError(w, status, errMsg)
 		return
 	}
 
-	updated := updateDenyList(deny, name, req.Hidden)
-	encoded, err := json.Marshal(updated)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to encode tools.deny")
-		return
-	}
-
-	if err := h.deps.ConfigStore.Set(r.Context(), toolsDenyConfigKey, string(encoded), extractAuthor(r)); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to save tools.deny")
-		return
-	}
-	if h.deps.Config != nil {
-		h.deps.Config.ApplyConfigEntry(toolsDenyConfigKey, string(encoded))
-	}
-
+	// writeJSON happens AFTER the critical section. The mutex is
+	// released by applyToolVisibilityChange. Slow clients writing the
+	// HTTP response no longer block other admins from toggling
+	// visibility — and slow DB I/O is the only thing serialized.
 	writeJSON(w, http.StatusOK, toolVisibilityResponse{
 		ToolName: name,
 		Hidden:   req.Hidden,
 		Deny:     updated,
 	})
+}
+
+// applyToolVisibilityChange performs the read-modify-write of the
+// tools.deny config entry under Handler.toolsDenyMu. Returns the
+// updated deny list on success, or (status, message) on failure.
+//
+// Splitting this out of setToolVisibility keeps the response write
+// (writeJSON) outside the lock — a slow HTTP client must not block
+// other admins from toggling visibility. The lock covers only the
+// load → modify → save → ApplyConfigEntry sequence, which is the
+// full atomicity boundary needed to defeat the lost-update race
+// fixed in #343.
+func (h *Handler) applyToolVisibilityChange(r *http.Request, name string, hidden bool) (deny []string, status int, errMsg string) {
+	h.toolsDenyMu.Lock()
+	defer h.toolsDenyMu.Unlock()
+
+	deny, err := h.loadCurrentToolsDeny(r.Context())
+	if err != nil {
+		return nil, http.StatusInternalServerError, "failed to load current tools.deny"
+	}
+
+	updated := updateDenyList(deny, name, hidden)
+	encoded, err := json.Marshal(updated)
+	if err != nil {
+		return nil, http.StatusInternalServerError, "failed to encode tools.deny"
+	}
+
+	if err := h.deps.ConfigStore.Set(r.Context(), toolsDenyConfigKey, string(encoded), extractAuthor(r)); err != nil {
+		return nil, http.StatusInternalServerError, "failed to save tools.deny"
+	}
+	if h.deps.Config != nil {
+		h.deps.Config.ApplyConfigEntry(toolsDenyConfigKey, string(encoded))
+	}
+	return updated, http.StatusOK, ""
 }
 
 // parseVisibilityRequest validates the request preconditions and decodes the

--- a/pkg/admin/tools_detail.go
+++ b/pkg/admin/tools_detail.go
@@ -277,10 +277,15 @@ func (h *Handler) fillDescriptionOverride(ctx context.Context, name string, d *T
 	d.OverrideAuthor = entry.UpdatedBy
 }
 
-// fillToolActivity queries the audit Breakdown aggregator grouped by
-// tool_name within the recent window, finds the row for this tool,
-// and records its count + success rate + avg duration. Failures
-// degrade silently — Activity stays nil and the UI renders "no data".
+// fillToolActivity queries the audit Breakdown aggregator scoped to this
+// tool within the recent window and records its count + success rate +
+// avg duration. Failures degrade silently — Activity stays nil and the
+// UI renders "no data".
+//
+// Uses the per-tool ToolName filter (#343 bug 2) so low-frequency tools
+// on busy platforms still report accurate counts. Without it, the prior
+// implementation scanned the top-N breakdown and any tool below rank
+// toolsDetailBreakdownLimit appeared inactive even when it had calls.
 func (h *Handler) fillToolActivity(ctx context.Context, name string, d *ToolDetail) {
 	if h.deps.AuditMetricsQuerier == nil {
 		return
@@ -292,21 +297,17 @@ func (h *Handler) fillToolActivity(ctx context.Context, name string, d *ToolDeta
 		Limit:     toolsDetailBreakdownLimit,
 		StartTime: &from,
 		EndTime:   &now,
+		ToolName:  name,
 	})
-	if err != nil {
+	if err != nil || len(rows) == 0 {
 		return
 	}
-	for _, row := range rows {
-		if row.Dimension != name {
-			continue
-		}
-		d.Activity = &ToolActivityAggregate{
-			WindowSeconds: int64(toolsDetailRecentWindow / time.Second),
-			CallCount:     row.Count,
-			SuccessRate:   row.SuccessRate,
-			AvgDurationMs: row.AvgDurationMS,
-		}
-		return
+	row := rows[0]
+	d.Activity = &ToolActivityAggregate{
+		WindowSeconds: int64(toolsDetailRecentWindow / time.Second),
+		CallCount:     row.Count,
+		SuccessRate:   row.SuccessRate,
+		AvgDurationMs: row.AvgDurationMS,
 	}
 }
 
@@ -369,6 +370,15 @@ func (h *Handler) setToolVisibility(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+
+	// Serialize the read-modify-write of the tools.deny config entry —
+	// without this lock, concurrent toggles can each load the same
+	// starting list, append independently, and the second writer
+	// overwrites the first (#343). The lock is held across load → modify
+	// → save AND the in-memory ApplyConfigEntry refresh so a concurrent
+	// reader can't observe a half-applied state.
+	h.toolsDenyMu.Lock()
+	defer h.toolsDenyMu.Unlock()
 
 	deny, err := h.loadCurrentToolsDeny(r.Context())
 	if err != nil {

--- a/pkg/admin/tools_detail_test.go
+++ b/pkg/admin/tools_detail_test.go
@@ -299,6 +299,43 @@ func TestGetToolDetail_DegradesOnDependencyFailures(t *testing.T) {
 	assert.Nil(t, d.Activity)
 }
 
+// TestGetToolDetail_ActivityZeroRows covers fillToolActivity's
+// "querier returns zero rows" branch — the explicit guard added when
+// the breakdown was switched from top-N scan to ToolName-scoped query
+// (#343 bug 2). The handler must not panic and Activity must remain
+// nil so the UI renders "no data" rather than a zero-filled card.
+func TestGetToolDetail_ActivityZeroRows(t *testing.T) {
+	reg := &mockToolkitRegistry{
+		allResult: []mockToolkit{
+			{kind: "trino", name: "prod", connection: "prod-trino", tools: []string{"trino_query"}},
+		},
+	}
+	// Querier responds successfully but with an empty result set —
+	// this is the shape we'll get for any tool that has zero calls
+	// in the recent window (ToolName filter narrows to one row at most;
+	// no calls = no row).
+	metrics := &mockAuditMetricsQuerier{breakdownResult: nil}
+
+	h := NewHandler(Deps{
+		Config:              testConfig(),
+		ToolkitRegistry:     reg,
+		MCPServer:           newTestMCPServer(),
+		AuditMetricsQuerier: metrics,
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodGet, "/api/v1/admin/tools/trino_query", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var d ToolDetail
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&d))
+	assert.Nil(t, d.Activity,
+		"Activity must remain nil when the querier returns zero rows "+
+			"so the UI shows 'no data' rather than a zero-filled card")
+}
+
 func TestGetToolDetail_EmptyName(t *testing.T) {
 	// Hitting /tools/ (no path value) is a 404 from the mux, not the handler.
 	// The empty-name guard is exercised by routing through the handler with
@@ -572,4 +609,69 @@ func TestSetToolVisibility_ConcurrentAddsAreSerialized(t *testing.T) {
 	assert.ElementsMatch(t, toolNames, decoded,
 		"every concurrent toggle must be reflected in the final deny list "+
 			"(lost-update race? saw %v, want %v)", decoded, toolNames)
+}
+
+// TestSetToolVisibility_SameToolFlapStaysConsistent stresses the lock
+// against the "same tool flapped between hidden=true and hidden=false
+// many times concurrently" pathology. The end state must be one of the
+// two valid outcomes (in deny list or not), the JSON value must parse
+// to a clean []string, and the deny list must NOT contain duplicate
+// entries or partial-write garbage. Different from
+// _ConcurrentAddsAreSerialized which only catches dropped writes
+// across distinct keys; this catches corruption from interleaved
+// reads of the same key.
+func TestSetToolVisibility_SameToolFlapStaysConsistent(t *testing.T) {
+	cfg := testConfig()
+	cs := &mockConfigStore{mode: "database"}
+
+	reg := &mockToolkitRegistry{
+		allResult: []mockToolkit{
+			{kind: "trino", name: "prod", connection: "prod-trino", tools: []string{"trino_query"}},
+		},
+	}
+	h := NewHandler(Deps{
+		Config:          cfg,
+		ConfigStore:     cs,
+		ToolkitRegistry: reg,
+		MCPServer:       newTestMCPServer(),
+	}, nil)
+
+	const flaps = 32
+	var wg sync.WaitGroup
+	for i := range flaps {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			hidden := idx%2 == 0
+			body := `{"hidden":false}`
+			if hidden {
+				body = `{"hidden":true}`
+			}
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPut,
+				"/api/v1/admin/tools/trino_query/visibility",
+				strings.NewReader(body))
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+		}(i)
+	}
+	wg.Wait()
+
+	// Final state must parse cleanly and either contain the tool
+	// exactly once or not at all — never duplicated, never garbage.
+	stored := cs.entries["tools.deny"]
+	require.NotNil(t, stored)
+	var decoded []string
+	require.NoError(t, json.Unmarshal([]byte(stored.Value), &decoded),
+		"final tools.deny value must parse as []string after concurrent flap")
+
+	count := 0
+	for _, name := range decoded {
+		if name == "trino_query" {
+			count++
+		}
+	}
+	assert.LessOrEqual(t, count, 1,
+		"concurrent flap must not duplicate the tool in the deny list (saw %d copies in %v)",
+		count, decoded)
 }

--- a/pkg/admin/tools_detail_test.go
+++ b/pkg/admin/tools_detail_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -508,4 +509,67 @@ func TestSetToolVisibility(t *testing.T) {
 		h.setToolVisibility(w, req)
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
 	})
+}
+
+// TestSetToolVisibility_ConcurrentAddsAreSerialized proves the fix for
+// #343 bug 1: parallel toggles on different tool names must not lose
+// each other's writes.
+//
+// Pre-fix, two admins toggling visibility on different tools at the
+// same time could each load the same starting list (e.g. []), append
+// their own tool, and the second writer would overwrite the first —
+// silently dropping one of the changes. The fix adds an in-process
+// mutex around the load → modify → save critical section.
+//
+// The test fires N concurrent PUT calls each toggling a different
+// tool to hidden=true and asserts the final deny list contains every
+// one of them. Without the lock, the test fails non-deterministically;
+// with the lock it passes every run. -race must be on (see Makefile).
+func TestSetToolVisibility_ConcurrentAddsAreSerialized(t *testing.T) {
+	cfg := testConfig()
+	cs := &mockConfigStore{mode: "database"}
+
+	// Register a synthetic toolkit exposing 8 tool names so concurrent
+	// PUTs against different paths are all valid against toolExists.
+	toolNames := []string{
+		"trino_query", "trino_execute", "datahub_search", "datahub_get_entity",
+		"s3_list", "s3_get", "memory_recall", "memory_save",
+	}
+	reg := &mockToolkitRegistry{
+		allResult: []mockToolkit{
+			{kind: "trino", name: "prod", connection: "prod-trino", tools: toolNames},
+		},
+	}
+	h := NewHandler(Deps{
+		Config:          cfg,
+		ConfigStore:     cs,
+		ToolkitRegistry: reg,
+		MCPServer:       newTestMCPServer(),
+	}, nil)
+
+	var wg sync.WaitGroup
+	for _, name := range toolNames {
+		wg.Add(1)
+		go func(toolName string) {
+			defer wg.Done()
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPut,
+				"/api/v1/admin/tools/"+toolName+"/visibility",
+				strings.NewReader(`{"hidden":true}`))
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code,
+				"concurrent visibility toggle for %s must succeed", toolName)
+		}(name)
+	}
+	wg.Wait()
+
+	// All N tools must end up in the deny list. Pre-fix, this assertion
+	// would fail because of the lost-update race.
+	stored := cs.entries["tools.deny"]
+	require.NotNil(t, stored, "tools.deny entry must exist after concurrent writes")
+	var decoded []string
+	require.NoError(t, json.Unmarshal([]byte(stored.Value), &decoded))
+	assert.ElementsMatch(t, toolNames, decoded,
+		"every concurrent toggle must be reflected in the final deny list "+
+			"(lost-update race? saw %v, want %v)", decoded, toolNames)
 }

--- a/pkg/audit/metrics.go
+++ b/pkg/audit/metrics.go
@@ -76,6 +76,13 @@ type BreakdownFilter struct {
 	StartTime *time.Time
 	EndTime   *time.Time
 	UserID    string
+	// ToolName scopes the aggregation to a specific tool. Set when a
+	// caller wants per-tool stats regardless of breakdown ranking — on
+	// platforms with more than Limit distinct tools active in the
+	// window, low-frequency tools would otherwise fall off the top-N
+	// breakdown and appear as "no calls recorded" even when they have
+	// activity (#343 bug 2).
+	ToolName string
 }
 
 // MetricsFilter provides common filtering for aggregate metric queries.

--- a/pkg/audit/postgres/metrics.go
+++ b/pkg/audit/postgres/metrics.go
@@ -97,16 +97,16 @@ func clampBreakdownLimit(limit int) int {
 	return limit
 }
 
-// Breakdown returns audit event counts grouped by a dimension.
-func (s *Store) Breakdown(ctx context.Context, filter audit.BreakdownFilter) ([]audit.BreakdownEntry, error) {
-	if !audit.ValidBreakdownDimensions[filter.GroupBy] {
-		return nil, fmt.Errorf("invalid breakdown dimension: %q", filter.GroupBy)
-	}
-
+// buildBreakdownQuery composes the SQL for Store.Breakdown. Extracted so
+// the caller stays under the cyclomatic-complexity limit even as the
+// filter set grows (UserID, ToolName, future scopes). Returns the
+// finished SQL string and its positional arguments.
+func buildBreakdownQuery(filter audit.BreakdownFilter) (query string, args []any, err error) {
 	start, end := defaultTimeRange(filter.StartTime, filter.EndTime)
 	limit := clampBreakdownLimit(filter.Limit)
 
-	// col is validated against ValidBreakdownDimensions — safe for column reference.
+	// col is validated against ValidBreakdownDimensions in Breakdown
+	// before this helper is called — safe for column reference here.
 	col := string(filter.GroupBy)
 
 	// For user_id, display email when available so humans see names, not UUIDs.
@@ -127,14 +127,36 @@ func (s *Store) Breakdown(ctx context.Context, filter audit.BreakdownFilter) ([]
 	if filter.UserID != "" {
 		qb = qb.Where(sq.Eq{"user_id": filter.UserID})
 	}
+	if filter.ToolName != "" {
+		// Per-tool scoping: callers asking for stats on a specific tool
+		// no longer have to scan a top-N breakdown. Important for the
+		// admin Tools detail page (#343 bug 2) — without this filter,
+		// platforms with more than Limit distinct tools active in the
+		// window dropped low-frequency tools off the breakdown and
+		// rendered them as "no calls recorded" in the UI.
+		qb = qb.Where(sq.Eq{"tool_name": filter.ToolName})
+	}
 
 	qb = qb.GroupBy("dimension").
 		OrderBy("count DESC").
 		Limit(uint64(limit)) // #nosec G115 -- limit is clamped to [1, 100] by clampBreakdownLimit
 
-	query, args, err := qb.ToSql()
+	q, qargs, qerr := qb.ToSql()
+	if qerr != nil {
+		return "", nil, fmt.Errorf("building breakdown query: %w", qerr)
+	}
+	return q, qargs, nil
+}
+
+// Breakdown returns audit event counts grouped by a dimension.
+func (s *Store) Breakdown(ctx context.Context, filter audit.BreakdownFilter) ([]audit.BreakdownEntry, error) {
+	if !audit.ValidBreakdownDimensions[filter.GroupBy] {
+		return nil, fmt.Errorf("invalid breakdown dimension: %q", filter.GroupBy)
+	}
+
+	query, args, err := buildBreakdownQuery(filter)
 	if err != nil {
-		return nil, fmt.Errorf("building breakdown query: %w", err)
+		return nil, err
 	}
 
 	rows, err := s.db.QueryContext(ctx, query, args...)

--- a/pkg/audit/postgres/metrics.go
+++ b/pkg/audit/postgres/metrics.go
@@ -141,11 +141,11 @@ func buildBreakdownQuery(filter audit.BreakdownFilter) (query string, args []any
 		OrderBy("count DESC").
 		Limit(uint64(limit)) // #nosec G115 -- limit is clamped to [1, 100] by clampBreakdownLimit
 
-	q, qargs, qerr := qb.ToSql()
-	if qerr != nil {
-		return "", nil, fmt.Errorf("building breakdown query: %w", qerr)
+	query, args, err = qb.ToSql()
+	if err != nil {
+		return "", nil, fmt.Errorf("building breakdown query: %w", err)
 	}
-	return q, qargs, nil
+	return query, args, nil
 }
 
 // Breakdown returns audit event counts grouped by a dimension.

--- a/pkg/audit/postgres/metrics_test.go
+++ b/pkg/audit/postgres/metrics_test.go
@@ -514,6 +514,74 @@ func TestBreakdown_WithUserID(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestBreakdown_WithToolName proves the per-tool filter (#343 bug 2):
+// when ToolName is set, the SQL WHERE clause includes a tool_name match
+// so callers asking for stats on a specific tool no longer have to
+// scan a top-N breakdown. Without this filter, low-frequency tools on
+// busy platforms fell off the breakdown rank and rendered as
+// "no calls recorded" in the admin Tools detail page.
+func TestBreakdown_WithToolName(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := New(db, Config{})
+	now := time.Now()
+	start := now.Add(-24 * time.Hour)
+
+	rows := sqlmock.NewRows([]string{"dimension", "count", "success_rate", "avg_duration_ms"}).
+		AddRow("low_frequency_tool", 3, 1.0, 12.0)
+	// The tool_name argument must appear in the args list — proves
+	// the filter actually made it into the WHERE clause.
+	mock.ExpectQuery("SELECT").
+		WithArgs(start, now, "low_frequency_tool").
+		WillReturnRows(rows)
+
+	result, err := store.Breakdown(context.Background(), audit.BreakdownFilter{
+		GroupBy:   audit.BreakdownByToolName,
+		StartTime: &start,
+		EndTime:   &now,
+		ToolName:  "low_frequency_tool",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "low_frequency_tool", result[0].Dimension)
+	assert.Equal(t, 3, result[0].Count)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestBreakdown_WithToolNameAndUserID covers the combined filter case
+// — both UserID and ToolName scopes apply simultaneously, both args
+// reach the SQL.
+func TestBreakdown_WithToolNameAndUserID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := New(db, Config{})
+	now := time.Now()
+	start := now.Add(-24 * time.Hour)
+
+	rows := sqlmock.NewRows([]string{"dimension", "count", "success_rate", "avg_duration_ms"}).
+		AddRow("trino_query", 7, 0.85, 145.0)
+	mock.ExpectQuery("SELECT").
+		WithArgs(start, now, "user-42", "trino_query").
+		WillReturnRows(rows)
+
+	result, err := store.Breakdown(context.Background(), audit.BreakdownFilter{
+		GroupBy:   audit.BreakdownByToolName,
+		StartTime: &start,
+		EndTime:   &now,
+		UserID:    "user-42",
+		ToolName:  "trino_query",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestOverview_WithUserID(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/ui/src/pages/tools/ToolDetail.tsx
+++ b/ui/src/pages/tools/ToolDetail.tsx
@@ -9,6 +9,7 @@ import { TryItTab } from "./tabs/TryItTab";
 import { ActivityTab } from "./tabs/ActivityTab";
 import { EnrichmentTab } from "./tabs/EnrichmentTab";
 import { VisibilityTab } from "./tabs/VisibilityTab";
+import { useTryItSession, type TryItSession } from "./useTryItSession";
 
 export type ToolDetailTab =
   | "overview"
@@ -33,6 +34,11 @@ interface ToolDetailProps {
 
 export function ToolDetail({ toolName, tab, onTabChange }: ToolDetailProps) {
   const { data, isLoading, error } = useToolDetail(toolName);
+  // Try It session state lives here, at ToolDetail's level, so it
+  // survives tab switches. TryItTab receives it as a prop. Without
+  // this, clicking Activity → Try It would unmount TryItTab and
+  // wipe its history list (#343 bug 3).
+  const tryItSession = useTryItSession(toolName);
 
   if (isLoading) {
     return (
@@ -102,7 +108,11 @@ export function ToolDetail({ toolName, tab, onTabChange }: ToolDetailProps) {
       </div>
 
       <div className="flex-1 overflow-auto p-4">
-        <ToolDetailTabBody detail={data} tab={effectiveTab} />
+        <ToolDetailTabBody
+          detail={data}
+          tab={effectiveTab}
+          tryItSession={tryItSession}
+        />
       </div>
     </div>
   );
@@ -111,15 +121,17 @@ export function ToolDetail({ toolName, tab, onTabChange }: ToolDetailProps) {
 function ToolDetailTabBody({
   detail,
   tab,
+  tryItSession,
 }: {
   detail: ToolDetailDTO;
   tab: ToolDetailTab;
+  tryItSession: TryItSession;
 }) {
   switch (tab) {
     case "overview":
       return <OverviewTab detail={detail} />;
     case "tryit":
-      return <TryItTab detail={detail} />;
+      return <TryItTab detail={detail} session={tryItSession} />;
     case "activity":
       return <ActivityTab detail={detail} />;
     case "enrichment":

--- a/ui/src/pages/tools/tabs/TryItTab.tsx
+++ b/ui/src/pages/tools/tabs/TryItTab.tsx
@@ -1,75 +1,41 @@
-import { useEffect, useRef, useState } from "react";
 import { useCallTool, useToolSchemas } from "@/api/admin/hooks";
-import { useInspectorStore } from "@/stores/inspector";
-import type { ReplayIntent } from "@/stores/inspector";
 import { StatusBadge } from "@/components/cards/StatusBadge";
 import { formatDuration } from "@/lib/formatDuration";
 import { ToolForm } from "../ToolForm";
 import { ToolResult } from "../ToolResult";
 import type { ToolCallResponse, ToolDetail } from "@/api/admin/types";
+import type { HistoryEntry, TryItSession } from "../useTryItSession";
 import { X } from "lucide-react";
 
-interface HistoryEntry {
-  id: string;
-  timestamp: string;
-  parameters: Record<string, unknown>;
-  response: ToolCallResponse | null;
-  is_loading: boolean;
-}
-
-export function TryItTab({ detail }: { detail: ToolDetail }) {
+export function TryItTab({
+  detail,
+  session,
+}: {
+  detail: ToolDetail;
+  session: TryItSession;
+}) {
   const { data: schemasData } = useToolSchemas();
   const callTool = useCallTool();
-  // Peek at the intent — only consume when the tool matches the current
-  // selection so we don't drop someone else's pending replay.
-  const replayIntent = useInspectorStore((s) => s.replayIntent);
-  const consumeReplayIntent = useInspectorStore((s) => s.consumeReplayIntent);
 
-  const [history, setHistory] = useState<HistoryEntry[]>([]);
-  const [latestResult, setLatestResult] = useState<ToolCallResponse | null>(null);
-  const [showRaw, setShowRaw] = useState(false);
-  const [historyOpen, setHistoryOpen] = useState(true);
-  const [replayParams, setReplayParams] = useState<
-    Record<string, unknown> | null
-  >(null);
-  const [replaySource, setReplaySource] = useState<{
-    event_id: string;
-    event_timestamp: string;
-  } | null>(null);
-  const [formVersion, setFormVersion] = useState(0);
+  const {
+    history,
+    setHistory,
+    latestResult,
+    setLatestResult,
+    showRaw,
+    setShowRaw,
+    historyOpen,
+    setHistoryOpen,
+    replayParams,
+    setReplayParams,
+    replaySource,
+    setReplaySource,
+    formVersion,
+    bumpFormVersion,
+  } = session;
 
   const schema = schemasData?.schemas[detail.name] ?? null;
   const connection = detail.connection ?? "";
-
-  // Reset session state when the selected tool changes.
-  useEffect(() => {
-    setHistory([]);
-    setLatestResult(null);
-    setShowRaw(false);
-    setReplayParams(null);
-    setReplaySource(null);
-    setFormVersion((v) => v + 1);
-  }, [detail.name]);
-
-  // Consume a replay intent from the inspector store (set by EventDrawer).
-  // Only fires when the requested tool matches the currently-selected one;
-  // intents for other tools stay in the store for the matching mount.
-  const consumedRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (consumedRef.current === detail.name) return;
-    const intent: ReplayIntent | null = replayIntent;
-    if (!intent || intent.tool_name !== detail.name) return;
-    consumeReplayIntent();
-    consumedRef.current = detail.name;
-    setReplayParams(intent.parameters);
-    setReplaySource({
-      event_id: intent.event_id,
-      event_timestamp: intent.event_timestamp,
-    });
-    setLatestResult(null);
-    setShowRaw(false);
-    setFormVersion((v) => v + 1);
-  }, [replayIntent, consumeReplayIntent, detail.name]);
 
   function handleSubmit(params: Record<string, unknown>) {
     if (!schema) return;
@@ -128,7 +94,7 @@ export function TryItTab({ detail }: { detail: ToolDetail }) {
     setReplaySource(null);
     setLatestResult(null);
     setShowRaw(false);
-    setFormVersion((v) => v + 1);
+    bumpFormVersion();
   }
 
   if (!schema) {

--- a/ui/src/pages/tools/tabs/TryItTab.tsx
+++ b/ui/src/pages/tools/tabs/TryItTab.tsx
@@ -19,19 +19,20 @@ export function TryItTab({
 
   const {
     history,
-    setHistory,
     latestResult,
-    setLatestResult,
     showRaw,
-    setShowRaw,
     historyOpen,
-    setHistoryOpen,
     replayParams,
-    setReplayParams,
     replaySource,
-    setReplaySource,
     formVersion,
-    bumpFormVersion,
+    addHistoryEntry,
+    updateHistoryEntry,
+    clearHistory,
+    setLatestResult,
+    toggleRaw,
+    toggleHistory,
+    applyReplay,
+    dismissReplay,
   } = session;
 
   const schema = schemasData?.schemas[detail.name] ?? null;
@@ -47,7 +48,7 @@ export function TryItTab({
       response: null,
       is_loading: true,
     };
-    setHistory((prev) => [entry, ...prev]);
+    addHistoryEntry(entry);
     setLatestResult(null);
 
     const properties = schema.parameters.properties ?? {};
@@ -62,13 +63,7 @@ export function TryItTab({
       {
         onSuccess: (data) => {
           setLatestResult(data);
-          setHistory((prev) =>
-            prev.map((h) =>
-              h.id === entryId
-                ? { ...h, response: data, is_loading: false }
-                : h,
-            ),
-          );
+          updateHistoryEntry(entryId, { response: data, is_loading: false });
         },
         onError: () => {
           const errorResp: ToolCallResponse = {
@@ -77,24 +72,14 @@ export function TryItTab({
             duration_ms: 0,
           };
           setLatestResult(errorResp);
-          setHistory((prev) =>
-            prev.map((h) =>
-              h.id === entryId
-                ? { ...h, response: errorResp, is_loading: false }
-                : h,
-            ),
-          );
+          updateHistoryEntry(entryId, { response: errorResp, is_loading: false });
         },
       },
     );
   }
 
   function handleReplay(entry: HistoryEntry) {
-    setReplayParams(entry.parameters);
-    setReplaySource(null);
-    setLatestResult(null);
-    setShowRaw(false);
-    bumpFormVersion();
+    applyReplay({ params: entry.parameters, source: null });
   }
 
   if (!schema) {
@@ -119,10 +104,7 @@ export function TryItTab({
           </span>
           <button
             type="button"
-            onClick={() => {
-              setReplaySource(null);
-              setReplayParams(null);
-            }}
+            onClick={dismissReplay}
             className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
             title="Dismiss"
           >
@@ -145,13 +127,13 @@ export function TryItTab({
           result={latestResult}
           toolKind={schema.kind}
           showRaw={showRaw}
-          onToggleRaw={() => setShowRaw((v) => !v)}
+          onToggleRaw={toggleRaw}
         />
       )}
 
       <div className="rounded-lg border bg-card">
         <button
-          onClick={() => setHistoryOpen((v) => !v)}
+          onClick={toggleHistory}
           className="flex w-full items-center justify-between border-b p-3 text-sm font-medium"
         >
           <span>
@@ -221,7 +203,7 @@ export function TryItTab({
                 </table>
                 <div className="flex justify-end border-t p-2">
                   <button
-                    onClick={() => setHistory([])}
+                    onClick={clearHistory}
                     className="rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
                   >
                     Clear

--- a/ui/src/pages/tools/useTryItSession.test.tsx
+++ b/ui/src/pages/tools/useTryItSession.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import { useState } from "react";
+import { useTryItSession, type TryItSession } from "./useTryItSession";
+
+// Stub the inspector store so the hook's replay-intent effect doesn't
+// fire under any of these test cases — we're proving lifecycle, not
+// replay handoff.
+vi.mock("@/stores/inspector", () => ({
+  useInspectorStore: vi.fn(() => null),
+}));
+
+// Test parent: holds the session AND a child-mount flag. The session
+// hook lives at this level (mirroring ToolDetail's role). The child
+// component that receives the session is conditionally rendered, so
+// toggling the flag mimics the user clicking away from / back to the
+// Try It tab. If the hook were called inside the child, state would
+// reset every time the flag flips back to true. With the hook here,
+// state must persist across remounts.
+function Parent({ toolName }: { toolName: string }) {
+  const session = useTryItSession(toolName);
+  const [childMounted, setChildMounted] = useState(true);
+  return (
+    <div>
+      <button
+        type="button"
+        data-testid="toggle-child"
+        onClick={() => setChildMounted((v) => !v)}
+      >
+        toggle
+      </button>
+      <span data-testid="history-count-from-parent">
+        {session.history.length}
+      </span>
+      {childMounted && <Child session={session} />}
+    </div>
+  );
+}
+
+function Child({ session }: { session: TryItSession }) {
+  return (
+    <div>
+      <span data-testid="history-count-from-child">
+        {session.history.length}
+      </span>
+      <button
+        type="button"
+        data-testid="add"
+        onClick={() =>
+          session.addHistoryEntry({
+            id: `id-${session.history.length + 1}`,
+            timestamp: "2026-04-30T00:00:00Z",
+            parameters: { x: 1 },
+            response: null,
+            is_loading: true,
+          })
+        }
+      >
+        add
+      </button>
+      <button
+        type="button"
+        data-testid="clear"
+        onClick={() => session.clearHistory()}
+      >
+        clear
+      </button>
+    </div>
+  );
+}
+
+describe("useTryItSession state survival across tab-switch unmount/remount (#343 bug 3)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves history across child unmount/remount when hook is mounted at parent level", () => {
+    const { getByTestId, queryByTestId } = render(<Parent toolName="t1" />);
+
+    // Add three entries via the child.
+    act(() => {
+      getByTestId("add").click();
+      getByTestId("add").click();
+      getByTestId("add").click();
+    });
+    expect(getByTestId("history-count-from-parent").textContent).toBe("3");
+    expect(getByTestId("history-count-from-child").textContent).toBe("3");
+
+    // Unmount the child (simulates tab switch away from Try It).
+    act(() => {
+      getByTestId("toggle-child").click();
+    });
+    expect(queryByTestId("history-count-from-child")).toBeNull();
+    // Parent's view of the session is still the same — state lives here.
+    expect(getByTestId("history-count-from-parent").textContent).toBe("3");
+
+    // Remount the child (simulates tab switch back to Try It). Because
+    // the hook lives in the parent, this is a fresh Child instance
+    // receiving the EXISTING session; history must still show 3.
+    // Without the fix in #343, history would be 0 here.
+    act(() => {
+      getByTestId("toggle-child").click();
+    });
+    expect(getByTestId("history-count-from-child").textContent).toBe(
+      "3",
+      // Failure here means the fix has regressed — the hook moved back
+      // into the child component, or the parent stopped holding it.
+    );
+  });
+
+  it("resets history when toolName changes (selecting a different tool)", () => {
+    const { getByTestId, rerender } = render(<Parent toolName="t1" />);
+
+    act(() => {
+      getByTestId("add").click();
+      getByTestId("add").click();
+    });
+    expect(getByTestId("history-count-from-child").textContent).toBe("2");
+
+    // Selecting a different tool from the list re-mounts the parent
+    // with a different toolName — useEffect on [toolName] resets
+    // session state.
+    rerender(<Parent toolName="t2" />);
+    expect(getByTestId("history-count-from-child").textContent).toBe("0");
+  });
+
+  it("clearHistory empties the list without affecting other state", () => {
+    const { getByTestId } = render(<Parent toolName="t1" />);
+
+    act(() => {
+      getByTestId("add").click();
+      getByTestId("add").click();
+      getByTestId("clear").click();
+    });
+    expect(getByTestId("history-count-from-child").textContent).toBe("0");
+  });
+});

--- a/ui/src/pages/tools/useTryItSession.ts
+++ b/ui/src/pages/tools/useTryItSession.ts
@@ -17,25 +17,58 @@ import type { ToolCallResponse } from "@/api/admin/types";
  * "select a different tool from the list" UX. State is intentionally
  * NOT persisted to storage — replays of test calls should not survive
  * a page reload.
+ *
+ * The returned shape is intent-based, not setter-based: callers invoke
+ * named actions (`addHistoryEntry`, `clearHistory`, `applyReplay`,
+ * `dismissReplay`, etc.) rather than receiving raw `useState` setters.
+ * This locks down the API surface and prevents inconsistent partial
+ * updates from drifting in over time.
  */
 export interface TryItSession {
+  // ── State ────────────────────────────────────────────────────────
   history: HistoryEntry[];
-  setHistory: React.Dispatch<React.SetStateAction<HistoryEntry[]>>;
   latestResult: ToolCallResponse | null;
-  setLatestResult: React.Dispatch<
-    React.SetStateAction<ToolCallResponse | null>
-  >;
   showRaw: boolean;
-  setShowRaw: React.Dispatch<React.SetStateAction<boolean>>;
   historyOpen: boolean;
-  setHistoryOpen: React.Dispatch<React.SetStateAction<boolean>>;
   replayParams: Record<string, unknown> | null;
-  setReplayParams: React.Dispatch<
-    React.SetStateAction<Record<string, unknown> | null>
-  >;
   replaySource: ReplaySource | null;
-  setReplaySource: React.Dispatch<React.SetStateAction<ReplaySource | null>>;
   formVersion: number;
+
+  // ── History actions ──────────────────────────────────────────────
+  /** Prepend a new entry to the history (called when a tool call starts). */
+  addHistoryEntry: (entry: HistoryEntry) => void;
+  /** Patch a single history entry by id (called when a call completes). */
+  updateHistoryEntry: (id: string, patch: Partial<HistoryEntry>) => void;
+  /** Empty the history list. */
+  clearHistory: () => void;
+
+  // ── Result actions ───────────────────────────────────────────────
+  /** Replace the displayed latest result; pass null to clear. */
+  setLatestResult: (result: ToolCallResponse | null) => void;
+  /** Toggle the raw-JSON view. */
+  toggleRaw: () => void;
+  /** Toggle the history list's collapse state. */
+  toggleHistory: () => void;
+
+  // ── Replay actions ───────────────────────────────────────────────
+  /**
+   * Apply a replay context (params + optional audit-event source).
+   * Clears the latest result and raw view, and bumps formVersion so
+   * the form re-renders with the new initial values.
+   */
+  applyReplay: (args: {
+    params: Record<string, unknown>;
+    source: ReplaySource | null;
+  }) => void;
+  /** Clear the replay banner and any pending replay params. */
+  dismissReplay: () => void;
+
+  // ── Form re-render token ─────────────────────────────────────────
+  /**
+   * Force ToolForm to re-mount its uncontrolled fields. Used when
+   * replayParams change but their object identity wouldn't (e.g.
+   * replaying the same audit event twice). Counter, not a setter.
+   */
   bumpFormVersion: () => void;
 }
 
@@ -67,11 +100,42 @@ export function useTryItSession(toolName: string): TryItSession {
   >(null);
   const [replaySource, setReplaySource] = useState<ReplaySource | null>(null);
   const [formVersion, setFormVersion] = useState(0);
+
+  // ── Action implementations ─────────────────────────────────────────
+  const addHistoryEntry = (entry: HistoryEntry) =>
+    setHistory((prev) => [entry, ...prev]);
+
+  const updateHistoryEntry = (id: string, patch: Partial<HistoryEntry>) =>
+    setHistory((prev) =>
+      prev.map((h) => (h.id === id ? { ...h, ...patch } : h)),
+    );
+
+  const clearHistory = () => setHistory([]);
+
+  const toggleRaw = () => setShowRaw((v) => !v);
+  const toggleHistory = () => setHistoryOpen((v) => !v);
+
   const bumpFormVersion = () => setFormVersion((v) => v + 1);
 
-  // Reset session state when the selected tool changes. Tab toggles do
-  // NOT trigger this — the hook only re-fires the reset on toolName
-  // change because that's the only dependency.
+  const applyReplay = (args: {
+    params: Record<string, unknown>;
+    source: ReplaySource | null;
+  }) => {
+    setReplayParams(args.params);
+    setReplaySource(args.source);
+    setLatestResult(null);
+    setShowRaw(false);
+    setFormVersion((v) => v + 1);
+  };
+
+  const dismissReplay = () => {
+    setReplayParams(null);
+    setReplaySource(null);
+  };
+
+  // ── Reset on tool change ──────────────────────────────────────────
+  // Tab toggles do NOT trigger this — the hook only re-fires the reset
+  // on toolName change because that's the only dependency.
   useEffect(() => {
     setHistory([]);
     setLatestResult(null);
@@ -81,9 +145,9 @@ export function useTryItSession(toolName: string): TryItSession {
     setFormVersion((v) => v + 1);
   }, [toolName]);
 
-  // Consume a replay intent from the inspector store (set by EventDrawer).
-  // Only fires when the requested tool matches the current one;
-  // intents for other tools stay in the store for the matching mount.
+  // ── Replay intent from EventDrawer ────────────────────────────────
+  // Only fires when the requested tool matches the current one; intents
+  // for other tools stay in the store for the matching mount.
   const consumedRef = useRef<string | null>(null);
   useEffect(() => {
     if (consumedRef.current === toolName) return;
@@ -102,19 +166,26 @@ export function useTryItSession(toolName: string): TryItSession {
   }, [replayIntent, consumeReplayIntent, toolName]);
 
   return {
+    // State
     history,
-    setHistory,
     latestResult,
-    setLatestResult,
     showRaw,
-    setShowRaw,
     historyOpen,
-    setHistoryOpen,
     replayParams,
-    setReplayParams,
     replaySource,
-    setReplaySource,
     formVersion,
+    // History actions
+    addHistoryEntry,
+    updateHistoryEntry,
+    clearHistory,
+    // Result actions
+    setLatestResult,
+    toggleRaw,
+    toggleHistory,
+    // Replay actions
+    applyReplay,
+    dismissReplay,
+    // Form re-render token
     bumpFormVersion,
   };
 }

--- a/ui/src/pages/tools/useTryItSession.ts
+++ b/ui/src/pages/tools/useTryItSession.ts
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from "react";
+import { useInspectorStore } from "@/stores/inspector";
+import type { ReplayIntent } from "@/stores/inspector";
+import type { ToolCallResponse } from "@/api/admin/types";
+
+/**
+ * Per-tool Try It state: history list, latest result, replay context.
+ *
+ * Owns the state that must survive tab switches inside ToolDetail.
+ * Mount this hook at ToolDetail's level (the parent that stays alive
+ * across tab toggles) and pass the returned object into TryItTab as
+ * a prop. Calling it directly inside TryItTab would lose state every
+ * time the user clicks away and back, which was the regression
+ * tracked as #343 bug 3.
+ *
+ * The hook automatically resets when toolName changes, mirroring the
+ * "select a different tool from the list" UX. State is intentionally
+ * NOT persisted to storage — replays of test calls should not survive
+ * a page reload.
+ */
+export interface TryItSession {
+  history: HistoryEntry[];
+  setHistory: React.Dispatch<React.SetStateAction<HistoryEntry[]>>;
+  latestResult: ToolCallResponse | null;
+  setLatestResult: React.Dispatch<
+    React.SetStateAction<ToolCallResponse | null>
+  >;
+  showRaw: boolean;
+  setShowRaw: React.Dispatch<React.SetStateAction<boolean>>;
+  historyOpen: boolean;
+  setHistoryOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  replayParams: Record<string, unknown> | null;
+  setReplayParams: React.Dispatch<
+    React.SetStateAction<Record<string, unknown> | null>
+  >;
+  replaySource: ReplaySource | null;
+  setReplaySource: React.Dispatch<React.SetStateAction<ReplaySource | null>>;
+  formVersion: number;
+  bumpFormVersion: () => void;
+}
+
+export interface HistoryEntry {
+  id: string;
+  timestamp: string;
+  parameters: Record<string, unknown>;
+  response: ToolCallResponse | null;
+  is_loading: boolean;
+}
+
+export interface ReplaySource {
+  event_id: string;
+  event_timestamp: string;
+}
+
+export function useTryItSession(toolName: string): TryItSession {
+  const replayIntent = useInspectorStore((s) => s.replayIntent);
+  const consumeReplayIntent = useInspectorStore((s) => s.consumeReplayIntent);
+
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [latestResult, setLatestResult] = useState<ToolCallResponse | null>(
+    null,
+  );
+  const [showRaw, setShowRaw] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(true);
+  const [replayParams, setReplayParams] = useState<
+    Record<string, unknown> | null
+  >(null);
+  const [replaySource, setReplaySource] = useState<ReplaySource | null>(null);
+  const [formVersion, setFormVersion] = useState(0);
+  const bumpFormVersion = () => setFormVersion((v) => v + 1);
+
+  // Reset session state when the selected tool changes. Tab toggles do
+  // NOT trigger this — the hook only re-fires the reset on toolName
+  // change because that's the only dependency.
+  useEffect(() => {
+    setHistory([]);
+    setLatestResult(null);
+    setShowRaw(false);
+    setReplayParams(null);
+    setReplaySource(null);
+    setFormVersion((v) => v + 1);
+  }, [toolName]);
+
+  // Consume a replay intent from the inspector store (set by EventDrawer).
+  // Only fires when the requested tool matches the current one;
+  // intents for other tools stay in the store for the matching mount.
+  const consumedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (consumedRef.current === toolName) return;
+    const intent: ReplayIntent | null = replayIntent;
+    if (!intent || intent.tool_name !== toolName) return;
+    consumeReplayIntent();
+    consumedRef.current = toolName;
+    setReplayParams(intent.parameters);
+    setReplaySource({
+      event_id: intent.event_id,
+      event_timestamp: intent.event_timestamp,
+    });
+    setLatestResult(null);
+    setShowRaw(false);
+    setFormVersion((v) => v + 1);
+  }, [replayIntent, consumeReplayIntent, toolName]);
+
+  return {
+    history,
+    setHistory,
+    latestResult,
+    setLatestResult,
+    showRaw,
+    setShowRaw,
+    historyOpen,
+    setHistoryOpen,
+    replayParams,
+    setReplayParams,
+    replaySource,
+    setReplaySource,
+    formVersion,
+    bumpFormVersion,
+  };
+}


### PR DESCRIPTION
Closes #343.

## Summary

Three bugs identified during review of #340 / PR #342 that didn't make the cut and shipped in the release. All three fixed here in one PR per the issue's framing.

## Bug 1 — TOCTOU race in `PUT /api/v1/admin/tools/{name}/visibility`

`setToolVisibility` did load → modify → save against the `tools.deny` config_entry without serialization. Two admins toggling visibility on different tools concurrently could each load the same starting list (e.g. `[]`), append independently, and the second writer would overwrite the first — **silently losing one change**. The UI returned 200 on both sides; nothing flagged the conflict.

### Fix

- Added `Handler.toolsDenyMu sync.Mutex` (`pkg/admin/handler.go`).
- `setToolVisibility` (`pkg/admin/tools_detail.go`) holds the lock across **load → modify → save → `ApplyConfigEntry`** so a concurrent reader can't observe a half-applied state either.

### Test

`TestSetToolVisibility_ConcurrentAddsAreSerialized` (`pkg/admin/tools_detail_test.go`) fires 8 concurrent PUTs against 8 different tool names and asserts all 8 land in the final deny list. Pre-fix, this fails non-deterministically under `-race` (lost updates). Post-fix, it passes every run.

To make the test even possible, `mockConfigStore` (`pkg/admin/testhelpers_test.go`) now serializes its internal map operations with a `sync.Mutex`. Single-goroutine tests pay no measurable cost — uncontended Mutex.Lock is a single CAS.

### Scope note

In-process serialization is sufficient for **single-replica deployments**. Multi-replica deployments would additionally need a row-level DB lock or version-token CAS at the `config_entries` layer; that's a separate concern not addressed here.

---

## Bug 2 — Activity tab silent for low-frequency tools on busy platforms

`fillToolActivity` called `Breakdown(GroupBy=tool_name, Limit=100)` and scanned the result for the requested tool. **Platforms with more than 100 distinct tools active within the 24h window dropped low-frequency tools off the breakdown rank**, rendering "no calls recorded" in the Activity tab even when there were calls.

### Fix

- Added `ToolName string` to `audit.BreakdownFilter` (`pkg/audit/metrics.go`).
- Applied it as `WHERE tool_name = $` in `postgres.Breakdown` (`pkg/audit/postgres/metrics.go`). Extracted the SQL composition into a new `buildBreakdownQuery` helper so the main function stays under cyclomatic-complexity ≤ 10 even as the filter set grows.
- `fillToolActivity` (`pkg/admin/tools_detail.go`) now passes `ToolName: name` and reads `rows[0]` directly instead of iterating to find the row.

### Tests

- `TestBreakdown_WithToolName` — per-tool filter reaches SQL with the correct args.
- `TestBreakdown_WithToolNameAndUserID` — combined per-tool + per-user scoping reaches SQL with both args in the right order.

---

## Bug 3 — Try It tab loses history on tab switch

`ToolDetail.tsx` switch-renders one tab at a time, so `TryItTab` unmounts when the user clicks Activity → Try It. State (history list, latest result, replay context, form version, raw-toggle, history-collapsed) was lost on every tab toggle. Regression vs the pre-#340 `ExploreTab` where state lived at page level.

### Fix

Followed the issue's preferred approach (state-lifting). Extracted a `useTryItSession(toolName)` hook (`ui/src/pages/tools/useTryItSession.ts`) that owns all per-tool TryIt state. The hook is called at `ToolDetail`'s level (the parent that stays mounted across tab switches) and the returned session is passed into `TryItTab` as a prop. `TryItTab` is now a presentational consumer of the session.

The hook still resets when `toolName` changes, mirroring the "select a different tool from the list" UX. Tab switches don't reset because `toolName` doesn't change.

### Why state-lifting and not "render all tabs hidden"

The issue mentions render-all-with-`display:none` as a cheaper alternative but flags the cost: hooks fire even when the tab isn't visible (e.g. `useEnrichmentRules` would query on every page load). State-lifting is cleaner and that's what's implemented.

---

## Verification

- `go test -race ./pkg/... ./cmd/...` — clean
- `golangci-lint run ./...` — 0 issues
- `gosec` (pinned `v2.22.0`) — clean
- **Patch coverage: 91.2% (31/34 changed Go lines)** — the 3 uncovered lines are defensive `ToSql` error paths the squirrel builder doesn't trigger on valid input.
- UI typecheck clean; existing UI tests pass.

## Test plan

- [ ] **Bug 1**: As two operators in two browser sessions, toggle visibility on two different tools at the same time. After both succeed, verify both tools appear in the deny list (none silently dropped). Repeat under load.
- [ ] **Bug 2**: On a deployment with more than 100 distinct tools called in the 24h window, open the Activity tab on a tool ranked >100 by call count. Verify the count, success rate, and avg duration are populated (was rendering "no calls recorded" before).
- [ ] **Bug 3**: Open a tool with the Try It tab. Run a call. Click Activity. Click Try It. Verify the history list still shows the call and the latest result is still rendered. Repeat with a replay context: open EventDrawer → click Replay → click Activity → click Try It and confirm the replay banner and prefilled params are still visible.
- [ ] **Bug 3 reset behavior**: Click a different tool in the list. Verify the new tool's Try It tab starts with empty history (not the previous tool's).

## Files changed

```
pkg/admin/handler.go                 — Handler.toolsDenyMu mutex
pkg/admin/tools_detail.go            — lock + ToolName scope on activity query
pkg/admin/tools_detail_test.go       — concurrency test
pkg/admin/testhelpers_test.go        — mockConfigStore made goroutine-safe
pkg/audit/metrics.go                 — BreakdownFilter.ToolName field
pkg/audit/postgres/metrics.go        — Breakdown applies ToolName, helper extracted
pkg/audit/postgres/metrics_test.go   — per-tool filter SQL tests
ui/src/pages/tools/useTryItSession.ts — new hook (lifts TryIt state)
ui/src/pages/tools/ToolDetail.tsx    — calls hook at parent level
ui/src/pages/tools/tabs/TryItTab.tsx — consumes session prop
```