### PR TITLE
fix(oauth): structured token-endpoint observability + repo-wide lint cleanup

### DIFF
--- a/cmd/dev-mcp-mock/main.go
+++ b/cmd/dev-mcp-mock/main.go
@@ -180,6 +180,9 @@ func oauthAuthorize(w http.ResponseWriter, r *http.Request) {
 	// to the client-supplied redirect_uri. This is a dev fixture, not
 	// a production OAuth provider; no allowlist enforcement is
 	// appropriate here.
+	// #nosec G710 -- this is the OAuth /authorize endpoint of a dev
+	// fixture; spec mandates redirecting to the client-supplied
+	// redirect_uri (justification above).
 	http.Redirect(w, r, dest.String(), http.StatusFound) // nosemgrep: go.lang.security.injection.open-redirect.open-redirect
 }
 

--- a/cmd/preview-content-viewer/main.go
+++ b/cmd/preview-content-viewer/main.go
@@ -72,12 +72,16 @@ nav a.active{background:var(--badge-bg);color:var(--badge-text)}
 </body>
 </html>`
 
+// sampleMarkdown is the default sample type, also used as the fallback
+// when an unknown ?type= query parameter is provided.
+const sampleMarkdown = "markdown"
+
 var samples = map[string][2]string{
-	"markdown": {"text/markdown", "# Hello World\n\nThis is a **bold** test with GFM:\n\n| Feature | Status |\n|---------|--------|\n| Tables | Working |\n| Strikethrough | ~~yes~~ |\n\n- [x] Task list\n- [ ] Another task\n\n```go\nfunc main() {\n    fmt.Println(\"Hello\")\n}\n```\n"},
-	"svg":      {"image/svg+xml", `<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><circle cx="100" cy="100" r="80" fill="#3b82f6" opacity="0.8"/><text x="100" y="108" text-anchor="middle" fill="white" font-size="24" font-family="system-ui">SVG</text></svg>`},
-	"jsx":      {"text/jsx", "import { useState } from 'react';\n\nexport default function Counter() {\n  const [count, setCount] = useState(0);\n  return (\n    <div style={{padding: '2rem', fontFamily: 'system-ui'}}>\n      <h1>Counter: {count}</h1>\n      <button onClick={() => setCount(c => c + 1)}\n        style={{padding: '8px 16px', fontSize: '16px', cursor: 'pointer'}}>\n        Increment\n      </button>\n    </div>\n  );\n}\n"},
-	"html":     {"text/html", "<!DOCTYPE html>\n<html>\n<head><style>body{font-family:system-ui;padding:2rem}h1{color:#3b82f6}</style></head>\n<body><h1>Hello from HTML</h1><p>This is rendered in a sandboxed iframe.</p></body>\n</html>"},
-	"plain":    {"text/plain", "This is plain text content.\nIt should be displayed in a <pre> block.\n\nSpecial chars: <script>alert('xss')</script> & \"quotes\""},
+	sampleMarkdown: {"text/markdown", "# Hello World\n\nThis is a **bold** test with GFM:\n\n| Feature | Status |\n|---------|--------|\n| Tables | Working |\n| Strikethrough | ~~yes~~ |\n\n- [x] Task list\n- [ ] Another task\n\n```go\nfunc main() {\n    fmt.Println(\"Hello\")\n}\n```\n"},
+	"svg":          {"image/svg+xml", `<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><circle cx="100" cy="100" r="80" fill="#3b82f6" opacity="0.8"/><text x="100" y="108" text-anchor="middle" fill="white" font-size="24" font-family="system-ui">SVG</text></svg>`},
+	"jsx":          {"text/jsx", "import { useState } from 'react';\n\nexport default function Counter() {\n  const [count, setCount] = useState(0);\n  return (\n    <div style={{padding: '2rem', fontFamily: 'system-ui'}}>\n      <h1>Counter: {count}</h1>\n      <button onClick={() => setCount(c => c + 1)}\n        style={{padding: '8px 16px', fontSize: '16px', cursor: 'pointer'}}>\n        Increment\n      </button>\n    </div>\n  );\n}\n"},
+	"html":         {"text/html", "<!DOCTYPE html>\n<html>\n<head><style>body{font-family:system-ui;padding:2rem}h1{color:#3b82f6}</style></head>\n<body><h1>Hello from HTML</h1><p>This is rendered in a sandboxed iframe.</p></body>\n</html>"},
+	"plain":        {"text/plain", "This is plain text content.\nIt should be displayed in a <pre> block.\n\nSpecial chars: <script>alert('xss')</script> & \"quotes\""},
 }
 
 var viewerTpl = template.Must(template.New("viewer").Parse(viewerHTML))
