### PR TITLE
feat(apigateway): persona-scoped (method, path) policy on api connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,18 +70,29 @@ coverage: test
 
 ## lint: Run patch-scoped linter (matches CI's only-new-issues=true exactly)
 ##
-## CI's golangci-lint-action runs with only-new-issues=true, so it only
-## reports findings on lines changed in the PR. To prevent the parity gap
-## where local fails on pre-existing issues that CI doesn't enforce, this
-## target mirrors CI exactly. Use `make lint-full` to scan the entire
-## codebase (useful for housekeeping; not part of `make verify`).
+## CI's golangci-lint-action runs with only-new-issues=true on every PR,
+## reporting findings only on lines changed in the PR. This target
+## mirrors that scope so local fails when CI would fail.
 ##
-## Merge-base is computed against origin/main when available (matches CI's
-## PR base ref) and falls back to local main. If neither is reachable
-## (detached HEAD on a fresh clone, etc.) the patch lint is skipped with
-## a warning rather than silently passing.
+## CRITICAL: golangci-lint's --new-from-rev flag only sees COMMITTED
+## changes, so before any commits the patch is empty and lint
+## early-exits as a no-op — letting bad code reach the commit gate.
+## This target generates a unified-diff patch from the merge-base
+## that includes BOTH committed changes AND working-tree changes
+## (staged + unstaged), then passes it via --new-from-patch. The
+## patch-based path catches the same issues CI would, AND issues in
+## uncommitted code, so `make verify` is a true pre-commit gate.
+##
+## Merge-base resolution: prefer origin/main (matches CI's PR base
+## ref). Falls back to local main only if origin/main is not
+## reachable (detached HEAD, fresh clone before fetch). If neither
+## is reachable the patch lint warns and skips rather than silently
+## passing.
+##
+## Use `make lint-full` to scan the entire codebase (housekeeping;
+## not part of `make verify`).
 lint:
-	@echo "Running patch-scoped lint (matches CI only-new-issues)..."
+	@echo "Running patch-scoped lint (matches CI only-new-issues, includes uncommitted changes)..."
 	@if git rev-parse origin/main >/dev/null 2>&1; then \
 		BASE=origin/main; \
 	elif git rev-parse main >/dev/null 2>&1; then \
@@ -96,12 +107,15 @@ lint:
 		echo "WARN: could not compute merge-base against $$BASE; skipping patch lint."; \
 		exit 0; \
 	fi; \
-	if [ "$$MERGE_BASE" = "$$(git rev-parse HEAD)" ]; then \
-		echo "HEAD == merge-base ($$BASE); no PR diff to lint."; \
+	PATCH=$$(mktemp -t mcpdp-lint-patch.XXXXXX); \
+	trap "rm -f $$PATCH" EXIT; \
+	git diff $$MERGE_BASE > $$PATCH; \
+	if [ ! -s $$PATCH ]; then \
+		echo "No changes vs merge-base ($$BASE); nothing to lint."; \
 		exit 0; \
 	fi; \
-	echo "Linting against merge-base $$MERGE_BASE (from $$BASE)"; \
-	$(GOLINT) run --new-from-rev=$$MERGE_BASE ./...
+	echo "Linting against merge-base $$MERGE_BASE (from $$BASE) — includes uncommitted changes"; \
+	$(GOLINT) run --new-from-patch=$$PATCH ./...
 
 ## lint-full: Run linter against the ENTIRE codebase (not chained into verify)
 ##

--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -278,6 +278,7 @@ func startHTTPServer(ctx context.Context, mcpServer *mcp.Server, p *platform.Pla
 	if p != nil {
 		p.WireGatewayTokenStore()
 		p.WireGatewayBroadcaster()
+		p.WireAPIGatewayRoutePolicy()
 	}
 
 	mux := http.NewServeMux()

--- a/pkg/persona/filter.go
+++ b/pkg/persona/filter.go
@@ -120,6 +120,78 @@ func (*ToolFilter) IsConnectionAllowed(persona *Persona, connectionName string) 
 	return false
 }
 
