### PR TITLE
feat(apigateway): OAuth2 authorization_code grant + admin reauth handler (#368)

### DIFF
--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -279,6 +279,7 @@ func startHTTPServer(ctx context.Context, mcpServer *mcp.Server, p *platform.Pla
 		p.WireGatewayTokenStore()
 		p.WireGatewayBroadcaster()
 		p.WireAPIGatewayRoutePolicy()
+		p.WireAPIGatewayTokenStore()
 	}
 
 	mux := http.NewServeMux()

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -15,6 +15,116 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/admin/api-gateway/connections/{name}/oauth-start": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Generates a PKCE verifier, derives the SHA256 challenge, registers a state token, and returns the authorization URL the operator should open in their browser. The upstream IdP redirects back to /api/v1/admin/api-gateway/oauth/callback after the user authenticates.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "Begin OAuth authorization-code flow for an API gateway connection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "API gateway connection name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Optional return URL",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/admin.startGatewayOAuthRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.startGatewayOAuthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/api-gateway/oauth/callback": {
+            "get": {
+                "description": "Public endpoint hit by the upstream IdP after the operator authenticates. Exchanges the code for tokens and persists them via the API gateway's TokenStore. Renders an HTML error page on failure so a stranded browser tab still gives a useful message.",
+                "produces": [
+                    "text/html"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "OAuth authorization-code callback for API gateway connections",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "OAuth authorization code",
+                        "name": "code",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "PKCE state token from oauth-start",
+                        "name": "state",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "OAuth error code from upstream",
+                        "name": "error",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Found"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/audit/events": {
             "get": {
                 "security": [

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -9,6 +9,116 @@
     "host": "localhost:8080",
     "basePath": "/api/v1",
     "paths": {
+        "/admin/api-gateway/connections/{name}/oauth-start": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Generates a PKCE verifier, derives the SHA256 challenge, registers a state token, and returns the authorization URL the operator should open in their browser. The upstream IdP redirects back to /api/v1/admin/api-gateway/oauth/callback after the user authenticates.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "Begin OAuth authorization-code flow for an API gateway connection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "API gateway connection name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Optional return URL",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/admin.startGatewayOAuthRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.startGatewayOAuthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/api-gateway/oauth/callback": {
+            "get": {
+                "description": "Public endpoint hit by the upstream IdP after the operator authenticates. Exchanges the code for tokens and persists them via the API gateway's TokenStore. Renders an HTML error page on failure so a stranded browser tab still gives a useful message.",
+                "produces": [
+                    "text/html"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "OAuth authorization-code callback for API gateway connections",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "OAuth authorization code",
+                        "name": "code",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "PKCE state token from oauth-start",
+                        "name": "state",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "OAuth error code from upstream",
+                        "name": "error",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "302": {
+                        "description": "Found"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/audit/events": {
             "get": {
                 "security": [

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -2238,6 +2238,82 @@ info:
   title: MCP Data Platform API
   version: "1.0"
 paths:
+  /admin/api-gateway/connections/{name}/oauth-start:
+    post:
+      consumes:
+      - application/json
+      description: Generates a PKCE verifier, derives the SHA256 challenge, registers
+        a state token, and returns the authorization URL the operator should open
+        in their browser. The upstream IdP redirects back to /api/v1/admin/api-gateway/oauth/callback
+        after the user authenticates.
+      parameters:
+      - description: API gateway connection name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Optional return URL
+        in: body
+        name: body
+        schema:
+          $ref: '#/definitions/admin.startGatewayOAuthRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/admin.startGatewayOAuthResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/admin.problemDetail'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/admin.problemDetail'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/admin.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Begin OAuth authorization-code flow for an API gateway connection
+      tags:
+      - Connections
+  /admin/api-gateway/oauth/callback:
+    get:
+      description: Public endpoint hit by the upstream IdP after the operator authenticates.
+        Exchanges the code for tokens and persists them via the API gateway's TokenStore.
+        Renders an HTML error page on failure so a stranded browser tab still gives
+        a useful message.
+      parameters:
+      - description: OAuth authorization code
+        in: query
+        name: code
+        type: string
+      - description: PKCE state token from oauth-start
+        in: query
+        name: state
+        required: true
+        type: string
+      - description: OAuth error code from upstream
+        in: query
+        name: error
+        type: string
+      produces:
+      - text/html
+      responses:
+        "302":
+          description: Found
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/admin.problemDetail'
+      summary: OAuth authorization-code callback for API gateway connections
+      tags:
+      - Connections
   /admin/audit/events:
     get:
       description: Returns paginated audit events with optional filtering.

--- a/pkg/admin/api_gateway_oauth_handler.go
+++ b/pkg/admin/api_gateway_oauth_handler.go
@@ -1,0 +1,493 @@
+package admin
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/txn2/mcp-data-platform/pkg/platform"
+	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
+)
+
+// registerAPIGatewayOAuthRoutes adds the authorization-code OAuth
+// endpoints for the HTTP API gateway. Mirrors the MCP gateway's
+// pair (POST oauth-start + GET callback) but reads from the api
+// gateway's config shape and writes to the api gateway's
+// TokenStore. The callback route is on the public mux so the
+// upstream IdP's redirect can hit it without an admin auth header
+// — the state token + PKCE verifier authenticate the callback.
+func (h *Handler) registerAPIGatewayOAuthRoutes() {
+	if !h.isMutable() || h.deps.ConnectionStore == nil {
+		return
+	}
+	h.mux.HandleFunc("POST /api/v1/admin/api-gateway/connections/{name}/oauth-start", h.startAPIGatewayOAuth)
+	h.publicMux.HandleFunc("GET /api/v1/admin/api-gateway/oauth/callback", h.apiGatewayOAuthCallback)
+}
+
+// startAPIGatewayOAuth handles POST .../api-gateway/connections/{name}/oauth-start.
+//
+// @Summary      Begin OAuth authorization-code flow for an API gateway connection
+// @Description  Generates a PKCE verifier, derives the SHA256 challenge, registers a state token, and returns the authorization URL the operator should open in their browser. The upstream IdP redirects back to /api/v1/admin/api-gateway/oauth/callback after the user authenticates.
+// @Tags         Connections
+// @Accept       json
+// @Produce      json
+// @Param        name  path  string                   true  "API gateway connection name"
+// @Param        body  body  startGatewayOAuthRequest  false  "Optional return URL"
+// @Success      200   {object}  startGatewayOAuthResponse
+// @Failure      400   {object}  problemDetail
+// @Failure      404   {object}  problemDetail
+// @Failure      409   {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /admin/api-gateway/connections/{name}/oauth-start [post]
+func (h *Handler) startAPIGatewayOAuth(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue(pathKeyName)
+	cfg, ok := h.loadAPIGatewayAuthCodeConfig(w, r, name)
+	if !ok {
+		return
+	}
+
+	var body startGatewayOAuthRequest
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+	}
+
+	verifier, state, ok := generatePKCEPair(w)
+	if !ok {
+		return
+	}
+	redirectURI := buildAPIGatewayCallbackURL(r)
+	authURL := buildAPIGatewayAuthorizationURL(cfg.OAuth2, state, verifier, redirectURI)
+
+	store := h.pkceStoreFor()
+	if store == nil {
+		writeError(w, http.StatusServiceUnavailable, "OAuth not available: PKCE store not configured")
+		return
+	}
+	startedBy := authorEmailOrID(r.Context())
+	if err := store.Put(r.Context(), state, &PKCEState{
+		connection:   name,
+		codeVerifier: verifier,
+		startedBy:    startedBy,
+		createdAt:    time.Now(),
+		returnURL:    body.ReturnURL,
+		redirectURI:  redirectURI,
+	}); err != nil {
+		slog.Error("api-gateway oauth-start: failed to persist pkce state",
+			logKeyName, name, logKeyStartedBy, startedBy, logKeyError, err)
+		writeError(w, http.StatusInternalServerError, "failed to register oauth state")
+		return
+	}
+	writeJSON(w, http.StatusOK, startGatewayOAuthResponse{
+		AuthorizationURL: authURL,
+		State:            state,
+		RedirectURI:      redirectURI,
+		ExpiresAt:        time.Now().Add(pkceTTL).UTC().Format(time.RFC3339),
+	})
+}
+
+// apiGatewayOAuthCallback handles GET /api/v1/admin/api-gateway/oauth/callback.
+//
+// @Summary      OAuth authorization-code callback for API gateway connections
+// @Description  Public endpoint hit by the upstream IdP after the operator authenticates. Exchanges the code for tokens and persists them via the API gateway's TokenStore. Renders an HTML error page on failure so a stranded browser tab still gives a useful message.
+// @Tags         Connections
+// @Produce      html
+// @Param        code   query  string  false  "OAuth authorization code"
+// @Param        state  query  string  true   "PKCE state token from oauth-start"
+// @Param        error  query  string  false  "OAuth error code from upstream"
+// @Success      302
+// @Failure      400  {object}  problemDetail
+// @Router       /admin/api-gateway/oauth/callback [get]
+func (h *Handler) apiGatewayOAuthCallback(w http.ResponseWriter, r *http.Request) {
+	pending := h.takeAPIGatewayCallbackState(w, r)
+	if pending == nil {
+		return
+	}
+	q := r.URL.Query()
+	if !validateAPIGatewayCallbackQuery(w, q, pending) {
+		return
+	}
+	if !h.completeAPIGatewayCallback(w, r, q.Get(formKeyCode), pending) {
+		return
+	}
+
+	// safeReturnURL constrains the post-OAuth redirect to a same-origin
+	// relative path or the constant fallback — without this, an admin
+	// (or someone with admin-session XSRF) could register
+	// `return_url: "https://evil.example/x"` via oauth-start and the
+	// IdP redirect would bounce the operator's browser there.
+	dest := safeReturnURL(pending.returnURL)
+	if pending.returnURL != "" && dest != pending.returnURL {
+		slog.Warn("api-gateway oauth-callback: returnURL rewritten by safeReturnURL guard",
+			logKeyName, pending.connection,
+			logKeyStartedBy, pending.startedBy,
+			"requested_return_url", pending.returnURL,
+			"rewritten_to", dest)
+	}
+	// #nosec G710 -- safeReturnURL has already constrained dest to a
+	// same-origin relative path or the constant fallback (see
+	// safeReturnURL contract in gateway_oauth_handler.go and
+	// TestSafeReturnURL).
+	http.Redirect(w, r, dest, http.StatusFound) // nosemgrep: go.lang.security.injection.open-redirect.open-redirect
+}
+
+// takeAPIGatewayCallbackState validates state, looks up the PKCE
+// store, and consumes the pending entry. Returns nil and writes the
+// HTML error page on any failure (so the caller can return early).
+func (h *Handler) takeAPIGatewayCallbackState(w http.ResponseWriter, r *http.Request) *PKCEState {
+	state := r.URL.Query().Get("state")
+	if state == "" {
+		writeOAuthError(w, "missing state parameter")
+		return nil
+	}
+	store := h.pkceStoreFor()
+	if store == nil {
+		writeOAuthError(w, "OAuth not available: PKCE store not configured")
+		return nil
+	}
+	pending, err := store.Take(r.Context(), state)
+	if err != nil {
+		// Replay (state already consumed) or expired. Either way the
+		// safe response is to refuse without leaking which.
+		writeOAuthError(w, "invalid or expired state token")
+		return nil
+	}
+	return pending
+}
+
+// validateAPIGatewayCallbackQuery handles the upstream-error and
+// missing-code cases. Returns false (and writes the HTML error page)
+// when the callback should not proceed past this point.
+func validateAPIGatewayCallbackQuery(w http.ResponseWriter, q url.Values, pending *PKCEState) bool {
+	if oauthErr := q.Get("error"); oauthErr != "" {
+		// Upstream signaled an error. Echo at warning level — the
+		// description is operator-supplied so it's safe to surface
+		// directly (unlike a 4xx response body, which we scrub).
+		// Use "idp_error" here (matches gateway_oauth_handler.go's
+		// log key for SIEM cross-grep), NOT formKeyCode (= "code").
+		// The value is the upstream OAuth `error` query parameter
+		// (e.g. access_denied), not the authorization code. Logging
+		// it under `code` would mislead any SIEM rule grepping for
+		// authorization-code reuse.
+		slog.Warn("api-gateway oauth-callback: upstream error",
+			logKeyName, pending.connection, "idp_error", oauthErr,
+			"idp_error_description", q.Get("error_description"))
+		writeOAuthError(w, "upstream OAuth error: "+oauthErr)
+		return false
+	}
+	if q.Get(formKeyCode) == "" {
+		writeOAuthError(w, "missing authorization code")
+		return false
+	}
+	return true
+}
+
+// completeAPIGatewayCallback runs the connection-load → token-
+// exchange → token-persist sequence. Returns false (and writes the
+// HTML error page) on any sub-step failure; the caller should not
+// proceed to the redirect when this returns false.
+func (h *Handler) completeAPIGatewayCallback(w http.ResponseWriter, r *http.Request, code string, pending *PKCEState) bool {
+	inst, err := h.deps.ConnectionStore.Get(r.Context(), apigatewaykit.Kind, pending.connection)
+	if err != nil {
+		writeOAuthError(w, "connection not found")
+		return false
+	}
+	cfg, err := apigatewaykit.ParseConfig(inst.Config)
+	if err != nil {
+		writeOAuthError(w, "connection config invalid")
+		return false
+	}
+	tok, err := exchangeAPIGatewayCode(r.Context(), cfg.OAuth2, code, pending.codeVerifier, pending.redirectURI)
+	if err != nil {
+		slog.Warn("api-gateway oauth-callback: token exchange failed",
+			logKeyName, pending.connection, logKeyError, err)
+		writeOAuthError(w, "token exchange failed")
+		return false
+	}
+	tk := h.findAPIGatewayToolkit()
+	if tk == nil || tk.TokenStore() == nil {
+		writeOAuthError(w, "api gateway toolkit not configured for OAuth")
+		return false
+	}
+	persisted := apigatewaykit.PersistedToken{
+		ConnectionName:   pending.connection,
+		AccessToken:      tok.AccessToken,
+		RefreshToken:     tok.RefreshToken,
+		ExpiresAt:        tok.Expiry,
+		RefreshExpiresAt: tok.RefreshExpiresAt,
+		Scope:            tok.Scope,
+		AuthenticatedBy:  pending.startedBy,
+		AuthenticatedAt:  time.Now(),
+	}
+	if err := tk.TokenStore().Set(r.Context(), persisted); err != nil {
+		slog.Error("api-gateway oauth-callback: persist token failed",
+			logKeyName, pending.connection, logKeyError, err)
+		writeOAuthError(w, "failed to persist token")
+		return false
+	}
+	return true
+}
+
+// loadAPIGatewayAuthCodeConfig is the api-gateway analog of
+// loadAuthCodeOAuthConfig in gateway_oauth_handler.go. Verifies the
+// connection exists, parses its config, and confirms it's set up
+// for the authorization_code grant before any PKCE state is
+// generated.
+func (h *Handler) loadAPIGatewayAuthCodeConfig(w http.ResponseWriter, r *http.Request, name string) (apigatewaykit.Config, bool) {
+	inst, err := h.deps.ConnectionStore.Get(r.Context(), apigatewaykit.Kind, name)
+	if err != nil {
+		if errors.Is(err, platform.ErrConnectionNotFound) {
+			writeError(w, http.StatusNotFound, "api gateway connection not found")
+		} else {
+			writeError(w, http.StatusInternalServerError, "failed to load connection")
+		}
+		return apigatewaykit.Config{}, false
+	}
+	cfg, err := apigatewaykit.ParseConfig(inst.Config)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return apigatewaykit.Config{}, false
+	}
+	if cfg.AuthMode != apigatewaykit.AuthModeOAuth2AuthorizationCode {
+		writeError(w, http.StatusConflict, "connection is not configured for authorization_code OAuth")
+		return apigatewaykit.Config{}, false
+	}
+	return cfg, true
+}
+
+// findAPIGatewayToolkit returns the live api gateway toolkit from
+// the registry, or nil when none is registered. Mirrors
+// findGatewayToolkit but for kind=api.
+func (h *Handler) findAPIGatewayToolkit() *apigatewaykit.Toolkit {
+	if h.deps.ToolkitRegistry == nil {
+		return nil
+	}
+	for _, tk := range h.deps.ToolkitRegistry.All() {
+		if api, ok := tk.(*apigatewaykit.Toolkit); ok {
+			return api
+		}
+	}
+	return nil
+}
+
+// buildAPIGatewayCallbackURL composes the callback URL the IdP
+// should redirect to after authentication. Built from the request's
+// scheme + host so deployments behind a reverse proxy (where the
+// platform sees a different host than the operator's browser) Just
+// Work as long as the proxy populates X-Forwarded-Host.
+func buildAPIGatewayCallbackURL(r *http.Request) string {
+	scheme := "https"
+	if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") == "" {
+		scheme = "http"
+	}
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	}
+	host := r.Host
+	if fh := r.Header.Get("X-Forwarded-Host"); fh != "" {
+		host = fh
+	}
+	return scheme + "://" + host + "/api/v1/admin/api-gateway/oauth/callback"
+}
+
+// buildAPIGatewayAuthorizationURL composes the IdP's authorization
+// URL with the PKCE challenge attached. SHA-256 challenge per RFC
+// 7636 §4.2 — the only method OAuth 2.1 mandates.
+func buildAPIGatewayAuthorizationURL(cfg apigatewaykit.OAuth2Config, state, verifier, redirectURI string) string {
+	challenge := pkceS256Challenge(verifier)
+	v := url.Values{}
+	v.Set("response_type", "code")
+	v.Set("client_id", cfg.ClientID)
+	v.Set("redirect_uri", redirectURI)
+	v.Set("state", state)
+	v.Set("code_challenge", challenge)
+	v.Set("code_challenge_method", "S256")
+	if len(cfg.Scopes) > 0 {
+		v.Set("scope", joinScopes(cfg.Scopes))
+	}
+	if cfg.Prompt != "" {
+		v.Set("prompt", cfg.Prompt)
+	}
+	sep := "?"
+	if u, err := url.Parse(cfg.AuthorizationURL); err == nil && u.RawQuery != "" {
+		sep = "&"
+	}
+	return cfg.AuthorizationURL + sep + v.Encode()
+}
+
+// pkceS256Challenge derives the code_challenge from the verifier
+// using SHA-256 + base64url-no-padding (RFC 7636 §4.2).
+func pkceS256Challenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// joinScopes assembles the space-delimited scope string OAuth 2.1
+// expects on the authorize URL. Single-allocation for the common
+// case of 0–4 scopes.
+func joinScopes(scopes []string) string {
+	if len(scopes) == 0 {
+		return ""
+	}
+	out := scopes[0]
+	for _, s := range scopes[1:] {
+		out = out + " " + s
+	}
+	return out
+}
+
+// exchangeAPIGatewayCode performs the authorization-code → token
+// exchange against the IdP. Mirrors the MCP gateway's
+// exchangeAuthorizationCode in security guards:
+//   - codeExchangeClient (CheckRedirect: ErrUseLastResponse) refuses
+//     to follow 3xx so a misconfigured or compromised IdP cannot
+//     redirect the credential-bearing POST (client_secret +
+//     authorization_code + code_verifier) to an attacker URL.
+//   - LimitReader caps the response read at maxCodeExchangeBodyBytes
+//     so a hostile IdP cannot OOM the platform with a multi-GB
+//     stream; oversize bodies are explicitly rejected (silently
+//     parsing a truncated JSON document would let an attacker feed
+//     attacker-controlled fields into the freshly-stored token row).
+//   - The decode struct includes refresh_expires_in (Keycloak-style)
+//     so RefreshExpiresAt is populated when the IdP discloses it.
+func exchangeAPIGatewayCode(ctx context.Context, cfg apigatewaykit.OAuth2Config, code, verifier, redirectURI string) (*apiGatewayExchangeResult, error) {
+	req, err := buildAPIGatewayTokenRequest(ctx, cfg, code, verifier, redirectURI)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := codeExchangeClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("token request: %w", err)
+	}
+	// Drain remaining bytes before close so net/http can pool the TCP
+	// connection. With LimitReader capping the read, an oversize body
+	// would otherwise leave bytes on the wire and force a re-handshake.
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+	bodyBytes, err := readCappedTokenBody(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		// Status only — body can include sensitive material.
+		return nil, errors.New("token endpoint returned non-200")
+	}
+	return decodeAPIGatewayTokenResponse(bodyBytes)
+}
+
+// buildAPIGatewayTokenRequest assembles the POST that exchanges the
+// authorization code (or, in callers that reuse it, any other grant
+// fragment in `form`) for tokens. Split out so exchangeAPIGatewayCode
+// stays under the cyclomatic complexity ceiling.
+func buildAPIGatewayTokenRequest(ctx context.Context, cfg apigatewaykit.OAuth2Config, code, verifier, redirectURI string) (*http.Request, error) {
+	form := url.Values{}
+	form.Set(formKeyGrantType, grantTypeAuthorizationCode)
+	form.Set(formKeyCode, code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("client_id", cfg.ClientID)
+	form.Set("code_verifier", verifier)
+	if cfg.EndpointAuthStyle == apigatewaykit.OAuth2AuthStyleParams {
+		form.Set("client_secret", cfg.ClientSecret)
+	}
+
+	// #nosec G107 G704 -- TokenURL is operator-authored connection config
+	// (admin endpoint, validated by ParseConfig). Same sink shape as
+	// gateway exchangeAuthorizationCode (already audited).
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.TokenURL,
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	if cfg.EndpointAuthStyle != apigatewaykit.OAuth2AuthStyleParams {
+		req.SetBasicAuth(cfg.ClientID, cfg.ClientSecret)
+	}
+	return req, nil
+}
+
+// readCappedTokenBody reads up to maxCodeExchangeBodyBytes+1 from
+// the response body and rejects the read with an explicit
+// cap-exceeded error if the body exceeded the limit. The +1 is
+// what lets the caller DETECT truncation rather than silently
+// parse a truncated JSON document.
+func readCappedTokenBody(body io.Reader) ([]byte, error) {
+	bodyBytes, err := io.ReadAll(io.LimitReader(body, maxCodeExchangeBodyBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read token response: %w", err)
+	}
+	if int64(len(bodyBytes)) > maxCodeExchangeBodyBytes {
+		return nil, fmt.Errorf("token response exceeds %d-byte cap (likely misbehaving IdP)", maxCodeExchangeBodyBytes)
+	}
+	return bodyBytes, nil
+}
+
+// decodeAPIGatewayTokenResponse parses the IdP's token-endpoint
+// JSON. RefreshExpiresIn is Keycloak-style; absent on most other
+// IdPs, in which case PersistedToken.RefreshExpiresAt stays zero.
+func decodeAPIGatewayTokenResponse(bodyBytes []byte) (*apiGatewayExchangeResult, error) {
+	var raw struct {
+		AccessToken      string `json:"access_token"`
+		RefreshToken     string `json:"refresh_token"`
+		TokenType        string `json:"token_type"`
+		ExpiresIn        int64  `json:"expires_in"`
+		RefreshExpiresIn int64  `json:"refresh_expires_in"`
+		Scope            string `json:"scope"`
+	}
+	if err := json.Unmarshal(bodyBytes, &raw); err != nil {
+		return nil, errors.New("token endpoint returned malformed JSON")
+	}
+	if raw.AccessToken == "" {
+		return nil, errors.New("token endpoint returned no access_token")
+	}
+	now := time.Now()
+	expiry := time.Time{}
+	if raw.ExpiresIn > 0 {
+		expiry = now.Add(time.Duration(raw.ExpiresIn) * time.Second)
+	}
+	refreshExpiresAt := time.Time{}
+	if raw.RefreshExpiresIn > 0 {
+		refreshExpiresAt = now.Add(time.Duration(raw.RefreshExpiresIn) * time.Second)
+	}
+	return &apiGatewayExchangeResult{
+		AccessToken:      raw.AccessToken,
+		RefreshToken:     raw.RefreshToken,
+		Expiry:           expiry,
+		RefreshExpiresAt: refreshExpiresAt,
+		Scope:            raw.Scope,
+	}, nil
+}
+
+// formKeyCode / formKeyGrantType are the OAuth 2.1 form keys; these
+// names appear in 4+ places (this file's exchange path plus tests
+// that build their own fixtures), so a single source resolves the
+// add-constant lint and prevents typos across the surface.
+const (
+	formKeyCode                = "code"
+	formKeyGrantType           = "grant_type"
+	grantTypeAuthorizationCode = "authorization_code"
+)
+
+// apiGatewayExchangeResult carries the parsed token-exchange
+// response. Mirrors oauth2.Token but adds RefreshExpiresAt so a
+// Keycloak-style refresh_expires_in is preserved through to
+// PersistedToken (the auth.go refresh path checks RefreshExpiresAt
+// to short-circuit dead-refresh attempts).
+type apiGatewayExchangeResult struct {
+	AccessToken      string
+	RefreshToken     string
+	Expiry           time.Time
+	RefreshExpiresAt time.Time
+	Scope            string
+}

--- a/pkg/admin/api_gateway_oauth_handler_test.go
+++ b/pkg/admin/api_gateway_oauth_handler_test.go
@@ -1,0 +1,533 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/platform"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
+)
+
+// apiAuthCodeConfig builds a connection_instances row for an API
+// gateway connection running the authorization_code grant. Tests
+// overlay the authorization_url + token_url from local httptest
+// servers so the exchange path can be exercised end-to-end.
+func apiAuthCodeConfig(authURL, tokenURL string) map[string]any {
+	return map[string]any{
+		"base_url":                 "https://api.example.com",
+		"connection_name":          "vendor",
+		"auth_mode":                apigatewaykit.AuthModeOAuth2AuthorizationCode,
+		"oauth2_token_url":         tokenURL,
+		"oauth2_authorization_url": authURL,
+		"oauth2_client_id":         "client-x",
+		"oauth2_client_secret":     "secret-x",
+		"oauth2_scopes":            []any{"read:users"},
+		"connect_timeout":          "3s",
+		"call_timeout":             "3s",
+	}
+}
+
+// apiGatewayOAuthHandlerWithToolkit builds a Handler whose live api
+// gateway toolkit shares its TokenStore with the test, so callback
+// ingestion can be observed by reading the store. Each call gets its
+// OWN PKCE store — there is no process global to share.
+func apiGatewayOAuthHandlerWithToolkit(t *testing.T, store ConnectionStore) (*Handler, apigatewaykit.TokenStore) {
+	t.Helper()
+	tk := apigatewaykit.New("primary")
+	tokenStore := apigatewaykit.NewMemoryTokenStore()
+	tk.SetTokenStore(tokenStore)
+	t.Cleanup(func() { _ = tk.Close() })
+
+	pkceStore := NewMemoryPKCEStore()
+	t.Cleanup(func() { _ = pkceStore.Close() })
+
+	reg := &mockToolkitRegistry{rawToolkits: []registry.Toolkit{tk}}
+	h := NewHandler(Deps{
+		Config:          testConfig(),
+		ConnectionStore: store,
+		ToolkitRegistry: reg,
+		ConfigStore:     &mockConfigStore{mode: "database"},
+		PKCEStore:       pkceStore,
+	}, nil)
+	return h, tokenStore
+}
+
+func TestStartAPIGatewayOAuth_NotFound(t *testing.T) {
+	h, _ := apiGatewayOAuthHandlerWithToolkit(t, &mockConnectionStore{getErr: platform.ErrConnectionNotFound})
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/api/v1/admin/api-gateway/connections/missing/oauth-start", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestStartAPIGatewayOAuth_RejectsClientCredentialsConnection(t *testing.T) {
+	// A client_credentials connection must not be accepted by the
+	// authorization_code start endpoint — the user-flow only makes
+	// sense for grants that involve a browser redirect.
+	store := &mockConnectionStore{
+		getResult: &platform.ConnectionInstance{
+			Kind: apigatewaykit.Kind, Name: "ccg",
+			Config: map[string]any{
+				"base_url":             "https://api.example.com",
+				"connection_name":      "ccg",
+				"auth_mode":            apigatewaykit.AuthModeOAuth2ClientCredentials,
+				"oauth2_token_url":     "https://idp/token",
+				"oauth2_client_id":     "id",
+				"oauth2_client_secret": "sec",
+				"connect_timeout":      "3s",
+				"call_timeout":         "3s",
+			},
+		},
+	}
+	h, _ := apiGatewayOAuthHandlerWithToolkit(t, store)
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/api/v1/admin/api-gateway/connections/ccg/oauth-start", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+// TestStartAPIGatewayOAuth_NoPKCEStoreReturns503 covers the
+// fail-fast guard. A handler built without Deps.PKCEStore must
+// return a clear 503 rather than panic or silently fall back.
+func TestStartAPIGatewayOAuth_NoPKCEStoreReturns503(t *testing.T) {
+	store := &mockConnectionStore{
+		getResult: &platform.ConnectionInstance{
+			Kind: apigatewaykit.Kind, Name: "vendor",
+			Config: apiAuthCodeConfig("https://idp/auth", "https://idp/token"),
+		},
+	}
+	tk := apigatewaykit.New("primary")
+	tk.SetTokenStore(apigatewaykit.NewMemoryTokenStore())
+	t.Cleanup(func() { _ = tk.Close() })
+
+	reg := &mockToolkitRegistry{rawToolkits: []registry.Toolkit{tk}}
+	h := NewHandler(Deps{
+		Config:          testConfig(),
+		ConnectionStore: store,
+		ToolkitRegistry: reg,
+		ConfigStore:     &mockConfigStore{mode: "database"},
+		// PKCEStore intentionally nil
+	}, nil)
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/api/v1/admin/api-gateway/connections/vendor/oauth-start", http.NoBody)
+	req.Host = "platform.example.com"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, w.Body.String(), "PKCE store not configured")
+}
+
+func TestStartAPIGatewayOAuth_ReturnsAuthorizationURL(t *testing.T) {
+	store := &mockConnectionStore{
+		getResult: &platform.ConnectionInstance{
+			Kind: apigatewaykit.Kind, Name: "vendor",
+			Config: apiAuthCodeConfig("https://idp.example.com/authorize", "https://idp.example.com/token"),
+		},
+	}
+	h, _ := apiGatewayOAuthHandlerWithToolkit(t, store)
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/api/v1/admin/api-gateway/connections/vendor/oauth-start", http.NoBody)
+	req.Host = "platform.example.com"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp startGatewayOAuthResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+
+	u, err := url.Parse(resp.AuthorizationURL)
+	require.NoError(t, err)
+	q := u.Query()
+	assert.Equal(t, "code", q.Get("response_type"))
+	assert.Equal(t, "client-x", q.Get("client_id"))
+	assert.Equal(t, "S256", q.Get("code_challenge_method"))
+	assert.NotEmpty(t, q.Get("code_challenge"))
+	assert.Equal(t, resp.State, q.Get("state"))
+	assert.Contains(t, q.Get("redirect_uri"), "/api/v1/admin/api-gateway/oauth/callback")
+}
+
+// TestAPIGatewayOAuthCallback_Success exercises the full
+// start → callback → token-persisted path. Distinct from the unit
+// tests because it proves PKCE state plumbed from start is actually
+// the verifier that lands in the token-exchange POST body, and that
+// the toolkit's TokenStore receives the exchanged tokens.
+func TestAPIGatewayOAuthCallback_Success(t *testing.T) {
+	var receivedForm url.Values
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		receivedForm, _ = url.ParseQuery(string(body))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"acc","refresh_token":"ref","expires_in":3600,"scope":"read:users"}`))
+	}))
+	t.Cleanup(tokenSrv.Close)
+
+	store := &mockConnectionStore{
+		getResult: &platform.ConnectionInstance{
+			Kind: apigatewaykit.Kind, Name: "vendor",
+			Config: apiAuthCodeConfig("https://idp.example.com/authorize", tokenSrv.URL),
+		},
+	}
+	h, tokenStore := apiGatewayOAuthHandlerWithToolkit(t, store)
+
+	startReq := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/api/v1/admin/api-gateway/connections/vendor/oauth-start", http.NoBody)
+	startReq.Host = "platform.example.com"
+	startW := httptest.NewRecorder()
+	h.ServeHTTP(startW, startReq)
+	require.Equal(t, http.StatusOK, startW.Code)
+	var startResp startGatewayOAuthResponse
+	require.NoError(t, json.NewDecoder(startW.Body).Decode(&startResp))
+
+	cbURL := "/api/v1/admin/api-gateway/oauth/callback?code=auth-code&state=" + url.QueryEscape(startResp.State)
+	cbReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, cbURL, http.NoBody)
+	cbReq.Host = "platform.example.com"
+	cbW := httptest.NewRecorder()
+	h.ServeHTTP(cbW, cbReq)
+
+	require.Equalf(t, http.StatusFound, cbW.Code, "expected redirect after exchange; body: %s", cbW.Body.String())
+	assert.Contains(t, cbW.Header().Get("Location"), "/portal/admin/connections")
+
+	stored, err := tokenStore.Get(context.Background(), "vendor")
+	require.NoError(t, err)
+	assert.Equal(t, "acc", stored.AccessToken)
+	assert.Equal(t, "ref", stored.RefreshToken)
+	assert.Equal(t, "read:users", stored.Scope)
+
+	assert.Equal(t, "auth-code", receivedForm.Get("code"))
+	assert.NotEmpty(t, receivedForm.Get("code_verifier"))
+	assert.Equal(t, "authorization_code", receivedForm.Get("grant_type"))
+}
+
+func TestAPIGatewayOAuthCallback_MissingState(t *testing.T) {
+	h, _ := apiGatewayOAuthHandlerWithToolkit(t, &mockConnectionStore{})
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodGet, "/api/v1/admin/api-gateway/oauth/callback?code=abc", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "missing state")
+}
+
+func TestAPIGatewayOAuthCallback_UnknownState(t *testing.T) {
+	// State that was never registered (e.g. an attacker fabricating
+	// a callback) must be rejected. The error message is deliberately
+	// uniform with the "expired" case so the handler does not leak
+	// which condition fired.
+	h, _ := apiGatewayOAuthHandlerWithToolkit(t, &mockConnectionStore{})
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodGet, "/api/v1/admin/api-gateway/oauth/callback?code=abc&state=does-not-exist", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid or expired state")
+}
+
+func TestPkceS256Challenge_Deterministic(t *testing.T) {
+	a := pkceS256Challenge("verifier-x")
+	b := pkceS256Challenge("verifier-x")
+	assert.Equal(t, a, b)
+	c := pkceS256Challenge("different-verifier")
+	assert.NotEqual(t, a, c)
+}
+
+func TestJoinScopes(t *testing.T) {
+	assert.Equal(t, "", joinScopes(nil))
+	assert.Equal(t, "", joinScopes([]string{}))
+	assert.Equal(t, "read:users", joinScopes([]string{"read:users"}))
+	assert.Equal(t, "read:users write:orders openid",
+		joinScopes([]string{"read:users", "write:orders", "openid"}))
+}
+
+func TestBuildAPIGatewayCallbackURL_HonorsForwardedHeaders(t *testing.T) {
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://internal/", http.NoBody)
+	r.Host = "internal.svc"
+	r.Header.Set("X-Forwarded-Proto", "https")
+	r.Header.Set("X-Forwarded-Host", "platform.example.com")
+	got := buildAPIGatewayCallbackURL(r)
+	assert.Equal(t,
+		"https://platform.example.com/api/v1/admin/api-gateway/oauth/callback",
+		got)
+}
+
+func TestBuildAPIGatewayAuthorizationURL_AppendsToExistingQuery(t *testing.T) {
+	cfg := apigatewaykit.OAuth2Config{
+		ClientID:         "id",
+		AuthorizationURL: "https://idp.example/authorize?app=foo",
+		Scopes:           []string{"read:users"},
+		Prompt:           "login",
+	}
+	got := buildAPIGatewayAuthorizationURL(cfg, "state-x", "verifier-y", "https://platform.example.com/cb")
+	u, err := url.Parse(got)
+	require.NoError(t, err)
+	q := u.Query()
+	assert.Equal(t, "foo", q.Get("app"), "should preserve existing query")
+	assert.Equal(t, "state-x", q.Get("state"))
+	assert.Equal(t, "S256", q.Get("code_challenge_method"))
+	assert.Equal(t, "read:users", q.Get("scope"))
+	assert.Equal(t, "login", q.Get("prompt"))
+}
+
+func TestBuildAPIGatewayAuthorizationURL_OmitsEmptyOptionals(t *testing.T) {
+	// No scopes and no prompt — neither parameter should appear on
+	// the resulting URL. Some IdPs reject unknown empty parameters
+	// with invalid_request, so the build must omit them entirely.
+	cfg := apigatewaykit.OAuth2Config{
+		ClientID:         "id",
+		AuthorizationURL: "https://idp.example/authorize",
+	}
+	got := buildAPIGatewayAuthorizationURL(cfg, "state-x", "verifier-y", "https://platform.example.com/cb")
+	u, err := url.Parse(got)
+	require.NoError(t, err)
+	q := u.Query()
+	assert.False(t, q.Has("scope"), "scope must be omitted when no scopes configured")
+	assert.False(t, q.Has("prompt"), "prompt must be omitted when not configured")
+}
+
+func TestExchangeAPIGatewayCode_NonOKReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := apigatewaykit.OAuth2Config{
+		TokenURL:          srv.URL + "/token",
+		ClientID:          "id",
+		ClientSecret:      "sec",
+		EndpointAuthStyle: apigatewaykit.OAuth2AuthStyleHeader,
+	}
+	_, err := exchangeAPIGatewayCode(context.Background(), cfg, "code", "verifier", "https://cb")
+	require.Error(t, err)
+	// Body content must not bleed through — only the status-derived
+	// message. (Bodies on error responses can include sensitive
+	// material from misbehaving IdPs.)
+	assert.NotContains(t, err.Error(), "invalid_grant",
+		"exchangeAPIGatewayCode must NOT echo upstream error body content — "+
+			"a misbehaving IdP could include sensitive material there")
+}
+
+func TestExchangeAPIGatewayCode_MalformedJSONReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{not json`))
+	}))
+	t.Cleanup(srv.Close)
+	cfg := apigatewaykit.OAuth2Config{
+		TokenURL:          srv.URL + "/token",
+		ClientID:          "id",
+		ClientSecret:      "sec",
+		EndpointAuthStyle: apigatewaykit.OAuth2AuthStyleHeader,
+	}
+	_, err := exchangeAPIGatewayCode(context.Background(), cfg, "code", "verifier", "https://cb")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "malformed JSON")
+}
+
+func TestExchangeAPIGatewayCode_MissingAccessTokenReturnsError(t *testing.T) {
+	// IdP returns 200 + valid JSON but no access_token field. Must
+	// be rejected so the TokenStore is not populated with an empty
+	// access_token (which would silently fail on the next API call
+	// instead of surfacing the misconfiguration here).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"refresh_token":"r","expires_in":3600}`))
+	}))
+	t.Cleanup(srv.Close)
+	cfg := apigatewaykit.OAuth2Config{
+		TokenURL:          srv.URL + "/token",
+		ClientID:          "id",
+		ClientSecret:      "sec",
+		EndpointAuthStyle: apigatewaykit.OAuth2AuthStyleHeader,
+	}
+	_, err := exchangeAPIGatewayCode(context.Background(), cfg, "code", "verifier", "https://cb")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no access_token")
+}
+
+// TestExchangeAPIGatewayCode_OversizeBodyDetected proves the
+// admin-side counterpart to the gateway's same-named test. A
+// malicious or misbehaving IdP that streams more than
+// maxCodeExchangeBodyBytes must be rejected with an explicit
+// cap-exceeded error rather than silently parsing a truncated JSON
+// document (which an attacker could exploit to feed
+// attacker-controlled fields into the freshly-stored token row).
+func TestExchangeAPIGatewayCode_OversizeBodyDetected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// 2 MiB — twice the 1 MiB cap.
+		_, _ = w.Write(bytes.Repeat([]byte("x"), 2<<20))
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := apigatewaykit.OAuth2Config{
+		TokenURL:          srv.URL + "/token",
+		ClientID:          "id",
+		ClientSecret:      "sec",
+		EndpointAuthStyle: apigatewaykit.OAuth2AuthStyleHeader,
+	}
+	_, err := exchangeAPIGatewayCode(context.Background(), cfg, "code", "verifier", "https://cb")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds",
+		"oversize body must surface as an explicit cap-exceeded error — "+
+			"silently parsing a truncated JSON response would let a "+
+			"malicious IdP inject attacker-controlled fields into the "+
+			"freshly-stored token row")
+}
+
+// TestExchangeAPIGatewayCode_DoesNotFollowRedirects proves the
+// admin-side counterpart to the gateway's same-named test. The
+// admin POST carries client_secret + authorization_code +
+// code_verifier — a misconfigured or compromised IdP that
+// 3xx-redirects must NOT cause the platform to forward those
+// credentials to the redirect target.
+func TestExchangeAPIGatewayCode_DoesNotFollowRedirects(t *testing.T) {
+	var attackerHits atomic.Int32
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attackerHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "stolen",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	t.Cleanup(attacker.Close)
+
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Redirect(w, &http.Request{}, attacker.URL+"/token", http.StatusFound)
+	}))
+	t.Cleanup(idp.Close)
+
+	cfg := apigatewaykit.OAuth2Config{
+		TokenURL:          idp.URL + "/token",
+		ClientID:          "id",
+		ClientSecret:      "sec",
+		EndpointAuthStyle: apigatewaykit.OAuth2AuthStyleHeader,
+	}
+	_, err := exchangeAPIGatewayCode(context.Background(), cfg, "code-x", "verifier-x", "https://cb")
+	require.Error(t, err,
+		"a 3xx response must surface as an error — the redirect target must not be hit")
+	assert.Equal(t, int32(0), attackerHits.Load(),
+		"redirect target must NEVER receive the credential-bearing POST. "+
+			"Following redirects on the token endpoint would leak the "+
+			"client_secret + authorization_code + code_verifier to the redirect target")
+}
+
+// TestExchangeAPIGatewayCode_CapturesRefreshExpiresIn proves a
+// Keycloak-style refresh_expires_in is parsed from the response
+// and surfaces on apiGatewayExchangeResult.RefreshExpiresAt — so
+// the callback handler can populate PersistedToken.RefreshExpiresAt
+// and the auth.go refresh path can short-circuit dead-refresh
+// attempts. Without this, the field stays zero and the auth-side
+// expiry check is dead code.
+func TestExchangeAPIGatewayCode_CapturesRefreshExpiresIn(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"a","refresh_token":"r","token_type":"Bearer","expires_in":300,"refresh_expires_in":1800}`))
+	}))
+	t.Cleanup(srv.Close)
+	cfg := apigatewaykit.OAuth2Config{
+		TokenURL:          srv.URL + "/token",
+		ClientID:          "id",
+		ClientSecret:      "sec",
+		EndpointAuthStyle: apigatewaykit.OAuth2AuthStyleHeader,
+	}
+	got, err := exchangeAPIGatewayCode(context.Background(), cfg, "code", "verifier", "https://cb")
+	require.NoError(t, err)
+	if got.RefreshExpiresAt.IsZero() {
+		t.Fatal("RefreshExpiresAt is zero — refresh_expires_in dropped during decode")
+	}
+	// 30 min ± 5s window allows for test scheduling jitter.
+	deltaSec := got.RefreshExpiresAt.Sub(got.Expiry).Seconds()
+	assert.InDelta(t, 1500.0, deltaSec, 5.0,
+		"RefreshExpiresAt should be ~1500s after Expiry (1800 refresh - 300 access)")
+}
+
+// TestStartAPIGatewayOAuth_OpenRedirectGuard verifies that a
+// malicious return_url is rewritten by safeReturnURL on the
+// callback path. Without this guard, an admin (or someone with
+// admin-session XSRF) could register `return_url:
+// "https://evil.example/x"` via oauth-start and the IdP redirect
+// would bounce the operator's browser there.
+func TestAPIGatewayOAuthCallback_RejectsExternalReturnURL(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"acc","refresh_token":"ref","expires_in":3600}`))
+	}))
+	t.Cleanup(tokenSrv.Close)
+
+	store := &mockConnectionStore{
+		getResult: &platform.ConnectionInstance{
+			Kind: apigatewaykit.Kind, Name: "vendor",
+			Config: apiAuthCodeConfig("https://idp.example.com/authorize", tokenSrv.URL),
+		},
+	}
+	h, _ := apiGatewayOAuthHandlerWithToolkit(t, store)
+
+	// Step 1: oauth-start with a malicious return_url.
+	body := bytes.NewBufferString(`{"return_url":"https://evil.example/x"}`)
+	startReq := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/api/v1/admin/api-gateway/connections/vendor/oauth-start", body)
+	startReq.Host = "platform.example.com"
+	startW := httptest.NewRecorder()
+	h.ServeHTTP(startW, startReq)
+	require.Equal(t, http.StatusOK, startW.Code)
+	var startResp startGatewayOAuthResponse
+	require.NoError(t, json.NewDecoder(startW.Body).Decode(&startResp))
+
+	// Step 2: callback. The redirect must NOT go to evil.example.
+	cbURL := "/api/v1/admin/api-gateway/oauth/callback?code=auth-code&state=" + url.QueryEscape(startResp.State)
+	cbReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, cbURL, http.NoBody)
+	cbReq.Host = "platform.example.com"
+	cbW := httptest.NewRecorder()
+	h.ServeHTTP(cbW, cbReq)
+
+	require.Equal(t, http.StatusFound, cbW.Code)
+	loc := cbW.Header().Get("Location")
+	assert.NotContains(t, loc, "evil.example",
+		"callback redirect must NOT bounce to operator-supplied external URL")
+	assert.Equal(t, "/portal/admin/connections", loc,
+		"safeReturnURL should fall back to the constant on rejection")
+}
+
+func TestExchangeAPIGatewayCode_AuthStyleParams(t *testing.T) {
+	// EndpointAuthStyle "params" puts client_secret in the form body
+	// instead of HTTP Basic auth. Verify both that the secret reaches
+	// the form AND that no Authorization header is sent (some IdPs
+	// reject having both).
+	var sawAuthHeader bool
+	var sawClientSecret string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuthHeader = r.Header.Get("Authorization") != ""
+		body, _ := io.ReadAll(r.Body)
+		form, _ := url.ParseQuery(string(body))
+		sawClientSecret = form.Get("client_secret")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"a","expires_in":3600}`))
+	}))
+	t.Cleanup(srv.Close)
+	cfg := apigatewaykit.OAuth2Config{
+		TokenURL:          srv.URL + "/token",
+		ClientID:          "id",
+		ClientSecret:      "in-body-secret",
+		EndpointAuthStyle: apigatewaykit.OAuth2AuthStyleParams,
+	}
+	_, err := exchangeAPIGatewayCode(context.Background(), cfg, "code", "verifier", "https://cb")
+	require.NoError(t, err)
+	assert.False(t, sawAuthHeader, "Authorization header must not be sent in params style")
+	assert.Equal(t, "in-body-secret", sawClientSecret)
+}

