### PR TITLE
feat(portal): collection viewer header parity + OG/Twitter card metadata

### DIFF
--- a/pkg/portal/handler.go
+++ b/pkg/portal/handler.go
@@ -198,6 +198,10 @@ func (h *Handler) registerRoutes() {
 		h.rateLimiter.Middleware(http.HandlerFunc(h.publicView)))
 	h.publicMux.Handle("GET /portal/view/{token}/content",
 		h.rateLimiter.Middleware(http.HandlerFunc(h.publicAssetContent)))
+	h.publicMux.Handle("GET /portal/view/{token}/thumbnail",
+		h.rateLimiter.Middleware(http.HandlerFunc(h.publicAssetThumbnail)))
+	h.publicMux.Handle("GET /portal/view/{token}/collection-thumbnail",
+		h.rateLimiter.Middleware(http.HandlerFunc(h.publicCollectionThumbnail)))
 	h.publicMux.Handle("GET /portal/view/{token}/items/{assetId}/content",
 		h.rateLimiter.Middleware(http.HandlerFunc(h.publicCollectionItemContent)))
 	h.publicMux.Handle("GET /portal/view/{token}/items/{assetId}/thumbnail",

--- a/pkg/portal/public.go
+++ b/pkg/portal/public.go
@@ -9,10 +9,110 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/txn2/mcp-data-platform/internal/contentviewer"
 )
+
+// resolvePublicBaseURL returns the absolute URL prefix the public viewer
+// should use for canonical (og:url) and asset (og:image) links. When the
+// operator has set portal.public_base_url that wins; otherwise we derive
+// scheme+host from the inbound request — social-media crawlers always
+// follow the share URL, so the request's Host header reflects how end
+// users will reach the page. Returns empty when neither is available
+// (e.g. unit-test requests with no Host); callers should treat empty as
+// "skip absolute-URL OG tags".
+//
+// X-Forwarded-Proto is honored only when r.TLS is nil (a reverse proxy is
+// plausibly in front). When the server is the TLS terminator itself, an
+// attacker-supplied X-Forwarded-Proto must not be allowed to override the
+// real scheme. Multi-proxy chains may produce comma-separated values
+// (e.g. "https, http"); we take the first token, which is the originating
+// client's scheme. Only http/https are accepted — any other value falls
+// back to the default to keep og:url URLs well-formed and prevent a
+// misbehaving proxy (or a request without a trusted-proxy boundary) from
+// emitting a non-HTTP scheme.
+func resolvePublicBaseURL(r *http.Request, configBaseURL string) string {
+	if s := strings.TrimRight(configBaseURL, "/"); s != "" {
+		return s
+	}
+	if r == nil || r.Host == "" {
+		return ""
+	}
+	if r.TLS != nil {
+		return schemeHTTPS + "://" + r.Host
+	}
+	return forwardedScheme(r) + "://" + r.Host
+}
+
+// schemeHTTP and schemeHTTPS are the only two values that may appear in
+// the resolved scheme — used both as the default and as the validation
+// allow-list for X-Forwarded-Proto.
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
+)
+
+// forwardedScheme returns "http" by default, upgrading to "https" only when
+// X-Forwarded-Proto explicitly says so. The header may carry a comma-
+// separated chain through multiple proxies (e.g. "https, http"); we use
+// the leftmost token, which is the originating client's scheme. Anything
+// other than "http"/"https" falls back to the default to keep og:url
+// well-formed even if a misbehaving proxy injects an arbitrary value.
+func forwardedScheme(r *http.Request) string {
+	forwarded := r.Header.Get("X-Forwarded-Proto")
+	if forwarded == "" {
+		return schemeHTTP
+	}
+	if i := strings.IndexByte(forwarded, ','); i >= 0 {
+		forwarded = forwarded[:i]
+	}
+	forwarded = strings.TrimSpace(forwarded)
+	if forwarded == schemeHTTP || forwarded == schemeHTTPS {
+		return forwarded
+	}
+	return schemeHTTP
+}
+
+// publicAssetOGImage returns the absolute URL of the OG card image for a
+// single-asset share, or empty if no suitable image exists. Preference
+// order: image-typed asset content → asset thumbnail → empty (template
+// then falls back to the brand logo). Empty baseURL disables absolute
+// URL emission entirely.
+func publicAssetOGImage(asset *Asset, token, baseURL string) string {
+	if baseURL == "" || asset == nil {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(asset.ContentType), "image/") {
+		return baseURL + publicViewPathPrefix + token + "/content"
+	}
+	if asset.ThumbnailS3Key != "" {
+		return baseURL + publicViewPathPrefix + token + "/thumbnail"
+	}
+	return ""
+}
+
+// publicCollectionOGImage returns the absolute URL of the OG card image
+// for a collection share. Preference: collection's own thumbnail → first
+// item with a thumbnail → empty. Empty baseURL disables absolute URL
+// emission entirely.
+func publicCollectionOGImage(coll *Collection, assets map[string]*Asset, token, baseURL string) string {
+	if baseURL == "" || coll == nil {
+		return ""
+	}
+	if coll.ThumbnailS3Key != "" {
+		return baseURL + publicViewPathPrefix + token + "/collection-thumbnail"
+	}
+	for _, sec := range coll.Sections {
+		for _, item := range sec.Items {
+			if a, ok := assets[item.AssetID]; ok && a != nil && a.ThumbnailS3Key != "" {
+				return baseURL + publicViewPathPrefix + token + "/items/" + a.ID + "/thumbnail"
+			}
+		}
+	}
+	return ""
+}
 
 // incrementAccessTimeout bounds the background goroutine that increments
 // share access counters after the HTTP response has been sent.
@@ -20,6 +120,12 @@ const incrementAccessTimeout = 5 * time.Second
 
 // pathKeyAssetID is the path parameter name for asset IDs in collection share URLs.
 const pathKeyAssetID = "assetId"
+
+// pathKeyToken is the path parameter name for share tokens in public viewer URLs.
+const pathKeyToken = "token"
+
+// publicViewPathPrefix is the URL prefix for public share endpoints.
+const publicViewPathPrefix = "/portal/view/"
 
 // defaultLogoSVG is the MCP Data Platform logo used in the public viewer header
 // when no brand logo is configured. Matches the platform-info app's default icon.
