### PR TITLE
fix(admin): list-tools attributes per-tool connection for fan-out toolkits (gateway)

### DIFF
--- a/pkg/admin/system.go
+++ b/pkg/admin/system.go
@@ -8,6 +8,7 @@ import (
 
 	mcpserver "github.com/txn2/mcp-data-platform/internal/server"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
 )
 
 // systemInfoResponse is returned by GET /system/info.
@@ -156,13 +157,29 @@ func (h *Handler) listTools(w http.ResponseWriter, r *http.Request) {
 	var tools []toolInfo
 	if h.deps.ToolkitRegistry != nil {
 		for _, tk := range h.deps.ToolkitRegistry.All() {
+			// resolver is non-nil for toolkits that fan out across
+			// multiple upstream connections (the gateway). Tools from
+			// such toolkits are namespaced and each maps back to a
+			// specific upstream — falling back to tk.Connection() (the
+			// toolkit's instance-level default) would lump every
+			// gateway tool under one bucket regardless of which upstream
+			// owns it, making the admin Tools page group all of them
+			// under "platform" / the toolkit's default name.
+			resolver, _ := tk.(registry.ConnectionResolver)
+			defaultConn := tk.Connection()
 			for _, name := range tk.Tools() {
+				conn := defaultConn
+				if resolver != nil {
+					if perTool := resolver.ConnectionForTool(name); perTool != "" {
+						conn = perTool
+					}
+				}
 				tools = append(tools, toolInfo{
 					Name:       name,
 					Title:      titleMap[name],
 					Toolkit:    tk.Name(),
 					Kind:       tk.Kind(),
-					Connection: tk.Connection(),
+					Connection: conn,
 					Hidden:     !middleware.IsToolVisible(name, allow, deny),
 				})
 			}

--- a/pkg/admin/system_test.go
+++ b/pkg/admin/system_test.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/txn2/mcp-data-platform/internal/apidocs" // register swagger docs
 	mcpserver "github.com/txn2/mcp-data-platform/internal/server"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
 )
 
 func TestGetSystemInfo(t *testing.T) {
@@ -285,7 +286,70 @@ func TestListTools(t *testing.T) {
 		assert.Equal(t, 1, body.Total)
 		assert.Equal(t, "platform_info", body.Tools[0].Name)
 	})
+
+	t.Run("uses ConnectionResolver per tool when toolkit fans out across upstreams", func(t *testing.T) {
+		// Mirrors the gateway toolkit's behavior: one toolkit instance,
+		// many upstream connections, each tool maps to a specific
+		// upstream via ConnectionForTool. Without resolver use, every
+		// tool would inherit the toolkit's instance-level Connection()
+		// (or empty string) and the admin Tools page would group them
+		// all under "platform" / the toolkit's default name.
+		gw := gatewayLikeToolkit{
+			mockToolkit: mockToolkit{
+				kind:       "mcp",
+				name:       "primary",
+				connection: "primary", // would be the bucket key without per-tool resolution
+				tools:      []string{"vendor_a__list", "vendor_b__list", "unrouted_tool"},
+			},
+			perTool: map[string]string{
+				"vendor_a__list": "vendor-a",
+				"vendor_b__list": "vendor-b",
+				// "unrouted_tool" deliberately absent to exercise the
+				// empty-string fallback to tk.Connection().
+			},
+		}
+		reg := &mockToolkitRegistry{rawToolkits: []registry.Toolkit{gw}}
+		h := NewHandler(Deps{ToolkitRegistry: reg}, nil)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/admin/tools", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		var body toolListResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+		require.Len(t, body.Tools, 3)
+
+		byName := make(map[string]toolInfo, len(body.Tools))
+		for _, ti := range body.Tools {
+			byName[ti.Name] = ti
+		}
+		assert.Equal(t, "vendor-a", byName["vendor_a__list"].Connection,
+			"per-tool resolver must override toolkit default for tools that ConnectionForTool resolves")
+		assert.Equal(t, "vendor-b", byName["vendor_b__list"].Connection)
+		assert.Equal(t, "primary", byName["unrouted_tool"].Connection,
+			"empty ConnectionForTool result must fall back to tk.Connection() so tools aren't dropped into the platform bucket")
+	})
 }
+
+// gatewayLikeToolkit embeds mockToolkit and adds ConnectionForTool so it
+// satisfies registry.ConnectionResolver — modeling the gateway
+// toolkit's 1:many fan-out behavior in a unit test without pulling in
+// the gateway package.
+type gatewayLikeToolkit struct {
+	mockToolkit
+	perTool map[string]string
+}
+
+func (g gatewayLikeToolkit) ConnectionForTool(toolName string) string {
+	return g.perTool[toolName]
+}
+
+// Verify the test mock implements both interfaces.
+var (
+	_ registry.Toolkit            = gatewayLikeToolkit{}
+	_ registry.ConnectionResolver = gatewayLikeToolkit{}
+)
 
 func TestListConnections(t *testing.T) {
 	t.Run("returns connections from registry", func(t *testing.T) {


### PR DESCRIPTION
## Summary

The admin **Tools** page grouped every gateway-proxied tool under "Platform" because the list-tools endpoint labeled each tool's owning connection with the toolkit's instance-level default. For the gateway toolkit (one instance, many upstreams) that default is the same string for every tool — typically empty — so the UI's fallback `t.connection || "platform"` lumped them all together.

This PR makes `GET /api/v1/admin/tools` resolve each tool's connection per-tool via the existing `registry.ConnectionResolver` interface.

## Root cause

`pkg/admin/system.go:listTools` populated `toolInfo.Connection` from `tk.Connection()` for every tool:

```go
for _, name := range tk.Tools() {
    tools = append(tools, toolInfo{
        ...
        Connection: tk.Connection(), // toolkit's instance-level default
    })
}
```

For 1:1 toolkits (trino, datahub, s3) that's correct — one toolkit instance ↔ one connection. For the **gateway** toolkit it isn't: `pkg/toolkits/gateway/toolkit.go:Connection()` returns the toolkit's `defaultName`, while each proxied tool's actual upstream is resolved via `ConnectionForTool(toolName)` (already used by the audit middleware to attribute proxied calls).

The UI then bucketed by connection in `ui/src/pages/tools/ToolsList.tsx:38-41`:

```ts
const key =
  groupBy === "connection"
    ? t.connection || "platform"
    : t.kind || "other";
```

Empty `connection` → "platform" bucket. Every gateway tool landed there regardless of which upstream actually owned it.

## Fix

`listTools` now type-asserts each toolkit to `registry.ConnectionResolver` (the interface already declared at `pkg/registry/toolkit.go:75-77`) and calls `ConnectionForTool(name)` per tool when implemented, falling back to `tk.Connection()` when the resolver returns empty:

```go
resolver, _ := tk.(registry.ConnectionResolver)
defaultConn := tk.Connection()
for _, name := range tk.Tools() {
    conn := defaultConn
    if resolver != nil {
        if perTool := resolver.ConnectionForTool(name); perTool != "" {
            conn = perTool
        }
    }
    tools = append(tools, toolInfo{
        ...
        Connection: conn,
    })
}
```

No interface changes, no upstream toolkit changes (`txn2/mcp-{trino,datahub,s3}` are unaffected — they don't implement `ConnectionResolver` and never need to). The gateway toolkit already implements it.

## Test

`TestListTools/uses_ConnectionResolver_per_tool_when_toolkit_fans_out_across_upstreams` adds a `gatewayLikeToolkit` mock (embeds `mockToolkit`, implements `ConnectionForTool`) and asserts both branches:

- Tools with explicit per-tool mapping get the per-tool connection (`vendor-a`, `vendor-b`)
- Tools without a mapping fall back to `tk.Connection()` so they don't drop into the platform bucket

## Behavior change visible in the UI

Before: gateway-proxied tools grouped under **Platform**.
After: gateway-proxied tools grouped under their respective upstream connection name (matching how the **Connections** page already labels them, and how the audit log already attributes them).

Platform tools (`platform_info`, `list_connections`, `manage_prompt`, etc.) continue to group under **Platform** — they have no toolkit and no `Connection`.

## Files changed

- `pkg/admin/system.go` — resolver type-assert + per-tool resolution in `listTools`
- `pkg/admin/system_test.go` — `gatewayLikeToolkit` mock + new subtest

## Verification

- 48 Go packages pass `go test -race -count=1`
- `golangci-lint run --new-from-rev=main`: 0 new issues
- Patch coverage **100%** (16/16 changed lines)

## Test plan

- [x] `go test -race -count=1 -run TestListTools ./pkg/admin/`
- [x] `go test -race -count=1 -timeout=300s ./...`
- [x] `golangci-lint run --new-from-rev=main ./...`
- [x] `make patch-coverage`
- [ ] Deploy to demo and verify the Tools page groups gateway connections under their own upstream names instead of "Platform"