--- a/pkg/admin/handler.go
+++ b/pkg/admin/handler.go
@@ -149,6 +149,14 @@ const publicPrefix = "/api/v1/admin/public/"
 // session.
 const oauthCallbackPrefix = "/api/v1/admin/oauth/"
 
+// apiGatewayOAuthCallbackPrefix is the parallel callback URL for the
+// HTTP API gateway's authorization-code flow. Kept distinct from the
+// MCP gateway's prefix so an operator can read the URL and tell which
+// connection family the redirect belongs to. Same admin-session
+// bypass rationale as oauthCallbackPrefix — PKCE state, not session,
+// authenticates the callback.
+const apiGatewayOAuthCallbackPrefix = "/api/v1/admin/api-gateway/oauth/"
+
 // Handler provides admin REST API endpoints.
 type Handler struct {
 	mux        *http.ServeMux
@@ -204,7 +212,8 @@ func NewHandler(deps Deps, authMiddle func(http.Handler) http.Handler) *Handler 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if strings.HasPrefix(r.URL.Path, docsPrefix) ||
 		strings.HasPrefix(r.URL.Path, publicPrefix) ||
-		strings.HasPrefix(r.URL.Path, oauthCallbackPrefix) {
+		strings.HasPrefix(r.URL.Path, oauthCallbackPrefix) ||
+		strings.HasPrefix(r.URL.Path, apiGatewayOAuthCallbackPrefix) {
 		h.publicMux.ServeHTTP(w, r)
 		return
 	}
@@ -229,6 +238,7 @@ func (h *Handler) registerRoutes() {
 	h.registerConnectionRoutes()
 	h.registerGatewayRoutes()
 	h.registerGatewayOAuthRoutes()
+	h.registerAPIGatewayOAuthRoutes()
 	h.registerEnrichmentRoutes()
 	h.registerPromptRoutes()
 }

--- a/pkg/database/migrate/migrate_unit_test.go
+++ b/pkg/database/migrate/migrate_unit_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	migrateTestFileCount    = 74
+	migrateTestFileCount    = 76
 	migrateTestSuccess      = "success"
 	migrateTestFactoryError = "factory error"
 )

--- a/pkg/database/migrate/migrations/000038_apigateway_oauth_tokens.down.sql
+++ b/pkg/database/migrate/migrations/000038_apigateway_oauth_tokens.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS apigateway_oauth_tokens;

--- a/pkg/database/migrate/migrations/000038_apigateway_oauth_tokens.up.sql
+++ b/pkg/database/migrate/migrations/000038_apigateway_oauth_tokens.up.sql
@@ -1,0 +1,17 @@
+-- Persistent OAuth token storage for the HTTP API gateway's
+-- authorization_code grant. Parallel to gateway_oauth_tokens
+-- (the MCP gateway's table) — kept separate so the two toolkit
+-- families' connection-name spaces cannot collide. Schema is
+-- intentionally identical so future shared infrastructure can
+-- consume both with the same row shape.
+CREATE TABLE IF NOT EXISTS apigateway_oauth_tokens (
+    connection_name    VARCHAR(255) PRIMARY KEY,
+    access_token       TEXT,
+    refresh_token      TEXT,
+    expires_at         TIMESTAMPTZ,
+    refresh_expires_at TIMESTAMPTZ,
+    scope              TEXT NOT NULL DEFAULT '',
+    authenticated_by   VARCHAR(255) NOT NULL DEFAULT '',
+    authenticated_at   TIMESTAMPTZ,
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -116,15 +116,16 @@ type Platform struct {
 	auditStore *auditpostgres.Store
 
 	// Config store
-	configStore       configstore.Store
-	fileDefaults      map[string]string
-	connectionStore   ConnectionStore
-	connectionSources *ConnectionSourceMap
-	enrichmentStore   enrichment.Store
-	gatewayTokenStore gatewaykit.TokenStore
-	restEncryptor     *RestFieldEncryptor
-	personaStore      PersonaStore
-	apiKeyStore       APIKeyStore
+	configStore          configstore.Store
+	fileDefaults         map[string]string
+	connectionStore      ConnectionStore
+	connectionSources    *ConnectionSourceMap
+	enrichmentStore      enrichment.Store
+	gatewayTokenStore    gatewaykit.TokenStore
+	apigatewayTokenStore apigatewaykit.TokenStore
+	restEncryptor        *RestFieldEncryptor
+	personaStore         PersonaStore
+	apiKeyStore          APIKeyStore
 
 	// Providers
 	semanticProvider semantic.Provider
@@ -444,6 +445,7 @@ func (p *Platform) initConnectionStore(opts *Options) error {
 	p.connectionStore = NewPostgresConnectionStore(p.db, encryptor)
 	p.enrichmentStore = enrichment.NewPostgresStore(p.db)
 	p.gatewayTokenStore = gatewaykit.NewPostgresTokenStore(p.db, p.restEncryptor)
+	p.apigatewayTokenStore = apigatewaykit.NewPostgresTokenStore(p.db, p.restEncryptor)
 	return nil
 }
 
@@ -633,6 +635,30 @@ func (a apiGatewayRoutePolicy) resolveRoles(ctx context.Context) []string {
 		}
 	}
 	return nil
+}
+
+// APIGatewayTokenStore returns the persistent OAuth token store used
+// by the api gateway's authorization_code grant. nil when the
+// platform was constructed without a database — auth_mode
+// oauth2_authorization_code requires a database to function.
+func (p *Platform) APIGatewayTokenStore() apigatewaykit.TokenStore {
+	return p.apigatewayTokenStore
+}
+
+// WireAPIGatewayTokenStore attaches the persistent OAuth token
+// store to every live api gateway toolkit. Mirrors
+// WireGatewayTokenStore in placement and lifecycle. Safe to call
+// multiple times — the toolkit's SetTokenStore re-threads any
+// already-materialized authorization_code Authenticators.
+func (p *Platform) WireAPIGatewayTokenStore() {
+	if p.apigatewayTokenStore == nil {
+		return
+	}
+	for _, tk := range p.toolkitRegistry.All() {
+		if api, ok := tk.(*apigatewaykit.Toolkit); ok {
+			api.SetTokenStore(p.apigatewayTokenStore)
+		}
+	}
 }
 
 // WireAPIGatewayRoutePolicy installs a per-(connection, method, path)

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -4996,6 +4996,84 @@ func TestWireAPIGatewayRoutePolicy_NoToolkit_NoOp(t *testing.T) {
 	p.WireAPIGatewayRoutePolicy() // must not panic when no api toolkit registered
 }
 
+// TestWireAPIGatewayTokenStore proves the api gateway parallel of
+// WireGatewayTokenStore: when the platform has a non-nil
+// apigatewayTokenStore, calling WireAPIGatewayTokenStore must reach
+// every registered api gateway toolkit's SetTokenStore. Without this,
+// authorization_code grants would silently come up with no
+// persistence and refresh tokens would vanish on process restart.
+//
+// Owns: structural contract (a) WireAPIGatewayTokenStore is a no-op
+// when the platform has no token store (stateless mode), and (b) when
+// a store is set it actually reaches the toolkit. The Authenticator's
+// behavior with a wired store is covered by the apigateway package's
+// own tests.
+func TestWireAPIGatewayTokenStore(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Name: testServerName},
+		Semantic: SemanticConfig{Provider: testProviderNoop},
+		Query:    QueryConfig{Provider: testProviderNoop},
+		Storage:  StorageConfig{Provider: testProviderNoop},
+	}
+	p, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	// Build an api gateway toolkit and register it.
+	mc, err := apigatewaykit.ParseMultiConfig("api", map[string]map[string]any{
+		"crm": {"base_url": "https://api.example.com"},
+	})
+	if err != nil {
+		t.Fatalf("ParseMultiConfig: %v", err)
+	}
+	tk := apigatewaykit.NewMulti(mc)
+	if err := p.toolkitRegistry.Register(tk); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Pre-condition: no DB → apigatewayTokenStore is nil → wire must
+	// be a safe no-op and leave the toolkit's TokenStore unset.
+	if p.apigatewayTokenStore != nil {
+		t.Fatalf("expected nil apigatewayTokenStore in test (no DB), got %T", p.apigatewayTokenStore)
+	}
+	p.WireAPIGatewayTokenStore()
+	if tk.TokenStore() != nil {
+		t.Error("WireAPIGatewayTokenStore set a TokenStore when platform store is nil")
+	}
+
+	// Now simulate the DB-backed mode: install a memory store as the
+	// platform-level token store and re-wire. Every api gateway
+	// toolkit must observe the store.
+	want := apigatewaykit.NewMemoryTokenStore()
+	p.apigatewayTokenStore = want
+	p.WireAPIGatewayTokenStore()
+	if got := tk.TokenStore(); got == nil {
+		t.Fatal("WireAPIGatewayTokenStore did not deliver the store to the toolkit")
+	}
+}
+
+// TestWireAPIGatewayTokenStore_NoToolkit_NoOp proves the helper is
+// safe when no api gateway toolkit is registered. Mirrors
+// TestWireAPIGatewayRoutePolicy_NoToolkit_NoOp.
+func TestWireAPIGatewayTokenStore_NoToolkit_NoOp(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Name: testServerName},
+		Semantic: SemanticConfig{Provider: testProviderNoop},
+		Query:    QueryConfig{Provider: testProviderNoop},
+		Storage:  StorageConfig{Provider: testProviderNoop},
+	}
+	p, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	p.apigatewayTokenStore = apigatewaykit.NewMemoryTokenStore()
+	p.WireAPIGatewayTokenStore() // no api toolkit registered → must not panic
+}
+
 // TestWireAPIGatewayRoutePolicy_NoAuthorizer_NoOp proves the helper
 // silently no-ops when the platform's authorizer is not the
 // persona-based implementation (custom authorizer use-case).

