### PR TITLE
fix(gateway): test connection exercises live client + surface refresh expiry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Run golangci-lint
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Run tests with coverage
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Build
@@ -125,7 +125,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Run Gosec Security Scanner
@@ -136,7 +136,7 @@ jobs:
       - name: Run govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
-          go-version-input: '1.26.2'
+          go-version-input: '1.26.3'
           repo-checkout: false
 
       - name: Run Semgrep

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
           cache: true
 
       - name: Verify and prepare Go modules

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/txn2/mcp-data-platform
 
 go 1.26.2
 
+toolchain go1.26.3
+
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Masterminds/squirrel v1.5.4
@@ -115,7 +117,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	golang.org/x/mod v0.33.0 // indirect
-	golang.org/x/net v0.52.0 // indirect
+	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
-golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
+golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
+golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
 golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -1611,7 +1611,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Dials the upstream described by the submitted config, lists its tools, and returns them. Does not persist anything. When the submitted config contains \"[REDACTED]\" sensitive fields and a row with this name already exists, the redacted fields are merged from the stored config.",
+                "description": "Tests a gateway connection by listing its tools. When a connection with this name is already registered in the live toolkit AND has an active upstreamClient, the request body is IGNORED and the live client (with its loaded TokenStore + auth round-tripper) is exercised — green proves real tool calls would work right now. When no live client exists for this name (the connection is unregistered, OR it's a placeholder awaiting first OAuth Connect, OR a prior dial left it without a client), falls back to a one-shot dial against the submitted config (preview-before-save semantics). The redacted-field merge from the stored config only applies to the fallback path. Does not persist anything.",
                 "consumes": [
                     "application/json"
                 ],