@@ -49,7 +155,7 @@ var viewerTemplate = template.Must(template.ParseFS(templateFS, "templates/publi
 var collectionViewerTemplate = template.Must(template.ParseFS(templateFS, "templates/public_collection_viewer.html"))
 
 func (h *Handler) publicView(w http.ResponseWriter, r *http.Request) {
-	token := r.PathValue("token")
+	token := r.PathValue(pathKeyToken)
 	if token == "" {
 		http.NotFound(w, r)
 		return
@@ -142,6 +248,16 @@ func (h *Handler) renderAssetViewer(w http.ResponseWriter, r *http.Request, pad 
 		expiresAtISO = share.ExpiresAt.UTC().Format(time.RFC3339)
 	}
 
+	// OG/Twitter metadata. Empty baseURL → ShareURL/OGImageURL stay empty,
+	// and the template gates each meta tag on its corresponding field, so
+	// requests without a resolvable base URL still render valid HTML — they
+	// just don't emit OG tags (which require absolute URLs anyway).
+	baseURL := resolvePublicBaseURL(r, h.deps.PublicBaseURL)
+	var shareURL string
+	if baseURL != "" {
+		shareURL = baseURL + publicViewPathPrefix + share.Token
+	}
+
 	_ = viewerTemplate.Execute(w, map[string]any{
 		"Name":               asset.Name,
 		"ContentType":        asset.ContentType,
@@ -163,6 +279,8 @@ func (h *Handler) renderAssetViewer(w http.ResponseWriter, r *http.Request, pad 
 		"HideExpiration":     share.HideExpiration,
 		"NoticeText":         share.NoticeText,
 		"Embedded":           r.URL.Query().Get("embedded") == "1",
+		"ShareURL":           shareURL,
+		"OGImageURL":         publicAssetOGImage(asset, share.Token, baseURL),
 	})
 }
 
@@ -181,7 +299,7 @@ func validateShareAccess(share *Share) string {
 // publicAssetContent serves the raw content for a single-asset public share.
 // Always fetches from S3 regardless of size — this is a download endpoint.
 func (h *Handler) publicAssetContent(w http.ResponseWriter, r *http.Request) {
-	token := r.PathValue("token")
+	token := r.PathValue(pathKeyToken)
 	if token == "" {
 		http.NotFound(w, r)
 		return
@@ -351,6 +469,13 @@ func (h *Handler) publicCollectionView(w http.ResponseWriter, r *http.Request, s
 		expiresAtISO = share.ExpiresAt.UTC().Format(time.RFC3339)
 	}
 
+	// OG/Twitter metadata. See renderAssetViewer for empty-baseURL handling.
+	baseURL := resolvePublicBaseURL(r, h.deps.PublicBaseURL)
+	var shareURL string
+	if baseURL != "" {
+		shareURL = baseURL + publicViewPathPrefix + share.Token
+	}
+
 	_ = collectionViewerTemplate.Execute(w, map[string]any{
 		"Name":               coll.Name,
 		"Description":        coll.Description,
@@ -367,13 +492,15 @@ func (h *Handler) publicCollectionView(w http.ResponseWriter, r *http.Request, s
 		"ExpiresAtISO":       expiresAtISO,
 		"HideExpiration":     share.HideExpiration,
 		"NoticeText":         share.NoticeText,
+		"ShareURL":           shareURL,
+		"OGImageURL":         publicCollectionOGImage(coll, assets, share.Token, baseURL),
 	})
 }
 
 // validateCollectionItemAccess checks that a token/assetId pair is valid for a collection share.
 // Returns the share on success, or writes an HTTP error and returns nil.
 func (h *Handler) validateCollectionItemAccess(w http.ResponseWriter, r *http.Request) *Share {
-	token := r.PathValue("token")
+	token := r.PathValue(pathKeyToken)
 	assetID := r.PathValue(pathKeyAssetID)
 	if token == "" || assetID == "" {
 		http.NotFound(w, r)
@@ -464,6 +591,106 @@ func (h *Handler) publicCollectionItemThumbnail(w http.ResponseWriter, r *http.R
 	}
 
 	data, contentType, s3Err := h.deps.S3Client.GetObject(r.Context(), asset.S3Bucket, asset.ThumbnailS3Key)
+	if s3Err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set(headerContentType, contentType)
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data) // #nosec G705 -- thumbnail from S3, content-type set by uploader
+}
+
+// publicAssetThumbnail serves the thumbnail for the asset behind a single-asset
+// public share. Used as the og:image source when the share's asset has a
+// thumbnail but is not itself an image content type. Mirrors
+// publicCollectionItemThumbnail but resolves the asset via the share token
+// rather than a path-bound assetId, since single-asset shares only expose one
+// asset and can't take an assetId path arg.
+func (h *Handler) publicAssetThumbnail(w http.ResponseWriter, r *http.Request) {
+	token := r.PathValue(pathKeyToken)
+	if token == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	share, err := h.deps.ShareStore.GetByToken(r.Context(), token)
+	if err != nil || share.AssetID == "" {
+		http.NotFound(w, r)
+		return
+	}
+	if msg := validateShareAccess(share); msg != "" {
+		http.Error(w, msg, http.StatusGone)
+		return
+	}
+	if h.deps.S3Client == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	asset, getErr := h.deps.AssetStore.Get(r.Context(), share.AssetID)
+	if getErr != nil || asset.DeletedAt != nil || asset.ThumbnailS3Key == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	data, contentType, s3Err := h.deps.S3Client.GetObject(r.Context(), asset.S3Bucket, asset.ThumbnailS3Key)
+	if s3Err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set(headerContentType, contentType)
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data) // #nosec G705 -- thumbnail from S3, content-type set by uploader
+}
+
+// resolveCollectionForThumbnail loads a non-deleted collection that has an
+// uploaded thumbnail, given a share token. Writes 404/410 directly on
+// failure and returns nil so callers can early-return without their own
+// guard ladder. Extracted from publicCollectionThumbnail to keep that
+// handler under the cyclomatic-complexity gate.
+func (h *Handler) resolveCollectionForThumbnail(w http.ResponseWriter, r *http.Request) *Collection {
+	token := r.PathValue(pathKeyToken)
+	if token == "" {
+		http.NotFound(w, r)
+		return nil
+	}
+	share, err := h.deps.ShareStore.GetByToken(r.Context(), token)
+	if err != nil || share.CollectionID == "" {
+		http.NotFound(w, r)
+		return nil
+	}
+	if msg := validateShareAccess(share); msg != "" {
+		http.Error(w, msg, http.StatusGone)
+		return nil
+	}
+	if h.deps.CollectionStore == nil || h.deps.S3Client == nil {
+		http.NotFound(w, r)
+		return nil
+	}
+	coll, collErr := h.deps.CollectionStore.Get(r.Context(), share.CollectionID)
+	if collErr != nil || coll.DeletedAt != nil || coll.ThumbnailS3Key == "" {
+		http.NotFound(w, r)
+		return nil
+	}
+	return coll
+}
+
+// publicCollectionThumbnail serves the collection's own thumbnail behind a
+// collection public share. Used as the og:image source when the collection
+// has a thumbnail uploaded. Falls through to 404 if the collection has no
+// thumbnail; the og:image gating in publicCollectionOGImage prevents the
+// template from emitting a URL pointing at this endpoint in that case.
+func (h *Handler) publicCollectionThumbnail(w http.ResponseWriter, r *http.Request) {
+	coll := h.resolveCollectionForThumbnail(w, r)
+	if coll == nil {
+		return
+	}
+
+	data, contentType, s3Err := h.deps.S3Client.GetObject(r.Context(), h.deps.S3Bucket, coll.ThumbnailS3Key)
 	if s3Err != nil {
 		http.NotFound(w, r)
 		return

--- a/pkg/portal/public_test.go
+++ b/pkg/portal/public_test.go
@@ -2,6 +2,7 @@ package portal
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	htmlpkg "html"
 	"net/http"
@@ -1704,4 +1705,376 @@ func TestPublicAssetContentLargeStillDownloads(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "big content", w.Body.String())
+}
+
+// --- OG / link-preview metadata ---
+
+// TestResolvePublicBaseURL covers each branch of the base-URL resolver:
+// configured value wins, request-derived fallback works, X-Forwarded-Proto
+// is honored only when not directly TLS, multi-proxy chains are collapsed
+// to the originating client scheme, and missing Host yields empty (so
+// callers omit OG tags rather than emit relative URLs that crawlers reject).
+func TestResolvePublicBaseURL(t *testing.T) {
+	t.Run("configured value wins and trailing slash is trimmed", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/", http.NoBody)
+		req.Host = "should-be-ignored.example.com"
+		got := resolvePublicBaseURL(req, "https://share.example.com/")
+		assert.Equal(t, "https://share.example.com", got)
+	})
+	t.Run("falls back to request scheme+host when config empty", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "http://example.com/x", http.NoBody)
+		req.Host = "example.com"
+		got := resolvePublicBaseURL(req, "")
+		assert.Equal(t, "http://example.com", got)
+	})
+	t.Run("X-Forwarded-Proto upgrades scheme behind a proxy", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "http://example.com/x", http.NoBody)
+		req.Host = "example.com"
+		req.Header.Set("X-Forwarded-Proto", "https")
+		got := resolvePublicBaseURL(req, "")
+		assert.Equal(t, "https://example.com", got)
+	})
+	t.Run("X-Forwarded-Proto with comma-chain takes first token", func(t *testing.T) {
+		// Multi-proxy chains can produce values like "https, http".
+		// The leftmost value is the originating client's scheme — taking
+		// it whole would yield "https, http://example.com/...", which is
+		// malformed and would be rejected by every social-media crawler.
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "http://example.com/x", http.NoBody)
+		req.Host = "example.com"
+		req.Header.Set("X-Forwarded-Proto", "https, http")
+		got := resolvePublicBaseURL(req, "")
+		assert.Equal(t, "https://example.com", got)
+	})
+	t.Run("X-Forwarded-Proto with bogus value falls back to default", func(t *testing.T) {
+		// Only http/https are accepted; anything else must fall back to
+		// the default scheme to prevent a misbehaving proxy from emitting
+		// non-HTTP og:url URLs (e.g. "javascript://..." or "ftp://...").
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "http://example.com/x", http.NoBody)
+		req.Host = "example.com"
+		req.Header.Set("X-Forwarded-Proto", "javascript")
+		got := resolvePublicBaseURL(req, "")
+		assert.Equal(t, "http://example.com", got)
+	})
+	t.Run("X-Forwarded-Proto cannot downgrade direct TLS scheme", func(t *testing.T) {
+		// When the server is the TLS terminator itself (r.TLS != nil),
+		// an attacker-controlled X-Forwarded-Proto must not be allowed to
+		// override the real scheme. Without this guard, a request
+		// arriving on https:// could emit http:// og:url tags, a
+		// gratuitous client-trust regression.
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/", http.NoBody)
+		req.Host = "example.com"
+		req.TLS = &tls.ConnectionState{}
+		req.Header.Set("X-Forwarded-Proto", "http")
+		got := resolvePublicBaseURL(req, "")
+		assert.Equal(t, "https://example.com", got)
+	})
+	t.Run("empty when no config and no Host", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/", http.NoBody)
+		req.Host = ""
+		got := resolvePublicBaseURL(req, "")
+		assert.Equal(t, "", got)
+	})
+}
+
+// TestPublicAssetOGImage covers the og:image URL selection for single-asset
+// shares: image content types win, then thumbnail key, else empty.
+func TestPublicAssetOGImage(t *testing.T) {
+	const base = "https://share.example.com"
+	t.Run("image content type uses asset content URL", func(t *testing.T) {
+		got := publicAssetOGImage(&Asset{ContentType: "image/png"}, "tok", base)
+		assert.Equal(t, base+"/portal/view/tok/content", got)
+	})
+	t.Run("non-image with thumbnail uses thumbnail URL", func(t *testing.T) {
+		got := publicAssetOGImage(&Asset{ContentType: "text/csv", ThumbnailS3Key: "k"}, "tok", base)
+		assert.Equal(t, base+"/portal/view/tok/thumbnail", got)
+	})
+	t.Run("non-image without thumbnail returns empty", func(t *testing.T) {
+		got := publicAssetOGImage(&Asset{ContentType: "text/csv"}, "tok", base)
+		assert.Equal(t, "", got)
+	})
+	t.Run("empty baseURL disables emission entirely", func(t *testing.T) {
+		got := publicAssetOGImage(&Asset{ContentType: "image/png"}, "tok", "")
+		assert.Equal(t, "", got)
+	})
+	t.Run("nil asset returns empty without panicking", func(t *testing.T) {
+		got := publicAssetOGImage(nil, "tok", base)
+		assert.Equal(t, "", got)
+	})
+}
+
+// TestPublicCollectionOGImage covers og:image selection for collection
+// shares: collection's own thumbnail wins, else first item with thumbnail,
+// else empty.
+func TestPublicCollectionOGImage(t *testing.T) {
+	const base = "https://share.example.com"
+	t.Run("collection thumbnail wins", func(t *testing.T) {
+		coll := &Collection{ThumbnailS3Key: "k"}
+		got := publicCollectionOGImage(coll, nil, "tok", base)
+		assert.Equal(t, base+"/portal/view/tok/collection-thumbnail", got)
+	})
+	t.Run("falls back to first item with thumbnail", func(t *testing.T) {
+		coll := &Collection{Sections: []CollectionSection{
+			{Items: []CollectionItem{{AssetID: "a1"}, {AssetID: "a2"}}},
+		}}
+		assets := map[string]*Asset{
+			"a1": {ID: "a1"},                          // no thumbnail
+			"a2": {ID: "a2", ThumbnailS3Key: "thumb"}, // has thumbnail
+		}
+		got := publicCollectionOGImage(coll, assets, "tok", base)
+		assert.Equal(t, base+"/portal/view/tok/items/a2/thumbnail", got)
+	})
+	t.Run("returns empty when no thumbnails available", func(t *testing.T) {
+		coll := &Collection{Sections: []CollectionSection{
+			{Items: []CollectionItem{{AssetID: "a1"}}},
+		}}
+		assets := map[string]*Asset{"a1": {ID: "a1"}}
+		got := publicCollectionOGImage(coll, assets, "tok", base)
+		assert.Equal(t, "", got)
+	})
+	t.Run("empty baseURL disables emission entirely", func(t *testing.T) {
+		coll := &Collection{ThumbnailS3Key: "k"}
+		got := publicCollectionOGImage(coll, nil, "tok", "")
+		assert.Equal(t, "", got)
+	})
+}
+
+// TestPublicAssetViewerEmitsOGMetadata asserts the asset viewer renders
+// og:title/og:url/og:image/og:site_name and the Twitter card variants.
+// Uses an explicit PublicBaseURL so the test doesn't depend on the
+// httptest Host fallback path (covered separately by
+// TestResolvePublicBaseURL).
+func TestPublicAssetViewerEmitsOGMetadata(t *testing.T) {
+	now := time.Now()
+	share := &Share{ID: "s1", AssetID: "a1", Token: "tok1"}
+	asset := &Asset{
+		ID: "a1", Name: "Cover.png", ContentType: "image/png",
+		Description: "Quarterly cover image",
+		S3Bucket:    "b1", S3Key: "assets/a1.png",
+		CreatedAt: now, UpdatedAt: now,
+	}
+
+	h := NewHandler(Deps{
+		AssetStore:    &mockAssetStore{getAsset: asset},
+		ShareStore:    &mockShareStore{getByTokenRes: share},
+		S3Client:      &mockS3Client{getData: []byte("png"), getCT: "image/png"},
+		PublicBaseURL: "https://share.example.com",
+		BrandName:     "ACME Data Platform",
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/portal/view/tok1", http.NoBody)
+	req.SetPathValue("token", "tok1")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+
+	assert.Contains(t, body, `<meta property="og:type" content="website">`)
+	assert.Contains(t, body, `<meta property="og:title" content="Cover.png">`)
+	assert.Contains(t, body, `<meta property="og:description" content="Quarterly cover image">`)
+	assert.Contains(t, body, `<meta property="og:url" content="https://share.example.com/portal/view/tok1">`)
+	assert.Contains(t, body, `<meta property="og:site_name" content="ACME Data Platform">`)
+	// Image-typed asset → og:image points at /content (raw asset).
+	assert.Contains(t, body, `<meta property="og:image" content="https://share.example.com/portal/view/tok1/content">`)
+	// Twitter card upgrades to summary_large_image when og:image is present.
+	assert.Contains(t, body, `<meta name="twitter:card" content="summary_large_image">`)
+	assert.Contains(t, body, `<meta name="twitter:title" content="Cover.png">`)
+	assert.Contains(t, body, `<meta name="twitter:image" content="https://share.example.com/portal/view/tok1/content">`)
+}
+
+// TestPublicAssetViewerOGFallsBackToSummaryWhenNoImage asserts a non-image,
+// no-thumbnail asset still emits Twitter+OG basics but downgrades the
+// Twitter card to "summary" and omits og:image.
+func TestPublicAssetViewerOGFallsBackToSummaryWhenNoImage(t *testing.T) {
+	now := time.Now()
+	share := &Share{ID: "s1", AssetID: "a1", Token: "tok1"}
+	asset := &Asset{
+		ID: "a1", Name: "data.csv", ContentType: "text/csv",
+		S3Bucket: "b1", S3Key: "assets/a1.csv",
+		CreatedAt: now, UpdatedAt: now,
+	}
+
+	h := NewHandler(Deps{
+		AssetStore:    &mockAssetStore{getAsset: asset},
+		ShareStore:    &mockShareStore{getByTokenRes: share},
+		S3Client:      &mockS3Client{getData: []byte("a,b\n1,2"), getCT: "text/csv"},
+		PublicBaseURL: "https://share.example.com",
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/portal/view/tok1", http.NoBody)
+	req.SetPathValue("token", "tok1")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+
+	assert.NotContains(t, body, `property="og:image"`,
+		"og:image must be omitted when asset isn't an image and has no thumbnail")
+	assert.Contains(t, body, `<meta name="twitter:card" content="summary">`,
+		"twitter:card must downgrade to summary when no image is available")
+}
+
+// TestPublicCollectionViewerEmitsOGMetadata asserts collection share pages
+// emit OG/Twitter meta tags pointing at the collection's own thumbnail
+// endpoint when one is configured.
+func TestPublicCollectionViewerEmitsOGMetadata(t *testing.T) {
+	now := time.Now()
+	share := &Share{ID: "s1", Token: "tok1", CollectionID: "c1"}
+	coll := &Collection{
+		ID: "c1", Name: "Q4 Review", Description: "Executive review pack",
+		ThumbnailS3Key: "collections/c1/thumb.png",
+		CreatedAt:      now, UpdatedAt: now,
+	}
+
+	h := NewHandler(Deps{
+		AssetStore:      &mockMultiAssetStore{assets: map[string]*Asset{}},
+		ShareStore:      &mockShareStore{getByTokenRes: share},
+		CollectionStore: &mockCollectionStore{getResult: coll},
+		S3Client:        &mockS3Client{},
+		PublicBaseURL:   "https://share.example.com",
+		BrandName:       "ACME Data Platform",
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/portal/view/tok1", http.NoBody)
+	req.SetPathValue("token", "tok1")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+
+	assert.Contains(t, body, `<meta property="og:title" content="Q4 Review">`)
+	assert.Contains(t, body, `<meta property="og:description" content="Executive review pack">`)
+	assert.Contains(t, body, `<meta property="og:url" content="https://share.example.com/portal/view/tok1">`)
+	assert.Contains(t, body, `<meta property="og:image" content="https://share.example.com/portal/view/tok1/collection-thumbnail">`)
+	assert.Contains(t, body, `<meta name="twitter:card" content="summary_large_image">`)
+}
+
+// --- Public single-asset thumbnail endpoint ---
+
+func TestPublicAssetThumbnail(t *testing.T) {
+	now := time.Now()
+	share := &Share{ID: "s1", AssetID: "a1", Token: "tok1"}
+	asset := &Asset{
+		ID: "a1", Name: "doc.pdf", ContentType: "application/pdf",
+		S3Bucket: "b1", S3Key: "assets/a1.pdf", ThumbnailS3Key: "thumb/a1.png",
+		CreatedAt: now, UpdatedAt: now,
+	}
+
+	h := NewHandler(Deps{
+		AssetStore: &mockAssetStore{getAsset: asset},
+		ShareStore: &mockShareStore{getByTokenRes: share},
+		S3Client:   &mockS3Client{getData: []byte("pngdata"), getCT: "image/png"},
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/portal/view/tok1/thumbnail", http.NoBody)
+	req.SetPathValue("token", "tok1")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
+	assert.Equal(t, "public, max-age=3600", w.Header().Get("Cache-Control"))
+	assert.Equal(t, "pngdata", w.Body.String())
+}
+
+func TestPublicAssetThumbnailNotFoundWhenNoThumbKey(t *testing.T) {
+	share := &Share{ID: "s1", AssetID: "a1", Token: "tok1"}
+	asset := &Asset{ID: "a1", Name: "doc.pdf", ContentType: "application/pdf"} // no ThumbnailS3Key
+
+	h := NewHandler(Deps{
+		AssetStore: &mockAssetStore{getAsset: asset},
+		ShareStore: &mockShareStore{getByTokenRes: share},
+		S3Client:   &mockS3Client{},
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/portal/view/tok1/thumbnail", http.NoBody)
+	req.SetPathValue("token", "tok1")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestPublicAssetThumbnailRejectsCollectionShare(t *testing.T) {
+	// A collection-share token must not resolve via the single-asset
+	// thumbnail endpoint — share.AssetID is empty, so we 404.
+	share := &Share{ID: "s1", Token: "tok1", CollectionID: "c1"}
+
+	h := NewHandler(Deps{
+		AssetStore: &mockAssetStore{},
+		ShareStore: &mockShareStore{getByTokenRes: share},
+		S3Client:   &mockS3Client{},
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/portal/view/tok1/thumbnail", http.NoBody)
+	req.SetPathValue("token", "tok1")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Public collection thumbnail endpoint ---
+
+func TestPublicCollectionThumbnail(t *testing.T) {
+	now := time.Now()
+	share := &Share{ID: "s1", Token: "tok1", CollectionID: "c1"}
+	coll := &Collection{
+		ID: "c1", Name: "Q4", ThumbnailS3Key: "collections/c1/thumb.png",
+		CreatedAt: now, UpdatedAt: now,
+	}
+
+	h := NewHandler(Deps{
+		AssetStore:      &mockAssetStore{},
+		ShareStore:      &mockShareStore{getByTokenRes: share},
+		CollectionStore: &mockCollectionStore{getResult: coll},
+		S3Client:        &mockS3Client{getData: []byte("png"), getCT: "image/png"},
+		S3Bucket:        "b1",
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/portal/view/tok1/collection-thumbnail", http.NoBody)
+	req.SetPathValue("token", "tok1")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
+	assert.Equal(t, "public, max-age=3600", w.Header().Get("Cache-Control"))
+	assert.Equal(t, "png", w.Body.String())
+}
+
+func TestPublicCollectionThumbnailNotFoundWhenNoKey(t *testing.T) {
+	share := &Share{ID: "s1", Token: "tok1", CollectionID: "c1"}
+	coll := &Collection{ID: "c1", Name: "Q4"} // no ThumbnailS3Key
+
+	h := NewHandler(Deps{
+		AssetStore:      &mockAssetStore{},
+		ShareStore:      &mockShareStore{getByTokenRes: share},
+		CollectionStore: &mockCollectionStore{getResult: coll},
+		S3Client:        &mockS3Client{},
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/portal/view/tok1/collection-thumbnail", http.NoBody)
+	req.SetPathValue("token", "tok1")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestPublicCollectionThumbnailRejectsAssetShare(t *testing.T) {
+	share := &Share{ID: "s1", AssetID: "a1", Token: "tok1"}
+
+	h := NewHandler(Deps{
+		AssetStore:      &mockAssetStore{},
+		ShareStore:      &mockShareStore{getByTokenRes: share},
+		CollectionStore: &mockCollectionStore{},
+		S3Client:        &mockS3Client{},
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/portal/view/tok1/collection-thumbnail", http.NoBody)
+	req.SetPathValue("token", "tok1")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }

--- a/pkg/portal/templates/public_collection_viewer.html
+++ b/pkg/portal/templates/public_collection_viewer.html
@@ -1,34 +1,166 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>{{.Name}}</title>
+{{/* Open Graph / Twitter Card metadata for link previews. See
+     public_viewer.html for the gating rationale. */}}
+{{if .Description}}<meta name="description" content="{{.Description}}">{{end}}
+<meta property="og:type" content="website">
+<meta property="og:title" content="{{.Name}}">
+{{if .Description}}<meta property="og:description" content="{{.Description}}">{{end}}
+{{if .ShareURL}}<meta property="og:url" content="{{.ShareURL}}">{{end}}
+{{if .BrandName}}<meta property="og:site_name" content="{{.BrandName}}">{{end}}
+{{if .OGImageURL}}<meta property="og:image" content="{{.OGImageURL}}">{{end}}
+<meta name="twitter:card" content="{{if .OGImageURL}}summary_large_image{{else}}summary{{end}}">
+<meta name="twitter:title" content="{{.Name}}">
+{{if .Description}}<meta name="twitter:description" content="{{.Description}}">{{end}}
+{{if .OGImageURL}}<meta name="twitter:image" content="{{.OGImageURL}}">{{end}}
 <style>{{.ContentViewerCSS}}</style>
 <style>
-:root{--bg:#fff;--fg:#111;--muted:#666;--border:#e5e5e5;--card-bg:#fafafa;--accent:#2563eb}
-@media(prefers-color-scheme:dark){:root{--bg:#0a0a0a;--fg:#e5e5e5;--muted:#999;--border:#333;--card-bg:#1a1a1a;--accent:#60a5fa}}
-[data-theme=light]{--bg:#fff;--fg:#111;--muted:#666;--border:#e5e5e5;--card-bg:#fafafa;--accent:#2563eb}
-[data-theme=dark]{--bg:#0a0a0a;--fg:#e5e5e5;--muted:#999;--border:#333;--card-bg:#1a1a1a;--accent:#60a5fa}
+/* Header palette + body palette aliased to the same physical colors so the
+   header CSS lifted from public_viewer.html (asset viewer) and the body
+   rules (.collection-desc/.section-desc/.item-card) read consistent values.
+   Names mirror public_viewer.html's variables for easier diffing. */
+:root, [data-theme="light"] {
+  --bg: #f5f5f5;
+  --bg-surface: #fff;
+  --text: #1a1a1a;
+  --text-muted: #6b7280;
+  --page-border: #e5e5e5;
+  --badge-bg: #e5e7eb;
+  --badge-text: #374151;
+  --toggle-hover: #f3f4f6;
+  --accent: #2563eb;
+  /* Aliases for legacy body rules that still reference the old names. */
+  --fg: var(--text);
+  --muted: var(--text-muted);
+  --border: var(--page-border);
+  --card-bg: var(--bg-surface);
+}
+[data-theme="dark"] {
+  --bg: #111113;
+  --bg-surface: #1a1a1e;
+  --text: #e4e4e7;
+  --text-muted: #71717a;
+  --page-border: #27272a;
+  --badge-bg: #27272a;
+  --badge-text: #a1a1aa;
+  --toggle-hover: #27272a;
+  --accent: #60a5fa;
+  --fg: var(--text);
+  --muted: var(--text-muted);
+  --border: var(--page-border);
+  --card-bg: var(--bg-surface);
+}
 *{margin:0;padding:0;box-sizing:border-box}
-body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--fg);min-height:100vh}
-header{display:flex;align-items:center;gap:12px;padding:0 24px;height:56px;border-bottom:1px solid var(--border);background:var(--card-bg)}
-.brand{display:flex;align-items:center;gap:8px;text-decoration:none;color:var(--muted);flex-shrink:0}
-.brand a{display:flex;align-items:center;gap:8px;color:inherit;text-decoration:none}
-.brand a:hover{opacity:.8}
-.brand-logo{width:24px;height:24px;display:flex;align-items:center}
-.brand-logo svg{width:24px;height:24px}
-.brand-implementor .brand-logo{width:auto;height:28px}
-.brand-implementor .brand-logo svg{width:auto;height:28px}
-.brand-name{font-weight:500;font-size:13px;color:var(--muted)}
-.separator{width:1px;height:20px;background:var(--border);flex-shrink:0}
-.header-center{display:flex;align-items:center;gap:12px;flex:1;min-width:0}
-.header-center h1{font-size:16px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--fg)}
-.header-right{display:flex;align-items:center;gap:12px;flex-shrink:0}
-.theme-toggle{display:flex;gap:2px;border:1px solid var(--border);border-radius:6px;padding:2px}
-.theme-toggle button{background:none;border:none;padding:4px 6px;border-radius:4px;cursor:pointer;color:var(--muted);font-size:12px}
-.theme-toggle button.active{background:var(--border);color:var(--fg)}
-main{max-width:960px;margin:0 auto;padding:32px 24px}
+html, body { height: 100%; }
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+/* Header — ported verbatim from public_viewer.html so the collection
+   viewer and asset viewer share an identical header on mobile and
+   desktop. Keep these rules in sync with public_viewer.html. */
+.header {
+  box-sizing: border-box;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--page-border);
+  padding: 12px 24px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+.brand a {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: inherit;
+  text-decoration: none;
+}
+.brand a:hover { opacity: 0.8; }
+.brand-logo {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+}
+.brand-logo svg {
+  /* display:block + max-width:100% defends against operator-supplied SVGs
+     whose root element carries width="100%"/height="100%" attributes that
+     would otherwise force the logo to overflow on narrow viewports. */
+  width: 24px;
+  height: 24px;
+  display: block;
+  max-width: 100%;
+}
+.brand-implementor .brand-logo { width: auto; height: 28px; }
+.brand-implementor .brand-logo svg { width: auto; height: 28px; max-width: 100%; }
+.brand-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+.separator {
+  width: 1px;
+  height: 20px;
+  background: var(--page-border);
+  flex-shrink: 0;
+}
+.header-center {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  min-width: 0;
+}
+.header-center h1 {
+  font-size: 16px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.theme-toggle {
+  background: none;
+  border: 1px solid var(--page-border);
+  border-radius: 6px;
+  padding: 4px 6px;
+  cursor: pointer;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.15s;
+}
+.theme-toggle:hover { background: var(--toggle-hover); }
+.theme-toggle svg { width: 16px; height: 16px; }
+.notice {
+  box-sizing: border-box;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-align: center;
+  padding: 4px 24px;
+  border-bottom: 1px solid var(--page-border);
+  background: var(--bg-surface);
+  flex-shrink: 0;
+  line-height: 1.4;
+}
+main{max-width:960px;margin:0 auto;padding:32px 24px;width:100%}
 .collection-desc{margin-bottom:32px}
 .collection-desc,.section-desc{font-size:14px;line-height:1.7;color:var(--fg)}
 .collection-desc h1,.section-desc h1{font-size:1.25em;font-weight:700;margin:16px 0 8px}
@@ -79,12 +211,24 @@ main{max-width:960px;margin:0 auto;padding:32px 24px}
 .modal-close:hover{background:var(--border)}
 .modal-body{flex:1;overflow:auto;position:relative}
 .modal-body iframe{width:100%;height:100%;border:none}
-.notice{text-align:center;padding:8px;font-size:11px;color:var(--muted);border-top:1px solid var(--border)}
-.expires{font-size:11px;color:var(--muted)}
 </style>
+<script>
+/* Apply the saved theme before <body> paints to avoid a flash-of-light
+   on first render in dark mode. Mirrors the early-execution block in
+   public_viewer.html. */
+(function(){
+  var saved = null;
+  try { saved = localStorage.getItem("mdp-theme"); } catch(e) {}
+  var theme = saved === "dark" || saved === "light"
+    ? saved
+    : (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+  document.documentElement.setAttribute("data-theme", theme);
+  document.documentElement.classList.toggle("dark", theme === "dark");
+})();
+</script>
 </head>
 <body>
-<header>
+<div class="header">
   {{if or .ImplementorName .ImplementorLogoSVG}}
   <div class="brand brand-implementor">
     {{if .ImplementorURL}}<a href="{{.ImplementorURL}}" target="_blank" rel="noopener noreferrer">{{end}}
@@ -97,32 +241,35 @@ main{max-width:960px;margin:0 auto;padding:32px 24px}
   <div class="header-center">
     <h1>{{.Name}}</h1>
   </div>
-  <div class="header-right">
-    {{if and .ExpiresAtISO (not .HideExpiration)}}<span class="expires" id="expires"></span>{{end}}
-    <div class="theme-toggle">
-      <button onclick="setTheme('light')" id="tl">Light</button>
-      <button onclick="setTheme('dark')" id="td">Dark</button>
-      <button onclick="setTheme('system')" id="ts">System</button>
-    </div>
-    {{/* Platform brand block. The Go handler always populates BrandName
-         (defaults to "MCP Data Platform") and BrandLogoSVG (defaults to
-         the bundled logo SVG) in pkg/portal/public.go, so in practice these
-         are never empty — but we guard anyway for symmetry with the
-         implementor block and to remain robust to future handler changes
-         that might allow opting out. {{.BrandLogoSVG}} is rendered as
-         template.HTML by the handler (see public.go: template.HTML(brandLogo)),
-         so the inline SVG passes through unescaped. */}}
-    {{if or .BrandName .BrandLogoSVG}}
-    <div class="separator"></div>
-    <div class="brand brand-platform">
-      {{if .BrandURL}}<a href="{{.BrandURL}}" target="_blank" rel="noopener noreferrer">{{end}}
-      {{if .BrandLogoSVG}}<div class="brand-logo">{{.BrandLogoSVG}}</div>{{end}}
-      {{if .BrandName}}<span class="brand-name">{{.BrandName}}</span>{{end}}
-      {{if .BrandURL}}</a>{{end}}
-    </div>
-    {{end}}
+  <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+    <svg id="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+    <svg id="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+  </button>
+  {{/* Platform brand block. The Go handler always populates BrandName
+       (defaults to "MCP Data Platform") and BrandLogoSVG (defaults to
+       the bundled logo SVG) in pkg/portal/public.go, so in practice these
+       are never empty — but we guard anyway for symmetry with the
+       implementor block and to remain robust to future handler changes
+       that might allow opting out. {{.BrandLogoSVG}} is rendered as
+       template.HTML by the handler (see public.go: template.HTML(brandLogo)),
+       so the inline SVG passes through unescaped. */}}
+  {{if or .BrandName .BrandLogoSVG}}
+  <div class="separator"></div>
+  <div class="brand brand-platform">
+    {{if .BrandURL}}<a href="{{.BrandURL}}" target="_blank" rel="noopener noreferrer">{{end}}
+    {{if .BrandLogoSVG}}<div class="brand-logo">{{.BrandLogoSVG}}</div>{{end}}
+    {{if .BrandName}}<span class="brand-name">{{.BrandName}}</span>{{end}}
+    {{if .BrandURL}}</a>{{end}}
   </div>
-</header>
+  {{end}}
+</div>
+{{if or .NoticeText (and .ExpiresAtISO (not .HideExpiration))}}
+<div class="notice" id="notice">
+  {{if and .ExpiresAtISO (not .HideExpiration)}}<span id="expires">This page expires <span id="expiry-rel"></span></span>{{end}}
+  {{if and .ExpiresAtISO (not .HideExpiration) .NoticeText}}<span class="notice-sep"> &middot; </span>{{end}}
+  {{if .NoticeText}}<span>{{.NoticeText}}</span>{{end}}
+</div>
+{{end}}
 
 <main id="main"></main>
 
@@ -136,37 +283,60 @@ main{max-width:960px;margin:0 auto;padding:32px 24px}
   </div>
 </div>
 
-{{if .NoticeText}}<div class="notice">{{.NoticeText}}</div>{{end}}
-
 <script type="application/json" id="collection-data">{{.CollectionJSON}}</script>
 <script>{{.ContentViewerJS}}</script>
 <script>
 (function(){
-  var theme = localStorage.getItem('mdp-theme') || 'system';
-  function applyTheme(t){
-    theme = t; localStorage.setItem('mdp-theme', t);
-    var isDark = t === 'dark' || (t === 'system' && window.matchMedia('(prefers-color-scheme:dark)').matches);
-    document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
-    document.documentElement.classList.toggle('dark', isDark);
-    document.querySelectorAll('.theme-toggle button').forEach(function(b){b.className=''});
-    var btn = document.getElementById(t==='light'?'tl':t==='dark'?'td':'ts');
-    if(btn) btn.className='active';
-  }
-  window.setTheme = applyTheme;
-  applyTheme(theme);
+  // Theme toggle — mirrors public_viewer.html's single sun/moon button.
+  // Persists under the same `mdp-theme` key the asset viewer uses, so
+  // navigating between a single-asset share and a collection share keeps
+  // the user's choice. Treat any persisted "system" value (from prior
+  // builds that exposed Light/Dark/System) as a request to follow the
+  // OS preference at render time, then upgrade to the resolved theme.
+  var html = document.documentElement;
+  var btn = document.getElementById('theme-toggle');
+  var sunIcon = document.getElementById('icon-sun');
+  var moonIcon = document.getElementById('icon-moon');
 
-  // Expiration countdown
+  function applyTheme(t){
+    if(t !== 'dark' && t !== 'light'){
+      t = window.matchMedia('(prefers-color-scheme:dark)').matches ? 'dark' : 'light';
+    }
+    html.setAttribute('data-theme', t);
+    html.classList.toggle('dark', t === 'dark');
+    if(sunIcon) sunIcon.style.display = t === 'dark' ? 'block' : 'none';
+    if(moonIcon) moonIcon.style.display = t === 'dark' ? 'none' : 'block';
+  }
+
+  var saved = null;
+  try { saved = localStorage.getItem('mdp-theme'); } catch(e) {}
+  applyTheme(saved || (window.matchMedia('(prefers-color-scheme:dark)').matches ? 'dark' : 'light'));
+
+  if(btn){
+    btn.addEventListener('click', function(){
+      var next = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      applyTheme(next);
+      try { localStorage.setItem('mdp-theme', next); } catch(e) {}
+    });
+  }
+
+  // Expiration text rendered in the .notice band (parity with asset viewer):
+  // "This page expires in N day(s)/hour(s)/minute(s)". Computed once on load
+  // — short-share TTLs are typically days, so a per-minute interval would
+  // be needless work; the asset viewer also computes once.
+  var expiryEl = document.getElementById('expiry-rel');
   var expiresISO = '{{.ExpiresAtISO}}';
-  if(expiresISO){
-    var el = document.getElementById('expires');
-    if(el){
-      function updateExpiry(){
-        var diff = new Date(expiresISO) - Date.now();
-        if(diff <= 0){ el.textContent = 'Expired'; return; }
-        var h = Math.floor(diff/3600000), m = Math.floor((diff%3600000)/60000);
-        el.textContent = 'Expires in ' + (h > 0 ? h + 'h ' : '') + m + 'm';
-      }
-      updateExpiry(); setInterval(updateExpiry, 60000);
+  if(expiryEl && expiresISO){
+    var diff = new Date(expiresISO) - new Date();
+    if(diff > 0){
+      var mins = Math.floor(diff / 60000);
+      var hrs = Math.floor(mins / 60);
+      var days = Math.floor(hrs / 24);
+      if(days > 0) expiryEl.textContent = 'in ' + days + ' day' + (days !== 1 ? 's' : '');
+      else if(hrs > 0) expiryEl.textContent = 'in ' + hrs + ' hour' + (hrs !== 1 ? 's' : '');
+      else expiryEl.textContent = 'in ' + Math.max(1, mins) + ' minute' + (mins !== 1 ? 's' : '');
+    } else {
+      expiryEl.textContent = 'soon';
     }
   }
 

--- a/pkg/portal/templates/public_viewer.html
+++ b/pkg/portal/templates/public_viewer.html
@@ -4,6 +4,23 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{.Name}}</title>
+    {{/* Open Graph / Twitter Card metadata for link previews on Slack,
+         iMessage, Twitter/X, LinkedIn, etc. ShareURL and OGImageURL are
+         absolute URLs computed in renderAssetViewer; when either is empty
+         (no PublicBaseURL set and no resolvable Host), the corresponding
+         tag is omitted — most platforms tolerate missing og:image but
+         require og:url to be absolute, so we never emit a relative one. */}}
+    {{if .Description}}<meta name="description" content="{{.Description}}">{{end}}
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="{{.Name}}">
+    {{if .Description}}<meta property="og:description" content="{{.Description}}">{{end}}
+    {{if .ShareURL}}<meta property="og:url" content="{{.ShareURL}}">{{end}}
+    {{if .BrandName}}<meta property="og:site_name" content="{{.BrandName}}">{{end}}
+    {{if .OGImageURL}}<meta property="og:image" content="{{.OGImageURL}}">{{end}}
+    <meta name="twitter:card" content="{{if .OGImageURL}}summary_large_image{{else}}summary{{end}}">
+    <meta name="twitter:title" content="{{.Name}}">
+    {{if .Description}}<meta name="twitter:description" content="{{.Description}}">{{end}}
+    {{if .OGImageURL}}<meta name="twitter:image" content="{{.OGImageURL}}">{{end}}
     <style>
         :root, [data-theme="light"] {
             --bg: #f5f5f5;
@@ -90,8 +107,14 @@
             align-items: center;
         }
         .brand-logo svg {
+            /* display:block + max-width:100% defend against operator-supplied
+               SVGs whose root element carries width="100%"/height="100%"
+               attributes that would otherwise force the logo to overflow on
+               narrow viewports. */
             width: 24px;
             height: 24px;
+            display: block;
+            max-width: 100%;
         }
         .brand-implementor .brand-logo {
             width: auto;
@@ -100,6 +123,7 @@
         .brand-implementor .brand-logo svg {
             width: auto;
             height: 28px;
+            max-width: 100%;
         }
         .brand-name {
             font-size: 13px;


### PR DESCRIPTION
## Summary

- **Public collection viewer header** now mirrors the asset viewer's header structure exactly — same single sun/moon theme toggle, same `.notice` band for expiration, same SVG-defensive CSS — so both viewers fit the same way on mobile and the implementor logo can no longer overflow on narrow viewports.
- **Open Graph and Twitter Card metadata** is emitted by both viewers, so links shared in Slack, iMessage, X/Twitter, LinkedIn, etc. unfurl with a title, description, site name, and a preview image when available.
- **Two new public endpoints** serve the OG image when the asset is non-image or when the collection has its own thumbnail: `GET /portal/view/{token}/thumbnail` and `GET /portal/view/{token}/collection-thumbnail`.

## Background

Two independent issues with the public share viewers, surfaced together because they touch the same templates.

### Header parity / mobile fit

PR #359 brought the collection viewer's header structure into rough alignment with the asset viewer's, but the two diverged in several details that affect mobile:

- The collection viewer used a 3-button **Light / Dark / System** toggle group; the asset viewer uses a single sun/moon icon button. The 3-button group eats more horizontal space, which on narrow viewports forces other header elements to compress.
- The collection viewer had no `.notice` band — expiration text was inlined in `header-right` next to the theme toggle, further crowding the header on mobile.
- Neither template guarded against operator-supplied SVGs whose root element carries `width=\"100%\" height=\"100%\"` attributes. Those SVGs ignore CSS `width: auto` in some browsers and overflow the header on narrow viewports.
- The collection viewer had a brief flash-of-light on dark-mode first paint because its theme script ran from `<body>` rather than `<head>`.

### OG / Twitter Card metadata

When a public share URL is pasted into Slack, iMessage, or any social-media client, the unfurler fetches the page and reads `<meta>` tags. Without `og:title` / `og:description` / `og:image` it shows just the bare URL. Both public viewers (asset and collection) shipped without any OG tags at all.

## What changed

### Header parity

- **`pkg/portal/templates/public_collection_viewer.html`**: replaced the header CSS + HTML with a near-verbatim copy of `public_viewer.html`'s `.header` block. Same single-button theme toggle (sun/moon icons), same `.notice` band (positioned just below the header) for expiration text and `NoticeText`, same color variables. The legacy body-content variables (`--fg`, `--muted`, `--border`, `--card-bg`) are preserved as aliases so `.collection-desc`, `.section-desc`, and `.item-card` rules still resolve.
- **Theme persistence**: chosen theme now persists under the same `mdp-theme` key the asset viewer uses, so navigating between a single-asset share and a collection share preserves the user's preference.
- **Flash-of-light fix**: an early-execution theme script runs from `<head>` before `<body>` paints, mirroring the asset viewer.
- **SVG defense in both templates**: `.brand-logo svg` now also sets `display: block; max-width: 100%`, which prevents operator-supplied SVGs that declare `width=\"100%\" height=\"100%\"` from overflowing the header. The `.brand-implementor` variant additionally caps `max-width: 100%` for the same reason.

### OG / Twitter Card metadata

Both `public_viewer.html` and `public_collection_viewer.html` now emit:

- `og:type=\"website\"`
- `og:title` (asset/collection name)
- `og:description` (when description is non-empty)
- `og:url` (canonical share URL)
- `og:site_name` (`BrandName`)
- `og:image` (when an image source is available)
- Twitter Card variants (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`). The card upgrades to `summary_large_image` when an image is present and downgrades to `summary` otherwise.

**`og:image` source priority**:

| Viewer | Priority |
| --- | --- |
| Single asset | image-typed asset content → asset thumbnail → none |
| Collection | collection's own thumbnail → first item with a thumbnail → none |

When no image source resolves, `og:image` is omitted entirely and the Twitter card downgrades to `summary` rather than emitting a broken reference.

### New public endpoints

To back the `og:image` URLs for non-image-typed assets and collections with their own thumbnails:

- `GET /portal/view/{token}/thumbnail` — serves `asset.ThumbnailS3Key` for the asset behind a single-asset share. Mirrors the existing `…/items/{assetId}/thumbnail` handler but resolves the asset via the share token alone (no path-bound `assetId`). 404 when the share is a collection share, when no thumbnail key is set, or when S3 fetch fails.
- `GET /portal/view/{token}/collection-thumbnail` — serves `coll.ThumbnailS3Key` for a collection share. 404 when the share is an asset share, when no thumbnail is uploaded, or when S3 fetch fails.

Both endpoints are rate-limited via the existing `h.rateLimiter` middleware and set `Cache-Control: public, max-age=3600` to match the existing item-thumbnail endpoint.

### Base URL resolution

`resolvePublicBaseURL` (`pkg/portal/public.go`) prefers `portal.public_base_url` when set, then falls back to the inbound request's scheme + Host so OG tags work even when the operator hasn't set the base URL. Hardening:

- Direct-TLS requests (`r.TLS != nil`) ignore `X-Forwarded-Proto` so an attacker cannot downgrade `og:url` to `http://`.
- Non-TLS requests honor the header but only when its first comma-separated token (multi-proxy chains can produce `\"https, http\"`) is exactly `http` or `https`. Bogus values fall back to the default scheme. This keeps `og:url` well-formed regardless of upstream proxy quirks.
- When neither config nor request resolves, the absolute-URL OG tags are omitted entirely rather than emitting relative URLs that crawlers reject.

## Test plan

Coverage adds tests for every new code path. **`make verify` is clean** (all gates: fmt → test+race → lint → security → coverage → dead-code → mutate → release-check).

### Resolver / base URL

- Configured `PublicBaseURL` wins; trailing `/` is trimmed.
- Falls back to request `scheme://Host` when config is empty.
- `X-Forwarded-Proto: https` upgrades scheme behind a non-TLS proxy.
- `X-Forwarded-Proto: \"https, http\"` (multi-proxy chain) takes the first token only.
- `X-Forwarded-Proto: javascript` (bogus value) falls back to the default scheme.
- Direct-TLS request (`r.TLS != nil`) cannot be downgraded to `http://` by an attacker-supplied `X-Forwarded-Proto: http`.
- Empty when neither config nor `Host` is available.

### OG image source selection

- Asset viewer: image-typed content → `/content` URL.
- Asset viewer: non-image with thumbnail → `/thumbnail` URL.
- Asset viewer: non-image, no thumbnail → empty.
- Collection viewer: collection thumbnail → `/collection-thumbnail` URL.
- Collection viewer: no collection thumb, first item with thumb → `/items/{id}/thumbnail` URL.
- Collection viewer: nothing → empty.
- Empty `baseURL` → empty for both helpers.
- `nil` asset / collection → empty without panic.

### Template emission

- Image-typed asset viewer: emits `og:type/title/description/url/site_name/image` and Twitter card upgraded to `summary_large_image`.
- Non-image, no-thumbnail asset viewer: omits `og:image`, downgrades Twitter card to `summary`.
- Collection viewer with thumbnail: emits the full set with `og:image` pointing at `/collection-thumbnail`.

### Endpoint behavior

- `/thumbnail`: 200 + correct `Content-Type` + `Cache-Control: public, max-age=3600` for valid asset share with thumbnail key.
- `/thumbnail`: 404 when no thumbnail key set.
- `/thumbnail`: 404 when token resolves to a collection share (cross-type rejection).
- `/collection-thumbnail`: 200 for valid collection share with thumbnail.
- `/collection-thumbnail`: 404 when collection has no thumbnail.
- `/collection-thumbnail`: 404 when token resolves to an asset share.

### Manual verification (recommended on first deploy)

- [ ] Paste a single-asset share URL into Slack — preview unfurls with title, description, and (for image assets) the asset itself or thumbnail.
- [ ] Paste a collection share URL into Slack — preview unfurls with title, description, and the collection thumbnail (if uploaded).
- [ ] Open a collection share on a phone-width viewport — header fits without horizontal scroll, theme toggle is the single sun/moon button.
- [ ] Open a collection share with a wide-aspect implementor logo on a phone-width viewport — logo no longer overflows.
- [ ] Toggle theme on the asset viewer, then navigate to a collection share via the modal — theme preference is preserved.