--- a/pkg/toolkits/apigateway/auth.go
+++ b/pkg/toolkits/apigateway/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -40,6 +41,14 @@ func NewAuthenticator(c Config) (Authenticator, error) {
 		return newAPIKeyAuth(c)
 	case AuthModeOAuth2ClientCredentials:
 		return newOAuth2ClientCredentialsAuth(c), nil
+	case AuthModeOAuth2AuthorizationCode:
+		// authorization_code requires a TokenStore. NewAuthenticator
+		// alone cannot supply one (it has no DB handle); the toolkit's
+		// addParsedConnection wires the TokenStore at materialization
+		// time. Returning the un-stored variant here keeps the call
+		// site consistent — the toolkit immediately calls
+		// SetTokenStore on it.
+		return newOAuth2AuthorizationCodeAuth(c), nil
 	default:
 		return nil, fmt.Errorf("apigateway: no authenticator for auth_mode %q", c.AuthMode)
 	}
@@ -144,6 +153,22 @@ type oauth2ClientCredentialsAuth struct {
 // staying generous for IdPs with slow first-token issuance.
 const oauth2TokenFetchTimeout = 30 * time.Second
 
+// newTokenExchangeClient builds the http.Client used for any
+// credential-bearing POST to an OAuth token endpoint (initial code
+// exchange, refresh-token grant, client_credentials acquire). The
+// CheckRedirect hook refuses 3xx so a misconfigured or compromised
+// IdP cannot redirect the form body — which carries client_secret
+// and (on refresh) the long-lived refresh_token — to an attacker
+// URL. Mirrors the MCP gateway's same-purpose helper.
+func newTokenExchangeClient() *http.Client {
+	return &http.Client{
+		Timeout: oauth2TokenFetchTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
 func newOAuth2ClientCredentialsAuth(c Config) oauth2ClientCredentialsAuth {
 	authStyle := oauth2.AuthStyleInHeader
 	if c.OAuth2.EndpointAuthStyle == OAuth2AuthStyleParams {
@@ -158,10 +183,12 @@ func newOAuth2ClientCredentialsAuth(c Config) oauth2ClientCredentialsAuth {
 	}
 	// Bound token-endpoint requests via a custom http.Client. The
 	// oauth2 library reads ctx-value oauth2.HTTPClient and falls
-	// back to http.DefaultClient (no timeout) otherwise.
-	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{
-		Timeout: oauth2TokenFetchTimeout,
-	})
+	// back to http.DefaultClient (no timeout) otherwise. CheckRedirect
+	// refuses to follow 3xx so a misconfigured or compromised IdP
+	// cannot redirect this credential-bearing POST (carrying
+	// client_secret in the form body or HTTP Basic header) to an
+	// attacker URL.
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, newTokenExchangeClient())
 	// The token source caches in-memory and re-fetches when expired.
 	// Wrap with oauth2.ReuseTokenSource so the cache is reused
 	// across Apply calls; clientcredentials.Config.TokenSource
@@ -219,4 +246,276 @@ func tokenFetchError(err error) error {
 		return errors.New("apigateway: oauth2 token fetch failed (details redacted)")
 	}
 	return fmt.Errorf("apigateway: oauth2 token fetch failed: %s", msg)
+}
+
+// ErrNeedsReauth is the structured error api_invoke_endpoint surfaces
+// when an authorization_code connection's stored refresh token is
+// missing, expired beyond refresh_expires_at, or definitively rejected
+// by the IdP (RFC 6749 §5.2 invalid_grant on the refresh_token grant).
+// Transient failures (network, 5xx, request cancellation) DO NOT
+// produce this error — see Apply for the distinction.
+//
+// The error message intentionally points the operator at the
+// platform's reauth path rather than echoing the underlying IdP
+// response (which can include sensitive material from a partial
+// grant exchange). See tokenFetchError for the parallel scrubber on
+// transport failures.
+var ErrNeedsReauth = errors.New("apigateway: oauth2 connection needs admin reconnect")
+
+// errRefreshTokenRevoked wraps the underlying error when the IdP
+// definitively rejects a refresh_token grant — RFC 6749 §5.2
+// invalid_grant at HTTP 400. Distinguished from transient failures
+// (network drops, 5xx, request cancellation) so Apply only deletes
+// the persisted row when the IdP says the refresh is dead. Without
+// this distinction a single flaky-network event during a tool call
+// would permanently invalidate a long-lived refresh token.
+var errRefreshTokenRevoked = errors.New("apigateway: refresh token rejected by IdP (invalid_grant)")
+
+// oauth2AuthorizationCodeAuth applies an OAuth 2.1 access token
+// acquired via the user-driven authorization_code grant. The
+// initial token is fetched at admin "Connect" time by the API
+// gateway's OAuth callback handler and persisted (with refresh
+// token) to TokenStore. Subsequent calls read the cached access
+// token; when it expires the underlying golang.org/x/oauth2
+// TokenSource silently exchanges the refresh token for a fresh
+// access token and writes both back to the store. When the IdP
+// rejects the refresh token (revoked, refresh_expires_at passed),
+// Apply returns ErrNeedsReauth and the admin must click Connect
+// again.
+type oauth2AuthorizationCodeAuth struct {
+	cfg   Config
+	store TokenStore
+}
+
+func newOAuth2AuthorizationCodeAuth(c Config) *oauth2AuthorizationCodeAuth {
+	return &oauth2AuthorizationCodeAuth{cfg: c}
+}
+
+// SetTokenStore wires the persistent token store. Required before
+// Apply can be called — the toolkit's addParsedConnection invokes
+// this immediately after constructing the Authenticator. Stored as
+// a method (not a constructor argument) because NewAuthenticator
+// is called from contexts (config validation, factory code) that
+// don't have a database handle.
+func (a *oauth2AuthorizationCodeAuth) SetTokenStore(s TokenStore) {
+	a.store = s
+}
+
+// Apply attaches the cached or freshly-refreshed access token. The
+// flow:
+//  1. Read the persisted token. ErrTokenNotFound → ErrNeedsReauth.
+//  2. If access token still valid (with the library's 10s buffer),
+//     attach it as Authorization: Bearer <token>.
+//  3. If expired, exchange refresh_token → fresh access token via
+//     the IdP's token endpoint. On success, persist the new token
+//     pair (the IdP MAY rotate the refresh token).
+//  4. On REVOKED refresh (RFC 6749 §5.2 invalid_grant @ 400, OR
+//     refresh_expires_at passed, OR refresh token absent): delete
+//     the row and return ErrNeedsReauth so the admin sees the
+//     reconnect prompt.
+//  5. On TRANSIENT failure (network drop, 5xx, ctx cancellation):
+//     return the scrubbed error WITHOUT deleting the row. The
+//     persisted refresh stays intact so a retry on the next call
+//     can succeed; misclassifying a transient failure as revoked
+//     would force the operator to manually reconnect over a
+//     network blip.
+func (a *oauth2AuthorizationCodeAuth) Apply(req *http.Request) error {
+	if a.store == nil {
+		return errors.New("apigateway: oauth2 authorization_code: token store not wired")
+	}
+	ctx := req.Context()
+	persisted, err := a.store.Get(ctx, a.cfg.ConnectionName)
+	if err != nil {
+		if errors.Is(err, ErrTokenNotFound) {
+			return ErrNeedsReauth
+		}
+		return fmt.Errorf("apigateway: load oauth token: %w", err)
+	}
+	tok := persistedToOAuth2Token(*persisted)
+	if tok.Valid() {
+		req.Header.Set(authorizationHeader, "Bearer "+tok.AccessToken)
+		return nil
+	}
+	// Access token expired (or about to). Refresh.
+	fresh, refreshErr := a.refresh(ctx, persisted)
+	if refreshErr != nil {
+		// Distinguish revoked from transient. Revoked → delete row
+		// (admin must reconnect). Transient → keep row, surface the
+		// error so the caller can retry.
+		if isRevokedRefresh(refreshErr) {
+			_ = a.store.Delete(ctx, a.cfg.ConnectionName)
+			return ErrNeedsReauth
+		}
+		return refreshErr
+	}
+	req.Header.Set(authorizationHeader, "Bearer "+fresh.AccessToken)
+	return nil
+}
+
+// isRevokedRefresh reports whether the refresh-error indicates the
+// IdP definitively rejected the refresh token (vs a transient
+// failure that may succeed on retry). The local-side checks
+// (no refresh token persisted, refresh_expires_at passed) are
+// always definitive. For IdP responses, only RFC 6749 §5.2
+// invalid_grant at HTTP 400 is treated as definitive — matching
+// the MCP gateway's isRefreshDeadError. Keep this in sync with
+// pkg/toolkits/gateway/oauth.go:isRefreshDeadError.
+func isRevokedRefresh(err error) bool {
+	if errors.Is(err, errRefreshTokenRevoked) {
+		return true
+	}
+	// Local-side definitive errors (no refresh token, refresh
+	// expired) — the refresh() helper produces these BEFORE any
+	// network call, so they are safe to treat as revoked even
+	// without an IdP response.
+	if errors.Is(err, errNoRefreshToken) || errors.Is(err, errRefreshExpired) {
+		return true
+	}
+	return false
+}
+
+// errNoRefreshToken / errRefreshExpired are sentinel locals so
+// Apply can fold them into the "needs reauth" branch alongside
+// errRefreshTokenRevoked. Both indicate state that won't recover
+// without admin action.
+var (
+	errNoRefreshToken = errors.New("apigateway: no refresh token persisted")
+	errRefreshExpired = errors.New("apigateway: refresh token has expired")
+)
+
+// refresh exchanges the persisted refresh_token for a fresh access
+// token at the IdP's token endpoint and writes the result back to
+// the store. The new refresh token (if rotated by the IdP) is
+// persisted alongside the new access token, with RefreshExpiresAt
+// updated when the IdP echoes refresh_expires_in (Keycloak-style).
+// Errors are scrubbed via tokenFetchError before the caller sees
+// them so IdP response bodies and embedded URL credentials don't
+// leak; RFC 6749 §5.2 invalid_grant at HTTP 400 is wrapped with
+// errRefreshTokenRevoked so Apply can distinguish it from
+// transient failures.
+func (a *oauth2AuthorizationCodeAuth) refresh(ctx context.Context, persisted *PersistedToken) (*oauth2.Token, error) {
+	if persisted.RefreshToken == "" {
+		return nil, errNoRefreshToken
+	}
+	if !persisted.RefreshExpiresAt.IsZero() && time.Now().After(persisted.RefreshExpiresAt) {
+		return nil, errRefreshExpired
+	}
+	endpoint := oauth2.Endpoint{
+		TokenURL:  a.cfg.OAuth2.TokenURL,
+		AuthStyle: oauth2.AuthStyleInHeader,
+	}
+	if a.cfg.OAuth2.EndpointAuthStyle == OAuth2AuthStyleParams {
+		endpoint.AuthStyle = oauth2.AuthStyleInParams
+	}
+	cfg := &oauth2.Config{
+		ClientID:     a.cfg.OAuth2.ClientID,
+		ClientSecret: a.cfg.OAuth2.ClientSecret,
+		Endpoint:     endpoint,
+		Scopes:       a.cfg.OAuth2.Scopes,
+	}
+	refreshCtx := context.WithValue(ctx, oauth2.HTTPClient, newTokenExchangeClient())
+
+	src := cfg.TokenSource(refreshCtx, persistedToOAuth2Token(*persisted))
+	fresh, err := src.Token()
+	if err != nil {
+		return nil, classifyRefreshError(err)
+	}
+	// Persist the rotated token (IdP MAY have issued a new
+	// refresh_token; keep the old one if the response didn't carry
+	// one). RefreshExpiresAt is recomputed from the IdP's
+	// refresh_expires_in extra-field when present; on rotation
+	// without a fresh hint, it's reset to zero so a stale Keycloak
+	// deadline doesn't outlive the rotation.
+	updated := *persisted
+	updated.AccessToken = fresh.AccessToken
+	if fresh.RefreshToken != "" {
+		updated.RefreshToken = fresh.RefreshToken
+	}
+	updated.ExpiresAt = fresh.Expiry
+	updated.RefreshExpiresAt = computeRefreshExpiresAt(fresh, persisted, time.Now())
+	if setErr := a.store.Set(ctx, updated); setErr != nil {
+		// Persistence failure: the model still gets a working
+		// token this turn, but next process restart will re-fetch
+		// using the OLD refresh token. That's safe (the IdP would
+		// just reject if the refresh was rotated and revoked) — log
+		// the failure, return success on the in-memory token.
+		slog.Warn("apigateway: persisting refreshed oauth token failed",
+			"connection", a.cfg.ConnectionName, "error", setErr)
+	}
+	return fresh, nil
+}
+
+// classifyRefreshError wraps the underlying refresh error with
+// errRefreshTokenRevoked when the IdP's response is RFC 6749 §5.2
+// invalid_grant @ HTTP 400 (the canonical "this refresh is dead"
+// signal) and otherwise scrubs via tokenFetchError so the caller
+// receives a transient-vs-revoked distinguishable error without
+// any IdP body content leaking into logs or model output.
+func classifyRefreshError(err error) error {
+	var retrieve *oauth2.RetrieveError
+	if errors.As(err, &retrieve) &&
+		retrieve.Response != nil &&
+		retrieve.Response.StatusCode == http.StatusBadRequest &&
+		retrieve.ErrorCode == "invalid_grant" {
+		// Wrap so errors.Is(err, errRefreshTokenRevoked) holds. The
+		// scrubbed message comes through tokenFetchError so no IdP
+		// body content leaks.
+		return fmt.Errorf("apigateway: refresh dead: %s (%w)", tokenFetchError(err).Error(), errRefreshTokenRevoked)
+	}
+	return tokenFetchError(err)
+}
+
+// computeRefreshExpiresAt extracts the refresh-token deadline from
+// the IdP's response. golang.org/x/oauth2 stores extension fields
+// (refresh_expires_in is one) in tok.Extra. The returned time.Time
+// follows the policy:
+//   - refresh_expires_in > 0 → absolute deadline = now + that many seconds
+//   - refresh token rotated AND no refresh_expires_in → zero (IdP
+//     did not disclose a fresh deadline; do NOT keep the old one,
+//     it belonged to the previous refresh token)
+//   - refresh token NOT rotated AND no refresh_expires_in → keep
+//     the prior deadline (still tracking the same refresh token)
+func computeRefreshExpiresAt(fresh *oauth2.Token, prior *PersistedToken, now time.Time) time.Time {
+	if secs := refreshExpiresInSeconds(fresh); secs > 0 {
+		return now.Add(time.Duration(secs) * time.Second)
+	}
+	if fresh.RefreshToken != "" {
+		// Rotated without a fresh deadline → clear the old one.
+		return time.Time{}
+	}
+	return prior.RefreshExpiresAt
+}
+
+// refreshExpiresInSeconds reads refresh_expires_in from the
+// oauth2.Token's Extra fields and coerces to int64 seconds. The
+// JSON decoder in golang.org/x/oauth2 leaves numeric extension
+// fields as float64 (the JSON-default), so the cast checks both
+// shapes for safety.
+func refreshExpiresInSeconds(tok *oauth2.Token) int64 {
+	v := tok.Extra("refresh_expires_in")
+	if v == nil {
+		return 0
+	}
+	switch n := v.(type) {
+	case float64:
+		return int64(n)
+	case int64:
+		return n
+	case int:
+		return int64(n)
+	default:
+		return 0
+	}
+}
+
+// persistedToOAuth2Token converts the row form to the library form.
+// AccessToken absent → token treated as expired (Valid() returns false)
+// because the zero ExpiresAt time is in the past; the refresh path
+// kicks in.
+func persistedToOAuth2Token(p PersistedToken) *oauth2.Token {
+	return &oauth2.Token{
+		AccessToken:  p.AccessToken,
+		RefreshToken: p.RefreshToken,
+		Expiry:       p.ExpiresAt,
+	}
 }

--- a/pkg/toolkits/apigateway/auth_test.go
+++ b/pkg/toolkits/apigateway/auth_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewAuthenticator_DispatchesByMode(t *testing.T) {
@@ -370,5 +371,318 @@ func TestTokenFetchError_PassesThroughOpaqueErrors(t *testing.T) {
 	err := tokenFetchError(errors.New("kaboom"))
 	if err == nil || !strings.Contains(err.Error(), "kaboom") {
 		t.Errorf("tokenFetchError lost the underlying message: %v", err)
+	}
+}
+
+// authorization_code Authenticator tests.
+
+func newAuthCodeForTest(t *testing.T, tokenURL string) (*oauth2AuthorizationCodeAuth, TokenStore) {
+	t.Helper()
+	cfg := Config{
+		ConnectionName: "c1",
+		AuthMode:       AuthModeOAuth2AuthorizationCode,
+		OAuth2: OAuth2Config{
+			TokenURL:          tokenURL,
+			ClientID:          "client",
+			ClientSecret:      "secret",
+			AuthorizationURL:  "https://idp.example/auth",
+			EndpointAuthStyle: OAuth2AuthStyleHeader,
+		},
+	}
+	store := NewMemoryTokenStore()
+	a := newOAuth2AuthorizationCodeAuth(cfg)
+	a.SetTokenStore(store)
+	return a, store
+}
+
+func TestAuthCodeAuth_NoStoreWired(t *testing.T) {
+	cfg := Config{
+		ConnectionName: "c1",
+		AuthMode:       AuthModeOAuth2AuthorizationCode,
+		OAuth2:         OAuth2Config{TokenURL: "https://idp/token", ClientID: "c", ClientSecret: "s"},
+	}
+	a := newOAuth2AuthorizationCodeAuth(cfg)
+	// Deliberately do NOT call SetTokenStore.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://x/", http.NoBody)
+	if err := a.Apply(req); err == nil {
+		t.Error("Apply: want error when token store not wired")
+	}
+}
+
+func TestAuthCodeAuth_NoPersistedToken_ReturnsNeedsReauth(t *testing.T) {
+	a, _ := newAuthCodeForTest(t, "https://idp.example/token")
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://x/", http.NoBody)
+	err := a.Apply(req)
+	if !errors.Is(err, ErrNeedsReauth) {
+		t.Errorf("Apply with no token: got %v; want ErrNeedsReauth", err)
+	}
+}
+
+func TestAuthCodeAuth_CachedToken_AppliedDirectly(t *testing.T) {
+	a, store := newAuthCodeForTest(t, "https://idp.example/token")
+	_ = store.Set(context.Background(), PersistedToken{
+		ConnectionName: "c1",
+		AccessToken:    "live-access-token",
+		ExpiresAt:      time.Now().Add(time.Hour),
+	})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://x/", http.NoBody)
+	if err := a.Apply(req); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer live-access-token" {
+		t.Errorf("Authorization = %q; want Bearer live-access-token", got)
+	}
+}
+
+func TestAuthCodeAuth_ExpiredToken_RefreshesAndPersists(t *testing.T) {
+	var fetches int
+	srv := fakeTokenServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		fetches++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"refreshed-` + fmt.Sprintf("%d", fetches) + `","refresh_token":"new-refresh","token_type":"Bearer","expires_in":3600}`))
+	})
+	defer srv.Close()
+
+	a, store := newAuthCodeForTest(t, srv.URL+"/token")
+	// Persist a token whose access has already expired but whose
+	// refresh is still valid (RefreshExpiresAt zero = no IdP-side
+	// expiry signal, treated as "still good").
+	_ = store.Set(context.Background(), PersistedToken{
+		ConnectionName: "c1",
+		AccessToken:    "stale",
+		RefreshToken:   "old-refresh",
+		ExpiresAt:      time.Now().Add(-time.Minute),
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://x/", http.NoBody)
+	if err := a.Apply(req); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer refreshed-1" {
+		t.Errorf("Authorization = %q; want Bearer refreshed-1", got)
+	}
+	if fetches != 1 {
+		t.Errorf("token endpoint fetched %d times; want 1", fetches)
+	}
+
+	// The store should now hold the rotated tokens.
+	persisted, _ := store.Get(context.Background(), "c1")
+	if persisted.AccessToken != "refreshed-1" {
+		t.Errorf("stored access token = %q; want refreshed-1", persisted.AccessToken)
+	}
+	if persisted.RefreshToken != "new-refresh" {
+		t.Errorf("stored refresh token = %q; want new-refresh (rotated)", persisted.RefreshToken)
+	}
+}
+
+func TestAuthCodeAuth_ExpiredRefreshToken_ReturnsNeedsReauth(t *testing.T) {
+	a, store := newAuthCodeForTest(t, "https://idp.example/token")
+	_ = store.Set(context.Background(), PersistedToken{
+		ConnectionName:   "c1",
+		AccessToken:      "stale",
+		RefreshToken:     "old-refresh",
+		ExpiresAt:        time.Now().Add(-time.Minute),
+		RefreshExpiresAt: time.Now().Add(-time.Minute), // refresh also expired
+	})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://x/", http.NoBody)
+	err := a.Apply(req)
+	if !errors.Is(err, ErrNeedsReauth) {
+		t.Errorf("Apply with expired refresh: got %v; want ErrNeedsReauth", err)
+	}
+	// And the store row should have been deleted so the only path
+	// forward is admin Reconnect.
+	if _, gerr := store.Get(context.Background(), "c1"); !errors.Is(gerr, ErrTokenNotFound) {
+		t.Errorf("after refresh failure: Get = %v; want ErrTokenNotFound (row deleted)", gerr)
+	}
+}
+
+func TestAuthCodeAuth_InvalidGrant400_ReturnsNeedsReauth(t *testing.T) {
+	// RFC 6749 §5.2 invalid_grant at HTTP 400 is the canonical
+	// "this refresh token is dead" signal. Apply must delete the
+	// row and return ErrNeedsReauth so the admin must reconnect.
+	// Content-Type: application/json is required so oauth2's
+	// internal parser populates RetrieveError.ErrorCode (under
+	// text/plain detection it falls into the form-encoded branch
+	// and ErrorCode stays empty).
+	srv := fakeTokenServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"refresh token expired"}`))
+	})
+	defer srv.Close()
+
+	a, store := newAuthCodeForTest(t, srv.URL+"/token")
+	_ = store.Set(context.Background(), PersistedToken{
+		ConnectionName: "c1",
+		AccessToken:    "stale",
+		RefreshToken:   "revoked",
+		ExpiresAt:      time.Now().Add(-time.Minute),
+	})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://x/", http.NoBody)
+	err := a.Apply(req)
+	if !errors.Is(err, ErrNeedsReauth) {
+		t.Errorf("got %v; want ErrNeedsReauth on invalid_grant @ 400", err)
+	}
+	// Row must be deleted so the only forward path is admin reconnect.
+	if _, gerr := store.Get(context.Background(), "c1"); !errors.Is(gerr, ErrTokenNotFound) {
+		t.Errorf("after invalid_grant: Get = %v; want ErrTokenNotFound (row deleted)", gerr)
+	}
+}
+
+func TestAuthCodeAuth_TransientFailure_PreservesRow(t *testing.T) {
+	// Transient failures (5xx, network drops) MUST NOT destroy the
+	// persisted refresh token. A flaky-network event during a
+	// single tool call would otherwise force the operator to
+	// manually reconnect — invalidating a still-good refresh.
+	srv := fakeTokenServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":"server_error"}`))
+	})
+	defer srv.Close()
+
+	a, store := newAuthCodeForTest(t, srv.URL+"/token")
+	_ = store.Set(context.Background(), PersistedToken{
+		ConnectionName: "c1",
+		AccessToken:    "stale",
+		RefreshToken:   "still-good-refresh",
+		ExpiresAt:      time.Now().Add(-time.Minute),
+	})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://x/", http.NoBody)
+	err := a.Apply(req)
+	if err == nil {
+		t.Fatal("Apply: want error on transient IdP failure")
+	}
+	if errors.Is(err, ErrNeedsReauth) {
+		t.Errorf("transient failure incorrectly mapped to ErrNeedsReauth: %v", err)
+	}
+	// Row MUST still exist — the refresh token may still be valid,
+	// retry on next call should be possible.
+	got, gerr := store.Get(context.Background(), "c1")
+	if gerr != nil {
+		t.Fatalf("after transient failure: Get = %v; row should still exist", gerr)
+	}
+	if got.RefreshToken != "still-good-refresh" {
+		t.Errorf("refresh token wrongly mutated: %q", got.RefreshToken)
+	}
+}
+
+func TestAuthCodeAuth_RefreshExpiresIn_PersistedOnRotation(t *testing.T) {
+	// Keycloak-style refresh_expires_in must propagate into the
+	// stored RefreshExpiresAt so future Apply calls can short-
+	// circuit dead-refresh attempts before hitting the IdP.
+	srv := fakeTokenServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-acc","refresh_token":"new-ref","token_type":"Bearer","expires_in":300,"refresh_expires_in":1800}`))
+	})
+	defer srv.Close()
+
+	a, store := newAuthCodeForTest(t, srv.URL+"/token")
+	_ = store.Set(context.Background(), PersistedToken{
+		ConnectionName: "c1",
+		AccessToken:    "stale",
+		RefreshToken:   "old-ref",
+		ExpiresAt:      time.Now().Add(-time.Minute),
+		// Note: prior RefreshExpiresAt deliberately set to a SHORT
+		// future window — proves the rotation overwrites it with
+		// the new IdP-supplied 1800s window. Past values would
+		// short-circuit refresh via errRefreshExpired and never
+		// reach the IdP.
+		RefreshExpiresAt: time.Now().Add(5 * time.Minute),
+	})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://x/", http.NoBody)
+	if err := a.Apply(req); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	got, _ := store.Get(context.Background(), "c1")
+	if got.RefreshExpiresAt.IsZero() {
+		t.Fatal("RefreshExpiresAt is zero after rotation — refresh_expires_in dropped")
+	}
+	expected := time.Now().Add(1800 * time.Second)
+	if delta := got.RefreshExpiresAt.Sub(expected); delta > 5*time.Second || delta < -5*time.Second {
+		t.Errorf("RefreshExpiresAt = %v; want ~%v (Δ=%v)", got.RefreshExpiresAt, expected, delta)
+	}
+}
+
+// TestAuthCodeAuth_RefreshDoesNotFollowRedirects proves the refresh
+// path's http.Client refuses to follow 3xx — without this, a
+// misconfigured or compromised IdP could redirect the
+// credential-bearing POST (carrying client_secret + refresh_token) to
+// an attacker URL. Mirrors the admin-side
+// TestExchangeAPIGatewayCode_DoesNotFollowRedirects.
+func TestAuthCodeAuth_RefreshDoesNotFollowRedirects(t *testing.T) {
+	var attackerHits int
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attackerHits++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"stolen","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer attacker.Close()
+
+	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Redirect(w, &http.Request{}, attacker.URL+"/token", http.StatusFound)
+	}))
+	defer idp.Close()
+
+	a, store := newAuthCodeForTest(t, idp.URL+"/token")
+	_ = store.Set(context.Background(), PersistedToken{
+		ConnectionName: "c1",
+		AccessToken:    "stale",
+		RefreshToken:   "long-lived",
+		ExpiresAt:      time.Now().Add(-time.Minute),
+	})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://x/", http.NoBody)
+	if err := a.Apply(req); err == nil {
+		t.Fatal("Apply: want error on IdP 3xx; got nil (redirect followed?)")
+	}
+	if attackerHits != 0 {
+		t.Errorf("attacker received %d hits; refresh path must NOT follow redirects "+
+			"(would leak refresh_token + client_secret)", attackerHits)
+	}
+}
+
+func TestAuthCodeAuth_RotationWithoutRefreshExpiresIn_ClearsDeadline(t *testing.T) {
+	// IdP rotates the refresh token but does NOT echo
+	// refresh_expires_in. The OLD deadline cannot apply to the new
+	// token; the safe choice is to clear it so a stale value
+	// doesn't outlive the rotation.
+	srv := fakeTokenServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-acc","refresh_token":"rotated-ref","token_type":"Bearer","expires_in":300}`))
+	})
+	defer srv.Close()
+
+	a, store := newAuthCodeForTest(t, srv.URL+"/token")
+	priorDeadline := time.Now().Add(time.Hour)
+	_ = store.Set(context.Background(), PersistedToken{
+		ConnectionName:   "c1",
+		AccessToken:      "stale",
+		RefreshToken:     "old-ref",
+		ExpiresAt:        time.Now().Add(-time.Minute),
+		RefreshExpiresAt: priorDeadline,
+	})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://x/", http.NoBody)
+	if err := a.Apply(req); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	got, _ := store.Get(context.Background(), "c1")
+	if !got.RefreshExpiresAt.IsZero() {
+		t.Errorf("after rotation w/o refresh_expires_in: RefreshExpiresAt = %v; want zero (stale value cleared)", got.RefreshExpiresAt)
+	}
+	if got.RefreshToken != "rotated-ref" {
+		t.Errorf("refresh token not rotated: %q", got.RefreshToken)
+	}
+}
+
+func TestAuthCodeAuth_NoRefreshToken_ReturnsNeedsReauth(t *testing.T) {
+	a, store := newAuthCodeForTest(t, "https://idp.example/token")
+	_ = store.Set(context.Background(), PersistedToken{
+		ConnectionName: "c1",
+		AccessToken:    "stale",
+		// No RefreshToken at all.
+		ExpiresAt: time.Now().Add(-time.Minute),
+	})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "https://x/", http.NoBody)
+	if err := a.Apply(req); !errors.Is(err, ErrNeedsReauth) {
+		t.Errorf("got %v; want ErrNeedsReauth when refresh token missing", err)
 	}
 }