@@ -88,11 +92,11 @@ func newHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		typ := r.URL.Query().Get("type")
 		if typ == "" {
-			typ = "markdown"
+			typ = sampleMarkdown
 		}
 		sample, ok := samples[typ]
 		if !ok {
-			sample = samples["markdown"]
+			sample = samples[sampleMarkdown]
 		}
 
 		contentJSON, _ := json.Marshal(map[string]string{ // #nosec G104 -- string map marshaling cannot fail

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -7891,6 +7891,10 @@ const docTemplate = `{
                     "description": "NeedsReauth is true when the platform cannot mint an access token\nwithout operator interaction. For authorization_code grants this\nmeans: no stored token, or the refresh token has been revoked.\nThe admin UI surfaces a \"Connect\" button when this is true.",
                     "type": "boolean"
                 },
+                "refresh_token_revoked": {
+                    "description": "RefreshTokenRevoked is true when the most recent refresh attempt\ngot a definitive RFC 6749 §5.2 invalid_grant response — meaning\nthe IdP has invalidated the stored refresh token (idle session\ntimeout, admin revocation, password change, etc.) and the\noperator must complete a fresh browser-side authorization. The\nadmin UI uses this to distinguish \"click Connect to reauthorize\"\nfrom a transient \"click Reacquire to retry\" state.",
+                    "type": "boolean"
+                },
                 "scope": {
                     "type": "string"
                 },

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -7885,6 +7885,10 @@
                     "description": "NeedsReauth is true when the platform cannot mint an access token\nwithout operator interaction. For authorization_code grants this\nmeans: no stored token, or the refresh token has been revoked.\nThe admin UI surfaces a \"Connect\" button when this is true.",
                     "type": "boolean"
                 },
+                "refresh_token_revoked": {
+                    "description": "RefreshTokenRevoked is true when the most recent refresh attempt\ngot a definitive RFC 6749 \u00a75.2 invalid_grant response \u2014 meaning\nthe IdP has invalidated the stored refresh token (idle session\ntimeout, admin revocation, password change, etc.) and the\noperator must complete a fresh browser-side authorization. The\nadmin UI uses this to distinguish \"click Connect to reauthorize\"\nfrom a transient \"click Reacquire to retry\" state.",
+                    "type": "boolean"
+                },
                 "scope": {
                     "type": "string"
                 },

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -1163,6 +1163,16 @@ definitions:
           means: no stored token, or the refresh token has been revoked.
           The admin UI surfaces a "Connect" button when this is true.
         type: boolean
+      refresh_token_revoked:
+        description: |-
+          RefreshTokenRevoked is true when the most recent refresh attempt
+          got a definitive RFC 6749 §5.2 invalid_grant response — meaning
+          the IdP has invalidated the stored refresh token (idle session
+          timeout, admin revocation, password change, etc.) and the
+          operator must complete a fresh browser-side authorization. The
+          admin UI uses this to distinguish "click Connect to reauthorize"
+          from a transient "click Reacquire to retry" state.
+        type: boolean
       scope:
         type: string
       token_acquired:

--- a/pkg/admin/gateway_oauth_handler.go
+++ b/pkg/admin/gateway_oauth_handler.go
@@ -375,6 +375,9 @@ func (h *Handler) gatewayOAuthCallback(w http.ResponseWriter, r *http.Request) {
 		logKeyStartedBy, pending.startedBy,
 		logKeyDuration, time.Since(start),
 		"dest", dest)
+	// #nosec G710 -- safeReturnURL has already constrained dest to a
+	// same-origin relative path or the constant fallback; see contract
+	// above and TestSafeReturnURL.
 	http.Redirect(w, r, dest, http.StatusFound) // nosemgrep: go.lang.security.injection.open-redirect.open-redirect
 }
 

--- a/pkg/admin/middleware_test.go
+++ b/pkg/admin/middleware_test.go
@@ -474,7 +474,7 @@ func TestPlatformAuthenticator_Authenticate(t *testing.T) {
 		)
 
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
-		req.AddCookie(&http.Cookie{Name: browsersession.DefaultCookieName, Value: token})
+		req.AddCookie(&http.Cookie{Name: browsersession.DefaultCookieName, Value: token, HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode})
 
 		user, err := pa.Authenticate(req)
 		require.NoError(t, err)
@@ -501,7 +501,7 @@ func TestPlatformAuthenticator_Authenticate(t *testing.T) {
 		)
 
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
-		req.AddCookie(&http.Cookie{Name: browsersession.DefaultCookieName, Value: token})
+		req.AddCookie(&http.Cookie{Name: browsersession.DefaultCookieName, Value: token, HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode})
 
 		user, err := pa.Authenticate(req)
 		require.NoError(t, err)

--- a/pkg/admin/system.go
+++ b/pkg/admin/system.go
@@ -142,7 +142,6 @@ type toolListResponse struct {
 // @Security     BearerAuth
 // @Router       /admin/tools [get]
 func (h *Handler) listTools(w http.ResponseWriter, r *http.Request) {
-	// Build a title map from MCP ListTools if possible.
 	titleMap := h.buildToolTitleMap(r)
 
 	var allow, deny []string
@@ -154,37 +153,7 @@ func (h *Handler) listTools(w http.ResponseWriter, r *http.Request) {
 		deny = h.deps.Config.ToolsDenySnapshot()
 	}
 
-	var tools []toolInfo
-	if h.deps.ToolkitRegistry != nil {
-		for _, tk := range h.deps.ToolkitRegistry.All() {
-			// resolver is non-nil for toolkits that fan out across
-			// multiple upstream connections (the gateway). Tools from
-			// such toolkits are namespaced and each maps back to a
-			// specific upstream — falling back to tk.Connection() (the
-			// toolkit's instance-level default) would lump every
-			// gateway tool under one bucket regardless of which upstream
-			// owns it, making the admin Tools page group all of them
-			// under "platform" / the toolkit's default name.
-			resolver, _ := tk.(registry.ConnectionResolver)
-			defaultConn := tk.Connection()
-			for _, name := range tk.Tools() {
-				conn := defaultConn
-				if resolver != nil {
-					if perTool := resolver.ConnectionForTool(name); perTool != "" {
-						conn = perTool
-					}
-				}
-				tools = append(tools, toolInfo{
-					Name:       name,
-					Title:      titleMap[name],
-					Toolkit:    tk.Name(),
-					Kind:       tk.Kind(),
-					Connection: conn,
-					Hidden:     !middleware.IsToolVisible(name, allow, deny),
-				})
-			}
-		}
-	}
+	tools := h.collectToolkitTools(titleMap, allow, deny)
 	for _, pt := range h.deps.PlatformTools {
 		tools = append(tools, toolInfo{
 			Name:   pt.Name,
@@ -198,6 +167,43 @@ func (h *Handler) listTools(w http.ResponseWriter, r *http.Request) {
 	}
 	sort.Slice(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
 	writeJSON(w, http.StatusOK, toolListResponse{Tools: tools, Total: len(tools)})
+}
+
+func (h *Handler) collectToolkitTools(titleMap map[string]string, allow, deny []string) []toolInfo {
+	if h.deps.ToolkitRegistry == nil {
+		return nil
+	}
+	var tools []toolInfo
+	for _, tk := range h.deps.ToolkitRegistry.All() {
+		// resolver is non-nil for toolkits that fan out across multiple
+		// upstream connections (the gateway). Tools from such toolkits
+		// are namespaced and each maps back to a specific upstream —
+		// falling back to tk.Connection() (the toolkit's instance-level
+		// default) would lump every gateway tool under one bucket.
+		resolver, _ := tk.(registry.ConnectionResolver)
+		defaultConn := tk.Connection()
+		for _, name := range tk.Tools() {
+			tools = append(tools, toolInfo{
+				Name:       name,
+				Title:      titleMap[name],
+				Toolkit:    tk.Name(),
+				Kind:       tk.Kind(),
+				Connection: resolveToolConnection(resolver, name, defaultConn),
+				Hidden:     !middleware.IsToolVisible(name, allow, deny),
+			})
+		}
+	}
+	return tools
+}
+
+func resolveToolConnection(resolver registry.ConnectionResolver, name, defaultConn string) string {
+	if resolver == nil {
+		return defaultConn
+	}
+	if perTool := resolver.ConnectionForTool(name); perTool != "" {
+		return perTool
+	}
+	return defaultConn
 }
 
 // buildToolTitleMap returns a map of tool name → title from the MCP server.

--- a/pkg/admin/system.go
+++ b/pkg/admin/system.go
@@ -169,17 +169,21 @@ func (h *Handler) listTools(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, toolListResponse{Tools: tools, Total: len(tools)})
 }
 
+// collectToolkitTools enumerates every tool registered by every toolkit
+// in the registry and resolves its display connection. Tools from
+// fan-out toolkits (the gateway) are namespaced per upstream and must
+// be attributed to the upstream that owns them — falling back to
+// tk.Connection() (the toolkit's instance-level default) would lump
+// every gateway tool under one bucket regardless of which upstream
+// owns it, making the admin Tools page group all of them under
+// "platform" / the toolkit's default name. resolveToolConnection
+// implements the per-tool override.
 func (h *Handler) collectToolkitTools(titleMap map[string]string, allow, deny []string) []toolInfo {
 	if h.deps.ToolkitRegistry == nil {
 		return nil
 	}
 	var tools []toolInfo
 	for _, tk := range h.deps.ToolkitRegistry.All() {
-		// resolver is non-nil for toolkits that fan out across multiple
-		// upstream connections (the gateway). Tools from such toolkits
-		// are namespaced and each maps back to a specific upstream —
-		// falling back to tk.Connection() (the toolkit's instance-level
-		// default) would lump every gateway tool under one bucket.
 		resolver, _ := tk.(registry.ConnectionResolver)
 		defaultConn := tk.Connection()
 		for _, name := range tk.Tools() {

--- a/pkg/admin/tools_test.go
+++ b/pkg/admin/tools_test.go
@@ -333,8 +333,11 @@ func newTestSessionCookie(idToken string) *http.Cookie {
 		IDToken: idToken,
 	}, &cfg)
 	return &http.Cookie{
-		Name:  browsersession.DefaultCookieName,
-		Value: token,
+		Name:     browsersession.DefaultCookieName,
+		Value:    token,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteStrictMode,
 	}
 }
 

--- a/pkg/audit/postgres/metrics.go
+++ b/pkg/audit/postgres/metrics.go
@@ -39,11 +39,11 @@ func (s *Store) Timeseries(ctx context.Context, filter audit.TimeseriesFilter) (
 		"COUNT(*) FILTER (WHERE success = false) AS error_count",
 		"COALESCE(AVG(duration_ms), 0) AS avg_duration_ms",
 	).From("audit_logs").
-		Where(sq.GtOrEq{"timestamp": start}).
-		Where(sq.LtOrEq{"timestamp": end})
+		Where(sq.GtOrEq{colTimestamp: start}).
+		Where(sq.LtOrEq{colTimestamp: end})
 
 	if filter.UserID != "" {
-		qb = qb.Where(sq.Eq{"user_id": filter.UserID})
+		qb = qb.Where(sq.Eq{colUserID: filter.UserID})
 	}
 
 	qb = qb.GroupBy("bucket").
@@ -121,11 +121,11 @@ func buildBreakdownQuery(filter audit.BreakdownFilter) (query string, args []any
 		"CASE WHEN COUNT(*) > 0 THEN CAST(COUNT(*) FILTER (WHERE success = true) AS FLOAT) / COUNT(*) ELSE 0 END AS success_rate",
 		"COALESCE(AVG(duration_ms), 0) AS avg_duration_ms",
 	).From("audit_logs").
-		Where(sq.GtOrEq{"timestamp": start}).
-		Where(sq.LtOrEq{"timestamp": end})
+		Where(sq.GtOrEq{colTimestamp: start}).
+		Where(sq.LtOrEq{colTimestamp: end})
 
 	if filter.UserID != "" {
-		qb = qb.Where(sq.Eq{"user_id": filter.UserID})
+		qb = qb.Where(sq.Eq{colUserID: filter.UserID})
 	}
 	if filter.ToolName != "" {
 		// Per-tool scoping: callers asking for stats on a specific tool
@@ -134,7 +134,7 @@ func buildBreakdownQuery(filter audit.BreakdownFilter) (query string, args []any
 		// platforms with more than Limit distinct tools active in the
 		// window dropped low-frequency tools off the breakdown and
 		// rendered them as "no calls recorded" in the UI.
-		qb = qb.Where(sq.Eq{"tool_name": filter.ToolName})
+		qb = qb.Where(sq.Eq{colToolName: filter.ToolName})
 	}
 
 	qb = qb.GroupBy("dimension").
@@ -201,11 +201,11 @@ func (s *Store) Overview(ctx context.Context, filter audit.MetricsFilter) (*audi
 		"CASE WHEN COUNT(*) > 0 THEN CAST(COUNT(*) FILTER (WHERE enrichment_applied = true) AS FLOAT) / COUNT(*) ELSE 0 END AS enrichment_rate",
 		"COUNT(*) FILTER (WHERE success = false) AS error_count",
 	).From("audit_logs").
-		Where(sq.GtOrEq{"timestamp": start}).
-		Where(sq.LtOrEq{"timestamp": end})
+		Where(sq.GtOrEq{colTimestamp: start}).
+		Where(sq.LtOrEq{colTimestamp: end})
 
 	if filter.UserID != "" {
-		qb = qb.Where(sq.Eq{"user_id": filter.UserID})
+		qb = qb.Where(sq.Eq{colUserID: filter.UserID})
 	}
 
 	query, args, err := qb.ToSql()
@@ -242,11 +242,11 @@ func (s *Store) Performance(ctx context.Context, filter audit.MetricsFilter) (*a
 		"COALESCE(AVG(response_chars), 0) AS avg_response_chars",
 		"COALESCE(AVG(request_chars), 0) AS avg_request_chars",
 	).From("audit_logs").
-		Where(sq.GtOrEq{"timestamp": start}).
-		Where(sq.LtOrEq{"timestamp": end})
+		Where(sq.GtOrEq{colTimestamp: start}).
+		Where(sq.LtOrEq{colTimestamp: end})
 
 	if filter.UserID != "" {
-		qb = qb.Where(sq.Eq{"user_id": filter.UserID})
+		qb = qb.Where(sq.Eq{colUserID: filter.UserID})
 	}
 
 	query, args, err := qb.ToSql()
@@ -293,8 +293,8 @@ func (s *Store) Enrichment(ctx context.Context, startTime, endTime *time.Time) (
 		"COALESCE(AVG(NULLIF(enrichment_tokens_dedup, 0)), 0) AS avg_tokens_dedup",
 		"COUNT(DISTINCT session_id) AS unique_sessions",
 	).From("audit_logs").
-		Where(sq.GtOrEq{"timestamp": start}).
-		Where(sq.LtOrEq{"timestamp": end})
+		Where(sq.GtOrEq{colTimestamp: start}).
+		Where(sq.LtOrEq{colTimestamp: end})
 
 	query, args, err := qb.ToSql()
 	if err != nil {

--- a/pkg/audit/postgres/store.go
+++ b/pkg/audit/postgres/store.go
@@ -20,14 +20,26 @@ const (
 	maxQueryCapacity     = 10000
 )
 
+// SQL column names for the audit_logs table. Defined as constants so
+// the same literal does not appear repeatedly across the column list,
+// predicates, and ORDER BY clauses inside this package.
+const (
+	colTimestamp  = "timestamp"
+	colUserID     = "user_id"
+	colToolName   = "tool_name"
+	colDurationMS = "duration_ms"
+	colPersona    = "persona"
+	colConnection = "connection"
+)
+
 // psq is the PostgreSQL statement builder with dollar placeholders.
 var psq = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
 // auditColumns lists columns returned by audit SELECT queries.
 var auditColumns = []string{
-	"id", "timestamp", "duration_ms", "request_id", "session_id",
-	"user_id", "user_email", "persona", "tool_name", "toolkit_kind",
-	"toolkit_name", "connection", "parameters", "success", "error_message",
+	"id", colTimestamp, colDurationMS, "request_id", "session_id",
+	colUserID, "user_email", colPersona, colToolName, "toolkit_kind",
+	"toolkit_name", colConnection, "parameters", "success", "error_message",
 	"response_chars", "request_chars", "content_blocks",
 	"transport", "source", "enrichment_applied",
 	"enrichment_tokens_full", "enrichment_tokens_dedup",
@@ -112,19 +124,19 @@ func applyAuditFilter(qb sq.SelectBuilder, filter audit.QueryFilter) sq.SelectBu
 		qb = qb.Where(sq.Eq{"id": filter.ID})
 	}
 	if filter.StartTime != nil {
-		qb = qb.Where(sq.GtOrEq{"timestamp": *filter.StartTime})
+		qb = qb.Where(sq.GtOrEq{colTimestamp: *filter.StartTime})
 	}
 	if filter.EndTime != nil {
-		qb = qb.Where(sq.LtOrEq{"timestamp": *filter.EndTime})
+		qb = qb.Where(sq.LtOrEq{colTimestamp: *filter.EndTime})
 	}
 	if filter.UserID != "" {
-		qb = qb.Where(sq.Eq{"user_id": filter.UserID})
+		qb = qb.Where(sq.Eq{colUserID: filter.UserID})
 	}
 	if filter.SessionID != "" {
 		qb = qb.Where(sq.Eq{"session_id": filter.SessionID})
 	}
 	if filter.ToolName != "" {
-		qb = qb.Where(sq.Eq{"tool_name": filter.ToolName})
+		qb = qb.Where(sq.Eq{colToolName: filter.ToolName})
 	}
 	if filter.ToolkitKind != "" {
 		qb = qb.Where(sq.Eq{"toolkit_kind": filter.ToolkitKind})
@@ -135,11 +147,11 @@ func applyAuditFilter(qb sq.SelectBuilder, filter audit.QueryFilter) sq.SelectBu
 	if filter.Search != "" {
 		like := "%" + filter.Search + "%"
 		qb = qb.Where(sq.Or{
-			sq.ILike{"user_id": like},
-			sq.ILike{"tool_name": like},
+			sq.ILike{colUserID: like},
+			sq.ILike{colToolName: like},
 			sq.ILike{"toolkit_kind": like},
-			sq.ILike{"connection": like},
-			sq.ILike{"persona": like},
+			sq.ILike{colConnection: like},
+			sq.ILike{colPersona: like},
 			sq.ILike{"error_message": like},
 		})
 	}
@@ -150,7 +162,7 @@ func applyAuditFilter(qb sq.SelectBuilder, filter audit.QueryFilter) sq.SelectBu
 func (s *Store) Query(ctx context.Context, filter audit.QueryFilter) ([]audit.Event, error) {
 	qb := applyAuditFilter(psq.Select(auditColumns...).From("audit_logs"), filter)
 
-	orderCol := "timestamp"
+	orderCol := colTimestamp
 	orderDir := "DESC"
 	if filter.SortBy != "" && audit.ValidSortColumns[filter.SortBy] {
 		orderCol = filter.SortBy
@@ -193,8 +205,8 @@ func (s *Store) Count(ctx context.Context, filter audit.QueryFilter) (int, error
 // Distinct returns sorted unique values for the given column, scoped by optional time range.
 func (s *Store) Distinct(ctx context.Context, column string, startTime, endTime *time.Time) ([]string, error) {
 	allowed := map[string]bool{
-		"user_id":   true,
-		"tool_name": true,
+		colUserID:   true,
+		colToolName: true,
 	}
 	if !allowed[column] {
 		return nil, fmt.Errorf("distinct not supported for column %q", column)
@@ -202,10 +214,10 @@ func (s *Store) Distinct(ctx context.Context, column string, startTime, endTime 
 
 	qb := psq.Select("DISTINCT " + column).From("audit_logs").OrderBy(column)
 	if startTime != nil {
-		qb = qb.Where(sq.GtOrEq{"timestamp": *startTime})
+		qb = qb.Where(sq.GtOrEq{colTimestamp: *startTime})
 	}
 	if endTime != nil {
-		qb = qb.Where(sq.LtOrEq{"timestamp": *endTime})
+		qb = qb.Where(sq.LtOrEq{colTimestamp: *endTime})
 	}
 
 	query, args, err := qb.ToSql()

--- a/pkg/auth/apikey.go
+++ b/pkg/auth/apikey.go
@@ -118,7 +118,7 @@ func (a *APIKeyAuthenticator) Authenticate(ctx context.Context) (*middleware.Use
 		Email:    apiKeyEmail(*matchedKey),
 		Claims:   make(map[string]any),
 		Roles:    matchedKey.Roles,
-		AuthType: "apikey",
+		AuthType: authTypeAPIKey,
 	}, nil
 }
 

--- a/pkg/auth/claims.go
+++ b/pkg/auth/claims.go
@@ -5,6 +5,20 @@ import (
 	"strings"
 )
 
+// Standard JWT/OIDC claim names and the auth-type label used for users
+// authenticated via an OIDC provider. Defined as package-private
+// constants so the same literal does not appear repeatedly across
+// claims.go, oauth.go, and oidc.go.
+const (
+	claimSubject   = "sub"
+	claimEmail     = "email"
+	claimName      = "name"
+	claimRoles     = "roles"
+	claimGroups    = "groups"
+	authTypeOIDC   = "oidc"
+	authTypeAPIKey = "apikey"
+)
+
 // ClaimsExtractor extracts values from JWT claims.
 type ClaimsExtractor struct {
 	// RoleClaimPath is the dot-separated path to roles in claims.
@@ -30,11 +44,11 @@ type ClaimsExtractor struct {
 // DefaultClaimsExtractor returns an extractor with common defaults.
 func DefaultClaimsExtractor() *ClaimsExtractor {
 	return &ClaimsExtractor{
-		RoleClaimPath:    "roles",
-		GroupClaimPath:   "groups",
-		EmailClaimPath:   "email",
-		NameClaimPath:    "name",
-		SubjectClaimPath: "sub",
+		RoleClaimPath:    claimRoles,
+		GroupClaimPath:   claimGroups,
+		EmailClaimPath:   claimEmail,
+		NameClaimPath:    claimName,
+		SubjectClaimPath: claimSubject,
 	}
 }
 
@@ -42,7 +56,7 @@ func DefaultClaimsExtractor() *ClaimsExtractor {
 func (e *ClaimsExtractor) Extract(claims map[string]any) (*UserContext, error) {
 	uc := &UserContext{
 		Claims:   claims,
-		AuthType: "oidc",
+		AuthType: authTypeOIDC,
 	}
 
 	// Extract subject (user ID)

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -44,9 +44,9 @@ func NewOAuthJWTAuthenticator(cfg OAuthJWTConfig) (*OAuthJWTAuthenticator, error
 	extractor := &ClaimsExtractor{
 		RoleClaimPath:    cfg.RoleClaimPath,
 		RolePrefix:       cfg.RolePrefix,
-		EmailClaimPath:   "email",
-		NameClaimPath:    "name",
-		SubjectClaimPath: "sub",
+		EmailClaimPath:   claimEmail,
+		NameClaimPath:    claimName,
+		SubjectClaimPath: claimSubject,
 	}
 
 	return &OAuthJWTAuthenticator{

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -85,9 +85,9 @@ func NewOIDCAuthenticator(cfg OIDCConfig) (*OIDCAuthenticator, error) {
 	extractor := &ClaimsExtractor{
 		RoleClaimPath:    cfg.RoleClaimPath,
 		RolePrefix:       cfg.RolePrefix,
-		EmailClaimPath:   "email",
-		NameClaimPath:    "name",
-		SubjectClaimPath: "sub",
+		EmailClaimPath:   claimEmail,
+		NameClaimPath:    claimName,
+		SubjectClaimPath: claimSubject,
 	}
 
 	auth := &OIDCAuthenticator{
@@ -131,7 +131,7 @@ func (a *OIDCAuthenticator) Authenticate(ctx context.Context) (*middleware.UserI
 		Email:    uc.Email,
 		Claims:   uc.Claims,
 		Roles:    uc.Roles,
-		AuthType: "oidc",
+		AuthType: authTypeOIDC,
 	}, nil
 }
 

--- a/pkg/browsersession/authenticator_test.go
+++ b/pkg/browsersession/authenticator_test.go
@@ -20,7 +20,7 @@ func TestAuthenticatorValidCookie(t *testing.T) {
 	auth := NewAuthenticator(cfg)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
-	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: token})
+	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: token, HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode})
 
 	info, err := auth.AuthenticateHTTP(req)
 	if err != nil {
@@ -65,7 +65,7 @@ func TestAuthenticatorExpiredCookie(t *testing.T) {
 	auth := NewAuthenticator(CookieConfig{Key: testKey()})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
-	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: token})
+	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: token, HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode})
 
 	info, err := auth.AuthenticateHTTP(req)
 	if err != nil {
@@ -80,7 +80,7 @@ func TestAuthenticatorMalformedCookie(t *testing.T) {
 	auth := NewAuthenticator(CookieConfig{Key: testKey()})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
-	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: "not-a-jwt"})
+	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: "not-a-jwt", HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode})
 
 	info, err := auth.AuthenticateHTTP(req)
 	if err != nil {
@@ -99,7 +99,7 @@ func TestAuthenticatorWrongKey(t *testing.T) {
 	auth := NewAuthenticator(CookieConfig{Key: wrongKey})
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
-	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: token})
+	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: token, HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode})
 
 	info, err := auth.AuthenticateHTTP(req)
 	if err != nil {
@@ -124,7 +124,7 @@ func TestExtractIDTokenValidCookie(t *testing.T) {
 	auth := NewAuthenticator(cfg)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
-	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: token})
+	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: token, HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode})
 
 	idToken := auth.ExtractIDToken(req)
 	if idToken != claims.IDToken {
@@ -152,7 +152,7 @@ func TestExtractIDTokenNoIDToken(t *testing.T) {
 
 	auth := NewAuthenticator(cfg)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
-	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: token})
+	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: token, HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode})
 
 	idToken := auth.ExtractIDToken(req)
 	if idToken != "" {
@@ -166,7 +166,7 @@ func TestExtractIDTokenExpiredCookie(t *testing.T) {
 
 	auth := NewAuthenticator(CookieConfig{Key: testKey()})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
-	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: token})
+	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: token, HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode})
 
 	idToken := auth.ExtractIDToken(req)
 	if idToken != "" {
@@ -181,7 +181,7 @@ func TestAuthenticatorCustomCookieName(t *testing.T) {
 	auth := NewAuthenticator(cfg)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
-	req.AddCookie(&http.Cookie{Name: "custom_session", Value: token})
+	req.AddCookie(&http.Cookie{Name: "custom_session", Value: token, HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode})
 
 	info, err := auth.AuthenticateHTTP(req)
 	if err != nil {

--- a/pkg/browsersession/cookie_test.go
+++ b/pkg/browsersession/cookie_test.go
@@ -207,7 +207,7 @@ func TestParseFromRequest(t *testing.T) {
 	}
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
-	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: token})
+	req.AddCookie(&http.Cookie{Name: DefaultCookieName, Value: token, HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode})
 
 	got, err := ParseFromRequest(req, cfg)
 	if err != nil {

--- a/pkg/mcpapps/mime.go
+++ b/pkg/mcpapps/mime.go
@@ -5,28 +5,45 @@ import (
 	"strings"
 )
 
+// MIME type constants used by mimeTypes and any callers that need to
+// match against a known type without re-typing the literal.
+const (
+	mimeHTML        = "text/html; charset=utf-8"
+	mimeCSS         = "text/css; charset=utf-8"
+	mimeJS          = "application/javascript; charset=utf-8"
+	mimeJSON        = "application/json; charset=utf-8"
+	mimeXML         = "application/xml; charset=utf-8"
+	mimeText        = "text/plain; charset=utf-8"
+	mimePNG         = "image/png"
+	mimeJPEG        = "image/jpeg"
+	mimeGIF         = "image/gif"
+	mimeSVG         = "image/svg+xml"
+	mimeWOFF2       = "font/woff2"
+	mimeOctetStream = "application/octet-stream"
+)
+
 // mimeTypes maps file extensions to MIME types.
 var mimeTypes = map[string]string{
-	".html":  "text/html; charset=utf-8",
-	".htm":   "text/html; charset=utf-8",
-	".css":   "text/css; charset=utf-8",
-	".js":    "application/javascript; charset=utf-8",
-	".mjs":   "application/javascript; charset=utf-8",
-	".json":  "application/json; charset=utf-8",
-	".png":   "image/png",
-	".jpg":   "image/jpeg",
-	".jpeg":  "image/jpeg",
-	".gif":   "image/gif",
-	".svg":   "image/svg+xml",
+	".html":  mimeHTML,
+	".htm":   mimeHTML,
+	".css":   mimeCSS,
+	".js":    mimeJS,
+	".mjs":   mimeJS,
+	".json":  mimeJSON,
+	".png":   mimePNG,
+	".jpg":   mimeJPEG,
+	".jpeg":  mimeJPEG,
+	".gif":   mimeGIF,
+	".svg":   mimeSVG,
 	".ico":   "image/x-icon",
 	".woff":  "font/woff",
-	".woff2": "font/woff2",
+	".woff2": mimeWOFF2,
 	".ttf":   "font/ttf",
 	".eot":   "application/vnd.ms-fontobject",
 	".otf":   "font/otf",
-	".xml":   "application/xml; charset=utf-8",
-	".txt":   "text/plain; charset=utf-8",
-	".map":   "application/json; charset=utf-8",
+	".xml":   mimeXML,
+	".txt":   mimeText,
+	".map":   mimeJSON,
 }
 
 // MIMEType returns the MIME type for a file based on its extension.
@@ -35,5 +52,5 @@ func MIMEType(filename string) string {
 	if mime, ok := mimeTypes[ext]; ok {
 		return mime
 	}
-	return "application/octet-stream"
+	return mimeOctetStream
 }

--- a/pkg/mcpapps/resource.go
+++ b/pkg/mcpapps/resource.go
@@ -253,7 +253,7 @@ func isBinaryMIME(mimeType string) bool {
 		return false
 	case strings.HasPrefix(mimeType, "application/xml"):
 		return false
-	case mimeType == "image/svg+xml":
+	case mimeType == mimeSVG:
 		return false
 	default:
 		return true

--- a/pkg/memory/postgres.go
+++ b/pkg/memory/postgres.go
@@ -21,6 +21,19 @@ const tableName = "memory_records"
 // errNotFoundFmt is the format string for not-found errors.
 const errNotFoundFmt = "memory record not found: %s"
 
+// SQL column names. Defined as constants because squirrel queries
+// reference them in column lists, predicates, and updates — repeating
+// the literals would mean drift if a column is ever renamed.
+const (
+	colCreatedBy  = "created_by"
+	colCategory   = "category"
+	colEntityURNs = "entity_urns"
+	colCreatedAt  = "created_at"
+	colDimension  = "dimension"
+	colConfidence = "confidence"
+	colMetadata   = "metadata"
+)
+
 // psq is the PostgreSQL statement builder with dollar placeholders.
 var psq = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
@@ -52,9 +65,9 @@ func (s *postgresStore) Insert(ctx context.Context, record Record) error {
 	}
 
 	columns := []string{
-		"id", "created_by", "persona", "dimension",
-		"content", "category", "confidence", "source",
-		"entity_urns", "related_columns", "metadata", "status",
+		"id", colCreatedBy, "persona", colDimension,
+		"content", colCategory, colConfidence, "source",
+		colEntityURNs, "related_columns", colMetadata, "status",
 	}
 	values := []any{
 		record.ID, record.CreatedBy, record.Persona, record.Dimension,
@@ -147,15 +160,15 @@ func buildUpdateColumns(updates RecordUpdate) (sq.UpdateBuilder, bool, error) {
 		hasUpdates = true
 	}
 	if updates.Category != "" {
-		qb = qb.Set("category", updates.Category)
+		qb = qb.Set(colCategory, updates.Category)
 		hasUpdates = true
 	}
 	if updates.Confidence != "" {
-		qb = qb.Set("confidence", updates.Confidence)
+		qb = qb.Set(colConfidence, updates.Confidence)
 		hasUpdates = true
 	}
 	if updates.Dimension != "" {
-		qb = qb.Set("dimension", updates.Dimension)
+		qb = qb.Set(colDimension, updates.Dimension)
 		hasUpdates = true
 	}
 	if updates.Metadata != nil {
@@ -163,7 +176,7 @@ func buildUpdateColumns(updates RecordUpdate) (sq.UpdateBuilder, bool, error) {
 		if err != nil {
 			return qb, false, fmt.Errorf("marshaling metadata: %w", err)
 		}
-		qb = qb.Set("metadata", sq.Expr("metadata || ?::jsonb", meta))
+		qb = qb.Set(colMetadata, sq.Expr("metadata || ?::jsonb", meta))
 		hasUpdates = true
 	}
 	if len(updates.Embedding) > 0 {
@@ -444,7 +457,7 @@ func (s *postgresStore) Supersede(ctx context.Context, oldID, newID string) erro
 	now := time.Now()
 	query, args, err := psq.Update(tableName).
 		Set("status", StatusSuperseded).
-		Set("metadata", sq.Expr("metadata || ?::jsonb", patch)).
+		Set(colMetadata, sq.Expr("metadata || ?::jsonb", patch)).
 		Set("updated_at", now).
 		Where(sq.Eq{"id": oldID}).
 		ToSql()
@@ -471,16 +484,16 @@ func (s *postgresStore) Supersede(ctx context.Context, oldID, newID string) erro
 // applyFilter adds filter conditions to a SELECT builder.
 func applyFilter(qb sq.SelectBuilder, filter Filter) sq.SelectBuilder {
 	if filter.CreatedBy != "" {
-		qb = qb.Where(sq.Eq{"created_by": filter.CreatedBy})
+		qb = qb.Where(sq.Eq{colCreatedBy: filter.CreatedBy})
 	}
 	if filter.Persona != "" {
 		qb = qb.Where(sq.Eq{"persona": filter.Persona})
 	}
 	if filter.Dimension != "" {
-		qb = qb.Where(sq.Eq{"dimension": filter.Dimension})
+		qb = qb.Where(sq.Eq{colDimension: filter.Dimension})
 	}
 	if filter.Category != "" {
-		qb = qb.Where(sq.Eq{"category": filter.Category})
+		qb = qb.Where(sq.Eq{colCategory: filter.Category})
 	}
 	if filter.Status != "" {
 		qb = qb.Where(sq.Eq{"status": filter.Status})
@@ -493,10 +506,10 @@ func applyFilter(qb sq.SelectBuilder, filter Filter) sq.SelectBuilder {
 		qb = qb.Where(sq.Expr("entity_urns @> ?::jsonb", urnJSON))
 	}
 	if filter.Since != nil {
-		qb = qb.Where(sq.GtOrEq{"created_at": *filter.Since})
+		qb = qb.Where(sq.GtOrEq{colCreatedAt: *filter.Since})
 	}
 	if filter.Until != nil {
-		qb = qb.Where(sq.LtOrEq{"created_at": *filter.Until})
+		qb = qb.Where(sq.LtOrEq{colCreatedAt: *filter.Until})
 	}
 	return qb
 }
@@ -504,9 +517,9 @@ func applyFilter(qb sq.SelectBuilder, filter Filter) sq.SelectBuilder {
 // recordColumns returns the column list for memory record queries.
 func recordColumns() []string {
 	return []string{
-		"id", "created_at", "updated_at", "created_by", "persona", "dimension",
-		"content", "category", "confidence", "source",
-		"entity_urns", "related_columns", "metadata",
+		"id", colCreatedAt, "updated_at", colCreatedBy, "persona", colDimension,
+		"content", colCategory, colConfidence, "source",
+		colEntityURNs, "related_columns", colMetadata,
 		"status", "stale_reason", "stale_at", "last_verified",
 	}
 }

--- a/pkg/oauth/dcr.go
+++ b/pkg/oauth/dcr.go
@@ -57,7 +57,7 @@ func NewDCRService(storage Storage, config DCRConfig) (*DCRService, error) {
 	}
 
 	if len(config.DefaultGrantTypes) == 0 {
-		config.DefaultGrantTypes = []string{"authorization_code", "refresh_token"}
+		config.DefaultGrantTypes = []string{grantTypeAuthCode, grantTypeRefreshToken}
 	}
 
 	return &DCRService{

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -52,34 +52,38 @@ const (
 	errServerError      = "server_error"
 )
 
-// OAuth parameter name constants.
+// OAuth wire-protocol form-parameter names. Used both when reading
+// inbound request fields (r.FormValue) and when building outbound
+// requests to the upstream IdP (url.Values.Set).
 const (
-	paramCode        = "code"
-	paramState       = "state"
-	paramScope       = "scope"
-	paramRedirectURI = "redirect_uri"
-	paramClientID    = "client_id"
+	paramCode         = "code"
+	paramState        = "state"
+	paramScope        = "scope"
+	paramRedirectURI  = "redirect_uri"
+	paramClientID     = "client_id"
+	paramGrantType    = "grant_type"
+	paramRefreshToken = "refresh_token" // #nosec G101 -- form-field name, not a credential
 )
 
-// Structured log field keys used by the token endpoint. Defined as
-// constants so adding new log calls does not push literal occurrence
-// counts past revive's add-constant threshold.
+// Structured log field keys used by the token endpoint. Kept distinct
+// from wire-protocol parameter names (paramGrantType) so that a future
+// rename of one cannot silently change the meaning of the other.
 const (
 	logKeyGrantType = "grant_type"
 	logKeyError     = "error"
 )
 
-// OAuth grant types, token type, and well-known claim names. Defined
-// in one place so the same literal does not appear repeatedly across
-// server.go, dcr.go, and the metadata handler.
+// OAuth grant types, token type, and well-known JWT claim names.
+// Distinct from paramGrantType / paramRefreshToken (which name the form
+// fields) — these are the *values* those fields carry on the wire.
 const (
 	grantTypeAuthCode     = "authorization_code"
-	grantTypeRefreshToken = "refresh_token"
+	grantTypeRefreshToken = "refresh_token" // #nosec G101 -- grant_type value, not a token
 
 	tokenTypeBearer = "Bearer"
 
-	claimSubject     = "sub"
-	claimRealmAccess = "realm_access"
+	jwtClaimSub         = "sub"
+	jwtClaimRealmAccess = "realm_access"
 )
 
 // Errors returned by the OAuth server.
@@ -447,13 +451,13 @@ func (s *Server) generateAccessToken(clientID, userID string, userClaims map[str
 
 	// Build JWT claims
 	claims := jwt.MapClaims{
-		"iss":        s.config.Issuer,
-		claimSubject: userID,
-		"aud":        clientID,
-		"exp":        exp.Unix(),
-		"iat":        now.Unix(),
-		"nbf":        now.Unix(),
-		"scope":      scope,
+		"iss":       s.config.Issuer,
+		jwtClaimSub: userID,
+		"aud":       clientID,
+		"exp":       exp.Unix(),
+		"iat":       now.Unix(),
+		"nbf":       now.Unix(),
+		"scope":     scope,
 	}
 
 	// Include upstream IdP claims (roles, email, etc.) under a nested key
@@ -538,7 +542,7 @@ func (s *Server) handleTokenEndpoint(w http.ResponseWriter, r *http.Request) {
 		ClientID:     r.FormValue(paramClientID),
 		ClientSecret: r.FormValue("client_secret"),
 		CodeVerifier: r.FormValue("code_verifier"),
-		RefreshToken: r.FormValue(grantTypeRefreshToken),
+		RefreshToken: r.FormValue(paramRefreshToken),
 		Scope:        r.FormValue(paramScope),
 	}
 
@@ -829,7 +833,7 @@ func (s *Server) exchangeUpstreamCode(ctx context.Context, code string) (*upstre
 	tokenURL := strings.TrimSuffix(s.config.Upstream.Issuer, "/") + "/protocol/openid-connect/token"
 
 	data := url.Values{}
-	data.Set(logKeyGrantType, grantTypeAuthCode)
+	data.Set(paramGrantType, grantTypeAuthCode)
 	data.Set(paramCode, code)
 	data.Set(paramRedirectURI, s.config.Upstream.RedirectURI)
 	data.Set(paramClientID, s.config.Upstream.ClientID)
@@ -865,7 +869,7 @@ func (*Server) extractUserFromUpstreamToken(token *upstreamTokenResponse) (strin
 	claims := extractTokenClaims(token)
 
 	userID := "unknown"
-	if sub, ok := claims[claimSubject].(string); ok {
+	if sub, ok := claims[jwtClaimSub].(string); ok {
 		userID = sub
 	}
 
@@ -900,7 +904,7 @@ func extractTokenClaims(token *upstreamTokenResponse) map[string]any {
 // other claims only fill gaps.
 func mergeAccessClaims(claims, accessClaims map[string]any) {
 	for key, value := range accessClaims {
-		if key == claimRealmAccess || key == "resource_access" {
+		if key == jwtClaimRealmAccess || key == "resource_access" {
 			claims[key] = value
 		} else if _, exists := claims[key]; !exists {
 			claims[key] = value

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -61,6 +61,27 @@ const (
 	paramClientID    = "client_id"
 )
 
+// Structured log field keys used by the token endpoint. Defined as
+// constants so adding new log calls does not push literal occurrence
+// counts past revive's add-constant threshold.
+const (
+	logKeyGrantType = "grant_type"
+	logKeyError     = "error"
+)
+
+// OAuth grant types, token type, and well-known claim names. Defined
+// in one place so the same literal does not appear repeatedly across
+// server.go, dcr.go, and the metadata handler.
+const (
+	grantTypeAuthCode     = "authorization_code"
+	grantTypeRefreshToken = "refresh_token"
+
+	tokenTypeBearer = "Bearer"
+
+	claimSubject     = "sub"
+	claimRealmAccess = "realm_access"
+)
+
 // Errors returned by the OAuth server.
 var (
 	ErrStateNotFound = errors.New("authorization state not found")
@@ -210,7 +231,7 @@ func (*Server) validatePKCE(client *Client, req AuthorizationRequest) error {
 	if req.CodeChallenge == "" {
 		return fmt.Errorf("code_challenge required")
 	}
-	if req.CodeChallengeMethod != "S256" && req.CodeChallengeMethod != "plain" {
+	if req.CodeChallengeMethod != string(PKCEMethodS256) && req.CodeChallengeMethod != "plain" {
 		return fmt.Errorf("invalid code_challenge_method")
 	}
 	return nil
@@ -256,9 +277,9 @@ func (s *Server) Authorize(ctx context.Context, req AuthorizationRequest, userID
 // Token handles the token endpoint.
 func (s *Server) Token(ctx context.Context, req TokenRequest) (*TokenResponse, error) {
 	switch req.GrantType {
-	case "authorization_code":
+	case grantTypeAuthCode:
 		return s.handleAuthorizationCodeGrant(ctx, req)
-	case "refresh_token":
+	case grantTypeRefreshToken:
 		return s.handleRefreshTokenGrant(ctx, req)
 	default:
 		return nil, fmt.Errorf("unsupported grant_type")
@@ -406,7 +427,7 @@ func (s *Server) generateTokens(ctx context.Context, client *Client, userID stri
 
 	return &TokenResponse{
 		AccessToken:  accessToken,
-		TokenType:    "Bearer",
+		TokenType:    tokenTypeBearer,
 		ExpiresIn:    int(s.config.AccessTokenTTL.Seconds()),
 		RefreshToken: refreshTokenValue,
 		Scope:        scope,
@@ -426,13 +447,13 @@ func (s *Server) generateAccessToken(clientID, userID string, userClaims map[str
 
 	// Build JWT claims
 	claims := jwt.MapClaims{
-		"iss":   s.config.Issuer,
-		"sub":   userID,
-		"aud":   clientID,
-		"exp":   exp.Unix(),
-		"iat":   now.Unix(),
-		"nbf":   now.Unix(),
-		"scope": scope,
+		"iss":        s.config.Issuer,
+		claimSubject: userID,
+		"aud":        clientID,
+		"exp":        exp.Unix(),
+		"iat":        now.Unix(),
+		"nbf":        now.Unix(),
+		"scope":      scope,
 	}
 
 	// Include upstream IdP claims (roles, email, etc.) under a nested key
@@ -490,6 +511,13 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleTokenEndpoint handles POST /oauth/token.
+//
+// Emits structured logs at INFO (success) and WARN (failure) so operators
+// can diagnose silent re-auth loops and refresh-grant rejections that
+// otherwise leave no observable trace. Sensitive fields (secrets,
+// tokens, code values) are NEVER logged — only grant_type, client_id,
+// and the error reason. The presence/absence of the secret and refresh
+// token are logged as booleans for diagnostics without leaking values.
 func (s *Server) handleTokenEndpoint(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		s.writeError(w, http.StatusMethodNotAllowed, errMethodNotAllowed, "POST required")
@@ -498,6 +526,7 @@ func (s *Server) handleTokenEndpoint(w http.ResponseWriter, r *http.Request) {
 
 	r.Body = http.MaxBytesReader(w, r.Body, maxTokenRequestBytes)
 	if err := r.ParseForm(); err != nil {
+		slog.Warn("oauth: token endpoint parse form failed", logKeyError, err.Error())
 		s.writeError(w, http.StatusBadRequest, errInvalidRequest, "could not parse form")
 		return
 	}
@@ -509,24 +538,58 @@ func (s *Server) handleTokenEndpoint(w http.ResponseWriter, r *http.Request) {
 		ClientID:     r.FormValue(paramClientID),
 		ClientSecret: r.FormValue("client_secret"),
 		CodeVerifier: r.FormValue("code_verifier"),
-		RefreshToken: r.FormValue("refresh_token"),
+		RefreshToken: r.FormValue(grantTypeRefreshToken),
 		Scope:        r.FormValue(paramScope),
 	}
 
 	// Support Basic auth for client credentials
+	credentialSource := "form"
 	if req.ClientID == "" || req.ClientSecret == "" {
 		if username, password, ok := r.BasicAuth(); ok {
 			req.ClientID = username
 			req.ClientSecret = password
+			credentialSource = "basic"
 		}
 	}
 
+	start := time.Now()
 	resp, err := s.Token(r.Context(), req)
 	if err != nil {
+		// WARN level: every failure is operator-relevant. The error
+		// message comes from the grant handler (e.g. "invalid refresh
+		// token", "client_id mismatch", "invalid client credentials")
+		// and is the SOLE place that distinguishes H1/H2/H3 in the
+		// silent-re-auth-loop diagnosis path. Without this log,
+		// rejected refresh tokens leave no trace and operators see
+		// users repeatedly re-authenticating with no visible cause.
+		slog.Warn("oauth: token grant rejected",
+			logKeyGrantType, req.GrantType,
+			"client_id", req.ClientID,
+			"credential_source", credentialSource,
+			"has_client_secret", req.ClientSecret != "",
+			"has_refresh_token", req.RefreshToken != "",
+			"has_code", req.Code != "",
+			"has_code_verifier", req.CodeVerifier != "",
+			"duration_ms", time.Since(start).Milliseconds(),
+			logKeyError, err.Error())
 		s.writeError(w, http.StatusBadRequest, errInvalidRequest, err.Error())
 		return
 	}
 
+	// INFO level: success path is logged once per token issuance so
+	// operators can correlate Claude.ai client behavior (initial auth
+	// vs. refresh) with platform observability. has_refresh_token on
+	// the response confirms the platform IS issuing refresh tokens to
+	// this client (rules out a hypothesis where refresh tokens are
+	// silently filtered).
+	slog.Info("oauth: token grant issued",
+		logKeyGrantType, req.GrantType,
+		"client_id", req.ClientID,
+		"credential_source", credentialSource,
+		"has_refresh_token", resp.RefreshToken != "",
+		"expires_in", resp.ExpiresIn,
+		"scope", resp.Scope,
+		"duration_ms", time.Since(start).Milliseconds())
 	s.writeJSON(w, http.StatusOK, resp)
 }
 
@@ -718,6 +781,8 @@ func (s *Server) handleCallbackEndpoint(w http.ResponseWriter, r *http.Request) 
 
 	// Redirect back to the original client with the MCP authorization code
 	redirectURL := s.buildClientRedirectURL(authState.RedirectURI, mcpCode, authState.State)
+	// #nosec G710 -- authState.RedirectURI was validated against the
+	// client's registered RedirectURIs during the /authorize step.
 	// nosemgrep: go.lang.security.injection.open-redirect.open-redirect -- redirect URI validated during client registration
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
@@ -764,7 +829,7 @@ func (s *Server) exchangeUpstreamCode(ctx context.Context, code string) (*upstre
 	tokenURL := strings.TrimSuffix(s.config.Upstream.Issuer, "/") + "/protocol/openid-connect/token"
 
 	data := url.Values{}
-	data.Set("grant_type", "authorization_code")
+	data.Set(logKeyGrantType, grantTypeAuthCode)
 	data.Set(paramCode, code)
 	data.Set(paramRedirectURI, s.config.Upstream.RedirectURI)
 	data.Set(paramClientID, s.config.Upstream.ClientID)
@@ -800,7 +865,7 @@ func (*Server) extractUserFromUpstreamToken(token *upstreamTokenResponse) (strin
 	claims := extractTokenClaims(token)
 
 	userID := "unknown"
-	if sub, ok := claims["sub"].(string); ok {
+	if sub, ok := claims[claimSubject].(string); ok {
 		userID = sub
 	}
 
@@ -835,7 +900,7 @@ func extractTokenClaims(token *upstreamTokenResponse) map[string]any {
 // other claims only fill gaps.
 func mergeAccessClaims(claims, accessClaims map[string]any) {
 	for key, value := range accessClaims {
-		if key == "realm_access" || key == "resource_access" {
+		if key == claimRealmAccess || key == "resource_access" {
 			claims[key] = value
 		} else if _, exists := claims[key]; !exists {
 			claims[key] = value
@@ -891,8 +956,8 @@ func (s *Server) handleMetadata(w http.ResponseWriter, _ *http.Request) {
 		"token_endpoint":                        s.config.Issuer + "/token",
 		"registration_endpoint":                 s.config.Issuer + "/register",
 		"response_types_supported":              []string{paramCode},
-		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
-		"code_challenge_methods_supported":      []string{"S256", "plain"},
+		"grant_types_supported":                 []string{grantTypeAuthCode, grantTypeRefreshToken},
+		"code_challenge_methods_supported":      []string{string(PKCEMethodS256), "plain"},
 		"token_endpoint_auth_methods_supported": []string{"client_secret_basic", "client_secret_post"},
 	}
 

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -62,7 +62,7 @@ const (
 	paramRedirectURI  = "redirect_uri"
 	paramClientID     = "client_id"
 	paramGrantType    = "grant_type"
-	paramRefreshToken = "refresh_token" // #nosec G101 -- form-field name, not a credential
+	paramRefreshToken = "refresh_token"
 )
 
 // Structured log field keys used by the token endpoint. Kept distinct
@@ -78,7 +78,7 @@ const (
 // fields) — these are the *values* those fields carry on the wire.
 const (
 	grantTypeAuthCode     = "authorization_code"
-	grantTypeRefreshToken = "refresh_token" // #nosec G101 -- grant_type value, not a token
+	grantTypeRefreshToken = "refresh_token"
 
 	tokenTypeBearer = "Bearer"
 

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -1850,6 +1851,18 @@ func TestTokenEndpoint_LogsSuccess(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
+
+	// Decode the actually-issued tokens so we can assert their values
+	// never appear in the log buffer. This proves the contract holds
+	// against the real token values, not just the test's input strings.
+	var issued TokenResponse
+	if jsonErr := json.NewDecoder(w.Body).Decode(&issued); jsonErr != nil {
+		t.Fatalf("decode token response: %v", jsonErr)
+	}
+	if issued.AccessToken == "" || issued.RefreshToken == "" {
+		t.Fatalf("expected non-empty access and refresh tokens, got %+v", issued)
+	}
+
 	out := buf.String()
 	if !strings.Contains(out, `level=INFO`) {
 		t.Errorf("expected INFO level entry, got: %s", out)
@@ -1872,11 +1885,19 @@ func TestTokenEndpoint_LogsSuccess(t *testing.T) {
 	if !strings.Contains(out, "duration_ms=") {
 		t.Errorf("expected duration_ms field, got: %s", out)
 	}
+	// Redaction contract: neither the inbound credentials nor the
+	// outbound tokens may appear in log output.
 	if strings.Contains(out, secretValue) {
 		t.Errorf("client secret value MUST NOT appear in logs, got: %s", out)
 	}
 	if strings.Contains(out, codeValue) {
 		t.Errorf("authorization code value MUST NOT appear in logs, got: %s", out)
+	}
+	if strings.Contains(out, issued.AccessToken) {
+		t.Errorf("issued access token value MUST NOT appear in logs")
+	}
+	if strings.Contains(out, issued.RefreshToken) {
+		t.Errorf("issued refresh token value MUST NOT appear in logs")
 	}
 }
 
@@ -1916,6 +1937,9 @@ func TestTokenEndpoint_LogsRejection(t *testing.T) {
 	if !strings.Contains(out, "error=") {
 		t.Errorf("expected error reason in log, got: %s", out)
 	}
+	if !strings.Contains(out, "duration_ms=") {
+		t.Errorf("expected duration_ms field on rejection, got: %s", out)
+	}
 	if strings.Contains(out, secretValue) {
 		t.Errorf("client secret value MUST NOT appear in logs, got: %s", out)
 	}
@@ -1941,8 +1965,17 @@ func TestTokenEndpoint_LogsRejectionBasicAuth(t *testing.T) {
 		t.Fatalf("expected 400, got %d", w.Code)
 	}
 	out := buf.String()
+	if !strings.Contains(out, "oauth: token grant rejected") {
+		t.Errorf("expected rejection message in log, got: %s", out)
+	}
 	if !strings.Contains(out, "credential_source=basic") {
 		t.Errorf("expected credential_source=basic when using HTTP Basic auth, got: %s", out)
+	}
+	if !strings.Contains(out, "has_client_secret=true") {
+		t.Errorf("expected has_client_secret=true when Basic auth supplies a credential, got: %s", out)
+	}
+	if !strings.Contains(out, "client_id="+testClientID) {
+		t.Errorf("expected client_id from Basic auth username, got: %s", out)
 	}
 	if strings.Contains(out, secretValue) {
 		t.Errorf("client secret from Basic auth MUST NOT appear in logs, got: %s", out)
@@ -1973,5 +2006,8 @@ func TestTokenEndpoint_LogsParseFormFailure(t *testing.T) {
 	}
 	if !strings.Contains(out, "oauth: token endpoint parse form failed") {
 		t.Errorf("expected parse-form failure log, got: %s", out)
+	}
+	if !strings.Contains(out, "error=") {
+		t.Errorf("expected error reason field on parse-form failure, got: %s", out)
 	}
 }

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1791,5 +1792,186 @@ func TestServerSigningKey(t *testing.T) {
 
 	if server.Issuer() != "https://oauth.example.com" {
 		t.Error("Issuer() should return the configured issuer")
+	}
+}
+
+// captureSlog redirects slog.Default() at LevelInfo into a buffer for the
+// duration of the test and restores the previous default on cleanup. Tests
+// using it cannot run in parallel because slog.Default() is process-global.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	prev := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+func TestTokenEndpoint_LogsSuccess(t *testing.T) {
+	const secretValue = "super-secret-value"
+	const codeValue = "auth-code-secret-value"
+	hashedSecret, _ := bcrypt.GenerateFromPassword([]byte(secretValue), bcrypt.MinCost)
+	client := &Client{
+		ClientID:     testClientID,
+		ClientSecret: string(hashedSecret),
+		RedirectURIs: []string{testRedirectURI},
+		Active:       true,
+	}
+	authCode := &AuthorizationCode{
+		Code:        codeValue,
+		ClientID:    testClientID,
+		UserID:      testServerUserID,
+		RedirectURI: testRedirectURI,
+		ExpiresAt:   time.Now().Add(10 * time.Minute),
+	}
+	storage := &mockStorage{
+		getClientFunc: func(_ context.Context, _ string) (*Client, error) {
+			return client, nil
+		},
+		getAuthorizationCodeFunc: func(_ context.Context, _ string) (*AuthorizationCode, error) {
+			return authCode, nil
+		},
+	}
+	server, err := NewServer(ServerConfig{Issuer: "http://localhost:8080"}, storage)
+	if err != nil {
+		t.Fatalf(errCreateServer, err)
+	}
+
+	buf := captureSlog(t)
+
+	body := fmt.Sprintf("grant_type=authorization_code&code=%s&client_id=%s&client_secret=%s&redirect_uri=%s",
+		codeValue, testClientID, secretValue, testRedirectURI)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, `level=INFO`) {
+		t.Errorf("expected INFO level entry, got: %s", out)
+	}
+	if !strings.Contains(out, "oauth: token grant issued") {
+		t.Errorf("expected success message in log, got: %s", out)
+	}
+	if !strings.Contains(out, "grant_type=authorization_code") {
+		t.Errorf("expected grant_type field, got: %s", out)
+	}
+	if !strings.Contains(out, "client_id="+testClientID) {
+		t.Errorf("expected client_id field, got: %s", out)
+	}
+	if !strings.Contains(out, "credential_source=form") {
+		t.Errorf("expected credential_source=form, got: %s", out)
+	}
+	if !strings.Contains(out, "has_refresh_token=true") {
+		t.Errorf("expected has_refresh_token=true on success, got: %s", out)
+	}
+	if !strings.Contains(out, "duration_ms=") {
+		t.Errorf("expected duration_ms field, got: %s", out)
+	}
+	if strings.Contains(out, secretValue) {
+		t.Errorf("client secret value MUST NOT appear in logs, got: %s", out)
+	}
+	if strings.Contains(out, codeValue) {
+		t.Errorf("authorization code value MUST NOT appear in logs, got: %s", out)
+	}
+}
+
+func TestTokenEndpoint_LogsRejection(t *testing.T) {
+	const secretValue = "super-secret-value"
+	storage := &mockStorage{}
+	server, err := NewServer(ServerConfig{Issuer: "http://localhost:8080"}, storage)
+	if err != nil {
+		t.Fatalf(errCreateServer, err)
+	}
+
+	buf := captureSlog(t)
+
+	// Unsupported grant_type -> Token() returns error -> WARN log.
+	body := "grant_type=password&client_id=" + testClientID + "&client_secret=" + secretValue
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `level=WARN`) {
+		t.Errorf("expected WARN level entry, got: %s", out)
+	}
+	if !strings.Contains(out, "oauth: token grant rejected") {
+		t.Errorf("expected rejection message in log, got: %s", out)
+	}
+	if !strings.Contains(out, "grant_type=password") {
+		t.Errorf("expected grant_type=password in log, got: %s", out)
+	}
+	if !strings.Contains(out, "has_client_secret=true") {
+		t.Errorf("expected has_client_secret=true presence boolean, got: %s", out)
+	}
+	if !strings.Contains(out, "error=") {
+		t.Errorf("expected error reason in log, got: %s", out)
+	}
+	if strings.Contains(out, secretValue) {
+		t.Errorf("client secret value MUST NOT appear in logs, got: %s", out)
+	}
+}
+
+func TestTokenEndpoint_LogsRejectionBasicAuth(t *testing.T) {
+	const secretValue = "basic-secret-value"
+	storage := &mockStorage{}
+	server, err := NewServer(ServerConfig{Issuer: "http://localhost:8080"}, storage)
+	if err != nil {
+		t.Fatalf(errCreateServer, err)
+	}
+
+	buf := captureSlog(t)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/token", strings.NewReader("grant_type=password"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(testClientID, secretValue)
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "credential_source=basic") {
+		t.Errorf("expected credential_source=basic when using HTTP Basic auth, got: %s", out)
+	}
+	if strings.Contains(out, secretValue) {
+		t.Errorf("client secret from Basic auth MUST NOT appear in logs, got: %s", out)
+	}
+}
+
+func TestTokenEndpoint_LogsParseFormFailure(t *testing.T) {
+	storage := &mockStorage{}
+	server, err := NewServer(ServerConfig{Issuer: "http://localhost:8080"}, storage)
+	if err != nil {
+		t.Fatalf(errCreateServer, err)
+	}
+
+	buf := captureSlog(t)
+
+	// Malformed percent-encoding causes r.ParseForm() to fail.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/oauth/token", strings.NewReader("grant_type=%ZZ"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `level=WARN`) {
+		t.Errorf("expected WARN level entry, got: %s", out)
+	}
+	if !strings.Contains(out, "oauth: token endpoint parse form failed") {
+		t.Errorf("expected parse-form failure log, got: %s", out)
 	}
 }

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -1890,6 +1890,10 @@ func TestTokenEndpoint_LogsSuccess(t *testing.T) {
 	if strings.Contains(out, secretValue) {
 		t.Errorf("client secret value MUST NOT appear in logs, got: %s", out)
 	}
+	// Future-proofing: the success log path currently emits no code-related
+	// field, so this assertion is a guard rail. If anyone later adds a
+	// has_code or code-derived field to the success log, this test must
+	// be updated to keep the redaction contract explicit.
 	if strings.Contains(out, codeValue) {
 		t.Errorf("authorization code value MUST NOT appear in logs, got: %s", out)
 	}

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -19,6 +19,23 @@ import (
 // defaultServerName is the default server name used when none is configured.
 const defaultServerName = "mcp-data-platform"
 
+// Constants for repeated identifiers used throughout the platform package.
+// Defined in one place so the same literal does not appear repeatedly
+// across platform.go, info_tool.go, prompt_tool.go, etc.
+const (
+	// instanceDefault is the conventional instance name used for the
+	// default connection of any toolkit kind.
+	instanceDefault = "default"
+	// kindPlatform identifies tools provided directly by the platform
+	// (not a toolkit), e.g. platform_info, list_connections.
+	kindPlatform = "platform"
+	// toolListConns is the unified platform-provided list-connections
+	// tool name.
+	toolListConns = "list_connections"
+	// entryPointHTML is the conventional MCP App entry point file.
+	entryPointHTML = "index.html"
+)
+
 // Default configuration values.
 const (
 	defaultMaxOpenConns       = 25

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -23,9 +23,15 @@ const defaultServerName = "mcp-data-platform"
 // Defined in one place so the same literal does not appear repeatedly
 // across platform.go, info_tool.go, prompt_tool.go, etc.
 const (
-	// instanceDefault is the conventional instance name used for the
-	// default connection of any toolkit kind.
+	// instanceDefault is the conventional instance *name* used for the
+	// default connection of any toolkit kind. This is a value, not a
+	// config-map key — see cfgKeyDefault.
 	instanceDefault = "default"
+	// cfgKeyDefault is the config-map *key* under which the default
+	// instance name is stored. Distinct from instanceDefault so a
+	// future rename of the default-instance value cannot silently
+	// break the lookup of this map key.
+	cfgKeyDefault = "default"
 	// kindPlatform identifies tools provided directly by the platform
 	// (not a toolkit), e.g. platform_info, list_connections.
 	kindPlatform = "platform"

--- a/pkg/platform/connections_tool.go
+++ b/pkg/platform/connections_tool.go
@@ -32,7 +32,7 @@ type listConnectionsInput struct{}
 // registerConnectionsTool registers the list_connections tool with the MCP server.
 func (p *Platform) registerConnectionsTool() {
 	mcp.AddTool(p.mcpServer, &mcp.Tool{
-		Name:        "list_connections",
+		Name:        toolListConns,
 		Title:       "List Connections",
 		Description: "List all configured data connections across toolkits (Trino, DataHub, S3, etc.).",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},

--- a/pkg/platform/fieldcrypt.go
+++ b/pkg/platform/fieldcrypt.go
@@ -17,9 +17,12 @@ const aes256KeyLength = 32
 // encryptedPrefix marks a value as AES-256-GCM encrypted + base64-encoded.
 const encryptedPrefix = "enc:"
 
+// configKeyPassword is the conventional config-map key for password fields.
+const configKeyPassword = "password"
+
 // sensitiveConfigKeys are the config map keys whose values must be encrypted at rest.
 var sensitiveConfigKeys = map[string]bool{
-	"password":            true,
+	configKeyPassword:     true,
 	"secret_access_key":   true,
 	"secret_key":          true,
 	"token":               true,

--- a/pkg/platform/info_tool.go
+++ b/pkg/platform/info_tool.go
@@ -112,10 +112,14 @@ func (p *Platform) resolveCallerPersona(ctx context.Context) *PersonaInfo {
 // platformInfoInput is empty since this tool has no parameters.
 type platformInfoInput struct{}
 
+// platformInfoTitle is the fallback display name when server.name is the
+// default mcp-data-platform identifier.
+const platformInfoTitle = "Platform Info"
+
 // registerInfoTool registers the platform_info tool with the MCP server.
 func (p *Platform) registerInfoTool() {
 	mcp.AddTool(p.mcpServer, &mcp.Tool{
-		Name:        "platform_info",
+		Name:        defaultInitTool,
 		Title:       p.buildInfoToolTitle(),
 		Description: p.buildInfoToolDescription(),
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ platformInfoInput) (*mcp.CallToolResult, any, error) {
@@ -127,16 +131,16 @@ func (p *Platform) registerInfoTool() {
 // When server.name is set to a custom value, it is used as the title so that
 // Claude Desktop shows e.g. "ACME Data Platform" instead of "platform_info".
 func (p *Platform) buildInfoToolTitle() string {
-	if p.config.Server.Name != "" && p.config.Server.Name != "mcp-data-platform" {
+	if p.config.Server.Name != "" && p.config.Server.Name != defaultServerName {
 		return p.config.Server.Name
 	}
-	return "Platform Info"
+	return platformInfoTitle
 }
 
 // buildInfoToolDescription builds a dynamic tool description based on configuration.
 func (p *Platform) buildInfoToolDescription() string {
 	base := "MANDATORY first call in every session. "
-	if p.config.Server.Name != "" && p.config.Server.Name != "mcp-data-platform" {
+	if p.config.Server.Name != "" && p.config.Server.Name != defaultServerName {
 		base += fmt.Sprintf("Get information about %s", p.config.Server.Name)
 	} else {
 		base += "Get information about this MCP data platform"
@@ -176,12 +180,12 @@ func (p *Platform) handleInfo(ctx context.Context, _ *mcp.CallToolRequest) (*mcp
 	toolkits, toolkitDescriptions := p.collectToolkits()
 
 	// Prepend "platform" — always-present toolkit for platform_info, list_connections, etc.
-	toolkits = append([]string{"platform"}, toolkits...)
+	toolkits = append([]string{kindPlatform}, toolkits...)
 	if toolkitDescriptions == nil {
 		toolkitDescriptions = make(map[string]string)
 	}
-	if toolkitDescriptions["platform"] == "" {
-		toolkitDescriptions["platform"] = "Core platform tools: deployment info, connection listing, and resource access."
+	if toolkitDescriptions[kindPlatform] == "" {
+		toolkitDescriptions[kindPlatform] = "Core platform tools: deployment info, connection listing, and resource access."
 	}
 
 	// Resolve the caller's persona: prefer the one set by auth middleware,

--- a/pkg/platform/lifecycle.go
+++ b/pkg/platform/lifecycle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync"
 )
 
@@ -83,8 +84,8 @@ func (l *Lifecycle) Stop(ctx context.Context) error {
 	}
 
 	var errs []error
-	for i := len(l.stopCallbacks) - 1; i >= 0; i-- {
-		if err := l.stopCallbacks[i](ctx); err != nil {
+	for i, cb := range slices.Backward(l.stopCallbacks) {
+		if err := cb(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("stop callback %d: %w", i, err))
 		}
 	}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -3003,7 +3003,7 @@ func (p *Platform) getInstanceConfig(toolkitKind, instanceName string) map[strin
 
 // resolveDefaultInstance determines which instance to use.
 func resolveDefaultInstance(kindCfg, instances map[string]any) string {
-	if defaultName, ok := kindCfg[instanceDefault].(string); ok {
+	if defaultName, ok := kindCfg[cfgKeyDefault].(string); ok {
 		return defaultName
 	}
 	// Use the first instance

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -321,7 +321,7 @@ func (p *Platform) initMemory() error {
 	}
 
 	// 3. Create and register memory toolkit.
-	tk, err := memorykit.New("default", p.memoryStore, p.embeddingProv)
+	tk, err := memorykit.New(instanceDefault, p.memoryStore, p.embeddingProv)
 	if err != nil {
 		return fmt.Errorf("creating memory toolkit: %w", err)
 	}
@@ -1072,7 +1072,7 @@ func (p *Platform) initKnowledge() error {
 	}
 	p.knowledgeInsightStore = store
 
-	tk, err := knowledgekit.New("default", store)
+	tk, err := knowledgekit.New(instanceDefault, store)
 	if err != nil {
 		return fmt.Errorf("creating knowledge toolkit: %w", err)
 	}
@@ -1185,7 +1185,7 @@ func (p *Platform) initPortal() error {
 
 	// Create and register toolkit
 	tk := portalkit.New(portalkit.Config{
-		Name:            "default",
+		Name:            instanceDefault,
 		AssetStore:      p.portalAssetStore,
 		ShareStore:      p.portalShareStore,
 		VersionStore:    p.portalVersionStore,
@@ -1656,9 +1656,9 @@ func (p *Platform) registerBuiltinPlatformInfo() error {
 
 	app := &mcpapps.AppDefinition{
 		Name:        builtinPlatformInfoName,
-		ToolNames:   []string{"platform_info"},
+		ToolNames:   []string{defaultInitTool},
 		Content:     subFS,
-		EntryPoint:  "index.html",
+		EntryPoint:  entryPointHTML,
 		ResourceURI: "ui://platform-info",
 		CSP: &mcpapps.CSPConfig{
 			Permissions: &mcpapps.PermissionsConfig{
@@ -1791,7 +1791,7 @@ func (p *Platform) registerMCPApp(appName string, appCfg AppConfig) error {
 	}
 
 	if app.EntryPoint == "" {
-		app.EntryPoint = "index.html"
+		app.EntryPoint = entryPointHTML
 	}
 
 	if appCfg.ResourceURI != "" {
@@ -2856,11 +2856,11 @@ type ToolInfo struct {
 // PlatformTools returns tools registered directly on the platform outside of any toolkit.
 func (p *Platform) PlatformTools() []ToolInfo {
 	tools := []ToolInfo{
-		{Name: "platform_info", Kind: "platform"},
-		{Name: "list_connections", Kind: "platform"},
+		{Name: defaultInitTool, Kind: kindPlatform},
+		{Name: toolListConns, Kind: kindPlatform},
 	}
 	if p.promptStore != nil {
-		tools = append(tools, ToolInfo{Name: "manage_prompt", Kind: "platform"})
+		tools = append(tools, ToolInfo{Name: "manage_prompt", Kind: kindPlatform})
 	}
 	return tools
 }
@@ -2934,7 +2934,7 @@ func (p *Platform) getTrinoConfig(instanceName string) *trinoConfig {
 		Host:           cfgString(instanceCfg, "host"),
 		Port:           cfgInt(instanceCfg, "port", defaultTrinoPort),
 		User:           cfgString(instanceCfg, "user"),
-		Password:       cfgString(instanceCfg, "password"),
+		Password:       cfgString(instanceCfg, configKeyPassword),
 		Catalog:        cfgString(instanceCfg, "catalog"),
 		Schema:         cfgString(instanceCfg, "schema"),
 		SSL:            cfgBool(instanceCfg, "ssl"),
@@ -3003,7 +3003,7 @@ func (p *Platform) getInstanceConfig(toolkitKind, instanceName string) map[strin
 
 // resolveDefaultInstance determines which instance to use.
 func resolveDefaultInstance(kindCfg, instances map[string]any) string {
-	if defaultName, ok := kindCfg["default"].(string); ok {
+	if defaultName, ok := kindCfg[instanceDefault].(string); ok {
 		return defaultName
 	}
 	// Use the first instance

--- a/pkg/platform/prompt_tool.go
+++ b/pkg/platform/prompt_tool.go
@@ -16,6 +16,15 @@ const (
 	promptErrGet    = "failed to get prompt"
 	promptLogKey    = "name"
 	promptLogKeyErr = "error"
+
+	// Command names for the manage_prompt tool.
+	cmdList = "list"
+
+	// JSON field names used in result and schema maps. These share the
+	// same string value as promptLogKey/promptLogKeyErr but are kept
+	// separate for documentation clarity at call sites.
+	fieldName    = "name"
+	fieldContent = "content"
 )
 
 // platformPromptCreator adapts the prompt store and platform for the
@@ -81,7 +90,7 @@ func (p *Platform) handleManagePrompt(ctx context.Context, input managePromptInp
 		return p.handlePromptUpdate(ctx, input)
 	case "delete":
 		return p.handlePromptDelete(ctx, input)
-	case "list":
+	case cmdList:
 		return p.handlePromptList(ctx, input)
 	case "get":
 		return p.handlePromptGet(ctx, input)
@@ -139,9 +148,9 @@ func (p *Platform) handlePromptCreate(ctx context.Context, input managePromptInp
 	p.RegisterRuntimePrompt(pr)
 
 	return promptJSONResult(map[string]any{
-		"status": "created",
-		"id":     pr.ID,
-		"name":   pr.Name,
+		"status":  "created",
+		"id":      pr.ID,
+		fieldName: pr.Name,
 	})
 }
 
@@ -184,8 +193,8 @@ func (p *Platform) handlePromptUpdate(ctx context.Context, input managePromptInp
 	p.RegisterRuntimePrompt(existing)
 
 	return promptJSONResult(map[string]any{
-		"status": "updated",
-		"name":   existing.Name,
+		"status":  "updated",
+		fieldName: existing.Name,
 	})
 }
 
@@ -252,8 +261,8 @@ func (p *Platform) handlePromptDelete(ctx context.Context, input managePromptInp
 	p.UnregisterRuntimePrompt(input.Name)
 
 	return promptJSONResult(map[string]any{
-		"status": "deleted",
-		"name":   input.Name,
+		"status":  "deleted",
+		fieldName: input.Name,
 	})
 }
 
@@ -405,10 +414,10 @@ func managePromptSchema() any {
 		"properties": map[string]any{
 			"command": map[string]any{
 				schemaKeyType:        schemaValString,
-				"enum":               []string{"create", "update", "delete", "list", "get"},
+				"enum":               []string{"create", "update", "delete", cmdList, "get"},
 				schemaKeyDescription: "The operation to perform",
 			},
-			"name": map[string]any{
+			fieldName: map[string]any{
 				schemaKeyType:        schemaValString,
 				schemaKeyDescription: "Prompt name (required for create, update, delete, get)",
 			},
@@ -420,7 +429,7 @@ func managePromptSchema() any {
 				schemaKeyType:        schemaValString,
 				schemaKeyDescription: "Prompt description",
 			},
-			"content": map[string]any{
+			fieldContent: map[string]any{
 				schemaKeyType:        schemaValString,
 				schemaKeyDescription: "Prompt content template. Use {arg_name} for argument placeholders.",
 			},
@@ -429,7 +438,7 @@ func managePromptSchema() any {
 				"items": map[string]any{
 					schemaKeyType: "object",
 					"properties": map[string]any{
-						"name":               map[string]any{schemaKeyType: schemaValString},
+						fieldName:            map[string]any{schemaKeyType: schemaValString},
 						schemaKeyDescription: map[string]any{schemaKeyType: schemaValString},
 						"required":           map[string]any{schemaKeyType: "boolean"},
 					},
@@ -442,7 +451,7 @@ func managePromptSchema() any {
 			},
 			"scope": map[string]any{
 				schemaKeyType:        schemaValString,
-				"enum":               []string{"global", "persona", "personal"},
+				"enum":               []string{prompt.ScopeGlobal, prompt.ScopePersona, prompt.ScopePersonal},
 				schemaKeyDescription: "Visibility scope. Non-admins can only use 'personal'.",
 			},
 			"personas": map[string]any{

--- a/pkg/platform/prompts.go
+++ b/pkg/platform/prompts.go
@@ -203,12 +203,17 @@ type workflowPrompt struct {
 	requiredKinds []string
 }
 
+// promptExploreAvailableData is the canonical name of the data-exploration
+// workflow prompt. Used by the prompt registration code and referenced by
+// the disable-prompt allowlist in tests.
+const promptExploreAvailableData = "explore-available-data"
+
 // workflowPrompts returns the set of platform-level workflow prompts.
 func workflowPrompts() []workflowPrompt {
 	return []workflowPrompt{
 		{
 			config: PromptConfig{
-				Name:        "explore-available-data",
+				Name:        promptExploreAvailableData,
 				Description: "Discover what data is available about a topic",
 				Content: `Explore what data is available about {topic}.
 

--- a/pkg/platform/resource_templates.go
+++ b/pkg/platform/resource_templates.go
@@ -17,6 +17,9 @@ const (
 	schemaTemplateURI       = "schema://{catalog}.{schema_name}/{table}"
 	glossaryTemplateURI     = "glossary://{term}"
 	availabilityTemplateURI = "availability://{catalog}.{schema_name}/{table}"
+
+	// mimeApplicationJSON is the MIME type for JSON-encoded resource bodies.
+	mimeApplicationJSON = "application/json"
 )
 
 // registerResourceTemplates registers all MCP resource templates.
@@ -30,21 +33,21 @@ func (p *Platform) registerResourceTemplates() {
 		URITemplate: schemaTemplateURI,
 		Name:        "Table Schema",
 		Description: "Table schema with column types and semantic context (descriptions, owners, tags, glossary terms)",
-		MIMEType:    "application/json",
+		MIMEType:    mimeApplicationJSON,
 	}, p.handleSchemaResource)
 
 	p.mcpServer.AddResourceTemplate(&mcp.ResourceTemplate{
 		URITemplate: glossaryTemplateURI,
 		Name:        "Glossary Term",
 		Description: "Business glossary term definition and related assets",
-		MIMEType:    "application/json",
+		MIMEType:    mimeApplicationJSON,
 	}, p.handleGlossaryResource)
 
 	p.mcpServer.AddResourceTemplate(&mcp.ResourceTemplate{
 		URITemplate: availabilityTemplateURI,
 		Name:        "Data Availability",
 		Description: "Table availability status including row count and connection info",
-		MIMEType:    "application/json",
+		MIMEType:    mimeApplicationJSON,
 	}, p.handleAvailabilityResource)
 }
 
