### PR TITLE
fix(gateway): disable standalone SSE GET on token endpoint; remove toolkit mutex contention during network I/O

### DIFF
--- a/pkg/toolkits/gateway/client.go
+++ b/pkg/toolkits/gateway/client.go
@@ -45,6 +45,34 @@ func dial(ctx context.Context, cfg Config, connection string, store TokenStore) 
 	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
 		Endpoint:   cfg.Endpoint,
 		HTTPClient: httpClient,
+		// DisableStandaloneSSE: do NOT open a long-poll GET against the
+		// upstream's Streamable HTTP endpoint after initialize.
+		//
+		// Per MCP spec §2.2.3, after a successful initialize the client MAY
+		// open a `GET /` with `Accept: text/event-stream` so the server can
+		// push asynchronous notifications (tools/list_changed, progress,
+		// etc.). The go-sdk does this SYNCHRONOUSLY inside Client.Connect's
+		// sessionUpdated() callback BEFORE sending notifications/initialized.
+		//
+		// When the upstream is fronted by Cloudflare (or any proxy with
+		// response buffering), the proxy buffers the SSE response waiting
+		// for the upstream to produce data. If the upstream has nothing to
+		// push (the steady state for most servers), the proxy holds the
+		// connection open until ITS timeout — Cloudflare returns HTTP 524
+		// after ~100s. The synchronous Connect() then takes the full 100s+
+		// to return, and our 10s dial context has long since expired by
+		// the time it gets to send notifications/initialized — which then
+		// surfaces as the misleading "round trip: context deadline exceeded
+		// on notifications/initialized" error.
+		//
+		// We don't currently consume server-pushed notifications in the
+		// gateway forwarder — every tool call is a synchronous request /
+		// response. Disabling the standalone SSE eliminates the proxy hang
+		// without losing functionality. If we add streaming-tool support
+		// later, revisit this and either negotiate with the operator's
+		// proxy config (disable buffering for /api/mcp) or open the SSE
+		// stream lazily on demand.
+		DisableStandaloneSSE: true,
 	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("connect to %s: %w", cfg.Endpoint, err)

