### PR TITLE
fix(ui): raise minimum font size to 12px across admin surface

### DIFF
--- a/ui/e2e/screenshots/route-manifest.ts
+++ b/ui/e2e/screenshots/route-manifest.ts
@@ -155,21 +155,13 @@ export const routes: ScreenshotRoute[] = [
     category: "admin",
     tabs: ["overview", "knowledge", "memory", "changesets"],
   },
-  // NOTE: admin-description and admin-agent-instructions are excluded because
-  // the MarkdownEditor (CodeMirror) crashes in headless mode due to duplicate
-  // @codemirror/state instances. Re-enable once the portal fixes this.
-  // {
-  //   slug: "admin-description",
-  //   path: "/portal/admin/description",
-  //   category: "admin",
-  //   waitFor: ".cm-editor",
-  // },
-  // {
-  //   slug: "admin-agent-instructions",
-  //   path: "/portal/admin/agent-instructions",
-  //   category: "admin",
-  //   waitFor: ".cm-editor",
-  // },
+  // admin-description and admin-agent-instructions are intentionally
+  // excluded from screenshot capture (see excludedRoutes below) — the
+  // MarkdownEditor (CodeMirror) crashes in headless mode due to
+  // duplicate @codemirror/state instances. Re-enable once the portal
+  // fixes this. The excludedRoutes registration below is what keeps
+  // the route-sync test green: it documents the gap as intentional
+  // rather than masking it as a missing manifest entry.
   {
     slug: "admin-connections",
     path: "/portal/admin/connections",
@@ -213,3 +205,18 @@ export const routes: ScreenshotRoute[] = [
     category: "admin",
   },
 ];
+
+/**
+ * Routes intentionally NOT captured in screenshot runs. Documented
+ * here so the route-sync test can distinguish "missing manifest entry
+ * (bug)" from "deliberately excluded (known infra constraint)."
+ *
+ * Each entry MUST include the AppShell pageTitles key (without the
+ * /portal prefix) and a reason. When re-enabling a route, remove its
+ * key from this set AND add a normal entry to `routes` above.
+ */
+export const excludedRoutes: ReadonlySet<string> = new Set([
+  // CodeMirror crash in headless mode (duplicate @codemirror/state instances).
+  "/admin/description",
+  "/admin/agent-instructions",
+]);

--- a/ui/e2e/screenshots/route-sync.test.ts
+++ b/ui/e2e/screenshots/route-sync.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import fs from "fs";
 import path from "path";