--- a/pkg/toolkits/apigateway/config.go
+++ b/pkg/toolkits/apigateway/config.go
@@ -44,6 +44,15 @@ const (
 	// refresh tokens + a browser flow) is its own follow-up issue.
 	AuthModeOAuth2ClientCredentials = "oauth2_client_credentials" // #nosec G101 -- mode name, not a credential
 
+	// AuthModeOAuth2AuthorizationCode runs the user-driven OAuth 2.1
+	// authorization-code grant: an admin completes a one-time browser
+	// flow at connection setup; the resulting refresh token is
+	// persisted (encrypted) so subsequent platform restarts and
+	// background workloads keep working without further interaction.
+	// Tokens are refreshed automatically before expiry. Requires the
+	// platform's database (refresh-token state survives restarts).
+	AuthModeOAuth2AuthorizationCode = "oauth2_authorization_code" // #nosec G101 -- mode name, not a credential
+
 	// APIKeyPlacementHeader (default) sends the credential as an HTTP
 	// header named by APIKeyHeader.
 	APIKeyPlacementHeader = "header"
@@ -113,6 +122,8 @@ const (
 	cfgKeyOAuth2ClientSecret = "oauth2_client_secret"       // #nosec G101 -- map key, not a credential
 	cfgKeyOAuth2Scopes       = "oauth2_scopes"              // #nosec G101 -- map key, not a credential
 	cfgKeyOAuth2EndpointAuth = "oauth2_endpoint_auth_style" // #nosec G101 -- "header" or "params" — map key, not a credential
+	cfgKeyOAuth2AuthURL      = "oauth2_authorization_url"   // #nosec G101 -- map key, not a credential
+	cfgKeyOAuth2Prompt       = "oauth2_prompt"              // #nosec G101 -- map key, not a credential
 )
 
 // Config holds api-gateway toolkit configuration for a single upstream
@@ -190,6 +201,21 @@ type OAuth2Config struct {
 	// sends them as POST body parameters. Some IdPs require one
 	// or the other; "header" is the OAuth 2.1 default.
 	EndpointAuthStyle string
+	// AuthorizationURL is the upstream's authorization endpoint.
+	// Required only for the authorization_code grant — that's
+	// where the platform redirects the admin's browser to start
+	// the flow.
+	AuthorizationURL string
+	// Prompt is an optional OIDC prompt parameter (RFC OIDC
+	// §3.1.2.1). Common values: "login" (force credential prompt),
+	// "consent" (force consent screen), "select_account",
+	// "none" (silent auth). Empty by default — the IdP decides.
+	// Operators of strict OIDC realms (Keycloak, Auth0, Okta)
+	// typically set this to "login" so admin Reconnect actions
+	// always re-prompt the user. Pure-OAuth (non-OIDC) providers
+	// often reject unknown parameters with invalid_request, so
+	// leave empty for those.
+	Prompt string
 }
 
 // EndpointAuthStyle values.
@@ -296,9 +322,26 @@ func (c Config) validateAuth() error {
 		return c.validateAPIKeyAuth()
 	case AuthModeOAuth2ClientCredentials:
 		return c.validateOAuth2()
+	case AuthModeOAuth2AuthorizationCode:
+		return c.validateOAuth2AuthCode()
 	default:
-		return fmt.Errorf("apigateway: invalid auth_mode %q (want none, bearer, api_key, or oauth2_client_credentials)", c.AuthMode)
+		return fmt.Errorf("apigateway: invalid auth_mode %q (want none, bearer, api_key, oauth2_client_credentials, or oauth2_authorization_code)", c.AuthMode)
 	}
+}
+
+// validateOAuth2AuthCode adds the authorization_code-specific
+// requirement (AuthorizationURL) on top of the client_credentials
+// validation. ClientSecret is still required because OAuth 2.1
+// authorization-code with confidential clients exchanges
+// (client_id, client_secret, code) for tokens.
+func (c Config) validateOAuth2AuthCode() error {
+	if err := c.validateOAuth2(); err != nil {
+		return err
+	}
+	if c.OAuth2.AuthorizationURL == "" {
+		return errors.New("apigateway: oauth2.authorization_url is required when auth_mode is \"oauth2_authorization_code\"")
+	}
+	return nil
 }
 
 func (c Config) validateOAuth2() error {
@@ -350,6 +393,8 @@ func parseOAuth2Config(cfg map[string]any) OAuth2Config {
 		ClientSecret:      getString(cfg, cfgKeyOAuth2ClientSecret),
 		EndpointAuthStyle: getStringDefault(cfg, cfgKeyOAuth2EndpointAuth, OAuth2AuthStyleHeader),
 		Scopes:            getStringSlice(cfg, cfgKeyOAuth2Scopes),
+		AuthorizationURL:  getString(cfg, cfgKeyOAuth2AuthURL),
+		Prompt:            getString(cfg, cfgKeyOAuth2Prompt),
 	}
 }
 