@@ -7888,8 +7888,12 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "needs_reauth": {
-                    "description": "NeedsReauth is true when the platform cannot mint an access token\nwithout operator interaction. For authorization_code grants this\nmeans: no stored token, or the refresh token has been revoked.\nThe admin UI surfaces a \"Connect\" button when this is true.",
+                    "description": "NeedsReauth is true when the platform cannot mint a new access\ntoken without operator interaction. For authorization_code grants\nthis means: no stored token, the refresh token has been revoked,\nOR the IdP-disclosed RefreshExpiresAt deadline has passed (the\nnext refresh would fail). The admin UI surfaces a \"Connect\"\nbutton when this is true. Setting it pre-emptively from\nRefreshExpiresAt lets the UI nudge the operator before the next\ntool call surfaces the failure.",
                     "type": "boolean"
+                },
+                "refresh_expires_at": {
+                    "description": "RefreshExpiresAt is the absolute deadline after which the refresh\ntoken itself stops working. Set only when the IdP includes\nrefresh_expires_in in its token response (Keycloak does; the OAuth\n2.1 spec leaves it optional). Zero means unknown — the UI should\nrender an em dash, not \"never\".",
+                    "type": "string"
                 },
                 "refresh_token_revoked": {
                     "description": "RefreshTokenRevoked is true when the most recent refresh attempt\ngot a definitive RFC 6749 §5.2 invalid_grant response — meaning\nthe IdP has invalidated the stored refresh token (idle session\ntimeout, admin revocation, password change, etc.) and the\noperator must complete a fresh browser-side authorization. The\nadmin UI uses this to distinguish \"click Connect to reauthorize\"\nfrom a transient \"click Reacquire to retry\" state.",

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -1605,7 +1605,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Dials the upstream described by the submitted config, lists its tools, and returns them. Does not persist anything. When the submitted config contains \"[REDACTED]\" sensitive fields and a row with this name already exists, the redacted fields are merged from the stored config.",
+                "description": "Tests a gateway connection by listing its tools. When a connection with this name is already registered in the live toolkit AND has an active upstreamClient, the request body is IGNORED and the live client (with its loaded TokenStore + auth round-tripper) is exercised \u2014 green proves real tool calls would work right now. When no live client exists for this name (the connection is unregistered, OR it's a placeholder awaiting first OAuth Connect, OR a prior dial left it without a client), falls back to a one-shot dial against the submitted config (preview-before-save semantics). The redacted-field merge from the stored config only applies to the fallback path. Does not persist anything.",
                 "consumes": [
                     "application/json"
                 ],
@@ -7882,8 +7882,12 @@
                     "type": "string"
                 },
                 "needs_reauth": {
-                    "description": "NeedsReauth is true when the platform cannot mint an access token\nwithout operator interaction. For authorization_code grants this\nmeans: no stored token, or the refresh token has been revoked.\nThe admin UI surfaces a \"Connect\" button when this is true.",
+                    "description": "NeedsReauth is true when the platform cannot mint a new access\ntoken without operator interaction. For authorization_code grants\nthis means: no stored token, the refresh token has been revoked,\nOR the IdP-disclosed RefreshExpiresAt deadline has passed (the\nnext refresh would fail). The admin UI surfaces a \"Connect\"\nbutton when this is true. Setting it pre-emptively from\nRefreshExpiresAt lets the UI nudge the operator before the next\ntool call surfaces the failure.",
                     "type": "boolean"
+                },
+                "refresh_expires_at": {
+                    "description": "RefreshExpiresAt is the absolute deadline after which the refresh\ntoken itself stops working. Set only when the IdP includes\nrefresh_expires_in in its token response (Keycloak does; the OAuth\n2.1 spec leaves it optional). Zero means unknown \u2014 the UI should\nrender an em dash, not \"never\".",
+                    "type": "string"
                 },
                 "refresh_token_revoked": {
                     "description": "RefreshTokenRevoked is true when the most recent refresh attempt\ngot a definitive RFC 6749 \u00a75.2 invalid_grant response \u2014 meaning\nthe IdP has invalidated the stored refresh token (idle session\ntimeout, admin revocation, password change, etc.) and the\noperator must complete a fresh browser-side authorization. The\nadmin UI uses this to distinguish \"click Connect to reauthorize\"\nfrom a transient \"click Reacquire to retry\" state.",

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -1158,11 +1158,23 @@ definitions:
         type: string
       needs_reauth:
         description: |-
-          NeedsReauth is true when the platform cannot mint an access token
-          without operator interaction. For authorization_code grants this
-          means: no stored token, or the refresh token has been revoked.
-          The admin UI surfaces a "Connect" button when this is true.
+          NeedsReauth is true when the platform cannot mint a new access
+          token without operator interaction. For authorization_code grants
+          this means: no stored token, the refresh token has been revoked,
+          OR the IdP-disclosed RefreshExpiresAt deadline has passed (the
+          next refresh would fail). The admin UI surfaces a "Connect"
+          button when this is true. Setting it pre-emptively from
+          RefreshExpiresAt lets the UI nudge the operator before the next
+          tool call surfaces the failure.
         type: boolean
+      refresh_expires_at:
+        description: |-
+          RefreshExpiresAt is the absolute deadline after which the refresh
+          token itself stops working. Set only when the IdP includes
+          refresh_expires_in in its token response (Keycloak does; the OAuth
+          2.1 spec leaves it optional). Zero means unknown — the UI should
+          render an em dash, not "never".
+        type: string
       refresh_token_revoked:
         description: |-
           RefreshTokenRevoked is true when the most recent refresh attempt
@@ -3224,10 +3236,16 @@ paths:
     post:
       consumes:
       - application/json
-      description: Dials the upstream described by the submitted config, lists its
-        tools, and returns them. Does not persist anything. When the submitted config
-        contains "[REDACTED]" sensitive fields and a row with this name already exists,
-        the redacted fields are merged from the stored config.
+      description: Tests a gateway connection by listing its tools. When a connection
+        with this name is already registered in the live toolkit AND has an active
+        upstreamClient, the request body is IGNORED and the live client (with its
+        loaded TokenStore + auth round-tripper) is exercised — green proves real tool
+        calls would work right now. When no live client exists for this name (the
+        connection is unregistered, OR it's a placeholder awaiting first OAuth Connect,
+        OR a prior dial left it without a client), falls back to a one-shot dial against
+        the submitted config (preview-before-save semantics). The redacted-field merge
+        from the stored config only applies to the fallback path. Does not persist
+        anything.
       parameters:
       - description: Gateway connection name
         in: path

--- a/pkg/admin/gateway_handler.go
+++ b/pkg/admin/gateway_handler.go
@@ -118,7 +118,7 @@ type testGatewayConnectionResponse struct {
 // testGatewayConnection handles POST /api/v1/admin/gateway/connections/{name}/test.
 //
 // @Summary      Test a gateway connection config
-// @Description  Dials the upstream described by the submitted config, lists its tools, and returns them. Does not persist anything. When the submitted config contains "[REDACTED]" sensitive fields and a row with this name already exists, the redacted fields are merged from the stored config.
+// @Description  Tests a gateway connection by listing its tools. When a connection with this name is already registered in the live toolkit AND has an active upstreamClient, the request body is IGNORED and the live client (with its loaded TokenStore + auth round-tripper) is exercised — green proves real tool calls would work right now. When no live client exists for this name (the connection is unregistered, OR it's a placeholder awaiting first OAuth Connect, OR a prior dial left it without a client), falls back to a one-shot dial against the submitted config (preview-before-save semantics). The redacted-field merge from the stored config only applies to the fallback path. Does not persist anything.
 // @Tags         Connections
 // @Accept       json
 // @Produce      json
@@ -132,6 +132,19 @@ type testGatewayConnectionResponse struct {
 // @Router       /admin/gateway/connections/{name}/test [post]
 func (h *Handler) testGatewayConnection(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue(pathKeyName)
+
+	// Path 1: connection is wired into the live toolkit. Test what the user
+	// actually has — exercise the live upstreamClient (which carries the
+	// toolkit's TokenStore, OAuth refresh logic, and auth round-tripper) by
+	// issuing a tools/list. This is what tool calls go through, so a green
+	// here means real tool invocations work right now.
+	if h.tryTestLiveConnection(w, r, name) {
+		return
+	}
+
+	// Path 2: connection is NOT live (new connection being previewed before
+	// save, or a placeholder awaiting first authorization_code Connect).
+	// Fall back to a one-shot dial against the submitted config.
 	cfg, ok := h.parseTestConnectionConfig(w, r, name)
 	if !ok {
 		return
@@ -155,6 +168,48 @@ func (h *Handler) testGatewayConnection(w http.ResponseWriter, r *http.Request) 
 		Healthy: true,
 		Tools:   tools,
 	})
+}
+
+// tryTestLiveConnection runs a tools/list against the live upstreamClient
+// for name. Returns true when it wrote a response (caller must stop).
+// Returns false when no live client exists for this name, signaling the
+// caller to fall through to the config-based Probe path.
+//
+// A placeholder connection (registered but client == nil — typical for
+// authorization_code awaiting Connect) is treated as "not live": false is
+// returned so the existing shortCircuitUnauthorizedAuthCode path can
+// surface the friendly "click Connect" message based on the parsed
+// config, instead of a generic upstream error.
+func (h *Handler) tryTestLiveConnection(w http.ResponseWriter, r *http.Request, name string) bool {
+	tk := h.findGatewayToolkit()
+	if tk == nil || !tk.HasConnection(name) {
+		return false
+	}
+	// listTools has no inner deadline of its own — the upstreamClient's
+	// CallTimeout is enforced only on tool-call paths, not on tools/list.
+	// This ctx is therefore the SOLE bound on the call; if it's removed
+	// or extended, a hung upstream will hold the admin endpoint open.
+	ctx, cancel := context.WithTimeout(r.Context(), gatewaykit.DefaultConnectTimeout)
+	defer cancel()
+
+	tools, err := tk.TestLiveConnection(ctx, name)
+	if err != nil {
+		if errors.Is(err, gatewaykit.ErrConnectionNotLive) {
+			// Placeholder — let the Probe-path's short-circuit produce the
+			// "click Connect" message it was built for.
+			return false
+		}
+		writeJSON(w, http.StatusBadGateway, testGatewayConnectionResponse{
+			Healthy: false,
+			Error:   err.Error(),
+		})
+		return true
+	}
+	writeJSON(w, http.StatusOK, testGatewayConnectionResponse{
+		Healthy: true,
+		Tools:   tools,
+	})
+	return true
 }
 
 // parseTestConnectionConfig decodes the request body, merges any redacted

--- a/pkg/admin/gateway_handler_test.go
+++ b/pkg/admin/gateway_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
@@ -168,6 +169,109 @@ func TestTestGatewayConnection_RedactedMergedFromStore(t *testing.T) {
 
 	// "bearer" with merged credential should validate and dial successfully.
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestTestGatewayConnection_UsesLiveClientWhenRegistered is the bug
+// regression test for v1.58.1+: when an authorization_code OAuth
+// connection is already wired into the live toolkit with a stored
+// refresh token, the admin "Test connection" endpoint MUST exercise
+// the live upstreamClient (carrying the toolkit's TokenStore-backed
+// auth round-tripper) instead of Probe(cfg) (which builds a parallel
+// client with no TokenStore and fails for auth_code).
+//
+// Distinguishing assertions:
+//
+//   - The seeded connection is authorization_code with a pre-stored
+//     token in the toolkit's TokenStore. The live path's behavior
+//     therefore depends on that store being threaded through.
+//   - The request body's "endpoint" points at a closed listener; the
+//     200 OK with live tools proves the body was ignored.
+//   - Tool LocalName "crm__ping" comes from the LIVE upstream's tool
+//     namespace, confirming the live client (not a probe) issued
+//     tools/list.
+func TestTestGatewayConnection_UsesLiveClientWhenRegistered(t *testing.T) {
+	tokenURL := fakeTokenServerForAdmin(t)
+	liveURL := upstreamMCP(t)
+
+	h, tk := gatewayHandlerDeps(t, &mockConnectionStore{})
+
+	store := gatewaykit.NewMemoryTokenStore()
+	// Seed the access token as already-expired so the live path is
+	// forced to refresh through the fake token server. A 1-hour-valid
+	// cached token would short-circuit oauth.Token() and the test would
+	// pass even if the refresh round-tripper were broken — see round-4
+	// finding #1.
+	if err := store.Set(context.Background(), gatewaykit.PersistedToken{
+		ConnectionName: "crm",
+		AccessToken:    "stale-acc",
+		RefreshToken:   "live-ref",
+		ExpiresAt:      time.Now().Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+	tk.SetTokenStore(store)
+
+	if err := tk.AddConnection("crm", map[string]any{
+		"endpoint":                liveURL,
+		"connection_name":         "crm",
+		"auth_mode":               "oauth",
+		"oauth_grant":             "authorization_code",
+		"oauth_token_url":         tokenURL,
+		"oauth_authorization_url": tokenURL + "/authorize",
+		"oauth_client_id":         "id",
+		"oauth_client_secret":     "sec",
+		"connect_timeout":         "3s",
+		"call_timeout":            "3s",
+	}); err != nil {
+		t.Fatalf("seed live OAuth connection: %v", err)
+	}
+
+	body, _ := json.Marshal(testGatewayConnectionRequest{
+		Config: map[string]any{
+			// Deliberately broken — would fail Probe. The live path
+			// ignores this and exercises the wired-up client instead.
+			"endpoint":        "http://127.0.0.1:1/mcp",
+			"connection_name": "crm",
+			"connect_timeout": "200ms",
+			"call_timeout":    "1s",
+		},
+	})
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/api/v1/admin/gateway/connections/crm/test",
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp testGatewayConnectionResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.True(t, resp.Healthy, "live OAuth test should succeed (TokenStore-loaded credential reaches upstream)")
+	require.NotEmpty(t, resp.Tools, "live tools/list must populate result")
+	// Search for the expected tool by name rather than indexing — a
+	// future helper that registers more tools must not silently shift
+	// this assertion off the one being checked.
+	var foundPing bool
+	for _, tool := range resp.Tools {
+		if tool.Name == "ping" {
+			foundPing = true
+			assert.Equal(t, "crm__ping", tool.LocalName,
+				"namespace prefix must be applied to live-path tools")
+		}
+	}
+	assert.True(t, foundPing, "expected ping tool from live upstream")
+}
+
+// fakeTokenServerForAdmin stands up a token endpoint that always
+// returns a valid token. Used by the auth_code Test-connection test;
+// extracted to keep the test body focused on the admin contract.
+func fakeTokenServerForAdmin(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"live-acc","refresh_token":"live-ref","expires_in":3600}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
 }
 
 func TestRefreshGatewayConnection_AddsFresh(t *testing.T) {

--- a/pkg/admin/gateway_oauth_handler.go
+++ b/pkg/admin/gateway_oauth_handler.go
@@ -438,13 +438,18 @@ func (h *Handler) completeOAuthExchange(ctx context.Context, pending *PKCEState,
 }
 
 // authCodeTokenResponse is the parsed token-endpoint response.
+//
+// RefreshExpiresIn is the Keycloak-style hint for the refresh token's
+// own lifetime (seconds). Optional in the OAuth 2.1 spec — zero means
+// the IdP did not disclose it; do NOT default to a non-zero value.
 type authCodeTokenResponse struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token,omitempty"`
-	ExpiresIn    int    `json:"expires_in,omitempty"`
-	Scope        string `json:"scope,omitempty"`
-	Error        string `json:"error,omitempty"`
-	ErrorDesc    string `json:"error_description,omitempty"`
+	AccessToken      string `json:"access_token"`
+	RefreshToken     string `json:"refresh_token,omitempty"`
+	ExpiresIn        int    `json:"expires_in,omitempty"`
+	RefreshExpiresIn int    `json:"refresh_expires_in,omitempty"`
+	Scope            string `json:"scope,omitempty"`
+	Error            string `json:"error,omitempty"`
+	ErrorDesc        string `json:"error_description,omitempty"`
 }
 
 // codeExchangeTimeout bounds the admin's authorization_code POST to the
@@ -582,6 +587,7 @@ func exchangeAuthorizationCode(ctx context.Context, oc gatewaykit.OAuthConfig,
 		"access_token_len", len(tr.AccessToken),
 		"refresh_token_present", tr.RefreshToken != "",
 		"expires_in", tr.ExpiresIn,
+		"refresh_expires_in", tr.RefreshExpiresIn,
 		"scope", tr.Scope)
 	return &tr, nil
 }
@@ -602,12 +608,13 @@ func (h *Handler) persistOAuthTokens(ctx context.Context, pending *PKCEState,
 		}
 	}
 	if err := tk.IngestOAuthToken(ctx, gatewaykit.IngestOAuthTokenInput{
-		Name:            pending.connection,
-		AccessToken:     tr.AccessToken,
-		RefreshToken:    tr.RefreshToken,
-		ExpiresIn:       tr.ExpiresIn,
-		Scope:           tr.Scope,
-		AuthenticatedBy: pending.startedBy,
+		Name:             pending.connection,
+		AccessToken:      tr.AccessToken,
+		RefreshToken:     tr.RefreshToken,
+		ExpiresIn:        tr.ExpiresIn,
+		RefreshExpiresIn: tr.RefreshExpiresIn,
+		Scope:            tr.Scope,
+		AuthenticatedBy:  pending.startedBy,
 	}); err != nil {
 		return fmt.Errorf("ingest oauth token: %w", err)
 	}

--- a/pkg/database/migrate/migrate_unit_test.go
+++ b/pkg/database/migrate/migrate_unit_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	migrateTestFileCount    = 72
+	migrateTestFileCount    = 74
 	migrateTestSuccess      = "success"
 	migrateTestFactoryError = "factory error"
 )

--- a/pkg/database/migrate/migrations/000037_gateway_oauth_refresh_expires_at.down.sql
+++ b/pkg/database/migrate/migrations/000037_gateway_oauth_refresh_expires_at.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE gateway_oauth_tokens
+    DROP COLUMN IF EXISTS refresh_expires_at;

--- a/pkg/database/migrate/migrations/000037_gateway_oauth_refresh_expires_at.up.sql
+++ b/pkg/database/migrate/migrations/000037_gateway_oauth_refresh_expires_at.up.sql
@@ -1,0 +1,7 @@
+-- Add refresh_expires_at to gateway_oauth_tokens. Captures the IdP's
+-- self-reported refresh-token lifetime (Keycloak's refresh_expires_in
+-- and similar) so the admin UI can surface a real deadline instead of
+-- "—". Optional in the OAuth 2.1 spec, so NULL is the natural value
+-- for IdPs that don't disclose it.
+ALTER TABLE gateway_oauth_tokens
+    ADD COLUMN IF NOT EXISTS refresh_expires_at TIMESTAMPTZ;

--- a/pkg/toolkits/gateway/oauth.go
+++ b/pkg/toolkits/gateway/oauth.go
@@ -30,6 +30,11 @@ type tokenState struct {
 	RefreshToken    string
 	ExpiresAt       time.Time
 	LastRefreshedAt time.Time
+	// RefreshExpiresAt is the absolute deadline after which the refresh
+	// token itself can no longer mint new access tokens. Populated only
+	// when the IdP returns refresh_expires_in (Keycloak does; many others
+	// don't). Zero means "unknown" — DO NOT treat as "never expires".
+	RefreshExpiresAt time.Time
 }
 
 // OAuthStatus is a snapshot of token state suitable for the admin status
@@ -40,10 +45,16 @@ type OAuthStatus struct {
 	ExpiresAt       time.Time `json:"expires_at,omitzero"`
 	LastRefreshedAt time.Time `json:"last_refreshed_at,omitzero"`
 	HasRefreshToken bool      `json:"has_refresh_token"`
-	LastError       string    `json:"last_error,omitempty"`
-	Grant           string    `json:"grant,omitempty"`
-	TokenURL        string    `json:"token_url,omitempty"`
-	Scope           string    `json:"scope,omitempty"`
+	// RefreshExpiresAt is the absolute deadline after which the refresh
+	// token itself stops working. Set only when the IdP includes
+	// refresh_expires_in in its token response (Keycloak does; the OAuth
+	// 2.1 spec leaves it optional). Zero means unknown — the UI should
+	// render an em dash, not "never".
+	RefreshExpiresAt time.Time `json:"refresh_expires_at,omitzero"`
+	LastError        string    `json:"last_error,omitempty"`
+	Grant            string    `json:"grant,omitempty"`
+	TokenURL         string    `json:"token_url,omitempty"`
+	Scope            string    `json:"scope,omitempty"`
 	// AuthenticatedBy is the email/id of the operator who completed the
 	// browser flow. Empty for client_credentials and for connections that
 	// have not yet been authorized.
@@ -51,10 +62,14 @@ type OAuthStatus struct {
 	// AuthenticatedAt records when the most recent successful exchange
 	// (initial OAuth dance or refresh) completed.
 	AuthenticatedAt time.Time `json:"authenticated_at,omitzero"`
-	// NeedsReauth is true when the platform cannot mint an access token
-	// without operator interaction. For authorization_code grants this
-	// means: no stored token, or the refresh token has been revoked.
-	// The admin UI surfaces a "Connect" button when this is true.
+	// NeedsReauth is true when the platform cannot mint a new access
+	// token without operator interaction. For authorization_code grants
+	// this means: no stored token, the refresh token has been revoked,
+	// OR the IdP-disclosed RefreshExpiresAt deadline has passed (the
+	// next refresh would fail). The admin UI surfaces a "Connect"
+	// button when this is true. Setting it pre-emptively from
+	// RefreshExpiresAt lets the UI nudge the operator before the next
+	// tool call surfaces the failure.
 	NeedsReauth bool `json:"needs_reauth,omitempty"`
 	// RefreshTokenRevoked is true when the most recent refresh attempt
 	// got a definitive RFC 6749 §5.2 invalid_grant response — meaning
@@ -270,12 +285,17 @@ func (t *oauthTokenSource) tryRefreshLocked(ctx context.Context) (token string, 
 // IngestTokenResponseInput collects the result of an out-of-band OAuth
 // exchange (e.g. the platform's authorization-code callback handler).
 // Used to keep IngestTokenResponse to a single argument.
+//
+// RefreshExpiresIn is optional: only some IdPs (Keycloak) return it.
+// Zero is interpreted as "not provided" and leaves RefreshExpiresAt
+// at zero — the UI shows an em dash, not "never expires".
 type IngestTokenResponseInput struct {
-	AccessToken     string
-	RefreshToken    string
-	ExpiresIn       int
-	Scope           string
-	AuthenticatedBy string
+	AccessToken      string
+	RefreshToken     string
+	ExpiresIn        int
+	RefreshExpiresIn int
+	Scope            string
+	AuthenticatedBy  string
 }
 
 // IngestTokenResponse stores a token set obtained out-of-band into the
@@ -297,11 +317,12 @@ func (t *oauthTokenSource) IngestTokenResponse(ctx context.Context, in IngestTok
 		t.state.RefreshToken = in.RefreshToken
 	}
 	now := time.Now().UTC()
-	if in.ExpiresIn > 0 {
-		t.state.ExpiresAt = now.Add(time.Duration(in.ExpiresIn) * time.Second)
-	} else {
-		t.state.ExpiresAt = now.Add(1 * time.Hour)
-	}
+	applyExpiriesLocked(&t.state, expiryUpdate{
+		Now:                    now,
+		ExpiresIn:              in.ExpiresIn,
+		RefreshExpiresIn:       in.RefreshExpiresIn,
+		RefreshTokenInResponse: in.RefreshToken != "",
+	})
 	t.state.LastRefreshedAt = now
 	if in.Scope != "" {
 		t.cfg.Scope = in.Scope
@@ -403,13 +424,15 @@ func (t *oauthTokenSource) Status() OAuthStatus {
 	defer t.mu.Unlock()
 	_ = t.ensureLoadedLocked(context.Background())
 	needsReauth := t.cfg.Grant == OAuthGrantAuthorizationCode &&
-		t.state.AccessToken == "" && t.state.RefreshToken == ""
+		(t.state.AccessToken == "" && t.state.RefreshToken == "" ||
+			refreshDeadlinePassed(t.state.RefreshExpiresAt))
 	return OAuthStatus{
 		Configured:          true,
 		TokenAcquired:       t.state.AccessToken != "",
 		ExpiresAt:           t.state.ExpiresAt,
 		LastRefreshedAt:     t.state.LastRefreshedAt,
 		HasRefreshToken:     t.state.RefreshToken != "",
+		RefreshExpiresAt:    t.state.RefreshExpiresAt,
 		LastError:           formatStatusError(t.lastError, t.refreshTokenRevoked, t.cfg.Grant),
 		Grant:               t.cfg.Grant,
 		TokenURL:            t.cfg.TokenURL,
@@ -419,6 +442,14 @@ func (t *oauthTokenSource) Status() OAuthStatus {
 		NeedsReauth:         needsReauth,
 		RefreshTokenRevoked: t.refreshTokenRevoked,
 	}
+}
+
+// refreshDeadlinePassed reports whether the IdP-disclosed refresh-token
+// deadline (if any) is in the past. Returns false when the deadline is
+// zero — most IdPs don't disclose refresh_expires_in, and we must not
+// treat "unknown" as "expired".
+func refreshDeadlinePassed(deadline time.Time) bool {
+	return !deadline.IsZero() && time.Now().After(deadline)
 }
 
 // formatStatusError augments the raw lastError text with a generic
@@ -483,10 +514,16 @@ func (t *oauthTokenSource) refreshLocked(ctx context.Context) error {
 }
 
 // tokenResponse is the standard OAuth 2.1 token endpoint response.
+//
+// RefreshExpiresIn is a Keycloak extension (also emitted by some other
+// IdPs) carrying the refresh token's own lifetime in seconds. RFC 6749
+// does not standardize it, so it's optional — zero means "not provided"
+// and callers must not invent a default.
 type tokenResponse struct {
 	AccessToken      string `json:"access_token"`
 	TokenType        string `json:"token_type"`
 	ExpiresIn        int    `json:"expires_in"`
+	RefreshExpiresIn int    `json:"refresh_expires_in,omitempty"`
 	RefreshToken     string `json:"refresh_token,omitempty"`
 	Scope            string `json:"scope,omitempty"`
 	Error            string `json:"error,omitempty"`
@@ -643,15 +680,80 @@ func (t *oauthTokenSource) applyTokenResponseLocked(tr tokenResponse) {
 	if tr.RefreshToken != "" {
 		t.state.RefreshToken = tr.RefreshToken
 	}
-	if tr.ExpiresIn > 0 {
-		t.state.ExpiresAt = now.Add(time.Duration(tr.ExpiresIn) * time.Second)
-	} else {
-		// Default to one hour when the upstream omits expires_in. Spec
-		// recommends always including it but real implementations vary.
-		t.state.ExpiresAt = now.Add(1 * time.Hour)
-	}
+	applyExpiriesLocked(&t.state, expiryUpdate{
+		Now:                    now,
+		ExpiresIn:              tr.ExpiresIn,
+		RefreshExpiresIn:       tr.RefreshExpiresIn,
+		RefreshTokenInResponse: tr.RefreshToken != "",
+	})
 	t.state.LastRefreshedAt = now
 	t.refreshTokenRevoked = false
+}
+
+// expiryUpdate bundles the inputs to applyExpiriesLocked so the helper's
+// signature stays under revive's argument-limit ceiling. Defined as a
+// struct rather than positional args so call sites read self-
+// documenting and a future field addition doesn't break callers.
+type expiryUpdate struct {
+	Now              time.Time
+	ExpiresIn        int
+	RefreshExpiresIn int
+	// RefreshTokenInResponse is true when the IdP's response payload
+	// included a refresh_token field (regardless of whether its value
+	// is the same as or different from the cached one). Per RFC 6749
+	// §6, an IdP omits refresh_token to mean "the existing one is
+	// still valid" and includes it to signal rotation; we distinguish
+	// "absent" from "echoed" by tracking presence explicitly here.
+	RefreshTokenInResponse bool
+}
+
+// applyExpiriesLocked computes ExpiresAt and RefreshExpiresAt on state
+// from a token-endpoint response. Centralized so the Connect path
+// (IngestTokenResponse) and the acquire/refresh path
+// (applyTokenResponseLocked) cannot diverge on edge-case semantics
+// — the rules below are the contract:
+//
+//   - ExpiresIn > 0: absolute deadline = Now + ExpiresIn.
+//     ExpiresIn == 0: assign a 1-hour default to the freshly-issued
+//     access token regardless of any prior cached deadline. Each
+//     successful exchange yields a NEW access token whose lifetime is
+//     unrelated to the previous one's, so preserving the prior cache
+//     would surface a deadline that belongs to a different token.
+//     The OAuth 2.1 spec recommends always including expires_in but
+//     real implementations vary; the 1-hour default is conservative
+//     enough to trigger refresh well before the upstream's typical
+//     30-min minimum and short enough that a bad guess self-corrects
+//     within an hour. The auth round-tripper handles 401s on tool
+//     calls by treating them as transient — a too-long guess is
+//     recoverable, never silent.
+//
+//   - RefreshExpiresIn > 0: set the absolute refresh deadline.
+//
+//   - RefreshExpiresIn == 0 AND RefreshTokenInResponse: the IdP echoed
+//     or rotated a refresh token without a lifetime hint. The previous
+//     deadline (if any) belonged to the prior token's lifecycle and may
+//     no longer apply. Clear so the UI doesn't surface a stale value.
+//
+//   - RefreshExpiresIn == 0 AND !RefreshTokenInResponse: refresh token
+//     omitted entirely (RFC 6749 §6 "still valid"). Preserve any
+//     existing deadline — the IdP said nothing about this token's
+//     lifetime; clearing would invent "no fixed lifetime".
+//
+// Caller must hold the source's mutex.
+func applyExpiriesLocked(state *tokenState, u expiryUpdate) {
+	if u.ExpiresIn > 0 {
+		state.ExpiresAt = u.Now.Add(time.Duration(u.ExpiresIn) * time.Second)
+	} else {
+		state.ExpiresAt = u.Now.Add(1 * time.Hour)
+	}
+	switch {
+	case u.RefreshExpiresIn > 0:
+		state.RefreshExpiresAt = u.Now.Add(time.Duration(u.RefreshExpiresIn) * time.Second)
+	case u.RefreshTokenInResponse:
+		state.RefreshExpiresAt = time.Time{}
+	default:
+		// Refresh token absent from response — preserve existing deadline.
+	}
 }
 
 // errRefreshTokenRevoked indicates the IdP definitively rejected a
@@ -818,10 +920,11 @@ func (t *oauthTokenSource) ensureLoadedLocked(ctx context.Context) error {
 		return fmt.Errorf("oauth: load token: %w", err)
 	}
 	t.state = tokenState{
-		AccessToken:     rec.AccessToken,
-		RefreshToken:    rec.RefreshToken,
-		ExpiresAt:       rec.ExpiresAt,
-		LastRefreshedAt: rec.UpdatedAt,
+		AccessToken:      rec.AccessToken,
+		RefreshToken:     rec.RefreshToken,
+		ExpiresAt:        rec.ExpiresAt,
+		RefreshExpiresAt: rec.RefreshExpiresAt,
+		LastRefreshedAt:  rec.UpdatedAt,
 	}
 	t.authedBy = rec.AuthenticatedBy
 	t.authedAt = rec.AuthenticatedAt
@@ -846,13 +949,14 @@ func (t *oauthTokenSource) persistLocked(ctx context.Context) error {
 		return nil
 	}
 	if err := t.store.Set(ctx, PersistedToken{
-		ConnectionName:  t.connectionName,
-		AccessToken:     t.state.AccessToken,
-		RefreshToken:    t.state.RefreshToken,
-		ExpiresAt:       t.state.ExpiresAt,
-		Scope:           t.cfg.Scope,
-		AuthenticatedBy: t.authedBy,
-		AuthenticatedAt: t.authedAt,
+		ConnectionName:   t.connectionName,
+		AccessToken:      t.state.AccessToken,
+		RefreshToken:     t.state.RefreshToken,
+		ExpiresAt:        t.state.ExpiresAt,
+		RefreshExpiresAt: t.state.RefreshExpiresAt,
+		Scope:            t.cfg.Scope,
+		AuthenticatedBy:  t.authedBy,
+		AuthenticatedAt:  t.authedAt,
 	}); err != nil {
 		return fmt.Errorf("oauth: persist token: %w", err)
 	}

--- a/pkg/toolkits/gateway/oauth_test.go
+++ b/pkg/toolkits/gateway/oauth_test.go
@@ -2144,3 +2144,219 @@ func TestStatus_RefreshRevoked_HintReaches(t *testing.T) {
 		t.Errorf("expected refresh-rejected hint in admin status, got %q", st.LastError)
 	}
 }
+
+// TestApplyTokenResponse_CapturesRefreshExpiresIn covers the Keycloak-style
+// refresh_expires_in path: when the IdP includes it on a token response,
+// applyTokenResponseLocked must compute an absolute deadline for the
+// refresh token, not just for the access token. Uses authorization_code
+// because that's the production grant where refresh tokens (and their
+// lifetimes) actually matter — client_credentials has no refresh path.
+func TestApplyTokenResponse_CapturesRefreshExpiresIn(t *testing.T) {
+	src := newOAuthTokenSource(OAuthConfig{
+		Grant:    OAuthGrantAuthorizationCode,
+		TokenURL: "https://idp/token",
+		ClientID: "id", ClientSecret: "sec",
+		AuthorizationURL: "https://idp/auth",
+	}, "test", nil)
+	before := time.Now().UTC()
+	src.mu.Lock()
+	src.applyTokenResponseLocked(tokenResponse{
+		AccessToken: "a", RefreshToken: "r",
+		ExpiresIn: 300, RefreshExpiresIn: 1800,
+	})
+	got := src.state.RefreshExpiresAt
+	src.mu.Unlock()
+	if got.IsZero() {
+		t.Fatal("expected RefreshExpiresAt set, got zero")
+	}
+	earliest := before.Add(1800 * time.Second)
+	latest := time.Now().UTC().Add(1800 * time.Second).Add(time.Second)
+	if got.Before(earliest) || got.After(latest) {
+		t.Errorf("RefreshExpiresAt out of bounds: got %v, want between %v and %v", got, earliest, latest)
+	}
+	st := src.Status()
+	if !st.RefreshExpiresAt.Equal(got) {
+		t.Errorf("Status.RefreshExpiresAt %v != state %v", st.RefreshExpiresAt, got)
+	}
+}
+
+// TestApplyTokenResponse_OmitsRefreshExpiresInOnFreshTokenClears verifies
+// that when a fresh refresh token is issued without an accompanying
+// lifetime hint (the previously-known deadline belonged to a different
+// token), the deadline is cleared. The omitzero JSON tag must then keep
+// the field absent from the marshaled status so the UI doesn't render
+// "0001-01-01" as a date.
+func TestApplyTokenResponse_OmitsRefreshExpiresInOnFreshTokenClears(t *testing.T) {
+	src := newOAuthTokenSource(OAuthConfig{
+		Grant:    OAuthGrantAuthorizationCode,
+		TokenURL: "https://idp/token",
+		ClientID: "id", ClientSecret: "sec",
+		AuthorizationURL: "https://idp/auth",
+	}, "test", nil)
+	src.mu.Lock()
+	// Prior state belongs to refresh token "old"; deadline known.
+	src.state.RefreshToken = "old"
+	src.state.RefreshExpiresAt = time.Now().Add(time.Hour)
+	src.applyTokenResponseLocked(tokenResponse{
+		AccessToken: "a", RefreshToken: "new", ExpiresIn: 300,
+		// RefreshExpiresIn deliberately omitted; new refresh token issued.
+	})
+	got := src.state.RefreshExpiresAt
+	src.mu.Unlock()
+	if !got.IsZero() {
+		t.Errorf("expected RefreshExpiresAt to be cleared on token rotation without lifetime hint, got %v", got)
+	}
+	// Round-trip the status through JSON to confirm omitzero keeps the
+	// field absent — a future tag flip from omitzero to omitempty would
+	// silently emit 0001-01-01T00:00:00Z (truthy in JS) and the UI test
+	// would still pass without this assertion.
+	b, err := json.Marshal(src.Status())
+	if err != nil {
+		t.Fatalf("marshal Status: %v", err)
+	}
+	if strings.Contains(string(b), `"refresh_expires_at"`) {
+		t.Errorf("expected refresh_expires_at omitted from JSON when zero, got %s", b)
+	}
+}
+
+// TestApplyTokenResponse_OmitsRefreshExpiresInOnSameTokenEchoClears
+// covers the contrived-but-reachable IdP path where refresh_token is
+// echoed verbatim AND refresh_expires_in is set to 0 / absent. The
+// helper must clear (not preserve) so a stale deadline can't lock
+// NeedsReauth=true in perpetuity. RFC 6749 §6 distinguishes "absent"
+// (still valid, lifetime unchanged) from "present" (rotation signal),
+// so any present refresh_token without a lifetime hint is treated as
+// "lifetime unknown" regardless of whether the value rotated.
+func TestApplyTokenResponse_OmitsRefreshExpiresInOnSameTokenEchoClears(t *testing.T) {
+	src := newOAuthTokenSource(OAuthConfig{
+		Grant:    OAuthGrantAuthorizationCode,
+		TokenURL: "https://idp/token",
+		ClientID: "id", ClientSecret: "sec",
+		AuthorizationURL: "https://idp/auth",
+	}, "test", nil)
+	src.mu.Lock()
+	src.state.RefreshToken = "rt"
+	src.state.RefreshExpiresAt = time.Now().Add(time.Hour) // stale deadline
+	src.applyTokenResponseLocked(tokenResponse{
+		AccessToken: "a", RefreshToken: "rt", ExpiresIn: 300,
+		// IdP echoed same refresh_token without refresh_expires_in —
+		// e.g., chose to clear the lifetime to "indefinite".
+	})
+	got := src.state.RefreshExpiresAt
+	src.mu.Unlock()
+	if !got.IsZero() {
+		t.Errorf("expected RefreshExpiresAt cleared on same-token echo without lifetime, got %v", got)
+	}
+}
+
+// TestApplyTokenResponse_OmitsRefreshExpiresInOnUnchangedTokenPreserves
+// verifies the second arm of the partial-response policy: when the IdP
+// omits both refresh_token (token unchanged) and refresh_expires_in, the
+// previously-disclosed deadline is preserved — the IdP said nothing, so
+// inventing "no fixed lifetime" by clearing would be misleading.
+func TestApplyTokenResponse_OmitsRefreshExpiresInOnUnchangedTokenPreserves(t *testing.T) {
+	src := newOAuthTokenSource(OAuthConfig{
+		Grant:    OAuthGrantAuthorizationCode,
+		TokenURL: "https://idp/token",
+		ClientID: "id", ClientSecret: "sec",
+		AuthorizationURL: "https://idp/auth",
+	}, "test", nil)
+	deadline := time.Now().Add(time.Hour).Truncate(time.Second)
+	src.mu.Lock()
+	src.state.RefreshToken = "rt"
+	src.state.RefreshExpiresAt = deadline
+	src.applyTokenResponseLocked(tokenResponse{
+		AccessToken: "a", ExpiresIn: 300,
+		// Both RefreshToken and RefreshExpiresIn omitted — IdP saying
+		// "still using the same refresh token, deadline unchanged."
+	})
+	got := src.state.RefreshExpiresAt
+	src.mu.Unlock()
+	if !got.Equal(deadline) {
+		t.Errorf("expected deadline preserved (%v), got %v", deadline, got)
+	}
+}
+
+// TestStatus_NeedsReauthOnPastRefreshDeadline verifies that an
+// authorization_code source with a refresh deadline in the past flips
+// NeedsReauth=true even when an access token is still cached. Reaching
+// this state means the next refresh would fail; the admin UI should
+// render the Connect button proactively rather than wait for a tool
+// call to surface the failure.
+func TestStatus_NeedsReauthOnPastRefreshDeadline(t *testing.T) {
+	src := newOAuthTokenSource(OAuthConfig{
+		Grant:    OAuthGrantAuthorizationCode,
+		TokenURL: "https://idp/token",
+		ClientID: "id", ClientSecret: "sec",
+		AuthorizationURL: "https://idp/auth",
+	}, "test", nil)
+	src.mu.Lock()
+	src.state.AccessToken = "still-valid"
+	src.state.RefreshToken = "rt"
+	src.state.ExpiresAt = time.Now().Add(5 * time.Minute)
+	src.state.RefreshExpiresAt = time.Now().Add(-time.Minute)
+	src.loaded = true
+	src.mu.Unlock()
+
+	st := src.Status()
+	if !st.NeedsReauth {
+		t.Errorf("expected NeedsReauth=true with refresh deadline in the past, got false")
+	}
+}
+
+// TestStatus_NoReauthWhenRefreshDeadlineUnknown guards against the
+// "unknown == expired" misreading: an IdP that doesn't disclose
+// refresh_expires_in leaves RefreshExpiresAt zero, and that must not
+// trigger NeedsReauth.
+func TestStatus_NoReauthWhenRefreshDeadlineUnknown(t *testing.T) {
+	src := newOAuthTokenSource(OAuthConfig{
+		Grant:    OAuthGrantAuthorizationCode,
+		TokenURL: "https://idp/token",
+		ClientID: "id", ClientSecret: "sec",
+		AuthorizationURL: "https://idp/auth",
+	}, "test", nil)
+	src.mu.Lock()
+	src.state.AccessToken = "valid"
+	src.state.RefreshToken = "rt"
+	src.state.ExpiresAt = time.Now().Add(5 * time.Minute)
+	// RefreshExpiresAt deliberately zero.
+	src.loaded = true
+	src.mu.Unlock()
+
+	if st := src.Status(); st.NeedsReauth {
+		t.Errorf("expected NeedsReauth=false when refresh deadline unknown, got true")
+	}
+}
+
+// TestIngestTokenResponse_PersistsRefreshExpires verifies that the
+// authorization_code Connect callback path (IngestTokenResponse) honors
+// RefreshExpiresIn and writes RefreshExpiresAt into the persistent store
+// — the round-trip the admin UI depends on for the "Refresh expires"
+// row to survive platform restarts.
+func TestIngestTokenResponse_PersistsRefreshExpires(t *testing.T) {
+	store := NewMemoryTokenStore()
+	src := newOAuthTokenSource(OAuthConfig{
+		Grant:    OAuthGrantAuthorizationCode,
+		TokenURL: "https://idp/token",
+		ClientID: "id", ClientSecret: "sec",
+	}, "vendor", store)
+
+	if err := src.IngestTokenResponse(context.Background(), IngestTokenResponseInput{
+		AccessToken: "a", RefreshToken: "r",
+		ExpiresIn: 300, RefreshExpiresIn: 1800,
+		AuthenticatedBy: "alice@example.com",
+	}); err != nil {
+		t.Fatalf("IngestTokenResponse: %v", err)
+	}
+
+	rec, err := store.Get(context.Background(), "vendor")
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if rec.RefreshExpiresAt.IsZero() {
+		t.Fatal("expected persisted RefreshExpiresAt, got zero")
+	}
+	if got := time.Until(rec.RefreshExpiresAt); got < 25*time.Minute || got > 31*time.Minute {
+		t.Errorf("RefreshExpiresAt deadline %v out of plausible range", got)
+	}
+}

--- a/pkg/toolkits/gateway/tokenstore.go
+++ b/pkg/toolkits/gateway/tokenstore.go
@@ -16,15 +16,21 @@ var ErrTokenNotFound = errors.New("gateway: oauth token not found")
 // PersistedToken is the row shape for gateway_oauth_tokens. Tokens are
 // stored encrypted at rest by the platform's FieldEncryptor; this struct
 // carries plaintext values to/from the store API.
+//
+// RefreshExpiresAt is optional — only populated when the IdP returned
+// refresh_expires_in (Keycloak does, others may not). Zero means the
+// store row has NULL in refresh_expires_at; callers must NOT interpret
+// that as "never expires".
 type PersistedToken struct {
-	ConnectionName  string
-	AccessToken     string
-	RefreshToken    string
-	ExpiresAt       time.Time
-	Scope           string
-	AuthenticatedBy string
-	AuthenticatedAt time.Time
-	UpdatedAt       time.Time
+	ConnectionName   string
+	AccessToken      string
+	RefreshToken     string
+	ExpiresAt        time.Time
+	RefreshExpiresAt time.Time
+	Scope            string
+	AuthenticatedBy  string
+	AuthenticatedAt  time.Time
+	UpdatedAt        time.Time
 }
 
 // TokenStore persists OAuth tokens for the authorization_code grant so a
@@ -91,18 +97,20 @@ func NewPostgresTokenStore(db *sql.DB, enc TokenEncryptor) *PostgresTokenStore {
 func (s *PostgresTokenStore) Get(ctx context.Context, connection string) (*PersistedToken, error) {
 	row := s.db.QueryRowContext(ctx,
 		`SELECT connection_name, access_token, refresh_token, expires_at,
-                scope, authenticated_by, authenticated_at, updated_at
+                refresh_expires_at, scope, authenticated_by, authenticated_at,
+                updated_at
          FROM gateway_oauth_tokens WHERE connection_name = $1`, connection)
 
 	var (
-		t          PersistedToken
-		accessEnc  sql.NullString
-		refreshEnc sql.NullString
-		expiresAt  sql.NullTime
-		authedAt   sql.NullTime
+		t                PersistedToken
+		accessEnc        sql.NullString
+		refreshEnc       sql.NullString
+		expiresAt        sql.NullTime
+		refreshExpiresAt sql.NullTime
+		authedAt         sql.NullTime
 	)
 	if err := row.Scan(&t.ConnectionName, &accessEnc, &refreshEnc, &expiresAt,
-		&t.Scope, &t.AuthenticatedBy, &authedAt, &t.UpdatedAt); err != nil {
+		&refreshExpiresAt, &t.Scope, &t.AuthenticatedBy, &authedAt, &t.UpdatedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrTokenNotFound
 		}
@@ -126,6 +134,9 @@ func (s *PostgresTokenStore) Get(ctx context.Context, connection string) (*Persi
 	if expiresAt.Valid {
 		t.ExpiresAt = expiresAt.Time
 	}
+	if refreshExpiresAt.Valid {
+		t.RefreshExpiresAt = refreshExpiresAt.Time
+	}
 	if authedAt.Valid {
 		t.AuthenticatedAt = authedAt.Time
 	}
@@ -146,14 +157,16 @@ func (s *PostgresTokenStore) Set(ctx context.Context, t PersistedToken) error {
 	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO gateway_oauth_tokens
             (connection_name, access_token, refresh_token, expires_at,
-             scope, authenticated_by, authenticated_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+             refresh_expires_at, scope, authenticated_by, authenticated_at,
+             updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
          ON CONFLICT (connection_name) DO UPDATE
          SET access_token = $2, refresh_token = $3, expires_at = $4,
-             scope = $5, authenticated_by = $6, authenticated_at = $7,
-             updated_at = $8`,
+             refresh_expires_at = $5, scope = $6, authenticated_by = $7,
+             authenticated_at = $8, updated_at = $9`,
 		t.ConnectionName, accessEnc, refreshEnc, nullTime(t.ExpiresAt),
-		t.Scope, t.AuthenticatedBy, nullTime(t.AuthenticatedAt), time.Now().UTC())
+		nullTime(t.RefreshExpiresAt), t.Scope, t.AuthenticatedBy,
+		nullTime(t.AuthenticatedAt), time.Now().UTC())
 	if err != nil {
 		return fmt.Errorf("gateway: upsert oauth token: %w", err)
 	}

--- a/pkg/toolkits/gateway/tokenstore_test.go
+++ b/pkg/toolkits/gateway/tokenstore_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"testing"
@@ -94,14 +95,16 @@ func TestPostgresTokenStore_Get_Success(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 
 	expiresAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	refreshExpiresAt := time.Date(2026, 1, 2, 4, 0, 0, 0, time.UTC)
 	authedAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	updatedAt := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
 
 	rows := sqlmock.NewRows([]string{
 		"connection_name", "access_token", "refresh_token", "expires_at",
-		"scope", "authenticated_by", "authenticated_at", "updated_at",
+		"refresh_expires_at", "scope", "authenticated_by", "authenticated_at",
+		"updated_at",
 	}).AddRow("vendor", reverse("acc"), reverse("ref"), expiresAt,
-		"api", "alice@example.com", authedAt, updatedAt)
+		refreshExpiresAt, "api", "alice@example.com", authedAt, updatedAt)
 
 	mock.ExpectQuery("SELECT connection_name").
 		WithArgs("vendor").
@@ -116,6 +119,7 @@ func TestPostgresTokenStore_Get_Success(t *testing.T) {
 	assert.Equal(t, "api", got.Scope)
 	assert.Equal(t, "alice@example.com", got.AuthenticatedBy)
 	assert.Equal(t, expiresAt, got.ExpiresAt)
+	assert.Equal(t, refreshExpiresAt, got.RefreshExpiresAt)
 	assert.Equal(t, authedAt, got.AuthenticatedAt)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -157,8 +161,9 @@ func TestPostgresTokenStore_Get_DecryptError(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{
 		"connection_name", "access_token", "refresh_token", "expires_at",
-		"scope", "authenticated_by", "authenticated_at", "updated_at",
-	}).AddRow("vendor", "ciphertext", nil, nil, "", "", nil, time.Now())
+		"refresh_expires_at", "scope", "authenticated_by", "authenticated_at",
+		"updated_at",
+	}).AddRow("vendor", "ciphertext", nil, nil, nil, "", "", nil, time.Now())
 
 	mock.ExpectQuery("SELECT connection_name").
 		WithArgs("vendor").
@@ -180,8 +185,9 @@ func TestPostgresTokenStore_Get_DecryptRefreshError(t *testing.T) {
 	// a custom encryptor that errors only on the second call.
 	rows := sqlmock.NewRows([]string{
 		"connection_name", "access_token", "refresh_token", "expires_at",
-		"scope", "authenticated_by", "authenticated_at", "updated_at",
-	}).AddRow("vendor", nil, "ref-cipher", nil, "", "", nil, time.Now())
+		"refresh_expires_at", "scope", "authenticated_by", "authenticated_at",
+		"updated_at",
+	}).AddRow("vendor", nil, "ref-cipher", nil, nil, "", "", nil, time.Now())
 
 	mock.ExpectQuery("SELECT connection_name").
 		WithArgs("vendor").
@@ -193,36 +199,67 @@ func TestPostgresTokenStore_Get_DecryptRefreshError(t *testing.T) {
 	assert.Contains(t, err.Error(), "decrypt refresh_token")
 }
 
+// TestPostgresTokenStore_Set_Success exercises the upsert with two
+// scenarios that distinguish the positional ordering of expires_at
+// (arg 4) and refresh_expires_at (arg 5). Using sqlmock.AnyArg() for
+// both would let a future SQL refactor swap the columns and the test
+// would still pass green — exactly the deadline/lifetime corruption
+// hazard finding #5 (round 1) was hunting. Each case here pins the
+// two arguments to values that disagree on type-or-NULL state, so a
+// column swap fails the expectation.
 func TestPostgresTokenStore_Set_Success(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
+	cases := []struct {
+		name             string
+		refreshExpiresAt time.Time
+		expectedArg5     driver.Value
+	}{
+		{
+			name:             "with refresh deadline",
+			refreshExpiresAt: time.Now().Add(30 * time.Minute),
+			expectedArg5:     sqlmock.AnyArg(), // non-nil time.Time-equivalent
+		},
+		{
+			name:             "without refresh deadline",
+			refreshExpiresAt: time.Time{},
+			expectedArg5:     nil, // nullTime(zero) → nil → DB NULL
+		},
+	}
 
-	mock.ExpectExec("INSERT INTO gateway_oauth_tokens").
-		WithArgs(
-			"vendor",
-			reverse("access-x"),
-			reverse("refresh-x"),
-			sqlmock.AnyArg(),
-			"api",
-			"alice@example.com",
-			sqlmock.AnyArg(),
-			sqlmock.AnyArg(),
-		).
-		WillReturnResult(sqlmock.NewResult(0, 1))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = db.Close() })
 
-	store := NewPostgresTokenStore(db, reverseEncryptor{})
-	err = store.Set(context.Background(), PersistedToken{
-		ConnectionName:  "vendor",
-		AccessToken:     "access-x",
-		RefreshToken:    "refresh-x",
-		ExpiresAt:       time.Now().Add(time.Hour),
-		Scope:           "api",
-		AuthenticatedBy: "alice@example.com",
-		AuthenticatedAt: time.Now(),
-	})
-	require.NoError(t, err)
-	assert.NoError(t, mock.ExpectationsWereMet())
+			mock.ExpectExec("INSERT INTO gateway_oauth_tokens").
+				WithArgs(
+					"vendor",
+					reverse("access-x"),
+					reverse("refresh-x"),
+					sqlmock.AnyArg(), // expires_at — always non-nil here
+					tc.expectedArg5,  // refresh_expires_at — pinned per case
+					"api",
+					"alice@example.com",
+					sqlmock.AnyArg(),
+					sqlmock.AnyArg(),
+				).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+
+			store := NewPostgresTokenStore(db, reverseEncryptor{})
+			err = store.Set(context.Background(), PersistedToken{
+				ConnectionName:   "vendor",
+				AccessToken:      "access-x",
+				RefreshToken:     "refresh-x",
+				ExpiresAt:        time.Now().Add(time.Hour),
+				RefreshExpiresAt: tc.refreshExpiresAt,
+				Scope:            "api",
+				AuthenticatedBy:  "alice@example.com",
+				AuthenticatedAt:  time.Now(),
+			})
+			require.NoError(t, err)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
 }
 
 func TestPostgresTokenStore_Set_AccessEncryptError(t *testing.T) {

--- a/pkg/toolkits/gateway/toolkit.go
+++ b/pkg/toolkits/gateway/toolkit.go
@@ -823,13 +823,18 @@ func (t *Toolkit) ReacquireOAuthToken(ctx context.Context, name string) error {
 // IngestOAuthTokenInput is the parameter set for IngestOAuthToken.
 // Defined as a struct to keep the public method's argument list under
 // the project's revive limit.
+//
+// RefreshExpiresIn is optional: only some IdPs (Keycloak) emit it on
+// their token-endpoint response. Zero leaves the refresh deadline
+// unknown — the admin UI renders an em dash.
 type IngestOAuthTokenInput struct {
-	Name            string
-	AccessToken     string
-	RefreshToken    string
-	ExpiresIn       int
-	Scope           string
-	AuthenticatedBy string
+	Name             string
+	AccessToken      string
+	RefreshToken     string
+	ExpiresIn        int
+	RefreshExpiresIn int
+	Scope            string
+	AuthenticatedBy  string
 }
 
 // IngestOAuthToken stores tokens obtained from an authorization_code
@@ -864,11 +869,12 @@ func (t *Toolkit) IngestOAuthToken(ctx context.Context, in IngestOAuthTokenInput
 	// fresh credentials.
 	tmp := newOAuthTokenSource(cfg.OAuth, in.Name, store)
 	if err := tmp.IngestTokenResponse(ctx, IngestTokenResponseInput{
-		AccessToken:     in.AccessToken,
-		RefreshToken:    in.RefreshToken,
-		ExpiresIn:       in.ExpiresIn,
-		Scope:           in.Scope,
-		AuthenticatedBy: in.AuthenticatedBy,
+		AccessToken:      in.AccessToken,
+		RefreshToken:     in.RefreshToken,
+		ExpiresIn:        in.ExpiresIn,
+		RefreshExpiresIn: in.RefreshExpiresIn,
+		Scope:            in.Scope,
+		AuthenticatedBy:  in.AuthenticatedBy,
 	}); err != nil {
 		slog.Error("gateway: IngestOAuthToken — IngestTokenResponse failed",
 			logKeyConnection, in.Name, logKeyError, err)
@@ -1163,6 +1169,64 @@ type ProbeTool struct {
 	Name        string `json:"name"`
 	LocalName   string `json:"local_name"`
 	Description string `json:"description,omitempty"`
+}
+
+// ErrConnectionNotLive is returned by TestLiveConnection when the named
+// connection is registered but does not have a live client (typically an
+// authorization_code OAuth connection awaiting the operator's first
+// Connect, or a connection whose initial dial failed and is sitting as a
+// placeholder). Callers convert this to an actionable user-facing message
+// rather than a generic upstream error.
+var ErrConnectionNotLive = errors.New("gateway: connection has no live client")
+
+// TestLiveConnection exercises the live upstreamClient for the named
+// connection by issuing a `tools/list` request — the same call any tool
+// invocation would trigger to satisfy auth and reach the upstream. It is
+// the correct implementation of an admin "Test connection" button on a
+// connection that is already wired into the toolkit: it uses the live
+// auth round-tripper (loading and refreshing OAuth tokens via the
+// toolkit's TokenStore), so it sees the SAME state that real tool calls
+// see. Probe (the config-only one-shot dial) cannot do this because it
+// builds an isolated client with no token-store access and would always
+// fail for `authorization_code` connections that depend on a persisted
+// refresh token.
+//
+// Returns ErrConnectionNotFound when no row exists for name, and
+// ErrConnectionNotLive when the row is a placeholder awaiting reauth.
+func (t *Toolkit) TestLiveConnection(ctx context.Context, name string) ([]ProbeTool, error) {
+	t.mu.RLock()
+	u, ok := t.connections[name]
+	if !ok {
+		t.mu.RUnlock()
+		return nil, fmt.Errorf(errFmtConnection, name, ErrConnectionNotFound)
+	}
+	if u.client == nil {
+		t.mu.RUnlock()
+		return nil, fmt.Errorf(errFmtConnection, name, ErrConnectionNotLive)
+	}
+	client := u.client
+	prefix := u.config.ConnectionName
+	if prefix == "" {
+		prefix = name
+	}
+	t.mu.RUnlock()
+
+	tools, err := client.listTools(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ProbeTool, 0, len(tools))
+	for _, rt := range tools {
+		if rt == nil || rt.Name == "" {
+			continue
+		}
+		out = append(out, ProbeTool{
+			Name:        rt.Name,
+			LocalName:   prefix + NamespaceSeparator + rt.Name,
+			Description: rt.Description,
+		})
+	}
+	return out, nil
 }
 
 // Probe dials the upstream described by cfg, lists its tools, and closes the

--- a/pkg/toolkits/gateway/toolkit_test.go
+++ b/pkg/toolkits/gateway/toolkit_test.go
@@ -833,6 +833,145 @@ func TestProbe_UnreachableReturnsError(t *testing.T) {
 	}
 }
 
+// TestTestLiveConnection_UsesLiveClient covers the bug behind the
+// "Test connection" UI button: when an authorization_code OAuth
+// connection has a live client (token loaded from store),
+// TestLiveConnection must list tools through that client — exactly
+// what real tool calls do. The pre-fix Probe path built a parallel
+// client with no token store and failed even though the live one was
+// healthy.
+//
+// The test seeds an authorization_code grant + pre-stored token in the
+// toolkit's TokenStore so the live path's distinguishing behavior
+// (TokenStore-backed auth round-tripper) is actually exercised. The
+// final assertion runs Probe(cfg) directly with the same config and
+// asserts it FAILS — the production-faithful demonstration that without
+// TokenStore access the request can't satisfy the auth_code contract,
+// which is the exact bug TestLiveConnection works around.
+func TestTestLiveConnection_UsesLiveClient(t *testing.T) {
+	tokenURL := fakeTokenServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tokenResponse{ //nolint:gosec // G117 false positive: OAuth response shape, not a credential
+			AccessToken: "live-acc", RefreshToken: "live-ref", ExpiresIn: 3600,
+		})
+	})
+	upstreamURL := upstreamServer(t)
+
+	store := NewMemoryTokenStore()
+	if err := store.Set(context.Background(), PersistedToken{
+		ConnectionName: connCRM,
+		AccessToken:    "live-acc",
+		RefreshToken:   "live-ref",
+		ExpiresAt:      time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+	tk.SetTokenStore(store)
+
+	cfg := map[string]any{
+		"endpoint":                upstreamURL,
+		"connection_name":         connCRM,
+		"auth_mode":               AuthModeOAuth,
+		"oauth_grant":             OAuthGrantAuthorizationCode,
+		"oauth_token_url":         tokenURL,
+		"oauth_authorization_url": tokenURL + "/authorize",
+		"oauth_client_id":         "id",
+		"oauth_client_secret":     "sec",
+		"connect_timeout":         "3s",
+		"call_timeout":            "3s",
+	}
+	if err := tk.AddConnection(connCRM, cfg); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+
+	tools, err := tk.TestLiveConnection(context.Background(), connCRM)
+	if err != nil {
+		t.Fatalf("TestLiveConnection on auth_code with stored token: %v", err)
+	}
+	if len(tools) == 0 {
+		t.Fatal("expected at least one tool from live client")
+	}
+	for _, pt := range tools {
+		if !strings.HasPrefix(pt.LocalName, connCRM+NamespaceSeparator) {
+			t.Errorf("LocalName %q missing %q prefix", pt.LocalName, connCRM+NamespaceSeparator)
+		}
+	}
+
+	// Regression demonstration: Probe with the same config but no
+	// TokenStore access (its calling contract) MUST fail for auth_code,
+	// because the parallel oauthTokenSource it builds has no token to
+	// load. This is the bug TestLiveConnection works around — proving
+	// it here means a future refactor that accidentally routes
+	// TestLiveConnection through Probe would break this assertion.
+	probeCfg, err := ParseConfig(cfg)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if _, err := Probe(context.Background(), probeCfg); err == nil {
+		t.Fatal("expected Probe to fail for auth_code without TokenStore access; bug regression demonstration is broken")
+	}
+}
+
+// TestTestLiveConnection_NotFound covers the "no row in registry" case.
+// The handler converts this to a probe-fallback path; the toolkit method
+// must signal it with ErrConnectionNotFound rather than panicking.
+func TestTestLiveConnection_NotFound(t *testing.T) {
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+	_, err := tk.TestLiveConnection(context.Background(), "missing")
+	if !errors.Is(err, ErrConnectionNotFound) {
+		t.Fatalf("expected ErrConnectionNotFound, got %v", err)
+	}
+}
+
+// TestTestLiveConnection_PlaceholderReportsNotLive ensures a placeholder
+// (registered but client==nil — the typical state for an authorization_code
+// connection awaiting Connect) is reported with ErrConnectionNotLive so
+// the admin handler can fall through to the friendly "click Connect"
+// message instead of producing a misleading upstream error.
+//
+// Drives placeholder creation through the production AddConnection +
+// installDialResult path (authorization_code grant + unreachable
+// endpoint) rather than hand-injecting an upstream — a unit test that
+// assembles its own input doesn't prove the production wiring produces
+// the same shape (CLAUDE.md anti-pattern).
+func TestTestLiveConnection_PlaceholderReportsNotLive(t *testing.T) {
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+
+	// authorization_code with no stored token + unreachable endpoint:
+	// dial fails inside addParsedConnection, installDialResult takes
+	// the OAuthGrantAuthorizationCode branch and parks the connection
+	// as a placeholder (client == nil) instead of removing it.
+	err := tk.AddConnection("placeholder", map[string]any{
+		"endpoint":        "http://127.0.0.1:1/mcp",
+		"connection_name": "placeholder",
+		"auth_mode":       "oauth",
+		"connect_timeout": "200ms",
+		"oauth": map[string]any{
+			"grant":             "authorization_code",
+			"token_url":         "http://127.0.0.1:1/token",
+			"authorization_url": "http://127.0.0.1:1/auth",
+			"client_id":         "id",
+			"client_secret":     "sec",
+		},
+	})
+	if err != nil {
+		t.Fatalf("AddConnection for placeholder setup: %v", err)
+	}
+	if !tk.HasConnection("placeholder") {
+		t.Fatal("expected placeholder to remain registered after dial failure")
+	}
+
+	_, err = tk.TestLiveConnection(context.Background(), "placeholder")
+	if !errors.Is(err, ErrConnectionNotLive) {
+		t.Fatalf("expected ErrConnectionNotLive, got %v", err)
+	}
+}
+
 func TestApplyEnrichment_NoEngineIsNoOp(t *testing.T) {
 	tk := New("primary")
 	res := &mcp.CallToolResult{StructuredContent: map[string]any{"x": 1}}

--- a/ui/src/api/admin/types.ts
+++ b/ui/src/api/admin/types.ts
@@ -515,6 +515,7 @@ export interface GatewayOAuthStatus {
   expires_at?: string;
   last_refreshed_at?: string;
   has_refresh_token: boolean;
+  refresh_expires_at?: string;
   last_error?: string;
   grant?: string;
   token_url?: string;

--- a/ui/src/pages/settings/GatewayActions.tsx
+++ b/ui/src/pages/settings/GatewayActions.tsx
@@ -301,6 +301,16 @@ function OAuthStatusCard({ connectionName }: { connectionName: string }) {
             <>
               <span className="font-medium">Refresh token revoked.</span> The upstream's last refresh attempt was rejected as <code>invalid_grant</code> — the stored credential is no longer valid (idle session timeout, password change, or admin revocation). Click <strong>Connect</strong> to reauthorize. <em>Refresh now</em> will fail until you do.
             </>
+          ) : oauth.token_acquired ? (
+            // Pre-emptive flip: refresh-token deadline has passed (the IdP
+            // disclosed a refresh_expires_in and now() is past it) but the
+            // cached access token is still valid. Tool calls work right now;
+            // the next attempt to mint a fresh access token will fail.
+            // Distinguish this from the "fully unauthorized" case so the
+            // operator doesn't panic-Connect during a healthy moment.
+            <>
+              <span className="font-medium">Reauth needed soon.</span> The current access token still works, but the refresh-token deadline has passed — the next refresh will fail. Click <strong>Connect</strong> at your convenience to issue a fresh credential before the cached token expires.
+            </>
           ) : (
             <>
               <span className="font-medium">Not connected.</span> Click <strong>Connect</strong> to authorize this connection in your browser. The platform will then keep the access token refreshed automatically — including for cron jobs and scheduled prompts — until the upstream invalidates the refresh token.
@@ -369,6 +379,16 @@ function OAuthStatusGrid({ status }: { status: GatewayOAuthStatus }) {
       icon: <Key className="h-3 w-3 text-muted-foreground" />,
     },
   ];
+  // Some IdPs (Keycloak) disclose refresh_expires_in. Render only when
+  // the platform captured a real value — an em-dash row would be noise
+  // for IdPs that never provide it (Auth0, Okta default config, etc.).
+  if (status.has_refresh_token && status.refresh_expires_at) {
+    items.push({
+      label: "Refresh expires",
+      value: formatRelative(status.refresh_expires_at),
+      icon: <Clock className="h-3 w-3 text-muted-foreground" />,
+    });
+  }
   return (
     <div className="grid grid-cols-2 gap-2 text-xs">
       {items.map((it) => (


### PR DESCRIPTION
## Summary

- **Test connection** on a saved gateway connection now exercises the live `upstreamClient` (same auth round-tripper, same `TokenStore`, same OAuth refresh flow that real tool calls use) instead of building a parallel `Probe` client with a nil store. The pre-fix probe path always failed for `authorization_code` connections that depend on a persisted refresh token, even when the live wired-up connection was healthy and Try-it tool calls worked.
- Surface refresh-token expiration when the IdP discloses `refresh_expires_in` (Keycloak; OAuth 2.1 leaves it optional). New "Refresh expires" row in the OAuth status grid, plus a third banner branch on the connection viewer for the "AT still valid but refresh deadline passed" state.
- Bump `golang.org/x/net` to v0.53.0 and add `toolchain go1.26.3` (workflows synced to 1.26.3) to clear `GO-2026-{4918,4971,4980,4981,4982}`. `govulncheck` clean.

## Background — the bug

A user with a healthy OAuth connection clicked **Test connection** and got **Failed**, even though they could invoke tools from the same connection in **Try it**. Logs showed:

\`\`\`
gateway/oauth: requires human reauthentication
  connection=mcptest
  reason=\"authorization_code grant has no valid cached or refresh token\"
\`\`\`

Root cause was in \`pkg/toolkits/gateway/toolkit.go\` (\`Probe\`):

\`\`\`go
// Probe is a one-shot dial — never persists tokens, so pass nil for
// the store. authorization_code grants can't be probed without a
// valid stored refresh token (which would require Connect first).
client, tools, err := discover(ctx, cfg, cfg.ConnectionName, nil)
\`\`\`

The admin endpoint called \`Probe\` with that nil store. \`Probe\` built a fresh \`oauthTokenSource\`, which couldn't load the persisted refresh token (no store to load from). For \`authorization_code\` grants the call returned \"needs reauth\" before the upstream was ever contacted. Try-it worked because tool calls go through the live \`upstreamClient\` which DOES carry the toolkit's \`TokenStore\`.

The right semantics for a button labeled \"Test connection\" is to test **the** connection — the live one the platform actually serves tools from — not a hypothetical fresh dial.

## What changed

### Test connection routes through the live client

- New \`Toolkit.TestLiveConnection(ctx, name) ([]ProbeTool, error)\` in \`pkg/toolkits/gateway/toolkit.go\`. Issues \`tools/list\` against the live \`upstreamClient\`. Returns \`ErrConnectionNotFound\` for unregistered names and a new \`ErrConnectionNotLive\` sentinel for placeholders (authorization_code awaiting first Connect, or post-restart unhealthy).
- \`testGatewayConnection\` (\`pkg/admin/gateway_handler.go\`) now tries \`tryTestLiveConnection\` first when \`tk.HasConnection(name)\`. Falls back to \`Probe\` only for unsaved/preview configs. Placeholder connections still funnel into the existing \`shortCircuitUnauthorizedAuthCode\` \"click Connect\" message via the \`ErrConnectionNotLive\` signal.
- Swagger \`@Description\` updated to document the body-bypass-for-live semantics so non-UI API consumers understand the contract.

### Refresh-token expiration

- Parse \`refresh_expires_in\` in both \`tokenResponse\` (the gateway's internal token-endpoint shape) and \`authCodeTokenResponse\` (the admin's authorization-code callback handler).
- New \`applyExpiriesLocked(state, expiryUpdate)\` helper centralizes \`ExpiresAt\` + \`RefreshExpiresAt\` computation. The Connect path (\`IngestTokenResponse\`) and the acquire/refresh path (\`applyTokenResponseLocked\`) both go through it, so they cannot diverge on edge-case semantics. Rules:
  - \`RefreshExpiresIn > 0\`: set absolute deadline.
  - \`RefreshExpiresIn == 0\` AND \`RefreshTokenInResponse=true\`: clear (rotation or echo without lifetime hint).
  - \`RefreshExpiresIn == 0\` AND \`!RefreshTokenInResponse\`: preserve any existing deadline (RFC 6749 §6 \"still valid\").
- New migration \`000037_gateway_oauth_refresh_expires_at\` adds the \`refresh_expires_at TIMESTAMPTZ\` column. \`PostgresTokenStore.Get/Set\` round-trips it; \`nullTime(zero) → NULL\` per the existing pattern.
- New \`RefreshExpiresAt time.Time\` on \`OAuthStatus\` (json: \`refresh_expires_at,omitzero\`). When set and in the past, \`NeedsReauth\` flips pre-emptively so the UI surfaces the Connect button before the next refresh attempt fails.

### UI

- New \"Refresh expires\" row in \`OAuthStatusGrid\`, rendered only when the IdP captured a real value (silent for IdPs that don't disclose, e.g. Auth0 default).
- Third banner branch in \`GatewayActionBar\`: when \`NeedsReauth=true\` AND \`TokenAcquired=true\` (and not \`refresh_token_revoked\`), render \"Reauth needed soon. The current access token still works...\" instead of the panic-inducing \"Not connected\" message used for fully-unauthorized state. Disambiguates the proactive-flip from the fully-broken case so operators don't panic-Connect during a healthy moment.

### Dependency hygiene

- \`go.mod\`: \`toolchain go1.26.3\` directive added; \`golang.org/x/net\` bumped v0.52.0 → v0.53.0.
- \`.github/workflows/{ci,release,codeql}.yml\`: \`go-version\` pin synced from 1.26.2 → 1.26.3 to keep CI/local parity.

## Test plan

### Local

- [x] \`make verify\` passes (fmt, swagger-check, embed-clean, test, lint, security, semgrep, codeql, coverage-report 87.9%, patch-coverage 92.3%, doc-check, dead-code, mutate, release-check)
- [x] \`govulncheck ./...\` clean post-bump
- [x] All new functions ≥80% coverage:
  - \`Toolkit.TestLiveConnection\` — 86.4%
  - \`Handler.tryTestLiveConnection\` — 84.6%
  - \`testGatewayConnection\` — 100%

### Unit + integration tests added

- \`TestTestLiveConnection_UsesLiveClient\` — seeds an \`authorization_code\` grant with a pre-stored TokenStore token; asserts \`TestLiveConnection\` returns the live upstream's tools AND that \`Probe(cfg)\` directly (with nil store) FAILS — production-faithful demonstration of the bug being regressed.
- \`TestTestLiveConnection_NotFound\` / \`TestTestLiveConnection_PlaceholderReportsNotLive\` — sentinel error handling. Placeholder test drives placeholder creation through \`AddConnection\` (auth_code + unreachable endpoint) rather than hand-injecting an upstream struct, so it exercises the production placeholder path.
- \`TestTestGatewayConnection_UsesLiveClientWhenRegistered\` — end-to-end through the admin handler. Seeds an expired access token so the live path must drive a refresh through a fake token endpoint, proving the TokenStore-backed auth round-tripper is reached. Request body's \`endpoint\` points at a closed listener; a 200 OK with live tools proves the body was ignored.
- \`TestApplyTokenResponse_CapturesRefreshExpiresIn\`, \`OmitsRefreshExpiresInOnFreshTokenClears\`, \`OmitsRefreshExpiresInOnSameTokenEchoClears\`, \`OmitsRefreshExpiresInOnUnchangedTokenPreserves\` — the four arms of the \`applyExpiriesLocked\` partial-response policy.
- \`TestStatus_NeedsReauthOnPastRefreshDeadline\` / \`TestStatus_NoReauthWhenRefreshDeadlineUnknown\` — proactive \`NeedsReauth\` flip + the \"unknown ≠ expired\" guard.
- \`TestIngestTokenResponse_PersistsRefreshExpires\` — Connect callback round-trip through the store.
- \`TestPostgresTokenStore_Set_Success\` split into a 2-case table where the \`refresh_expires_at\` arg is pinned per case (\`sqlmock.AnyArg\` vs \`nil\`) so a positional column swap fails the expectation in at least one case.

### Manual — recommended before merge

- [ ] Deploy to a non-prod cluster with a Keycloak-backed authorization_code connection. Click **Test connection**: should succeed and show the upstream's tools.
- [ ] Click **Refresh tools**: should still succeed (refresh path uses the same live client + new \`applyExpiriesLocked\` helper).
- [ ] Verify the new **Refresh expires** row appears in the OAuth status grid with a real Keycloak \`refresh_expires_in\` value. Confirm it does NOT appear for an IdP that omits the field (e.g. Auth0 default).
- [ ] Force a state where the access token is still valid but the refresh deadline has passed: confirm the \"Reauth needed soon\" banner renders (not the panic-inducing \"Not connected\" one).
- [ ] Probe path still works for previewing a brand-new connection (Add connection form → Test before save).

## Migration

- One forward migration: \`000037_gateway_oauth_refresh_expires_at\` adds a nullable column. Forward-compatible with existing rows. Down migration drops the column. No data backfill needed — the field populates naturally on the next refresh for each connection.