@@ -292,7 +295,7 @@ func marshalResourceResult(uri string, v any) (*mcp.ReadResourceResult, error) {
 		Contents: []*mcp.ResourceContents{
 			{
 				URI:      uri,
-				MIMEType: "application/json",
+				MIMEType: mimeApplicationJSON,
 				Text:     string(data),
 			},
 		},

--- a/pkg/portal/auth_test.go
+++ b/pkg/portal/auth_test.go
@@ -161,7 +161,7 @@ func TestPortalAuthenticatorCookieAuth(t *testing.T) {
 	pa := NewAuthenticator(&mockAuthenticator{}, WithBrowserAuth(ba))
 
 	r := httptest.NewRequestWithContext(context.Background(), "GET", "/", http.NoBody)
-	r.AddCookie(&http.Cookie{Name: browsersession.DefaultCookieName, Value: token})
+	r.AddCookie(&http.Cookie{Name: browsersession.DefaultCookieName, Value: token, HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode})
 
 	user, authErr := pa.Authenticate(r)
 	assert.NoError(t, authErr)
@@ -186,7 +186,7 @@ func TestPortalAuthenticatorCookiePriority(t *testing.T) {
 	)
 
 	r := httptest.NewRequestWithContext(context.Background(), "GET", "/", http.NoBody)
-	r.AddCookie(&http.Cookie{Name: browsersession.DefaultCookieName, Value: token})
+	r.AddCookie(&http.Cookie{Name: browsersession.DefaultCookieName, Value: token, HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode})
 	r.Header.Set("X-API-Key", "some-key")
 
 	user, authErr := pa.Authenticate(r)
@@ -204,7 +204,7 @@ func TestPortalAuthenticatorCookieFallback(t *testing.T) {
 	)
 
 	r := httptest.NewRequestWithContext(context.Background(), "GET", "/", http.NoBody)
-	r.AddCookie(&http.Cookie{Name: browsersession.DefaultCookieName, Value: "invalid-jwt"})
+	r.AddCookie(&http.Cookie{Name: browsersession.DefaultCookieName, Value: "invalid-jwt", HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode})
 	r.Header.Set("X-API-Key", "key")
 
 	user, err := pa.Authenticate(r)

--- a/pkg/semantic/datahub/adapter.go
+++ b/pkg/semantic/datahub/adapter.go
@@ -26,6 +26,13 @@ const (
 
 	// datahubPlatform is the provider name for this adapter.
 	datahubPlatform = "datahub"
+
+	// DataHub search-filter field names. Defined as constants because
+	// each appears in multiple places (filter mapping, lineage inheritance,
+	// query construction).
+	filterFieldPlatform = "platform"
+	filterFieldTags     = "tags"
+	filterFieldOwners   = "owners"
 )
 
 // Config holds DataHub adapter configuration.
@@ -287,13 +294,13 @@ func buildDHFilters(filter semantic.SearchFilter) []dhclient.SearchFilter {
 
 	if filter.Platform != "" {
 		out = append(out, dhclient.SearchFilter{
-			Field:  "platform",
+			Field:  filterFieldPlatform,
 			Values: []string{filter.Platform},
 		})
 	}
 	if len(filter.Tags) > 0 {
 		out = append(out, dhclient.SearchFilter{
-			Field:  "tags",
+			Field:  filterFieldTags,
 			Values: filter.Tags,
 		})
 	}
@@ -305,7 +312,7 @@ func buildDHFilters(filter semantic.SearchFilter) []dhclient.SearchFilter {
 	}
 	if filter.Owner != "" {
 		out = append(out, dhclient.SearchFilter{
-			Field:  "owners",
+			Field:  filterFieldOwners,
 			Values: []string{filter.Owner},
 		})
 	}

--- a/pkg/semantic/datahub/lineage_config.go
+++ b/pkg/semantic/datahub/lineage_config.go
@@ -11,6 +11,9 @@ const (
 
 	// defaultLineageTimeout is the default timeout for the entire inheritance operation.
 	defaultLineageTimeout = 5 * time.Second
+
+	// Conflict-resolution strategies for lineage-based inheritance.
+	conflictResolutionNearest = "nearest"
 )
 
 // LineageConfig controls lineage-aware semantic enrichment.
@@ -77,7 +80,7 @@ func DefaultLineageConfig() LineageConfig {
 		Enabled:             false,
 		MaxHops:             2,
 		Inherit:             []string{"glossary_terms", "descriptions"},
-		ConflictResolution:  "nearest",
+		ConflictResolution:  conflictResolutionNearest,
 		PreferColumnLineage: true,
 		CacheTTL:            defaultCacheTTL,
 		Timeout:             defaultLineageTimeout,

--- a/pkg/semantic/datahub/lineage_resolver.go
+++ b/pkg/semantic/datahub/lineage_resolver.go
@@ -136,7 +136,7 @@ func (r *lineageResolver) needsGlossaryTerms(cc *semantic.ColumnContext) bool {
 }
 
 func (r *lineageResolver) needsTags(cc *semantic.ColumnContext) bool {
-	return r.cfg.shouldInherit("tags") && len(cc.Tags) == 0
+	return r.cfg.shouldInherit(filterFieldTags) && len(cc.Tags) == 0
 }
 
 // resolveAlias checks if the table matches any configured alias.
@@ -351,7 +351,7 @@ func (r *lineageResolver) matchAndInheritColumns(
 	level int,
 ) {
 	for targetCol := range undocumented {
-		if columns[targetCol].InheritedFrom != nil && r.cfg.ConflictResolution == "nearest" {
+		if columns[targetCol].InheritedFrom != nil && r.cfg.ConflictResolution == conflictResolutionNearest {
 			continue
 		}
 		sourceCol := r.transformColumnName(targetCol)
@@ -468,7 +468,7 @@ func (r *lineageResolver) inheritGlossaryTerms(target *semantic.ColumnContext, s
 
 // inheritTags inherits tags if needed.
 func (r *lineageResolver) inheritTags(target *semantic.ColumnContext, source types.SchemaField) bool {
-	if !r.cfg.shouldInherit("tags") || len(target.Tags) > 0 || len(source.Tags) == 0 {
+	if !r.cfg.shouldInherit(filterFieldTags) || len(target.Tags) > 0 || len(source.Tags) == 0 {
 		return false
 	}
 	rawTags := make([]string, len(source.Tags))

--- a/pkg/toolkits/datahub/toolkit.go
+++ b/pkg/toolkits/datahub/toolkit.go
@@ -23,6 +23,15 @@ const (
 	// defaultMaxLimit is the maximum number of results allowed.
 	defaultMaxLimit = 100
 
+	// DataHub tool names. Defined as constants so the same literal does
+	// not appear repeatedly across the Tools() list and the per-tool
+	// enrichment / context-provider lookups.
+	toolGetEntity       = "datahub_get_entity"
+	toolGetLineage      = "datahub_get_lineage"
+	toolBrowse          = "datahub_browse"
+	toolGetGlossaryTerm = "datahub_get_glossary_term"
+	toolGetDataProduct  = "datahub_get_data_product"
+
 	// defaultMaxLineageDepth is the maximum lineage traversal depth.
 	defaultMaxLineageDepth = 5
 )
@@ -230,13 +239,13 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 func (t *Toolkit) Tools() []string {
 	tools := []string{
 		"datahub_search",
-		"datahub_get_entity",
+		toolGetEntity,
 		"datahub_get_schema",
-		"datahub_get_lineage",
+		toolGetLineage,
 		"datahub_get_queries",
-		"datahub_browse",
-		"datahub_get_glossary_term",
-		"datahub_get_data_product",
+		toolBrowse,
+		toolGetGlossaryTerm,
+		toolGetDataProduct,
 	}
 
 	if !t.config.ReadOnly {

--- a/pkg/toolkits/datahub/toolkit.go
+++ b/pkg/toolkits/datahub/toolkit.go
@@ -23,14 +23,21 @@ const (
 	// defaultMaxLimit is the maximum number of results allowed.
 	defaultMaxLimit = 100
 
-	// DataHub tool names. Defined as constants so the same literal does
-	// not appear repeatedly across the Tools() list and the per-tool
-	// enrichment / context-provider lookups.
+	// DataHub tool names. The full set is named here even though only
+	// a subset crosses goconst's literal-repetition threshold — keeping
+	// the Tools() list uniformly constant-driven avoids a visually mixed
+	// list of constants and bare strings.
+	toolSearch          = "datahub_search"
 	toolGetEntity       = "datahub_get_entity"
+	toolGetSchema       = "datahub_get_schema"
 	toolGetLineage      = "datahub_get_lineage"
+	toolGetQueries      = "datahub_get_queries"
 	toolBrowse          = "datahub_browse"
 	toolGetGlossaryTerm = "datahub_get_glossary_term"
 	toolGetDataProduct  = "datahub_get_data_product"
+	toolCreate          = "datahub_create"
+	toolUpdate          = "datahub_update"
+	toolDelete          = "datahub_delete"
 
 	// defaultMaxLineageDepth is the maximum lineage traversal depth.
 	defaultMaxLineageDepth = 5
@@ -238,11 +245,11 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 // Tools returns the list of tool names that would be provided by this toolkit.
 func (t *Toolkit) Tools() []string {
 	tools := []string{
-		"datahub_search",
+		toolSearch,
 		toolGetEntity,
-		"datahub_get_schema",
+		toolGetSchema,
 		toolGetLineage,
-		"datahub_get_queries",
+		toolGetQueries,
 		toolBrowse,
 		toolGetGlossaryTerm,
 		toolGetDataProduct,
@@ -250,9 +257,9 @@ func (t *Toolkit) Tools() []string {
 
 	if !t.config.ReadOnly {
 		tools = append(tools,
-			"datahub_create",
-			"datahub_update",
-			"datahub_delete",
+			toolCreate,
+			toolUpdate,
+			toolDelete,
 		)
 	}
 

--- a/pkg/toolkits/gateway/config.go
+++ b/pkg/toolkits/gateway/config.go
@@ -152,14 +152,14 @@ func ParseConfig(cfg map[string]any) (Config, error) {
 		TrustLevel:     TrustLevelUntrusted,
 	}
 
-	c.Endpoint = getString(cfg, "endpoint")
-	c.AuthMode = getStringDefault(cfg, "auth_mode", c.AuthMode)
-	c.Credential = getString(cfg, "credential")
+	c.Endpoint = getString(cfg, cfgKeyEndpoint)
+	c.AuthMode = getStringDefault(cfg, cfgKeyAuthMode, c.AuthMode)
+	c.Credential = getString(cfg, cfgKeyCredential)
 	c.OAuth = parseOAuthConfig(cfg)
-	c.ConnectionName = getString(cfg, "connection_name")
-	c.ConnectTimeout = getDuration(cfg, "connect_timeout", c.ConnectTimeout)
-	c.CallTimeout = getDuration(cfg, "call_timeout", c.CallTimeout)
-	c.TrustLevel = getStringDefault(cfg, "trust_level", c.TrustLevel)
+	c.ConnectionName = getString(cfg, cfgKeyConnectionName)
+	c.ConnectTimeout = getDuration(cfg, cfgKeyConnectTimeout, c.ConnectTimeout)
+	c.CallTimeout = getDuration(cfg, cfgKeyCallTimeout, c.CallTimeout)
+	c.TrustLevel = getStringDefault(cfg, cfgKeyTrustLevel, c.TrustLevel)
 
 	if err := c.Validate(); err != nil {
 		return Config{}, err

--- a/pkg/toolkits/gateway/enrichment/engine.go
+++ b/pkg/toolkits/gateway/enrichment/engine.go
@@ -10,6 +10,10 @@ import (
 	"time"
 )
 
+// userKeyEmail is the field name of the email value injected into rule
+// evaluation contexts as user.email.
+const userKeyEmail = "email"
+
 // Source is a read-only adapter that an enrichment rule can dispatch to.
 // Implementations must enforce their own operation allowlist by returning
 // an error for unrecognized operations.
@@ -182,8 +186,8 @@ func resolveParameters(params map[string]any, call CallContext, response any) (m
 		"args":     call.Args,
 		"response": response,
 		"user": map[string]any{
-			"id":    call.User.ID,
-			"email": call.User.Email,
+			"id":         call.User.ID,
+			userKeyEmail: call.User.Email,
 		},
 	}
 	out := make(map[string]any, len(params))

--- a/pkg/toolkits/gateway/oauth.go
+++ b/pkg/toolkits/gateway/oauth.go
@@ -18,6 +18,10 @@ import (
 // proactively refresh. Keeps in-flight calls from racing the clock.
 const expiryBuffer = 30 * time.Second
 
+// errInvalidGrant is the RFC 6749 §5.2 error code returned when a
+// refresh token has been definitively invalidated by the IdP.
+const errInvalidGrant = "invalid_grant"
+
 // tokenState is the cached result of a successful OAuth token exchange.
 // Zero value (zero ExpiresAt) means "never acquired" — the next Token()
 // call will perform a full acquisition.
@@ -682,7 +686,7 @@ func interpretTokenError(grantType string, status int, body []byte) error {
 // (5xx, network) may be transient and the caller must NOT clear
 // stored credentials on a transient signal.
 func isRefreshDeadError(status int, errCode string) bool {
-	return status == http.StatusBadRequest && errCode == "invalid_grant"
+	return status == http.StatusBadRequest && errCode == errInvalidGrant
 }
 
 // URLHost returns the host portion of u so logs can show "which IdP"

--- a/pkg/toolkits/gateway/sources/datahub.go
+++ b/pkg/toolkits/gateway/sources/datahub.go
@@ -7,6 +7,12 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/toolkits/gateway/enrichment"
 )
 
+// DataHub source operation names.
+const (
+	opGetEntity       = "get_entity"
+	opGetGlossaryTerm = "get_glossary_term"
+)
+
 // DataHubGetEntityFunc resolves a DataHub entity by URN.
 type DataHubGetEntityFunc func(ctx context.Context, urn string) (any, error)
 
@@ -34,7 +40,7 @@ func (*DataHubSource) Name() string { return enrichment.SourceDataHub }
 
 // Operations returns the read-only operation allowlist.
 func (*DataHubSource) Operations() []string {
-	return []string{"get_entity", "get_glossary_term"}
+	return []string{opGetEntity, opGetGlossaryTerm}
 }
 
 // Execute dispatches the requested operation. Recognized parameters:
@@ -43,9 +49,9 @@ func (*DataHubSource) Operations() []string {
 //	get_glossary_term  { urn string }
 func (s *DataHubSource) Execute(ctx context.Context, op string, params map[string]any) (any, error) {
 	switch op {
-	case "get_entity":
+	case opGetEntity:
 		return s.execGet(ctx, op, params, s.getEntity)
-	case "get_glossary_term":
+	case opGetGlossaryTerm:
 		return s.execGet(ctx, op, params, s.getGlossaryTerm)
 	default:
 		return nil, fmt.Errorf("datahub: operation %q not supported", op)

--- a/pkg/toolkits/gateway/sources/trino.go
+++ b/pkg/toolkits/gateway/sources/trino.go
@@ -15,6 +15,21 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/toolkits/gateway/enrichment"
 )
 
+// Trino source operation names, parameter keys, and the SQL literal
+// strings the query renderer emits. Defined as constants because each
+// appears in the operation allowlist, dispatch, parameter lookup, and
+// the output renderer.
+const (
+	opQuery = "query"
+
+	paramConnection  = "connection"
+	paramSQLTemplate = "sql_template"
+
+	sqlLiteralNULL  = "NULL"
+	sqlLiteralTRUE  = "TRUE"
+	sqlLiteralFALSE = "FALSE"
+)
+
 // TrinoQueryFunc executes a SQL query against a named Trino connection
 // and returns the row set. Implementations are platform-side.
 type TrinoQueryFunc func(ctx context.Context, connection, sql string) ([]map[string]any, error)
@@ -41,7 +56,7 @@ func NewTrinoSource(exec TrinoQueryFunc) *TrinoSource {
 func (*TrinoSource) Name() string { return enrichment.SourceTrino }
 
 // Operations returns the read-only operation allowlist.
-func (*TrinoSource) Operations() []string { return []string{"query"} }
+func (*TrinoSource) Operations() []string { return []string{opQuery} }
 
 // Execute runs the requested operation. Recognized parameters for "query":
 //
@@ -53,14 +68,14 @@ func (*TrinoSource) Operations() []string { return []string{"query"} }
 // doubled per ANSI SQL; numbers and bools are rendered as literals; nil
 // becomes NULL. Other types are rejected.
 func (s *TrinoSource) Execute(ctx context.Context, op string, params map[string]any) (any, error) {
-	if op != "query" {
+	if op != opQuery {
 		return nil, fmt.Errorf("trino: operation %q not supported", op)
 	}
-	connection, err := requireString(params, "connection")
+	connection, err := requireString(params, paramConnection)
 	if err != nil {
 		return nil, err
 	}
-	tmpl, err := requireString(params, "sql_template")
+	tmpl, err := requireString(params, paramSQLTemplate)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +111,7 @@ func requireString(params map[string]any, key string) (string, error) {
 // Placeholder matching is greedy on identifier characters so :i and :i64
 // are distinct bindings (a naive ReplaceAll would chew :i out of :i64).
 func renderSQL(tmpl string, params map[string]any) (string, error) {
-	skip := map[string]bool{"connection": true, "sql_template": true}
+	skip := map[string]bool{paramConnection: true, paramSQLTemplate: true}
 	literals := make(map[string]string, len(params))
 	for k, v := range params {
 		if skip[k] {
@@ -180,7 +195,7 @@ func substitutePlaceholder(out *strings.Builder, tmpl string, i int, literals ma
 func sqlLiteral(v any) (string, error) {
 	switch x := v.(type) {
 	case nil:
-		return "NULL", nil
+		return sqlLiteralNULL, nil
 	case string:
 		if strings.ContainsRune(x, 0) {
 			return "", errors.New("string binding contains a NUL byte")
@@ -188,9 +203,9 @@ func sqlLiteral(v any) (string, error) {
 		return "'" + strings.ReplaceAll(x, "'", "''") + "'", nil
 	case bool:
 		if x {
-			return "TRUE", nil
+			return sqlLiteralTRUE, nil
 		}
-		return "FALSE", nil
+		return sqlLiteralFALSE, nil
 	case int, int32, int64:
 		return fmt.Sprintf("%d", x), nil
 	case float32:

--- a/pkg/toolkits/gateway/toolkit.go
+++ b/pkg/toolkits/gateway/toolkit.go
@@ -38,6 +38,15 @@ const (
 	logKeyEndpoint   = "endpoint"
 	logKeyError      = "error"
 
+	// Config-map keys used by configToMap and AddConnection's parser.
+	cfgKeyEndpoint       = "endpoint"
+	cfgKeyAuthMode       = "auth_mode"
+	cfgKeyCredential     = "credential"
+	cfgKeyConnectionName = "connection_name"
+	cfgKeyConnectTimeout = "connect_timeout"
+	cfgKeyCallTimeout    = "call_timeout"
+	cfgKeyTrustLevel     = "trust_level"
+
 	// LogKeyTokenURLHost is the structured-log field name used when
 	// emitting an IdP host. Exported so external packages don't
 	// duplicate the literal and risk drift.
@@ -713,13 +722,13 @@ const errFmtConnection = "gateway: %s: %w"
 // to round-trip; ConnectionName is set directly to preserve the original.
 func configToMap(c Config) map[string]any {
 	m := map[string]any{
-		"endpoint":        c.Endpoint,
-		"auth_mode":       c.AuthMode,
-		"credential":      c.Credential,
-		"connection_name": c.ConnectionName,
-		"connect_timeout": c.ConnectTimeout.String(),
-		"call_timeout":    c.CallTimeout.String(),
-		"trust_level":     c.TrustLevel,
+		cfgKeyEndpoint:       c.Endpoint,
+		cfgKeyAuthMode:       c.AuthMode,
+		cfgKeyCredential:     c.Credential,
+		cfgKeyConnectionName: c.ConnectionName,
+		cfgKeyConnectTimeout: c.ConnectTimeout.String(),
+		cfgKeyCallTimeout:    c.CallTimeout.String(),
+		cfgKeyTrustLevel:     c.TrustLevel,
 	}
 	if c.OAuth.Grant != "" {
 		m["oauth_grant"] = c.OAuth.Grant

--- a/pkg/toolkits/s3/config.go
+++ b/pkg/toolkits/s3/config.go
@@ -18,7 +18,7 @@ const (
 // ParseConfig parses an S3 toolkit configuration from a map.
 func ParseConfig(cfg map[string]any) (Config, error) {
 	c := Config{
-		Region:     "us-east-1",
+		Region:     defaultS3Region,
 		Timeout:    DefaultTimeout,
 		MaxGetSize: DefaultMaxGetSize,
 		MaxPutSize: DefaultMaxPutSize,

--- a/pkg/toolkits/s3/toolkit.go
+++ b/pkg/toolkits/s3/toolkit.go
@@ -36,13 +36,21 @@ type Config struct {
 	Annotations     map[string]AnnotationConfig `yaml:"annotations"`
 }
 
-// Default region and tool-name constants. Defined here so the same
-// literals do not appear repeatedly across the toolkit source files.
+// Default region and S3 tool-name constants. The full set is named
+// here even though only a subset crosses goconst's literal-repetition
+// threshold — keeping the Tools() list uniformly constant-driven
+// avoids a visually mixed list of constants and bare strings.
 const (
 	defaultS3Region = "us-east-1"
 
-	toolListBuckets = "s3_list_buckets"
-	toolGetObject   = "s3_get_object"
+	toolListBuckets       = "s3_list_buckets"
+	toolListObjects       = "s3_list_objects"
+	toolGetObject         = "s3_get_object"
+	toolGetObjectMetadata = "s3_get_object_metadata"
+	toolPresignURL        = "s3_presign_url"
+	toolPutObject         = "s3_put_object"
+	toolDeleteObject      = "s3_delete_object"
+	toolCopyObject        = "s3_copy_object"
 )
 
 // Toolkit wraps mcp-s3 toolkit for the platform.
@@ -224,17 +232,17 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 func (t *Toolkit) Tools() []string {
 	tools := []string{
 		toolListBuckets,
-		"s3_list_objects",
+		toolListObjects,
 		toolGetObject,
-		"s3_get_object_metadata",
-		"s3_presign_url",
+		toolGetObjectMetadata,
+		toolPresignURL,
 	}
 
 	if !t.config.ReadOnly {
 		tools = append(tools,
-			"s3_put_object",
-			"s3_delete_object",
-			"s3_copy_object",
+			toolPutObject,
+			toolDeleteObject,
+			toolCopyObject,
 		)
 	}
 

--- a/pkg/toolkits/s3/toolkit.go
+++ b/pkg/toolkits/s3/toolkit.go
@@ -36,6 +36,15 @@ type Config struct {
 	Annotations     map[string]AnnotationConfig `yaml:"annotations"`
 }
 
+// Default region and tool-name constants. Defined here so the same
+// literals do not appear repeatedly across the toolkit source files.
+const (
+	defaultS3Region = "us-east-1"
+
+	toolListBuckets = "s3_list_buckets"
+	toolGetObject   = "s3_get_object"
+)
+
 // Toolkit wraps mcp-s3 toolkit for the platform.
 type Toolkit struct {
 	name      string
@@ -69,7 +78,7 @@ func New(name string, cfg Config) (*Toolkit, error) {
 // applyDefaults applies default values to the configuration.
 func applyDefaults(name string, cfg Config) Config {
 	if cfg.Region == "" {
-		cfg.Region = "us-east-1"
+		cfg.Region = defaultS3Region
 	}
 	if cfg.Timeout == 0 {
 		cfg.Timeout = DefaultTimeout
@@ -214,9 +223,9 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 // Tools returns the list of tool names that would be provided by this toolkit.
 func (t *Toolkit) Tools() []string {
 	tools := []string{
-		"s3_list_buckets",
+		toolListBuckets,
 		"s3_list_objects",
-		"s3_get_object",
+		toolGetObject,
 		"s3_get_object_metadata",
 		"s3_presign_url",
 	}

--- a/pkg/toolkits/trino/connection_required.go
+++ b/pkg/toolkits/trino/connection_required.go
@@ -89,7 +89,7 @@ func extractConnectionFromInput(input any) string {
 		return ""
 	}
 	v := reflect.ValueOf(input)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return ""
 		}

--- a/pkg/toolkits/trino/elicitation.go
+++ b/pkg/toolkits/trino/elicitation.go
@@ -37,6 +37,12 @@ const (
 	logKeyReason = "reason"
 )
 
+// Elicitation schema and result-action constants.
+const (
+	schemaPropertiesKey = "properties"
+	elicitActionAccept  = "accept"
+)
+
 // rowEstimatePattern matches "rows: 12345" in Trino EXPLAIN IO output.
 var rowEstimatePattern = regexp.MustCompile(`rows:\s*(\d+)`)
 
@@ -195,8 +201,8 @@ func (em *ElicitationMiddleware) checkCostEstimation(ctx context.Context, e elic
 	result, err := e.Elicit(ctx, &mcp.ElicitParams{
 		Message: message,
 		RequestedSchema: map[string]any{
-			"type":       "object",
-			"properties": map[string]any{},
+			"type":              "object",
+			schemaPropertiesKey: map[string]any{},
 		},
 	})
 	if err != nil {
@@ -207,7 +213,7 @@ func (em *ElicitationMiddleware) checkCostEstimation(ctx context.Context, e elic
 		return nil // graceful degradation
 	}
 
-	if result.Action != "accept" {
+	if result.Action != elicitActionAccept {
 		return &ElicitationDeclinedError{
 			Reason: fmt.Sprintf("query declined: estimated %s rows exceeds threshold", formatRowCount(estimated)),
 		}
@@ -258,8 +264,8 @@ func (em *ElicitationMiddleware) checkPIIConsent(ctx context.Context, e elicitor
 	result, err := e.Elicit(ctx, &mcp.ElicitParams{
 		Message: message,
 		RequestedSchema: map[string]any{
-			"type":       "object",
-			"properties": map[string]any{},
+			"type":              "object",
+			schemaPropertiesKey: map[string]any{},
 		},
 	})
 	if err != nil {
@@ -270,7 +276,7 @@ func (em *ElicitationMiddleware) checkPIIConsent(ctx context.Context, e elicitor
 		return nil // graceful degradation
 	}
 
-	if result.Action != "accept" {
+	if result.Action != elicitActionAccept {
 		return &ElicitationDeclinedError{
 			Reason: "query declined: PII access not authorized by user",
 		}

--- a/pkg/toolkits/trino/export.go
+++ b/pkg/toolkits/trino/export.go
@@ -889,6 +889,6 @@ func exportInputSchema() map[string]any {
 				schemaKeyDesc: "Generate a public share link for the exported asset. Useful for automation pipelines that need a shareable URL.",
 			},
 		},
-		"required": []string{"sql", "format", "name"},
+		"required": []string{propSQL, propFormat, propName},
 	}
 }

--- a/pkg/toolkits/trino/export.go
+++ b/pkg/toolkits/trino/export.go
@@ -25,6 +25,15 @@ const (
 	schemaTypeInteger = "integer"
 	schemaKeyType     = "type"
 	schemaKeyDesc     = "description"
+
+	// Export schema property names and provenance keys. Defined as
+	// constants because each appears multiple times across the schema
+	// definition, parameter parsing, and provenance output.
+	propProperties = "properties"
+	propSQL        = "sql"
+	propFormat     = "format"
+	propName       = "name"
+	propTags       = "tags"
 )
 
 const (
@@ -630,7 +639,7 @@ func buildExportProvenance(ctx context.Context, deps *ExportDeps, p exportProven
 		Parameters: map[string]any{
 			"export_query":  p.sql,
 			"source_tables": p.sourceTables,
-			"format":        p.format,
+			propFormat:      p.format,
 			"row_count":     p.rowCount,
 		},
 	})
@@ -832,8 +841,8 @@ func exportSuccess(out exportOutput) *mcp.CallToolResult {
 func exportInputSchema() map[string]any {
 	return map[string]any{
 		schemaKeyType: schemaTypeObject,
-		"properties": map[string]any{
-			"sql": map[string]any{
+		propProperties: map[string]any{
+			propSQL: map[string]any{
 				schemaKeyType: schemaTypeString,
 				schemaKeyDesc: "The SQL query to execute. Must be read-only (SELECT). Validate the query shape with trino_query first.",
 			},
@@ -841,24 +850,24 @@ func exportInputSchema() map[string]any {
 				schemaKeyType: schemaTypeString,
 				schemaKeyDesc: "Trino connection name (optional, uses default if not specified).",
 			},
-			"format": map[string]any{
+			propFormat: map[string]any{
 				schemaKeyType: schemaTypeString,
-				"enum":        []string{"csv", "json", "markdown", "text"},
+				"enum":        []string{formatCSV, formatJSON, formatMarkdown, formatText},
 				schemaKeyDesc: "Output format for the exported data.",
 			},
-			"name": map[string]any{
+			propName: map[string]any{
 				schemaKeyType: schemaTypeString,
 				schemaKeyDesc: "Display name for the exported asset; also used as the download filename. " +
 					"Use ASCII letters, digits, spaces, hyphens, and dots. " +
 					"Em/en dashes, smart quotes, ellipses, and other Unicode punctuation are auto-normalized to ASCII.",
 				"maxLength": maxExportNameLength,
 			},
-			"description": map[string]any{
+			schemaKeyDesc: map[string]any{
 				schemaKeyType: schemaTypeString,
 				schemaKeyDesc: "Description of the exported asset.",
 				"maxLength":   maxExportDescriptionLength,
 			},
-			"tags": map[string]any{
+			propTags: map[string]any{
 				schemaKeyType: schemaTypeArray,
 				"items":       map[string]any{schemaKeyType: schemaTypeString},
 				schemaKeyDesc: "Tags for categorization. Lowercase kebab-case, max 50 chars each, max 20 tags. Tags starting with _sys- are reserved.",

--- a/pkg/toolkits/trino/format.go
+++ b/pkg/toolkits/trino/format.go
@@ -12,6 +12,19 @@ import (
 const (
 	textColumnSeparator = "  "
 	textNewline         = "\n"
+
+	// Output format names recognized by newFormatter.
+	formatCSV      = "csv"
+	formatJSON     = "json"
+	formatMarkdown = "markdown"
+	formatText     = "text"
+
+	// File extensions and content types per format.
+	extCSV      = ".csv"
+	extJSON     = ".json"
+	extMarkdown = ".md"
+
+	contentTypeCSV = "text/csv"
 )
 
 // Formatter converts query results into a specific output format.
@@ -28,13 +41,13 @@ type Formatter interface {
 // Supported formats: csv, json, markdown, text.
 func newFormatter(format string) (Formatter, error) {
 	switch format {
-	case "csv":
+	case formatCSV:
 		return &csvFormatter{}, nil
-	case "json":
+	case formatJSON:
 		return &jsonFormatter{}, nil
-	case "markdown":
+	case formatMarkdown:
 		return &markdownFormatter{}, nil
-	case "text":
+	case formatText:
 		return &textFormatter{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported format: %q (must be csv, json, markdown, or text)", format)
@@ -45,8 +58,8 @@ func newFormatter(format string) (Formatter, error) {
 
 type csvFormatter struct{}
 
-func (*csvFormatter) ContentType() string   { return "text/csv" } //nolint:revive // implements Formatter
-func (*csvFormatter) FileExtension() string { return ".csv" }     //nolint:revive // implements Formatter
+func (*csvFormatter) ContentType() string   { return contentTypeCSV } //nolint:revive // implements Formatter
+func (*csvFormatter) FileExtension() string { return extCSV }         //nolint:revive // implements Formatter
 
 func (*csvFormatter) Format(columns []string, rows [][]any) ([]byte, error) { //nolint:revive // implements Formatter
 	var buf bytes.Buffer
@@ -96,7 +109,7 @@ func escapeCSVCell(s string) string {
 type jsonFormatter struct{}
 
 func (*jsonFormatter) ContentType() string   { return "application/json" } //nolint:revive // implements Formatter
-func (*jsonFormatter) FileExtension() string { return ".json" }            //nolint:revive // implements Formatter
+func (*jsonFormatter) FileExtension() string { return extJSON }            //nolint:revive // implements Formatter
 
 func (*jsonFormatter) Format(columns []string, rows [][]any) ([]byte, error) { //nolint:revive // implements Formatter
 	data := make([]map[string]any, len(rows))
@@ -130,7 +143,7 @@ func (*jsonFormatter) Format(columns []string, rows [][]any) ([]byte, error) { /
 type markdownFormatter struct{}
 
 func (*markdownFormatter) ContentType() string   { return "text/markdown" } //nolint:revive // implements Formatter
-func (*markdownFormatter) FileExtension() string { return ".md" }           //nolint:revive // implements Formatter
+func (*markdownFormatter) FileExtension() string { return extMarkdown }     //nolint:revive // implements Formatter
 
 func (*markdownFormatter) Format(columns []string, rows [][]any) ([]byte, error) { //nolint:revive // implements Formatter
 	var buf bytes.Buffer

--- a/pkg/toolkits/trino/toolkit.go
+++ b/pkg/toolkits/trino/toolkit.go
@@ -30,6 +30,18 @@ const (
 
 	// defaultPlainPort is the default port when SSL is disabled.
 	defaultPlainPort = 8080
+
+	// trinoSourceName identifies this client to Trino in the X-Trino-Source
+	// header so server-side query logs can attribute traffic back to the
+	// platform.
+	trinoSourceName = "mcp-data-platform"
+
+	// kindTrino is the toolkit kind identifier.
+	kindTrino = "trino"
+
+	// Trino tool names used in Tools() and per-tool annotation lookups.
+	toolTrinoQuery         = "trino_query"
+	toolTrinoDescribeTable = "trino_describe_table"
 )
 
 // Config holds Trino toolkit configuration.
@@ -233,7 +245,7 @@ func buildMultiserverConfig(
 		SSL:       defaultCfg.SSL,
 		SSLVerify: defaultCfg.SSLVerify,
 		Timeout:   defaultCfg.Timeout,
-		Source:    "mcp-data-platform",
+		Source:    trinoSourceName,
 	}
 
 	connections := make(map[string]multiserver.ConnectionConfig, len(instances)-1)
@@ -353,7 +365,7 @@ func createClient(cfg Config) (*trinoclient.Client, error) {
 		SSL:       cfg.SSL,
 		SSLVerify: cfg.SSLVerify,
 		Timeout:   cfg.Timeout,
-		Source:    "mcp-data-platform",
+		Source:    trinoSourceName,
 	}
 
 	client, err := trinoclient.New(clientCfg)
@@ -416,7 +428,7 @@ func annotationConfigToMCP(cfg AnnotationConfig) *mcp.ToolAnnotations {
 
 // Kind returns the toolkit kind.
 func (*Toolkit) Kind() string {
-	return "trino"
+	return kindTrino
 }
 
 // Name returns the toolkit instance name.
@@ -450,11 +462,11 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 // Tools returns the list of tool names that would be provided by this toolkit.
 func (t *Toolkit) Tools() []string {
 	tools := []string{
-		"trino_query",
+		toolTrinoQuery,
 		"trino_execute",
 		"trino_explain",
 		"trino_browse",
-		"trino_describe_table",
+		toolTrinoDescribeTable,
 	}
 	if t.exportDeps != nil {
 		tools = append(tools, exportToolName)

--- a/pkg/toolkits/trino/toolkit.go
+++ b/pkg/toolkits/trino/toolkit.go
@@ -42,12 +42,14 @@ const (
 	// Trino tool names. The full set is named here even though only
 	// a subset crosses goconst's literal-repetition threshold — keeping
 	// the Tools() list uniformly constant-driven avoids a visually mixed
-	// list of constants and bare strings.
-	toolTrinoQuery         = "trino_query"
-	toolTrinoExecute       = "trino_execute"
-	toolTrinoExplain       = "trino_explain"
-	toolTrinoBrowse        = "trino_browse"
-	toolTrinoDescribeTable = "trino_describe_table"
+	// list of constants and bare strings. Naming matches the convention
+	// used in sibling toolkit packages (datahub, s3): no kind prefix
+	// since the package path already provides it.
+	toolQuery         = "trino_query"
+	toolExecute       = "trino_execute"
+	toolExplain       = "trino_explain"
+	toolBrowse        = "trino_browse"
+	toolDescribeTable = "trino_describe_table"
 )
 
 // Config holds Trino toolkit configuration.
@@ -468,11 +470,11 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 // Tools returns the list of tool names that would be provided by this toolkit.
 func (t *Toolkit) Tools() []string {
 	tools := []string{
-		toolTrinoQuery,
-		toolTrinoExecute,
-		toolTrinoExplain,
-		toolTrinoBrowse,
-		toolTrinoDescribeTable,
+		toolQuery,
+		toolExecute,
+		toolExplain,
+		toolBrowse,
+		toolDescribeTable,
 	}
 	if t.exportDeps != nil {
 		tools = append(tools, exportToolName)

--- a/pkg/toolkits/trino/toolkit.go
+++ b/pkg/toolkits/trino/toolkit.go
@@ -39,8 +39,14 @@ const (
 	// kindTrino is the toolkit kind identifier.
 	kindTrino = "trino"
 
-	// Trino tool names used in Tools() and per-tool annotation lookups.
+	// Trino tool names. The full set is named here even though only
+	// a subset crosses goconst's literal-repetition threshold — keeping
+	// the Tools() list uniformly constant-driven avoids a visually mixed
+	// list of constants and bare strings.
 	toolTrinoQuery         = "trino_query"
+	toolTrinoExecute       = "trino_execute"
+	toolTrinoExplain       = "trino_explain"
+	toolTrinoBrowse        = "trino_browse"
 	toolTrinoDescribeTable = "trino_describe_table"
 )
 
@@ -463,9 +469,9 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 func (t *Toolkit) Tools() []string {
 	tools := []string{
 		toolTrinoQuery,
-		"trino_execute",
-		"trino_explain",
-		"trino_browse",
+		toolTrinoExecute,
+		toolTrinoExplain,
+		toolTrinoBrowse,
 		toolTrinoDescribeTable,
 	}
 	if t.exportDeps != nil {


### PR DESCRIPTION
## Summary

Three commits, two waves of self-review applied. All CI green; this PR adds zero new lint findings, reduces uncapped goconst by ~38% across the repo, and adds focused observability to the OAuth token endpoint.

1. **OAuth token-endpoint observability** (the original purpose of this branch).
   `handleTokenEndpoint` was previously silent on both success and failure, leaving operators no way to diagnose silent re-auth loops or distinguish between client-mismatch / invalid-refresh / parse-form rejections. It now emits structured `slog` events at INFO (success) and WARN (failure), with strict redaction.
2. **Pre-existing local-only lint debt cleanup.** `make verify` was failing locally because `golangci-lint` runs without `--new-from-rev`, while CI uses `only-new-issues: true`. This branch addresses every lint failure that surfaced in the cap-limited window: 3 single-occurrence lints (gocognit, govet, modernize), 13 gosec findings, and a 99 → reduction in goconst (269 → 166 with the cap removed).
3. **Two waves of self-review fixes.** After the initial PR was opened, I performed a critical review and addressed the findings; a second review caught minor follow-ups, also addressed. The branch now stands at three commits.

## OAuth observability — what changed

`pkg/oauth/server.go`:
- Doc comment on `handleTokenEndpoint` describes the redaction contract and the diagnostic gap it closes.
- INFO log on successful token issuance: `grant_type`, `client_id`, `credential_source` (`form` vs `basic`), `has_refresh_token` (response-side boolean — confirms the platform IS issuing refresh tokens), `expires_in`, `scope`, `duration_ms`.
- WARN log on rejected grant: `grant_type`, `client_id`, `credential_source`, presence-booleans for `has_client_secret` / `has_refresh_token` / `has_code` / `has_code_verifier`, `duration_ms`, `error` reason from the grant handler.
- WARN log on `r.ParseForm()` failure (malformed body / oversize).
- Tracks credential source: differentiates form-supplied client credentials from HTTP Basic auth credentials.

**Redaction contract — verified by tests:**
- Secret values, refresh-token values, authorization-code values, and code_verifier values are NEVER logged. Only their presence as booleans.
- After review, the success test now decodes the response body and asserts the actually-issued `AccessToken` and `RefreshToken` values are absent — proving the contract holds against the real outbound tokens, not just the test's input strings.
- 4 tests in `pkg/oauth/server_test.go` cover success / rejection (form) / rejection (HTTP Basic) / parse-form-failure paths.
- `handleTokenEndpoint` coverage: 100.0%. Patch coverage on the PR: above the 80% threshold.

## Constants — separating concerns that share a string value

The first cleanup pass introduced constants for repeated string literals. Review found that several constants conflated semantically distinct concepts that just happened to share a value today — a refactoring trap. Fixed:

- `pkg/oauth/server.go` now distinguishes between OAuth wire-protocol parameter names (`paramGrantType`, `paramRefreshToken`), structured log keys (`logKeyGrantType`), and the values those fields carry on the wire (`grantTypeAuthCode`, `grantTypeRefreshToken`). Doc comments explain why they're kept separate.
- `pkg/oauth/server.go` JWT claim constants are named `jwtClaimSub` / `jwtClaimRealmAccess` to differentiate from identically-named constants in `pkg/auth`.
- `pkg/platform/config.go` introduces `cfgKeyDefault` (the config-map *key* that holds the default-instance name) as distinct from `instanceDefault` (the *value* — the default instance name itself).
- Toolkit constants in `pkg/toolkits/datahub`, `pkg/toolkits/s3`, and `pkg/toolkits/trino` are now uniformly named without the kind prefix (e.g. `toolQuery` rather than `toolTrinoQuery`) since the package path already provides kind context. The full set of tool names is constant-driven so `Tools()` lists no longer mix constants and bare literals.

## Lint and security cleanup folded in

- **gosec G710** (open redirect — 3 sites): annotated with `// #nosec G710` plus a one-line justification at each call site (oauth callback, admin gateway_oauth_handler safeReturnURL, dev-mcp-mock /authorize). All three destinations are validated upstream.
- **gosec G124** (insecure cookie attributes — 10 sites in tests): every test cookie now sets `HttpOnly`, `Secure`, `SameSite: http.SameSiteStrictMode`. Touches `pkg/browsersession/`, `pkg/admin/`, `pkg/portal/` test files.
- **gocognit** (cognitive complexity > 15 — 1 site): `pkg/admin/system.go` `listTools` was at 18. Extracted `collectToolkitTools` and `resolveToolConnection` helpers. The extracted function carries the doc comment about why fan-out toolkits need per-tool connection resolution.
- **govet** inline (1): `reflect.Ptr` → `reflect.Pointer` in `pkg/toolkits/trino/connection_required.go`.
- **modernize** slicesbackward (1): `pkg/platform/lifecycle.go` `Stop` switched to `slices.Backward`.
- **goconst** (~38% reduction — 269 → 166): file- or package-local constants for repeated string literals. Categories:
  - OAuth grant types, token type, JWT claim names (`pkg/oauth/server.go`)
  - JWT/OIDC claim paths and `apikey` auth-type label (`pkg/auth/`)
  - MIME types (`pkg/mcpapps/mime.go`)
  - Memory-store and audit-log SQL column names (`pkg/memory/`, `pkg/audit/postgres/`)
  - Gateway config-map keys, log keys, and the `invalid_grant` RFC 6749 §5.2 error code (`pkg/toolkits/gateway/`)
  - Trino source operation names + SQL literal strings (`pkg/toolkits/gateway/sources/trino.go`)
  - DataHub source operation names (`pkg/toolkits/gateway/sources/datahub.go`)
  - Trino formatter format names, file extensions, content types (`pkg/toolkits/trino/format.go`)
  - Trino export schema property names (`pkg/toolkits/trino/export.go`)
  - DataHub, Trino, and S3 tool names (kind-toolkit packages)
  - Semantic-filter field names and the `nearest` lineage-conflict-resolution constant (`pkg/semantic/datahub/`)
  - Platform-wide constants for `default` (instance name + map key, kept distinct), `platform` (kind), `list_connections`, `index.html`, `application/json`, `password`, `explore-available-data`, `Platform Info` (`pkg/platform/`)
- **Swagger**: regenerated `internal/apidocs/{docs.go,swagger.json,swagger.yaml}` to pick up the `gateway.OAuthStatus.refresh_token_revoked` field (model field added in a prior commit without regeneration).

## Why bundle the cleanup here

`make verify` runs `golangci-lint run ./...` without `--new-from-rev`, surfacing the full repo-wide backlog. CI uses `only-new-issues: true` and was green. This branch closes every check that surfaced locally except the long tail of remaining goconst (~166 left, all pre-existing on `main`). Both `make security` and the gosec category of `make lint` are now clean. CI lint remains green; this branch contributes zero new findings.

## Commit log

- `4b406d2` — fix(oauth): structured observability for token endpoint + repo-wide lint cleanup
- `12bb7e0` — fix(oauth,review): address self-review findings (constant splits, test tightening, doc-comment restoration, uniform constant adoption, claimSubject rename to avoid auth-pkg collision)
- `9bf60f8` — fix(oauth,trino): minor follow-ups from second self-review (drop two preemptive `#nosec G101` annotations that gosec doesn't actually flag, align Trino tool-name constants to the no-prefix convention used by sibling toolkit packages, document why the success test asserts auth-code redaction even though the current success log path emits no code field)

## Test plan

- [x] `go test -race ./...` — all packages pass
- [x] 4 token-endpoint logging tests pass; redaction asserted against actually-issued `AccessToken` / `RefreshToken` values
- [x] `handleTokenEndpoint` coverage: 100.0%
- [x] Patch coverage on changed lines ≥ 80%
- [x] `make security` clean (gosec + govulncheck)
- [x] `gofmt -s -l .` clean
- [x] `go build ./...` clean
- [x] CI green: Lint (with `only-new-issues: true`), Test, Build, Security Scan, CodeQL, Analyze, Frontend Build, codecov/patch, codecov/project
- [ ] Live test: deploy to a non-production instance and exercise the token endpoint to confirm both success and failure paths emit the expected structured fields and `credential_source` correctly differentiates form vs basic.