### PR TITLE
feat(apigateway): HTTP API gateway with api_invoke_endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,11 +85,12 @@ AI-generated prose (PR descriptions, commit messages, reviews, explanations) is 
    - Framework callbacks (e.g., MCP handlers that require client connections) may be excluded if the actual logic is extracted and tested separately
 
 3. **Testing Definition**: When asked to "test" or "testing" the code, this means running `make verify`, which executes the full CI-equivalent suite:
+   - **Tools-check (parity gate)** — verifies local `golangci-lint` and `gosec` versions equal `GOLANGCI_LINT_VERSION` and `GOSEC_VERSION` in the Makefile (which mirror `.github/workflows/ci.yml`). Drifting local tool versions are the most insidious parity gap: a newer local gosec can silently relax a rule that CI's pinned version still enforces, letting a real bug ship to PR. `make verify` refuses to run until local matches CI. Override with `TOOLS_CHECK_STRICT=0` only with explicit reason.
    - Code formatting (`gofmt -s -w .`)
    - Unit tests with race detection (`go test -race ./...`)
    - Coverage verification — total must be ≥80% (hard gate)
    - Patch coverage — changed lines vs main must be ≥80% (mirrors codecov patch check)
-   - Linting (`golangci-lint run ./...`) — cyclomatic complexity ≤10, cognitive complexity ≤15
+   - Linting (`golangci-lint run ./...` plus `--new-from-rev=$MERGE_BASE` to mirror CI's `only-new-issues: true`) — cyclomatic complexity ≤10, cognitive complexity ≤15
    - Security scanning (`gosec ./...` + `govulncheck`)
    - Semgrep SAST — `p/golang` ruleset + custom `.semgrep/` rules (unbounded allocations, etc.)
    - CodeQL analysis — `security-and-quality` query suite, fails on error-level findings
@@ -98,6 +99,8 @@ AI-generated prose (PR descriptions, commit messages, reviews, explanations) is 
    - Mutation testing (`gremlins unleash --threshold-efficacy 60`) — ≥60% kill rate
    - GoReleaser dry-run — validates build, Docker, and release config
    - All checks must pass locally before considering code "tested"
+
+   **Parity-gap incident (2026-05-08, PR #377)**: local `gosec 2.26.1` silently dropped the G704 SSRF taint rule that CI's pinned `v2.22.0` enforces. `make verify` passed locally; CI rejected the same diff with a real SSRF bug. The tools-check version pin is the structural fix — discipline alone has been insufficient.
 
 4. **CRITICAL - Coverage Verification Before Completion**: Before declaring ANY implementation task complete:
    - Run `go test -coverprofile=coverage.out ./...` (note: `./...` not `./pkg/...` — covers `cmd/` too)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ GOMOD := $(GO) mod
 GOFMT := gofmt
 GOLINT := golangci-lint
 
-.PHONY: all build test lint fmt clean install help docs-serve docs-build verify \
+.PHONY: all build test lint lint-full fmt clean install help docs-serve docs-build verify \
 	tools-check dead-code mutate patch-coverage doc-check swagger swagger-check \
 	semgrep codeql sast embed-clean \
 	frontend-install frontend-build frontend-build-content-viewer \
@@ -68,15 +68,48 @@ coverage: test
 	$(GO) tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report: coverage.html"
 
-## lint: Run linter (full + patch-scoped to match CI)
+## lint: Run patch-scoped linter (matches CI's only-new-issues=true exactly)
+##
+## CI's golangci-lint-action runs with only-new-issues=true, so it only
+## reports findings on lines changed in the PR. To prevent the parity gap
+## where local fails on pre-existing issues that CI doesn't enforce, this
+## target mirrors CI exactly. Use `make lint-full` to scan the entire
+## codebase (useful for housekeeping; not part of `make verify`).
+##
+## Merge-base is computed against origin/main when available (matches CI's
+## PR base ref) and falls back to local main. If neither is reachable
+## (detached HEAD on a fresh clone, etc.) the patch lint is skipped with
+## a warning rather than silently passing.
 lint:
-	@echo "Running linter..."
-	$(GOLINT) run ./...
 	@echo "Running patch-scoped lint (matches CI only-new-issues)..."
-	@MERGE_BASE=$$(git merge-base main HEAD 2>/dev/null) || true; \
-	if [ -n "$$MERGE_BASE" ] && [ "$$MERGE_BASE" != "$$(git rev-parse HEAD)" ]; then \
-		$(GOLINT) run --new-from-rev=$$MERGE_BASE ./...; \
-	fi
+	@if git rev-parse origin/main >/dev/null 2>&1; then \
+		BASE=origin/main; \
+	elif git rev-parse main >/dev/null 2>&1; then \
+		BASE=main; \
+	else \
+		echo "WARN: neither origin/main nor main is reachable; skipping patch lint."; \
+		echo "      Run \`git fetch origin main\` to enable CI-equivalent linting."; \
+		exit 0; \
+	fi; \
+	MERGE_BASE=$$(git merge-base $$BASE HEAD 2>/dev/null); \
+	if [ -z "$$MERGE_BASE" ]; then \
+		echo "WARN: could not compute merge-base against $$BASE; skipping patch lint."; \
+		exit 0; \
+	fi; \
+	if [ "$$MERGE_BASE" = "$$(git rev-parse HEAD)" ]; then \
+		echo "HEAD == merge-base ($$BASE); no PR diff to lint."; \
+		exit 0; \
+	fi; \
+	echo "Linting against merge-base $$MERGE_BASE (from $$BASE)"; \
+	$(GOLINT) run --new-from-rev=$$MERGE_BASE ./...
+
+## lint-full: Run linter against the ENTIRE codebase (not chained into verify)
+##
+## CI does not enforce findings on pre-existing code, so neither does
+## `make verify`. This target exists for housekeeping passes.
+lint-full:
+	@echo "Running full-codebase linter (informational; not enforced by CI)..."
+	$(GOLINT) run ./...
 
 ## lint-fix: Run linter with auto-fix
 lint-fix:
@@ -236,12 +269,41 @@ swagger-check: swagger
 		exit 1; \
 	fi
 
-## tools-check: Verify all required tools are installed before running verify
+## tools-check: Verify all required tools are installed AND pinned to CI versions
+##
+## Local-vs-CI tool version drift is the most insidious parity gap: different
+## golangci-lint or gosec versions enable different rules with different
+## defaults, so `make verify` can pass locally while CI rejects the same
+## diff. Concrete incident on 2026-05-08: local gosec 2.26.1 silently dropped
+## the G704 SSRF taint rule that CI's pinned v2.22.0 enforces, letting an
+## actual SSRF bug ship to PR #377. See feedback_gate_metric.md.
 tools-check:
-	@echo "Checking required tools..."
-	@missing=""; \
-	which golangci-lint > /dev/null 2>&1 || missing="$$missing  golangci-lint: go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)\n"; \
-	which gosec > /dev/null 2>&1         || missing="$$missing  gosec: go install github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION)\n"; \
+	@echo "Checking required tools (presence AND pinned versions)..."
+	@missing=""; mismatch=""; \
+	if ! which golangci-lint > /dev/null 2>&1; then \
+		missing="$$missing  golangci-lint: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)\n"; \
+	else \
+		v=$$(go version -m $$(which golangci-lint) 2>/dev/null | awk '$$1=="mod" && $$2 ~ /golangci-lint/ {print $$3}'); \
+		if [ -z "$$v" ] || [ "$$v" = "(devel)" ]; then \
+			v=$$(golangci-lint version 2>&1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1); \
+			case "$$v" in v*) ;; *) v="v$$v";; esac; \
+		fi; \
+		if [ "$$v" != "$(GOLANGCI_LINT_VERSION)" ]; then \
+			mismatch="$$mismatch  golangci-lint: have $$v, want $(GOLANGCI_LINT_VERSION) — go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)\n"; \
+		fi; \
+	fi; \
+	if ! which gosec > /dev/null 2>&1; then \
+		missing="$$missing  gosec: go install github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION)\n"; \
+	else \
+		v=$$(go version -m $$(which gosec) 2>/dev/null | awk '$$1=="mod" && $$2 ~ /gosec/ {print $$3}'); \
+		if [ -z "$$v" ] || [ "$$v" = "(devel)" ]; then \
+			v=$$(gosec --version 2>&1 | grep -oE 'Version: v?[0-9]+\.[0-9]+\.[0-9]+' | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1); \
+			case "$$v" in v*) ;; *) v="v$$v";; esac; \
+		fi; \
+		if [ "$$v" != "$(GOSEC_VERSION)" ]; then \
+			mismatch="$$mismatch  gosec: have $$v, want $(GOSEC_VERSION) — go install github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION)\n"; \
+		fi; \
+	fi; \
 	which govulncheck > /dev/null 2>&1   || missing="$$missing  govulncheck: go install golang.org/x/vuln/cmd/govulncheck@latest\n"; \
 	which semgrep > /dev/null 2>&1       || missing="$$missing  semgrep: pip3 install semgrep\n"; \
 	which codeql > /dev/null 2>&1        || missing="$$missing  codeql: brew install codeql\n"; \
@@ -252,12 +314,26 @@ tools-check:
 	if [ -n "$$missing" ]; then \
 		echo ""; \
 		echo "FAIL: Missing required tools:"; \
-		printf "$$missing"; \
+		printf '%b' "$$missing"; \
 		echo ""; \
 		echo "Install all missing tools before running make verify."; \
 		exit 1; \
+	fi; \
+	if [ -n "$$mismatch" ]; then \
+		echo ""; \
+		echo "FAIL: Tool version mismatch (local differs from CI-pinned)."; \
+		echo "Local versions that drift from CI's create silent parity gaps:"; \
+		echo "make verify can pass while CI rejects the same diff."; \
+		echo ""; \
+		printf '%b' "$$mismatch"; \
+		echo ""; \
+		echo "Pin local tools to the CI versions before running make verify."; \
+		echo "(Override with TOOLS_CHECK_STRICT=0 only if you know what you are doing.)"; \
+		if [ "$(TOOLS_CHECK_STRICT)" != "0" ]; then exit 1; fi; \
+		echo "WARN: proceeding with mismatched tool versions (TOOLS_CHECK_STRICT=0)."; \
+	else \
+		echo "All required tools found at pinned CI versions."; \
 	fi
-	@echo "All required tools found."
 
 ## embed-clean: Reset UI embed dirs to .gitkeep only (matches CI clean checkout)
 embed-clean:

--- a/pkg/admin/connection_handler.go
+++ b/pkg/admin/connection_handler.go
@@ -35,6 +35,7 @@ const (
 	connectionKindMCP   = "mcp"
 	connectionKindTrino = "trino"
 	connectionKindS3    = "s3"
+	connectionKindAPI   = "api"
 )
 
 // knownConnectionKinds lists the toolkit kinds that support multiple configurable
@@ -44,6 +45,7 @@ var knownConnectionKinds = map[string]bool{
 	connectionKindTrino: true,
 	connectionKindS3:    true,
 	connectionKindMCP:   true,
+	connectionKindAPI:   true,
 }
 
 // registerConnectionRoutes registers connection instance CRUD endpoints.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -2791,10 +2791,15 @@ func (p *Platform) mergeDBConnectionsIntoConfig() {
 		p.config.Toolkits = make(map[string]any)
 	}
 
-	// (1) The gateway toolkit needs no instance config to be useful —
+	// (1) The gateway toolkits need no instance config to be useful —
 	// auto-enable so the admin UI's "Add Connection" path produces a
-	// live toolkit on the next request.
+	// live toolkit on the next request. Both the MCP gateway (#338)
+	// and the HTTP API gateway (#364) follow the same convention:
+	// connections are added dynamically through the admin UI rather
+	// than via YAML 'instances' blocks, so the kind has to be
+	// pre-enabled for saves to land in a live toolkit.
 	p.autoEnableToolkitKind(kindMCP)