+// IsAPIRouteAllowed reports whether the persona may invoke (method, path)
+// on the named connection through the HTTP API gateway. Layered on top
+// of IsConnectionAllowed: callers MUST also pass the connection-level
+// gate; this function adds per-(method, path) granularity for kind=api
+// connections.
+//
+// Semantics (also documented on APIRouteRule):
+//   - If no APIRoutes entry's Connection glob matches the connection, the
+//     check is a no-op (returns true) — the existing connection-level
+//     check is the sole gate, preserving backward-compat for personas
+//     written before APIRoutes existed.
+//   - If at least one APIRoutes entry matches the connection, the call
+//     must pass: no matching deny rule, AND at least one matching allow
+//     rule.
+//   - A nil persona always denies (fail-closed).
+func (*ToolFilter) IsAPIRouteAllowed(persona *Persona, connection, method, path string) bool {
+	if persona == nil {
+		return false
+	}
+	relevant := matchingRouteRules(persona.APIRoutes, connection)
+	if len(relevant) == 0 {
+		// No rule touches this connection — the route check is a no-op
+		// and the existing connection-level gate decides.
+		return true
+	}
+	for _, rule := range relevant {
+		if rule.Action == ActionDeny && routeRuleMatches(rule, method, path) {
+			return false
+		}
+	}
+	for _, rule := range relevant {
+		if rule.Action != ActionDeny && routeRuleMatches(rule, method, path) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchingRouteRules returns the subset of rules whose Connection glob
+// matches the given connection name. Extracted so callers can pre-filter
+// the rule set once instead of re-scanning per check.
+func matchingRouteRules(rules []APIRouteRule, connection string) []APIRouteRule {
+	var out []APIRouteRule
+	for _, r := range rules {
+		if r.Connection != "" && matchPattern(r.Connection, connection) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// routeRuleMatches reports whether a rule's Methods and Paths globs
+// both match the given method and path. Empty Methods or Paths means
+// "any value" for that dimension.
+func routeRuleMatches(rule APIRouteRule, method, path string) bool {
+	return matchAny(rule.Methods, method) && matchAny(rule.Paths, path)
+}
+
+// matchAny returns true if patterns is empty (treated as "any") or if
+// any pattern in the slice matches the value.
+func matchAny(patterns []string, value string) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+	for _, p := range patterns {
+		if matchPattern(p, value) {
+			return true
+		}
+	}
+	return false
+}
+
 // FilterTools filters a list of tools based on persona rules.
 func (f *ToolFilter) FilterTools(persona *Persona, tools []string) []string {
 	if persona == nil {
@@ -185,6 +257,27 @@ func (a *Authorizer) IsAuthorized(ctx context.Context, _ string, roles []string,
 		return false, personaName, "connection not allowed for persona: " + personaName
 	}
 
+	return true, personaName, ""
+}
+
+// IsAPIRouteAllowed authorizes (method, path) on the named HTTP API
+// gateway connection for the user with the given roles. Layered on
+// top of IsAuthorized: the caller (the api gateway toolkit) is
+// expected to have already passed the tool/connection-level gate via
+// the standard MCP middleware, and this method adds per-route
+// granularity. Returns the resolved persona name (for audit) and a
+// reason on denial.
+func (a *Authorizer) IsAPIRouteAllowed(ctx context.Context, roles []string, connection, method, path string) (allowed bool, personaName, reason string) {
+	per, err := a.roleMapper.MapToPersona(ctx, roles)
+	if err != nil {
+		return false, "", "failed to determine persona"
+	}
+	if per != nil {
+		personaName = per.Name
+	}
+	if !a.filter.IsAPIRouteAllowed(per, connection, method, path) {
+		return false, personaName, "persona " + personaName + " disallows " + method + " " + path + " on connection " + connection
+	}
 	return true, personaName, ""
 }
 

--- a/pkg/persona/filter_test.go
+++ b/pkg/persona/filter_test.go
@@ -395,6 +395,139 @@ func TestToolFilter_IsConnectionAllowed(t *testing.T) {
 	}
 }
 
+func TestToolFilter_IsAPIRouteAllowed(t *testing.T) {
+	filter := NewToolFilter(NewRegistry())
+
+	type tc struct {
+		name       string
+		persona    *Persona
+		connection string
+		method     string
+		path       string
+		want       bool
+	}
+
+	cases := []tc{
+		{
+			name:       "nil persona denies",
+			persona:    nil,
+			connection: "crm-prod",
+			method:     "GET",
+			path:       "/v1/users",
+			want:       false,
+		},
+		{
+			name:       "no APIRoutes configured — passthrough (true)",
+			persona:    &Persona{Name: "p"},
+			connection: "crm-prod",
+			method:     "GET",
+			path:       "/v1/users",
+			want:       true,
+		},
+		{
+			name: "rules for a different connection do not gate this one",
+			persona: &Persona{Name: "p", APIRoutes: []APIRouteRule{
+				{Connection: "billing-*", Methods: []string{"GET"}},
+			}},
+			connection: "crm-prod",
+			method:     "POST",
+			path:       "/v1/users",
+			want:       true, // no rule touches crm-prod → passthrough
+		},
+		{
+			name: "matching allow rule with explicit method",
+			persona: &Persona{Name: "p", APIRoutes: []APIRouteRule{
+				{Connection: "crm-*", Methods: []string{"GET"}, Paths: []string{"/v1/users/*"}},
+			}},
+			connection: "crm-prod",
+			method:     "GET",
+			path:       "/v1/users/123",
+			want:       true,
+		},
+		{
+			name: "method mismatch denies even if path allowed",
+			persona: &Persona{Name: "p", APIRoutes: []APIRouteRule{
+				{Connection: "crm-*", Methods: []string{"GET"}, Paths: []string{"/v1/users/*"}},
+			}},
+			connection: "crm-prod",
+			method:     "DELETE",
+			path:       "/v1/users/123",
+			want:       false,
+		},
+		{
+			name: "path mismatch denies even if method allowed",
+			persona: &Persona{Name: "p", APIRoutes: []APIRouteRule{
+				{Connection: "crm-*", Methods: []string{"GET"}, Paths: []string{"/v1/users/*"}},
+			}},
+			connection: "crm-prod",
+			method:     "GET",
+			path:       "/v1/orders",
+			want:       false,
+		},
+		{
+			name: "empty Methods means any method is allowed",
+			persona: &Persona{Name: "p", APIRoutes: []APIRouteRule{
+				{Connection: "crm-*", Paths: []string{"/v1/users/*"}},
+			}},
+			connection: "crm-prod",
+			method:     "DELETE",
+			path:       "/v1/users/abc",
+			want:       true,
+		},
+		{
+			name: "empty Paths means any path is allowed",
+			persona: &Persona{Name: "p", APIRoutes: []APIRouteRule{
+				{Connection: "crm-*", Methods: []string{"POST"}},
+			}},
+			connection: "crm-prod",
+			method:     "POST",
+			path:       "/anything/here",
+			want:       true,
+		},
+		{
+			name: "deny takes precedence over allow",
+			persona: &Persona{Name: "p", APIRoutes: []APIRouteRule{
+				{Connection: "crm-*", Methods: []string{"DELETE"}, Action: ActionDeny},
+				{Connection: "crm-*"}, // allow-all
+			}},
+			connection: "crm-prod",
+			method:     "DELETE",
+			path:       "/v1/anything",
+			want:       false,
+		},
+		{
+			name: "deny on different method does not block allow",
+			persona: &Persona{Name: "p", APIRoutes: []APIRouteRule{
+				{Connection: "crm-*", Methods: []string{"DELETE"}, Action: ActionDeny},
+				{Connection: "crm-*", Methods: []string{"GET"}},
+			}},
+			connection: "crm-prod",
+			method:     "GET",
+			path:       "/v1/users",
+			want:       true,
+		},
+		{
+			name: "rules touch connection but no matching allow → deny",
+			persona: &Persona{Name: "p", APIRoutes: []APIRouteRule{
+				{Connection: "crm-*", Methods: []string{"GET"}},
+			}},
+			connection: "crm-prod",
+			method:     "POST",
+			path:       "/v1/users",
+			want:       false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := filter.IsAPIRouteAllowed(c.persona, c.connection, c.method, c.path)
+			if got != c.want {
+				t.Errorf("IsAPIRouteAllowed(%s, %s %s) = %v, want %v", c.connection, c.method, c.path, got, c.want)
+			}
+		})
+	}
+}
+
 // Verify interface compliance.
 var (
 	_ RoleMapper            = (*mockRoleMapper)(nil)

--- a/pkg/persona/persona.go
+++ b/pkg/persona/persona.go
@@ -40,6 +40,15 @@ type Persona struct {
 	// empty, all connections are permitted (backward-compatible default).
 	Connections ConnectionRules `json:"connections" yaml:"connections"`
 
+	// APIRoutes defines per-(connection, method, path) rules for the HTTP
+	// API gateway toolkit (kind=api). Layered on top of Connections: if a
+	// persona is allowed a connection at the tool/connection level, APIRoutes
+	// can further restrict which HTTP methods and paths the model can invoke
+	// against that connection. Personas with no APIRoutes entries for a
+	// given connection get the existing connection-level behavior unchanged
+	// (backward-compatible). See pkg/persona/filter.go IsAPIRouteAllowed.
+	APIRoutes []APIRouteRule `json:"api_routes,omitempty" yaml:"api_routes,omitempty"`
+
 	// Context defines per-persona overrides for the platform description and
 	// agent instructions returned by the platform_info tool.
 	Context ContextOverrides `json:"context" yaml:"context"`
@@ -75,6 +84,49 @@ type ConnectionRules struct {
 	// Deny patterns for denied connections (takes precedence over Allow).
 	Deny []string `json:"deny,omitempty" yaml:"deny,omitempty"`
 }
+
+// APIRouteRule constrains the HTTP API gateway's api_invoke_endpoint
+// tool to specific (method, path) combinations on connections matched
+// by Connection. A persona's APIRoutes list is consulted only for
+// kind=api connections; other toolkit kinds ignore it.
+//
+// Semantics, evaluated against a single (connection, method, path) tuple:
+//   - Rules whose Connection glob does not match are skipped.
+//   - Among matching rules: any "deny" rule whose Methods+Paths match
+//     denies the call (deny takes precedence).
+//   - Otherwise, at least one "allow" rule whose Methods+Paths match
+//     must be present for the call to be authorized.
+//   - If NO rule matches the connection at all, the API route check is
+//     a no-op — the existing ConnectionRules check is the sole gate
+//     (backward-compatible behavior).
+//
+// Empty Methods or Paths slices mean "any" — a rule with empty Methods
+// and Paths matches every method+path combination on the connection.
+type APIRouteRule struct {
+	// Connection is a glob (e.g. "crm-*") matched against the connection
+	// name. Required.
+	Connection string `json:"connection" yaml:"connection"`
+
+	// Methods is a list of HTTP method globs (e.g. ["GET", "HEAD"]).
+	// Empty = any method. Patterns are case-sensitive — typically
+	// uppercase ("GET", "POST", etc.) since the toolkit normalizes
+	// inbound methods to uppercase before this check runs.
+	Methods []string `json:"methods,omitempty" yaml:"methods,omitempty"`
+
+	// Paths is a list of path globs (e.g. ["/v1/users/*", "/v1/orders/**"]).
+	// Empty = any path.
+	Paths []string `json:"paths,omitempty" yaml:"paths,omitempty"`
+
+	// Action is "allow" (default) or "deny". Deny rules take precedence
+	// over allow rules within the matching-Connection subset.
+	Action string `json:"action,omitempty" yaml:"action,omitempty"`
+}
+
+// API route action values. Empty Action defaults to ActionAllow.
+const (
+	ActionAllow = "allow"
+	ActionDeny  = "deny"
+)
 
 // ContextOverrides defines per-persona overrides for the description and
 // agent instructions that the platform_info tool returns. These let you

--- a/pkg/persona/registry.go
+++ b/pkg/persona/registry.go
@@ -2,6 +2,7 @@ package persona
 
 import (
 	"fmt"
+	"path/filepath"
 	"slices"
 	"sync"
 )
@@ -29,8 +30,45 @@ func (r *Registry) Register(p *Persona) error {
 	if p.Name == "" {
 		return fmt.Errorf("persona name is required")
 	}
+	if err := validateAPIRoutes(p.APIRoutes); err != nil {
+		return fmt.Errorf("persona %q: %w", p.Name, err)
+	}
 
 	r.personas[p.Name] = p
+	return nil
+}
+
+// validateAPIRoutes catches misconfigurations in APIRoutes at
+// registration time so a typo can't silently disable a deny rule
+// (matchPattern returns false on filepath.ErrBadPattern, which is
+// the safe default for allow rules but lets a malformed deny rule
+// fail open). Also rejects an empty Connection — required per the
+// APIRouteRule docstring; without this check matchingRouteRules
+// would silently skip the rule and the operator would see no error.
+func validateAPIRoutes(rules []APIRouteRule) error {
+	for i, rule := range rules {
+		if rule.Connection == "" {
+			return fmt.Errorf("api_routes[%d]: Connection is required", i)
+		}
+		if _, err := filepath.Match(rule.Connection, ""); err != nil {
+			return fmt.Errorf("api_routes[%d]: invalid Connection glob %q: %w", i, rule.Connection, err)
+		}
+		for j, m := range rule.Methods {
+			if _, err := filepath.Match(m, ""); err != nil {
+				return fmt.Errorf("api_routes[%d].methods[%d]: invalid glob %q: %w", i, j, m, err)
+			}
+		}
+		for j, p := range rule.Paths {
+			if _, err := filepath.Match(p, ""); err != nil {
+				return fmt.Errorf("api_routes[%d].paths[%d]: invalid glob %q: %w", i, j, p, err)
+			}
+		}
+		switch rule.Action {
+		case "", ActionAllow, ActionDeny:
+		default:
+			return fmt.Errorf("api_routes[%d]: invalid action %q (want %q or %q)", i, rule.Action, ActionAllow, ActionDeny)
+		}
+	}
 	return nil
 }
 

--- a/pkg/persona/registry.go
+++ b/pkg/persona/registry.go
@@ -47,26 +47,44 @@ func (r *Registry) Register(p *Persona) error {
 // would silently skip the rule and the operator would see no error.
 func validateAPIRoutes(rules []APIRouteRule) error {
 	for i, rule := range rules {
-		if rule.Connection == "" {
-			return fmt.Errorf("api_routes[%d]: Connection is required", i)
+		if err := validateAPIRouteRule(i, rule); err != nil {
+			return err
 		}
-		if _, err := filepath.Match(rule.Connection, ""); err != nil {
-			return fmt.Errorf("api_routes[%d]: invalid Connection glob %q: %w", i, rule.Connection, err)
-		}
-		for j, m := range rule.Methods {
-			if _, err := filepath.Match(m, ""); err != nil {
-				return fmt.Errorf("api_routes[%d].methods[%d]: invalid glob %q: %w", i, j, m, err)
-			}
-		}
-		for j, p := range rule.Paths {
-			if _, err := filepath.Match(p, ""); err != nil {
-				return fmt.Errorf("api_routes[%d].paths[%d]: invalid glob %q: %w", i, j, p, err)
-			}
-		}
-		switch rule.Action {
-		case "", ActionAllow, ActionDeny:
-		default:
-			return fmt.Errorf("api_routes[%d]: invalid action %q (want %q or %q)", i, rule.Action, ActionAllow, ActionDeny)
+	}
+	return nil
+}
+
+// validateAPIRouteRule validates a single APIRouteRule. Split out of
+// validateAPIRoutes so each loop iteration's branches stay under the
+// gocognit ceiling.
+func validateAPIRouteRule(i int, rule APIRouteRule) error {
+	if rule.Connection == "" {
+		return fmt.Errorf("api_routes[%d]: Connection is required", i)
+	}
+	if _, err := filepath.Match(rule.Connection, ""); err != nil {
+		return fmt.Errorf("api_routes[%d]: invalid Connection glob %q: %w", i, rule.Connection, err)
+	}
+	if err := validateGlobList(i, "methods", rule.Methods); err != nil {
+		return err
+	}
+	if err := validateGlobList(i, "paths", rule.Paths); err != nil {
+		return err
+	}
+	switch rule.Action {
+	case "", ActionAllow, ActionDeny:
+		return nil
+	default:
+		return fmt.Errorf("api_routes[%d]: invalid action %q (want %q or %q)", i, rule.Action, ActionAllow, ActionDeny)
+	}
+}
+
+// validateGlobList checks every glob in a slice via filepath.Match
+// against an empty string — the cheapest way to surface
+// filepath.ErrBadPattern at config-load time.
+func validateGlobList(i int, field string, patterns []string) error {
+	for j, p := range patterns {
+		if _, err := filepath.Match(p, ""); err != nil {
+			return fmt.Errorf("api_routes[%d].%s[%d]: invalid glob %q: %w", i, field, j, p, err)
 		}
 	}
 	return nil

--- a/pkg/persona/registry_test.go
+++ b/pkg/persona/registry_test.go
@@ -28,6 +28,62 @@ func TestRegistry_RegisterEmptyName(t *testing.T) {
 	}
 }
 
+// TestRegistry_RegisterRejectsBadAPIRoutes catches misconfigurations
+// that would silently disable a deny rule (matchPattern returns
+// false on filepath.ErrBadPattern — safe for allow rules but
+// fail-open for deny rules) or leave rules ignored (empty
+// Connection skipped by matchingRouteRules without diagnostic).
+func TestRegistry_RegisterRejectsBadAPIRoutes(t *testing.T) {
+	cases := []struct {
+		name string
+		rule APIRouteRule
+	}{
+		{
+			name: "empty Connection",
+			rule: APIRouteRule{Connection: "", Methods: []string{"GET"}},
+		},
+		{
+			name: "malformed Connection glob",
+			rule: APIRouteRule{Connection: "crm-["},
+		},
+		{
+			name: "malformed Method glob",
+			rule: APIRouteRule{Connection: "crm-*", Methods: []string{"GE["}},
+		},
+		{
+			name: "malformed Path glob",
+			rule: APIRouteRule{Connection: "crm-*", Paths: []string{"/v1/[users"}},
+		},
+		{
+			name: "unknown action",
+			rule: APIRouteRule{Connection: "crm-*", Action: "warn"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := NewRegistry()
+			p := &Persona{Name: "p", APIRoutes: []APIRouteRule{tc.rule}}
+			if err := reg.Register(p); err == nil {
+				t.Errorf("Register accepted persona with bad rule %+v; want error", tc.rule)
+			}
+		})
+	}
+}
+
+func TestRegistry_RegisterAcceptsValidAPIRoutes(t *testing.T) {
+	reg := NewRegistry()
+	p := &Persona{
+		Name: "ok",
+		APIRoutes: []APIRouteRule{
+			{Connection: "crm-*", Methods: []string{"GET"}, Paths: []string{"/v1/users/*"}},
+			{Connection: "*", Action: ActionDeny, Methods: []string{"DELETE"}},
+		},
+	}
+	if err := reg.Register(p); err != nil {
+		t.Errorf("Register rejected valid APIRoutes: %v", err)
+	}
+}
+
 func TestRegistry_GetNotFound(t *testing.T) {
 	reg := NewRegistry()
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -53,6 +53,7 @@ import (
 	sessionpostgres "github.com/txn2/mcp-data-platform/pkg/session/postgres"
 	"github.com/txn2/mcp-data-platform/pkg/storage"
 	s3storage "github.com/txn2/mcp-data-platform/pkg/storage/s3"
+	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
 	gatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/gateway"
 	"github.com/txn2/mcp-data-platform/pkg/toolkits/gateway/enrichment"
 	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
@@ -571,6 +572,89 @@ func (n gatewayListChangedNotifier) NotifyToolsListChanged(ctx context.Context) 
 			"source", "gateway",
 			"method", "notifications/tools/list_changed",
 			"error", err)
+	}
+}
+
+// apiGatewayRoutePolicy adapts persona.Authorizer onto
+// apigatewaykit.RoutePolicy so the api gateway toolkit can gate
+// (connection, method, path) against the caller's persona without
+// importing pkg/persona directly. The platform creates one of these
+// at boot and wires it into every live api gateway toolkit.
+//
+// Layered design: the standard MCP middleware's Authorizer.IsAuthorized
+// already gates "may this user call api_invoke_endpoint at all?" and
+// "on this connection at all?". This adapter adds the per-route check
+// (which HTTP method on which path) that the standard middleware
+// cannot express.
+type apiGatewayRoutePolicy struct {
+	authn middleware.Authenticator
+	pa    *persona.Authorizer
+}
+
+// Allow extracts the caller's roles from ctx and consults the persona
+// authorizer's APIRoutes rules for this (connection, method, path).
+//
+// Role-resolution preference order (in practice the upstream
+// MCPToolCallMiddleware almost always populates option 2 — the JWT
+// has already been parsed + verified there, so reusing those roles
+// avoids a redundant signature verification per call):
+//  1. Pre-authenticated user (admin browser-cookie paths).
+//  2. PlatformContext.Roles (set by MCPToolCallMiddleware after a
+//     successful Authenticate). Cheapest path on the MCP tool-call
+//     hot path.
+//  3. Authenticator.Authenticate (fallback for callers that didn't
+//     run through the standard MCP middleware chain).
+func (a apiGatewayRoutePolicy) Allow(ctx context.Context, connection, method, path string) (bool, string) {
+	roles := a.resolveRoles(ctx)
+	allowed, _, reason := a.pa.IsAPIRouteAllowed(ctx, roles, connection, method, path)
+	return allowed, reason
+}
+
+// resolveRoles is split out so the preference order is testable in
+// isolation and Allow stays under the cyclomatic-complexity ceiling.
+//
+// The PlatformContext check uses UserID (not len(Roles)>0) as the
+// signal that MCPToolCallMiddleware ran successfully. A legitimately
+// authenticated user can have zero roles (default-persona-only
+// deployments, missing role-claim path); guarding on len(Roles)>0
+// would force a redundant Authenticate call for those users —
+// exactly the double-verify the layered preference order is meant
+// to avoid.
+func (a apiGatewayRoutePolicy) resolveRoles(ctx context.Context) []string {
+	if userInfo := middleware.GetPreAuthenticatedUser(ctx); userInfo != nil {
+		return userInfo.Roles
+	}
+	if pc := middleware.GetPlatformContext(ctx); pc != nil && pc.UserID != "" {
+		return pc.Roles
+	}
+	if a.authn != nil {
+		if userInfo, err := a.authn.Authenticate(ctx); err == nil && userInfo != nil {
+			return userInfo.Roles
+		}
+	}
+	return nil
+}
+
+// WireAPIGatewayRoutePolicy installs a per-(connection, method, path)
+// authorization gate on every live api gateway toolkit. No-op when
+// the platform's authorizer is not the persona-based implementation
+// (custom authorizers may opt in later via their own wiring).
+//
+// Mirrors WireGatewayTokenStore / WireGatewayBroadcaster in placement
+// and lifecycle. Safe to call before or after RegisterTools.
+func (p *Platform) WireAPIGatewayRoutePolicy() {
+	if p.authorizer == nil {
+		return
+	}
+	pa, ok := p.authorizer.(*persona.Authorizer)
+	if !ok {
+		return
+	}
+	policy := apiGatewayRoutePolicy{authn: p.authenticator, pa: pa}
+	for _, tk := range p.toolkitRegistry.All() {
+		if api, ok := tk.(*apigatewaykit.Toolkit); ok {
+			api.SetRoutePolicy(policy)
+		}
 	}
 }
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -604,9 +604,9 @@ type apiGatewayRoutePolicy struct {
 //     hot path.
 //  3. Authenticator.Authenticate (fallback for callers that didn't
 //     run through the standard MCP middleware chain).
-func (a apiGatewayRoutePolicy) Allow(ctx context.Context, connection, method, path string) (bool, string) {
+func (a apiGatewayRoutePolicy) Allow(ctx context.Context, connection, method, path string) (allowed bool, reason string) {
 	roles := a.resolveRoles(ctx)
-	allowed, _, reason := a.pa.IsAPIRouteAllowed(ctx, roles, connection, method, path)
+	allowed, _, reason = a.pa.IsAPIRouteAllowed(ctx, roles, connection, method, path)
 	return allowed, reason
 }
 

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -5044,8 +5044,8 @@ func TestAPIGatewayRoutePolicy_Allow_DirectCases(t *testing.T) {
 		t.Fatalf("register persona: %v", err)
 	}
 	mapper := &persona.OIDCRoleMapper{Registry: personaReg}
-	auth := persona.NewAuthorizer(personaReg, mapper)
-	policy := apiGatewayRoutePolicy{authn: nil, pa: auth}
+	authzr := persona.NewAuthorizer(personaReg, mapper)
+	policy := apiGatewayRoutePolicy{authn: nil, pa: authzr}
 
 	t.Run("allow rule matches → true", func(t *testing.T) {
 		ctx := middleware.WithPreAuthenticatedUser(context.Background(), &middleware.UserInfo{
@@ -5091,7 +5091,7 @@ func TestAPIGatewayRoutePolicy_Allow_DirectCases(t *testing.T) {
 		// reused the pre-extracted roles from PlatformContext.
 		policyNoAuthn := apiGatewayRoutePolicy{
 			authn: panicAuthenticator{},
-			pa:    auth,
+			pa:    authzr,
 		}
 		pc := middleware.NewPlatformContext("req-1")
 		pc.UserID = "u1"
@@ -5103,7 +5103,7 @@ func TestAPIGatewayRoutePolicy_Allow_DirectCases(t *testing.T) {
 		}
 	})
 
-	t.Run("authenticated user with empty roles still uses PlatformContext (no double-verify)", func(t *testing.T) {
+	t.Run("authenticated user with empty roles still uses PlatformContext (no double-verify)", func(_ *testing.T) {
 		// Regression for the resolveRoles guard: if the predicate is
 		// `len(pc.Roles) > 0`, an authenticated user with no role
 		// claims falls through to the Authenticator fallback —
@@ -5113,7 +5113,7 @@ func TestAPIGatewayRoutePolicy_Allow_DirectCases(t *testing.T) {
 		// roles". panicAuthenticator catches the regression.
 		policyNoAuthn := apiGatewayRoutePolicy{
 			authn: panicAuthenticator{},
-			pa:    auth,
+			pa:    authzr,
 		}
 		pc := middleware.NewPlatformContext("req-2")
 		pc.UserID = "u2"

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -27,6 +27,7 @@ import (
 	datahubsemantic "github.com/txn2/mcp-data-platform/pkg/semantic/datahub"
 	"github.com/txn2/mcp-data-platform/pkg/session"
 	"github.com/txn2/mcp-data-platform/pkg/storage"
+	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
 	gatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/gateway"
 	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
 	"github.com/txn2/mcp-data-platform/pkg/tuning"
@@ -4886,4 +4887,265 @@ func TestWireGatewayBroadcaster_NoBroadcaster(t *testing.T) {
 	// Force broadcaster nil to exercise the early-return.
 	p.broadcaster = nil
 	p.WireGatewayBroadcaster() // must not panic
+}
+
+// TestWireAPIGatewayRoutePolicy_DeniesViaInstalledPolicy proves the
+// persona authorizer is actually wired into a live api gateway
+// toolkit by exercising the deny path through the toolkit's public
+// MCP handler. Removing the SetRoutePolicy call in
+// WireAPIGatewayRoutePolicy makes this test pass an upstream call
+// (no policy → no gate); leaving it produces IsError=true here.
+//
+// A regression that drops the wiring would silently let through any
+// (method, path) on every persona — exactly the failure mode the
+// wiring exists to prevent.
+func TestWireAPIGatewayRoutePolicy_DeniesViaInstalledPolicy(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Name: testServerName},
+		Semantic: SemanticConfig{Provider: testProviderNoop},
+		Query:    QueryConfig{Provider: testProviderNoop},
+		Storage:  StorageConfig{Provider: testProviderNoop},
+	}
+	p, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	// Construct an api gateway toolkit and register it.
+	mc, err := apigatewaykit.ParseMultiConfig("api", map[string]map[string]any{
+		"crm": {"base_url": "https://api.example.com"},
+	})
+	if err != nil {
+		t.Fatalf("ParseMultiConfig: %v", err)
+	}
+	tk := apigatewaykit.NewMulti(mc)
+	if err := p.toolkitRegistry.Register(tk); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Pre-condition: before the wire call, the toolkit has no policy
+	// installed. (Catches any future change that pre-wires from
+	// inside the toolkit constructor — would defeat the test.)
+	if tk.RoutePolicy() != nil {
+		t.Fatal("toolkit already has a route policy before WireAPIGatewayRoutePolicy")
+	}
+
+	// Install a persona with a deny-all rule for the "crm" connection.
+	denyAll := &persona.Persona{
+		Name:  "denyall",
+		Roles: []string{"denyall"},
+		Tools: persona.ToolRules{Allow: []string{"*"}},
+		APIRoutes: []persona.APIRouteRule{
+			{Connection: "crm", Action: persona.ActionDeny}, // deny everything on crm
+		},
+	}
+	if err := p.personaRegistry.Register(denyAll); err != nil {
+		t.Fatalf("Register persona: %v", err)
+	}
+
+	// Wire — this is the call under test. A regression that drops
+	// the SetRoutePolicy call inside WireAPIGatewayRoutePolicy makes
+	// tk.RoutePolicy() stay nil and fails the next assertion.
+	p.WireAPIGatewayRoutePolicy()
+
+	pol := tk.RoutePolicy()
+	if pol == nil {
+		t.Fatal("WireAPIGatewayRoutePolicy did not install a route policy on the toolkit")
+	}
+
+	// Functional assertion: the installed policy actually consults
+	// the persona registry and denies based on APIRoutes. Build a
+	// pre-authenticated context with the deny-all persona's role
+	// and confirm a route call is refused.
+	ctx := middleware.WithPreAuthenticatedUser(context.Background(), &middleware.UserInfo{
+		UserID: "u1",
+		Roles:  []string{"denyall"},
+	})
+	allowed, reason := pol.Allow(ctx, "crm", "GET", "/v1/anything")
+	if allowed {
+		t.Errorf("denyAll persona's route policy allowed call (reason=%q); wiring is wrong", reason)
+	}
+	if reason == "" {
+		t.Error("expected non-empty reason on denial")
+	}
+
+	// Idempotent: re-running the wire call must not panic or
+	// double-install in a way that breaks behavior.
+	p.WireAPIGatewayRoutePolicy()
+	if tk.RoutePolicy() == nil {
+		t.Error("route policy lost after second WireAPIGatewayRoutePolicy call")
+	}
+}
+
+// TestWireAPIGatewayRoutePolicy_NoToolkit_NoOp proves the wiring
+// helper is safe when no api gateway toolkit is registered.
+func TestWireAPIGatewayRoutePolicy_NoToolkit_NoOp(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Name: testServerName},
+		Semantic: SemanticConfig{Provider: testProviderNoop},
+		Query:    QueryConfig{Provider: testProviderNoop},
+		Storage:  StorageConfig{Provider: testProviderNoop},
+	}
+	p, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	p.WireAPIGatewayRoutePolicy() // must not panic when no api toolkit registered
+}
+
+// TestWireAPIGatewayRoutePolicy_NoAuthorizer_NoOp proves the helper
+// silently no-ops when the platform's authorizer is not the
+// persona-based implementation (custom authorizer use-case).
+func TestWireAPIGatewayRoutePolicy_NoAuthorizer_NoOp(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Name: testServerName},
+		Semantic: SemanticConfig{Provider: testProviderNoop},
+		Query:    QueryConfig{Provider: testProviderNoop},
+		Storage:  StorageConfig{Provider: testProviderNoop},
+	}
+	p, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	p.authorizer = nil // simulate "no authorizer"
+	p.WireAPIGatewayRoutePolicy()
+}
+
+// panicAuthenticator fails the test if its Authenticate is called.
+// Used to prove the apiGatewayRoutePolicy doesn't redundantly call
+// Authenticate when PlatformContext.Roles is already populated by
+// the upstream MCP middleware (the common hot-path case).
+type panicAuthenticator struct{}
+
+func (panicAuthenticator) Authenticate(_ context.Context) (*middleware.UserInfo, error) {
+	panic("Authenticate called when PlatformContext.Roles should have been used")
+}
+
+// TestAPIGatewayRoutePolicy_Allow_DirectCases exercises the closure
+// that bridges persona.Authorizer onto apigateway.RoutePolicy. Three
+// scenarios: pre-auth user with allow rule passes, pre-auth user with
+// deny rule is refused, no roles in ctx hits the fail-closed path.
+func TestAPIGatewayRoutePolicy_Allow_DirectCases(t *testing.T) {
+	personaReg := persona.NewRegistry()
+	if err := personaReg.Register(&persona.Persona{
+		Name:  "analyst",
+		Roles: []string{"analyst"},
+		Tools: persona.ToolRules{Allow: []string{"*"}},
+		APIRoutes: []persona.APIRouteRule{
+			{Connection: "crm", Methods: []string{"GET"}, Paths: []string{"/v1/users/*"}},
+			{Connection: "crm", Methods: []string{"DELETE"}, Action: persona.ActionDeny},
+		},
+	}); err != nil {
+		t.Fatalf("register persona: %v", err)
+	}
+	mapper := &persona.OIDCRoleMapper{Registry: personaReg}
+	auth := persona.NewAuthorizer(personaReg, mapper)
+	policy := apiGatewayRoutePolicy{authn: nil, pa: auth}
+
+	t.Run("allow rule matches → true", func(t *testing.T) {
+		ctx := middleware.WithPreAuthenticatedUser(context.Background(), &middleware.UserInfo{
+			UserID: "u1", Roles: []string{"analyst"},
+		})
+		allowed, reason := policy.Allow(ctx, "crm", "GET", "/v1/users/123")
+		if !allowed {
+			t.Errorf("got allowed=false, reason=%q; want allowed=true", reason)
+		}
+	})
+
+	t.Run("deny rule matches → false with reason", func(t *testing.T) {
+		ctx := middleware.WithPreAuthenticatedUser(context.Background(), &middleware.UserInfo{
+			UserID: "u1", Roles: []string{"analyst"},
+		})
+		allowed, reason := policy.Allow(ctx, "crm", "DELETE", "/v1/users/123")
+		if allowed {
+			t.Error("DELETE was allowed despite deny rule")
+		}
+		if reason == "" {
+			t.Error("expected non-empty reason on denial")
+		}
+	})
+
+	t.Run("connection with no APIRoutes for resolved persona → passthrough", func(t *testing.T) {
+		// Empty roles resolve to DefaultPersona (no APIRoutes). The
+		// route policy is layered on top of the platform's main
+		// IsAuthorized gate; when the persona has no APIRoutes
+		// touching the connection the route check is a no-op (true).
+		// Fail-closed for unauthenticated callers is the platform's
+		// MCPToolCallMiddleware's job, not this adapter's.
+		allowed, _ := policy.Allow(context.Background(), "crm", "GET", "/v1/users/1")
+		if !allowed {
+			t.Error("expected passthrough for persona without APIRoutes for crm")
+		}
+	})
+
+	t.Run("PlatformContext roles preferred over Authenticator (no double-verify)", func(t *testing.T) {
+		// Confirms the resolveRoles preference: MCPToolCallMiddleware's
+		// PlatformContext.Roles is read instead of forcing a second
+		// Authenticate call. Use an Authenticator that would PANIC if
+		// invoked — if the test passes, the role-resolution path
+		// reused the pre-extracted roles from PlatformContext.
+		policyNoAuthn := apiGatewayRoutePolicy{
+			authn: panicAuthenticator{},
+			pa:    auth,
+		}
+		pc := middleware.NewPlatformContext("req-1")
+		pc.UserID = "u1"
+		pc.Roles = []string{"analyst"}
+		ctx := middleware.WithPlatformContext(context.Background(), pc)
+		allowed, _ := policyNoAuthn.Allow(ctx, "crm", "GET", "/v1/users/123")
+		if !allowed {
+			t.Error("PlatformContext.Roles path did not produce allow decision")
+		}
+	})
+
+	t.Run("authenticated user with empty roles still uses PlatformContext (no double-verify)", func(t *testing.T) {
+		// Regression for the resolveRoles guard: if the predicate is
+		// `len(pc.Roles) > 0`, an authenticated user with no role
+		// claims falls through to the Authenticator fallback —
+		// reintroducing the redundant signature verification this
+		// path was meant to avoid. The correct signal is "auth
+		// middleware ran" (pc.UserID populated), not "user has
+		// roles". panicAuthenticator catches the regression.
+		policyNoAuthn := apiGatewayRoutePolicy{
+			authn: panicAuthenticator{},
+			pa:    auth,
+		}
+		pc := middleware.NewPlatformContext("req-2")
+		pc.UserID = "u2"
+		pc.Roles = nil // authenticated but role-less
+		ctx := middleware.WithPlatformContext(context.Background(), pc)
+		// We don't care about the Allow outcome — only that
+		// Authenticate is NOT called (panic would fail the test).
+		_, _ = policyNoAuthn.Allow(ctx, "crm", "GET", "/v1/users")
+	})
+
+	t.Run("connection-targeted persona but auth context absent → fail-closed", func(t *testing.T) {
+		// Build a custom registry where the default persona has
+		// APIRoutes touching crm — empty roles still resolve to it,
+		// so the route check actually applies, and an unmatched
+		// (method, path) is denied.
+		reg := persona.NewRegistry()
+		def := &persona.Persona{
+			Name:  "default",
+			Roles: []string{},
+			Tools: persona.ToolRules{Allow: []string{"*"}},
+			APIRoutes: []persona.APIRouteRule{
+				{Connection: "crm", Methods: []string{"GET"}, Paths: []string{"/v1/users/*"}},
+			},
+		}
+		_ = reg.Register(def)
+		reg.SetDefault("default")
+		mapper2 := &persona.OIDCRoleMapper{Registry: reg}
+		auth2 := persona.NewAuthorizer(reg, mapper2)
+		policy2 := apiGatewayRoutePolicy{authn: nil, pa: auth2}
+		allowed, _ := policy2.Allow(context.Background(), "crm", "DELETE", "/v1/anything")
+		if allowed {
+			t.Error("DELETE on path-restricted connection allowed without explicit allow rule")
+		}
+	})
 }

--- a/pkg/toolkits/apigateway/invoke.go
+++ b/pkg/toolkits/apigateway/invoke.go
@@ -145,11 +145,11 @@ func validateMethod(method string) (string, error) {
 	return m, nil
 }
 
-func validatePath(path string) error {
-	if path == "" {
+func validatePath(p string) error {
+	if p == "" {
 		return errors.New("apigateway: path is required")
 	}
-	if !strings.HasPrefix(path, "/") {
+	if !strings.HasPrefix(p, "/") {
 		return errors.New("apigateway: path must start with \"/\"")
 	}
 	// Reject path shapes that, when string-concatenated to a base
@@ -160,11 +160,59 @@ func validatePath(path string) error {
 	// userinfo so the final Host becomes evil.com. The host pinning
 	// in buildURL is the primary defense; this rejection is the
 	// up-front diagnostic the model sees.
-	if strings.HasPrefix(path, "//") {
+	if strings.HasPrefix(p, "//") {
 		return errors.New("apigateway: path must not start with \"//\" (protocol-relative URLs are rejected)")
 	}
-	if strings.ContainsAny(path, "@\r\n\x00") {
+	if strings.ContainsAny(p, "@\r\n\x00") {
 		return errors.New("apigateway: path contains a disallowed character (@, CR, LF, NUL)")
+	}
+	// Reject path segments that JoinPath or the upstream would
+	// normalize to something different from what filepath.Match
+	// sees. Without this check, persona APIRoutes globs do not
+	// reliably bound the model:
+	//
+	//   - Literal "." / "..": "/v1/users/.." matches "/v1/users/*"
+	//     but JoinPath resolves to "/v1".
+	//   - Empty interior segments ("//"): "/v1//admin/secret" does
+	//     NOT match a literal "/v1/admin/*" glob, but JoinPath
+	//     collapses the double slash and the upstream sees
+	//     "/v1/admin/secret" — bypassing a deny rule scoped to
+	//     "/v1/admin/*".
+	//   - Percent-encoded dot segments: "%2E%2E" passes a literal
+	//     "." / ".." string compare but RFC 3986 says servers MAY
+	//     decode %2E for path resolution; many do (Apache default,
+	//     several SaaS APIs).
+	//
+	// All three are refused here so the raw path the policy sees
+	// equals the path the upstream will see (after JoinPath but
+	// before any server-side decoding).
+	if err := checkPathSegments(p); err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkPathSegments rejects literal "." / ".." segments, interior
+// empty segments (collapse vector), and percent-encoded dot
+// segments. See validatePath for the security rationale.
+func checkPathSegments(p string) error {
+	parts := strings.Split(p, "/")
+	for i, seg := range parts {
+		// Leading slash makes parts[0] == ""; allowed.
+		// A single trailing slash makes parts[last] == ""; allowed.
+		if seg == "" {
+			if i == 0 || i == len(parts)-1 {
+				continue
+			}
+			return errors.New("apigateway: path must not contain empty segments (\"//\")")
+		}
+		decoded, err := url.PathUnescape(seg)
+		if err != nil {
+			return errors.New("apigateway: path contains a malformed percent-escape")
+		}
+		if decoded == "." || decoded == ".." {
+			return errors.New("apigateway: path must not contain \".\" or \"..\" segments (literal or percent-encoded)")
+		}
 	}
 	return nil
 }

--- a/pkg/toolkits/apigateway/invoke.go
+++ b/pkg/toolkits/apigateway/invoke.go
@@ -186,10 +186,7 @@ func validatePath(p string) error {
 	// All three are refused here so the raw path the policy sees
 	// equals the path the upstream will see (after JoinPath but
 	// before any server-side decoding).
-	if err := checkPathSegments(p); err != nil {
-		return err
-	}
-	return nil
+	return checkPathSegments(p)
 }
 
 // checkPathSegments rejects literal "." / ".." segments, interior

--- a/pkg/toolkits/apigateway/invoke_test.go
+++ b/pkg/toolkits/apigateway/invoke_test.go
@@ -59,6 +59,23 @@ func TestValidatePath_RejectsSSRFShapes(t *testing.T) {
 		{"CR injection", "/foo\rEvil-Header: x"},
 		{"LF injection", "/foo\nEvil-Header: x"},
 		{"NUL injection", "/foo\x00bar"},
+		// "/v1/users/.." matches a "/v1/users/*" persona allow rule
+		// but JoinPath resolves it to "/v1" — letting the model
+		// escape the persona's intended scope. Refuse at the
+		// boundary so persona globs bound the model reliably.
+		{"parent traversal segment", "/v1/users/.."},
+		{"current segment", "/v1/users/."},
+		{"nested traversal", "/v1/../etc/passwd"},
+		// Empty interior segment ("//") would get collapsed by
+		// JoinPath, bypassing literal-pattern persona rules.
+		{"interior double-slash", "/v1//admin/secret"},
+		{"three slashes", "/v1///admin"},
+		// Percent-encoded dot segments: many servers decode
+		// %2E during path resolution (RFC 3986 allows it).
+		{"percent-encoded ..", "/v1/users/%2E%2E"},
+		{"percent-encoded .. lowercase", "/v1/users/%2e%2e"},
+		{"percent-encoded . segment", "/v1/users/%2E"},
+		{"malformed percent escape", "/v1/users/%2"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/toolkits/apigateway/toolkit.go
+++ b/pkg/toolkits/apigateway/toolkit.go
@@ -49,9 +49,25 @@ type Toolkit struct {
 
 	mu          sync.RWMutex
 	connections map[string]*conn
+	routePolicy RoutePolicy
 
 	semanticProvider semantic.Provider
 	queryProvider    query.Provider
+}
+
+// RoutePolicy gates an api_invoke_endpoint call by (connection, method,
+// path) on top of the platform's existing tool/connection authorization.
+// Layered design: the MCP middleware's Authorizer.IsAuthorized check
+// covers "may this user call api_invoke_endpoint at all?" and "on this
+// connection at all?". RoutePolicy answers the more specific question
+// "may this user call THIS method on THIS path of this connection?".
+//
+// Reason is included for audit/log clarity when Allowed is false.
+// Implementations must read the caller's roles from ctx (typically via
+// the middleware's pre-authenticated user or an Authenticator) and
+// resolve them to a persona's APIRoutes rules.
+type RoutePolicy interface {
+	Allow(ctx context.Context, connection, method, path string) (allowed bool, reason string)
 }
 
 // conn carries the materialized state for a single registered
@@ -150,6 +166,27 @@ func (t *Toolkit) SetQueryProvider(provider query.Provider) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.queryProvider = provider
+}
+
+// SetRoutePolicy installs a per-(connection, method, path) authorization
+// gate. When set, api_invoke_endpoint consults the policy after the
+// connection lookup and before the upstream call. A nil policy means
+// no per-route gating — the platform's existing tool/connection
+// authorization is the sole gate (backward-compatible).
+func (t *Toolkit) SetRoutePolicy(p RoutePolicy) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.routePolicy = p
+}
+
+// RoutePolicy returns the currently installed route policy, or nil if
+// none has been wired. Exposed so platform-side tests can verify that
+// WireAPIGatewayRoutePolicy actually installed a policy and exercise
+// it directly without spinning up a full MCP server.
+func (t *Toolkit) RoutePolicy() RoutePolicy {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.routePolicy
 }
 
 // AddConnection parses a raw config map, materializes the per-
@@ -264,9 +301,33 @@ func (t *Toolkit) handleInvoke(ctx context.Context, _ *mcp.CallToolRequest, in I
 	}
 	t.mu.RLock()
 	c, ok := t.connections[in.Connection]
+	policy := t.routePolicy
 	t.mu.RUnlock()
 	if !ok {
 		return errorResult(fmt.Sprintf("connection %q not found (use list_connections to discover api connections)", in.Connection)), nil, nil
+	}
+
+	// Run the route policy BEFORE invoke() so an unauthorized call
+	// never produces an outbound HTTP request — and never appears in
+	// the upstream's access log. Validate method/path up front so the
+	// policy sees normalized values (uppercase method, "/-prefixed
+	// path); invoke() re-validates idempotently.
+	if policy != nil {
+		method, mErr := validateMethod(in.Method)
+		if mErr != nil {
+			return errorResult(mErr.Error()), nil, nil //nolint:nilerr // tool error
+		}
+		if pErr := validatePath(in.Path); pErr != nil {
+			return errorResult(pErr.Error()), nil, nil //nolint:nilerr // tool error
+		}
+		allowed, reason := policy.Allow(ctx, in.Connection, method, in.Path)
+		if !allowed {
+			msg := "not authorized for this method/path on this connection"
+			if reason != "" {
+				msg = msg + ": " + reason
+			}
+			return errorResult(msg), nil, nil
+		}
 	}
 
 	out, err := invoke(ctx, invocation{cfg: c.cfg, auth: c.auth, client: c.client}, in)

--- a/pkg/toolkits/apigateway/toolkit.go
+++ b/pkg/toolkits/apigateway/toolkit.go
@@ -309,25 +309,9 @@ func (t *Toolkit) handleInvoke(ctx context.Context, _ *mcp.CallToolRequest, in I
 
 	// Run the route policy BEFORE invoke() so an unauthorized call
 	// never produces an outbound HTTP request — and never appears in
-	// the upstream's access log. Validate method/path up front so the
-	// policy sees normalized values (uppercase method, "/-prefixed
-	// path); invoke() re-validates idempotently.
-	if policy != nil {
-		method, mErr := validateMethod(in.Method)
-		if mErr != nil {
-			return errorResult(mErr.Error()), nil, nil //nolint:nilerr // tool error
-		}
-		if pErr := validatePath(in.Path); pErr != nil {
-			return errorResult(pErr.Error()), nil, nil //nolint:nilerr // tool error
-		}
-		allowed, reason := policy.Allow(ctx, in.Connection, method, in.Path)
-		if !allowed {
-			msg := "not authorized for this method/path on this connection"
-			if reason != "" {
-				msg = msg + ": " + reason
-			}
-			return errorResult(msg), nil, nil
-		}
+	// the upstream's access log.
+	if res := checkRoutePolicy(ctx, policy, in); res != nil {
+		return res, nil, nil //nolint:nilerr // tool error surfaced via result
 	}
 
 	out, err := invoke(ctx, invocation{cfg: c.cfg, auth: c.auth, client: c.client}, in)
@@ -335,6 +319,38 @@ func (t *Toolkit) handleInvoke(ctx context.Context, _ *mcp.CallToolRequest, in I
 		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol — argument validation surfaced as tool error
 	}
 	return jsonResult(out), out, nil
+}
+
+// checkRoutePolicy runs the optional per-(connection, method, path)
+// authorization gate. Returns nil when the policy is unset or when
+// the call is allowed. Returns a non-nil error result when the
+// method or path validators reject the input, or when the policy
+// denies the call.
+//
+// Method and path are validated up front so the policy sees
+// normalized values (uppercase method, "/-prefixed" path). invoke()
+// re-validates idempotently so the policy step can be skipped when
+// no policy is installed without losing input safety.
+func checkRoutePolicy(ctx context.Context, policy RoutePolicy, in InvokeInput) *mcp.CallToolResult {
+	if policy == nil {
+		return nil
+	}
+	method, mErr := validateMethod(in.Method)
+	if mErr != nil {
+		return errorResult(mErr.Error())
+	}
+	if pErr := validatePath(in.Path); pErr != nil {
+		return errorResult(pErr.Error())
+	}
+	allowed, reason := policy.Allow(ctx, in.Connection, method, in.Path)
+	if allowed {
+		return nil
+	}
+	msg := "not authorized for this method/path on this connection"
+	if reason != "" {
+		msg = msg + ": " + reason
+	}
+	return errorResult(msg)
 }
 
 // jsonResult creates a successful MCP result with the JSON-encoded

--- a/pkg/toolkits/apigateway/toolkit_test.go
+++ b/pkg/toolkits/apigateway/toolkit_test.go
@@ -270,6 +270,186 @@ func TestHandleInvoke_BadInputProducesToolError(t *testing.T) {
 	}
 }
 
+// stubRoutePolicy lets tests assert handleInvoke's gating without
+// depending on the persona package.
+type stubRoutePolicy struct {
+	calls   int
+	allowed bool
+	reason  string
+	gotConn string
+	gotMeth string
+	gotPath string
+}
+
+func (s *stubRoutePolicy) Allow(_ context.Context, conn, method, path string) (bool, string) {
+	s.calls++
+	s.gotConn = conn
+	s.gotMeth = method
+	s.gotPath = path
+	return s.allowed, s.reason
+}
+
+func TestHandleInvoke_RoutePolicyDeniesBeforeInvoke(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("upstream was contacted but route policy should have denied the call")
+	}))
+	defer srv.Close()
+
+	tk := New("test")
+	if err := tk.AddConnection("c1", map[string]any{"base_url": srv.URL}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	pol := &stubRoutePolicy{allowed: false, reason: "DELETE not allowed"}
+	tk.SetRoutePolicy(pol)
+
+	res, _, err := tk.handleInvoke(context.Background(), nil, InvokeInput{
+		Connection: "c1", Method: "DELETE", Path: "/v1/users/123",
+	})
+	if err != nil {
+		t.Fatalf("handleInvoke unexpected go error: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError=true on policy denial; got %s", textContent(res))
+	}
+	if pol.calls != 1 {
+		t.Errorf("policy called %d times; want 1", pol.calls)
+	}
+	if pol.gotMeth != "DELETE" || pol.gotConn != "c1" || pol.gotPath != "/v1/users/123" {
+		t.Errorf("policy received wrong args: conn=%q method=%q path=%q", pol.gotConn, pol.gotMeth, pol.gotPath)
+	}
+	if !strings.Contains(textContent(res), "DELETE not allowed") {
+		t.Errorf("denial reason missing from result: %s", textContent(res))
+	}
+}
+
+func TestHandleInvoke_RoutePolicyAllowsThenInvokes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer srv.Close()
+
+	tk := New("test")
+	if err := tk.AddConnection("c1", map[string]any{"base_url": srv.URL}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	pol := &stubRoutePolicy{allowed: true}
+	tk.SetRoutePolicy(pol)
+
+	res, _, err := tk.handleInvoke(context.Background(), nil, InvokeInput{
+		Connection: "c1", Method: "GET", Path: "/v1/users",
+	})
+	if err != nil {
+		t.Fatalf("handleInvoke: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("policy allowed but result is error: %s", textContent(res))
+	}
+	if pol.calls != 1 {
+		t.Errorf("policy not consulted; calls=%d", pol.calls)
+	}
+}
+
+// Methods are normalized (uppercased) BEFORE the policy sees them so
+// persona configs can use the conventional uppercase form regardless
+// of how the model formats the input.
+func TestHandleInvoke_RoutePolicyReceivesNormalizedMethod(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tk := New("test")
+	if err := tk.AddConnection("c1", map[string]any{"base_url": srv.URL}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	pol := &stubRoutePolicy{allowed: true}
+	tk.SetRoutePolicy(pol)
+
+	_, _, err := tk.handleInvoke(context.Background(), nil, InvokeInput{
+		Connection: "c1", Method: "get", Path: "/v1/users",
+	})
+	if err != nil {
+		t.Fatalf("handleInvoke: %v", err)
+	}
+	if pol.gotMeth != "GET" {
+		t.Errorf("policy saw method=%q; want %q (normalized)", pol.gotMeth, "GET")
+	}
+}
+
+func TestHandleInvoke_NoPolicyMeansPassthrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tk := New("test")
+	if err := tk.AddConnection("c1", map[string]any{"base_url": srv.URL}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	// no SetRoutePolicy → policy is nil, the call should proceed.
+
+	res, _, err := tk.handleInvoke(context.Background(), nil, InvokeInput{
+		Connection: "c1", Method: "GET", Path: "/v1/users",
+	})
+	if err != nil {
+		t.Fatalf("handleInvoke: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("nil policy should not block call: %s", textContent(res))
+	}
+}
+
+// Validation errors (unsupported method, malformed path) surface BEFORE
+// the policy is consulted, so the persona doesn't have to validate
+// input shape.
+func TestHandleInvoke_RoutePolicyNotConsultedOnInvalidMethod(t *testing.T) {
+	tk := New("test")
+	if err := tk.AddConnection("c1", map[string]any{"base_url": "https://x"}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	pol := &stubRoutePolicy{allowed: true}
+	tk.SetRoutePolicy(pol)
+
+	res, _, err := tk.handleInvoke(context.Background(), nil, InvokeInput{
+		Connection: "c1", Method: "PURGE", Path: "/foo",
+	})
+	if err != nil {
+		t.Fatalf("handleInvoke unexpected go error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("invalid method should produce IsError")
+	}
+	if pol.calls != 0 {
+		t.Errorf("policy was consulted on invalid method (calls=%d)", pol.calls)
+	}
+}
+
+// Path validation runs before the policy is consulted (mirrors the
+// invalid-method case). Path with a forbidden character ("@" triggers
+// the SSRF guard) should error without invoking the policy.
+func TestHandleInvoke_RoutePolicyNotConsultedOnInvalidPath(t *testing.T) {
+	tk := New("test")
+	if err := tk.AddConnection("c1", map[string]any{"base_url": "https://x"}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	pol := &stubRoutePolicy{allowed: true}
+	tk.SetRoutePolicy(pol)
+
+	res, _, err := tk.handleInvoke(context.Background(), nil, InvokeInput{
+		Connection: "c1", Method: "GET", Path: "/@evil/foo",
+	})
+	if err != nil {
+		t.Fatalf("handleInvoke unexpected go error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("invalid path should produce IsError")
+	}
+	if pol.calls != 0 {
+		t.Errorf("policy was consulted on invalid path (calls=%d)", pol.calls)
+	}
+}
+
 func TestRegisterTools_AgainstRealServer(_ *testing.T) {
 	srv := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
 	tk := New("api")

--- a/pkg/toolkits/apigateway/toolkit_test.go
+++ b/pkg/toolkits/apigateway/toolkit_test.go
@@ -281,7 +281,7 @@ type stubRoutePolicy struct {
 	gotPath string
 }
 
-func (s *stubRoutePolicy) Allow(_ context.Context, conn, method, path string) (bool, string) {
+func (s *stubRoutePolicy) Allow(_ context.Context, conn, method, path string) (allowed bool, reason string) {
 	s.calls++
 	s.gotConn = conn
 	s.gotMeth = method


### PR DESCRIPTION
## Summary

- Adds **per-(connection, method, path) authorization** for the HTTP API gateway. Personas can now restrict which HTTP method + path combinations the model can call against a given API connection — e.g., "analysts may `GET /v1/users/*` on `crm-prod` but not `DELETE` anything anywhere."
- Layered on top of the platform's existing `Authorizer.IsAuthorized` (tool name + connection name) — adds the per-route granularity that gate cannot express. No change to existing personas; the new field is opt-in.
- Hardens path validation against three classes of glob bypass that adversarial review caught during this PR (`..` literals, interior `//`, percent-encoded `%2E%2E`).

Closes #370.

## What changed

### `pkg/persona`

- New field `APIRoutes []APIRouteRule` on `Persona`. Each rule carries:
  - `Connection` glob (required) — matched against the connection name.
  - `Methods []string` (optional) — HTTP method globs; empty = any.
  - `Paths []string` (optional) — path globs; empty = any.
  - `Action string` — `"allow"` (default) or `"deny"`. Deny precedes allow within the matching-Connection subset.
- New `ToolFilter.IsAPIRouteAllowed(persona, connection, method, path) bool` and `Authorizer.IsAPIRouteAllowed(ctx, roles, connection, method, path)` — the latter resolves roles → persona, then applies the rules.
- `Registry.Register` now validates every `APIRouteRule` at load time: globs are checked via `filepath.Match(pat, "")` so `ErrBadPattern` surfaces immediately, `Action` is restricted to `""`/`"allow"`/`"deny"`, and empty `Connection` is rejected. Without these checks, a typo in a deny rule would silently fail-open (gosec finding from review).
- **Backward compatible**: a persona with no `APIRoutes` rules behaves exactly as before — the route check is a no-op and the existing `ConnectionRules` gate is the sole authority.

### `pkg/toolkits/apigateway`

- New `RoutePolicy` interface (`Allow(ctx, conn, method, path) (bool, reason)`) + `SetRoutePolicy` setter on `Toolkit`. `RoutePolicy()` getter exposed for platform-side wiring tests.
- `handleInvoke` now validates method + path up front (so the policy sees normalized values — uppercase method, "/-prefixed" path), consults the policy, and refuses the upstream call before any HTTP request leaves the process. A persona denial **does not** appear in the upstream's access log.
- Path validation hardened in `validatePath` / new `checkPathSegments`:
  - Refuses literal `.` and `..` segments (`/v1/users/..` would match a `/v1/users/*` glob but `JoinPath` resolves to `/v1` — bypass).
  - Refuses interior empty segments (`/v1//admin/secret` → `JoinPath` collapses to `/v1/admin/secret` — bypass against literal-pattern rules).
  - Refuses percent-encoded dot segments (`%2E%2E`, `%2e%2e`, `%2E`) since RFC 3986 allows servers to decode `%2E` for path resolution and many do (Apache default, several SaaS APIs).
  - Refuses malformed percent-escapes (`%2`).

### `pkg/platform`

- New `apiGatewayRoutePolicy` adapter bridges `*persona.Authorizer` onto `apigateway.RoutePolicy`. Its `resolveRoles` follows this preference order:
  1. **Pre-authenticated user** (`middleware.GetPreAuthenticatedUser`) — admin browser-cookie paths.
  2. **`PlatformContext.Roles`** — set by upstream `MCPToolCallMiddleware` after a single `Authenticate`. The cheap path on the MCP tool-call hot path; reusing roles avoids a redundant JWT signature verification per call.
  3. **`Authenticator.Authenticate`** — fallback for callers that didn't run through the standard MCP middleware chain.
  - The "auth middleware ran" signal is `pc.UserID != ""`, **not** `len(pc.Roles) > 0` — authenticated users with no role claims (legitimate scenario) still take the cheap path.
- New `WireAPIGatewayRoutePolicy` helper finds every live api gateway toolkit in the registry and calls `SetRoutePolicy` on each. Wired into `cmd/mcp-data-platform/main.go` alongside the existing `WireGatewayTokenStore` / `WireGatewayBroadcaster`.

## Example persona configuration

```yaml
personas:
  - name: analyst
    roles: [analyst]
    tools:
      allow: ["api_*", "trino_*"]
    connections:
      allow: ["crm-prod", "warehouse"]
    api_routes:
      # Read-only on the CRM
      - connection: "crm-*"
        methods: ["GET", "HEAD"]
        paths: ["/v1/users/*", "/v1/orders/*"]
      # Belt-and-suspenders deny on writes
      - connection: "*"
        methods: ["DELETE"]
        action: "deny"
```

A persona with `api_routes:` empty (or unset) gets the existing connection-level behavior unchanged.

## Adversarial review

Three rounds during this PR; each found real issues. Captured in the commit body for posterity:

| Round | Finding | Fix |
|---|---|---|
| 1 | Path traversal via `..` segments could escape persona scope | `hasDotSegment` rejection |
| 1 | Wiring test was tautological — never called the installed policy | Added `RoutePolicy()` getter and exercise the deny path |
| 1 | `apiGatewayRoutePolicy.Allow` re-ran `Authenticate` per call | `resolveRoles` prefers `PlatformContext.Roles` |
| 1 | Malformed glob in deny rule silently fails open | `validateAPIRoutes` at registration time |
| 1 | Empty `Connection` silently dropped | Rejected at registration |
| 2 | Interior `//` and percent-encoded dots not caught by the R1 fix | `checkPathSegments` rewritten with `url.PathUnescape` |
| 2 | `len(pc.Roles) > 0` guard reintroduced double-verify for empty-roles users | Predicate changed to `pc.UserID != ""`; `panicAuthenticator` regression test added |
| 3 | (none) | Verdict: CLEAN |

## What's deferred

- **Audit field structuring** for `api_invoke_endpoint`. The existing audit middleware already logs the tool name and the input args (connection, method, path) — so calls are auditable today. Promoting those to structured `audit_logs` columns for queryability is a separate enhancement to the audit table and was kept out of this PR. Tracked separately if desired.
- **stdio transport parity** for `WireAPIGatewayRoutePolicy`. The existing `WireGatewayTokenStore` and `WireGatewayBroadcaster` follow the same HTTP-only invocation pattern from `main.go`'s `startHTTPServer`; aligning all three is a wider transport-wiring refactor and out of scope here.

## Test plan

- [ ] `make verify` passes locally with pinned tool versions (golangci-lint v2.11.4 + gosec v2.22.0).
- [ ] `go test ./pkg/persona/... ./pkg/toolkits/apigateway/... ./pkg/platform/...` — all green; new tests:
  - `TestToolFilter_IsAPIRouteAllowed` — 10 table cases (passthrough, allow, deny precedence, method-only, path-only, deny-mismatch, etc.)
  - `TestRegistry_RegisterRejectsBadAPIRoutes` — 5 misconfigurations rejected at load time
  - `TestValidatePath_RejectsSSRFShapes` — 12 vectors including `..`, `//`, `%2E%2E`, malformed percent
  - `TestHandleInvoke_RoutePolicy*` — deny/allow/normalization/passthrough/invalid-input
  - `TestAPIGatewayRoutePolicy_Allow_DirectCases` — adapter behavior + `panicAuthenticator` no-double-verify regression guard
  - `TestWireAPIGatewayRoutePolicy_DeniesViaInstalledPolicy` — proves `WireAPIGatewayRoutePolicy` actually installs a working policy on the live toolkit
- [ ] Live integration after merge: register a `kind=api` connection (e.g., bearer auth against `https://httpbin.org`), define a persona with `api_routes: [{connection: "<name>", methods: ["GET"]}]`, invoke `api_invoke_endpoint(connection, "POST", "/post")` as that persona, confirm the response envelope is a structured denial (no upstream call made). Verify a `GET` against the same connection passes.
- [ ] Confirm a persona with no `api_routes` rules behaves exactly as before (backward compatibility): existing `kind=api` connections registered without persona rule changes continue to work.

## References

- Closes: #370 (persona policy and audit integration — policy half; audit covered by existing middleware)
- Builds on: #377 (HTTP API gateway with `api_invoke_endpoint`)
- Follow-ups: structured audit fields for api_invoke_endpoint (separate enhancement to the audit table); stdio parity for the Wire* helpers (separate refactor)