--- a/pkg/toolkits/gateway/toolkit.go
+++ b/pkg/toolkits/gateway/toolkit.go
@@ -381,11 +381,13 @@ func (t *Toolkit) AddConnection(name string, config map[string]any) error {
 //
 // A "claiming" sentinel entry is inserted in the connections map before
 // the dial so concurrent AddConnection calls for the same name see
-// ErrConnectionExists. The sentinel is replaced atomically when the
-// dial completes (with a live connection on success, a placeholder on
-// auth_code-no-token, or removed on transient failure).
+// ErrConnectionExists. The claim sentinel is identified by POINTER
+// IDENTITY (not just the claiming bool) so that a Remove + Add cycle
+// during a slow dial cannot install our result into a later caller's
+// slot — see installDialResult.
 func (t *Toolkit) addParsedConnection(name string, cfg Config) error {
-	if err := t.claimConnectionSlot(name, cfg); err != nil {
+	claim, err := t.claimConnectionSlot(name, cfg)
+	if err != nil {
 		return err
 	}
 	// Network I/O happens here, OUTSIDE the lock. A slow or hung
@@ -394,42 +396,68 @@ func (t *Toolkit) addParsedConnection(name string, cfg Config) error {
 	// connections) proceed without contention.
 	ctx, cancel := dialContext(cfg)
 	defer cancel()
-	client, tools, err := discover(ctx, cfg, name, t.tokenStore)
-	return t.installDialResult(name, cfg, client, tools, err)
+	client, tools, dialErr := discover(ctx, cfg, name, t.tokenStore)
+	return t.installDialResult(dialResult{
+		claim:   claim,
+		name:    name,
+		cfg:     cfg,
+		client:  client,
+		tools:   tools,
+		dialErr: dialErr,
+	})
 }
 
 // claimConnectionSlot inserts a sentinel "claiming" entry under the
 // lock so concurrent AddConnection calls for the same name see
 // ErrConnectionExists. Returns ErrConnectionExists if a real or
-// claiming entry already occupies the slot.
-func (t *Toolkit) claimConnectionSlot(name string, cfg Config) error {
+// claiming entry already occupies the slot. The returned *upstream is
+// the inserted sentinel — callers MUST pass it to installDialResult
+// so the install step can verify the slot still holds OUR claim
+// (and not a fresh claim from a concurrent Remove + Add cycle).
+func (t *Toolkit) claimConnectionSlot(name string, cfg Config) (*upstream, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if _, exists := t.connections[name]; exists {
-		return fmt.Errorf("gateway: %s: %w", name, ErrConnectionExists)
+		return nil, fmt.Errorf("gateway: %s: %w", name, ErrConnectionExists)
 	}
-	t.connections[name] = &upstream{
+	claim := &upstream{
 		name:     name,
 		config:   cfg,
 		desc:     "Connecting to " + cfg.Endpoint,
 		claiming: true,
 	}
-	return nil
+	t.connections[name] = claim
+	return claim, nil
 }
 
 // installDialResult finishes a claim by replacing the "claiming"
 // sentinel with the dial's result. Holds the lock only briefly to
-// mutate the map and register tools. If the entry no longer exists
-// (concurrent RemoveConnection during dial) OR no longer claiming
-// (concurrent install — shouldn't happen but defensive), the dialed
-// client is closed and dropped.
-func (t *Toolkit) installDialResult(
-	name string, cfg Config, client *upstreamClient, tools []*mcp.Tool, dialErr error,
-) error {
+// mutate the map and register tools.
+//
+// Identity check: the install only proceeds if the slot still holds
+// the SAME *upstream pointer that claimConnectionSlot inserted. A
+// Remove + Add cycle during our dial replaces the entry with a fresh
+// claim sentinel that has the same `claiming` bool but a different
+// pointer; without this check, our (potentially stale) dial result
+// would silently overwrite the second caller's claim.
+// dialResult bundles the inputs to installDialResult so the function
+// signature stays under revive's argument-limit ceiling without losing
+// any of the data the install step needs.
+type dialResult struct {
+	claim   *upstream
+	name    string
+	cfg     Config
+	client  *upstreamClient
+	tools   []*mcp.Tool
+	dialErr error
+}
+
+func (t *Toolkit) installDialResult(r dialResult) error {
+	claim, name, cfg, client, tools, dialErr := r.claim, r.name, r.cfg, r.client, r.tools, r.dialErr
 	t.mu.Lock()
-	existing, ok := t.connections[name]
-	if !ok || !existing.claiming {
-		// Concurrent removal during dial — discard the result.
+	if t.connections[name] != claim {
+		// Slot was removed (and possibly re-claimed) during our dial —
+		// discard the result. The other caller's dial owns the slot.
 		t.mu.Unlock()
 		if client != nil {
 			_ = client.close()
@@ -725,7 +753,11 @@ func (t *Toolkit) ListConnections() []toolkit.ConnectionDetail {
 //
 // Snapshots the live client pointers under the lock and closes them
 // outside the lock so a slow upstream cannot block other toolkit
-// operations during shutdown.
+// operations during shutdown. A concurrent AddConnection that lands
+// after the snapshot will leak its client at process exit — by design,
+// Close is called once at process shutdown and external callers are
+// expected to stop dispatching new AddConnection calls before invoking
+// Close (the platform's lifecycle layer enforces this).
 func (t *Toolkit) Close() error {
 	t.mu.Lock()
 	clients := make([]*upstreamClient, 0, len(t.connections))

--- a/pkg/toolkits/gateway/toolkit.go
+++ b/pkg/toolkits/gateway/toolkit.go
@@ -242,6 +242,15 @@ type upstream struct {
 	// fresh value (so lastError starts at the zero string ""); there is
 	// no in-place clear. Live connections never set or read this field.
 	lastError string
+
+	// claiming is set briefly while addParsedConnection is performing
+	// network I/O (discover) WITHOUT holding the toolkit's mutex. The
+	// entry exists in t.connections so concurrent AddConnection calls
+	// for the same name see ErrConnectionExists, but other readers
+	// (Status, ListConnections, Tools) treat this as a placeholder.
+	// Cleared when addParsedConnection completes (entry replaced with
+	// either a live connection or a real placeholder).
+	claiming bool
 }
 
 // New builds a Toolkit with the given default connection name and no
@@ -364,54 +373,96 @@ func (t *Toolkit) AddConnection(name string, config map[string]any) error {
 	return t.addParsedConnection(name, cfg)
 }
 
-// addParsedConnection performs the shared dial + registration work under the
-// toolkit's write lock.
+// addParsedConnection runs the dial + registration. The toolkit's mutex
+// is held ONLY for the brief slot-claim and slot-install steps; the
+// network I/O (dial + ListTools) runs WITHOUT the lock so other
+// operations (Status, ListConnections, Tools, RemoveConnection of a
+// different name) proceed in parallel.
+//
+// A "claiming" sentinel entry is inserted in the connections map before
+// the dial so concurrent AddConnection calls for the same name see
+// ErrConnectionExists. The sentinel is replaced atomically when the
+// dial completes (with a live connection on success, a placeholder on
+// auth_code-no-token, or removed on transient failure).
 func (t *Toolkit) addParsedConnection(name string, cfg Config) error {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	if _, exists := t.connections[name]; exists {
-		return fmt.Errorf("gateway: %s: %w", name, ErrConnectionExists)
+	if err := t.claimConnectionSlot(name, cfg); err != nil {
+		return err
 	}
-
-	// Bound the dial by cfg.ConnectTimeout. Without this, IngestOAuthToken
-	// (which calls Remove + Add right after the OAuth callback exchanges a
-	// code for tokens) can hold the callback's HTTP response open for the
-	// full duration of the SDK's internal handshake timeout — minutes at
-	// worst — when the upstream MCP-protocol initialize / notifications/
-	// initialized handshake hangs. Operators saw this as a long-spinning
-	// "Loading…" on the admin page after clicking Connect.
+	// Network I/O happens here, OUTSIDE the lock. A slow or hung
+	// upstream blocks only this call — other toolkit operations
+	// (Status polls, listing connections, calling tools on other
+	// connections) proceed without contention.
 	ctx, cancel := dialContext(cfg)
 	defer cancel()
 	client, tools, err := discover(ctx, cfg, name, t.tokenStore)
-	if err != nil {
+	return t.installDialResult(name, cfg, client, tools, err)
+}
+
+// claimConnectionSlot inserts a sentinel "claiming" entry under the
+// lock so concurrent AddConnection calls for the same name see
+// ErrConnectionExists. Returns ErrConnectionExists if a real or
+// claiming entry already occupies the slot.
+func (t *Toolkit) claimConnectionSlot(name string, cfg Config) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, exists := t.connections[name]; exists {
+		return fmt.Errorf("gateway: %s: %w", name, ErrConnectionExists)
+	}
+	t.connections[name] = &upstream{
+		name:     name,
+		config:   cfg,
+		desc:     "Connecting to " + cfg.Endpoint,
+		claiming: true,
+	}
+	return nil
+}
+
+// installDialResult finishes a claim by replacing the "claiming"
+// sentinel with the dial's result. Holds the lock only briefly to
+// mutate the map and register tools. If the entry no longer exists
+// (concurrent RemoveConnection during dial) OR no longer claiming
+// (concurrent install — shouldn't happen but defensive), the dialed
+// client is closed and dropped.
+func (t *Toolkit) installDialResult(
+	name string, cfg Config, client *upstreamClient, tools []*mcp.Tool, dialErr error,
+) error {
+	t.mu.Lock()
+	existing, ok := t.connections[name]
+	if !ok || !existing.claiming {
+		// Concurrent removal during dial — discard the result.
+		t.mu.Unlock()
+		if client != nil {
+			_ = client.close()
+		}
+		return nil
+	}
+
+	if dialErr != nil {
 		// authorization_code connections without a stored token are
-		// expected to fail discovery — record a placeholder so the admin
-		// status surface knows to render a Connect button. For other
-		// failure modes, keep the existing behavior of bubbling the
-		// error so retries from the admin path can succeed.
+		// expected to fail discovery — keep a placeholder so the admin
+		// status surface renders a Connect button. Other failure modes
+		// drop the slot and bubble the error so retries can succeed.
 		if cfg.AuthMode == AuthModeOAuth && cfg.OAuth.Grant == OAuthGrantAuthorizationCode {
-			// Include the discover() error in BOTH the warning log and
-			// the placeholder's lastError. Operators clicking Connect
-			// otherwise see only "awaiting reauth" with no clue WHY the
-			// upstream rejected — the error gets lost between layers.
-			slog.Warn("gateway: oauth authorization_code connection awaiting reauth",
-				logKeyConnection, cfg.ConnectionName,
-				logKeyEndpoint, cfg.Endpoint,
-				logKeyError, err)
 			t.connections[name] = &upstream{
 				name:      name,
 				config:    cfg,
 				desc:      "Awaiting OAuth authorization",
-				lastError: err.Error(),
+				lastError: dialErr.Error(),
 			}
+			t.mu.Unlock()
+			slog.Warn("gateway: oauth authorization_code connection awaiting reauth",
+				logKeyConnection, cfg.ConnectionName,
+				logKeyEndpoint, cfg.Endpoint,
+				logKeyError, dialErr)
 			return nil
 		}
+		delete(t.connections, name)
+		t.mu.Unlock()
 		slog.Warn("gateway: upstream unavailable",
 			logKeyConnection, cfg.ConnectionName,
 			logKeyEndpoint, cfg.Endpoint,
-			logKeyError, err)
-		return err
+			logKeyError, dialErr)
+		return dialErr
 	}
 
 	u := &upstream{
@@ -426,6 +477,7 @@ func (t *Toolkit) addParsedConnection(name string, cfg Config) error {
 	if t.server != nil {
 		t.addToolsToServerLocked(u)
 	}
+	t.mu.Unlock()
 	slog.Info("gateway: upstream connected",
 		logKeyConnection, cfg.ConnectionName,
 		logKeyEndpoint, cfg.Endpoint,
@@ -435,26 +487,34 @@ func (t *Toolkit) addParsedConnection(name string, cfg Config) error {
 
 // RemoveConnection unregisters a connection's tools from the MCP server,
 // closes its upstream session, and removes it from the toolkit.
+//
+// The toolkit's mutex is held only for the brief map mutation +
+// server.RemoveTools call. The actual client.close() — which performs
+// network I/O (DELETE the MCP session against the upstream) — runs
+// WITHOUT the lock so a slow upstream cannot block other toolkit
+// operations.
 func (t *Toolkit) RemoveConnection(name string) error {
 	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	u, ok := t.connections[name]
 	if !ok {
+		t.mu.Unlock()
 		return fmt.Errorf(errFmtConnection, name, ErrConnectionNotFound)
 	}
-
 	if t.server != nil && len(u.toolNames) > 0 {
 		t.server.RemoveTools(u.toolNames...)
 	}
-	if u.client != nil {
-		if err := u.client.close(); err != nil {
+	delete(t.connections, name)
+	client := u.client
+	connectionName := u.config.ConnectionName
+	t.mu.Unlock()
+
+	if client != nil {
+		if err := client.close(); err != nil {
 			slog.Warn("gateway: error closing upstream session",
-				logKeyConnection, u.config.ConnectionName,
+				logKeyConnection, connectionName,
 				logKeyError, err)
 		}
 	}
-	delete(t.connections, name)
 	return nil
 }
 
@@ -662,15 +722,23 @@ func (t *Toolkit) ListConnections() []toolkit.ConnectionDetail {
 
 // Close closes every upstream session. Safe to call on a never-registered
 // toolkit.
+//
+// Snapshots the live client pointers under the lock and closes them
+// outside the lock so a slow upstream cannot block other toolkit
+// operations during shutdown.
 func (t *Toolkit) Close() error {
 	t.mu.Lock()
-	defer t.mu.Unlock()
-	var firstErr error
+	clients := make([]*upstreamClient, 0, len(t.connections))
 	for _, u := range t.connections {
-		if u.client == nil {
-			continue
+		if u.client != nil {
+			clients = append(clients, u.client)
 		}
-		if err := u.client.close(); err != nil && firstErr == nil {
+	}
+	t.mu.Unlock()
+
+	var firstErr error
+	for _, c := range clients {
+		if err := c.close(); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}

--- a/pkg/toolkits/gateway/toolkit_test.go
+++ b/pkg/toolkits/gateway/toolkit_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
 
 	"github.com/txn2/mcp-data-platform/pkg/toolkits/gateway/enrichment"
 )
@@ -916,5 +917,183 @@ func captureAuthHeader(t *testing.T, header, authMode, credential string) string
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for upstream request")
 		return ""
+	}
+}
+
+// TestStatus_DoesNotBlockDuringSlowAddConnection proves the mutex
+// architecture fix: when AddConnection is performing a slow network
+// handshake against an unresponsive upstream, concurrent Status()
+// calls on OTHER connections must not block on the toolkit's mutex.
+//
+// Pre-fix: Toolkit.mu was held throughout discover() (network I/O).
+// Status() acquired the same mutex and waited for the dial to finish
+// or time out — typically minutes when the upstream hangs on
+// notifications/initialized, which is why /portal/admin/connections
+// hung whenever any connection was misbehaving.
+func TestStatus_DoesNotBlockDuringSlowAddConnection(t *testing.T) {
+	// hungSrv stalls long enough that the test's fast-assertion
+	// window (200ms) lands while AddConnection is still in
+	// discover(). The handler then writes a 500 so AddConnection
+	// terminates promptly when our wait window opens — this isolates
+	// the test to the mutex-contention question and prevents goroutine
+	// leaks from the SDK's HTTP handling on full dial-context expiry.
+	hangFor := 1500 * time.Millisecond
+	hungSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(hangFor):
+			http.Error(w, "simulated upstream rejection", http.StatusInternalServerError)
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(hungSrv.Close)
+
+	healthySrv := upstreamServer(t)
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+
+	require.NoError(t, tk.AddConnection("healthy", map[string]any{
+		"endpoint":        healthySrv,
+		"connection_name": "healthy",
+		"connect_timeout": "3s",
+		"call_timeout":    "3s",
+	}))
+
+	// Start the slow AddConnection in a goroutine.
+	addDone := make(chan error, 1)
+	go func() {
+		addDone <- tk.AddConnection("hung", map[string]any{
+			"endpoint":        hungSrv.URL,
+			"connection_name": "hung",
+			"connect_timeout": "5s",
+			"call_timeout":    "5s",
+		})
+	}()
+	time.Sleep(100 * time.Millisecond) // let the goroutine reach discover()
+
+	// THE assertion: Status() on the OTHER connection must return
+	// promptly while AddConnection on the hung connection is still in
+	// flight. Pre-fix (mutex held through discover) this would block
+	// until the hung dial returned.
+	statusDone := make(chan struct{})
+	go func() {
+		_ = tk.Status("healthy")
+		close(statusDone)
+	}()
+	select {
+	case <-statusDone:
+		// Pass.
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Status() blocked waiting for hung AddConnection — toolkit mutex held during network I/O")
+	}
+
+	// Drain the AddConnection goroutine. The hungSrv responds within
+	// hangFor (~1.5s); SDK round-trip + cleanup add overhead. 30s is a
+	// generous ceiling that won't mask real bugs but tolerates CI jitter.
+	select {
+	case <-addDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("AddConnection didn't return after upstream sent 500 — investigate SDK cleanup")
+	}
+}
+
+// TestListConnections_DoesNotBlockDuringSlowAddConnection is the
+// parallel proof for ListConnections — it's the endpoint backing the
+// /portal/admin/connections page, the visible symptom that prompted
+// the architectural fix.
+func TestListConnections_DoesNotBlockDuringSlowAddConnection(t *testing.T) {
+	hungSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(1500 * time.Millisecond):
+			http.Error(w, "simulated upstream rejection", http.StatusInternalServerError)
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(hungSrv.Close)
+
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+
+	addDone := make(chan error, 1)
+	go func() {
+		addDone <- tk.AddConnection("hung", map[string]any{
+			"endpoint":        hungSrv.URL,
+			"connection_name": "hung",
+			"connect_timeout": "3s",
+			"call_timeout":    "3s",
+		})
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	listDone := make(chan int, 1)
+	go func() {
+		listDone <- len(tk.ListConnections())
+	}()
+	select {
+	case n := <-listDone:
+		// Pass. n should be 1 (the claiming sentinel for "hung") OR 0
+		// depending on test timing — either is acceptable; the point
+		// is that the call returned promptly.
+		_ = n
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("ListConnections() blocked waiting for hung AddConnection — toolkit mutex still held during network I/O")
+	}
+
+	select {
+	case <-addDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("hung AddConnection didn't terminate")
+	}
+}
+
+// TestRemoveConnection_OfDifferentName_DoesNotBlockDuringSlowAddConnection
+// proves the mutex fix also unblocks RemoveConnection of OTHER
+// connections — Remove of an unrelated name must complete fast.
+func TestRemoveConnection_OfDifferentName_DoesNotBlockDuringSlowAddConnection(t *testing.T) {
+	hungSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(1500 * time.Millisecond):
+			http.Error(w, "simulated upstream rejection", http.StatusInternalServerError)
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(hungSrv.Close)
+	healthySrv := upstreamServer(t)
+
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+
+	require.NoError(t, tk.AddConnection("healthy", map[string]any{
+		"endpoint":        healthySrv,
+		"connection_name": "healthy",
+		"connect_timeout": "3s",
+		"call_timeout":    "3s",
+	}))
+
+	addDone := make(chan error, 1)
+	go func() {
+		addDone <- tk.AddConnection("hung", map[string]any{
+			"endpoint":        hungSrv.URL,
+			"connection_name": "hung",
+			"connect_timeout": "3s",
+			"call_timeout":    "3s",
+		})
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	removeDone := make(chan error, 1)
+	go func() {
+		removeDone <- tk.RemoveConnection("healthy")
+	}()
+	select {
+	case err := <-removeDone:
+		require.NoError(t, err)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("RemoveConnection('healthy') blocked waiting for hung AddConnection on a DIFFERENT name — mutex contention bug")
+	}
+
+	select {
+	case <-addDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("hung AddConnection didn't terminate")
 	}
 }

--- a/pkg/toolkits/gateway/toolkit_test.go
+++ b/pkg/toolkits/gateway/toolkit_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/txn2/mcp-data-platform/pkg/toolkits/gateway/enrichment"
@@ -1095,5 +1096,216 @@ func TestRemoveConnection_OfDifferentName_DoesNotBlockDuringSlowAddConnection(t 
 	case <-addDone:
 	case <-time.After(10 * time.Second):
 		t.Fatal("hung AddConnection didn't terminate")
+	}
+}
+
+// TestAddConnection_SameName_OnlyOneWins proves the slot-claim
+// contract under contention: two concurrent AddConnection calls for
+// the same name must serialize via the claim sentinel. Exactly one
+// returns nil (or an authcode-placeholder success); the other
+// returns ErrConnectionExists immediately, even while the first is
+// in the middle of its dial.
+func TestAddConnection_SameName_OnlyOneWins(t *testing.T) {
+	hangFor := 1 * time.Second
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(hangFor):
+			http.Error(w, "deliberate", http.StatusInternalServerError)
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+
+	cfg := map[string]any{
+		"endpoint":        srv.URL,
+		"connection_name": "vendor",
+		"connect_timeout": "5s",
+		"call_timeout":    "5s",
+	}
+
+	results := make(chan error, 2)
+	for range 2 {
+		go func() { results <- tk.AddConnection("vendor", cfg) }()
+	}
+
+	got := []error{<-results, <-results}
+	// One result must be ErrConnectionExists; the other is the
+	// outcome of the actual dial (in this case 500 → bubbled error
+	// since we're not in auth_code mode and there's no placeholder
+	// path). The exact dial-outcome error is incidental — the
+	// contract under test is "exactly one ErrConnectionExists."
+	conflicts := 0
+	for _, err := range got {
+		if errors.Is(err, ErrConnectionExists) {
+			conflicts++
+		}
+	}
+	require.Equal(t, 1, conflicts,
+		"exactly one of two concurrent AddConnection calls for the same name must return ErrConnectionExists; got %v", got)
+}
+
+// TestRemoveConnection_DuringSlowAdd_DiscardsResult proves the
+// install-time identity check: when a connection's slot is removed
+// while its dial is in flight, the dial's result is discarded
+// (client closed, no entry installed) instead of being silently
+// added back into the map.
+func TestRemoveConnection_DuringSlowAdd_DiscardsResult(t *testing.T) {
+	healthySrv := upstreamServer(t)
+
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+
+	// Start a healthy AddConnection in a goroutine. The dial against
+	// upstreamServer is fast (~50-100ms) so we have a narrow window —
+	// but we control the race by removing the claim BEFORE the dial
+	// completes from the perspective of the toolkit's mutex.
+	addDone := make(chan error, 1)
+	go func() {
+		addDone <- tk.AddConnection("vendor", map[string]any{
+			"endpoint":        healthySrv,
+			"connection_name": "vendor",
+			"connect_timeout": "3s",
+			"call_timeout":    "3s",
+		})
+	}()
+
+	// Race the goroutine to the lock. RemoveConnection acquires the
+	// mutex, sees the claim sentinel, deletes it, releases. By the
+	// time the goroutine's discover() finishes and tries to install,
+	// the slot is gone — installDialResult takes the discard path.
+	//
+	// Use a tiny spin to ensure the AddConnection goroutine has
+	// claimed the slot before we try to remove it. Without this,
+	// RemoveConnection might run BEFORE the claim and return
+	// ErrConnectionNotFound — which is also a valid outcome but
+	// doesn't exercise the discard path we're testing.
+	var removeErr error
+	for range 100 {
+		removeErr = tk.RemoveConnection("vendor")
+		if removeErr == nil {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	require.NoError(t, removeErr, "RemoveConnection must observe the claim sentinel and remove it")
+
+	// Wait for the AddConnection goroutine to finish — it should
+	// return without error (the discard path returns nil since the
+	// OAuth flow has effectively succeeded; the slot just isn't
+	// ours). The connection must NOT be present afterwards.
+	select {
+	case <-addDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("AddConnection goroutine didn't terminate")
+	}
+	assert.Nil(t, tk.Status("vendor"),
+		"after RemoveConnection-during-claim, the slot must remain empty — "+
+			"the dial result was discarded, not silently re-installed")
+}
+
+// TestAddConnection_RemoveAndReAdd_DuringSlowDial_DoesNotCorruptSlot
+// proves the pointer-identity check in installDialResult.
+//
+// Race scenario this test specifically exposes:
+//
+//	T1 AddConnection (slow dial 1) → claims S1 → dialing
+//	RemoveConnection → deletes S1 from map
+//	T2 AddConnection (slower dial 2) → claims S2 → dialing
+//	T1's dial completes WHILE T2 is still claiming
+//	   → installDialResult must compare *upstream pointers (S1 vs S2)
+//	     and DISCARD T1's result, NOT install based on existing.claiming
+//	     (which is true because S2 is still in flight).
+//
+// Without the identity check, T1 sees `existing.claiming == true` and
+// installs its result into S2's slot, overwriting T2's claim. T2's
+// own dial later finds the slot already live (claiming=false) and
+// discards. Net effect: operator's most recent Connect is silently
+// replaced by the previous Connect's result.
+func TestAddConnection_RemoveAndReAdd_DuringSlowDial_DoesNotCorruptSlot(t *testing.T) {
+	// T1's upstream: hangs ~600ms then returns 500.
+	slowSrv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(600 * time.Millisecond):
+			http.Error(w, "T1 deliberate", http.StatusInternalServerError)
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(slowSrv1.Close)
+
+	// T2's upstream: hangs ~2s. T2 is STILL claiming when T1 installs.
+	// T2 must outlast T1's dial so the install-time race fires.
+	slowSrv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(2 * time.Second):
+			http.Error(w, "T2 deliberate", http.StatusInternalServerError)
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(slowSrv2.Close)
+
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+
+	// T1: claim slot, dial slowSrv1.
+	t1Done := make(chan error, 1)
+	go func() {
+		t1Done <- tk.AddConnection("vendor", map[string]any{
+			"endpoint":        slowSrv1.URL,
+			"connection_name": "vendor",
+			"connect_timeout": "5s",
+			"call_timeout":    "5s",
+		})
+	}()
+	time.Sleep(50 * time.Millisecond) // ensure T1 has claimed
+
+	// Drop T1's claim from the map.
+	require.NoError(t, tk.RemoveConnection("vendor"))
+
+	// T2: claim slot, dial slowSrv2 (slower than T1).
+	t2Done := make(chan error, 1)
+	go func() {
+		t2Done <- tk.AddConnection("vendor", map[string]any{
+			"endpoint":        slowSrv2.URL,
+			"connection_name": "vendor",
+			"connect_timeout": "5s",
+			"call_timeout":    "5s",
+		})
+	}()
+	time.Sleep(50 * time.Millisecond) // ensure T2 has claimed and is dialing
+
+	// At this moment: T1 is still dialing slowSrv1 (~500ms left).
+	// T2 has just claimed and is dialing slowSrv2 (~2s left).
+	// The slot holds S2 (claiming=true).
+
+	// Wait for T1's dial to complete. With the pointer-identity check,
+	// T1's installDialResult sees `t.connections[name] != claim_S1`
+	// (it holds claim_S2) and discards. Without the check, T1 sees
+	// `existing.claiming == true` and installs over S2.
+	select {
+	case <-t1Done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("T1 AddConnection didn't terminate")
+	}
+
+	// Snapshot Status WHILE T2 is still claiming. After the
+	// pointer-identity fix, the slot still holds T2's claim sentinel
+	// (claiming=true, client=nil → Healthy=false, no toolNames). If
+	// T1 had clobbered the slot with its install path, Status would
+	// reflect a (transient) installed entry from T1's dial.
+	mid := tk.Status("vendor")
+	require.NotNil(t, mid, "T2's claim must still occupy the slot")
+	assert.False(t, mid.Healthy,
+		"slot must still be a claim sentinel — Healthy=true here means T1's stale dial corrupted T2's claim")
+	assert.Empty(t, mid.Tools,
+		"claim sentinel must have no tools — non-empty Tools means T1 installed against T2's slot")
+
+	// Wait for T2's dial to complete (~1.5s remaining at this point).
+	select {
+	case <-t2Done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("T2 AddConnection didn't terminate")
 	}
 }


### PR DESCRIPTION
## Summary

Two related fixes to the gateway toolkit:

1. **OAuth Connect flow no longer hangs for ~125 seconds against Cloudflare-fronted upstream MCP servers.** Sets `StreamableClientTransport.DisableStandaloneSSE = true`.
2. **`Toolkit.mu` no longer protects network I/O.** A slow connection's handshake can no longer block `Status`, `ListConnections`, `Tools`, or `RemoveConnection` of unrelated names. The admin connections page stays responsive regardless of any one connection's state.

## The Connect-flow hang — root cause and fix

When a gateway connection's upstream MCP server is fronted by a buffering proxy (Cloudflare in this case, but applies to any reverse proxy with response buffering), the OAuth callback handler took ~125 seconds to redirect after a successful Connect.

The MCP go-sdk's `Client.Connect()` performs this sequence:

1. `POST /` `initialize` → upstream returns SSE with the initialize result
2. `sessionUpdated()` callback runs **synchronously**
3. Inside `sessionUpdated()`, the SDK calls `connectStandaloneSSE()` — a `GET /` with `Accept: text/event-stream` to subscribe to server-pushed messages (MCP spec §2.2.3, OPTIONAL)
4. After that returns, the SDK sends `notifications/initialized`

For most steady-state MCP servers there are no server-initiated notifications to push immediately. The upstream holds the SSE GET open. Cloudflare's response buffer waits for the origin to produce data and times out at ~100s with HTTP 524. The synchronous `Connect()` therefore takes 100s+ to return; our 10s dial context has long since expired by the time the SDK gets to send `notifications/initialized` — which surfaced as the misleading error `round trip: context deadline exceeded on notifications/initialized` in production logs.

### Reproduction with curl

Against a real upstream:

```
POST /                                    # initialize
  → 200 SSE in 200ms ✓

GET / (Accept: text/event-stream + valid session ID)
  → HTTP 524 after 125s (Cloudflare timeout) ✗

POST / (notifications/initialized + session ID)
  → 202 Accepted in 200ms ✓
```

The hang is exclusively on the standalone SSE GET. Both protocol POSTs are fast.

### Fix

`StreamableClientTransport.DisableStandaloneSSE = true`. The SDK documents this exact option for our use case: *"useful when you only need request-response communication and don't need server-initiated notifications."* Gateway forwarding is a synchronous request/response model — every tool call is a discrete `tools/call` from the platform, response from the upstream. We don't currently consume server-pushed notifications.

If we add streaming-tool support later, this can be revisited: either re-enable the standalone SSE and disable Cloudflare's response buffering for the relevant path, or open the GET stream lazily on demand.

## The mutex architecture fix

`Toolkit.mu` was held during three network I/O operations:

| Method | Network I/O held under lock |
|---|---|
| `addParsedConnection` | `discover()` — full MCP handshake + `ListTools` |
| `RemoveConnection` | `client.close()` — DELETE the MCP session against the upstream |
| `Close` | every connection's `client.close()` in sequence |

Result: ANY slow connection serialized ALL toolkit operations. `Status` polls (admin UI poll loop), `ListConnections` (the connections page itself), `Tools`, even `RemoveConnection` of a different connection — all blocked behind the slow handshake.

### Refactor

Mirrors the pattern already used by `SetTokenStore` (snapshot under lock, do I/O outside the lock, install under lock):

- **`addParsedConnection`** — split into `claimConnectionSlot` (brief lock to insert a sentinel), `discover()` (no lock), and `installDialResult` (brief lock to install live connection / placeholder / drop on transient failure). A new `claiming bool` field on the `upstream` struct guards against concurrent `AddConnection` calls for the same name; concurrent `RemoveConnection` during a claim is also handled (dialed client is closed and discarded).

- **`RemoveConnection`** — pop entry from map and capture the client pointer under the lock; `client.close()` runs outside the lock.

- **`Close`** — snapshot all live client pointers under the lock; close them all outside the lock.

`Status`, `ListConnections`, `Tools`, `HasConnection`, `RegisterTools`, and the placeholder error-recording helpers remain RLock-only and unchanged — they were already correct in not doing network I/O, but were transitively blocked by the writers above.

## Testing

Three new tests in `pkg/toolkits/gateway/toolkit_test.go` exercise the mutex contract:

- `TestStatus_DoesNotBlockDuringSlowAddConnection`
- `TestListConnections_DoesNotBlockDuringSlowAddConnection`
- `TestRemoveConnection_OfDifferentName_DoesNotBlockDuringSlowAddConnection`

Each starts an `AddConnection` against an httptest server that delays its response, then asserts a parallel toolkit operation returns within 200ms. All three would fail before the refactor and pass after.

## Verification

- `go test -race -count=1 ./...` — **48 packages pass**
- `npm test --run` (UI) — **39 tests pass**
- `golangci-lint run --new-from-rev=main ./...` — **0 new issues**
- Patch coverage **91.8%** overall (`client.go` 100%, `toolkit.go` 87.7%)

## Test plan

- [x] `go test -race -count=1 -timeout=300s ./...`
- [x] UI test suite (`cd ui && npm test -- --run`)
- [x] `golangci-lint run --new-from-rev=main ./...`
- [x] `make patch-coverage`
- [ ] Deploy to demo environment and click Connect on the gateway connection — verify the OAuth callback redirects within seconds (not 125s)
- [ ] During a Connect flow, refresh `/portal/admin/connections` in a parallel tab — verify the page remains responsive

## Files changed

- `pkg/toolkits/gateway/client.go` — `DisableStandaloneSSE: true` on the SDK transport
- `pkg/toolkits/gateway/toolkit.go` — mutex refactor; `claiming` field on `upstream`; helpers extracted from `addParsedConnection`
- `pkg/toolkits/gateway/toolkit_test.go` — three concurrency tests