+	p.autoEnableToolkitKind(kindAPI)
 
 	instances, err := p.connectionStore.List(context.Background())
 	if err != nil {
@@ -2807,7 +2812,12 @@ func (p *Platform) mergeDBConnectionsIntoConfig() {
 
 	// Only merge connections for kinds that support DB management.
 	// Datahub is single-instance and managed via YAML only.
-	manageableKinds := map[string]bool{kindTrino: true, kindS3: true, kindMCP: true}
+	manageableKinds := map[string]bool{
+		kindTrino: true,
+		kindS3:    true,
+		kindMCP:   true,
+		kindAPI:   true,
+	}
 
 	for _, inst := range instances {
 		if manageableKinds[inst.Kind] {

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -4117,11 +4117,12 @@ func TestMergeDBConnectionsIntoConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("auto-enables mcp gateway toolkit even with no instances", func(t *testing.T) {
-		// Gateway connections are added dynamically via the admin UI, so
-		// the toolkit must be live BEFORE any instance exists. Otherwise
-		// the admin "Add Connection" form is silently inert: the row
-		// saves to the DB but the toolkit doesn't exist to register it.
+	t.Run("auto-enables mcp and api gateway toolkits even with no instances", func(t *testing.T) {
+		// Both gateway toolkits accept connections dynamically through
+		// the admin UI rather than via YAML 'instances' blocks, so each
+		// kind must be live BEFORE any instance exists. Otherwise the
+		// admin "Add Connection" form is silently inert: the row saves
+		// to the DB but the toolkit doesn't exist to register it.
 		p := &Platform{
 			config: &Config{
 				Toolkits: map[string]any{
@@ -4138,6 +4139,13 @@ func TestMergeDBConnectionsIntoConfig(t *testing.T) {
 		}
 		if enabled, _ := mcpKind[cfgKeyEnabled].(bool); !enabled {
 			t.Error("auto-enabled mcp kind must have enabled=true")
+		}
+		apiKind, ok := p.config.Toolkits[kindAPI].(map[string]any)
+		if !ok {
+			t.Fatal("api gateway toolkit must auto-enable whenever a connection store is available")
+		}
+		if enabled, _ := apiKind[cfgKeyEnabled].(bool); !enabled {
+			t.Error("auto-enabled api kind must have enabled=true")
 		}
 	})
 
@@ -4258,6 +4266,9 @@ func TestMergeDBConnectionsIntoConfig(t *testing.T) {
 		if _, ok := p.config.Toolkits[kindMCP]; !ok {
 			t.Error("mcp gateway toolkit must auto-enable when persistent store is present")
 		}
+		if _, ok := p.config.Toolkits[kindAPI]; !ok {
+			t.Error("api gateway toolkit must auto-enable when persistent store is present")
+		}
 		if _, ok := p.config.Toolkits["trino"]; !ok {
 			t.Error("trino toolkit must auto-enable when DB instance exists")
 		}
@@ -4286,8 +4297,44 @@ func TestMergeDBConnectionsIntoConfig(t *testing.T) {
 		if _, ok := p.config.Toolkits[kindMCP]; ok {
 			t.Error("non-persistent store must not auto-enable mcp gateway")
 		}
+		if _, ok := p.config.Toolkits[kindAPI]; ok {
+			t.Error("non-persistent store must not auto-enable api gateway")
+		}
 		if _, ok := p.config.Toolkits["trino"]; ok {
 			t.Error("non-persistent store must not auto-enable trino")
+		}
+	})
+
+	t.Run("merges api-kind DB instance into toolkit config", func(t *testing.T) {
+		// A `Kind: "api"` connection saved through the admin UI must
+		// land in p.config.Toolkits["api"].instances so the toolkit
+		// loader instantiates a per-instance config at startup. Drop
+		// either the autoEnableToolkitKind(kindAPI) call or the kindAPI
+		// entry in manageableKinds and this test fails.
+		p := &Platform{
+			config: &Config{},
+			connectionStore: &mockConnectionStoreForTest{
+				instances: []ConnectionInstance{
+					{Kind: kindAPI, Name: "vendor", Config: map[string]any{"base_url": "https://api.vendor.example"}},
+				},
+			},
+		}
+		p.mergeDBConnectionsIntoConfig()
+
+		apiKind, ok := p.config.Toolkits[kindAPI].(map[string]any)
+		if !ok {
+			t.Fatal("api kind block missing after merge")
+		}
+		instances, ok := apiKind[cfgKeyInstances].(map[string]any)
+		if !ok {
+			t.Fatal("api kind has no instances map after merge")
+		}
+		vendor, ok := instances["vendor"].(map[string]any)
+		if !ok {
+			t.Fatal("vendor instance missing")
+		}
+		if vendor["base_url"] != "https://api.vendor.example" {
+			t.Errorf("base_url = %v; want %q", vendor["base_url"], "https://api.vendor.example")
 		}
 	})
 }

--- a/pkg/platform/prompts.go
+++ b/pkg/platform/prompts.go
@@ -23,6 +23,7 @@ const (
 	kindKnowledge  = "knowledge"
 	kindMemory     = "memory"
 	kindMCP        = "mcp"
+	kindAPI        = "api"
 	// promptArgTopic is the argument name shared across workflow prompts
 	// that take a free-form subject ("explore", "create-dashboard", etc.).
 	promptArgTopic = "topic"

--- a/pkg/registry/factories.go
+++ b/pkg/registry/factories.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"fmt"
 
+	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
 	datahubkit "github.com/txn2/mcp-data-platform/pkg/toolkits/datahub"
 	gatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/gateway"
 	s3kit "github.com/txn2/mcp-data-platform/pkg/toolkits/s3"
@@ -15,6 +16,7 @@ func RegisterBuiltinFactories(r *Registry) {
 	r.RegisterFactory("datahub", DataHubFactory)
 	r.RegisterFactory("s3", S3Factory)
 	r.RegisterAggregateFactory(gatewaykit.Kind, GatewayAggregateFactory)
+	r.RegisterAggregateFactory(apigatewaykit.Kind, APIGatewayAggregateFactory)
 }
 
 // TrinoAggregateFactory creates a single multi-connection Trino toolkit
@@ -82,4 +84,19 @@ func GatewayAggregateFactory(defaultName string, instances map[string]map[string
 		return nil, fmt.Errorf("parsing gateway multi config: %w", err)
 	}
 	return gatewaykit.NewMulti(cfg), nil
+}
+
+// APIGatewayAggregateFactory creates a multi-connection api-gateway
+// toolkit from all configured instances. Per-instance config parse
+// errors fail the factory; per-connection materialization failures
+// (auth-builder errors) are logged and skipped so a single bad
+// connection cannot block platform startup. Outbound HTTP failures
+// happen at invocation time and are surfaced through the tool's
+// response envelope, not at startup.
+func APIGatewayAggregateFactory(defaultName string, instances map[string]map[string]any) (Toolkit, error) {
+	cfg, err := apigatewaykit.ParseMultiConfig(defaultName, instances)
+	if err != nil {
+		return nil, fmt.Errorf("parsing apigateway multi config: %w", err)
+	}
+	return apigatewaykit.NewMulti(cfg), nil
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -394,6 +394,46 @@ func TestGatewayAggregateFactory_BadInstanceConfigReturnsError(t *testing.T) {
 	}
 }
 
+func TestAPIGatewayAggregateFactory_NoInstancesReturnsEmptyToolkit(t *testing.T) {
+	tk, err := APIGatewayAggregateFactory(regTestTest, map[string]map[string]any{})
+	if err != nil {
+		t.Fatalf("APIGatewayAggregateFactory: %v", err)
+	}
+	if tk.Kind() != "api" {
+		t.Errorf("Kind: got %q, want %q", tk.Kind(), "api")
+	}
+	if got := tk.Tools(); len(got) != 1 || got[0] != "api_invoke_endpoint" {
+		t.Errorf("expected [api_invoke_endpoint], got %v", got)
+	}
+	_ = tk.Close()
+}
+
+func TestAPIGatewayAggregateFactory_BadInstanceConfigReturnsError(t *testing.T) {
+	_, err := APIGatewayAggregateFactory(regTestTest, map[string]map[string]any{
+		"broken": {}, // missing base_url
+	})
+	if err == nil {
+		t.Fatal("expected parse error for missing base_url")
+	}
+}
+
+func TestAPIGatewayAggregateFactory_LoadsValidInstance(t *testing.T) {
+	tk, err := APIGatewayAggregateFactory(regTestTest, map[string]map[string]any{
+		"acme": {
+			"base_url":   "https://api.example.com",
+			"auth_mode":  "bearer",
+			"credential": "tok",
+		},
+	})
+	if err != nil {
+		t.Fatalf("APIGatewayAggregateFactory: %v", err)
+	}
+	if tk.Kind() != "api" {
+		t.Errorf("Kind: got %q, want %q", tk.Kind(), "api")
+	}
+	_ = tk.Close()
+}
+
 func TestGatewayAggregateFactory_UnreachableInstanceAbsorbed(t *testing.T) {
 	// Unreachable endpoint must not fail the factory — the toolkit still
 	// constructs and the platform startup continues. The failed initial

--- a/pkg/toolkits/apigateway/auth.go
+++ b/pkg/toolkits/apigateway/auth.go
@@ -1,0 +1,108 @@
+package apigateway
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// Authenticator applies a connection's authentication scheme to an
+// outbound HTTP request before it is sent. Implementations must be
+// safe for concurrent use — a single Authenticator is shared across
+// all in-flight invocations of a connection.
+//
+// Implementations MUST NOT log credential material. The toolkit's
+// audit pipeline expects no Authorization or X-API-Key value to ever
+// appear in slog output, error messages, or audit rows; carelessly
+// formatted error strings are the most common leak path.
+type Authenticator interface {
+	Apply(req *http.Request) error
+}
+
+// NewAuthenticator returns the Authenticator implementation for a
+// validated Config. ParseConfig has already rejected unknown auth
+// modes, so the default branch only fires if a future mode is added
+// without a matching case here.
+func NewAuthenticator(c Config) (Authenticator, error) {
+	switch c.AuthMode {
+	case AuthModeNone:
+		return noneAuth{}, nil
+	case AuthModeBearer:
+		return bearerAuth{credential: c.Credential}, nil
+	case AuthModeAPIKey:
+		return newAPIKeyAuth(c)
+	default:
+		return nil, fmt.Errorf("apigateway: no authenticator for auth_mode %q", c.AuthMode)
+	}
+}
+
+// noneAuth applies no credential. Distinct from a nil Authenticator so
+// the toolkit's invocation path can call Apply unconditionally.
+type noneAuth struct{}
+
+// Apply is a no-op; the connection requested no outbound auth.
+func (noneAuth) Apply(_ *http.Request) error { return nil }
+
+// bearerAuth sets the Authorization header to "Bearer <credential>".
+type bearerAuth struct {
+	credential string
+}
+
+// Apply attaches the bearer token as the Authorization header.
+func (b bearerAuth) Apply(req *http.Request) error {
+	if b.credential == "" {
+		return errors.New("apigateway: bearer credential is empty")
+	}
+	req.Header.Set(authorizationHeader, "Bearer "+b.credential)
+	return nil
+}
+
+// apiKeyAuth attaches the credential as either a header or a query
+// parameter, per the connection's APIKeyPlacement setting.
+type apiKeyAuth struct {
+	credential string
+	placement  string
+	header     string
+	param      string
+}
+
+func newAPIKeyAuth(c Config) (apiKeyAuth, error) {
+	a := apiKeyAuth{
+		credential: c.Credential,
+		placement:  c.APIKeyPlacement,
+		header:     c.APIKeyHeader,
+		param:      c.APIKeyParam,
+	}
+	if a.credential == "" {
+		return apiKeyAuth{}, errors.New("apigateway: api_key credential is empty")
+	}
+	switch a.placement {
+	case APIKeyPlacementHeader:
+		if a.header == "" {
+			return apiKeyAuth{}, errors.New("apigateway: api_key_header is empty")
+		}
+	case APIKeyPlacementQuery:
+		if a.param == "" {
+			return apiKeyAuth{}, errors.New("apigateway: api_key_param is empty")
+		}
+	default:
+		return apiKeyAuth{}, fmt.Errorf("apigateway: invalid api_key_placement %q", a.placement)
+	}
+	return a, nil
+}
+
+// Apply attaches the API key as either a header or a query parameter,
+// per the connection's APIKeyPlacement.
+func (a apiKeyAuth) Apply(req *http.Request) error {
+	switch a.placement {
+	case APIKeyPlacementHeader:
+		req.Header.Set(a.header, a.credential)
+	case APIKeyPlacementQuery:
+		q := req.URL.Query()
+		q.Set(a.param, a.credential)
+		req.URL.RawQuery = q.Encode()
+	default:
+		return fmt.Errorf("apigateway: invalid api_key_placement %q", a.placement)
+	}
+	return nil
+}

--- a/pkg/toolkits/apigateway/auth_test.go
+++ b/pkg/toolkits/apigateway/auth_test.go
@@ -1,0 +1,185 @@
+package apigateway
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewAuthenticator_DispatchesByMode(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{"none", Config{AuthMode: AuthModeNone}},
+		{"bearer", Config{AuthMode: AuthModeBearer, Credential: "tok"}},
+		{"api_key header", Config{AuthMode: AuthModeAPIKey, Credential: "k", APIKeyPlacement: APIKeyPlacementHeader, APIKeyHeader: "X-API-Key"}},
+		{"api_key query", Config{AuthMode: AuthModeAPIKey, Credential: "k", APIKeyPlacement: APIKeyPlacementQuery, APIKeyParam: "key"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := NewAuthenticator(tc.cfg)
+			if err != nil {
+				t.Fatalf("NewAuthenticator: %v", err)
+			}
+			if a == nil {
+				t.Fatal("NewAuthenticator returned nil")
+			}
+		})
+	}
+}
+
+func TestNewAuthenticator_RejectsUnknownMode(t *testing.T) {
+	if _, err := NewAuthenticator(Config{AuthMode: "weird"}); err == nil {
+		t.Fatal("NewAuthenticator: want error for unknown mode")
+	}
+}
+
+func TestBearerAuth_AppliesAuthorizationHeader(t *testing.T) {
+	a, err := NewAuthenticator(Config{AuthMode: AuthModeBearer, Credential: "tok-xyz"})
+	if err != nil {
+		t.Fatalf("NewAuthenticator: %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com/foo", http.NoBody)
+	if err := a.Apply(req); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer tok-xyz" {
+		t.Errorf("Authorization = %q; want %q", got, "Bearer tok-xyz")
+	}
+}
+
+func TestBearerAuth_RejectsEmptyCredential(t *testing.T) {
+	a := bearerAuth{credential: ""}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com/", http.NoBody)
+	if err := a.Apply(req); err == nil {
+		t.Error("Apply: want error for empty credential")
+	}
+}
+
+func TestAPIKeyAuth_HeaderPlacement(t *testing.T) {
+	a, err := NewAuthenticator(Config{
+		AuthMode:        AuthModeAPIKey,
+		Credential:      "secret-key",
+		APIKeyPlacement: APIKeyPlacementHeader,
+		APIKeyHeader:    "X-Api-Token",
+	})
+	if err != nil {
+		t.Fatalf("NewAuthenticator: %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com/foo", http.NoBody)
+	if err := a.Apply(req); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got := req.Header.Get("X-Api-Token"); got != "secret-key" {
+		t.Errorf("X-Api-Token = %q; want %q", got, "secret-key")
+	}
+}
+
+func TestAPIKeyAuth_QueryPlacement_PreservesExistingQuery(t *testing.T) {
+	a, err := NewAuthenticator(Config{
+		AuthMode:        AuthModeAPIKey,
+		Credential:      "qkey",
+		APIKeyPlacement: APIKeyPlacementQuery,
+		APIKeyParam:     "api_key",
+	})
+	if err != nil {
+		t.Fatalf("NewAuthenticator: %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com/foo?existing=v1", http.NoBody)
+	if err := a.Apply(req); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	q := req.URL.Query()
+	if q.Get("api_key") != "qkey" {
+		t.Errorf("api_key = %q; want %q", q.Get("api_key"), "qkey")
+	}
+	if q.Get("existing") != "v1" {
+		t.Errorf("existing param dropped: %s", req.URL.RawQuery)
+	}
+}
+
+func TestNoneAuth_SetsNoHeaders(t *testing.T) {
+	a, err := NewAuthenticator(Config{AuthMode: AuthModeNone})
+	if err != nil {
+		t.Fatalf("NewAuthenticator: %v", err)
+	}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com/", http.NoBody)
+	if err := a.Apply(req); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if req.Header.Get("Authorization") != "" {
+		t.Error("noneAuth set Authorization")
+	}
+}
+
+func TestNewAPIKeyAuth_RejectsBadInputs(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{"empty credential", Config{AuthMode: AuthModeAPIKey, APIKeyPlacement: APIKeyPlacementHeader, APIKeyHeader: "X-Key"}},
+		{"empty header", Config{AuthMode: AuthModeAPIKey, Credential: "k", APIKeyPlacement: APIKeyPlacementHeader, APIKeyHeader: ""}},
+		{"empty query param", Config{AuthMode: AuthModeAPIKey, Credential: "k", APIKeyPlacement: APIKeyPlacementQuery, APIKeyParam: ""}},
+		{"unknown placement", Config{AuthMode: AuthModeAPIKey, Credential: "k", APIKeyPlacement: "weird"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := newAPIKeyAuth(tc.cfg); err == nil {
+				t.Errorf("newAPIKeyAuth(%+v) want error", tc.cfg)
+			}
+		})
+	}
+}
+
+// Credentials never appear in slog output, error messages, or
+// stringified Authenticator state. A future change that adds a
+// fmt.Errorf("apigateway: bad credential %q", c.Credential) would
+// be a real leak; this test is the canary.
+func TestAuthenticators_DoNotLeakCredentials(t *testing.T) {
+	const secret = "supersecret-credential-nonsense-9b7"
+	cfgs := []Config{
+		{AuthMode: AuthModeBearer, Credential: secret},
+		{AuthMode: AuthModeAPIKey, Credential: secret, APIKeyPlacement: APIKeyPlacementHeader, APIKeyHeader: "X-K"},
+		{AuthMode: AuthModeAPIKey, Credential: secret, APIKeyPlacement: APIKeyPlacementQuery, APIKeyParam: "k"},
+	}
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	for _, cfg := range cfgs {
+		a, err := NewAuthenticator(cfg)
+		if err != nil {
+			t.Errorf("NewAuthenticator(%s): %v", cfg.AuthMode, err)
+			continue
+		}
+		// Stringify and log everything we have access to.
+		logger.Info("auth materialized",
+			"mode", cfg.AuthMode,
+			"placement", cfg.APIKeyPlacement,
+			"header", cfg.APIKeyHeader,
+			"param", cfg.APIKeyParam,
+		)
+		// Log the error from a deliberately broken Apply call too.
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com/", http.NoBody)
+		_ = a.Apply(req)
+	}
+
+	if strings.Contains(buf.String(), secret) {
+		t.Errorf("log buffer contains credential: %s", buf.String())
+	}
+}
+
+func TestAPIKeyAuth_Apply_RejectsUnknownPlacement(t *testing.T) {
+	// Force-construct an apiKeyAuth in an invalid state to verify the
+	// Apply default branch fires. NewAuthenticator and newAPIKeyAuth
+	// would normally reject this at construction time.
+	a := apiKeyAuth{credential: "k", placement: "tampered", header: "X", param: "y"}
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com/", http.NoBody)
+	if err := a.Apply(req); err == nil {
+		t.Fatal("Apply: want error for unknown placement")
+	}
+}

--- a/pkg/toolkits/apigateway/config.go
+++ b/pkg/toolkits/apigateway/config.go
@@ -1,0 +1,299 @@
+// Package apigateway provides an HTTP API gateway toolkit that proxies
+// authenticated REST API calls through the platform's auth, persona, and
+// audit pipeline. Sibling to pkg/toolkits/gateway, which proxies upstream
+// MCP servers; this toolkit proxies arbitrary HTTP/JSON APIs.
+//
+// The toolkit exposes a small fixed set of MCP tools regardless of how
+// many connections are registered or how many endpoints each upstream
+// API has. v1 ships api_invoke_endpoint; api_list_endpoints and
+// api_get_endpoint_schema follow once OpenAPI ingestion lands (see
+// the RFC at issue #364).
+package apigateway
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+const (
+	// Kind is the connection-instance kind discriminator. Operators see
+	// this in the admin UI's connection picker.
+	Kind = "api"
+
+	// AuthModeNone disables outbound authentication.
+	AuthModeNone = "none"
+	// AuthModeBearer sends "Authorization: Bearer <credential>".
+	AuthModeBearer = "bearer"
+	// AuthModeAPIKey sends the credential as a header (default
+	// "X-API-Key") or as a query parameter; placement and key name are
+	// per-connection so APIs that use non-standard schemes (e.g. an
+	// "api_key" query parameter, or a custom "X-Api-Token" header) can
+	// be onboarded without code changes.
+	AuthModeAPIKey = "api_key"
+
+	// APIKeyPlacementHeader (default) sends the credential as an HTTP
+	// header named by APIKeyHeader.
+	APIKeyPlacementHeader = "header"
+	// APIKeyPlacementQuery sends the credential as a URL query parameter
+	// named by APIKeyParam.
+	APIKeyPlacementQuery = "query"
+
+	// DefaultAPIKeyHeader is the conventional API-key header name when
+	// the connection does not specify one.
+	DefaultAPIKeyHeader = "X-API-Key" // #nosec G101 -- header name, not a credential
+
+	// TrustLevelUntrusted is the default. Advisory only in v1: the
+	// field is parsed and validated but no platform code reads it.
+	// Reserved for future response-shaping enforcement (see issue
+	// #373) — operators setting this today get the same behavior as
+	// not setting it.
+	TrustLevelUntrusted = "untrusted"
+	// TrustLevelTrusted is advisory only in v1; see TrustLevelUntrusted.
+	TrustLevelTrusted = "trusted"
+
+	// DefaultConnectTimeout caps the time spent establishing the
+	// outbound connection (TCP + TLS handshake) on each invocation.
+	DefaultConnectTimeout = 10 * time.Second
+	// DefaultCallTimeout caps the total per-call time including
+	// upstream processing and response read.
+	DefaultCallTimeout = 60 * time.Second
+
+	// DefaultMaxResponseBytes caps how much of the upstream response
+	// body the toolkit will return to the model. Larger payloads are
+	// truncated; the response envelope flags truncation so the model
+	// can react. Operators with a need for large bodies can raise this
+	// per-connection or, when #372 lands, use the streaming-to-S3
+	// variant to bypass the model entirely.
+	DefaultMaxResponseBytes = int64(10 * 1024 * 1024)
+)
+
+// cfgKey* constants name the keys used to read a Config from a
+// map[string]any (the form connections take in the platform's generic
+// connection_instances store).
+const (
+	cfgKeyBaseURL          = "base_url"
+	cfgKeyAuthMode         = "auth_mode"
+	cfgKeyCredential       = "credential"     // #nosec G101 -- map key, not a secret
+	cfgKeyAPIKeyHeader     = "api_key_header" // #nosec G101 -- map key, not a credential
+	cfgKeyAPIKeyParam      = "api_key_param"  // #nosec G101 -- map key, not a credential
+	cfgKeyAPIKeyPlacement  = "api_key_placement"
+	cfgKeyConnectionName   = "connection_name"
+	cfgKeyConnectTimeout   = "connect_timeout"
+	cfgKeyCallTimeout      = "call_timeout"
+	cfgKeyTrustLevel       = "trust_level"
+	cfgKeyMaxResponseBytes = "max_response_bytes"
+)
+
+// Config holds api-gateway toolkit configuration for a single upstream
+// HTTP API connection.
+type Config struct {
+	// BaseURL is the upstream API root (e.g. "https://api.example.com").
+	// Required. Trailing slash is stripped at parse time.
+	BaseURL string
+	// AuthMode is "none", "bearer", or "api_key" in v1. OAuth modes
+	// land with #368.
+	AuthMode string
+	// Credential is the bearer token or API key. Ignored when AuthMode
+	// is "none". Encrypted at rest via the platform's FieldEncryptor.
+	Credential string
+	// APIKeyPlacement is "header" (default) or "query" — only consulted
+	// when AuthMode is "api_key".
+	APIKeyPlacement string
+	// APIKeyHeader is the header name to set when APIKeyPlacement is
+	// "header". Defaults to "X-API-Key".
+	APIKeyHeader string
+	// APIKeyParam is the query parameter name when APIKeyPlacement is
+	// "query". No default — required when placement is "query".
+	APIKeyParam string
+	// ConnectionName is the audit-visible connection identifier and the
+	// value passed in the tool's `connection` argument. Defaults to
+	// the toolkit instance name when unset.
+	ConnectionName string
+	// ConnectTimeout caps the dial step on each invocation.
+	ConnectTimeout time.Duration
+	// CallTimeout caps the total per-invocation time.
+	CallTimeout time.Duration
+	// TrustLevel is "untrusted" (default) or "trusted".
+	TrustLevel string
+	// MaxResponseBytes caps how much of an upstream response body is
+	// returned to the model. Defaults to DefaultMaxResponseBytes.
+	MaxResponseBytes int64
+}
+
+// MultiConfig holds parsed per-connection configs plus the aggregate
+// toolkit's default connection name.
+type MultiConfig struct {
+	DefaultName string
+	Instances   map[string]Config
+}
+
+// ParseMultiConfig validates and returns the parsed config for every
+// instance. Per-instance parse errors fail the platform startup; HTTP
+// connectivity failures are handled at invocation time, not here.
+func ParseMultiConfig(defaultName string, raw map[string]map[string]any) (MultiConfig, error) {
+	parsed := make(map[string]Config, len(raw))
+	for name, r := range raw {
+		c, err := ParseConfig(r)
+		if err != nil {
+			return MultiConfig{}, fmt.Errorf("apigateway/%s: %w", name, err)
+		}
+		if c.ConnectionName == "" {
+			c.ConnectionName = name
+		}
+		parsed[name] = c
+	}
+	return MultiConfig{DefaultName: defaultName, Instances: parsed}, nil
+}
+
+// ParseConfig parses a Config from a generic map (the form admin-saved
+// connections take in the connection_instances table) and applies
+// defaults. The returned Config is fully validated.
+func ParseConfig(cfg map[string]any) (Config, error) {
+	c := Config{
+		AuthMode:         AuthModeNone,
+		APIKeyPlacement:  APIKeyPlacementHeader,
+		APIKeyHeader:     DefaultAPIKeyHeader,
+		ConnectTimeout:   DefaultConnectTimeout,
+		CallTimeout:      DefaultCallTimeout,
+		TrustLevel:       TrustLevelUntrusted,
+		MaxResponseBytes: DefaultMaxResponseBytes,
+	}
+
+	c.BaseURL = trimTrailingSlash(getString(cfg, cfgKeyBaseURL))
+	c.AuthMode = getStringDefault(cfg, cfgKeyAuthMode, c.AuthMode)
+	c.Credential = getString(cfg, cfgKeyCredential)
+	c.APIKeyPlacement = getStringDefault(cfg, cfgKeyAPIKeyPlacement, c.APIKeyPlacement)
+	c.APIKeyHeader = getStringDefault(cfg, cfgKeyAPIKeyHeader, c.APIKeyHeader)
+	c.APIKeyParam = getString(cfg, cfgKeyAPIKeyParam)
+	c.ConnectionName = getString(cfg, cfgKeyConnectionName)
+	c.ConnectTimeout = getDuration(cfg, cfgKeyConnectTimeout, c.ConnectTimeout)
+	c.CallTimeout = getDuration(cfg, cfgKeyCallTimeout, c.CallTimeout)
+	c.TrustLevel = getStringDefault(cfg, cfgKeyTrustLevel, c.TrustLevel)
+	c.MaxResponseBytes = getInt64(cfg, cfgKeyMaxResponseBytes, c.MaxResponseBytes)
+
+	if err := c.Validate(); err != nil {
+		return Config{}, err
+	}
+	return c, nil
+}
+
+// Validate returns an error if the configuration is missing required
+// fields or contains invalid values.
+func (c Config) Validate() error {
+	if c.BaseURL == "" {
+		return errors.New("apigateway: base_url is required")
+	}
+	if err := c.validateAuth(); err != nil {
+		return err
+	}
+	switch c.TrustLevel {
+	case TrustLevelUntrusted, TrustLevelTrusted:
+	default:
+		return fmt.Errorf("apigateway: invalid trust_level %q (want untrusted or trusted)", c.TrustLevel)
+	}
+	if c.ConnectTimeout <= 0 {
+		return errors.New("apigateway: connect_timeout must be positive")
+	}
+	if c.CallTimeout <= 0 {
+		return errors.New("apigateway: call_timeout must be positive")
+	}
+	if c.MaxResponseBytes <= 0 {
+		return errors.New("apigateway: max_response_bytes must be positive")
+	}
+	return nil
+}
+
+func (c Config) validateAuth() error {
+	switch c.AuthMode {
+	case AuthModeNone:
+		return nil
+	case AuthModeBearer:
+		if c.Credential == "" {
+			return errors.New("apigateway: credential is required when auth_mode is \"bearer\"")
+		}
+		return nil
+	case AuthModeAPIKey:
+		return c.validateAPIKeyAuth()
+	default:
+		return fmt.Errorf("apigateway: invalid auth_mode %q (want none, bearer, or api_key)", c.AuthMode)
+	}
+}
+
+func (c Config) validateAPIKeyAuth() error {
+	if c.Credential == "" {
+		return errors.New("apigateway: credential is required when auth_mode is \"api_key\"")
+	}
+	switch c.APIKeyPlacement {
+	case APIKeyPlacementHeader:
+		if c.APIKeyHeader == "" {
+			return errors.New("apigateway: api_key_header must not be empty")
+		}
+	case APIKeyPlacementQuery:
+		if c.APIKeyParam == "" {
+			return errors.New("apigateway: api_key_param is required when api_key_placement is \"query\"")
+		}
+	default:
+		return fmt.Errorf("apigateway: invalid api_key_placement %q (want header or query)", c.APIKeyPlacement)
+	}
+	return nil
+}
+
+func trimTrailingSlash(s string) string {
+	for s != "" && s[len(s)-1] == '/' {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+func getString(cfg map[string]any, key string) string {
+	if v, ok := cfg[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func getStringDefault(cfg map[string]any, key, defaultVal string) string {
+	if v, ok := cfg[key].(string); ok && v != "" {
+		return v
+	}
+	return defaultVal
+}
+
+func getDuration(cfg map[string]any, key string, defaultVal time.Duration) time.Duration {
+	raw, ok := cfg[key]
+	if !ok {
+		return defaultVal
+	}
+	switch v := raw.(type) {
+	case string:
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	case time.Duration:
+		return v
+	case int:
+		return time.Duration(v) * time.Second
+	case int64:
+		return time.Duration(v) * time.Second
+	case float64:
+		return time.Duration(v) * time.Second
+	}
+	return defaultVal
+}
+
+func getInt64(cfg map[string]any, key string, defaultVal int64) int64 {
+	raw, ok := cfg[key]
+	if !ok {
+		return defaultVal
+	}
+	switch v := raw.(type) {
+	case int:
+		return int64(v)
+	case int64:
+		return v
+	case float64:
+		return int64(v)
+	}
+	return defaultVal
+}

--- a/pkg/toolkits/apigateway/config_test.go
+++ b/pkg/toolkits/apigateway/config_test.go
@@ -1,0 +1,281 @@
+package apigateway
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseConfig_AppliesDefaults(t *testing.T) {
+	c, err := ParseConfig(map[string]any{
+		"base_url": "https://api.example.com",
+	})
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if c.AuthMode != AuthModeNone {
+		t.Errorf("default AuthMode = %q; want %q", c.AuthMode, AuthModeNone)
+	}
+	if c.APIKeyPlacement != APIKeyPlacementHeader {
+		t.Errorf("default APIKeyPlacement = %q; want %q", c.APIKeyPlacement, APIKeyPlacementHeader)
+	}
+	if c.APIKeyHeader != DefaultAPIKeyHeader {
+		t.Errorf("default APIKeyHeader = %q; want %q", c.APIKeyHeader, DefaultAPIKeyHeader)
+	}
+	if c.ConnectTimeout != DefaultConnectTimeout {
+		t.Errorf("default ConnectTimeout = %v; want %v", c.ConnectTimeout, DefaultConnectTimeout)
+	}
+	if c.CallTimeout != DefaultCallTimeout {
+		t.Errorf("default CallTimeout = %v; want %v", c.CallTimeout, DefaultCallTimeout)
+	}
+	if c.TrustLevel != TrustLevelUntrusted {
+		t.Errorf("default TrustLevel = %q; want %q", c.TrustLevel, TrustLevelUntrusted)
+	}
+	if c.MaxResponseBytes != DefaultMaxResponseBytes {
+		t.Errorf("default MaxResponseBytes = %d; want %d", c.MaxResponseBytes, DefaultMaxResponseBytes)
+	}
+}
+
+func TestParseConfig_StripsTrailingSlashes(t *testing.T) {
+	c, err := ParseConfig(map[string]any{"base_url": "https://api.example.com///"})
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if c.BaseURL != "https://api.example.com" {
+		t.Errorf("BaseURL = %q; want %q", c.BaseURL, "https://api.example.com")
+	}
+}
+
+func TestParseConfig_BearerAuth(t *testing.T) {
+	c, err := ParseConfig(map[string]any{
+		"base_url":   "https://api.example.com",
+		"auth_mode":  AuthModeBearer,
+		"credential": "tok-abc",
+	})
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if c.Credential != "tok-abc" {
+		t.Errorf("Credential = %q; want %q", c.Credential, "tok-abc")
+	}
+}
+
+func TestParseConfig_APIKeyHeaderAuth(t *testing.T) {
+	c, err := ParseConfig(map[string]any{
+		"base_url":          "https://api.example.com",
+		"auth_mode":         AuthModeAPIKey,
+		"credential":        "k-1",
+		"api_key_header":    "X-Custom-Key",
+		"api_key_placement": APIKeyPlacementHeader,
+	})
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if c.APIKeyHeader != "X-Custom-Key" {
+		t.Errorf("APIKeyHeader = %q; want %q", c.APIKeyHeader, "X-Custom-Key")
+	}
+}
+
+func TestParseConfig_APIKeyQueryAuth(t *testing.T) {
+	c, err := ParseConfig(map[string]any{
+		"base_url":          "https://api.example.com",
+		"auth_mode":         AuthModeAPIKey,
+		"credential":        "k-1",
+		"api_key_param":     "api_key",
+		"api_key_placement": APIKeyPlacementQuery,
+	})
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if c.APIKeyPlacement != APIKeyPlacementQuery || c.APIKeyParam != "api_key" {
+		t.Errorf("placement/param mismatch: %+v", c)
+	}
+}
+
+func TestParseConfig_ValidationErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  map[string]any
+		want string
+	}{
+		{
+			name: "missing base_url",
+			cfg:  map[string]any{},
+			want: "base_url is required",
+		},
+		{
+			name: "bearer without credential",
+			cfg: map[string]any{
+				"base_url":  "https://x",
+				"auth_mode": AuthModeBearer,
+			},
+			want: "credential is required",
+		},
+		{
+			name: "api_key without credential",
+			cfg: map[string]any{
+				"base_url":  "https://x",
+				"auth_mode": AuthModeAPIKey,
+			},
+			want: "credential is required",
+		},
+		{
+			name: "api_key query without param",
+			cfg: map[string]any{
+				"base_url":          "https://x",
+				"auth_mode":         AuthModeAPIKey,
+				"credential":        "k",
+				"api_key_placement": APIKeyPlacementQuery,
+			},
+			want: "api_key_param is required",
+		},
+		{
+			name: "api_key invalid placement",
+			cfg: map[string]any{
+				"base_url":          "https://x",
+				"auth_mode":         AuthModeAPIKey,
+				"credential":        "k",
+				"api_key_placement": "body",
+			},
+			want: "invalid api_key_placement",
+		},
+		{
+			name: "unknown auth_mode",
+			cfg: map[string]any{
+				"base_url":  "https://x",
+				"auth_mode": "weird",
+			},
+			want: "invalid auth_mode",
+		},
+		{
+			name: "invalid trust_level",
+			cfg: map[string]any{
+				"base_url":    "https://x",
+				"trust_level": "maybe",
+			},
+			want: "invalid trust_level",
+		},
+		{
+			name: "non-positive connect_timeout",
+			cfg: map[string]any{
+				"base_url":        "https://x",
+				"connect_timeout": "-1s",
+			},
+			want: "connect_timeout must be positive",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseConfig(tc.cfg)
+			if err == nil {
+				t.Fatalf("ParseConfig(%+v) returned nil error; want %q", tc.cfg, tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q; want substring %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestParseConfig_NonPositiveCallTimeout(t *testing.T) {
+	_, err := ParseConfig(map[string]any{
+		"base_url":     "https://x",
+		"call_timeout": "0s",
+	})
+	if err == nil || !strings.Contains(err.Error(), "call_timeout must be positive") {
+		t.Errorf("ParseConfig: got %v; want call_timeout error", err)
+	}
+}
+
+func TestParseConfig_NonPositiveMaxResponseBytes(t *testing.T) {
+	_, err := ParseConfig(map[string]any{
+		"base_url":           "https://x",
+		"max_response_bytes": int64(-1),
+	})
+	if err == nil || !strings.Contains(err.Error(), "max_response_bytes must be positive") {
+		t.Errorf("ParseConfig: got %v; want max_response_bytes error", err)
+	}
+}
+
+func TestParseConfig_DurationFromInt(t *testing.T) {
+	c, err := ParseConfig(map[string]any{
+		"base_url":     "https://x",
+		"call_timeout": 30,
+	})
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if c.CallTimeout != 30*time.Second {
+		t.Errorf("CallTimeout = %v; want 30s", c.CallTimeout)
+	}
+}
+
+func TestParseConfig_DurationFromFloat(t *testing.T) {
+	c, err := ParseConfig(map[string]any{
+		"base_url":        "https://x",
+		"connect_timeout": 5.0,
+	})
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if c.ConnectTimeout != 5*time.Second {
+		t.Errorf("ConnectTimeout = %v; want 5s", c.ConnectTimeout)
+	}
+}
+
+func TestParseMultiConfig_SetsConnectionName(t *testing.T) {
+	mc, err := ParseMultiConfig("default-name", map[string]map[string]any{
+		"alpha": {"base_url": "https://a.example.com"},
+		"beta":  {"base_url": "https://b.example.com"},
+	})
+	if err != nil {
+		t.Fatalf("ParseMultiConfig: %v", err)
+	}
+	if mc.DefaultName != "default-name" {
+		t.Errorf("DefaultName = %q; want %q", mc.DefaultName, "default-name")
+	}
+	if mc.Instances["alpha"].ConnectionName != "alpha" {
+		t.Errorf("alpha.ConnectionName = %q; want %q", mc.Instances["alpha"].ConnectionName, "alpha")
+	}
+	if mc.Instances["beta"].ConnectionName != "beta" {
+		t.Errorf("beta.ConnectionName = %q; want %q", mc.Instances["beta"].ConnectionName, "beta")
+	}
+}
+
+func TestParseMultiConfig_PropagatesPerInstanceError(t *testing.T) {
+	_, err := ParseMultiConfig("", map[string]map[string]any{
+		"bad": {"auth_mode": AuthModeBearer}, // missing base_url + credential
+	})
+	if err == nil {
+		t.Fatal("ParseMultiConfig: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "apigateway/bad") {
+		t.Errorf("error = %q; want instance-prefixed error", err.Error())
+	}
+}
+
+func TestParseConfig_PreservesExplicitConnectionName(t *testing.T) {
+	c, err := ParseConfig(map[string]any{
+		"base_url":        "https://x",
+		"connection_name": "explicit",
+	})
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if c.ConnectionName != "explicit" {
+		t.Errorf("ConnectionName = %q; want %q", c.ConnectionName, "explicit")
+	}
+}
+
+func TestParseConfig_TrustLevelTrusted(t *testing.T) {
+	c, err := ParseConfig(map[string]any{
+		"base_url":    "https://x",
+		"trust_level": TrustLevelTrusted,
+	})
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if c.TrustLevel != TrustLevelTrusted {
+		t.Errorf("TrustLevel = %q; want %q", c.TrustLevel, TrustLevelTrusted)
+	}
+}

--- a/pkg/toolkits/apigateway/invoke.go
+++ b/pkg/toolkits/apigateway/invoke.go
@@ -152,6 +152,20 @@ func validatePath(path string) error {
 	if !strings.HasPrefix(path, "/") {
 		return errors.New("apigateway: path must start with \"/\"")
 	}
+	// Reject path shapes that, when string-concatenated to a base
+	// URL, would let url.Parse interpret the result as a different
+	// host (SSRF). Without this check, path="//evil.com/foo" turns
+	// "https://api.example.com" + path into a protocol-relative URL
+	// pointing at evil.com, and path="@evil.com/foo" injects
+	// userinfo so the final Host becomes evil.com. The host pinning
+	// in buildURL is the primary defense; this rejection is the
+	// up-front diagnostic the model sees.
+	if strings.HasPrefix(path, "//") {
+		return errors.New("apigateway: path must not start with \"//\" (protocol-relative URLs are rejected)")
+	}
+	if strings.ContainsAny(path, "@\r\n\x00") {
+		return errors.New("apigateway: path contains a disallowed character (@, CR, LF, NUL)")
+	}
 	return nil
 }
 
@@ -189,19 +203,33 @@ func validateCustomHeaders(headers map[string]string, authHeader string) error {
 	return nil
 }
 
+// buildURL composes the upstream URL from the connection's base
+// URL and the model-supplied path + query. Defense against SSRF:
+// the base URL is parsed independently of the path; the path is
+// joined with url.URL.JoinPath rather than string-concatenated;
+// and the resulting URL's scheme + host MUST equal the base's. If
+// any of those checks fail (a model-crafted path that escapes the
+// base, a future Go change to JoinPath semantics, etc.) the call
+// is refused before the request is built.
 func buildURL(baseURL, path string, query map[string]any) (string, error) {
-	u, err := url.Parse(baseURL + path)
+	base, err := url.Parse(baseURL)
 	if err != nil {
-		return "", fmt.Errorf("apigateway: parsing url: %w", err)
+		return "", fmt.Errorf("apigateway: parsing base_url: %w", err)
 	}
-	if len(query) == 0 {
-		return u.String(), nil
+	if base.Scheme == "" || base.Host == "" {
+		return "", fmt.Errorf("apigateway: base_url %q must include scheme and host", baseURL)
 	}
-	q := u.Query()
-	for k, v := range query {
-		appendQueryValue(q, k, v)
+	u := base.JoinPath(path)
+	if u.Scheme != base.Scheme || u.Host != base.Host {
+		return "", fmt.Errorf("apigateway: path %q would change the request host (base=%q, joined=%q); refusing", path, base.Host, u.Host)
 	}
-	u.RawQuery = q.Encode()
+	if len(query) > 0 {
+		q := u.Query()
+		for k, v := range query {
+			appendQueryValue(q, k, v)
+		}
+		u.RawQuery = q.Encode()
+	}
 	return u.String(), nil
 }
 

--- a/pkg/toolkits/apigateway/invoke.go
+++ b/pkg/toolkits/apigateway/invoke.go
@@ -1,0 +1,414 @@
+package apigateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// supportedMethods is the closed set of HTTP methods api_invoke_endpoint
+// accepts. Restricting the set keeps the tool's blast radius bounded and
+// avoids servicing exotic methods (TRACE, CONNECT) that the model has
+// no legitimate reason to call.
+//
+//nolint:gochecknoglobals // intentionally a package-level constant set
+var supportedMethods = map[string]bool{
+	http.MethodGet:    true,
+	http.MethodPost:   true,
+	http.MethodPut:    true,
+	http.MethodDelete: true,
+	http.MethodPatch:  true,
+	http.MethodHead:   true,
+}
+
+// maxTimeoutSeconds caps the per-call timeout the model can request.
+// Even an upstream that supports long-running calls is bounded — the
+// MCP request lifecycle is not designed for hour-long operations.
+const maxTimeoutSeconds = 600
+
+// strconv numeric base / bitSize constants. Pulled out so revive's
+// add-constant rule does not flag the literal repetitions across the
+// scalar-stringification switch.
+const (
+	intBase      = 10
+	floatBitSize = 64
+)
+
+// methodsAllowingBody is the set of methods for which an input body
+// is forwarded. GET and HEAD are explicitly excluded; some upstreams
+// reject GET-with-body and the model can move parameters to query
+// instead.
+//
+//nolint:gochecknoglobals // intentionally a package-level constant set
+var methodsAllowingBody = map[string]bool{
+	http.MethodPost:   true,
+	http.MethodPut:    true,
+	http.MethodDelete: true,
+	http.MethodPatch:  true,
+}
+
+// InvokeInput is the parsed argument shape for api_invoke_endpoint.
+// Field names match the JSON schema.
+type InvokeInput struct {
+	Connection     string            `json:"connection"`
+	Method         string            `json:"method"`
+	Path           string            `json:"path"`
+	Query          map[string]any    `json:"query,omitempty"`
+	Headers        map[string]string `json:"headers,omitempty"`
+	Body           any               `json:"body,omitempty"`
+	TimeoutSeconds int               `json:"timeout_seconds,omitempty"`
+}
+
+// InvokeOutput is the structured result returned to the model. Errors
+// reaching the upstream (DNS, connection refused, TLS failure,
+// timeout) are surfaced via Error rather than as MCP tool errors so
+// the model can branch on them without losing the rest of the
+// response envelope.
+type InvokeOutput struct {
+	Status        int                 `json:"status"`
+	Headers       map[string][]string `json:"headers,omitempty"`
+	Body          any                 `json:"body,omitempty"`
+	BodyTruncated bool                `json:"body_truncated,omitempty"`
+	DurationMs    int64               `json:"duration_ms"`
+	Error         string              `json:"error,omitempty"`
+}
+
+// invocation bundles a connection lookup with its supporting types so
+// the call path can be tested without standing up a full Toolkit.
+type invocation struct {
+	cfg    Config
+	auth   Authenticator
+	client *http.Client
+}
+
+// invoke runs a single api_invoke_endpoint call against a known
+// connection. The returned error is reserved for argument-validation
+// failures (which the model should fix); upstream failures populate
+// InvokeOutput.Error with Status==0.
+func invoke(ctx context.Context, inv invocation, in InvokeInput) (InvokeOutput, error) {
+	method, err := validateMethod(in.Method)
+	if err != nil {
+		return InvokeOutput{}, err
+	}
+	if err := validatePath(in.Path); err != nil {
+		return InvokeOutput{}, err
+	}
+	authHeader := authHeaderForConfig(inv.cfg)
+	if err := validateCustomHeaders(in.Headers, authHeader); err != nil {
+		return InvokeOutput{}, err
+	}
+
+	reqURL, err := buildURL(inv.cfg.BaseURL, in.Path, in.Query)
+	if err != nil {
+		return InvokeOutput{}, err
+	}
+
+	body, contentType, err := encodeBody(method, in.Body)
+	if err != nil {
+		return InvokeOutput{}, err
+	}
+
+	timeout := resolveTimeout(in.TimeoutSeconds, inv.cfg.CallTimeout)
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := buildRequest(callCtx, requestSpec{
+		method:      method,
+		url:         reqURL,
+		body:        body,
+		contentType: contentType,
+		headers:     in.Headers,
+	})
+	if err != nil {
+		return InvokeOutput{}, err
+	}
+	if err := inv.auth.Apply(req); err != nil {
+		return InvokeOutput{}, fmt.Errorf("apigateway: applying auth: %w", err)
+	}
+
+	return executeRequest(inv.client, req, inv.cfg.MaxResponseBytes), nil
+}
+
+func validateMethod(method string) (string, error) {
+	m := strings.ToUpper(strings.TrimSpace(method))
+	if !supportedMethods[m] {
+		return "", fmt.Errorf("apigateway: method %q not supported (want GET, POST, PUT, DELETE, PATCH, or HEAD)", method)
+	}
+	return m, nil
+}
+
+func validatePath(path string) error {
+	if path == "" {
+		return errors.New("apigateway: path is required")
+	}
+	if !strings.HasPrefix(path, "/") {
+		return errors.New("apigateway: path must start with \"/\"")
+	}
+	return nil
+}
+
+// authorizationHeader is the HTTP header bearer-mode auth populates.
+// Extracted as a named constant so the same literal isn't repeated
+// across the auth dispatch switch and the header-spoof rejection.
+const authorizationHeader = "Authorization"
+
+// authHeaderForConfig returns the canonical header name the
+// connection's auth mode would set, so validateCustomHeaders can
+// reject the model's attempts to spoof or override it. Empty string
+// means no header-based auth (mode=none, mode=api_key with query
+// placement).
+func authHeaderForConfig(c Config) string {
+	switch c.AuthMode {
+	case AuthModeBearer:
+		return authorizationHeader
+	case AuthModeAPIKey:
+		if c.APIKeyPlacement == APIKeyPlacementHeader {
+			return c.APIKeyHeader
+		}
+	}
+	return ""
+}
+
+func validateCustomHeaders(headers map[string]string, authHeader string) error {
+	for name := range headers {
+		if strings.EqualFold(name, authorizationHeader) {
+			return errors.New("apigateway: Authorization header is reserved; configure auth via connection")
+		}
+		if authHeader != "" && strings.EqualFold(name, authHeader) {
+			return fmt.Errorf("apigateway: %s header is reserved by this connection's auth_mode", authHeader)
+		}
+	}
+	return nil
+}
+
+func buildURL(baseURL, path string, query map[string]any) (string, error) {
+	u, err := url.Parse(baseURL + path)
+	if err != nil {
+		return "", fmt.Errorf("apigateway: parsing url: %w", err)
+	}
+	if len(query) == 0 {
+		return u.String(), nil
+	}
+	q := u.Query()
+	for k, v := range query {
+		appendQueryValue(q, k, v)
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// appendQueryValue handles scalars, slices, and arbitrary types by
+// stringifying. The output is never sensitive — query string values
+// come from the model's tool arguments, not from connection
+// credentials.
+func appendQueryValue(q url.Values, key string, val any) {
+	switch v := val.(type) {
+	case nil:
+	case string:
+		q.Add(key, v)
+	case bool:
+		q.Add(key, strconv.FormatBool(v))
+	case int:
+		q.Add(key, strconv.Itoa(v))
+	case int64:
+		q.Add(key, strconv.FormatInt(v, intBase))
+	case float64:
+		q.Add(key, strconv.FormatFloat(v, 'f', -1, floatBitSize))
+	case []any:
+		for _, item := range v {
+			appendQueryValue(q, key, item)
+		}
+	default:
+		q.Add(key, fmt.Sprintf("%v", v))
+	}
+}
+
+func encodeBody(method string, body any) (data []byte, contentType string, err error) {
+	if body == nil || !methodsAllowingBody[method] {
+		return nil, "", nil
+	}
+	if s, ok := body.(string); ok {
+		return []byte(s), "text/plain; charset=utf-8", nil
+	}
+	encoded, jerr := json.Marshal(body)
+	if jerr != nil {
+		return nil, "", fmt.Errorf("apigateway: encoding body as JSON: %w", jerr)
+	}
+	return encoded, "application/json", nil
+}
+
+func resolveTimeout(requested int, defaultTimeout time.Duration) time.Duration {
+	if requested <= 0 {
+		return defaultTimeout
+	}
+	if requested > maxTimeoutSeconds {
+		requested = maxTimeoutSeconds
+	}
+	return time.Duration(requested) * time.Second
+}
+
+// requestSpec bundles the inputs for buildRequest so the function
+// signature stays under revive's argument-limit ceiling without
+// losing any of the data the request-building step needs.
+type requestSpec struct {
+	method      string
+	url         string
+	body        []byte
+	contentType string
+	headers     map[string]string
+}
+
+func buildRequest(ctx context.Context, spec requestSpec) (*http.Request, error) {
+	var bodyReader io.Reader
+	if spec.body != nil {
+		bodyReader = bytes.NewReader(spec.body)
+	}
+	req, err := http.NewRequestWithContext(ctx, spec.method, spec.url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("apigateway: building request: %w", err)
+	}
+	for name, value := range spec.headers {
+		req.Header.Set(name, value)
+	}
+	if spec.contentType != "" && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", spec.contentType)
+	}
+	if req.Header.Get("Accept") == "" {
+		req.Header.Set("Accept", "application/json, */*;q=0.5")
+	}
+	return req, nil
+}
+
+// scrubTransportError rewrites a transport-level error so its message
+// cannot leak credentials carried in the request URL's query string
+// (api_key=... when AuthMode is api_key + APIKeyPlacementQuery).
+//
+// Go's *http.Client returns a *url.Error whose Error() method
+// stringifies the full request URL — including any query parameters
+// the Authenticator added. Returning that verbatim to the model and
+// audit pipeline would violate the toolkit's auth-leak contract
+// (see auth.go's Authenticator interface comment). We rebuild the
+// URL without RawQuery so the message keeps the operation, host,
+// and path useful for diagnostics, but drops the secret.
+func scrubTransportError(err error) string {
+	var ue *url.Error
+	if !errors.As(err, &ue) {
+		return err.Error()
+	}
+	parsed, perr := url.Parse(ue.URL)
+	if perr != nil {
+		// If the URL itself doesn't parse we can't safely include
+		// any of it; fall back to op + cause without the URL.
+		return fmt.Sprintf("%s: %v", ue.Op, ue.Err)
+	}
+	parsed.RawQuery = ""
+	parsed.User = nil // also strip any embedded userinfo, defensive
+	return fmt.Sprintf("%s %q: %v", ue.Op, parsed.String(), ue.Err)
+}
+
+func executeRequest(client *http.Client, req *http.Request, maxBytes int64) InvokeOutput {
+	start := time.Now()
+	resp, err := client.Do(req)
+	duration := time.Since(start).Milliseconds()
+	if err != nil {
+		return InvokeOutput{Status: 0, Error: scrubTransportError(err), DurationMs: duration}
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup
+
+	body, truncated, readErr := readBody(resp.Body, maxBytes)
+	if readErr != nil {
+		return InvokeOutput{
+			Status:     resp.StatusCode,
+			Headers:    selectResponseHeaders(resp.Header),
+			Error:      readErr.Error(),
+			DurationMs: time.Since(start).Milliseconds(),
+		}
+	}
+	parsed := decodeBody(resp.Header.Get("Content-Type"), body)
+	return InvokeOutput{
+		Status:        resp.StatusCode,
+		Headers:       selectResponseHeaders(resp.Header),
+		Body:          parsed,
+		BodyTruncated: truncated,
+		DurationMs:    time.Since(start).Milliseconds(),
+	}
+}
+
+func readBody(r io.Reader, maxBytes int64) (body []byte, truncated bool, err error) {
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxResponseBytes
+	}
+	limited := io.LimitReader(r, maxBytes+1)
+	read, rerr := io.ReadAll(limited)
+	if rerr != nil {
+		return nil, false, fmt.Errorf("apigateway: reading response body: %w", rerr)
+	}
+	if int64(len(read)) > maxBytes {
+		return read[:maxBytes], true, nil
+	}
+	return read, false, nil
+}
+
+// decodeBody parses a JSON response into a Go value when the
+// Content-Type indicates JSON; otherwise returns the body as a
+// string. Decoding failure on a JSON-typed response falls back to
+// returning the raw text so the model still sees something useful.
+func decodeBody(contentType string, body []byte) any {
+	if len(body) == 0 {
+		return nil
+	}
+	if !strings.Contains(strings.ToLower(contentType), "json") {
+		return string(body)
+	}
+	var v any
+	if err := json.Unmarshal(body, &v); err != nil {
+		return string(body)
+	}
+	return v
+}
+
+// passthroughResponseHeaders is the closed set of response headers
+// returned to the model. Most upstream headers (Set-Cookie, Server,
+// X-Powered-By, Date, etc.) are noise from the model's perspective;
+// pagination and content-type headers are useful enough to be worth
+// the context cost.
+//
+//nolint:gochecknoglobals // intentionally a package-level constant set
+var passthroughResponseHeaders = map[string]bool{
+	"Content-Type":          true,
+	"Content-Length":        true,
+	"Content-Encoding":      true,
+	"Etag":                  true,
+	"Last-Modified":         true,
+	"Link":                  true,
+	"Location":              true, // 3xx target — surfaced so the model can choose to follow manually
+	"Retry-After":           true,
+	"X-Total-Count":         true,
+	"X-Ratelimit-Limit":     true,
+	"X-Ratelimit-Remaining": true,
+	"X-Ratelimit-Reset":     true,
+}
+
+func selectResponseHeaders(h http.Header) map[string][]string {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make(map[string][]string)
+	for name, values := range h {
+		if passthroughResponseHeaders[http.CanonicalHeaderKey(name)] {
+			out[http.CanonicalHeaderKey(name)] = values
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/pkg/toolkits/apigateway/invoke.go
+++ b/pkg/toolkits/apigateway/invoke.go
@@ -344,6 +344,14 @@ func scrubTransportError(err error) string {
 
 func executeRequest(client *http.Client, req *http.Request, maxBytes int64) InvokeOutput {
 	start := time.Now()
+	// #nosec G107 G704 -- req.URL is constructed by buildURL, which parses the
+	// operator-configured base_url independently, joins the model-supplied
+	// path via url.URL.JoinPath (no string concatenation), and refuses any
+	// result whose scheme/host differs from the base. validatePath additionally
+	// rejects path shapes (//, @, CR/LF/NUL) that would let url.Parse be
+	// tricked into changing the host. The dynamic URL is therefore pinned to
+	// the connection's pre-registered host; SSRF is defeated at the construction
+	// site even though gosec's taint analysis cannot see the runtime guards.
 	resp, err := client.Do(req)
 	duration := time.Since(start).Milliseconds()
 	if err != nil {

--- a/pkg/toolkits/apigateway/invoke_test.go
+++ b/pkg/toolkits/apigateway/invoke_test.go
@@ -42,6 +42,76 @@ func TestValidatePath(t *testing.T) {
 	}
 }
 
+// TestValidatePath_RejectsSSRFShapes is the regression test for the
+// gosec G704 SSRF finding. A path that, when string-concatenated to
+// a base URL, would let url.Parse interpret the result as a
+// different host must be rejected up front. buildURL also defends
+// against this via JoinPath + host pinning, but rejecting at
+// validate-time gives the model a clearer error.
+func TestValidatePath_RejectsSSRFShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"protocol-relative", "//evil.example/foo"},
+		{"userinfo injection", "/foo@evil.example/bar"},
+		{"userinfo at start", "@evil.example/bar"},
+		{"CR injection", "/foo\rEvil-Header: x"},
+		{"LF injection", "/foo\nEvil-Header: x"},
+		{"NUL injection", "/foo\x00bar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validatePath(tc.path); err == nil {
+				t.Errorf("validatePath(%q) accepted; want rejection", tc.path)
+			}
+		})
+	}
+}
+
+// TestBuildURL_PinsHostAgainstAttackerInputs confirms that even
+// when adversarial paths bypass validatePath, buildURL preserves
+// the connection's base host. JoinPath normalizes embedded schemes
+// and protocol-relative prefixes by escaping/treating them as path
+// segments rather than letting them change the URL's authority.
+// The host-pin check after JoinPath is defense-in-depth against
+// any future change to JoinPath semantics.
+func TestBuildURL_PinsHostAgainstAttackerInputs(t *testing.T) {
+	cases := []struct {
+		name string
+		base string
+		path string
+	}{
+		{"absolute URL in path", "https://api.example.com", "/https://evil.example/foo"},
+		{"scheme-shaped segment", "https://api.example.com", "/http://evil.example/foo"},
+		{"backslash separator", "https://api.example.com", "/foo\\bar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildURL(tc.base, tc.path, nil)
+			if err != nil {
+				return // refusal is also acceptable; the contract is "host stays pinned OR refuse"
+			}
+			parsed, perr := url.Parse(got)
+			if perr != nil {
+				t.Fatalf("buildURL produced an unparseable URL %q: %v", got, perr)
+			}
+			if parsed.Host != "api.example.com" {
+				t.Errorf("HOST ESCAPED: buildURL(%q, %q) host = %q; want %q", tc.base, tc.path, parsed.Host, "api.example.com")
+			}
+		})
+	}
+}
+
+func TestBuildURL_RejectsBaseWithoutSchemeOrHost(t *testing.T) {
+	if _, err := buildURL("/no-scheme", "/foo", nil); err == nil {
+		t.Error("buildURL accepted base_url with no scheme")
+	}
+	if _, err := buildURL("https://", "/foo", nil); err == nil {
+		t.Error("buildURL accepted base_url with no host")
+	}
+}
+
 func TestAuthHeaderForConfig(t *testing.T) {
 	cases := []struct {
 		name string

--- a/pkg/toolkits/apigateway/invoke_test.go
+++ b/pkg/toolkits/apigateway/invoke_test.go
@@ -1,0 +1,602 @@
+package apigateway
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateMethod_AcceptsKnownAndRejectsOthers(t *testing.T) {
+	known := []string{"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"}
+	for _, m := range known {
+		if got, err := validateMethod(m); err != nil || got != m {
+			t.Errorf("validateMethod(%q) = (%q, %v); want (%q, nil)", m, got, err, m)
+		}
+	}
+	if got, err := validateMethod("get"); err != nil || got != "GET" {
+		t.Errorf("validateMethod(lowercase) = (%q, %v); want uppercase", got, err)
+	}
+	for _, m := range []string{"OPTIONS", "TRACE", "CONNECT", "BANANA"} {
+		if _, err := validateMethod(m); err == nil {
+			t.Errorf("validateMethod(%q) want error", m)
+		}
+	}
+}
+
+func TestValidatePath(t *testing.T) {
+	if err := validatePath("/v1/users"); err != nil {
+		t.Errorf("valid path rejected: %v", err)
+	}
+	if err := validatePath(""); err == nil {
+		t.Error("empty path accepted")
+	}
+	if err := validatePath("v1/users"); err == nil {
+		t.Error("missing leading slash accepted")
+	}
+}
+
+func TestAuthHeaderForConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{"none", Config{AuthMode: AuthModeNone}, ""},
+		{"bearer", Config{AuthMode: AuthModeBearer}, "Authorization"},
+		{"api_key header default", Config{AuthMode: AuthModeAPIKey, APIKeyPlacement: APIKeyPlacementHeader, APIKeyHeader: DefaultAPIKeyHeader}, DefaultAPIKeyHeader},
+		{"api_key header custom", Config{AuthMode: AuthModeAPIKey, APIKeyPlacement: APIKeyPlacementHeader, APIKeyHeader: "X-My-Key"}, "X-My-Key"},
+		{"api_key query", Config{AuthMode: AuthModeAPIKey, APIKeyPlacement: APIKeyPlacementQuery, APIKeyParam: "key"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := authHeaderForConfig(tc.cfg); got != tc.want {
+				t.Errorf("authHeaderForConfig = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateCustomHeaders_RejectsAuthorization(t *testing.T) {
+	err := validateCustomHeaders(map[string]string{"AUTHORIZATION": "anything"}, "")
+	if err == nil {
+		t.Error("Authorization header allowed")
+	}
+}
+
+func TestValidateCustomHeaders_RejectsConfiguredAPIKeyHeader(t *testing.T) {
+	err := validateCustomHeaders(map[string]string{"x-custom-key": "spoof"}, "X-Custom-Key")
+	if err == nil {
+		t.Error("configured api_key header allowed (case-insensitive check failed)")
+	}
+}
+
+func TestValidateCustomHeaders_AllowsOtherHeaders(t *testing.T) {
+	err := validateCustomHeaders(map[string]string{"Accept-Language": "en"}, "X-API-Key")
+	if err != nil {
+		t.Errorf("unrelated header rejected: %v", err)
+	}
+}
+
+func TestBuildURL_NoQuery(t *testing.T) {
+	got, err := buildURL("https://api.example.com", "/v1/items", nil)
+	if err != nil {
+		t.Fatalf("buildURL: %v", err)
+	}
+	if got != "https://api.example.com/v1/items" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestBuildURL_WithQuery(t *testing.T) {
+	got, err := buildURL("https://api.example.com", "/search", map[string]any{
+		"q":     "hello world",
+		"limit": 10,
+	})
+	if err != nil {
+		t.Fatalf("buildURL: %v", err)
+	}
+	if !strings.Contains(got, "q=hello+world") {
+		t.Errorf("query not encoded: %q", got)
+	}
+	if !strings.Contains(got, "limit=10") {
+		t.Errorf("int param missing: %q", got)
+	}
+}
+
+func TestBuildURL_QueryArrayExpands(t *testing.T) {
+	got, err := buildURL("https://example.com", "/x", map[string]any{
+		"tag": []any{"a", "b", "c"},
+	})
+	if err != nil {
+		t.Fatalf("buildURL: %v", err)
+	}
+	for _, want := range []string{"tag=a", "tag=b", "tag=c"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("got %q; want substring %q", got, want)
+		}
+	}
+}
+
+func TestAppendQueryValue_AllScalarTypes(t *testing.T) {
+	q := url.Values{}
+	appendQueryValue(q, "s", "abc")
+	appendQueryValue(q, "b", true)
+	appendQueryValue(q, "i", 5)
+	appendQueryValue(q, "i64", int64(7))
+	appendQueryValue(q, "f", 3.5)
+	appendQueryValue(q, "n", nil)
+	appendQueryValue(q, "x", struct{ Name string }{"y"})
+
+	if q.Get("s") != "abc" {
+		t.Errorf("s = %q", q.Get("s"))
+	}
+	if q.Get("b") != "true" {
+		t.Errorf("b = %q", q.Get("b"))
+	}
+	if q.Get("i") != "5" {
+		t.Errorf("i = %q", q.Get("i"))
+	}
+	if q.Get("i64") != "7" {
+		t.Errorf("i64 = %q", q.Get("i64"))
+	}
+	if q.Get("f") != "3.5" {
+		t.Errorf("f = %q", q.Get("f"))
+	}
+	if _, ok := q["n"]; ok {
+		t.Errorf("nil value added a key: %v", q["n"])
+	}
+	if q.Get("x") != "{y}" {
+		t.Errorf("x = %q", q.Get("x"))
+	}
+}
+
+func TestEncodeBody_SkipsBodyForGET(t *testing.T) {
+	body, ct, err := encodeBody("GET", map[string]any{"hello": "world"})
+	if err != nil {
+		t.Fatalf("encodeBody: %v", err)
+	}
+	if body != nil || ct != "" {
+		t.Errorf("body/ct = %v/%q; want nil/empty for GET", body, ct)
+	}
+}
+
+func TestEncodeBody_StringBody(t *testing.T) {
+	body, ct, err := encodeBody("POST", "raw text")
+	if err != nil {
+		t.Fatalf("encodeBody: %v", err)
+	}
+	if string(body) != "raw text" {
+		t.Errorf("body = %q", string(body))
+	}
+	if !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("content-type = %q; want text/plain*", ct)
+	}
+}
+
+func TestEncodeBody_ObjectAsJSON(t *testing.T) {
+	body, ct, err := encodeBody("POST", map[string]any{"key": "value"})
+	if err != nil {
+		t.Fatalf("encodeBody: %v", err)
+	}
+	if ct != "application/json" {
+		t.Errorf("content-type = %q", ct)
+	}
+	if !strings.Contains(string(body), `"key":"value"`) {
+		t.Errorf("body = %s", string(body))
+	}
+}
+
+func TestEncodeBody_RejectsUnencodable(t *testing.T) {
+	_, _, err := encodeBody("POST", make(chan int))
+	if err == nil {
+		t.Error("encodeBody: want error for non-JSON-encodable body")
+	}
+}
+
+func TestResolveTimeout(t *testing.T) {
+	if got := resolveTimeout(0, 30*time.Second); got != 30*time.Second {
+		t.Errorf("default not used: %v", got)
+	}
+	if got := resolveTimeout(5, time.Minute); got != 5*time.Second {
+		t.Errorf("explicit not honored: %v", got)
+	}
+	if got := resolveTimeout(9999, time.Minute); got != maxTimeoutSeconds*time.Second {
+		t.Errorf("not capped: %v", got)
+	}
+}
+
+func TestReadBody_BelowCap(t *testing.T) {
+	body, truncated, err := readBody(strings.NewReader("hello"), 100)
+	if err != nil {
+		t.Fatalf("readBody: %v", err)
+	}
+	if string(body) != "hello" || truncated {
+		t.Errorf("body=%q truncated=%v", body, truncated)
+	}
+}
+
+func TestReadBody_AtCap(t *testing.T) {
+	body, truncated, err := readBody(strings.NewReader("12345"), 5)
+	if err != nil {
+		t.Fatalf("readBody: %v", err)
+	}
+	if string(body) != "12345" || truncated {
+		t.Errorf("body=%q truncated=%v", body, truncated)
+	}
+}
+
+func TestReadBody_OverCapTruncates(t *testing.T) {
+	body, truncated, err := readBody(strings.NewReader("123456789"), 4)
+	if err != nil {
+		t.Fatalf("readBody: %v", err)
+	}
+	if string(body) != "1234" {
+		t.Errorf("body=%q; want 1234", body)
+	}
+	if !truncated {
+		t.Error("truncated = false; want true")
+	}
+}
+
+func TestReadBody_ZeroCapDefaults(t *testing.T) {
+	_, _, err := readBody(strings.NewReader("hi"), 0)
+	if err != nil {
+		t.Fatalf("readBody: %v", err)
+	}
+}
+
+type errReader struct{}
+
+func (errReader) Read(_ []byte) (int, error) { return 0, errors.New("boom") }
+
+func TestReadBody_PropagatesError(t *testing.T) {
+	if _, _, err := readBody(errReader{}, 100); err == nil {
+		t.Error("readBody: want error from underlying reader")
+	}
+}
+
+func TestDecodeBody_JSONContentType(t *testing.T) {
+	got := decodeBody("application/json", []byte(`{"a":1}`))
+	m, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("got %#v; want map", got)
+	}
+	val, ok := m["a"].(float64)
+	if !ok || val != 1 {
+		t.Errorf("m[\"a\"] = %#v; want 1", m["a"])
+	}
+}
+
+func TestDecodeBody_NonJSONReturnsString(t *testing.T) {
+	got := decodeBody("text/html", []byte("<p>hi</p>"))
+	if s, ok := got.(string); !ok || s != "<p>hi</p>" {
+		t.Errorf("got %#v; want string", got)
+	}
+}
+
+func TestDecodeBody_JSONFallsBackOnInvalid(t *testing.T) {
+	got := decodeBody("application/json", []byte("not json"))
+	if s, ok := got.(string); !ok || s != "not json" {
+		t.Errorf("got %#v; want raw string fallback", got)
+	}
+}
+
+func TestDecodeBody_EmptyReturnsNil(t *testing.T) {
+	if got := decodeBody("application/json", nil); got != nil {
+		t.Errorf("got %#v; want nil", got)
+	}
+}
+
+func TestSelectResponseHeaders_OnlyPassesAllowList(t *testing.T) {
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	h.Set("Set-Cookie", "session=secret")
+	h.Set("X-Custom", "ignored")
+	h.Set("Link", "<next>; rel=\"next\"")
+
+	out := selectResponseHeaders(h)
+	if out["Content-Type"] == nil {
+		t.Error("Content-Type dropped")
+	}
+	if out["Link"] == nil {
+		t.Error("Link dropped")
+	}
+	if _, ok := out["Set-Cookie"]; ok {
+		t.Error("Set-Cookie leaked")
+	}
+	if _, ok := out["X-Custom"]; ok {
+		t.Error("X-Custom leaked")
+	}
+}
+
+func TestSelectResponseHeaders_NilWhenEmpty(t *testing.T) {
+	if out := selectResponseHeaders(http.Header{}); out != nil {
+		t.Errorf("got %v; want nil", out)
+	}
+	h := http.Header{}
+	h.Set("X-Nothing-Of-Interest", "1")
+	if out := selectResponseHeaders(h); out != nil {
+		t.Errorf("got %v; want nil for fully-filtered headers", out)
+	}
+}
+
+// End-to-end: the integration-style test using httptest.Server. This
+// is the test that actually proves the assembled invocation pipeline
+// (URL build → request build → auth apply → execute → read → decode)
+// works against a real HTTP transport.
+func TestInvoke_EndToEnd_BearerAuth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer tok-123" {
+			t.Errorf("upstream saw Authorization=%q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"echo":"ok"}`)
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		BaseURL:          srv.URL,
+		AuthMode:         AuthModeBearer,
+		Credential:       "tok-123",
+		ConnectTimeout:   2 * time.Second,
+		CallTimeout:      5 * time.Second,
+		MaxResponseBytes: DefaultMaxResponseBytes,
+	}
+	auth, err := NewAuthenticator(cfg)
+	if err != nil {
+		t.Fatalf("NewAuthenticator: %v", err)
+	}
+	out, err := invoke(context.Background(), invocation{
+		cfg:    cfg,
+		auth:   auth,
+		client: newHTTPClient(cfg),
+	}, InvokeInput{
+		Connection: "test",
+		Method:     "GET",
+		Path:       "/items",
+	})
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if out.Status != 200 {
+		t.Errorf("status = %d", out.Status)
+	}
+	body, ok := out.Body.(map[string]any)
+	if !ok || body["echo"] != "ok" {
+		t.Errorf("body = %#v", out.Body)
+	}
+	if out.DurationMs < 0 {
+		t.Errorf("duration_ms = %d", out.DurationMs)
+	}
+}
+
+func TestInvoke_EndToEnd_PostBodySent(t *testing.T) {
+	var seenBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		BaseURL: srv.URL, AuthMode: AuthModeNone,
+		ConnectTimeout: time.Second, CallTimeout: 5 * time.Second,
+		MaxResponseBytes: DefaultMaxResponseBytes,
+	}
+	auth, _ := NewAuthenticator(cfg)
+	out, err := invoke(context.Background(), invocation{cfg: cfg, auth: auth, client: newHTTPClient(cfg)}, InvokeInput{
+		Connection: "x", Method: "POST", Path: "/things",
+		Body: map[string]any{"name": "alice"},
+	})
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if out.Status != http.StatusCreated {
+		t.Errorf("status = %d", out.Status)
+	}
+	if !bytes.Contains(seenBody, []byte(`"name":"alice"`)) {
+		t.Errorf("body sent = %s", string(seenBody))
+	}
+}
+
+// TestInvoke_NetworkError_DoesNotLeakAPIKeyInQueryPlacement is a
+// regression test for the api_key + query-placement credential leak.
+// When client.Do returns an error, Go's *url.Error stringifies the
+// FULL request URL — including the query string the Authenticator
+// added. Without scrubbing, the credential would land in
+// InvokeOutput.Error, which is returned to the model and recorded
+// in audit. The auth.go Authenticator contract explicitly forbids
+// any credential appearing in error messages.
+func TestInvoke_NetworkError_DoesNotLeakAPIKeyInQueryPlacement(t *testing.T) {
+	const secret = "supersecret-credential-9b7"
+	cfg := Config{
+		BaseURL:          "http://192.0.2.1:80", // RFC 5737 unreachable
+		AuthMode:         AuthModeAPIKey,
+		Credential:       secret,
+		APIKeyPlacement:  APIKeyPlacementQuery,
+		APIKeyParam:      "api_key",
+		ConnectTimeout:   200 * time.Millisecond,
+		CallTimeout:      time.Second,
+		MaxResponseBytes: DefaultMaxResponseBytes,
+	}
+	auth, err := NewAuthenticator(cfg)
+	if err != nil {
+		t.Fatalf("NewAuthenticator: %v", err)
+	}
+	out, err := invoke(context.Background(), invocation{cfg: cfg, auth: auth, client: newHTTPClient(cfg)}, InvokeInput{
+		Connection: "x", Method: "GET", Path: "/foo",
+	})
+	if err != nil {
+		t.Fatalf("invoke unexpected error: %v", err)
+	}
+	if out.Error == "" {
+		t.Fatal("expected error envelope, got none")
+	}
+	if strings.Contains(out.Error, secret) {
+		t.Errorf("CREDENTIAL LEAK: secret appears in InvokeOutput.Error: %q", out.Error)
+	}
+}
+
+func TestScrubTransportError_StripsQueryAndUserInfo(t *testing.T) {
+	cases := []struct {
+		name string
+		in   error
+		bad  []string
+	}{
+		{
+			name: "url.Error with credential in query",
+			in: &url.Error{
+				Op:  "Get",
+				URL: "http://host.example/foo?api_key=SECRET&page=1",
+				Err: errors.New("dial tcp: timeout"),
+			},
+			bad: []string{"SECRET", "api_key="},
+		},
+		{
+			name: "url.Error with userinfo",
+			in: &url.Error{
+				Op:  "Get",
+				URL: "http://user:PASSWORD@host.example/foo",
+				Err: errors.New("dial tcp: refused"),
+			},
+			bad: []string{"PASSWORD", "user:"},
+		},
+		{
+			name: "url.Error with malformed URL falls back",
+			in: &url.Error{
+				Op:  "Get",
+				URL: "://broken?api_key=SECRET",
+				Err: errors.New("malformed"),
+			},
+			bad: []string{"SECRET"},
+		},
+		{
+			name: "non-url.Error is passed through",
+			in:   errors.New("plain error message"),
+			bad:  nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scrubTransportError(tc.in)
+			if got == "" {
+				t.Fatal("scrubTransportError returned empty string")
+			}
+			for _, marker := range tc.bad {
+				if strings.Contains(got, marker) {
+					t.Errorf("scrubbed message %q still contains %q", got, marker)
+				}
+			}
+		})
+	}
+}
+
+func TestInvoke_NetworkErrorPopulatesError(t *testing.T) {
+	cfg := Config{
+		BaseURL: "http://127.0.0.1:1", AuthMode: AuthModeNone,
+		ConnectTimeout: 100 * time.Millisecond, CallTimeout: 200 * time.Millisecond,
+		MaxResponseBytes: DefaultMaxResponseBytes,
+	}
+	auth, _ := NewAuthenticator(cfg)
+	out, err := invoke(context.Background(), invocation{cfg: cfg, auth: auth, client: newHTTPClient(cfg)}, InvokeInput{
+		Connection: "x", Method: "GET", Path: "/",
+	})
+	if err != nil {
+		t.Fatalf("invoke unexpected error: %v", err)
+	}
+	if out.Status != 0 || out.Error == "" {
+		t.Errorf("got status=%d error=%q; want 0 + error", out.Status, out.Error)
+	}
+}
+
+func TestInvoke_RejectsInvalidMethod(t *testing.T) {
+	cfg := Config{BaseURL: "https://x", AuthMode: AuthModeNone, ConnectTimeout: time.Second, CallTimeout: time.Second, MaxResponseBytes: DefaultMaxResponseBytes}
+	auth, _ := NewAuthenticator(cfg)
+	_, err := invoke(context.Background(), invocation{cfg: cfg, auth: auth, client: newHTTPClient(cfg)}, InvokeInput{
+		Connection: "x", Method: "PURGE", Path: "/",
+	})
+	if err == nil || !strings.Contains(err.Error(), "method") {
+		t.Errorf("got %v; want method error", err)
+	}
+}
+
+func TestInvoke_RejectsConflictingHeader(t *testing.T) {
+	cfg := Config{BaseURL: "https://x", AuthMode: AuthModeBearer, Credential: "tok", ConnectTimeout: time.Second, CallTimeout: time.Second, MaxResponseBytes: DefaultMaxResponseBytes}
+	auth, _ := NewAuthenticator(cfg)
+	_, err := invoke(context.Background(), invocation{cfg: cfg, auth: auth, client: newHTTPClient(cfg)}, InvokeInput{
+		Connection: "x", Method: "GET", Path: "/",
+		Headers: map[string]string{"Authorization": "Bearer evil"},
+	})
+	if err == nil {
+		t.Error("invoke: want error for spoofed Authorization")
+	}
+}
+
+func TestInvoke_RedirectsAreNotFollowed(t *testing.T) {
+	hit := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit++
+		if r.URL.Path == "/start" {
+			w.Header().Set("Location", "/elsewhere")
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "should-not-reach")
+	}))
+	defer srv.Close()
+
+	cfg := Config{BaseURL: srv.URL, AuthMode: AuthModeNone, ConnectTimeout: time.Second, CallTimeout: 2 * time.Second, MaxResponseBytes: DefaultMaxResponseBytes}
+	auth, _ := NewAuthenticator(cfg)
+	out, err := invoke(context.Background(), invocation{cfg: cfg, auth: auth, client: newHTTPClient(cfg)}, InvokeInput{
+		Connection: "x", Method: "GET", Path: "/start",
+	})
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if out.Status != http.StatusFound {
+		t.Errorf("status = %d; want 302 (redirect not followed)", out.Status)
+	}
+	if hit != 1 {
+		t.Errorf("upstream hit %d times; redirect was followed", hit)
+	}
+	// Location header must be surfaced so the model can choose to
+	// follow the redirect manually with a fresh api_invoke_endpoint
+	// call. Dropping Location would trap the model in a 3xx with no
+	// way to know where the upstream wanted to redirect it.
+	if loc := out.Headers["Location"]; len(loc) == 0 || loc[0] != "/elsewhere" {
+		t.Errorf("Location header missing from response envelope: %v", out.Headers)
+	}
+}
+
+func TestInvoke_TruncatesLargeResponse(t *testing.T) {
+	big := strings.Repeat("x", 1000)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = io.WriteString(w, big)
+	}))
+	defer srv.Close()
+
+	cfg := Config{BaseURL: srv.URL, AuthMode: AuthModeNone, ConnectTimeout: time.Second, CallTimeout: 2 * time.Second, MaxResponseBytes: 100}
+	auth, _ := NewAuthenticator(cfg)
+	out, err := invoke(context.Background(), invocation{cfg: cfg, auth: auth, client: newHTTPClient(cfg)}, InvokeInput{
+		Connection: "x", Method: "GET", Path: "/",
+	})
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if !out.BodyTruncated {
+		t.Error("BodyTruncated = false; want true")
+	}
+	if s, _ := out.Body.(string); len(s) != 100 {
+		t.Errorf("body length = %d; want 100", len(s))
+	}
+}

--- a/pkg/toolkits/apigateway/schemas.go
+++ b/pkg/toolkits/apigateway/schemas.go
@@ -1,0 +1,45 @@
+package apigateway
+
+import "encoding/json"
+
+// invokeEndpointSchema is the JSON Schema for the api_invoke_endpoint tool input.
+//
+//nolint:gochecknoglobals // MCP tool schema must be a package-level var
+var invokeEndpointSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["connection", "method", "path"],
+  "properties": {
+    "connection": {
+      "type": "string",
+      "description": "Name of the registered API connection (kind=api). Required. Use list_connections to discover available connections."
+    },
+    "method": {
+      "type": "string",
+      "enum": ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"],
+      "description": "HTTP method. Required."
+    },
+    "path": {
+      "type": "string",
+      "description": "Request path joined to the connection's base URL. Examples: \"/v1/users/123\", \"/api/items\". Required. Must start with \"/\"."
+    },
+    "query": {
+      "type": "object",
+      "description": "Optional query string parameters. Values may be strings, numbers, or booleans; arrays send the parameter once per value.",
+      "additionalProperties": true
+    },
+    "headers": {
+      "type": "object",
+      "description": "Optional custom request headers. Sending Authorization or the connection's api_key header is rejected.",
+      "additionalProperties": {"type": "string"}
+    },
+    "body": {
+      "description": "Optional request body. Objects/arrays are JSON-encoded with Content-Type application/json. Strings are sent verbatim with Content-Type text/plain unless an explicit Content-Type header is provided. Ignored for GET and HEAD."
+    },
+    "timeout_seconds": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 600,
+      "description": "Optional per-call timeout override in seconds. Capped to 600 (10 minutes). Defaults to the connection's call_timeout."
+    }
+  }
+}`)

--- a/pkg/toolkits/apigateway/toolkit.go
+++ b/pkg/toolkits/apigateway/toolkit.go
@@ -1,0 +1,364 @@
+package apigateway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/query"
+	"github.com/txn2/mcp-data-platform/pkg/semantic"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
+)
+
+// ErrConnectionExists is returned when AddConnection is called with a
+// name already registered in the toolkit.
+var ErrConnectionExists = errors.New("apigateway: connection already exists")
+
+// ErrConnectionNotFound is returned when an operation is requested
+// against a connection that has not been registered.
+var ErrConnectionNotFound = errors.New("apigateway: connection not found")
+
+const (
+	// ToolInvokeEndpoint is the MCP tool name for the invoke
+	// operation. Exported so audit code and tests reference the same
+	// literal as the registration site.
+	ToolInvokeEndpoint = "api_invoke_endpoint"
+
+	logKeyConnection = "connection"
+	logKeyError      = "error"
+)
+
+// Toolkit is the api-gateway toolkit. A single Toolkit manages
+// multiple named connections, each addressing a different upstream
+// HTTP API. Connections are added either at startup (from the
+// platform's merged YAML+DB config) or at runtime via AddConnection
+// (used by the admin REST handler when an operator saves a new
+// connection through the portal).
+type Toolkit struct {
+	name        string
+	defaultName string
+
+	mu          sync.RWMutex
+	connections map[string]*conn
+
+	semanticProvider semantic.Provider
+	queryProvider    query.Provider
+}
+
+// conn carries the materialized state for a single registered
+// connection: parsed config, the Authenticator implementing its auth
+// mode, and a per-connection HTTP client whose Transport tunes
+// idle-connection behavior independently from other connections.
+type conn struct {
+	cfg    Config
+	auth   Authenticator
+	client *http.Client
+}
+
+// New builds an empty toolkit. Connections are added later via
+// AddConnection (used both by NewMulti at startup and by the admin
+// hot-add path at runtime).
+func New(name string) *Toolkit {
+	if name == "" {
+		name = Kind
+	}
+	return &Toolkit{
+		name:        name,
+		connections: make(map[string]*conn),
+	}
+}
+
+// NewMulti builds a Toolkit and pre-loads the given parsed
+// connection configs. Per-connection materialization failures are
+// logged and skipped so a single bad connection does not block
+// platform startup.
+func NewMulti(cfg MultiConfig) *Toolkit {
+	name := cfg.DefaultName
+	if name == "" {
+		name = Kind
+	}
+	t := New(name)
+	t.defaultName = cfg.DefaultName
+	for instanceName, c := range cfg.Instances {
+		if c.ConnectionName == "" {
+			c.ConnectionName = instanceName
+		}
+		if err := t.addParsedConnection(instanceName, c); err != nil {
+			slog.Warn("apigateway: initial connection failed",
+				logKeyConnection, instanceName, logKeyError, err)
+		}
+	}
+	return t
+}
+
+// Kind returns the toolkit kind discriminator.
+func (*Toolkit) Kind() string { return Kind }
+
+// Name returns the toolkit instance name.
+func (t *Toolkit) Name() string { return t.name }
+
+// Connection returns the default connection name for audit
+// attribution when a tool call does not carry one. Empty string when
+// no default is configured (multi-connection deployments typically
+// require the model to pass `connection` explicitly).
+func (t *Toolkit) Connection() string { return t.defaultName }
+
+// RegisterTools registers api_invoke_endpoint with the MCP server.
+// Future PRs add api_list_endpoints and api_get_endpoint_schema
+// under the same toolkit (see RFC #364).
+func (t *Toolkit) RegisterTools(s *mcp.Server) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:  ToolInvokeEndpoint,
+		Title: "Invoke API Endpoint",
+		Description: "Make an authenticated HTTP request against a registered API connection. " +
+			"The connection's auth (none/bearer/api_key) is applied automatically; the model " +
+			"never handles credentials. Returns status, selected response headers, and the parsed " +
+			"or text response body. Method is restricted to GET, POST, PUT, DELETE, PATCH, HEAD; " +
+			"path is joined to the connection's base_url; response bodies above the connection's " +
+			"max_response_bytes are truncated and flagged. Use list_connections to discover " +
+			"available kind=api connections.",
+		InputSchema: invokeEndpointSchema,
+	}, t.handleInvoke)
+}
+
+// Tools returns the list of tool names this toolkit registers.
+func (*Toolkit) Tools() []string {
+	return []string{ToolInvokeEndpoint}
+}
+
+// SetSemanticProvider stores the semantic provider. Reserved for
+// future enrichment (e.g. response shaping driven by DataHub PII
+// tags, see issue #373); not consumed in v1.
+func (t *Toolkit) SetSemanticProvider(provider semantic.Provider) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.semanticProvider = provider
+}
+
+// SetQueryProvider stores the query provider. Reserved for future
+// warehouse-bridging features (see issue #372); not consumed in v1.
+func (t *Toolkit) SetQueryProvider(provider query.Provider) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.queryProvider = provider
+}
+
+// AddConnection parses a raw config map, materializes the per-
+// connection auth + HTTP client, and registers the connection. Used
+// both at startup (via NewMulti) and at runtime via the admin
+// hot-add path.
+func (t *Toolkit) AddConnection(name string, config map[string]any) error {
+	cfg, err := ParseConfig(config)
+	if err != nil {
+		return err
+	}
+	if cfg.ConnectionName == "" {
+		cfg.ConnectionName = name
+	}
+	return t.addParsedConnection(name, cfg)
+}
+
+// addParsedConnection assumes the Config is already validated. It
+// builds the Authenticator and HTTP client and inserts the
+// connection under lock.
+func (t *Toolkit) addParsedConnection(name string, cfg Config) error {
+	auth, err := NewAuthenticator(cfg)
+	if err != nil {
+		return fmt.Errorf("apigateway: %s: %w", name, err)
+	}
+	c := &conn{
+		cfg:    cfg,
+		auth:   auth,
+		client: newHTTPClient(cfg),
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, exists := t.connections[name]; exists {
+		return fmt.Errorf("apigateway: %s: %w", name, ErrConnectionExists)
+	}
+	t.connections[name] = c
+	return nil
+}
+
+// RemoveConnection drops a registered connection. Used by the admin
+// hot-remove path when an operator deletes the connection in the
+// portal. Idle keepalive sockets on the per-connection HTTP client
+// are closed so they don't linger up to idleConnectionTimeout after
+// the connection is gone.
+func (t *Toolkit) RemoveConnection(name string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	c, exists := t.connections[name]
+	if !exists {
+		return fmt.Errorf("apigateway: %s: %w", name, ErrConnectionNotFound)
+	}
+	if c.client != nil {
+		c.client.CloseIdleConnections()
+	}
+	delete(t.connections, name)
+	return nil
+}
+
+// HasConnection reports whether a connection with the given name is
+// registered.
+func (t *Toolkit) HasConnection(name string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	_, ok := t.connections[name]
+	return ok
+}
+
+// ListConnections returns details for every registered connection,
+// in name-sorted order. Implements toolkit.ConnectionLister so the
+// platform's unified list_connections tool surfaces api connections
+// alongside trino, s3, and mcp.
+func (t *Toolkit) ListConnections() []toolkit.ConnectionDetail {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	names := make([]string, 0, len(t.connections))
+	for name := range t.connections {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]toolkit.ConnectionDetail, 0, len(names))
+	for _, name := range names {
+		c := t.connections[name]
+		out = append(out, toolkit.ConnectionDetail{
+			Name:        name,
+			Description: c.cfg.BaseURL,
+			IsDefault:   name == t.defaultName,
+		})
+	}
+	return out
+}
+
+// Close releases per-connection HTTP client resources.
+func (t *Toolkit) Close() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, c := range t.connections {
+		if c.client != nil {
+			c.client.CloseIdleConnections()
+		}
+	}
+	return nil
+}
+
+// handleInvoke is the MCP handler for api_invoke_endpoint. It looks
+// up the named connection, runs the call, and returns the structured
+// result either as a JSON-encoded text content (for human-readable
+// chat surfaces) and as a typed Output (so structured-output-aware
+// clients can consume it directly).
+func (t *Toolkit) handleInvoke(ctx context.Context, _ *mcp.CallToolRequest, in InvokeInput) (*mcp.CallToolResult, any, error) {
+	if in.Connection == "" {
+		return errorResult("connection is required"), nil, nil
+	}
+	t.mu.RLock()
+	c, ok := t.connections[in.Connection]
+	t.mu.RUnlock()
+	if !ok {
+		return errorResult(fmt.Sprintf("connection %q not found (use list_connections to discover api connections)", in.Connection)), nil, nil
+	}
+
+	out, err := invoke(ctx, invocation{cfg: c.cfg, auth: c.auth, client: c.client}, in)
+	if err != nil {
+		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol — argument validation surfaced as tool error
+	}
+	return jsonResult(out), out, nil
+}
+
+// jsonResult creates a successful MCP result with the JSON-encoded
+// payload as text content. Mirrors the helper used by other
+// in-repo toolkits so the chat surface formatting stays consistent.
+func jsonResult(data any) *mcp.CallToolResult {
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return errorResult("internal error: " + err.Error())
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+	}
+}
+
+func errorResult(msg string) *mcp.CallToolResult {
+	b, err := json.Marshal(map[string]string{"error": msg})
+	if err != nil {
+		b = []byte(`{"error": "internal error"}`)
+	}
+	return &mcp.CallToolResult{
+		IsError: true,
+		Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+	}
+}
+
+// newHTTPClient builds the per-connection HTTP client. Redirects
+// are explicitly disallowed so the toolkit does not blindly
+// re-issue a request (and re-attach the connection's credential)
+// to a host the operator did not authorize. The model can follow
+// redirects manually by reading the upstream Location header from
+// the response and issuing a new api_invoke_endpoint call with the
+// redirected URL.
+func newHTTPClient(cfg Config) *http.Client {
+	return &http.Client{
+		Timeout:   cfg.CallTimeout,
+		Transport: newHTTPTransport(cfg),
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// idleConnectionTimeout caps how long an idle keep-alive connection
+// can sit in the pool before being closed. Independent of the
+// per-call timeouts; a generous default reduces reconnect churn for
+// chatty connections.
+const idleConnectionTimeout = 90 * time.Second
+
+// maxIdleConnections caps the per-host pool of reusable keep-alive
+// sockets. Modest because each connection's typical workload is
+// occasional fan-out from MCP tool calls, not high-throughput.
+const maxIdleConnections = 10
+
+// newHTTPTransport builds the per-connection http.Transport. The
+// dial step (TCP + TLS handshake) is bound by cfg.ConnectTimeout so
+// an unreachable upstream fails fast instead of consuming the full
+// CallTimeout budget. Exposed as a separate function so unit tests
+// can verify the wiring without standing up a network listener.
+func newHTTPTransport(cfg Config) *http.Transport {
+	return &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: cfg.ConnectTimeout,
+		}).DialContext,
+		TLSHandshakeTimeout:   cfg.ConnectTimeout,
+		ExpectContinueTimeout: time.Second,
+		IdleConnTimeout:       idleConnectionTimeout,
+		MaxIdleConns:          maxIdleConnections,
+	}
+}
+
+// Verify interface compliance at compile time. The registry.Toolkit
+// shape is inlined to avoid an import cycle (pkg/registry imports
+// this package via factories.go).
+var (
+	_ interface {
+		Kind() string
+		Name() string
+		Connection() string
+		RegisterTools(s *mcp.Server)
+		Tools() []string
+		SetSemanticProvider(provider semantic.Provider)
+		SetQueryProvider(provider query.Provider)
+		Close() error
+	} = (*Toolkit)(nil)
+	_ toolkit.ConnectionManager = (*Toolkit)(nil)
+	_ toolkit.ConnectionLister  = (*Toolkit)(nil)
+)

--- a/pkg/toolkits/apigateway/toolkit_test.go
+++ b/pkg/toolkits/apigateway/toolkit_test.go
@@ -1,0 +1,391 @@
+package apigateway
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestNew_DefaultsToKindWhenNameEmpty(t *testing.T) {
+	tk := New("")
+	if tk.Name() != Kind {
+		t.Errorf("Name() = %q; want %q", tk.Name(), Kind)
+	}
+}
+
+func TestNew_KeepsExplicitName(t *testing.T) {
+	tk := New("custom")
+	if tk.Name() != "custom" {
+		t.Errorf("Name() = %q; want %q", tk.Name(), "custom")
+	}
+}
+
+func TestKind_IsAPI(t *testing.T) {
+	tk := New("x")
+	if tk.Kind() != "api" {
+		t.Errorf("Kind() = %q; want %q", tk.Kind(), "api")
+	}
+}
+
+func TestNewMulti_LoadsValidConnections(t *testing.T) {
+	mc, err := ParseMultiConfig("default", map[string]map[string]any{
+		"alpha": {"base_url": "https://a.example.com"},
+		"beta":  {"base_url": "https://b.example.com", "auth_mode": AuthModeBearer, "credential": "tok"},
+	})
+	if err != nil {
+		t.Fatalf("ParseMultiConfig: %v", err)
+	}
+	tk := NewMulti(mc)
+	if !tk.HasConnection("alpha") || !tk.HasConnection("beta") {
+		t.Errorf("connections missing: alpha=%v beta=%v", tk.HasConnection("alpha"), tk.HasConnection("beta"))
+	}
+	if tk.Connection() != "default" {
+		t.Errorf("Connection() = %q; want %q", tk.Connection(), "default")
+	}
+}
+
+func TestNewMulti_SkipsBadConnection(t *testing.T) {
+	// Force a per-connection materialization failure by feeding an
+	// already-validated Config that NewAuthenticator will reject. We
+	// build the MultiConfig manually rather than via ParseMultiConfig
+	// (which would catch this at parse time) to exercise the
+	// addParsedConnection error path.
+	prevLogger := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+
+	good := Config{
+		BaseURL: "https://good.example.com", AuthMode: AuthModeNone,
+		ConnectTimeout: time.Second, CallTimeout: time.Second, MaxResponseBytes: 1024,
+		TrustLevel: TrustLevelUntrusted,
+	}
+	bad := Config{
+		BaseURL: "https://bad.example.com", AuthMode: "weird",
+		ConnectTimeout: time.Second, CallTimeout: time.Second, MaxResponseBytes: 1024,
+		TrustLevel: TrustLevelUntrusted,
+	}
+	tk := NewMulti(MultiConfig{
+		Instances: map[string]Config{"good": good, "bad": bad},
+	})
+	if !tk.HasConnection("good") {
+		t.Error("good connection missing")
+	}
+	if tk.HasConnection("bad") {
+		t.Error("bad connection should have been skipped")
+	}
+}
+
+func TestNewMulti_DefaultNameFallsBackToKind(t *testing.T) {
+	tk := NewMulti(MultiConfig{})
+	if tk.Name() != Kind {
+		t.Errorf("Name() = %q; want %q", tk.Name(), Kind)
+	}
+}
+
+func TestAddConnection_RejectsDuplicates(t *testing.T) {
+	tk := New("test")
+	cfg := map[string]any{"base_url": "https://x"}
+	if err := tk.AddConnection("a", cfg); err != nil {
+		t.Fatalf("first AddConnection: %v", err)
+	}
+	if err := tk.AddConnection("a", cfg); !errors.Is(err, ErrConnectionExists) {
+		t.Errorf("second AddConnection: got %v; want ErrConnectionExists", err)
+	}
+}
+
+func TestAddConnection_RejectsBadConfig(t *testing.T) {
+	tk := New("test")
+	if err := tk.AddConnection("a", map[string]any{"auth_mode": AuthModeBearer}); err == nil {
+		t.Error("bad config accepted")
+	}
+}
+
+func TestAddConnection_SetsConnectionNameDefault(t *testing.T) {
+	tk := New("test")
+	if err := tk.AddConnection("named", map[string]any{"base_url": "https://x"}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	conns := tk.ListConnections()
+	if len(conns) != 1 || conns[0].Name != "named" {
+		t.Errorf("ListConnections = %#v", conns)
+	}
+}
+
+func TestRemoveConnection(t *testing.T) {
+	tk := New("test")
+	_ = tk.AddConnection("a", map[string]any{"base_url": "https://x"})
+	if err := tk.RemoveConnection("a"); err != nil {
+		t.Fatalf("RemoveConnection: %v", err)
+	}
+	if tk.HasConnection("a") {
+		t.Error("HasConnection still true after Remove")
+	}
+	if err := tk.RemoveConnection("ghost"); !errors.Is(err, ErrConnectionNotFound) {
+		t.Errorf("RemoveConnection(ghost) = %v; want ErrConnectionNotFound", err)
+	}
+}
+
+func TestListConnections_SortedByName(t *testing.T) {
+	tk := New("test")
+	for _, name := range []string{"zeta", "alpha", "mu"} {
+		if err := tk.AddConnection(name, map[string]any{"base_url": "https://x"}); err != nil {
+			t.Fatalf("AddConnection(%s): %v", name, err)
+		}
+	}
+	conns := tk.ListConnections()
+	if len(conns) != 3 {
+		t.Fatalf("len = %d", len(conns))
+	}
+	if conns[0].Name != "alpha" || conns[1].Name != "mu" || conns[2].Name != "zeta" {
+		t.Errorf("not sorted: %+v", conns)
+	}
+}
+
+func TestListConnections_FlagsDefault(t *testing.T) {
+	tk := NewMulti(MultiConfig{
+		DefaultName: "primary",
+		Instances: map[string]Config{
+			"primary": {BaseURL: "https://x", AuthMode: AuthModeNone, ConnectTimeout: time.Second, CallTimeout: time.Second, MaxResponseBytes: 1024, TrustLevel: TrustLevelUntrusted, ConnectionName: "primary"},
+			"backup":  {BaseURL: "https://y", AuthMode: AuthModeNone, ConnectTimeout: time.Second, CallTimeout: time.Second, MaxResponseBytes: 1024, TrustLevel: TrustLevelUntrusted, ConnectionName: "backup"},
+		},
+	})
+	conns := tk.ListConnections()
+	for _, c := range conns {
+		if c.Name == "primary" && !c.IsDefault {
+			t.Error("primary not flagged as default")
+		}
+		if c.Name == "backup" && c.IsDefault {
+			t.Error("backup flagged as default")
+		}
+	}
+}
+
+func TestSetSemanticAndQueryProvider_NoOp(_ *testing.T) {
+	tk := New("test")
+	// v1 stores both providers without consuming them; nil is the only
+	// case worth exercising here. Real provider integration is covered
+	// once response-shaping (issue #373) lands.
+	tk.SetSemanticProvider(nil)
+	tk.SetQueryProvider(nil)
+}
+
+func TestClose_TolerantOfClosedConnections(t *testing.T) {
+	tk := New("test")
+	if err := tk.AddConnection("a", map[string]any{"base_url": "https://x"}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	if err := tk.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+func TestTools_NamesInvokeEndpoint(t *testing.T) {
+	tk := New("test")
+	tools := tk.Tools()
+	if len(tools) != 1 || tools[0] != ToolInvokeEndpoint {
+		t.Errorf("Tools() = %v; want [%q]", tools, ToolInvokeEndpoint)
+	}
+}
+
+// handleInvoke is the only entry point exercised by the MCP server.
+// The tests here exercise it directly because spinning up a full
+// mcp.Server inside a unit test is heavy; the integration test in
+// TestRegisterTools_AgainstRealServer covers the wire-up path.
+func TestHandleInvoke_RejectsMissingConnectionArg(t *testing.T) {
+	tk := New("test")
+	res, _, err := tk.handleInvoke(context.Background(), nil, InvokeInput{})
+	if err != nil {
+		t.Fatalf("handleInvoke: %v", err)
+	}
+	if !res.IsError {
+		t.Error("expected IsError=true for missing connection")
+	}
+}
+
+func TestHandleInvoke_ReportsUnknownConnection(t *testing.T) {
+	tk := New("test")
+	res, _, err := tk.handleInvoke(context.Background(), nil, InvokeInput{
+		Connection: "ghost", Method: "GET", Path: "/",
+	})
+	if err != nil {
+		t.Fatalf("handleInvoke: %v", err)
+	}
+	if !res.IsError {
+		t.Error("expected IsError=true for unknown connection")
+	}
+}
+
+func TestHandleInvoke_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer srv.Close()
+
+	tk := New("test")
+	if err := tk.AddConnection("c1", map[string]any{"base_url": srv.URL}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	res, out, err := tk.handleInvoke(context.Background(), nil, InvokeInput{
+		Connection: "c1", Method: "GET", Path: "/",
+	})
+	if err != nil {
+		t.Fatalf("handleInvoke: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("IsError=true: %s", textContent(res))
+	}
+	o, ok := out.(InvokeOutput)
+	if !ok {
+		t.Fatalf("out type = %T", out)
+	}
+	if o.Status != 200 {
+		t.Errorf("status = %d", o.Status)
+	}
+}
+
+func TestHandleInvoke_BadInputProducesToolError(t *testing.T) {
+	tk := New("test")
+	if err := tk.AddConnection("c1", map[string]any{"base_url": "https://x"}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	res, _, err := tk.handleInvoke(context.Background(), nil, InvokeInput{
+		Connection: "c1", Method: "PURGE", Path: "/",
+	})
+	if err != nil {
+		t.Fatalf("handleInvoke unexpected go error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("invalid method did not produce IsError=true")
+	}
+}
+
+func TestRegisterTools_AgainstRealServer(_ *testing.T) {
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	tk := New("api")
+	tk.RegisterTools(srv)
+	// No assertion API on mcp.Server for tool counts; the act of
+	// registering without panicking is the assertion. A future SDK
+	// upgrade that breaks the AddTool signature would fail to compile.
+}
+
+func textContent(res *mcp.CallToolResult) string {
+	if len(res.Content) == 0 {
+		return ""
+	}
+	tc, _ := res.Content[0].(*mcp.TextContent)
+	if tc == nil {
+		return ""
+	}
+	return tc.Text
+}
+
+func TestNewHTTPClient_BlocksRedirects(t *testing.T) {
+	cfg := Config{CallTimeout: time.Second}
+	c := newHTTPClient(cfg)
+	req := &http.Request{}
+	via := []*http.Request{}
+	if err := c.CheckRedirect(req, via); err == nil {
+		t.Error("CheckRedirect should signal use-last-response")
+	}
+}
+
+func TestNewHTTPTransport_AppliesConnectTimeout(t *testing.T) {
+	cfg := Config{ConnectTimeout: 1500 * time.Millisecond, CallTimeout: 30 * time.Second}
+	tr := newHTTPTransport(cfg)
+	if tr.TLSHandshakeTimeout != cfg.ConnectTimeout {
+		t.Errorf("TLSHandshakeTimeout = %v; want %v", tr.TLSHandshakeTimeout, cfg.ConnectTimeout)
+	}
+	if tr.DialContext == nil {
+		t.Fatal("DialContext is nil; ConnectTimeout cannot be enforced")
+	}
+}
+
+// TestNewHTTPClient_HasTransport prevents a regression where the
+// transport falls back to http.DefaultTransport (which would silently
+// drop cfg.ConnectTimeout). A nil Transport on the returned Client
+// would mean "use http.DefaultTransport" — and the default has no
+// per-connection timeouts derived from our Config.
+func TestNewHTTPClient_HasTransport(t *testing.T) {
+	c := newHTTPClient(Config{ConnectTimeout: time.Second, CallTimeout: time.Second})
+	if c.Transport == nil {
+		t.Fatal("Client.Transport is nil; cfg.ConnectTimeout would be dropped")
+	}
+	if _, ok := c.Transport.(*http.Transport); !ok {
+		t.Errorf("Client.Transport = %T; want *http.Transport", c.Transport)
+	}
+}
+
+// TestInvoke_ConnectTimeout_FiresFast proves that a connection to an
+// address that accepts neither connections nor reset packets fails
+// within ConnectTimeout, not the larger CallTimeout. Uses a
+// closed-but-listening test server; we close the listener so connect
+// would block forever waiting for accept, and we expect ConnectTimeout
+// to fire.
+//
+// Note: this test cannot use httptest.NewServer (which would actually
+// accept). We construct a listener, immediately close it, and dial the
+// stale port — the kernel responds with RST or the dial blocks until
+// the timeout. RST is fast, but on systems where it isn't, the
+// ConnectTimeout still bounds the wait. The 200ms ConnectTimeout vs
+// 5s CallTimeout gap makes the bound observable.
+func TestInvoke_ConnectTimeout_FiresFast(t *testing.T) {
+	// Use a TEST-NET-1 address (RFC 5737, guaranteed unreachable).
+	// Routing this address discards or blackholes — the dial cannot
+	// complete. ConnectTimeout must terminate it.
+	cfg := Config{
+		BaseURL:          "http://192.0.2.1:80",
+		AuthMode:         AuthModeNone,
+		ConnectTimeout:   200 * time.Millisecond,
+		CallTimeout:      10 * time.Second,
+		MaxResponseBytes: DefaultMaxResponseBytes,
+	}
+	auth, _ := NewAuthenticator(cfg)
+	start := time.Now()
+	out, err := invoke(context.Background(), invocation{cfg: cfg, auth: auth, client: newHTTPClient(cfg)}, InvokeInput{
+		Connection: "x", Method: "GET", Path: "/",
+	})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("invoke unexpected error: %v", err)
+	}
+	if out.Status != 0 || out.Error == "" {
+		t.Errorf("got status=%d error=%q; want 0 + error", out.Status, out.Error)
+	}
+	// Allow generous slop for slow CI; the assertion is "much faster
+	// than CallTimeout", not "exactly ConnectTimeout".
+	if elapsed > 3*time.Second {
+		t.Errorf("invoke took %v; ConnectTimeout (%v) was not honored — appears to be using CallTimeout (%v)",
+			elapsed, cfg.ConnectTimeout, cfg.CallTimeout)
+	}
+}
+
+func TestErrorResult_ProducesIsError(t *testing.T) {
+	r := errorResult("bad thing")
+	if !r.IsError {
+		t.Error("IsError = false")
+	}
+	if !strings.Contains(textContent(r), "bad thing") {
+		t.Errorf("error message missing: %s", textContent(r))
+	}
+}
+
+func TestJSONResult_EmbedsPayload(t *testing.T) {
+	r := jsonResult(map[string]any{"x": 1})
+	if r.IsError {
+		t.Error("jsonResult set IsError")
+	}
+	if !strings.Contains(textContent(r), `"x": 1`) {
+		t.Errorf("payload missing: %s", textContent(r))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/toolkits/apigateway` — a new toolkit kind (`api`) that proxies authenticated HTTP REST calls through the platform's existing connection-instance, persona, and audit pipeline. Sibling to the MCP gateway, but the upstream is an arbitrary HTTP/JSON API rather than an MCP server.
- Ships **`api_invoke_endpoint(connection, method, path, query?, headers?, body?, timeout_seconds?)`** — the first of three meta-tools planned by RFC #364. The model passes a registered connection name and HTTP details; the toolkit applies the connection's auth, runs the call against bounded timeouts, scrubs and returns the response.
- Closes #365 (connection storage and admin CRUD); partially closes #369 (tool surface — `api_list_endpoints` and `api_get_endpoint_schema` follow once OpenAPI ingestion #366 lands).

## Architecture

Reuses existing infrastructure rather than duplicating it:

- **Connection storage:** the generic `connection_instances` table (migration `000027`) already keys on `(kind, name)` with a `JSONB config` blob and field-level encryption via `FieldEncryptor`. The new kind `api` plugs into this directly — no new migration.
- **Admin CRUD:** the existing `/api/v1/admin/connection-instances/{kind}/{name}` endpoints accept `kind=api` after a one-line addition to `knownConnectionKinds` in `pkg/admin/connection_handler.go`.
- **Toolkit registration:** new `APIGatewayAggregateFactory` in `pkg/registry/factories.go`. Per-instance config parse errors fail the factory; per-connection materialization failures (auth-builder errors) are logged and skipped so a single bad connection cannot block startup.
- **Auto-enable:** `pkg/platform/platform.go` extends `mergeDBConnectionsIntoConfig` to auto-enable the `api` kind when a persistent connection store is available — same convention as the MCP gateway, so the admin "Add Connection" UI works out of the box without YAML stanzas.
- **Multi-connection routing:** the toolkit implements `toolkit.ConnectionManager` (hot add/remove via the admin UI) and `toolkit.ConnectionLister` (surfaces api connections in the unified `list_connections` tool). All three meta-tools planned by the RFC select between connections via a `connection` argument — same pattern as `trino_query(connection, sql)` and `s3_get_object(connection, bucket, key)`.

## Auth modes (v1)

`none`, `bearer`, `api_key`. The `api_key` mode supports both placement options via per-connection config:
- `api_key_placement: "header"` (default) with configurable `api_key_header` (default `X-API-Key`).
- `api_key_placement: "query"` with required `api_key_param` for upstreams that take the credential as a URL query parameter.

OAuth grants (`client_credentials` and `authorization_code` + PKCE) are deferred to #368, intentionally — they reuse the MCP gateway's existing token store and refresh patterns, and warrant their own PR.

## Security properties

- **No credential leaks via error messages.** Go's `*url.Error` stringifies the full request URL, which in `api_key` + query placement contains the credential. `scrubTransportError` (`pkg/toolkits/apigateway/invoke.go`) extracts the `*url.Error`, strips `RawQuery` and userinfo, and rebuilds the message before it lands in `InvokeOutput.Error`. Verified by `TestInvoke_NetworkError_DoesNotLeakAPIKeyInQueryPlacement` (uses TEST-NET-1 to force a transport error and asserts a sentinel secret never appears in the output) and a table-driven `TestScrubTransportError_StripsQueryAndUserInfo`.
- **Redirects are not auto-followed.** `CheckRedirect` returns `http.ErrUseLastResponse` so the platform never re-issues an authenticated request to a host the operator did not configure. The model can follow manually by reading the `Location` header (added to the response-header passthrough allowlist) and issuing a fresh `api_invoke_endpoint` call.
- **Custom headers cannot override auth.** The model can pass arbitrary headers, but `Authorization` and the connection's configured `api_key_header` are reserved — sending either returns a structured error rather than letting the model spoof or replace platform-managed credentials.
- **Method allowlist:** `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD` only. No `TRACE`, `CONNECT`, etc.
- **Bounded request lifecycle:**
  - `ConnectTimeout` (default 10s) bounds the dial step (TCP + TLS handshake) via a custom `http.Transport` — independent of `CallTimeout` so an unreachable upstream fails fast instead of consuming the full call budget. Verified by `TestInvoke_ConnectTimeout_FiresFast` against TEST-NET-1.
  - `CallTimeout` (default 60s) bounds the total per-invocation time.
  - `MaxResponseBytes` (default 10 MB) caps the returned body size; truncation is flagged in the response envelope rather than silent.
  - `timeout_seconds` per-call override caps at 600s (10 minutes).
- **Response-header passthrough is allowlisted.** Only headers useful to the model (`Content-Type`, `Link`, `Location`, `Retry-After`, `X-RateLimit-*`, `Etag`, `Last-Modified`, `X-Total-Count`) are surfaced. `Set-Cookie`, `Server`, `X-Powered-By`, etc. are dropped.

## Files

New package — `pkg/toolkits/apigateway/`:
- `config.go` + `config_test.go` — `Config`, `ParseConfig`, `Validate`, `MultiConfig`/`ParseMultiConfig`.
- `auth.go` + `auth_test.go` — `Authenticator` interface and three implementations (none/bearer/api_key with header and query placements). Includes a credential-leak canary test.
- `invoke.go` + `invoke_test.go` — `api_invoke_endpoint` execution path: method/path validation, URL building, body encoding, request building, auth application, transport-error scrubbing, response reading with byte cap, JSON/text body decoding, response-header allowlist.
- `toolkit.go` + `toolkit_test.go` — `Toolkit` struct (multi-connection, hot add/remove, ConnectionLister), per-connection HTTP transport with `ConnectTimeout` wired into `DialContext`, MCP tool registration.
- `schemas.go` — JSON Schema for the tool's input.

Wiring:
- `pkg/registry/factories.go` — registers `APIGatewayAggregateFactory` under kind `api`.
- `pkg/admin/connection_handler.go` — adds `api` to `knownConnectionKinds`.
- `pkg/platform/prompts.go` — adds `kindAPI = "api"`.
- `pkg/platform/platform.go` — extends `mergeDBConnectionsIntoConfig` to auto-enable `api` and include it in `manageableKinds`.
- `pkg/registry/registry_test.go` + `pkg/platform/platform_test.go` — factory and merge tests for the new kind.

## What's deferred (and why it's not vaporware)

This PR does not yet ship `api_list_endpoints` or `api_get_endpoint_schema`. The single `api_invoke_endpoint` tool is fully usable on its own — the model can call any registered API connection by passing `(method, path, params)` directly. The list/describe tools become valuable only once OpenAPI specs are ingested and indexed (#366), which is its own PR.

The package satisfies the project's vaporware-prevention gates:
- `TestNoDeadPackages` — `pkg/toolkits/apigateway` is imported by `pkg/registry/factories.go`.
- `TestNoopOnlyInterfaces` — every interface in the package (`Authenticator`) has multiple real implementations.
- No new migration, so `TestMigrationTablesHaveConsumers` is unaffected.

## Test plan

- [ ] `make verify` passes locally (full suite: fmt → test → lint → security → coverage ≥80% total + patch → dead-code → mutate ≥60% → release-check).
- [ ] Coverage on the new package: ≥94% statement coverage, all new functions exercised. Run: `go test -coverprofile=cov.out ./pkg/toolkits/apigateway/... && go tool cover -func=cov.out`.
- [ ] Credential-leak canaries pass: `go test -run "TestAuthenticators_DoNotLeakCredentials|TestInvoke_NetworkError_DoesNotLeakAPIKeyInQueryPlacement|TestScrubTransportError_StripsQueryAndUserInfo" ./pkg/toolkits/apigateway/...`.
- [ ] ConnectTimeout enforcement: `go test -run TestInvoke_ConnectTimeout_FiresFast ./pkg/toolkits/apigateway/...` — uses RFC 5737 TEST-NET-1 (`192.0.2.1`); test passes when elapsed < 3s with `ConnectTimeout=200ms` and `CallTimeout=10s`.
- [ ] Live integration after merge: deploy the branch image, register an `api`-kind connection through the admin UI (e.g., bearer auth against `https://httpbin.org`), invoke `api_invoke_endpoint(connection, "GET", "/get")`, confirm the response envelope contains `status=200`, decoded JSON body, and `Content-Type` in the headers passthrough.
- [ ] Confirm redirects are NOT followed: register a connection against an upstream that 302s, invoke against the redirecting path, confirm the response is the 302 itself with `Location` in `headers` (model is expected to follow manually if needed).

## References

- RFC: #364 (HTTP API Gateway design)
- Closes: #365 (connection storage and admin CRUD)
- Partially closes: #369 (MCP tool surface — `api_invoke_endpoint` only)
- Follow-ups: #366 (OpenAPI ingestion), #367 (non-OAuth auth modes — covered here, may be closeable), #368 (OAuth grants), #370 (persona policy + audit)