--- a/pkg/toolkits/apigateway/config_test.go
+++ b/pkg/toolkits/apigateway/config_test.go
@@ -75,6 +75,31 @@ func TestParseConfig_OAuth2ClientCredentials(t *testing.T) {
 	}
 }
 
+func TestParseConfig_OAuth2AuthorizationCode(t *testing.T) {
+	c, err := ParseConfig(map[string]any{
+		"base_url":                 "https://api.example.com",
+		"auth_mode":                AuthModeOAuth2AuthorizationCode,
+		"oauth2_token_url":         "https://idp.example/token",
+		"oauth2_authorization_url": "https://idp.example/auth",
+		"oauth2_client_id":         "client-123",
+		"oauth2_client_secret":     "secret-xyz",
+		"oauth2_scopes":            []any{"openid", "profile"},
+		"oauth2_prompt":            "consent",
+	})
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if c.AuthMode != AuthModeOAuth2AuthorizationCode {
+		t.Errorf("AuthMode = %q; want %q", c.AuthMode, AuthModeOAuth2AuthorizationCode)
+	}
+	if c.OAuth2.AuthorizationURL != "https://idp.example/auth" {
+		t.Errorf("AuthorizationURL = %q", c.OAuth2.AuthorizationURL)
+	}
+	if c.OAuth2.Prompt != "consent" {
+		t.Errorf("Prompt = %q; want %q", c.OAuth2.Prompt, "consent")
+	}
+}
+
 func TestGetStringSlice_AcceptsBothShapes(t *testing.T) {
 	// Programmatic construction yields []string; YAML unmarshaling
 	// yields []any. parseOAuth2Config must accept both.
@@ -255,6 +280,31 @@ func TestParseConfig_ValidationErrors(t *testing.T) {
 				"oauth2_endpoint_auth_style": "invalid",
 			},
 			want: "invalid oauth2.endpoint_auth_style",
+		},
+		{
+			name: "oauth2_authorization_code missing authorization_url",
+			cfg: map[string]any{
+				"base_url":             "https://x",
+				"auth_mode":            AuthModeOAuth2AuthorizationCode,
+				"oauth2_token_url":     "https://idp/token",
+				"oauth2_client_id":     "c",
+				"oauth2_client_secret": "s",
+			},
+			want: "oauth2.authorization_url is required",
+		},
+		{
+			// authorization_code still requires the same client
+			// fields as client_credentials — verifies that the
+			// authorization_code validator chains validateOAuth2.
+			name: "oauth2_authorization_code missing client_secret",
+			cfg: map[string]any{
+				"base_url":                 "https://x",
+				"auth_mode":                AuthModeOAuth2AuthorizationCode,
+				"oauth2_token_url":         "https://idp/token",
+				"oauth2_client_id":         "c",
+				"oauth2_authorization_url": "https://idp/auth",
+			},
+			want: "oauth2.client_secret is required",
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/toolkits/apigateway/tokenstore.go
+++ b/pkg/toolkits/apigateway/tokenstore.go
@@ -1,0 +1,247 @@
+package apigateway
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrTokenNotFound is returned by TokenStore.Get when no row exists
+// for a connection. Distinct from a transport error so callers can
+// distinguish a never-authorized connection from a database that is
+// merely unreachable.
+var ErrTokenNotFound = errors.New("apigateway: oauth token not found")
+
+// PersistedToken is the row shape stored in apigateway_oauth_tokens.
+// Mirror of the MCP gateway's PersistedToken — kept separate so the
+// two systems remain independent and changes to one don't ripple.
+//
+// RefreshExpiresAt is optional — only populated when the IdP
+// returned refresh_expires_in (Keycloak does, others may not). Zero
+// means the database column is NULL; callers must NOT interpret a
+// zero value as "no expiry"; it means the IdP did not disclose one.
+type PersistedToken struct {
+	ConnectionName   string
+	AccessToken      string
+	RefreshToken     string
+	ExpiresAt        time.Time
+	RefreshExpiresAt time.Time
+	Scope            string
+	AuthenticatedBy  string
+	AuthenticatedAt  time.Time
+	UpdatedAt        time.Time
+}
+
+// TokenStore persists OAuth tokens for the authorization_code grant
+// so a one-time browser-based authentication grants long-running
+// background access. v1 stores a single shared identity per
+// connection (matches the MCP gateway's design).
+type TokenStore interface {
+	Get(ctx context.Context, connection string) (*PersistedToken, error)
+	Set(ctx context.Context, t PersistedToken) error
+	Delete(ctx context.Context, connection string) error
+}
+
+// FieldEncryptor abstracts the platform's at-rest field encryption.
+// Used here so this package doesn't import pkg/platform (which would
+// create a cycle via the registry's factory wiring). The concrete
+// implementation comes from pkg/platform.FieldEncryptor at startup.
+type FieldEncryptor interface {
+	Encrypt(plaintext string) (string, error)
+	Decrypt(ciphertext string) (string, error)
+}
+
+// noopEncryptor is the fallback when ENCRYPTION_KEY is unset. The
+// platform logs a startup warning when this code path is active so
+// operators know refresh tokens are stored unencrypted (poor
+// practice; only acceptable for dev environments).
+type noopEncryptor struct{}
+
+// Encrypt is the no-op pass-through used when at-rest encryption is disabled.
+func (noopEncryptor) Encrypt(s string) (string, error) { return s, nil }
+
+// Decrypt is the no-op pass-through used when at-rest encryption is disabled.
+func (noopEncryptor) Decrypt(s string) (string, error) { return s, nil }
+
+// PostgresTokenStore is a sql-backed TokenStore against the
+// apigateway_oauth_tokens table (migration #38).
+type PostgresTokenStore struct {
+	db  *sql.DB
+	enc FieldEncryptor
+}
+
+// NewPostgresTokenStore builds a TokenStore against the supplied
+// database. enc may be nil; if so, refresh tokens are stored
+// unencrypted (callers that want at-rest encryption should pass
+// the platform's FieldEncryptor).
+func NewPostgresTokenStore(db *sql.DB, enc FieldEncryptor) *PostgresTokenStore {
+	if enc == nil {
+		enc = noopEncryptor{}
+	}
+	return &PostgresTokenStore{db: db, enc: enc}
+}
+
+// Get returns the persisted token for connection or ErrTokenNotFound
+// when no row matches. Refresh and access tokens are decrypted via
+// the configured FieldEncryptor.
+func (s *PostgresTokenStore) Get(ctx context.Context, connection string) (*PersistedToken, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT connection_name, access_token, refresh_token, expires_at,
+		        refresh_expires_at, scope, authenticated_by, authenticated_at,
+		        updated_at
+		   FROM apigateway_oauth_tokens WHERE connection_name = $1`, connection)
+
+	var (
+		t                PersistedToken
+		accessEnc        sql.NullString
+		refreshEnc       sql.NullString
+		expiresAt        sql.NullTime
+		refreshExpiresAt sql.NullTime
+		authenticatedAt  sql.NullTime
+	)
+	err := row.Scan(&t.ConnectionName, &accessEnc, &refreshEnc, &expiresAt,
+		&refreshExpiresAt, &t.Scope, &t.AuthenticatedBy, &authenticatedAt, &t.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrTokenNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("apigateway: tokenstore get: %w", err)
+	}
+
+	if accessEnc.Valid {
+		dec, derr := s.enc.Decrypt(accessEnc.String)
+		if derr != nil {
+			return nil, fmt.Errorf("apigateway: decrypt access token: %w", derr)
+		}
+		t.AccessToken = dec
+	}
+	if refreshEnc.Valid {
+		dec, derr := s.enc.Decrypt(refreshEnc.String)
+		if derr != nil {
+			return nil, fmt.Errorf("apigateway: decrypt refresh token: %w", derr)
+		}
+		t.RefreshToken = dec
+	}
+	if expiresAt.Valid {
+		t.ExpiresAt = expiresAt.Time
+	}
+	if refreshExpiresAt.Valid {
+		t.RefreshExpiresAt = refreshExpiresAt.Time
+	}
+	if authenticatedAt.Valid {
+		t.AuthenticatedAt = authenticatedAt.Time
+	}
+	return &t, nil
+}
+
+// Set inserts or replaces the token row for a connection. Access
+// and refresh tokens are encrypted via the configured FieldEncryptor
+// before reaching the database.
+func (s *PostgresTokenStore) Set(ctx context.Context, t PersistedToken) error {
+	accessEnc, err := encryptOptional(s.enc, t.AccessToken)
+	if err != nil {
+		return fmt.Errorf("apigateway: encrypt access token: %w", err)
+	}
+	refreshEnc, err := encryptOptional(s.enc, t.RefreshToken)
+	if err != nil {
+		return fmt.Errorf("apigateway: encrypt refresh token: %w", err)
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO apigateway_oauth_tokens
+		   (connection_name, access_token, refresh_token, expires_at,
+		    refresh_expires_at, scope, authenticated_by, authenticated_at,
+		    updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+		 ON CONFLICT (connection_name) DO UPDATE
+		   SET access_token       = EXCLUDED.access_token,
+		       refresh_token      = EXCLUDED.refresh_token,
+		       expires_at         = EXCLUDED.expires_at,
+		       refresh_expires_at = EXCLUDED.refresh_expires_at,
+		       scope              = EXCLUDED.scope,
+		       authenticated_by   = EXCLUDED.authenticated_by,
+		       authenticated_at   = EXCLUDED.authenticated_at,
+		       updated_at         = NOW()`,
+		t.ConnectionName, accessEnc, refreshEnc,
+		nullableTime(t.ExpiresAt), nullableTime(t.RefreshExpiresAt),
+		t.Scope, t.AuthenticatedBy, nullableTime(t.AuthenticatedAt))
+	if err != nil {
+		return fmt.Errorf("apigateway: tokenstore set: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the token row, forcing the next call to surface a
+// "needs reauth" signal. Used by the admin reauth path and by the
+// Authenticator when the IdP rejects a refresh token (revoked or
+// expired beyond refresh_expires_at).
+func (s *PostgresTokenStore) Delete(ctx context.Context, connection string) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM apigateway_oauth_tokens WHERE connection_name = $1`, connection)
+	if err != nil {
+		return fmt.Errorf("apigateway: tokenstore delete: %w", err)
+	}
+	return nil
+}
+
+// encryptOptional encrypts a non-empty plaintext or returns "" for
+// empty input. NULL columns are represented as empty strings in the
+// PersistedToken struct, so an empty access_token is stored as NULL
+// (via nullableString) without ever invoking the encryptor.
+func encryptOptional(enc FieldEncryptor, plaintext string) (sql.NullString, error) {
+	if plaintext == "" {
+		return sql.NullString{}, nil
+	}
+	enced, err := enc.Encrypt(plaintext)
+	if err != nil {
+		return sql.NullString{}, fmt.Errorf("apigateway: encrypt field: %w", err)
+	}
+	return sql.NullString{String: enced, Valid: true}, nil
+}
+
+// nullableTime returns sql.NullTime{Valid: false} for the zero time
+// so the database column is set to NULL rather than 0001-01-01.
+func nullableTime(t time.Time) sql.NullTime {
+	if t.IsZero() {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: t, Valid: true}
+}
+
+// memoryTokenStore is the in-process implementation for tests and
+// stateless single-replica deployments. Production multi-replica
+// setups should use PostgresTokenStore so all replicas see the same
+// refresh-token state.
+type memoryTokenStore struct {
+	tokens map[string]PersistedToken
+}
+
+// NewMemoryTokenStore returns an in-process TokenStore. Not safe
+// across process restarts — refresh tokens are lost.
+func NewMemoryTokenStore() TokenStore {
+	return &memoryTokenStore{tokens: make(map[string]PersistedToken)}
+}
+
+// Get returns the cached token or ErrTokenNotFound.
+func (s *memoryTokenStore) Get(_ context.Context, connection string) (*PersistedToken, error) {
+	t, ok := s.tokens[connection]
+	if !ok {
+		return nil, ErrTokenNotFound
+	}
+	return &t, nil
+}
+
+// Set inserts or replaces the token row in memory.
+func (s *memoryTokenStore) Set(_ context.Context, t PersistedToken) error {
+	t.UpdatedAt = time.Now()
+	s.tokens[t.ConnectionName] = t
+	return nil
+}
+
+// Delete removes the cached token entry.
+func (s *memoryTokenStore) Delete(_ context.Context, connection string) error {
+	delete(s.tokens, connection)
+	return nil
+}

--- a/pkg/toolkits/apigateway/tokenstore_test.go
+++ b/pkg/toolkits/apigateway/tokenstore_test.go
@@ -1,0 +1,408 @@
+package apigateway
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryTokenStore_CRUD(t *testing.T) {
+	s := NewMemoryTokenStore()
+	ctx := context.Background()
+
+	// Get on missing connection returns ErrTokenNotFound.
+	if _, err := s.Get(ctx, "ghost"); !errors.Is(err, ErrTokenNotFound) {
+		t.Errorf("Get(missing) = %v; want ErrTokenNotFound", err)
+	}
+
+	// Set + Get round-trip.
+	now := time.Now()
+	tok := PersistedToken{
+		ConnectionName:  "c1",
+		AccessToken:     "access-abc",
+		RefreshToken:    "refresh-xyz",
+		ExpiresAt:       now.Add(time.Hour),
+		Scope:           "read:users",
+		AuthenticatedBy: "admin@example.com",
+		AuthenticatedAt: now,
+	}
+	if err := s.Set(ctx, tok); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, err := s.Get(ctx, "c1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AccessToken != "access-abc" || got.RefreshToken != "refresh-xyz" {
+		t.Errorf("round-trip lost tokens: %+v", got)
+	}
+	if got.Scope != "read:users" || got.AuthenticatedBy != "admin@example.com" {
+		t.Errorf("round-trip lost metadata: %+v", got)
+	}
+
+	// Delete + verify absent.
+	if err := s.Delete(ctx, "c1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := s.Get(ctx, "c1"); !errors.Is(err, ErrTokenNotFound) {
+		t.Errorf("after Delete: Get = %v; want ErrTokenNotFound", err)
+	}
+}
+
+func TestEncryptOptional_EmptyPlaintextDoesNotCallEncryptor(t *testing.T) {
+	called := false
+	enc := stubEncryptor{
+		encrypt: func(s string) (string, error) {
+			called = true
+			return "ENC:" + s, nil
+		},
+	}
+	got, err := encryptOptional(enc, "")
+	if err != nil {
+		t.Fatalf("encryptOptional(\"\"): %v", err)
+	}
+	if got.Valid {
+		t.Errorf("empty plaintext should produce NULL (Valid=false), got %+v", got)
+	}
+	if called {
+		t.Error("encryptor invoked for empty plaintext")
+	}
+}
+
+func TestEncryptOptional_RoundTrip(t *testing.T) {
+	enc := stubEncryptor{
+		encrypt: func(s string) (string, error) { return "ENC:" + s, nil },
+	}
+	got, err := encryptOptional(enc, "secret")
+	if err != nil {
+		t.Fatalf("encryptOptional: %v", err)
+	}
+	if !got.Valid || got.String != "ENC:secret" {
+		t.Errorf("unexpected encrypted value: %+v", got)
+	}
+}
+
+func TestNullableTime_ZeroProducesNull(t *testing.T) {
+	got := nullableTime(time.Time{})
+	if got.Valid {
+		t.Error("zero time should produce NULL (Valid=false)")
+	}
+	now := time.Now()
+	got = nullableTime(now)
+	if !got.Valid || !got.Time.Equal(now) {
+		t.Errorf("non-zero time lost: %+v", got)
+	}
+}
+
+// stubEncryptor lets tests inject a recordable / failable
+// encryptor without standing up the full platform AES wrapper.
+type stubEncryptor struct {
+	encrypt func(string) (string, error)
+	decrypt func(string) (string, error)
+}
+
+func (s stubEncryptor) Encrypt(p string) (string, error) {
+	if s.encrypt == nil {
+		return p, nil
+	}
+	return s.encrypt(p)
+}
+
+func (s stubEncryptor) Decrypt(c string) (string, error) {
+	if s.decrypt == nil {
+		return c, nil
+	}
+	return s.decrypt(c)
+}
+
+func TestNoopEncryptor_PassesThrough(t *testing.T) {
+	e := noopEncryptor{}
+	if got, _ := e.Encrypt("plaintext"); got != "plaintext" {
+		t.Errorf("noop Encrypt mutated value: %q", got)
+	}
+	if got, _ := e.Decrypt("ciphertext"); got != "ciphertext" {
+		t.Errorf("noop Decrypt mutated value: %q", got)
+	}
+}
+
+// reverseEncryptor is a deterministic stand-in for the platform's
+// FieldEncryptor: it reverses input bytes so tests can verify that
+// values were transformed on the way in and again on the way out.
+// (Mirror of pkg/toolkits/gateway's helper of the same name — kept
+// local rather than shared so the apigateway package has no
+// cross-package test imports.)
+type reverseEncryptor struct {
+	encErr error
+	decErr error
+}
+
+func (r reverseEncryptor) Encrypt(s string) (string, error) {
+	if r.encErr != nil {
+		return "", r.encErr
+	}
+	return reverseString(s), nil
+}
+
+func (r reverseEncryptor) Decrypt(s string) (string, error) {
+	if r.decErr != nil {
+		return "", r.decErr
+	}
+	return reverseString(s), nil
+}
+
+func reverseString(s string) string {
+	b := []byte(s)
+	for i, j := 0, len(b)-1; i < j; i, j = i+1, j-1 {
+		b[i], b[j] = b[j], b[i]
+	}
+	return string(b)
+}
+
+func TestPostgresTokenStore_NewWithNilEncryptor_UsesNoop(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	s := NewPostgresTokenStore(db, nil)
+	if _, ok := s.enc.(noopEncryptor); !ok {
+		t.Errorf("nil encryptor should default to noopEncryptor; got %T", s.enc)
+	}
+}
+
+func TestPostgresTokenStore_Get_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	expiresAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	refreshExpiresAt := time.Date(2026, 1, 2, 4, 0, 0, 0, time.UTC)
+	authedAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
+
+	rows := sqlmock.NewRows([]string{
+		"connection_name", "access_token", "refresh_token", "expires_at",
+		"refresh_expires_at", "scope", "authenticated_by", "authenticated_at",
+		"updated_at",
+	}).AddRow("vendor", reverseString("acc"), reverseString("ref"), expiresAt,
+		refreshExpiresAt, "api", "alice@example.com", authedAt, updatedAt)
+
+	mock.ExpectQuery("SELECT connection_name").
+		WithArgs("vendor").
+		WillReturnRows(rows)
+
+	store := NewPostgresTokenStore(db, reverseEncryptor{})
+	got, err := store.Get(context.Background(), "vendor")
+	require.NoError(t, err)
+	assert.Equal(t, "vendor", got.ConnectionName)
+	assert.Equal(t, "acc", got.AccessToken)
+	assert.Equal(t, "ref", got.RefreshToken)
+	assert.Equal(t, "api", got.Scope)
+	assert.Equal(t, "alice@example.com", got.AuthenticatedBy)
+	assert.Equal(t, expiresAt, got.ExpiresAt)
+	assert.Equal(t, refreshExpiresAt, got.RefreshExpiresAt)
+	assert.Equal(t, authedAt, got.AuthenticatedAt)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPostgresTokenStore_Get_NotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectQuery("SELECT connection_name").
+		WithArgs("missing").
+		WillReturnError(sql.ErrNoRows)
+
+	store := NewPostgresTokenStore(db, nil)
+	_, err = store.Get(context.Background(), "missing")
+	assert.ErrorIs(t, err, ErrTokenNotFound)
+}
+
+func TestPostgresTokenStore_Get_ScanError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectQuery("SELECT connection_name").
+		WithArgs("vendor").
+		WillReturnError(errors.New("connection refused"))
+
+	store := NewPostgresTokenStore(db, nil)
+	_, err = store.Get(context.Background(), "vendor")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrTokenNotFound)
+}
+
+func TestPostgresTokenStore_Get_DecryptAccessError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	rows := sqlmock.NewRows([]string{
+		"connection_name", "access_token", "refresh_token", "expires_at",
+		"refresh_expires_at", "scope", "authenticated_by", "authenticated_at",
+		"updated_at",
+	}).AddRow("vendor", "ciphertext", nil, nil, nil, "", "", nil, time.Now())
+
+	mock.ExpectQuery("SELECT connection_name").
+		WithArgs("vendor").
+		WillReturnRows(rows)
+
+	store := NewPostgresTokenStore(db, reverseEncryptor{decErr: errors.New("bad key")})
+	_, err = store.Get(context.Background(), "vendor")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decrypt access token")
+}
+
+func TestPostgresTokenStore_Get_DecryptRefreshError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	rows := sqlmock.NewRows([]string{
+		"connection_name", "access_token", "refresh_token", "expires_at",
+		"refresh_expires_at", "scope", "authenticated_by", "authenticated_at",
+		"updated_at",
+	}).AddRow("vendor", nil, "ref-cipher", nil, nil, "", "", nil, time.Now())
+
+	mock.ExpectQuery("SELECT connection_name").
+		WithArgs("vendor").
+		WillReturnRows(rows)
+
+	store := NewPostgresTokenStore(db, reverseEncryptor{decErr: errors.New("bad refresh key")})
+	_, err = store.Get(context.Background(), "vendor")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decrypt refresh token")
+}
+
+func TestPostgresTokenStore_Set_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectExec("INSERT INTO apigateway_oauth_tokens").
+		WithArgs(
+			"vendor",
+			sqlmock.AnyArg(), // access_token (encrypted)
+			sqlmock.AnyArg(), // refresh_token (encrypted)
+			sqlmock.AnyArg(), // expires_at
+			nil,              // refresh_expires_at: zero → NULL
+			"api",
+			"alice@example.com",
+			sqlmock.AnyArg(), // authenticated_at
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	store := NewPostgresTokenStore(db, reverseEncryptor{})
+	err = store.Set(context.Background(), PersistedToken{
+		ConnectionName:  "vendor",
+		AccessToken:     "access-x",
+		RefreshToken:    "refresh-x",
+		ExpiresAt:       time.Now().Add(time.Hour),
+		Scope:           "api",
+		AuthenticatedBy: "alice@example.com",
+		AuthenticatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPostgresTokenStore_Set_AccessEncryptError(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := NewPostgresTokenStore(db, reverseEncryptor{encErr: errors.New("crypto fail")})
+	err = store.Set(context.Background(), PersistedToken{
+		ConnectionName: "vendor",
+		AccessToken:    "x",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "encrypt access token")
+}
+
+func TestPostgresTokenStore_Set_RefreshEncryptError(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	calls := 0
+	store := NewPostgresTokenStore(db, &flakyEncryptor{
+		encrypt: func(s string) (string, error) {
+			calls++
+			if calls == 2 {
+				return "", errors.New("boom")
+			}
+			return s, nil
+		},
+	})
+	err = store.Set(context.Background(), PersistedToken{
+		ConnectionName: "vendor",
+		AccessToken:    "a",
+		RefreshToken:   "r",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "encrypt refresh token")
+}
+
+func TestPostgresTokenStore_Set_ExecError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectExec("INSERT INTO apigateway_oauth_tokens").
+		WillReturnError(errors.New("db down"))
+
+	store := NewPostgresTokenStore(db, nil)
+	err = store.Set(context.Background(), PersistedToken{ConnectionName: "v"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tokenstore set")
+}
+
+func TestPostgresTokenStore_Delete_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectExec("DELETE FROM apigateway_oauth_tokens").
+		WithArgs("vendor").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	store := NewPostgresTokenStore(db, nil)
+	require.NoError(t, store.Delete(context.Background(), "vendor"))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPostgresTokenStore_Delete_Error(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectExec("DELETE FROM apigateway_oauth_tokens").
+		WithArgs("vendor").
+		WillReturnError(errors.New("nope"))
+
+	store := NewPostgresTokenStore(db, nil)
+	err = store.Delete(context.Background(), "vendor")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tokenstore delete")
+}
+
+// flakyEncryptor lets a test inject per-call behavior. Used to drive
+// "first encrypt succeeds, second fails" — the only path that
+// exercises the refresh_token-specific error wrapper.
+type flakyEncryptor struct {
+	encrypt func(string) (string, error)
+}
+
+func (f *flakyEncryptor) Encrypt(s string) (string, error) { return f.encrypt(s) }
+func (*flakyEncryptor) Decrypt(s string) (string, error)   { return s, nil }
+
+// Compile-time assertion: flakyEncryptor satisfies FieldEncryptor.
+var _ FieldEncryptor = (*flakyEncryptor)(nil)

--- a/pkg/toolkits/apigateway/toolkit.go
+++ b/pkg/toolkits/apigateway/toolkit.go
@@ -56,9 +56,40 @@ type Toolkit struct {
 	mu          sync.RWMutex
 	connections map[string]*conn
 	routePolicy RoutePolicy
+	tokenStore  TokenStore
 
 	semanticProvider semantic.Provider
 	queryProvider    query.Provider
+}
+
+// TokenStore returns the OAuth token store wired into this toolkit,
+// or nil when the toolkit was constructed without one. The admin
+// OAuth-callback handler calls this to persist tokens after the
+// authorization-code exchange.
+func (t *Toolkit) TokenStore() TokenStore {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.tokenStore
+}
+
+// SetTokenStore wires the persistent OAuth token store. Required
+// for the authorization_code grant: the Authenticator reads
+// existing tokens at first call and writes back rotated tokens
+// after refresh. Connections registered before SetTokenStore is
+// called will pick up the store on first use; the toolkit re-runs
+// the wire step in addParsedConnection to keep startup-order
+// independent (mirrors how the MCP gateway threads its TokenStore).
+func (t *Toolkit) SetTokenStore(s TokenStore) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.tokenStore = s
+	// Re-thread into any already-materialized authorization_code
+	// connections so wiring order doesn't matter.
+	for _, c := range t.connections {
+		if ac, ok := c.auth.(*oauth2AuthorizationCodeAuth); ok {
+			ac.SetTokenStore(s)
+		}
+	}
 }
 
 // RoutePolicy gates an api_invoke_endpoint call by (connection, method,
@@ -329,6 +360,13 @@ func (t *Toolkit) addParsedConnection(name string, cfg Config) error {
 	defer t.mu.Unlock()
 	if _, exists := t.connections[name]; exists {
 		return fmt.Errorf("apigateway: %s: %w", name, ErrConnectionExists)
+	}
+	// Wire the token store into authorization_code authenticators
+	// inline so a connection added BEFORE SetTokenStore still
+	// becomes functional once SetTokenStore runs (which re-threads
+	// the store across all connections). Either ordering works.
+	if ac, ok := auth.(*oauth2AuthorizationCodeAuth); ok && t.tokenStore != nil {
+		ac.SetTokenStore(t.tokenStore)
 	}
 	t.connections[name] = c
 	return nil

--- a/pkg/toolkits/apigateway/toolkit_test.go
+++ b/pkg/toolkits/apigateway/toolkit_test.go
@@ -730,3 +730,55 @@ func TestJSONResult_EmbedsPayload(t *testing.T) {
 		t.Errorf("payload missing: %s", textContent(r))
 	}
 }
+
+// TestToolkit_SetTokenStore_RethreadsAuthorizationCodeAuth proves the
+// wiring contract that platform.WireAPIGatewayTokenStore depends on:
+// when SetTokenStore is called AFTER addParsedConnection has already
+// materialized an authorization_code Authenticator, the new store
+// must reach the existing Authenticator (not just future ones).
+//
+// Without this re-thread, an api gateway connection registered before
+// the platform's WireAPIGatewayTokenStore call would silently come
+// up with no persistence — the failure mode that v1.57.1 surfaced on
+// the MCP gateway side.
+func TestToolkit_SetTokenStore_RethreadsAuthorizationCodeAuth(t *testing.T) {
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+
+	if tk.TokenStore() != nil {
+		t.Fatal("freshly built toolkit unexpectedly has a TokenStore")
+	}
+
+	err := tk.AddConnection("acme", map[string]any{
+		"base_url":                 "https://api.example.com",
+		"auth_mode":                AuthModeOAuth2AuthorizationCode,
+		"oauth2_token_url":         "https://idp.example/token",
+		"oauth2_authorization_url": "https://idp.example/auth",
+		"oauth2_client_id":         "id",
+		"oauth2_client_secret":     "sec",
+	})
+	if err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+
+	want := NewMemoryTokenStore()
+	tk.SetTokenStore(want)
+
+	if got := tk.TokenStore(); got != want {
+		t.Errorf("TokenStore after SetTokenStore = %v; want %v", got, want)
+	}
+
+	tk.mu.RLock()
+	c := tk.connections["acme"]
+	tk.mu.RUnlock()
+	if c == nil {
+		t.Fatal("connection vanished")
+	}
+	ac, ok := c.auth.(*oauth2AuthorizationCodeAuth)
+	if !ok {
+		t.Fatalf("expected *oauth2AuthorizationCodeAuth, got %T", c.auth)
+	}
+	if ac.store != want {
+		t.Error("re-thread did not deliver the new store to the existing Authenticator")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #368. Adds the OAuth 2.1 **authorization_code grant** for HTTP API gateway connections — a one-time browser-driven Connect flow yields a refresh token persisted (encrypted) so background tool calls keep working across platform restarts. Mirrors the MCP gateway's existing authorization_code path so connection setup and reauth UX are consistent across both gateway families.

This is the last v1 sub-issue for RFC #364.

### Architecture

- **Migration 38** — new `apigateway_oauth_tokens` table, parallel to `gateway_oauth_tokens`. Kept separate so the two toolkit families' connection-name spaces cannot collide; schema is identical so future shared infrastructure can read both with one row shape.
- **TokenStore** (`pkg/toolkits/apigateway/tokenstore.go`) — Postgres-backed primary, in-memory variant for tests + stateless single-replica deployments. At-rest field encryption via `FieldEncryptor` (platform supplies AES-256-GCM; falls back to noop with startup warning when `ENCRYPTION_KEY` is unset).
- **Authenticator** (`pkg/toolkits/apigateway/auth.go`) — reads the cached access token; on expiry exchanges `refresh_token` at the IdP, persists rotated tokens (incl. `refresh_expires_in`), and applies the `Authorization: Bearer …` header. Distinguishes RFC 6749 §5.2 `invalid_grant` @ 400 (definitively dead → row deleted, `ErrNeedsReauth` surfaced) from transient failures (5xx, network drop, ctx cancel → row preserved, error returned for retry). A single flaky-network event will not invalidate a long-lived refresh token.
- **Admin endpoints** (`pkg/admin/api_gateway_oauth_handler.go`)
  - `POST /api/v1/admin/api-gateway/connections/{name}/oauth-start` — generates PKCE verifier + S256 challenge, registers state in the PKCE store, returns the IdP authorization URL.
  - `GET /api/v1/admin/api-gateway/oauth/callback` — public mux (no admin session header — PKCE state authenticates it). Validates state, exchanges code, persists token via the toolkit's TokenStore, redirects through `safeReturnURL`.
- **Platform wiring** — `WireAPIGatewayTokenStore()` re-threads the store into any already-materialized authorization_code Authenticator so toolkit-build-vs-store-init ordering doesn't matter (mirrors `WireGatewayTokenStore`).

### Security guards

Three rounds of adversarial review caught and addressed eight findings; all are now in tree with regression tests:

| # | Vulnerability | Mitigation |
|---|---|---|
| 1 | Open-redirect via `pending.returnURL` | `safeReturnURL` rewrite with warn-log on rewrite |
| 2 | Token-exchange POST followed 3xx (initial code) | `codeExchangeClient` (`CheckRedirect: ErrUseLastResponse`) |
| 3 | Unbounded body read from IdP token endpoint | `readCappedTokenBody` — `LimitReader(maxCodeExchangeBodyBytes+1)` rejects oversize |
| 4 | `refresh_expires_in` not captured at initial exchange | `decodeAPIGatewayTokenResponse` parses it; `apiGatewayExchangeResult.RefreshExpiresAt` plumbs it through |
| 5 | Transient refresh failures destroyed refresh token | `classifyRefreshError` wraps `invalid_grant @ 400` only; `Apply` keeps the row on transient errors |
| 6 | Successful rotation didn't update `RefreshExpiresAt` | `computeRefreshExpiresAt` reads `fresh.Extra("refresh_expires_in")`; clears stale deadline on rotation without a new hint |
| 7 | Refresh-token POST also followed 3xx (and pre-existing `client_credentials` had the same hole) | New `newTokenExchangeClient()` helper with `CheckRedirect: ErrUseLastResponse`, used by initial exchange + refresh + client_credentials |
| 8 | Misleading log key `code` carrying OAuth `error` value | Renamed to `idp_error` for SIEM cross-grep parity with `gateway_oauth_handler.go` |

### Verification

- `make verify` clean (fmt, test w/ race, lint patch-scoped against merge-base, security/gosec/govulncheck, semgrep, codeql, coverage ≥ 80% total / 80% patch, dead-code parity, gremlins ≥ 60% efficacy, release dry-run, swagger).
- New code coverage: TokenStore CRUD via sqlmock + memory; Authenticator covers cached / refresh / `ErrNeedsReauth` (no token, expired refresh, IdP rejection, no refresh token) / transient-preserves-row / refresh-redirects-blocked / rotation persists `RefreshExpiresIn` / rotation-without-`refresh_expires_in` clears stale deadline. Admin handlers cover oauth-start (404 / 503-no-PKCE / conflict on wrong grant / happy path) and callback (success end-to-end / missing-state / unknown-state / external-returnURL guard / oversize body / 3xx refused / params auth-style / missing-access-token).

## Test plan

- [ ] CI green (lint, test, security, codeql, codecov ≥ 80% total + patch).
- [ ] Spot-check Connect → tools/list → first invoke → restart → tools/list → invoke (verifies persisted refresh token survives restart).
- [ ] Manual: register an api gateway connection with `auth_mode: oauth2_authorization_code`, click Connect on a Keycloak realm, confirm token-row written, confirm `refresh_expires_at` populated.
- [ ] Manual: revoke the refresh token in the IdP, trigger a tool call, confirm `ErrNeedsReauth` surfaces and the row is deleted.
- [ ] Manual: simulate 5xx from the IdP token endpoint mid-refresh, confirm row stays put and a retry succeeds.