-import { routes } from "./route-manifest";
+import { routes, excludedRoutes } from "./route-manifest";
 
 describe("route manifest sync", () => {
   it("covers all pageTitles routes from AppShell", () => {
@@ -30,14 +30,19 @@ describe("route manifest sync", () => {
 
     const missing: string[] = [];
     for (const key of routeKeys) {
-      if (!manifestPaths.has(key)) {
+      // A route is "covered" if it's either in the live manifest OR
+      // explicitly in the excludedRoutes set (with a documented reason).
+      // The exclusion list lets us track known infra constraints
+      // (e.g. CodeMirror's headless-mode crash) without losing the
+      // bug-detection power of this test for accidental gaps.
+      if (!manifestPaths.has(key) && !excludedRoutes.has(key)) {
         missing.push(key);
       }
     }
 
     expect(
       missing,
-      `Routes in AppShell pageTitles missing from screenshot manifest: ${missing.join(", ")}. Add entries to route-manifest.ts.`,
+      `Routes in AppShell pageTitles missing from screenshot manifest: ${missing.join(", ")}. Add entries to route-manifest.ts (or to excludedRoutes if intentionally not captured).`,
     ).toEqual([]);
   });
 

--- a/ui/src/components/ShareDialog.tsx
+++ b/ui/src/components/ShareDialog.tsx
@@ -215,7 +215,7 @@ export function ShareDialog({ assetId, target, open, onOpenChange }: Props) {
                       {share.shared_with_user_id || share.shared_with_email ? (
                         <span className="text-muted-foreground">
                           User: {share.shared_with_email || share.shared_with_user_id}
-                          <span className={`ml-1.5 text-[10px] px-1.5 py-0.5 rounded-full font-medium ${share.permission === "editor" ? "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300" : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"}`}>
+                          <span className={`ml-1.5 text-xs px-1.5 py-0.5 rounded-full font-medium ${share.permission === "editor" ? "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300" : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"}`}>
                             {share.permission === "editor" ? "Editor" : "Viewer"}
                           </span>
                         </span>

--- a/ui/src/components/VersionHistoryPanel.tsx
+++ b/ui/src/components/VersionHistoryPanel.tsx
@@ -62,7 +62,7 @@ export function VersionHistoryPanel({
               <span className="font-medium">
                 v{v.version}
                 {v.version === currentVersion && (
-                  <span className="ml-1.5 text-[10px] text-primary font-normal">(current)</span>
+                  <span className="ml-1.5 text-xs text-primary font-normal">(current)</span>
                 )}
               </span>
               <span className="text-muted-foreground">

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -153,7 +153,7 @@ export function Sidebar({ currentPath, onNavigate, collapsed, onToggleCollapse, 
 
       <nav className="flex-1 space-y-1 overflow-auto p-2">
         {!effectiveCollapsed && (
-          <p className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          <p className="px-3 py-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             User
           </p>
         )}
@@ -180,7 +180,7 @@ export function Sidebar({ currentPath, onNavigate, collapsed, onToggleCollapse, 
           <>
             <div className="my-2 border-t" />
             {!effectiveCollapsed && (
-              <p className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              <p className="px-3 py-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                 Admin
               </p>
             )}

--- a/ui/src/pages/assets/MyAssetsPage.tsx
+++ b/ui/src/pages/assets/MyAssetsPage.tsx
@@ -181,14 +181,14 @@ export function MyAssetsPage({ onNavigate }: Props) {
                   )}
                   <div className="flex flex-wrap gap-1.5 mb-2">
                     <span
-                      className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${contentTypeBadgeColor(asset.content_type)}`}
+                      className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${contentTypeBadgeColor(asset.content_type)}`}
                     >
                       {asset.content_type}
                     </span>
                     {asset.tags.slice(0, 3).map((t) => (
                       <span
                         key={t}
-                        className="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground"
+                        className="text-xs px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground"
                       >
                         {t}
                       </span>
@@ -197,7 +197,7 @@ export function MyAssetsPage({ onNavigate }: Props) {
                   {(asset.collections ?? []).length > 0 && (
                     <div className="flex flex-wrap gap-1 mb-2">
                       {(asset.collections ?? []).slice(0, 2).map((c) => (
-                        <span key={c.id} className="text-[10px] px-1.5 py-0.5 rounded-full bg-primary/10 text-primary inline-flex items-center gap-0.5">
+                        <span key={c.id} className="text-xs px-1.5 py-0.5 rounded-full bg-primary/10 text-primary inline-flex items-center gap-0.5">
                           <FolderOpen className="h-2.5 w-2.5 shrink-0" />
                           {c.name}
                         </span>
@@ -250,7 +250,7 @@ export function MyAssetsPage({ onNavigate }: Props) {
                       </div>
                     </td>
                     <td className="px-4 py-2.5">
-                      <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium whitespace-nowrap ${contentTypeBadgeColor(asset.content_type)}`}>
+                      <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium whitespace-nowrap ${contentTypeBadgeColor(asset.content_type)}`}>
                         {asset.content_type}
                       </span>
                     </td>
@@ -259,13 +259,13 @@ export function MyAssetsPage({ onNavigate }: Props) {
                         {asset.tags.slice(0, 3).map((t) => (
                           <span
                             key={t}
-                            className="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground truncate max-w-[100px]"
+                            className="text-xs px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground truncate max-w-[100px]"
                           >
                             {t}
                           </span>
                         ))}
                         {asset.tags.length > 3 && (
-                          <span className="text-[10px] text-muted-foreground">+{asset.tags.length - 3}</span>
+                          <span className="text-xs text-muted-foreground">+{asset.tags.length - 3}</span>
                         )}
                       </div>
                     </td>
@@ -274,7 +274,7 @@ export function MyAssetsPage({ onNavigate }: Props) {
                         {(asset.collections ?? []).slice(0, 2).map((c) => (
                           <span
                             key={c.id}
-                            className="text-[10px] px-1.5 py-0.5 rounded-full bg-primary/10 text-primary truncate max-w-[100px] inline-flex items-center gap-0.5"
+                            className="text-xs px-1.5 py-0.5 rounded-full bg-primary/10 text-primary truncate max-w-[100px] inline-flex items-center gap-0.5"
                             onClick={(e) => { e.stopPropagation(); onNavigate(`/collections/${c.id}`); }}
                             role="button"
                             tabIndex={0}
@@ -285,7 +285,7 @@ export function MyAssetsPage({ onNavigate }: Props) {
                           </span>
                         ))}
                         {(asset.collections ?? []).length > 2 && (
-                          <span className="text-[10px] text-muted-foreground">+{(asset.collections ?? []).length - 2}</span>
+                          <span className="text-xs text-muted-foreground">+{(asset.collections ?? []).length - 2}</span>
                         )}
                       </div>
                     </td>

--- a/ui/src/pages/assets/MyAssetsPage.tsx
+++ b/ui/src/pages/assets/MyAssetsPage.tsx
@@ -10,8 +10,16 @@ const VIEW_STORAGE_KEY = "asset-view-mode";
 type ViewMode = "grid" | "table";
 
 function getStoredViewMode(): ViewMode {
-  const stored = localStorage.getItem(VIEW_STORAGE_KEY);
-  return stored === "table" ? "table" : "grid";
+  // Defensive: jsdom-based test environments and SSR contexts can
+  // either omit localStorage entirely or stub a partial object. The
+  // try/catch survives both. Default is "grid" — the safer fallback
+  // when persistence is unavailable.
+  try {
+    const stored = globalThis.localStorage?.getItem(VIEW_STORAGE_KEY);
+    return stored === "table" ? "table" : "grid";
+  } catch {
+    return "grid";
+  }
 }
 
 interface Props {

--- a/ui/src/pages/collections/CollectionEditorPage.tsx
+++ b/ui/src/pages/collections/CollectionEditorPage.tsx
@@ -85,15 +85,15 @@ function SortableItem({
       <FileText className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
       <span className="flex-1 truncate">{item.assetName || item.asset_id}</span>
       {item.assetContentType && (
-        <span className="text-[10px] text-muted-foreground shrink-0">{item.assetContentType}</span>
+        <span className="text-xs text-muted-foreground shrink-0">{item.assetContentType}</span>
       )}
       <button onClick={onPreview} className="text-muted-foreground hover:text-foreground shrink-0" title="Preview">
         <Eye className="h-3 w-3" />
       </button>
       {confirmDelete ? (
         <span className="flex items-center gap-1 shrink-0">
-          <button onClick={onRemove} className="text-[10px] text-destructive font-medium hover:underline">Remove</button>
-          <button onClick={() => setConfirmDelete(false)} className="text-[10px] text-muted-foreground hover:underline">Cancel</button>
+          <button onClick={onRemove} className="text-xs text-destructive font-medium hover:underline">Remove</button>
+          <button onClick={() => setConfirmDelete(false)} className="text-xs text-muted-foreground hover:underline">Cancel</button>
         </span>
       ) : (
         <button onClick={() => setConfirmDelete(true)} className="text-muted-foreground hover:text-destructive shrink-0" title="Remove">
@@ -207,7 +207,7 @@ function AssetBrowserModal({
                     {a.tags.length > 0 && (
                       <div className="flex gap-1 mt-0.5">
                         {a.tags.slice(0, 3).map((t) => (
-                          <span key={t} className="text-[9px] px-1 py-0.5 rounded bg-muted text-muted-foreground">{t}</span>
+                          <span key={t} className="text-xs px-1 py-0.5 rounded bg-muted text-muted-foreground">{t}</span>
                         ))}
                       </div>
                     )}
@@ -319,7 +319,7 @@ function SortableSection({
         >
           <ChevronDown className={`h-3.5 w-3.5 text-muted-foreground transition-transform ${collapsed ? "-rotate-90" : ""}`} />
           <span className="text-sm font-medium truncate">{displayTitle}</span>
-          <span className="text-[10px] text-muted-foreground">
+          <span className="text-xs text-muted-foreground">
             {itemCount} {itemCount === 1 ? "asset" : "assets"}
           </span>
         </button>

--- a/ui/src/pages/collections/CollectionViewerPage.tsx
+++ b/ui/src/pages/collections/CollectionViewerPage.tsx
@@ -190,7 +190,7 @@ export function CollectionViewerPage({ collectionId, onNavigate, onBack }: Props
                       </p>
                     )}
                     {item.asset_content_type && (
-                      <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${contentTypeBadgeColor(item.asset_content_type)}`}>
+                      <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${contentTypeBadgeColor(item.asset_content_type)}`}>
                         {item.asset_content_type}
                       </span>
                     )}

--- a/ui/src/pages/collections/CollectionsPage.tsx
+++ b/ui/src/pages/collections/CollectionsPage.tsx
@@ -141,12 +141,12 @@ export function CollectionsPage({ onNavigate }: Props) {
                   {tags.length > 0 && (
                     <div className="flex flex-wrap gap-1 mb-2">
                       {tags.slice(0, 4).map((t) => (
-                        <span key={t} className="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground">
+                        <span key={t} className="text-xs px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground">
                           {t}
                         </span>
                       ))}
                       {tags.length > 4 && (
-                        <span className="text-[10px] text-muted-foreground">+{tags.length - 4}</span>
+                        <span className="text-xs text-muted-foreground">+{tags.length - 4}</span>
                       )}
                     </div>
                   )}
@@ -193,12 +193,12 @@ export function CollectionsPage({ onNavigate }: Props) {
                     <td className="px-4 py-2.5 max-w-0">
                       <div className="flex flex-wrap gap-1">
                         {tags.slice(0, 4).map((t) => (
-                          <span key={t} className="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground truncate max-w-[100px]">
+                          <span key={t} className="text-xs px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground truncate max-w-[100px]">
                             {t}
                           </span>
                         ))}
                         {tags.length > 4 && (
-                          <span className="text-[10px] text-muted-foreground">+{tags.length - 4}</span>
+                          <span className="text-xs text-muted-foreground">+{tags.length - 4}</span>
                         )}
                       </div>
                     </td>

--- a/ui/src/pages/knowledge/MyKnowledgePage.tsx
+++ b/ui/src/pages/knowledge/MyKnowledgePage.tsx
@@ -75,7 +75,7 @@ function BadgeLabel({ status }: { status: string }) {
   };
   return (
     <span
-      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${badge.cls}`}
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${badge.cls}`}
     >
       {badge.label}
     </span>
@@ -106,7 +106,7 @@ function InsightCard({ insight }: { insight: Insight }) {
             <span
               key={urn}
               title={urn}
-              className="inline-block rounded bg-muted px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground"
+              className="inline-block rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-muted-foreground"
             >
               {formatEntityUrn(urn)}
             </span>
@@ -149,7 +149,7 @@ function MemoryCard({ record }: { record: MemoryRecord }) {
             <span
               key={urn}
               title={urn}
-              className="inline-block rounded bg-muted px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground"
+              className="inline-block rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-muted-foreground"
             >
               {formatEntityUrn(urn)}
             </span>

--- a/ui/src/pages/personas/PersonasPage.tsx
+++ b/ui/src/pages/personas/PersonasPage.tsx
@@ -171,7 +171,7 @@ function PersonaCard({
       {/* Header */}
       <div className="mb-2 flex items-center gap-2">
         <h3 className="text-sm font-semibold">{persona.display_name}</h3>
-        <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground">
+        <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-muted-foreground">
           {persona.name}
         </span>
       </div>
@@ -200,7 +200,7 @@ function PersonaCard({
               {detail.allow_tools.map((t) => (
                 <span
                   key={t}
-                  className="rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-mono text-green-800"
+                  className="rounded bg-green-100 px-1.5 py-0.5 text-xs font-mono text-green-800"
                 >
                   {t}
                 </span>
@@ -212,7 +212,7 @@ function PersonaCard({
               {detail.deny_tools.map((t) => (
                 <span
                   key={t}
-                  className="rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-mono text-red-800"
+                  className="rounded bg-red-100 px-1.5 py-0.5 text-xs font-mono text-red-800"
                 >
                   {t}
                 </span>
@@ -361,7 +361,7 @@ function DetailDrawer({
                 {detail.tools.map((t) => (
                   <span
                     key={t}
-                    className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground"
+                    className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-muted-foreground"
                   >
                     {t}
                   </span>

--- a/ui/src/pages/prompts/AdminPromptsPage.tsx
+++ b/ui/src/pages/prompts/AdminPromptsPage.tsx
@@ -407,7 +407,7 @@ export function AdminPromptsPage({ onNavigate: _onNavigate }: Props) {
                       </td>
                       <td className="px-4 py-2 text-right">
                         {p.scope === "system" ? (
-                          <span className="text-[10px] text-muted-foreground">read-only</span>
+                          <span className="text-xs text-muted-foreground">read-only</span>
                         ) : deleteConfirm === p.id ? (
                           <div className="inline-flex gap-1" onClick={(e) => e.stopPropagation()}>
                             <button onClick={() => handleDelete(p.id)} className="text-xs text-red-500 hover:text-red-400">Confirm</button>

--- a/ui/src/pages/resources/ResourcesPage.tsx
+++ b/ui/src/pages/resources/ResourcesPage.tsx
@@ -236,14 +236,14 @@ export function ResourcesPage({ admin }: Props) {
                     </td>
                     {admin && (
                       <td className="px-4 py-2.5">
-                        <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium whitespace-nowrap inline-flex items-center gap-0.5 ${scopeBadgeColor(r.scope)}`}>
+                        <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium whitespace-nowrap inline-flex items-center gap-0.5 ${scopeBadgeColor(r.scope)}`}>
                           <ScopeIcon className="h-2.5 w-2.5" />
                           {scopeLabel(r.scope, r.scope_id)}
                         </span>
                       </td>
                     )}
                     <td className="px-4 py-2.5">
-                      <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium whitespace-nowrap ${categoryColor(r.category)}`}>
+                      <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium whitespace-nowrap ${categoryColor(r.category)}`}>
                         {r.category}
                       </span>
                     </td>
@@ -251,12 +251,12 @@ export function ResourcesPage({ admin }: Props) {
                     <td className="px-4 py-2.5 max-w-0">
                       <div className="flex flex-wrap gap-1">
                         {r.tags.slice(0, 3).map((t) => (
-                          <span key={t} className="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground truncate max-w-[80px]">
+                          <span key={t} className="text-xs px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground truncate max-w-[80px]">
                             {t}
                           </span>
                         ))}
                         {r.tags.length > 3 && (
-                          <span className="text-[10px] text-muted-foreground">+{r.tags.length - 3}</span>
+                          <span className="text-xs text-muted-foreground">+{r.tags.length - 3}</span>
                         )}
                       </div>
                     </td>
@@ -584,7 +584,7 @@ function DetailModal({ resource: r, onClose, onEdit, onDelete, admin }: { resour
         {r.tags.length > 0 && (
           <div className="flex flex-wrap gap-1.5">
             {r.tags.map((t) => (
-              <span key={t} className="text-[10px] px-2 py-0.5 rounded-full bg-muted text-muted-foreground inline-flex items-center gap-1">
+              <span key={t} className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground inline-flex items-center gap-1">
                 <Tag className="h-2.5 w-2.5" />{t}
               </span>
             ))}

--- a/ui/src/pages/settings/ChangelogPage.tsx
+++ b/ui/src/pages/settings/ChangelogPage.tsx
@@ -22,7 +22,7 @@ function ErrorBanner({ message, onRetry }: { message: string; onRetry?: () => vo
         <button
           type="button"
           onClick={onRetry}
-          className="inline-flex items-center gap-1 rounded px-2 py-1 text-[10px] font-medium hover:bg-red-100 dark:hover:bg-red-900/30"
+          className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium hover:bg-red-100 dark:hover:bg-red-900/30"
         >
           <RefreshCw className="h-3 w-3" />
           Retry
@@ -95,7 +95,7 @@ function ChangelogRow({ entry }: { entry: ConfigChangelogEntry }) {
         <span className="font-mono text-xs text-foreground">{entry.key}</span>
         <span
           className={cn(
-            "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium",
+            "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
             entry.action === "set"
               ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
               : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
@@ -104,17 +104,17 @@ function ChangelogRow({ entry }: { entry: ConfigChangelogEntry }) {
           {entry.action === "set" ? "Updated" : "Deleted"}
         </span>
         <span className="flex-1" />
-        <span className="text-[10px] text-muted-foreground">
+        <span className="text-xs text-muted-foreground">
           {entry.changed_by || "unknown"}
         </span>
-        <span className="text-[10px] text-muted-foreground">
+        <span className="text-xs text-muted-foreground">
           {new Date(entry.changed_at).toLocaleString()}
         </span>
         {hasValue && (
           <button
             type="button"
             onClick={() => setExpanded((prev) => !prev)}
-            className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+            className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
           >
             <ChevronDown className={cn("h-3 w-3 transition-transform", expanded && "rotate-180")} />
             {expanded ? "Hide" : "Show value"}

--- a/ui/src/pages/settings/ConfigEditorPage.tsx
+++ b/ui/src/pages/settings/ConfigEditorPage.tsx
@@ -40,7 +40,7 @@ function ErrorBanner({ message, onRetry }: { message: string; onRetry?: () => vo
         <button
           type="button"
           onClick={onRetry}
-          className="inline-flex items-center gap-1 rounded px-2 py-1 text-[10px] font-medium hover:bg-red-100 dark:hover:bg-red-900/30"
+          className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium hover:bg-red-100 dark:hover:bg-red-900/30"
         >
           <RefreshCw className="h-3 w-3" />
           Retry
@@ -142,7 +142,7 @@ export function ConfigEditorPage({ configKey, label, description }: Props) {
             <p className="mt-1 text-xs text-muted-foreground">{description}</p>
           </div>
           {hasOverride && (
-            <span className="rounded-full border border-primary/20 bg-primary/5 px-2.5 py-0.5 text-[10px] font-medium text-primary">
+            <span className="rounded-full border border-primary/20 bg-primary/5 px-2.5 py-0.5 text-xs font-medium text-primary">
               <Database className="mr-1 inline-block h-2.5 w-2.5" />
               Database override
             </span>
@@ -151,7 +151,7 @@ export function ConfigEditorPage({ configKey, label, description }: Props) {
 
         <div className="flex items-center gap-2">
           {entry?.updated_by && (
-            <span className="text-[10px] text-muted-foreground">
+            <span className="text-xs text-muted-foreground">
               Updated by {entry.updated_by}
               {entry.updated_at &&
                 ` · ${new Date(entry.updated_at).toLocaleDateString()}`}

--- a/ui/src/pages/settings/ConnectionsPanel.tsx
+++ b/ui/src/pages/settings/ConnectionsPanel.tsx
@@ -143,7 +143,7 @@ export function ConnectionsPanel() {
             .map(([kind, items]) => (
               <div key={kind}>
                 <div className="bg-muted/30 px-4 py-1.5 border-b">
-                  <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                     {kind}
                   </span>
                 </div>
@@ -164,7 +164,7 @@ export function ConnectionsPanel() {
                       <div className="flex items-center gap-1.5">
                         <span className="text-sm font-medium truncate">{c.name}</span>
                         <span className={cn(
-                          "shrink-0 rounded px-1 py-0 text-[9px] font-medium",
+                          "shrink-0 rounded px-1 py-0 text-xs font-medium",
                           c.source === "file" ? "bg-muted text-muted-foreground" :
                           "bg-primary/10 text-primary",
                         )}>
@@ -172,12 +172,12 @@ export function ConnectionsPanel() {
                         </span>
                       </div>
                       {c.description && (
-                        <span className="mt-0.5 text-[10px] text-muted-foreground truncate">
+                        <span className="mt-0.5 text-xs text-muted-foreground truncate">
                           {c.description}
                         </span>
                       )}
                       {c.tools && c.tools.length > 0 && (
-                        <span className="mt-0.5 text-[10px] text-muted-foreground">
+                        <span className="mt-0.5 text-xs text-muted-foreground">
                           {c.tools.length} tools
                         </span>
                       )}
@@ -298,7 +298,7 @@ function ConnectionViewer({
         <div>
           <div className="flex items-center gap-2">
             <h2 className="text-lg font-semibold">{connection.name}</h2>
-            <span className={cn("rounded-full px-2.5 py-0.5 text-[10px] font-medium", kindColor(connection.kind))}>
+            <span className={cn("rounded-full px-2.5 py-0.5 text-xs font-medium", kindColor(connection.kind))}>
               {connection.kind}
             </span>
           </div>
@@ -306,7 +306,7 @@ function ConnectionViewer({
             <p className="mt-1 text-sm text-muted-foreground">{connection.description}</p>
           )}
           {connection.source === "both" && (
-            <p className="mt-1 text-[10px] text-muted-foreground">
+            <p className="mt-1 text-xs text-muted-foreground">
               This connection is managed in the database. A fallback version also exists in the config file and can be removed once database management is confirmed.
             </p>
           )}
@@ -367,7 +367,7 @@ function ConnectionViewer({
             <button
               type="button"
               onClick={() => setShowSensitive((v) => !v)}
-              className="ml-auto text-[10px] text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+              className="ml-auto text-xs text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
             >
               {showSensitive ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
               {showSensitive ? "Hide sensitive" : "Show sensitive"}
@@ -618,7 +618,7 @@ function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: Edito
                 </option>
               ))}
             </select>
-            <p className="mt-1 text-[10px] text-muted-foreground">
+            <p className="mt-1 text-xs text-muted-foreground">
               Connection type. Cannot be changed after creation.
             </p>
           </div>
@@ -632,7 +632,7 @@ function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: Edito
               placeholder="my-connection"
               className="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono outline-none ring-ring focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed"
             />
-            <p className="mt-1 text-[10px] text-muted-foreground">
+            <p className="mt-1 text-xs text-muted-foreground">
               Unique name within this kind. Cannot be changed after creation.
             </p>
           </div>
@@ -679,7 +679,7 @@ function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: Edito
 function InfoCard({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-md border bg-muted/20 px-3 py-2">
-      <p className="text-[10px] font-medium text-muted-foreground">{label}</p>
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
       <p className="text-sm font-medium truncate">{value}</p>
     </div>
   );
@@ -727,7 +727,7 @@ function ConfigField({
           mono && "font-mono",
         )}
       />
-      {help && <p className="mt-1 text-[10px] text-muted-foreground">{help}</p>}
+      {help && <p className="mt-1 text-xs text-muted-foreground">{help}</p>}
     </div>
   );
 }
@@ -764,7 +764,7 @@ function ConfigToggle({
       </button>
       <div>
         <label className="text-xs font-medium">{label}</label>
-        {help && <p className="text-[10px] text-muted-foreground">{help}</p>}
+        {help && <p className="text-xs text-muted-foreground">{help}</p>}
       </div>
     </div>
   );
@@ -853,7 +853,7 @@ function TrinoConfigForm({ config, onChange }: ConfigFormProps) {
         />
         <div className="mt-4">
           <label className="mb-1 block text-xs font-medium">Catalog Mapping</label>
-          <p className="mb-2 text-[10px] text-muted-foreground">
+          <p className="mb-2 text-xs text-muted-foreground">
             Maps this connection's catalog names to DataHub catalog names. For example, if this connection uses catalog "rdbms" but DataHub knows it as "postgres", add rdbms → postgres.
           </p>
           <KeyValueEditor
@@ -1045,7 +1045,7 @@ function GatewayConfigForm({ config, onChange }: ConfigFormProps) {
             <option value="api_key">API key</option>
             <option value="oauth">OAuth 2.1</option>
           </select>
-          <p className="mt-1 text-[10px] text-muted-foreground">
+          <p className="mt-1 text-xs text-muted-foreground">
             Bearer sends Authorization header; API key sends X-API-Key; OAuth obtains a managed bearer token via client_credentials or authorization_code+PKCE.
           </p>
         </div>
@@ -1069,7 +1069,7 @@ function GatewayConfigForm({ config, onChange }: ConfigFormProps) {
       )}
       {config.auth_mode === "oauth" && (
         <div className="rounded-md border bg-muted/20 px-3 py-3 space-y-3">
-          <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             OAuth 2.1
           </div>
           <div>
@@ -1082,7 +1082,7 @@ function GatewayConfigForm({ config, onChange }: ConfigFormProps) {
               <option value="client_credentials">client_credentials (machine-to-machine)</option>
               <option value="authorization_code">authorization_code + PKCE (browser sign-in)</option>
             </select>
-            <p className="mt-1 text-[10px] text-muted-foreground">
+            <p className="mt-1 text-xs text-muted-foreground">
               Use authorization_code for upstreams that require a human sign-in (Salesforce Hosted MCP, etc.). After saving the connection, click Connect to authorize once — the platform refreshes the token automatically thereafter.
             </p>
           </div>
@@ -1160,7 +1160,7 @@ function GatewayConfigForm({ config, onChange }: ConfigFormProps) {
           <option value="untrusted">Untrusted (default)</option>
           <option value="trusted">Trusted</option>
         </select>
-        <p className="mt-1 text-[10px] text-muted-foreground">
+        <p className="mt-1 text-xs text-muted-foreground">
           Reserved for future content-fencing of upstream responses. Leave at "untrusted" unless you control the upstream.
         </p>
       </div>

--- a/ui/src/pages/settings/GatewayActions.tsx
+++ b/ui/src/pages/settings/GatewayActions.tsx
@@ -133,7 +133,7 @@ export function GatewayActionBar({
           <div className="mt-0.5">{testResult.message}</div>
           {testResult.tools && testResult.tools.length > 0 && (
             <details className="mt-1.5">
-              <summary className="cursor-pointer text-[10px] uppercase tracking-wider opacity-70">
+              <summary className="cursor-pointer text-xs uppercase tracking-wider opacity-70">
                 Discovered tools
               </summary>
               <ul className="mt-1 space-y-0.5 font-mono">
@@ -141,7 +141,7 @@ export function GatewayActionBar({
                   <li key={t.local_name}>
                     {t.local_name}
                     {t.description && (
-                      <span className="ml-2 text-[10px] opacity-70 font-sans">{t.description}</span>
+                      <span className="ml-2 text-xs opacity-70 font-sans">{t.description}</span>
                     )}
                   </li>
                 ))}
@@ -233,10 +233,10 @@ function OAuthStatusCard({ connectionName }: { connectionName: string }) {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <KeyRound className="h-3.5 w-3.5 text-muted-foreground" />
-          <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             OAuth status
           </span>
-          <span className="rounded bg-muted text-muted-foreground px-1 py-0 text-[9px] font-medium font-mono">
+          <span className="rounded bg-muted text-muted-foreground px-1 py-0 text-xs font-medium font-mono">
             {oauth.grant}
           </span>
         </div>
@@ -247,7 +247,7 @@ function OAuthStatusCard({ connectionName }: { connectionName: string }) {
               onClick={handleConnect}
               disabled={startOAuth.isPending}
               className={cn(
-                "inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[10px] font-medium disabled:opacity-50",
+                "inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium disabled:opacity-50",
                 oauth.needs_reauth
                   ? "bg-primary text-primary-foreground border-primary hover:bg-primary/90"
                   : "text-muted-foreground hover:bg-muted hover:text-foreground",
@@ -262,7 +262,7 @@ function OAuthStatusCard({ connectionName }: { connectionName: string }) {
               type="button"
               onClick={handleReacquire}
               disabled={reacquire.isPending}
-              className="inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[10px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+              className="inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
             >
               <RefreshCw className={cn("h-3 w-3", reacquire.isPending && "animate-spin")} />
               {reacquire.isPending ? "Refreshing..." : "Refresh now"}
@@ -272,7 +272,7 @@ function OAuthStatusCard({ connectionName }: { connectionName: string }) {
       </div>
 
       {oauth.needs_reauth && (
-        <div className="rounded border border-amber-500/30 bg-amber-50 px-2 py-1.5 text-[10px] text-amber-900 dark:bg-amber-900/20 dark:text-amber-200">
+        <div className="rounded border border-amber-500/30 bg-amber-50 px-2 py-1.5 text-xs text-amber-900 dark:bg-amber-900/20 dark:text-amber-200">
           <span className="font-medium">Not connected.</span> Click <strong>Connect</strong> to authorize this connection in your browser. The platform will then keep the access token refreshed automatically — including for cron jobs and scheduled prompts — until the upstream invalidates the refresh token.
         </div>
       )}
@@ -280,7 +280,7 @@ function OAuthStatusCard({ connectionName }: { connectionName: string }) {
       <OAuthStatusGrid status={oauth} />
 
       {oauth.authenticated_by && (
-        <div className="text-[10px] text-muted-foreground">
+        <div className="text-xs text-muted-foreground">
           Authorized by{" "}
           <span className="font-mono">{oauth.authenticated_by}</span>
           {oauth.authenticated_at && <> {formatRelative(oauth.authenticated_at)}</>}
@@ -288,7 +288,7 @@ function OAuthStatusCard({ connectionName }: { connectionName: string }) {
       )}
 
       {oauth.last_error && (
-        <div className="rounded border border-destructive/30 bg-destructive/10 px-2 py-1 text-[10px] text-destructive">
+        <div className="rounded border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs text-destructive">
           <span className="font-medium">Last error:</span> {oauth.last_error}
         </div>
       )}
@@ -296,7 +296,7 @@ function OAuthStatusCard({ connectionName }: { connectionName: string }) {
       {actionMsg && (
         <div
           className={cn(
-            "rounded border px-2 py-1 text-[10px]",
+            "rounded border px-2 py-1 text-xs",
             actionMsg.ok
               ? "border-emerald-500/30 bg-emerald-50 text-emerald-900 dark:bg-emerald-900/20 dark:text-emerald-200"
               : "border-destructive/30 bg-destructive/10 text-destructive",
@@ -338,7 +338,7 @@ function OAuthStatusGrid({ status }: { status: GatewayOAuthStatus }) {
     },
   ];
   return (
-    <div className="grid grid-cols-2 gap-2 text-[10px]">
+    <div className="grid grid-cols-2 gap-2 text-xs">
       {items.map((it) => (
         <div key={it.label} className="flex items-center gap-1.5">
           {it.icon}
@@ -471,7 +471,7 @@ function RuleListItem({
             <span className="font-mono text-xs">{rule.tool_name}</span>
             <span
               className={cn(
-                "rounded px-1.5 py-0 text-[9px] font-medium",
+                "rounded px-1.5 py-0 text-xs font-medium",
                 rule.enabled
                   ? "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400"
                   : "bg-muted text-muted-foreground",
@@ -483,7 +483,7 @@ function RuleListItem({
           {rule.description && (
             <p className="mt-1 text-xs text-muted-foreground">{rule.description}</p>
           )}
-          <p className="mt-1 text-[10px] text-muted-foreground font-mono">
+          <p className="mt-1 text-xs text-muted-foreground font-mono">
             {rule.enrich_action.source}.{rule.enrich_action.operation} →{" "}
             {rule.merge_strategy.path || "enrichment"}
           </p>
@@ -492,7 +492,7 @@ function RuleListItem({
           <button
             type="button"
             onClick={onEdit}
-            className="rounded-md border px-2 py-1 text-[10px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+            className="rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
           >
             Edit
           </button>
@@ -504,14 +504,14 @@ function RuleListItem({
                   await del.mutateAsync(rule.id);
                   setConfirmDelete(false);
                 }}
-                className="rounded-md bg-destructive px-2 py-1 text-[10px] font-medium text-destructive-foreground hover:bg-destructive/90"
+                className="rounded-md bg-destructive px-2 py-1 text-xs font-medium text-destructive-foreground hover:bg-destructive/90"
               >
                 Confirm
               </button>
               <button
                 type="button"
                 onClick={() => setConfirmDelete(false)}
-                className="rounded-md border px-2 py-1 text-[10px] font-medium text-muted-foreground hover:bg-muted"
+                className="rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted"
               >
                 Cancel
               </button>
@@ -520,7 +520,7 @@ function RuleListItem({
             <button
               type="button"
               onClick={() => setConfirmDelete(true)}
-              className="rounded-md border px-2 py-1 text-[10px] font-medium text-muted-foreground hover:bg-destructive/10 hover:text-destructive hover:border-destructive/30"
+              className="rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-destructive/10 hover:text-destructive hover:border-destructive/30"
             >
               <Trash2 className="h-3 w-3" />
             </button>
@@ -769,7 +769,7 @@ function DryRunPanel({ connectionName, ruleId }: { connectionName: string; ruleI
           {result.fired && result.fired.length > 0 && (
             <div className="rounded-md border px-3 py-2 text-xs">
               <div className="font-semibold mb-1">Trace</div>
-              <ul className="space-y-1 font-mono text-[10px]">
+              <ul className="space-y-1 font-mono text-xs">
                 {result.fired.map((f) => (
                   <li key={f.rule_id} className="flex items-center gap-2">
                     {f.skipped ? (
@@ -801,7 +801,7 @@ function DryRunPanel({ connectionName, ruleId }: { connectionName: string; ruleI
             <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
               Merged response
             </div>
-            <pre className="rounded-md border bg-muted/30 p-2 text-[10px] font-mono overflow-x-auto">
+            <pre className="rounded-md border bg-muted/30 p-2 text-xs font-mono overflow-x-auto">
               {JSON.stringify(result.response, null, 2)}
             </pre>
           </div>
@@ -827,10 +827,10 @@ function Field({
   return (
     <div>
       <div className="mb-1 flex items-baseline justify-between gap-2">
-        <label className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        <label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           {label}
         </label>
-        {hint && <span className="text-[10px] text-muted-foreground">{hint}</span>}
+        {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
       </div>
       {children}
     </div>
@@ -875,7 +875,7 @@ function JSONField<T>({
         value={text}
         onChange={(e) => handleChange(e.target.value)}
       />
-      {error && <p className="mt-1 text-[10px] text-destructive">{error}</p>}
+      {error && <p className="mt-1 text-xs text-destructive">{error}</p>}
     </Field>
   );
 }

--- a/ui/src/pages/settings/GatewayActions.tsx
+++ b/ui/src/pages/settings/GatewayActions.tsx
@@ -236,7 +236,7 @@ function OAuthStatusCard({ connectionName }: { connectionName: string }) {
           <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             OAuth status
           </span>
-          <span className="rounded bg-muted text-muted-foreground px-1 py-0 text-xs font-medium font-mono">
+          <span className="rounded bg-muted text-muted-foreground px-1 py-0 text-[11px] font-medium font-mono">
             {oauth.grant}
           </span>
         </div>

--- a/ui/src/pages/settings/KeysPage.tsx
+++ b/ui/src/pages/settings/KeysPage.tsx
@@ -189,7 +189,7 @@ export function KeysPage() {
                       <span className={cn(k.expired && "line-through")}>{k.name}</span>
                       {k.source && (
                         <span className={cn(
-                          "shrink-0 rounded px-1 py-0 text-[9px] font-medium",
+                          "shrink-0 rounded px-1 py-0 text-xs font-medium",
                           k.source === "file" ? "bg-muted text-muted-foreground" :
                           "bg-primary/10 text-primary",
                         )}>
@@ -197,7 +197,7 @@ export function KeysPage() {
                         </span>
                       )}
                       {k.expired && (
-                        <span className="shrink-0 rounded-full bg-red-100 px-1.5 py-0.5 text-[9px] font-semibold text-red-700 dark:bg-red-900/30 dark:text-red-400">
+                        <span className="shrink-0 rounded-full bg-red-100 px-1.5 py-0.5 text-xs font-semibold text-red-700 dark:bg-red-900/30 dark:text-red-400">
                           Expired
                         </span>
                       )}
@@ -214,7 +214,7 @@ export function KeysPage() {
                       {k.roles.map((r) => (
                         <span
                           key={r}
-                          className="rounded-full border bg-muted/50 px-2 py-0.5 text-[10px] font-medium"
+                          className="rounded-full border bg-muted/50 px-2 py-0.5 text-xs font-medium"
                         >
                           {r}
                         </span>
@@ -230,21 +230,21 @@ export function KeysPage() {
                   {!isReadOnly && (
                     <td className="px-5 py-3">
                       {k.source === "file" ? (
-                        <span className="text-[10px] text-muted-foreground italic">config file</span>
+                        <span className="text-xs text-muted-foreground italic">config file</span>
                       ) : deleteConfirm === k.name ? (
                         <div className="flex items-center gap-1.5">
                           <button
                             type="button"
                             onClick={() => handleDelete(k.name)}
                             disabled={deleteMutation.isPending}
-                            className="inline-flex items-center gap-1 rounded bg-red-600 px-2 py-1 text-[10px] font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                            className="inline-flex items-center gap-1 rounded bg-red-600 px-2 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50"
                           >
                             {deleteMutation.isPending ? "..." : "Confirm"}
                           </button>
                           <button
                             type="button"
                             onClick={() => setDeleteConfirm(null)}
-                            className="inline-flex items-center rounded border px-1.5 py-1 text-[10px] text-muted-foreground hover:bg-muted"
+                            className="inline-flex items-center rounded border px-1.5 py-1 text-xs text-muted-foreground hover:bg-muted"
                           >
                             <X className="h-3 w-3" />
                           </button>
@@ -253,7 +253,7 @@ export function KeysPage() {
                         <button
                           type="button"
                           onClick={() => setDeleteConfirm(k.name)}
-                          className="inline-flex items-center gap-1 rounded border border-transparent px-2 py-1 text-[10px] text-muted-foreground hover:border-red-200 hover:text-red-600 dark:hover:border-red-800 dark:hover:text-red-400"
+                          className="inline-flex items-center gap-1 rounded border border-transparent px-2 py-1 text-xs text-muted-foreground hover:border-red-200 hover:text-red-600 dark:hover:border-red-800 dark:hover:text-red-400"
                         >
                           <Trash2 className="h-3 w-3" />
                           Delete
@@ -454,7 +454,7 @@ function AddKeyForm({
                   {draft.roles.map((r) => (
                     <span
                       key={r}
-                      className="inline-flex items-center gap-1 rounded-full border bg-muted/50 px-2 py-0.5 text-[10px] font-medium"
+                      className="inline-flex items-center gap-1 rounded-full border bg-muted/50 px-2 py-0.5 text-xs font-medium"
                     >
                       {r}
                       <button
@@ -546,7 +546,7 @@ function RoleBrowser({ onSelect }: { onSelect: (role: string) => void }) {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="text-[10px] text-primary hover:underline"
+        className="text-xs text-primary hover:underline"
       >
         {open ? "Hide available roles" : "Browse available roles"}
       </button>

--- a/ui/src/pages/settings/PersonasPanel.tsx
+++ b/ui/src/pages/settings/PersonasPanel.tsx
@@ -205,7 +205,7 @@ export function PersonasPanel() {
                 <span className="text-sm font-medium truncate">{p.display_name}</span>
                 {p.source && (
                   <span className={cn(
-                    "shrink-0 rounded px-1 py-0 text-[9px] font-medium",
+                    "shrink-0 rounded px-1 py-0 text-xs font-medium",
                     p.source === "file" ? "bg-muted text-muted-foreground" :
                     "bg-primary/10 text-primary",
                   )}>
@@ -213,8 +213,8 @@ export function PersonasPanel() {
                   </span>
                 )}
               </div>
-              <span className="text-[10px] font-mono text-muted-foreground truncate">{p.name}</span>
-              <div className="mt-1 flex items-center gap-3 text-[10px] text-muted-foreground">
+              <span className="text-xs font-mono text-muted-foreground truncate">{p.name}</span>
+              <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
                 <span>{p.roles.length} roles</span>
                 <span>{p.tool_count} tools</span>
               </div>
@@ -356,12 +356,12 @@ function PersonaViewer({
             <p className="mt-1 text-sm text-muted-foreground">{detail.description}</p>
           )}
           {detail.source === "both" && (
-            <p className="mt-1 text-[10px] text-muted-foreground">
+            <p className="mt-1 text-xs text-muted-foreground">
               This persona is managed in the database. A fallback version also exists in the config file and can be removed once database management is confirmed.
             </p>
           )}
           {detail.source === "file" && !isReadOnly && (
-            <p className="mt-1 text-[10px] text-muted-foreground">
+            <p className="mt-1 text-xs text-muted-foreground">
               This persona is defined in the config file. Editing will create a database override.
             </p>
           )}
@@ -450,7 +450,7 @@ function PersonaViewer({
         <Collapsible title={`Resolved Tools (${detail.tools.length})`} defaultOpen={false}>
           <div className="flex flex-wrap gap-1">
             {detail.tools.map((t) => (
-              <span key={t} className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground">{t}</span>
+              <span key={t} className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-muted-foreground">{t}</span>
             ))}
           </div>
         </Collapsible>
@@ -555,7 +555,7 @@ function PersonaEditor({
             {isCreate ? "New Persona" : `Edit: ${draft.displayName}`}
           </h2>
           {dirty && (
-            <span className="flex items-center gap-1 text-[10px] text-amber-600 dark:text-amber-400">
+            <span className="flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
               <AlertCircle className="h-3 w-3" />
               Unsaved
             </span>
@@ -600,7 +600,7 @@ function PersonaEditor({
                 placeholder="my-persona"
                 className="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono outline-none ring-ring focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed"
               />
-              <p className="mt-1 text-[10px] text-muted-foreground">Unique identifier. Lowercase, hyphens allowed. Cannot be changed after creation.</p>
+              <p className="mt-1 text-xs text-muted-foreground">Unique identifier. Lowercase, hyphens allowed. Cannot be changed after creation.</p>
             </div>
             <div>
               <label className="mb-1 block text-xs font-medium">Display Name</label>
@@ -674,7 +674,7 @@ function PersonaEditor({
 
         {/* Connection Access */}
         <EditSection icon={Cable} title="Connection Access">
-          <p className="text-[10px] text-muted-foreground mb-3">
+          <p className="text-xs text-muted-foreground mb-3">
             Connection-level access controls work alongside tool access. A tool call must pass both checks. If the allow list is empty, all connections are permitted. Deny rules override allow rules.
           </p>
           <div className="space-y-4">
@@ -811,7 +811,7 @@ function ToolPatternEditor({
           </span>
         ))}
         {patterns.length === 0 && (
-          <span className="text-[10px] text-muted-foreground italic">No patterns — {variant === "green" ? "no tools allowed" : "nothing denied"}</span>
+          <span className="text-xs text-muted-foreground italic">No patterns — {variant === "green" ? "no tools allowed" : "nothing denied"}</span>
         )}
       </div>
 
@@ -855,12 +855,12 @@ function ToolPatternEditor({
             {Object.entries(filteredGroups).sort(([a], [b]) => a.localeCompare(b)).map(([kind, tools]) => (
               <div key={kind}>
                 <div className="flex items-center justify-between bg-muted/30 px-3 py-1.5 border-b">
-                  <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{kind}</span>
+                  <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{kind}</span>
                   <button
                     type="button"
                     onClick={() => addWildcard(kind)}
                     disabled={patterns.includes(`${kind}_*`)}
-                    className="text-[10px] font-mono text-primary hover:underline disabled:opacity-30 disabled:no-underline"
+                    className="text-xs font-mono text-primary hover:underline disabled:opacity-30 disabled:no-underline"
                   >
                     {kind}_*
                   </button>
@@ -965,7 +965,7 @@ function ConnectionPatternEditor({
           </span>
         ))}
         {patterns.length === 0 && (
-          <span className="text-[10px] text-muted-foreground italic">
+          <span className="text-xs text-muted-foreground italic">
             {variant === "green" ? "None (all connections permitted)" : "Nothing denied"}
           </span>
         )}
@@ -1011,7 +1011,7 @@ function ConnectionPatternEditor({
             {Object.entries(filteredGroups).sort(([a], [b]) => a.localeCompare(b)).map(([kind, conns]) => (
               <div key={kind}>
                 <div className="bg-muted/30 px-3 py-1.5 border-b">
-                  <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{kind}</span>
+                  <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{kind}</span>
                 </div>
                 {conns.map((c) => {
                   const connId = c.connection;
@@ -1054,7 +1054,7 @@ function ConnectionPatternEditor({
 function InfoCard({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-md border bg-muted/20 px-3 py-2">
-      <p className="text-[10px] font-medium text-muted-foreground">{label}</p>
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
       <p className="text-sm font-medium truncate">{value}</p>
     </div>
   );

--- a/ui/src/pages/shared/SharedWithMePage.tsx
+++ b/ui/src/pages/shared/SharedWithMePage.tsx
@@ -131,7 +131,7 @@ export function SharedWithMePage({ onNavigate }: Props) {
                       <span className="text-muted-foreground truncate block">{item.shared_by}</span>
                     </td>
                     <td className="px-4 py-2.5 text-center">
-                      <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${item.permission === "editor" ? "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300" : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"}`}>
+                      <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${item.permission === "editor" ? "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300" : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"}`}>
                         {item.permission === "editor" ? "Editor" : "Viewer"}
                       </span>
                     </td>
@@ -246,14 +246,14 @@ export function SharedWithMePage({ onNavigate }: Props) {
                   )}
                   <div className="flex flex-wrap gap-1.5 mb-2">
                     <span
-                      className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${contentTypeBadgeColor(item.asset.content_type)}`}
+                      className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${contentTypeBadgeColor(item.asset.content_type)}`}
                     >
                       {item.asset.content_type}
                     </span>
                     {item.asset.tags.slice(0, 3).map((t) => (
                       <span
                         key={t}
-                        className="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground"
+                        className="text-xs px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground"
                       >
                         {t}
                       </span>
@@ -262,7 +262,7 @@ export function SharedWithMePage({ onNavigate }: Props) {
                   <div className="flex items-center justify-between w-full text-xs text-muted-foreground">
                     <span className="flex items-center gap-1.5">
                       Shared by {item.shared_by}
-                      <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${item.permission === "editor" ? "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300" : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"}`}>
+                      <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${item.permission === "editor" ? "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300" : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"}`}>
                         {item.permission === "editor" ? "Editor" : "Viewer"}
                       </span>
                     </span>
@@ -311,7 +311,7 @@ export function SharedWithMePage({ onNavigate }: Props) {
                       </div>
                     </td>
                     <td className="px-4 py-2.5">
-                      <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium whitespace-nowrap ${contentTypeBadgeColor(item.asset.content_type)}`}>
+                      <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium whitespace-nowrap ${contentTypeBadgeColor(item.asset.content_type)}`}>
                         {item.asset.content_type}
                       </span>
                     </td>
@@ -320,13 +320,13 @@ export function SharedWithMePage({ onNavigate }: Props) {
                         {item.asset.tags.slice(0, 3).map((t) => (
                           <span
                             key={t}
-                            className="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground truncate max-w-[100px]"
+                            className="text-xs px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground truncate max-w-[100px]"
                           >
                             {t}
                           </span>
                         ))}
                         {item.asset.tags.length > 3 && (
-                          <span className="text-[10px] text-muted-foreground">+{item.asset.tags.length - 3}</span>
+                          <span className="text-xs text-muted-foreground">+{item.asset.tags.length - 3}</span>
                         )}
                       </div>
                     </td>
@@ -334,7 +334,7 @@ export function SharedWithMePage({ onNavigate }: Props) {
                       <span className="text-muted-foreground truncate block">{item.shared_by}</span>
                     </td>
                     <td className="px-4 py-2.5 text-center">
-                      <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${item.permission === "editor" ? "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300" : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"}`}>
+                      <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${item.permission === "editor" ? "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300" : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"}`}>
                         {item.permission === "editor" ? "Editor" : "Viewer"}
                       </span>
                     </td>

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -14,5 +14,17 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     css: false,
+    // Exclude Playwright specs from vitest. They live under e2e/
+    // and use @playwright/test, which throws when picked up by
+    // vitest's runner ("test.describe() called here"). Vitest
+    // owns *.test.ts(x); Playwright owns *.spec.ts.
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/cypress/**",
+      "**/.{idea,git,cache,output,temp}/**",
+      "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*",
+      "e2e/**/*.spec.ts",
+    ],
   },
 });


### PR DESCRIPTION
## Summary

The admin and portal UI relied on `text-[10px]` and `text-[9px]` Tailwind class overrides for dense surfaces. At standard viewport DPI those render at 10px and 9px respectively — well under the 12px accessibility floor and reported as "microscopic" / "barely readable" on the OAuth status panel. This PR raises the entire UI to a uniform 12px floor.

## Why a global sweep instead of a targeted fix

The reported pain point was the OAuth status panel, but the same `text-[10px]` / `text-[9px]` pattern was used on 18 surfaces — every admin page that shows tabular data, badges, or metadata grids. A targeted fix would have left the same readability problem on 17 other pages, guaranteeing follow-up complaints. The blanket bump is the right scope.

## Approach

- 95 `text-[10px]` → `text-xs` (12px)
- 19 `text-[9px]` → `text-xs` (12px)
- One exception: the `oauth.grant` monospace pill in `GatewayActions.tsx` was set to `text-[11px]` instead of `text-xs` because monospace `authorization_code` (17 chars) at 12px overflows tight inline pill containers. 11px is still above 10px, still readable, and stays under the visual weight of the surrounding label.

`text-xs` computes to **`font-size: 0.75rem; line-height: 1rem`** (12px / 16px) — verified live in the browser, see Verification.

## Pre-existing test failures fixed in this PR

Earlier code review noted that `vitest run` had 5 pre-existing failures unrelated to font sizes. While addressing the review, those were investigated and resolved on this branch since they sit on the same UI surface:

1. **`MyAssetsPage.test.tsx`** (4 failures): `localStorage.getItem is not a function` in jsdom. Made `getStoredViewMode` defensive against missing `localStorage` (works in jsdom AND SSR).
2. **`route-sync.test.ts`** (1 failure): `/admin/description` and `/admin/agent-instructions` are intentionally excluded from screenshot capture (CodeMirror crashes headless), but the sync test treated them as missing manifest entries. Added `excludedRoutes` to the manifest with documented reason; sync test now distinguishes "missing (bug)" from "deliberately excluded (known)".
3. **`screenshot.spec.ts`** (1 failure): Vitest was picking up the Playwright spec and crashing with "test.describe() called here". Added `e2e/**/*.spec.ts` to the vitest exclude list — Playwright owns `*.spec.ts`, vitest owns `*.test.ts(x)`.

CI on this branch now goes from 5 red to **39/39 green**.

## Affected files

```
ui/src/components/ShareDialog.tsx
ui/src/components/VersionHistoryPanel.tsx
ui/src/components/layout/Sidebar.tsx
ui/src/pages/assets/MyAssetsPage.tsx              (+ localStorage guard)
ui/src/pages/collections/CollectionEditorPage.tsx
ui/src/pages/collections/CollectionViewerPage.tsx
ui/src/pages/collections/CollectionsPage.tsx
ui/src/pages/knowledge/MyKnowledgePage.tsx
ui/src/pages/personas/PersonasPage.tsx
ui/src/pages/prompts/AdminPromptsPage.tsx
ui/src/pages/resources/ResourcesPage.tsx
ui/src/pages/settings/ChangelogPage.tsx
ui/src/pages/settings/ConfigEditorPage.tsx
ui/src/pages/settings/ConnectionsPanel.tsx
ui/src/pages/settings/GatewayActions.tsx          (+ oauth.grant pill at 11px)
ui/src/pages/settings/KeysPage.tsx
ui/src/pages/settings/PersonasPanel.tsx
ui/src/pages/shared/SharedWithMePage.tsx

# Pre-existing test failures fixed:
ui/e2e/screenshots/route-manifest.ts              (excludedRoutes set)
ui/e2e/screenshots/route-sync.test.ts             (consume exclusion list)
ui/vitest.config.ts                               (exclude e2e/*.spec.ts)
```

## Verification

**Static**:
- `npx tsc --noEmit` — clean
- `npx vitest run` — **39/39 tests pass** (was 34/39)

**Live (chrome-devtools-mcp against vite dev server with MSW mocks)**:
- `text-xs` confirmed at **12px** in the live browser DOM
- `text-[11px]` confirmed at **11px** in the live browser DOM (oauth.grant pill exception)
- Connection Viewer page: configuration table, metadata cards, sidebar — all render cleanly, no overflow, no awkward truncation
- Personas page: dense persona list (name + role identifier + "1 roles 20 tools" subtext) all readable, role badges fit
- Keys page: 5-row table with all columns (Name + source pill + Email + Description + Roles + Expiration + Actions) renders without horizontal overflow, description column truncates with ellipsis where needed

The OAuth status panel itself wasn't visually verified because the MSW mocks don't include a `kind=mcp` connection. The classes used in `GatewayActions.tsx` are the same `text-xs` (and `text-[11px]` for the grant pill) that were verified to compute correctly on the surfaces above.

Page-wide font-size inventory after the sweep (Connection Viewer):
- 12px × 34 occurrences (the new floor)
- 14px × 11 occurrences (labels)
- 0 occurrences below 12px

## Test plan

- [ ] Verify the OAuth status panel under Settings → Connections renders all labels at 12px and is readable without zoom.
- [ ] Confirm `oauth.grant` pill (`authorization_code`, `client_credentials`) fits inline at 11px monospace without wrapping.
- [ ] Spot-check tables/grids on Personas, Keys, Changelog, Config Editor, Assets, Collections, Knowledge, Prompts, Resources, Shared.