### PR TITLE
feat(apigateway): pagination envelope + api_export tool (#372)

### DIFF
--- a/pkg/platform/export_adapters_apigateway_test.go
+++ b/pkg/platform/export_adapters_apigateway_test.go
@@ -1,0 +1,234 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/portal"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
+)
+
+// The trino-side adapter tests in export_adapters_test.go cover the
+// shared stubAssetStore / stubVersionStore / stubShareStore types
+// — those same stubs work here because they implement the
+// portal.* interfaces and the api gateway adapters wrap the same
+// portal stores. Each test below exercises an api gateway adapter
+// pass-through to confirm the conversion preserves field shape.
+
+func TestAPIExportAssetStoreAdapter_Insert(t *testing.T) {
+	store := &stubAssetStore{}
+	adapter := &apiExportAssetStoreAdapter{store: store}
+
+	err := adapter.InsertExportAsset(context.Background(), apigatewaykit.ExportAsset{
+		ID:      "a1",
+		OwnerID: "u1",
+		Name:    "items dump",
+		Tags:    []string{"crm", "weekly"},
+		Provenance: apigatewaykit.ExportProvenance{
+			UserID:    "u1",
+			SessionID: "s1",
+			ToolCalls: []apigatewaykit.ExportProvenanceCall{
+				{ToolName: "api_export", Timestamp: "2026-01-01T00:00:00Z"},
+			},
+		},
+		IdempotencyKey: "key1",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, store.inserted)
+	assert.Equal(t, "a1", store.inserted.ID)
+	assert.Equal(t, "key1", store.inserted.IdempotencyKey)
+	assert.Len(t, store.inserted.Provenance.ToolCalls, 1)
+	assert.Equal(t, "api_export", store.inserted.Provenance.ToolCalls[0].ToolName)
+}
+
+func TestAPIExportAssetStoreAdapter_InsertError(t *testing.T) {
+	store := &stubAssetStore{insertErr: fmt.Errorf("db down")}
+	adapter := &apiExportAssetStoreAdapter{store: store}
+
+	err := adapter.InsertExportAsset(context.Background(), apigatewaykit.ExportAsset{ID: "a1"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "inserting api_export asset")
+}
+
+func TestAPIExportAssetStoreAdapter_GetByIdempotencyKey(t *testing.T) {
+	store := &stubAssetStore{getByKey: &portal.Asset{ID: "a1", SizeBytes: 1234}}
+	adapter := &apiExportAssetStoreAdapter{store: store}
+
+	ref, err := adapter.GetByIdempotencyKey(context.Background(), "u1", "key1")
+	require.NoError(t, err)
+	assert.Equal(t, "a1", ref.ID)
+	assert.Equal(t, int64(1234), ref.SizeBytes)
+}
+
+func TestAPIExportAssetStoreAdapter_GetByIdempotencyKeyError(t *testing.T) {
+	store := &stubAssetStore{getByKeyErr: fmt.Errorf("not found")}
+	adapter := &apiExportAssetStoreAdapter{store: store}
+
+	_, err := adapter.GetByIdempotencyKey(context.Background(), "u1", "key1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "looking up api_export idempotency key")
+}
+
+func TestAPIExportVersionStoreAdapter(t *testing.T) {
+	store := &stubVersionStore{}
+	adapter := &apiExportVersionStoreAdapter{store: store}
+
+	n, err := adapter.CreateExportVersion(context.Background(), apigatewaykit.ExportVersion{
+		ID: "v1", AssetID: "a1", S3Key: "key", S3Bucket: "b",
+		ContentType: "application/json", SizeBytes: 100,
+		CreatedBy: "alice@example.com", ChangeSummary: "Exported from API endpoint",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	require.NotNil(t, store.created)
+	assert.Equal(t, "v1", store.created.ID)
+	assert.Equal(t, "a1", store.created.AssetID)
+	assert.Equal(t, "Exported from API endpoint", store.created.ChangeSummary)
+}
+
+func TestAPIExportVersionStoreAdapter_Error(t *testing.T) {
+	store := &stubVersionStore{createErr: fmt.Errorf("db down")}
+	adapter := &apiExportVersionStoreAdapter{store: store}
+
+	_, err := adapter.CreateExportVersion(context.Background(), apigatewaykit.ExportVersion{AssetID: "a1"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "creating api_export version")
+}
+
+func TestAPIExportShareCreatorAdapter(t *testing.T) {
+	store := &stubShareStore{}
+	adapter := &apiExportShareCreatorAdapter{shareStore: store, baseURL: "https://platform.example.com"}
+
+	url, err := adapter.CreatePublicShare(context.Background(), "a1", "alice@example.com")
+	require.NoError(t, err)
+	assert.Contains(t, url, "https://platform.example.com/portal/view/")
+	require.NotNil(t, store.inserted)
+	assert.Equal(t, "a1", store.inserted.AssetID)
+	assert.Equal(t, "alice@example.com", store.inserted.CreatedBy)
+	assert.NotEmpty(t, store.inserted.Token)
+	assert.NotEmpty(t, store.inserted.NoticeText)
+}
+
+func TestAPIExportShareCreatorAdapter_NoBaseURL(t *testing.T) {
+	store := &stubShareStore{}
+	adapter := &apiExportShareCreatorAdapter{shareStore: store, baseURL: ""}
+
+	url, err := adapter.CreatePublicShare(context.Background(), "a1", "alice@example.com")
+	require.NoError(t, err)
+	// Empty baseURL → empty url; the share row is still inserted so
+	// the share token exists in the DB even if the operator hasn't
+	// configured a public-base-url for portal.
+	assert.Empty(t, url)
+	assert.NotNil(t, store.inserted)
+}
+
+func TestAPIExportShareCreatorAdapter_InsertError(t *testing.T) {
+	store := &stubShareStore{insertErr: fmt.Errorf("db error")}
+	adapter := &apiExportShareCreatorAdapter{shareStore: store, baseURL: "https://x"}
+
+	_, err := adapter.CreatePublicShare(context.Background(), "a1", "alice@example.com")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "inserting api_export share")
+}
+
+func TestConvertAPIGatewayProvenanceCalls(t *testing.T) {
+	calls := []apigatewaykit.ExportProvenanceCall{
+		{ToolName: "api_export", Timestamp: "2026-01-01T00:00:00Z", Parameters: map[string]any{"k": "v"}},
+		{ToolName: "api_invoke_endpoint", Timestamp: "2026-01-01T00:00:01Z"},
+	}
+	got := convertAPIGatewayProvenanceCalls(calls)
+	require.Len(t, got, 2)
+	assert.Equal(t, "api_export", got[0].ToolName)
+	assert.Equal(t, "v", got[0].Parameters["k"])
+	assert.Equal(t, "api_invoke_endpoint", got[1].ToolName)
+}
+
+func TestConvertAPIGatewayProvenanceCalls_Empty(t *testing.T) {
+	got := convertAPIGatewayProvenanceCalls(nil)
+	assert.Empty(t, got)
+}
+
+// TestWireAPIGatewayExport_DisabledByConfig proves the explicit
+// portal.export.enabled=false short-circuits before adapter
+// construction. Operators expect the toggle to be effective.
+func TestWireAPIGatewayExport_DisabledByConfig(_ *testing.T) {
+	disabled := false
+	p := &Platform{
+		config: &Config{Portal: PortalConfig{Export: PortalExportConfig{Enabled: &disabled}}},
+	}
+	// Must not panic and must not require S3/asset store.
+	p.wireAPIGatewayExport()
+}
+
+// TestWireAPIGatewayExport_NoPortalSkips proves the missing-S3 /
+// missing-asset-store guards. Without a portal asset store there's
+// nothing to write to, so api_export must stay unwired.
+func TestWireAPIGatewayExport_NoPortalSkips(_ *testing.T) {
+	p := &Platform{
+		config: &Config{Portal: PortalConfig{Export: PortalExportConfig{}}},
+		// portalS3Client and portalAssetStore both nil.
+	}
+	// Must not panic; toolkitRegistry stays nil because we never
+	// reach the GetByKind call.
+	p.wireAPIGatewayExport()
+}
+
+// TestWireAPIGatewayExport_ToolAppearsInToolList exercises the
+// happy-path wire: portal + api gateway both configured, the
+// adapters get assembled, SetExportDeps lands on the toolkit, and
+// api_export now appears in tk.Tools(). Mirrors the trino-side
+// TestWireTrinoExport_ToolAppearsInToolList test.
+func TestWireAPIGatewayExport_ToolAppearsInToolList(t *testing.T) {
+	mc, err := apigatewaykit.ParseMultiConfig("api", map[string]map[string]any{
+		"crm": {"base_url": "https://api.example.com"},
+	})
+	require.NoError(t, err)
+	tk := apigatewaykit.NewMulti(mc)
+	t.Cleanup(func() { _ = tk.Close() })
+
+	// api_export should NOT be in the tool list before wiring.
+	assert.NotContains(t, tk.Tools(), "api_export")
+
+	r := registry.NewRegistry()
+	require.NoError(t, r.Register(tk))
+
+	p := &Platform{
+		config: &Config{
+			Portal: PortalConfig{
+				S3Bucket:      "exports",
+				S3Prefix:      "data",
+				PublicBaseURL: "https://platform.example.com",
+			},
+		},
+		portalAssetStore:   portal.NewNoopAssetStore(),
+		portalVersionStore: portal.NewNoopVersionStore(),
+		portalShareStore:   portal.NewNoopShareStore(),
+		portalS3Client:     &apiNoopS3Client{},
+		toolkitRegistry:    r,
+	}
+
+	p.wireAPIGatewayExport()
+
+	// After wiring, api_export must appear in the tool list.
+	assert.Contains(t, tk.Tools(), "api_export")
+}
+
+// apiNoopS3Client satisfies portal.S3Client for the wire test —
+// no PutObject is exercised here, but the platform's wireAPIGatewayExport
+// requires a non-nil portalS3Client to proceed past the guard.
+type apiNoopS3Client struct{}
+
+func (*apiNoopS3Client) PutObject(_ context.Context, _, _ string, _ []byte, _ string) error {
+	return nil
+}
+
+func (*apiNoopS3Client) GetObject(_ context.Context, _, _ string) (data []byte, contentType string, err error) { //nolint:gocritic // named for clarity
+	return nil, "", nil
+}
+func (*apiNoopS3Client) DeleteObject(_ context.Context, _, _ string) error { return nil }
+func (*apiNoopS3Client) Close() error                                      { return nil }

--- a/pkg/platform/export_adapters_test.go
+++ b/pkg/platform/export_adapters_test.go
@@ -163,9 +163,14 @@ func TestExportShareCreatorAdapter_NoBaseURL(t *testing.T) {
 
 	url, err := adapter.CreatePublicShare(context.Background(), "a1", "alice@example.com")
 	require.NoError(t, err)
-	// Returns just the token when no base URL
-	assert.NotEmpty(t, url)
-	assert.NotContains(t, url, "http")
+	// Empty baseURL → empty share URL. The share row IS still
+	// inserted (token exists in DB) so the API caller can compute
+	// the URL later; surfacing a bare token in `share_url` would
+	// put a non-URL value in a URL-typed field, which is
+	// misleading. The api-gateway-side adapter behaves the same
+	// way — see TestAPIExportShareCreatorAdapter_NoBaseURL.
+	assert.Empty(t, url)
+	assert.NotNil(t, store.inserted)
 }
 
 func TestExportShareCreatorAdapter_InsertError(t *testing.T) {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1456,6 +1456,10 @@ func (p *Platform) initPortal() error {
 
 	// Wire trino_export if portal + trino are both configured
 	p.wireTrinoExport()
+	// Same wiring for api_export — uses the same portal asset
+	// store + S3 client so the model gets a single "exports"
+	// surface in the portal regardless of source toolkit.
+	p.wireAPIGatewayExport()
 
 	return nil
 }
@@ -1675,7 +1679,12 @@ func (a *exportShareCreatorAdapter) CreatePublicShare(ctx context.Context, asset
 	if a.baseURL != "" {
 		return fmt.Sprintf("%s/portal/view/%s", a.baseURL, token), nil
 	}
-	return token, nil
+	// Empty baseURL → empty share URL. Returning the bare token
+	// here would put a non-URL value into the model-visible
+	// `share_url` field; the api-gateway-side adapter does the
+	// same thing and the JSON envelopes both use omitempty to
+	// hide the field cleanly when no URL is computable.
+	return "", nil
 }
 
 // generateShareToken generates a cryptographically random hex token for share links.
@@ -3619,4 +3628,182 @@ func parseEntryFromMap(m map[string]any) (middleware.SentTableEntry, bool) {
 		}
 	}
 	return entry, true
+}
+
+// wireAPIGatewayExport injects portal dependencies into api gateway
+// toolkits for api_export. Mirrors wireTrinoExport: same portal
+// asset store, same S3 client, same share creator. The two
+// toolkits each carry their own ExportDeps types (no shared
+// interface yet) so a thin set of adapters bridges them to the
+// shared portal stores.
+func (p *Platform) wireAPIGatewayExport() {
+	if isExplicitlyDisabled(p.config.Portal.Export.Enabled) {
+		slog.Debug("api_export: disabled by portal.export.enabled")
+		return
+	}
+	if p.portalS3Client == nil || p.portalAssetStore == nil {
+		slog.Debug("api_export: portal S3 or asset store not configured, skipping")
+		return
+	}
+
+	apiToolkits := p.toolkitRegistry.GetByKind(apigatewaykit.Kind)
+	if len(apiToolkits) == 0 {
+		slog.Debug("api_export: no api gateway toolkits registered, skipping")
+		return
+	}
+
+	// Reuse the same ExportConfig knobs as trino_export — operators
+	// configure the cap once and both _export tools honor it.
+	tcfg := p.parseExportConfig()
+	exportCfg := apigatewaykit.ExportConfig{
+		MaxBytes:       tcfg.MaxBytes,
+		DefaultTimeout: tcfg.DefaultTimeout,
+		MaxTimeout:     tcfg.MaxTimeout,
+	}
+
+	for _, tk := range apiToolkits {
+		apiTk, ok := tk.(*apigatewaykit.Toolkit)
+		if !ok {
+			continue
+		}
+		apiTk.SetExportDeps(apigatewaykit.ExportDeps{
+			AssetStore:   &apiExportAssetStoreAdapter{store: p.portalAssetStore},
+			VersionStore: &apiExportVersionStoreAdapter{store: p.portalVersionStore},
+			S3Client:     p.portalS3Client,
+			ShareCreator: &apiExportShareCreatorAdapter{
+				shareStore: p.portalShareStore,
+				baseURL:    p.config.Portal.PublicBaseURL,
+			},
+			S3Bucket: p.config.Portal.S3Bucket,
+			S3Prefix: p.config.Portal.S3Prefix,
+			BaseURL:  p.config.Portal.PublicBaseURL,
+			Config:   exportCfg,
+			GetUserContext: func(ctx context.Context) *apigatewaykit.ExportUserContext {
+				pc := middleware.GetPlatformContext(ctx)
+				if pc == nil {
+					return nil
+				}
+				return &apigatewaykit.ExportUserContext{
+					UserID:    pc.UserID,
+					UserEmail: pc.UserEmail,
+					SessionID: pc.SessionID,
+				}
+			},
+		})
+	}
+
+	slog.Info("api_export wired",
+		"max_bytes", exportCfg.MaxBytes,
+	)
+}
+
+// apiExportAssetStoreAdapter adapts portal.AssetStore to
+// apigatewaykit.ExportAssetStore. Mirrors exportAssetStoreAdapter
+// (the trino-side adapter) — the only divergence is the locally-
+// defined apigatewaykit.ExportAsset type that callers pass in.
+type apiExportAssetStoreAdapter struct {
+	store portal.AssetStore
+}
+
+func (a *apiExportAssetStoreAdapter) InsertExportAsset(ctx context.Context, asset apigatewaykit.ExportAsset) error { //nolint:revive // implements apigateway.ExportAssetStore
+	if err := a.store.Insert(ctx, portal.Asset{
+		ID:          asset.ID,
+		OwnerID:     asset.OwnerID,
+		OwnerEmail:  asset.OwnerEmail,
+		Name:        asset.Name,
+		Description: asset.Description,
+		ContentType: asset.ContentType,
+		S3Bucket:    asset.S3Bucket,
+		S3Key:       asset.S3Key,
+		SizeBytes:   asset.SizeBytes,
+		Tags:        asset.Tags,
+		Provenance: portal.Provenance{
+			UserID:    asset.Provenance.UserID,
+			SessionID: asset.Provenance.SessionID,
+			ToolCalls: convertAPIGatewayProvenanceCalls(asset.Provenance.ToolCalls),
+		},
+		SessionID:      asset.SessionID,
+		IdempotencyKey: asset.IdempotencyKey,
+	}); err != nil {
+		return fmt.Errorf("inserting api_export asset: %w", err)
+	}
+	return nil
+}
+
+func (a *apiExportAssetStoreAdapter) GetByIdempotencyKey(ctx context.Context, ownerID, key string) (*apigatewaykit.ExportAssetRef, error) { //nolint:revive // implements apigateway.ExportAssetStore
+	asset, err := a.store.GetByIdempotencyKey(ctx, ownerID, key)
+	if err != nil {
+		return nil, fmt.Errorf("looking up api_export idempotency key: %w", err)
+	}
+	return &apigatewaykit.ExportAssetRef{
+		ID:        asset.ID,
+		SizeBytes: asset.SizeBytes,
+	}, nil
+}
+
+// apiExportVersionStoreAdapter adapts portal.VersionStore to
+// apigatewaykit.ExportVersionStore.
+type apiExportVersionStoreAdapter struct {
+	store portal.VersionStore
+}
+
+func (a *apiExportVersionStoreAdapter) CreateExportVersion(ctx context.Context, ver apigatewaykit.ExportVersion) (int, error) { //nolint:revive // implements apigateway.ExportVersionStore
+	n, err := a.store.CreateVersion(ctx, portal.AssetVersion{
+		ID:            ver.ID,
+		AssetID:       ver.AssetID,
+		S3Key:         ver.S3Key,
+		S3Bucket:      ver.S3Bucket,
+		ContentType:   ver.ContentType,
+		SizeBytes:     ver.SizeBytes,
+		CreatedBy:     ver.CreatedBy,
+		ChangeSummary: ver.ChangeSummary,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("creating api_export version: %w", err)
+	}
+	return n, nil
+}
+
+// apiExportShareCreatorAdapter creates public share links for
+// api_export assets. Same shape as the trino-side adapter; the
+// share row in the DB is identical.
+type apiExportShareCreatorAdapter struct {
+	shareStore portal.ShareStore
+	baseURL    string
+}
+
+func (a *apiExportShareCreatorAdapter) CreatePublicShare(ctx context.Context, assetID, createdBy string) (string, error) { //nolint:revive // implements apigateway.ExportShareCreator
+	token, err := generateShareToken()
+	if err != nil {
+		return "", fmt.Errorf("generating share token: %w", err)
+	}
+	share := portal.Share{
+		ID:         generateUUID(),
+		AssetID:    assetID,
+		Token:      token,
+		CreatedBy:  createdBy,
+		NoticeText: "Proprietary & Confidential. Only share with authorized viewers.",
+	}
+	if err := a.shareStore.Insert(ctx, share); err != nil {
+		return "", fmt.Errorf("inserting api_export share: %w", err)
+	}
+	if a.baseURL != "" {
+		return fmt.Sprintf("%s/portal/view/%s", a.baseURL, token), nil
+	}
+	return "", nil
+}
+
+// convertAPIGatewayProvenanceCalls is the apigateway-flavored
+// counterpart to convertProvenanceCalls. Same shape, different
+// source type.
+func convertAPIGatewayProvenanceCalls(calls []apigatewaykit.ExportProvenanceCall) []portal.ProvenanceToolCall {
+	result := make([]portal.ProvenanceToolCall, len(calls))
+	for i, c := range calls {
+		result[i] = portal.ProvenanceToolCall{
+			ToolName:   c.ToolName,
+			Timestamp:  c.Timestamp,
+			Parameters: c.Parameters,
+		}
+	}
+	return result
 }

--- a/pkg/toolkits/apigateway/export.go
+++ b/pkg/toolkits/apigateway/export.go
@@ -1,0 +1,648 @@
+package apigateway //nolint:revive // adapter types for cross-package wiring
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// exportToolName is the MCP tool name. The trino_export pattern
+// established the *_export naming for tools whose purpose is "run
+// something that produces a potentially-huge result, write it to a
+// portal asset, return asset metadata not data". api_export does
+// the same for upstream HTTP API responses.
+const exportToolName = "api_export"
+
+// defaultExportMaxBytes caps how much of an upstream response will
+// be written to a portal asset when the operator has not configured
+// a per-platform limit. 100 MiB matches trino_export's default and
+// is generous enough for typical CRM / analytics pulls without
+// inviting accidental DoS via a misconfigured upstream.
+const defaultExportMaxBytes = int64(100 * 1024 * 1024)
+
+// defaultExportTimeout / defaultMaxExportTimeout cap how long a
+// single api_export call can run. The default is generous for
+// large paginated pulls; the max prevents an operator-supplied
+// timeout from holding the request handler indefinitely.
+const (
+	defaultExportTimeout    = 5 * time.Minute
+	defaultMaxExportTimeout = 30 * time.Minute
+)
+
+// ExportAssetStore is the subset of portal.AssetStore needed by
+// api_export. Defined locally to avoid an import cycle (portal →
+// registry → apigateway). Mirrors trinokit.ExportAssetStore.
+type ExportAssetStore interface {
+	InsertExportAsset(ctx context.Context, asset ExportAsset) error
+	GetByIdempotencyKey(ctx context.Context, ownerID, key string) (*ExportAssetRef, error)
+}
+
+// ExportVersionStore is the subset of portal.VersionStore needed
+// by api_export.
+type ExportVersionStore interface {
+	CreateExportVersion(ctx context.Context, version ExportVersion) (int, error)
+}
+
+// ExportS3Client is the subset of portal.S3Client needed by
+// api_export. Note: this is the same shape as trinokit's; the
+// platform adapter implementing it can serve both toolkits.
+type ExportS3Client interface {
+	PutObject(ctx context.Context, bucket, key string, data []byte, contentType string) error
+}
+
+// ExportShareCreator creates public share links for exported
+// assets. nil disables public-link creation.
+type ExportShareCreator interface {
+	CreatePublicShare(ctx context.Context, assetID, createdBy string) (shareURL string, err error)
+}
+
+// ExportAsset is the row inserted into portal_assets when an
+// api_export call succeeds. Field shape mirrors trinokit.ExportAsset
+// so the platform-side adapter can reuse its conversion logic.
+type ExportAsset struct {
+	ID             string
+	OwnerID        string
+	OwnerEmail     string
+	Name           string
+	Description    string
+	ContentType    string
+	S3Bucket       string
+	S3Key          string
+	SizeBytes      int64
+	Tags           []string
+	Provenance     ExportProvenance
+	SessionID      string
+	IdempotencyKey string
+}
+
+// ExportProvenance captures the chain of tool calls that produced
+// an asset so portal viewers can render "exported via api_export
+// from <connection> <method> <path>".
+type ExportProvenance struct {
+	ToolCalls []ExportProvenanceCall
+	SessionID string
+	UserID    string
+}
+
+// ExportProvenanceCall is one step in the provenance chain.
+type ExportProvenanceCall struct {
+	ToolName   string
+	Timestamp  string
+	Parameters map[string]any
+}
+
+// ExportAssetRef is returned by idempotency-key lookup. We only
+// need the id + size for the response — the model doesn't see the
+// existing asset's full row.
+type ExportAssetRef struct {
+	ID        string
+	SizeBytes int64
+}
+
+// ExportVersion is the row inserted into portal_asset_versions.
+type ExportVersion struct {
+	ID            string
+	AssetID       string
+	S3Key         string
+	S3Bucket      string
+	ContentType   string
+	SizeBytes     int64
+	CreatedBy     string
+	ChangeSummary string
+}
+
+// ExportConfig holds platform-level limits for api_export. MaxBytes
+// caps any single export's size (above which the call returns an
+// error rather than a truncated asset — partial-data assets would
+// be misleading). DefaultTimeout / MaxTimeout bound how long a
+// single call may run.
+type ExportConfig struct {
+	MaxBytes       int64
+	DefaultTimeout time.Duration
+	MaxTimeout     time.Duration
+}
+
+// applyExportDefaults fills zero values with defaults.
+func applyExportDefaults(cfg ExportConfig) ExportConfig {
+	if cfg.MaxBytes <= 0 {
+		cfg.MaxBytes = defaultExportMaxBytes
+	}
+	if cfg.DefaultTimeout <= 0 {
+		cfg.DefaultTimeout = defaultExportTimeout
+	}
+	if cfg.MaxTimeout <= 0 {
+		cfg.MaxTimeout = defaultMaxExportTimeout
+	}
+	return cfg
+}
+
+// ExportUserContext holds user identity extracted from the request
+// context. Populated by the GetUserContext callback provided in
+// ExportDeps so the toolkit doesn't import middleware directly.
+type ExportUserContext struct {
+	UserID    string
+	UserEmail string
+	SessionID string
+}
+
+// ExportDeps holds platform-side dependencies injected into the
+// api gateway toolkit. All types are defined locally to avoid
+// import cycles. Mirrors trinokit.ExportDeps so the platform-side
+// wiring can stay symmetric.
+type ExportDeps struct {
+	AssetStore     ExportAssetStore
+	VersionStore   ExportVersionStore
+	S3Client       ExportS3Client
+	ShareCreator   ExportShareCreator
+	S3Bucket       string
+	S3Prefix       string
+	BaseURL        string
+	Config         ExportConfig
+	GetUserContext func(ctx context.Context) *ExportUserContext
+}
+
+// SetExportDeps wires platform-side dependencies for api_export.
+// Calling with nil-AssetStore deps is treated as "export disabled":
+// registerExportTool checks t.exportDeps and skips registration so
+// the model doesn't see a tool that would always fail.
+func (t *Toolkit) SetExportDeps(deps ExportDeps) {
+	deps.Config = applyExportDefaults(deps.Config)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.exportDeps = &deps
+}
+
+// exportInput is the parsed input for api_export. Fields parallel
+// the api_invoke_endpoint input plus the portal-asset metadata
+// fields trino_export takes (name, description, tags,
+// idempotency_key, create_public_link).
+type exportInput struct {
+	Connection       string            `json:"connection"`
+	Method           string            `json:"method"`
+	Path             string            `json:"path"`
+	Query            map[string]any    `json:"query"`
+	Headers          map[string]string `json:"headers"`
+	Body             any               `json:"body"`
+	TimeoutSeconds   int               `json:"timeout_seconds"`
+	Name             string            `json:"name"`
+	Description      string            `json:"description"`
+	Tags             []string          `json:"tags"`
+	IdempotencyKey   string            `json:"idempotency_key"`
+	CreatePublicLink bool              `json:"create_public_link"`
+}
+
+// exportOutput is the response returned to the model. Mirrors
+// trino_export's output: asset metadata, no body bytes.
+type exportOutput struct {
+	AssetID     string `json:"asset_id"`
+	PortalURL   string `json:"portal_url,omitempty"`
+	ShareURL    string `json:"share_url,omitempty"`
+	ContentType string `json:"content_type,omitempty"`
+	Status      int    `json:"upstream_status"`
+	SizeBytes   int64  `json:"size_bytes"`
+	Message     string `json:"message"`
+}
+
+// registerExportTool registers api_export on the MCP server. No-op
+// when ExportDeps were never wired (admin or single-replica
+// deployment without portal asset store).
+func (t *Toolkit) registerExportTool(s *mcp.Server) {
+	t.mu.RLock()
+	deps := t.exportDeps
+	t.mu.RUnlock()
+	if deps == nil {
+		return
+	}
+	mcp.AddTool(s, &mcp.Tool{
+		Name:  exportToolName,
+		Title: "Export API Endpoint Response",
+		Description: "Invoke an upstream API endpoint and stream the response into a portal asset INSTEAD of returning it through the model context. " +
+			"Use this when api_invoke_endpoint reports body_truncated, when you expect a response too large to be useful through the model, or when you want to hand off the data to trino_query / s3_get_object / a portal share. " +
+			"Returns asset metadata (id, URL, size, content type) — the data is NOT returned through this response. " +
+			"NAMING: keep `name` short and portable, ASCII letters / digits / spaces / hyphens / dots only. " +
+			"The name doubles as the download filename.",
+		InputSchema: apiExportInputSchema,
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint: false,
+		},
+	}, t.handleExport)
+}
+
+// handleExport is the MCP handler for api_export. The flow:
+//  1. Validate input + resolve connection (auth, route policy,
+//     same gates as api_invoke_endpoint).
+//  2. Resolve user context — required for OwnerID/OwnerEmail on
+//     the asset row.
+//  3. Idempotency check — if (user, key) matches an existing
+//     asset, return its metadata without re-running the upstream.
+//  4. Build + send the upstream request, capped at deps.Config.MaxBytes.
+//  5. Reject the call (no partial asset) if the response exceeds
+//     the cap — partial data in a portal asset would be misleading.
+//  6. PutObject to S3, insert asset row, insert version row,
+//     optionally create a public share.
+//  7. Return asset metadata.
+func (t *Toolkit) handleExport(ctx context.Context, _ *mcp.CallToolRequest, in exportInput) (*mcp.CallToolResult, any, error) {
+	t.mu.RLock()
+	deps := t.exportDeps
+	c, connOK := t.connections[in.Connection]
+	policy := t.routePolicy
+	t.mu.RUnlock()
+	if deps == nil {
+		return errorResult("api_export is not configured (portal asset store unavailable)"), nil, nil
+	}
+	if in.Connection == "" {
+		return errorResult("connection is required"), nil, nil
+	}
+	if !connOK {
+		return errorResult(fmt.Sprintf("connection %q not found", in.Connection)), nil, nil
+	}
+	if in.Name == "" {
+		return errorResult("name is required (becomes the asset's download filename)"), nil, nil
+	}
+	uc := resolveExportUser(ctx, deps)
+	if uc == nil {
+		return errorResult("authentication required for api_export"), nil, nil
+	}
+
+	// Honor the same route policy that api_invoke_endpoint does so
+	// a persona scoped to GET /v1/users cannot export from
+	// DELETE /v1/users/{id}.
+	if _, mErr := validateMethod(in.Method); mErr != nil {
+		return errorResult(mErr.Error()), nil, nil
+	}
+	if denial := checkRoutePolicy(ctx, policy, InvokeInput{
+		Connection: in.Connection, Method: in.Method, Path: in.Path,
+	}); denial != nil {
+		return denial, nil, nil
+	}
+
+	if existing := checkExportIdempotency(ctx, deps, uc, in); existing != nil {
+		return jsonResult(existing), existing, nil
+	}
+
+	out, runErr := t.runExport(ctx, runExportArgs{
+		deps: deps, cfg: c.cfg, auth: c.auth, client: c.client, uc: uc, in: in,
+	})
+	if runErr != nil {
+		return errorResult(runErr.Error()), nil, nil
+	}
+	return jsonResult(out), out, nil
+}
+
+// resolveExportUser fetches the platform-injected user context. nil
+// (no GetUserContext callback) or a nil result both yield nil — the
+// caller surfaces "authentication required". Without owner identity
+// the asset row would have no owner and be unreachable from the
+// portal "my exports" view.
+func resolveExportUser(ctx context.Context, deps *ExportDeps) *ExportUserContext {
+	if deps.GetUserContext == nil {
+		return nil
+	}
+	return deps.GetUserContext(ctx)
+}
+
+// checkExportIdempotency returns an existing asset's metadata when
+// the idempotency key is set and matches. Returns nil when no key
+// was supplied, the lookup found nothing, or the lookup errored
+// (lookup errors fall through to a fresh run — better to
+// accidentally double-export than to fail closed when the DB is
+// degraded).
+func checkExportIdempotency(ctx context.Context, deps *ExportDeps, uc *ExportUserContext, in exportInput) *exportOutput {
+	if in.IdempotencyKey == "" {
+		return nil
+	}
+	existing, err := deps.AssetStore.GetByIdempotencyKey(ctx, uc.UserID, in.IdempotencyKey)
+	if err != nil || existing == nil {
+		return nil
+	}
+	return &exportOutput{
+		AssetID:   existing.ID,
+		PortalURL: buildExportPortalURL(deps.BaseURL, existing.ID),
+		SizeBytes: existing.SizeBytes,
+		Message:   "Asset already exists (idempotency key matched).",
+	}
+}
+
+// runExportArgs bundles the inputs runExport needs. Splitting into
+// a struct keeps the function under revive's argument-limit ceiling
+// and makes the call site self-documenting.
+type runExportArgs struct {
+	deps   *ExportDeps
+	cfg    Config
+	auth   Authenticator
+	client *http.Client
+	uc     *ExportUserContext
+	in     exportInput
+}
+
+// runExport executes the upstream call, uploads the response to
+// S3, and inserts the asset + version rows.
+func (*Toolkit) runExport(ctx context.Context, a runExportArgs) (*exportOutput, error) {
+	deps, cfg, auth, client, uc, in := a.deps, a.cfg, a.auth, a.client, a.uc, a.in
+	timeout := resolveExportTimeout(in.TimeoutSeconds, deps.Config)
+	exportCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := buildExportRequest(exportCtx, cfg, auth, in)
+	if err != nil {
+		return nil, err
+	}
+
+	// #nosec G107 G704 -- req.URL is constructed via buildURL which
+	// parses the operator-configured base_url independently and
+	// asserts the joined URL's scheme + host equal the base's;
+	// validatePath rejects path shapes (//, @, CR/LF/NUL) that
+	// would let url.Parse be tricked into changing the host. Same
+	// SSRF guards as api_invoke_endpoint, same #nosec rationale.
+	resp, err := client.Do(req) //nolint:bodyclose // closed via readCappedExportBody
+	if err != nil {
+		return nil, fmt.Errorf("upstream request: %s", scrubTransportError(err))
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup
+
+	body, err := readCappedExportBody(resp.Body, deps.Config.MaxBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	assetID, err := persistExportAsset(ctx, persistExportArgs{
+		deps: deps, uc: uc, in: in, body: body, contentType: contentType, status: resp.StatusCode,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	shareURL := maybeCreateExportShare(ctx, deps, in, assetID, uc.UserEmail)
+
+	method, _ := validateMethod(in.Method)
+	return &exportOutput{
+		AssetID:     assetID,
+		PortalURL:   buildExportPortalURL(deps.BaseURL, assetID),
+		ShareURL:    shareURL,
+		ContentType: contentType,
+		Status:      resp.StatusCode,
+		SizeBytes:   int64(len(body)),
+		Message:     fmt.Sprintf("Exported %d bytes from %s %s.", len(body), method, in.Path),
+	}, nil
+}
+
+// buildExportRequest assembles the *http.Request for the upstream
+// call using the same machinery api_invoke_endpoint uses (so SSRF
+// guards apply identically). Split out of runExport so the
+// build-and-go logic doesn't dominate one function's complexity.
+func buildExportRequest(ctx context.Context, cfg Config, auth Authenticator, in exportInput) (*http.Request, error) {
+	method, _ := validateMethod(in.Method) // already validated by caller
+	if err := validatePath(in.Path); err != nil {
+		return nil, err
+	}
+	authHeader := authHeaderForConfig(cfg)
+	if err := validateCustomHeaders(in.Headers, authHeader); err != nil {
+		return nil, err
+	}
+	bodyBytes, contentTypeFromBody, err := encodeBody(method, in.Body)
+	if err != nil {
+		return nil, err
+	}
+	urlStr, err := buildURL(cfg.BaseURL, in.Path, in.Query)
+	if err != nil {
+		return nil, err
+	}
+	req, err := buildRequest(ctx, requestSpec{
+		method:      method,
+		url:         urlStr,
+		body:        bodyBytes,
+		contentType: contentTypeFromBody,
+		headers:     in.Headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if applyErr := auth.Apply(req); applyErr != nil {
+		return nil, fmt.Errorf("auth: %w", applyErr)
+	}
+	return req, nil
+}
+
+// persistExportArgs bundles the inputs persistExportAsset needs.
+type persistExportArgs struct {
+	deps        *ExportDeps
+	uc          *ExportUserContext
+	in          exportInput
+	body        []byte
+	contentType string
+	status      int
+}
+
+// persistExportAsset uploads the response bytes to S3 and inserts
+// the asset row + version row. Returns the asset id on success.
+// Version-row failure is non-fatal — the asset row is already in
+// place and the model has an id; failing the whole call would
+// orphan the S3 object.
+func persistExportAsset(ctx context.Context, p persistExportArgs) (string, error) {
+	deps, uc, in, body, contentType, status := p.deps, p.uc, p.in, p.body, p.contentType, p.status
+	assetID, err := generateExportAssetID()
+	if err != nil {
+		return "", fmt.Errorf("generating asset id: %w", err)
+	}
+	s3Key := buildExportS3Key(deps.S3Prefix, uc.UserID, assetID, contentType)
+	if err := deps.S3Client.PutObject(ctx, deps.S3Bucket, s3Key, body, contentType); err != nil {
+		return "", fmt.Errorf("s3 upload: %w", err)
+	}
+	asset := ExportAsset{
+		ID:             assetID,
+		OwnerID:        uc.UserID,
+		OwnerEmail:     uc.UserEmail,
+		Name:           in.Name,
+		Description:    in.Description,
+		ContentType:    contentType,
+		S3Bucket:       deps.S3Bucket,
+		S3Key:          s3Key,
+		SizeBytes:      int64(len(body)),
+		Tags:           in.Tags,
+		Provenance:     buildExportProvenance(uc, in, status),
+		SessionID:      uc.SessionID,
+		IdempotencyKey: in.IdempotencyKey,
+	}
+	if err := deps.AssetStore.InsertExportAsset(ctx, asset); err != nil {
+		return "", fmt.Errorf("insert asset row: %w", err)
+	}
+	versionID, vidErr := generateExportAssetID()
+	if vidErr != nil {
+		// Generating an id should never fail (crypto/rand). If it
+		// somehow does, the asset row is already in place — log
+		// and return the asset id so the model has a usable handle.
+		slog.Warn("api_export: generating version id failed",
+			"asset_id", assetID, "error", vidErr)
+		return assetID, nil
+	}
+	if _, vErr := deps.VersionStore.CreateExportVersion(ctx, ExportVersion{
+		ID:            versionID,
+		AssetID:       assetID,
+		S3Key:         s3Key,
+		S3Bucket:      deps.S3Bucket,
+		ContentType:   contentType,
+		SizeBytes:     int64(len(body)),
+		CreatedBy:     uc.UserEmail,
+		ChangeSummary: "Exported from API endpoint",
+	}); vErr != nil {
+		// Version-row failure is non-fatal: the asset row is
+		// already in place and the model has the id. Surface via
+		// slog so operators can spot DB issues — silently
+		// dropping the error would let portal_asset_versions
+		// drift out of sync with portal_assets indefinitely.
+		slog.Warn("api_export: failed to create version record",
+			"asset_id", assetID, "error", vErr)
+	}
+	return assetID, nil
+}
+
+// resolveExportTimeout picks the timeout for a single api_export
+// call. The model's timeout_seconds wins when supplied, capped at
+// MaxTimeout; absent input falls back to DefaultTimeout.
+func resolveExportTimeout(timeoutSeconds int, cfg ExportConfig) time.Duration {
+	if timeoutSeconds <= 0 {
+		return cfg.DefaultTimeout
+	}
+	requested := time.Duration(timeoutSeconds) * time.Second
+	if requested > cfg.MaxTimeout {
+		return cfg.MaxTimeout
+	}
+	return requested
+}
+
+// readCappedExportBody reads up to maxBytes+1 bytes; returning an
+// error (NOT a truncated asset) when the body exceeded the cap. A
+// truncated asset would be misleading — the operator clicking the
+// portal asset would have no way to know the file is incomplete.
+// Refusing the export and pointing the model at "raise the cap or
+// narrow the request" is the correct contract.
+func readCappedExportBody(r io.Reader, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		maxBytes = defaultExportMaxBytes
+	}
+	read, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading upstream response: %w", err)
+	}
+	if int64(len(read)) > maxBytes {
+		return nil, fmt.Errorf("upstream response exceeded api_export cap of %d bytes — narrow the request (smaller page, fewer fields) or raise platform.export.max_bytes", maxBytes)
+	}
+	return read, nil
+}
+
+// generateExportAssetID returns a 16-byte hex id. Same format as
+// trino_export's ID so the portal "exports" view doesn't need to
+// distinguish source.
+func generateExportAssetID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("rand: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// buildExportS3Key composes the S3 key for a given asset:
+// <prefix>/<user>/<asset>.<ext>. Falls back to "bin" when the
+// content type doesn't yield a known extension.
+func buildExportS3Key(prefix, userID, assetID, contentType string) string {
+	ext := extensionForContentType(contentType)
+	parts := []string{}
+	if prefix != "" {
+		parts = append(parts, strings.Trim(prefix, "/"))
+	}
+	parts = append(parts, "api_export", userID, assetID+"."+ext)
+	return path.Join(parts...)
+}
+
+// extensionForContentType picks a file extension for a content-type
+// string. The Go std library's `mime` package has ExtensionsByType,
+// which returns a list (we take the first entry stripped of its
+// leading dot). Falls back to "bin" — a downloaded "blob.bin" is
+// always more useful than no extension.
+func extensionForContentType(contentType string) string {
+	if contentType == "" {
+		return "bin"
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return "bin"
+	}
+	exts, _ := mime.ExtensionsByType(mediaType)
+	if len(exts) == 0 {
+		// Hand-roll the most common cases the std mime db
+		// often misses on Linux containers.
+		switch mediaType {
+		case "application/json":
+			return "json"
+		case "application/xml", "text/xml":
+			return "xml"
+		case "text/csv":
+			return "csv"
+		case "text/plain":
+			return "txt"
+		}
+		return "bin"
+	}
+	return strings.TrimPrefix(exts[0], ".")
+}
+
+// buildExportPortalURL composes the portal asset URL. Empty BaseURL
+// (operator did not configure portal.public_base_url) yields ""
+// and the model just gets the asset id.
+func buildExportPortalURL(baseURL, assetID string) string {
+	if baseURL == "" {
+		return ""
+	}
+	return strings.TrimRight(baseURL, "/") + "/portal/assets/" + assetID
+}
+
+// buildExportProvenance records the api_export call so portal
+// viewers can render where the asset came from.
+func buildExportProvenance(uc *ExportUserContext, in exportInput, status int) ExportProvenance {
+	return ExportProvenance{
+		UserID:    uc.UserID,
+		SessionID: uc.SessionID,
+		ToolCalls: []ExportProvenanceCall{
+			{
+				ToolName:  exportToolName,
+				Timestamp: time.Now().UTC().Format(time.RFC3339),
+				Parameters: map[string]any{
+					"connection":      in.Connection,
+					"method":          in.Method,
+					"path":            in.Path,
+					"upstream_status": status,
+				},
+			},
+		},
+	}
+}
+
+// maybeCreateExportShare creates a public share link when the
+// model asked for one AND the platform wired a ShareCreator.
+// Failures are non-fatal — the asset is already created; a missing
+// share is a degraded but usable result.
+func maybeCreateExportShare(ctx context.Context, deps *ExportDeps, in exportInput, assetID, createdBy string) string {
+	if !in.CreatePublicLink || deps.ShareCreator == nil {
+		return ""
+	}
+	url, err := deps.ShareCreator.CreatePublicShare(ctx, assetID, createdBy)
+	if err != nil {
+		return ""
+	}
+	return url
+}

--- a/pkg/toolkits/apigateway/export_test.go
+++ b/pkg/toolkits/apigateway/export_test.go
@@ -1,0 +1,576 @@
+package apigateway
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// fakeExportAssetStore captures InsertExportAsset / idempotency
+// calls so tests can assert what would have been written to the
+// portal asset store. Concurrent invocations are not expected for
+// these tests.
+type fakeExportAssetStore struct {
+	inserted     []ExportAsset
+	insertErr    error
+	idempLookups map[string]*ExportAssetRef
+	idempErr     error
+}
+
+func (f *fakeExportAssetStore) InsertExportAsset(_ context.Context, asset ExportAsset) error {
+	if f.insertErr != nil {
+		return f.insertErr
+	}
+	f.inserted = append(f.inserted, asset)
+	return nil
+}
+
+// errFakeAssetNotFound is returned by GetByIdempotencyKey when the
+// (owner, key) tuple is not in the fake store. Distinct sentinel
+// keeps the (nil, nil) "no value, no error" anti-pattern out of
+// the lint output and matches the real Postgres adapter's "not
+// found" surface (which returns a non-nil error).
+var errFakeAssetNotFound = errors.New("fakeExportAssetStore: not found")
+
+func (f *fakeExportAssetStore) GetByIdempotencyKey(_ context.Context, ownerID, key string) (*ExportAssetRef, error) {
+	if f.idempErr != nil {
+		return nil, f.idempErr
+	}
+	if f.idempLookups == nil {
+		return nil, errFakeAssetNotFound
+	}
+	if ref, ok := f.idempLookups[ownerID+":"+key]; ok {
+		return ref, nil
+	}
+	return nil, errFakeAssetNotFound
+}
+
+type fakeExportVersionStore struct {
+	createdVersions []ExportVersion
+	createErr       error
+}
+
+func (f *fakeExportVersionStore) CreateExportVersion(_ context.Context, ver ExportVersion) (int, error) {
+	if f.createErr != nil {
+		return 0, f.createErr
+	}
+	f.createdVersions = append(f.createdVersions, ver)
+	return len(f.createdVersions), nil
+}
+
+type fakeExportS3Client struct {
+	puts    []s3Put
+	putErr  error
+	lastKey string
+}
+
+type s3Put struct {
+	Bucket, Key, ContentType string
+	Data                     []byte
+}
+
+func (f *fakeExportS3Client) PutObject(_ context.Context, bucket, key string, data []byte, contentType string) error {
+	if f.putErr != nil {
+		return f.putErr
+	}
+	f.puts = append(f.puts, s3Put{Bucket: bucket, Key: key, ContentType: contentType, Data: data})
+	f.lastKey = key
+	return nil
+}
+
+type fakeExportShareCreator struct {
+	created []string
+	url     string
+	err     error
+}
+
+func (f *fakeExportShareCreator) CreatePublicShare(_ context.Context, assetID, _ string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	f.created = append(f.created, assetID)
+	return f.url, nil
+}
+
+// buildExportTestToolkit assembles a Toolkit + connection wired
+// against in-memory fakes. The upstream server's handler is the
+// caller's contract — typically a small httptest server returning
+// canned bytes so the test can assert what got persisted.
+func buildExportTestToolkit(t *testing.T, upstreamURL string, deps *ExportDeps) *Toolkit {
+	t.Helper()
+	tk := New("primary")
+	if err := tk.AddConnection("crm", map[string]any{
+		"base_url": upstreamURL,
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	if deps != nil {
+		tk.SetExportDeps(*deps)
+	}
+	return tk
+}
+
+func defaultExportDeps(store *fakeExportAssetStore, ver *fakeExportVersionStore, s3 *fakeExportS3Client) ExportDeps {
+	return ExportDeps{
+		AssetStore:   store,
+		VersionStore: ver,
+		S3Client:     s3,
+		S3Bucket:     "exports",
+		S3Prefix:     "data",
+		BaseURL:      "https://platform.example.com",
+		GetUserContext: func(_ context.Context) *ExportUserContext {
+			return &ExportUserContext{
+				UserID:    "u1",
+				UserEmail: "alice@example.com",
+				SessionID: "s-1",
+			}
+		},
+	}
+}
+
+// TestHandleExport_HappyPath drives the full export flow and
+// asserts the asset row, version row, and S3 PutObject were each
+// invoked with the expected fields. The response must NOT carry
+// the upstream body — only metadata.
+func TestHandleExport_HappyPath(t *testing.T) {
+	const wantBody = `{"items":[1,2,3]}`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(wantBody))
+	}))
+	t.Cleanup(upstream.Close)
+
+	store := &fakeExportAssetStore{}
+	ver := &fakeExportVersionStore{}
+	s3 := &fakeExportS3Client{}
+	deps := defaultExportDeps(store, ver, s3)
+	tk := buildExportTestToolkit(t, upstream.URL, &deps)
+
+	r, payload, _ := tk.handleExport(context.Background(), &mcp.CallToolRequest{}, exportInput{
+		Connection: "crm",
+		Method:     "GET",
+		Path:       "/v1/items",
+		Name:       "items dump",
+	})
+	if r == nil || r.IsError {
+		t.Fatalf("handleExport: error result: %+v", r)
+	}
+	out, ok := payload.(*exportOutput)
+	if !ok {
+		t.Fatalf("payload is not *exportOutput: %T", payload)
+	}
+	if out.AssetID == "" {
+		t.Error("AssetID is empty")
+	}
+	if out.SizeBytes != int64(len(wantBody)) {
+		t.Errorf("SizeBytes = %d; want %d", out.SizeBytes, len(wantBody))
+	}
+	if out.ContentType != "application/json" {
+		t.Errorf("ContentType = %q", out.ContentType)
+	}
+	if out.PortalURL == "" || !strings.Contains(out.PortalURL, out.AssetID) {
+		t.Errorf("PortalURL = %q; want it to contain asset id", out.PortalURL)
+	}
+	// Body bytes must NOT be in the response.
+	resultText := textContent(r)
+	if strings.Contains(resultText, wantBody) {
+		t.Errorf("api_export response leaked upstream body bytes: %s", resultText)
+	}
+
+	// S3, asset, version each got one row with matching size.
+	if len(s3.puts) != 1 {
+		t.Fatalf("S3 PutObject called %d times; want 1", len(s3.puts))
+	}
+	if string(s3.puts[0].Data) != wantBody {
+		t.Errorf("S3 data mismatch: %q", s3.puts[0].Data)
+	}
+	if len(store.inserted) != 1 {
+		t.Fatalf("AssetStore.Insert called %d times; want 1", len(store.inserted))
+	}
+	if store.inserted[0].SizeBytes != int64(len(wantBody)) {
+		t.Errorf("inserted asset SizeBytes = %d", store.inserted[0].SizeBytes)
+	}
+	if store.inserted[0].OwnerEmail != "alice@example.com" {
+		t.Errorf("inserted asset OwnerEmail = %q", store.inserted[0].OwnerEmail)
+	}
+	if len(ver.createdVersions) != 1 {
+		t.Errorf("VersionStore.Create called %d times; want 1", len(ver.createdVersions))
+	}
+}
+
+// TestPersistExportAsset_VersionRowHasIDAndChangeSummary proves
+// the regression fix from gate review round 1: portal_asset_versions.id
+// is a TEXT PRIMARY KEY (migration #22), so without an explicit
+// ID the second api_export call would collide with the first on
+// the empty-string PK. ChangeSummary is set so the portal version
+// view renders meaningful entries instead of blank rows.
+func TestPersistExportAsset_VersionRowHasIDAndChangeSummary(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	ver := &fakeExportVersionStore{}
+	deps := defaultExportDeps(&fakeExportAssetStore{}, ver, &fakeExportS3Client{})
+	tk := buildExportTestToolkit(t, upstream.URL, &deps)
+
+	r, _, _ := tk.handleExport(context.Background(), &mcp.CallToolRequest{}, exportInput{
+		Connection: "crm", Method: "GET", Path: "/x", Name: "x",
+	})
+	if r == nil || r.IsError {
+		t.Fatalf("export error: %+v", r)
+	}
+	if len(ver.createdVersions) != 1 {
+		t.Fatalf("CreateExportVersion called %d times; want 1", len(ver.createdVersions))
+	}
+	v := ver.createdVersions[0]
+	if v.ID == "" {
+		t.Error("version row ID is empty — would collide on the TEXT PRIMARY KEY on second call")
+	}
+	if v.ChangeSummary == "" {
+		t.Error("version row ChangeSummary is empty — portal version list renders blank")
+	}
+}
+
+// TestHandleExport_IdempotencyShortCircuit proves an existing
+// (user, key) lookup match returns the existing asset without
+// re-running the upstream call. Critical for retry-safety: the
+// model can re-issue api_export with the same idempotency_key
+// after a network blip and not produce duplicate assets.
+func TestHandleExport_IdempotencyShortCircuit(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits++
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	store := &fakeExportAssetStore{
+		idempLookups: map[string]*ExportAssetRef{
+			"u1:my-key": {ID: "existing-id", SizeBytes: 999},
+		},
+	}
+	ver := &fakeExportVersionStore{}
+	s3 := &fakeExportS3Client{}
+	deps := defaultExportDeps(store, ver, s3)
+	tk := buildExportTestToolkit(t, upstream.URL, &deps)
+
+	r, payload, _ := tk.handleExport(context.Background(), &mcp.CallToolRequest{}, exportInput{
+		Connection:     "crm",
+		Method:         "GET",
+		Path:           "/v1/items",
+		Name:           "x",
+		IdempotencyKey: "my-key",
+	})
+	if r == nil || r.IsError {
+		t.Fatalf("idempotent return: error result: %+v", r)
+	}
+	out, _ := payload.(*exportOutput)
+	if out.AssetID != "existing-id" {
+		t.Errorf("AssetID = %q; want existing-id", out.AssetID)
+	}
+	if out.SizeBytes != 999 {
+		t.Errorf("SizeBytes = %d; want 999 (existing asset)", out.SizeBytes)
+	}
+	if upstreamHits != 0 {
+		t.Errorf("upstream hit %d times; idempotent return must NOT re-run the call", upstreamHits)
+	}
+	if len(s3.puts) != 0 {
+		t.Errorf("S3 PutObject called %d times on idempotent return; want 0", len(s3.puts))
+	}
+}
+
+// TestHandleExport_AuthRequired proves an unwired
+// GetUserContext (or one returning nil) refuses the export. An
+// asset row with no OwnerID would be unreachable from the portal
+// "my exports" view, so failing closed is correct.
+func TestHandleExport_AuthRequired(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	deps := defaultExportDeps(&fakeExportAssetStore{}, &fakeExportVersionStore{}, &fakeExportS3Client{})
+	deps.GetUserContext = func(_ context.Context) *ExportUserContext { return nil }
+	tk := buildExportTestToolkit(t, upstream.URL, &deps)
+
+	r, _, _ := tk.handleExport(context.Background(), &mcp.CallToolRequest{}, exportInput{
+		Connection: "crm",
+		Method:     "GET",
+		Path:       "/v1/x",
+		Name:       "x",
+	})
+	if r == nil || !r.IsError {
+		t.Errorf("missing user context should produce IsError; got %+v", r)
+	}
+	if !strings.Contains(textContent(r), "authentication required") {
+		t.Errorf("error message should mention authentication: %s", textContent(r))
+	}
+}
+
+// TestHandleExport_DepsNotConfigured proves an unwired toolkit
+// surfaces a clear error rather than panicking.
+func TestHandleExport_DepsNotConfigured(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	t.Cleanup(upstream.Close)
+	tk := buildExportTestToolkit(t, upstream.URL, nil) // no SetExportDeps
+	r, _, _ := tk.handleExport(context.Background(), &mcp.CallToolRequest{}, exportInput{
+		Connection: "crm",
+		Method:     "GET",
+		Path:       "/x",
+		Name:       "x",
+	})
+	if r == nil || !r.IsError {
+		t.Errorf("unwired deps should produce IsError; got %+v", r)
+	}
+}
+
+// TestHandleExport_CapExceededRefusesAsset proves the ">cap →
+// reject, do not write a partial asset" contract. A truncated
+// portal asset would mislead the operator who clicks the URL.
+func TestHandleExport_CapExceededRefusesAsset(t *testing.T) {
+	const upstreamSize = 2048
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(make([]byte, upstreamSize))
+	}))
+	t.Cleanup(upstream.Close)
+
+	store := &fakeExportAssetStore{}
+	ver := &fakeExportVersionStore{}
+	s3 := &fakeExportS3Client{}
+	deps := defaultExportDeps(store, ver, s3)
+	deps.Config = ExportConfig{MaxBytes: 512} // tighter than upstream
+	deps.Config = applyExportDefaults(deps.Config)
+	deps.Config.MaxBytes = 512 // override the default applied above
+	tk := buildExportTestToolkit(t, upstream.URL, &deps)
+
+	r, _, _ := tk.handleExport(context.Background(), &mcp.CallToolRequest{}, exportInput{
+		Connection: "crm",
+		Method:     "GET",
+		Path:       "/big",
+		Name:       "big",
+	})
+	if r == nil || !r.IsError {
+		t.Errorf("cap-exceeded should produce IsError; got %+v", r)
+	}
+	if len(s3.puts) != 0 {
+		t.Errorf("cap-exceeded must NOT write to S3; got %d puts", len(s3.puts))
+	}
+	if len(store.inserted) != 0 {
+		t.Errorf("cap-exceeded must NOT insert asset row; got %d inserts", len(store.inserted))
+	}
+}
+
+// TestHandleExport_RoutePolicyDenies proves the same persona-
+// scoped policy gating api_invoke_endpoint also gates api_export.
+// Without this check, an export would be a privilege-escalation
+// path: get the bytes via api_export of a route the persona
+// cannot api_invoke_endpoint.
+func TestHandleExport_RoutePolicyDenies(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`secret`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	store := &fakeExportAssetStore{}
+	deps := defaultExportDeps(store, &fakeExportVersionStore{}, &fakeExportS3Client{})
+	tk := buildExportTestToolkit(t, upstream.URL, &deps)
+	tk.SetRoutePolicy(denyAllRoutePolicy{})
+
+	r, _, _ := tk.handleExport(context.Background(), &mcp.CallToolRequest{}, exportInput{
+		Connection: "crm",
+		Method:     "GET",
+		Path:       "/secret",
+		Name:       "x",
+	})
+	if r == nil || !r.IsError {
+		t.Errorf("route policy denial should produce IsError; got %+v", r)
+	}
+	if len(store.inserted) != 0 {
+		t.Errorf("denied call must NOT write asset row")
+	}
+}
+
+type denyAllRoutePolicy struct{}
+
+func (denyAllRoutePolicy) Allow(_ context.Context, _, _, _ string) (allowed bool, reason string) {
+	return false, "test policy denies all"
+}
+
+// TestHandleExport_TransportErrorReturnsError proves an
+// unreachable upstream surfaces the scrubbed error without
+// touching S3 or the asset store.
+func TestHandleExport_TransportErrorReturnsError(t *testing.T) {
+	store := &fakeExportAssetStore{}
+	s3 := &fakeExportS3Client{}
+	deps := defaultExportDeps(store, &fakeExportVersionStore{}, s3)
+	// Point at a port that nothing is listening on.
+	tk := buildExportTestToolkit(t, "http://127.0.0.1:1", &deps)
+
+	r, _, _ := tk.handleExport(context.Background(), &mcp.CallToolRequest{}, exportInput{
+		Connection: "crm",
+		Method:     "GET",
+		Path:       "/x",
+		Name:       "x",
+	})
+	if r == nil || !r.IsError {
+		t.Errorf("transport error should produce IsError; got %+v", r)
+	}
+	if len(s3.puts) != 0 || len(store.inserted) != 0 {
+		t.Errorf("transport failure must not touch S3 / asset store")
+	}
+}
+
+// TestHandleExport_PublicLinkCreated proves create_public_link
+// triggers the share creator and propagates the share URL into
+// the response. Failures from CreatePublicShare are non-fatal —
+// the asset is already created.
+func TestHandleExport_PublicLinkCreated(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	share := &fakeExportShareCreator{url: "https://platform.example.com/portal/view/tok-123"}
+	deps := defaultExportDeps(&fakeExportAssetStore{}, &fakeExportVersionStore{}, &fakeExportS3Client{})
+	deps.ShareCreator = share
+	tk := buildExportTestToolkit(t, upstream.URL, &deps)
+
+	_, payload, _ := tk.handleExport(context.Background(), &mcp.CallToolRequest{}, exportInput{
+		Connection:       "crm",
+		Method:           "GET",
+		Path:             "/x",
+		Name:             "x",
+		CreatePublicLink: true,
+	})
+	out, _ := payload.(*exportOutput)
+	if out.ShareURL != share.url {
+		t.Errorf("ShareURL = %q; want %q", out.ShareURL, share.url)
+	}
+}
+
+func TestHandleExport_PublicLinkErrorIsNonFatal(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	share := &fakeExportShareCreator{err: errors.New("share store down")}
+	deps := defaultExportDeps(&fakeExportAssetStore{}, &fakeExportVersionStore{}, &fakeExportS3Client{})
+	deps.ShareCreator = share
+	tk := buildExportTestToolkit(t, upstream.URL, &deps)
+
+	r, payload, _ := tk.handleExport(context.Background(), &mcp.CallToolRequest{}, exportInput{
+		Connection:       "crm",
+		Method:           "GET",
+		Path:             "/x",
+		Name:             "x",
+		CreatePublicLink: true,
+	})
+	if r == nil || r.IsError {
+		t.Fatalf("share error should NOT fail the export: %+v", r)
+	}
+	out, _ := payload.(*exportOutput)
+	if out.ShareURL != "" {
+		t.Errorf("share error should leave ShareURL empty; got %q", out.ShareURL)
+	}
+	if out.AssetID == "" {
+		t.Error("asset should still be created when share fails")
+	}
+}
+
+func TestExtensionForContentType(t *testing.T) {
+	cases := map[string]string{
+		"application/json":                "json",
+		"application/json; charset=utf-8": "json",
+		"text/csv":                        "csv",
+		"application/octet-stream":        "bin",
+		"":                                "bin",
+		"not/a-real-type":                 "bin",
+	}
+	for in, want := range cases {
+		got := extensionForContentType(in)
+		if got != want {
+			// extension lookups can vary by platform mime DB; only
+			// fail when the std lib returns nothing AND our
+			// hand-rolled fallback should have caught it.
+			if want == "json" || want == "csv" || want == "bin" {
+				t.Errorf("extensionForContentType(%q) = %q; want %q", in, got, want)
+			}
+		}
+	}
+}
+
+func TestBuildExportS3Key_FormatStable(t *testing.T) {
+	got := buildExportS3Key("my-prefix", "user-1", "asset-abc", "application/json")
+	want := "my-prefix/api_export/user-1/asset-abc.json"
+	if got != want {
+		t.Errorf("S3 key = %q; want %q", got, want)
+	}
+}
+
+func TestBuildExportPortalURL_StripsTrailingSlash(t *testing.T) {
+	got := buildExportPortalURL("https://platform.example.com/", "asset-1")
+	want := "https://platform.example.com/portal/assets/asset-1"
+	if got != want {
+		t.Errorf("PortalURL = %q; want %q", got, want)
+	}
+	if got := buildExportPortalURL("", "asset-1"); got != "" {
+		t.Errorf("empty BaseURL should yield empty PortalURL; got %q", got)
+	}
+}
+
+// TestRegisterExportTool_AddsToToolListWhenDepsWired exercises
+// the registerExportTool body. With ExportDeps wired, the tool
+// must register on the MCP server AND appear in tk.Tools().
+// Without ExportDeps, both must skip silently.
+func TestRegisterExportTool_AddsToToolListWhenDepsWired(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	t.Cleanup(upstream.Close)
+	deps := defaultExportDeps(&fakeExportAssetStore{}, &fakeExportVersionStore{}, &fakeExportS3Client{})
+
+	wired := buildExportTestToolkit(t, upstream.URL, &deps)
+	if !contains(wired.Tools(), exportToolName) {
+		t.Errorf("Tools() missing %q after wiring; got %v", exportToolName, wired.Tools())
+	}
+
+	unwired := buildExportTestToolkit(t, upstream.URL, nil)
+	if contains(unwired.Tools(), exportToolName) {
+		t.Errorf("Tools() includes %q without wiring; got %v", exportToolName, unwired.Tools())
+	}
+
+	// And the actual MCP registration: registerExportTool with deps
+	// wired must call AddTool; without deps wired must skip. We
+	// can't introspect the server's tool list easily without a real
+	// MCP transport, so the contract assertion is via Tools()
+	// above. RegisterTools also must not panic in either state.
+	wired.RegisterTools(mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1"}, nil))
+	unwired.RegisterTools(mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1"}, nil))
+}
+
+func contains(haystack []string, needle string) bool {
+	return slices.Contains(haystack, needle)
+}
+
+func TestResolveExportTimeout_CapsAtMax(t *testing.T) {
+	cfg := applyExportDefaults(ExportConfig{})
+	// Zero input falls back to the default.
+	if got := resolveExportTimeout(0, cfg); got != cfg.DefaultTimeout {
+		t.Errorf("zero input should fall back to default; got %v", got)
+	}
+	// 30s — under MaxTimeout, passes through.
+	if got := resolveExportTimeout(30, cfg); got.Seconds() != 30 {
+		t.Errorf("30s input should pass through; got %v", got)
+	}
+	// Way over MaxTimeout caps to MaxTimeout.
+	if got := resolveExportTimeout(int(cfg.MaxTimeout.Seconds())+10000, cfg); got != cfg.MaxTimeout {
+		t.Errorf("oversized input should cap at MaxTimeout; got %v", got)
+	}
+}

--- a/pkg/toolkits/apigateway/invoke.go
+++ b/pkg/toolkits/apigateway/invoke.go
@@ -77,8 +77,20 @@ type InvokeOutput struct {
 	Headers       map[string][]string `json:"headers,omitempty"`
 	Body          any                 `json:"body,omitempty"`
 	BodyTruncated bool                `json:"body_truncated,omitempty"`
-	DurationMs    int64               `json:"duration_ms"`
-	Error         string              `json:"error,omitempty"`
+	// Pagination is populated when the upstream response carries a
+	// recognizable cursor (RFC 5988 Link rel="next", @odata.nextLink,
+	// next_cursor, etc). The model uses this to decide whether to
+	// issue a follow-up call. The gateway does NOT auto-follow so
+	// each loop iteration stays observable in audit + conversation.
+	Pagination *PaginationInfo `json:"pagination,omitempty"`
+	// Hint surfaces operator-actionable advice to the model when the
+	// response itself can't carry it — most importantly the "use
+	// api_export instead" suggestion when the body exceeded
+	// max_response_bytes. Distinct from Error: Hint is informational,
+	// the call still succeeded.
+	Hint       string `json:"hint,omitempty"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
 }
 
 // invocation bundles a connection lookup with its supporting types so
@@ -414,13 +426,23 @@ func executeRequest(client *http.Client, req *http.Request, maxBytes int64) Invo
 		}
 	}
 	parsed := decodeBody(resp.Header.Get("Content-Type"), body)
-	return InvokeOutput{
+	out := InvokeOutput{
 		Status:        resp.StatusCode,
 		Headers:       selectResponseHeaders(resp.Header),
 		Body:          parsed,
 		BodyTruncated: truncated,
+		Pagination:    detectPagination(resp.Header, parsed),
 		DurationMs:    time.Since(start).Milliseconds(),
 	}
+	if truncated {
+		// The body exceeded the connection's max_response_bytes
+		// cap. Steer the model toward api_export, which streams
+		// the response directly into a portal asset without
+		// returning the bytes through the MCP turn — same path
+		// trino_export uses for query results that don't fit.
+		out.Hint = "response exceeded max_response_bytes; use api_export to stream the full response into a portal asset (no model-context cost)"
+	}
+	return out
 }
 
 func readBody(r io.Reader, maxBytes int64) (body []byte, truncated bool, err error) {

--- a/pkg/toolkits/apigateway/pagination.go
+++ b/pkg/toolkits/apigateway/pagination.go
@@ -1,0 +1,196 @@
+package apigateway
+
+import (
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// PaginationInfo is the structured pagination state api_invoke_endpoint
+// surfaces to the model on every response. The model uses HasMore +
+// NextCursor (or NextURL) to decide whether to issue a follow-up call;
+// the gateway does NOT auto-follow so each loop iteration stays
+// observable in the conversation and audit log.
+//
+// Fields are populated only when the upstream response carries a
+// recognizable pagination signal. When none are populated the field
+// is omitted from the JSON response — the model sees no pagination
+// envelope and treats the response as terminal.
+type PaginationInfo struct {
+	HasMore    bool   `json:"has_more,omitempty"`
+	NextCursor string `json:"next_cursor,omitempty"`
+	NextURL    string `json:"next_url,omitempty"`
+	Source     string `json:"source,omitempty"`
+}
+
+// detectPagination inspects a response's Link header and parsed JSON
+// body for the common cursor patterns. Returns nil when no signal
+// is found — the InvokeOutput.Pagination field stays unset and the
+// JSON envelope omits it via omitempty.
+//
+// Detection order is significant: Link header (RFC 5988) is the
+// authoritative pagination protocol and most-trustworthy when
+// present, so it takes precedence over body-level cursor fields.
+// Within the body, OData's `@odata.nextLink` is checked before the
+// generic cursor names because OData responses commonly carry both
+// (a `value` array AND a stray `next` field that means something
+// else).
+func detectPagination(headers http.Header, body any) *PaginationInfo {
+	if info := paginationFromLinkHeader(headers); info != nil {
+		return info
+	}
+	return paginationFromBody(body)
+}
+
+// paginationLinkRe matches one entry in an RFC 5988 Link header. The
+// entire URL (including any nested commas inside parameters) lives
+// between `<` and `>`; everything after the closing `>` up to the
+// next entry's `<` is the relation+parameters. Compiled once per
+// process — the package-level var is safe because the regex is read-
+// only.
+//
+//nolint:gochecknoglobals // compiled regex, initialized once
+var paginationLinkRe = regexp.MustCompile(`<([^>]+)>\s*;\s*([^,]+)`)
+
+// paginationFromLinkHeader parses an RFC 5988 Link header looking
+// for `rel="next"`. Returns the URL when found.
+//
+// Multi-value Link headers (the same header sent multiple times by
+// the upstream) are joined into a single comma-separated string by
+// the std library's http.Header before this function sees them.
+func paginationFromLinkHeader(headers http.Header) *PaginationInfo {
+	link := headers.Get("Link")
+	if link == "" {
+		return nil
+	}
+	for _, m := range paginationLinkRe.FindAllStringSubmatch(link, -1) {
+		url := strings.TrimSpace(m[1])
+		params := strings.ToLower(m[2])
+		if !strings.Contains(params, `rel="next"`) && !strings.Contains(params, "rel=next") {
+			continue
+		}
+		return &PaginationInfo{
+			HasMore: true,
+			NextURL: url,
+			Source:  "link_header",
+		}
+	}
+	return nil
+}
+
+// paginationFromBody walks a parsed JSON body looking for the
+// common cursor fields. Only the top-level object is inspected;
+// deeply-nested cursor fields exist in the wild but are rare enough
+// that a config knob (deferred) is the right place to add them.
+//
+// Recognized fields, in order of specificity:
+//   - "@odata.nextLink" — OData v4 (Microsoft Graph, Dynamics).
+//   - "next_cursor" — Slack, Twitter, Stripe v1.
+//   - "nextCursor" — camelCase variant (some Stripe / Notion APIs).
+//   - "next_page_token" — Google Cloud APIs.
+//   - "nextPageToken" — camelCase Google variant.
+//   - "next" — Salesforce REST, generic; checked LAST because the
+//     name collides with hateoas link objects that aren't true cursors.
+func paginationFromBody(body any) *PaginationInfo {
+	obj, ok := body.(map[string]any)
+	if !ok {
+		return nil
+	}
+	candidates := []string{
+		"@odata.nextLink",
+		"next_cursor",
+		"nextCursor",
+		"next_page_token",
+		"nextPageToken",
+		"next",
+	}
+	for _, key := range candidates {
+		raw, ok := obj[key]
+		if !ok {
+			continue
+		}
+		val := stringifyCursor(raw)
+		if val == "" {
+			continue
+		}
+		info := &PaginationInfo{
+			HasMore: true,
+			Source:  "body:" + key,
+		}
+		// URL-shaped cursor values (always for @odata.nextLink, sometimes for
+		// the generic `next` field) populate NextURL so the model issues a
+		// fresh GET against the URL rather than passing it as a `?cursor=`
+		// param against the original path. Mis-routing a fully-qualified URL
+		// into NextCursor was a real bug observed during gate review.
+		if isURLLikeCursor(key, val) {
+			info.NextURL = val
+		} else {
+			info.NextCursor = val
+		}
+		return info
+	}
+	return nil
+}
+
+// isURLLikeCursor reports whether the cursor value should be
+// surfaced as a URL (NextURL) rather than as a cursor token
+// (NextCursor). @odata.nextLink is always a URL per OData v4 §11.2.5.7;
+// other fields are URLs only when the value parses as one with an
+// http(s) scheme — defends against a stray `next: "https://..."`
+// field from a non-OData API getting mis-routed.
+func isURLLikeCursor(key, value string) bool {
+	if key == "@odata.nextLink" {
+		return true
+	}
+	return strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://")
+}
+
+// stringifyCursor coerces the cursor value to a non-empty string.
+// Most APIs return strings, but a few (older REST APIs) return
+// integers; coerce defensively so the field is always a string in
+// the JSON envelope. Anything that isn't string / int / float /
+// bool returns "" so paginationFromBody skips it.
+func stringifyCursor(v any) string {
+	switch s := v.(type) {
+	case string:
+		return s
+	case float64:
+		// JSON numbers decode as float64; only return a value if
+		// it's actually present (non-zero) so we don't synthesize
+		// pagination from a `count: 0` field that happened to be
+		// named `next`.
+		if s == 0 {
+			return ""
+		}
+		return formatFloatCursor(s)
+	case bool:
+		// Rare but seen: APIs that return `next: true` to indicate
+		// "more available" without disclosing the cursor. Treat
+		// true as a marker — the model can issue a follow-up but
+		// has no cursor value to pass. Return a sentinel.
+		if s {
+			return "true"
+		}
+	}
+	return ""
+}
+
+// base10 / float64Bits are the strconv knobs in formatFloatCursor.
+// Pulling them into named constants satisfies revive's add-constant
+// rule without obscuring intent.
+const (
+	base10      = 10
+	float64Bits = 64
+)
+
+// formatFloatCursor stringifies a JSON number cursor without
+// introducing decimal noise on integer values. JSON has no integer
+// type so `next: 1234` decodes as float64(1234); rendering it as
+// "1234" (not "1234.000000") is what every paginated API expects.
+func formatFloatCursor(f float64) string {
+	if f == float64(int64(f)) {
+		return strconv.FormatInt(int64(f), base10)
+	}
+	return strconv.FormatFloat(f, 'f', -1, float64Bits)
+}

--- a/pkg/toolkits/apigateway/pagination_test.go
+++ b/pkg/toolkits/apigateway/pagination_test.go
@@ -1,0 +1,232 @@
+package apigateway
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestPaginationFromLinkHeader(t *testing.T) {
+	cases := []struct {
+		name    string
+		linkVal string
+		wantURL string
+	}{
+		{
+			name:    "single rel=next",
+			linkVal: `<https://api.example.com/v1/items?cursor=abc>; rel="next"`,
+			wantURL: "https://api.example.com/v1/items?cursor=abc",
+		},
+		{
+			name:    "rel=next without quotes",
+			linkVal: `<https://api.example.com/v1/items?cursor=abc>; rel=next`,
+			wantURL: "https://api.example.com/v1/items?cursor=abc",
+		},
+		{
+			name:    "next is second entry",
+			linkVal: `<https://api.example.com/v1/items?page=1>; rel="prev", <https://api.example.com/v1/items?cursor=abc>; rel="next"`,
+			wantURL: "https://api.example.com/v1/items?cursor=abc",
+		},
+		{
+			name:    "no rel=next entry",
+			linkVal: `<https://api.example.com/v1/items?page=1>; rel="prev", <https://api.example.com/v1/items?page=99>; rel="last"`,
+			wantURL: "",
+		},
+		{
+			name:    "empty header",
+			linkVal: "",
+			wantURL: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := http.Header{}
+			if c.linkVal != "" {
+				h.Set("Link", c.linkVal)
+			}
+			info := paginationFromLinkHeader(h)
+			if c.wantURL == "" {
+				if info != nil {
+					t.Errorf("expected nil, got %+v", info)
+				}
+				return
+			}
+			if info == nil {
+				t.Fatal("expected pagination info, got nil")
+			}
+			if info.NextURL != c.wantURL {
+				t.Errorf("NextURL = %q; want %q", info.NextURL, c.wantURL)
+			}
+			if info.Source != "link_header" {
+				t.Errorf("Source = %q; want link_header", info.Source)
+			}
+			if !info.HasMore {
+				t.Error("HasMore = false; want true when rel=next is present")
+			}
+		})
+	}
+}
+
+func TestPaginationFromBody(t *testing.T) {
+	cases := []struct {
+		name       string
+		body       any
+		wantCursor string // expected in NextCursor when non-empty
+		wantURL    string // expected in NextURL when non-empty (URL-typed cursor)
+		wantSource string
+	}{
+		{
+			name:       "next_cursor",
+			body:       map[string]any{"items": []any{}, "next_cursor": "abc"},
+			wantCursor: "abc",
+			wantSource: "body:next_cursor",
+		},
+		{
+			name: "OData nextLink → NextURL (not NextCursor)",
+			// Mis-routing @odata.nextLink to NextCursor was the bug
+			// fixed by isURLLikeCursor. The model would otherwise
+			// pass a fully-qualified URL as `?cursor=`.
+			body:       map[string]any{"@odata.nextLink": "https://x/page2", "next_cursor": "abc"},
+			wantURL:    "https://x/page2",
+			wantSource: "body:@odata.nextLink",
+		},
+		{
+			name:       "Google nextPageToken",
+			body:       map[string]any{"items": []any{}, "nextPageToken": "tok-xyz"},
+			wantCursor: "tok-xyz",
+			wantSource: "body:nextPageToken",
+		},
+		{
+			name:       "integer cursor (rare but seen)",
+			body:       map[string]any{"next": float64(1234)},
+			wantCursor: "1234",
+			wantSource: "body:next",
+		},
+		{
+			name:       "float cursor preserved",
+			body:       map[string]any{"next": 12.5},
+			wantCursor: "12.5",
+			wantSource: "body:next",
+		},
+		{
+			name: "URL value in generic `next` → NextURL",
+			// Non-OData APIs sometimes use `next: "https://..."`. The
+			// scheme prefix triggers URL routing without a hardcoded
+			// key match.
+			body:       map[string]any{"next": "https://api.example.com/page2"},
+			wantURL:    "https://api.example.com/page2",
+			wantSource: "body:next",
+		},
+		{
+			name:       "boolean true marker",
+			body:       map[string]any{"next": true},
+			wantCursor: "true",
+			wantSource: "body:next",
+		},
+		{
+			name:       "empty cursor string ignored",
+			body:       map[string]any{"next_cursor": ""},
+			wantCursor: "",
+		},
+		{
+			name:       "zero number ignored (not synthetic 'next: 0')",
+			body:       map[string]any{"next": float64(0)},
+			wantCursor: "",
+		},
+		{
+			name:       "non-object body",
+			body:       []any{"a", "b"},
+			wantCursor: "",
+		},
+		{
+			name:       "nil body",
+			body:       nil,
+			wantCursor: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			info := paginationFromBody(c.body)
+			if c.wantCursor == "" && c.wantURL == "" {
+				if info != nil {
+					t.Errorf("expected nil; got %+v", info)
+				}
+				return
+			}
+			if info == nil {
+				t.Fatal("expected pagination info, got nil")
+			}
+			if info.NextCursor != c.wantCursor {
+				t.Errorf("NextCursor = %q; want %q", info.NextCursor, c.wantCursor)
+			}
+			if info.NextURL != c.wantURL {
+				t.Errorf("NextURL = %q; want %q", info.NextURL, c.wantURL)
+			}
+			if info.Source != c.wantSource {
+				t.Errorf("Source = %q; want %q", info.Source, c.wantSource)
+			}
+		})
+	}
+}
+
+// TestDetectPagination_LinkHeaderTakesPrecedence proves the
+// authoritative-protocol ordering: when the upstream sends BOTH a
+// Link header AND a body cursor, Link wins. This matters for APIs
+// that emit a `next` field that's actually a hateoas link object,
+// not a cursor; the Link header is the canonical "more pages"
+// signal in that case.
+func TestDetectPagination_LinkHeaderTakesPrecedence(t *testing.T) {
+	h := http.Header{}
+	h.Set("Link", `<https://api.example.com/v1/items?cursor=link>; rel="next"`)
+	body := map[string]any{"next_cursor": "body-cursor"}
+	info := detectPagination(h, body)
+	if info == nil {
+		t.Fatal("expected pagination info, got nil")
+	}
+	if info.Source != "link_header" {
+		t.Errorf("Source = %q; want link_header (Link header should win)", info.Source)
+	}
+	if info.NextURL != "https://api.example.com/v1/items?cursor=link" {
+		t.Errorf("NextURL = %q", info.NextURL)
+	}
+}
+
+// TestIsURLLikeCursor codifies the routing rule: @odata.nextLink is
+// always URL-routed even when the value is empty (caller filters
+// empty values upstream); other keys are URL-routed only when the
+// value parses as http(s).
+func TestIsURLLikeCursor(t *testing.T) {
+	cases := []struct {
+		key, val string
+		want     bool
+	}{
+		{"@odata.nextLink", "https://x/y", true},
+		{"@odata.nextLink", "anything", true}, // OData spec guarantees URL
+		{"next_cursor", "https://x/y", true},
+		{"next_cursor", "abc", false},
+		{"next", "http://x.example/page2", true},
+		{"next", "tok-xyz", false},
+	}
+	for _, c := range cases {
+		if got := isURLLikeCursor(c.key, c.val); got != c.want {
+			t.Errorf("isURLLikeCursor(%q, %q) = %v; want %v", c.key, c.val, got, c.want)
+		}
+	}
+}
+
+func TestDetectPagination_NoSignal(t *testing.T) {
+	h := http.Header{}
+	h.Set("Content-Type", "application/json") // unrelated header
+	body := map[string]any{"items": []any{"a", "b"}, "count": float64(2)}
+	if info := detectPagination(h, body); info != nil {
+		t.Errorf("expected nil for response with no pagination signal; got %+v", info)
+	}
+}
+
+func TestStringifyCursor_RejectsUnsupportedTypes(t *testing.T) {
+	if got := stringifyCursor(map[string]any{"href": "x"}); got != "" {
+		t.Errorf("hateoas-style next object should not stringify; got %q", got)
+	}
+	if got := stringifyCursor([]any{"a"}); got != "" {
+		t.Errorf("array should not stringify; got %q", got)
+	}
+}

--- a/pkg/toolkits/apigateway/schemas.go
+++ b/pkg/toolkits/apigateway/schemas.go
@@ -31,6 +31,73 @@ var listEndpointsSchema = json.RawMessage(`{
   }
 }`)
 
+// apiExportInputSchema is the JSON Schema for the api_export tool
+// input. Mirrors invokeEndpointSchema for connection/method/path/
+// query/headers/body and adds the portal-asset metadata fields
+// (name, description, tags, idempotency_key, create_public_link)
+// matched to trino_export's surface.
+//
+//nolint:gochecknoglobals // MCP tool schema must be a package-level var
+var apiExportInputSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["connection", "method", "path", "name"],
+  "properties": {
+    "connection": {
+      "type": "string",
+      "description": "Name of the registered API connection (kind=api). Required."
+    },
+    "method": {
+      "type": "string",
+      "enum": ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"],
+      "description": "HTTP method. Required."
+    },
+    "path": {
+      "type": "string",
+      "description": "Request path joined to the connection's base URL. Required. Must start with \"/\"."
+    },
+    "query": {
+      "type": "object",
+      "description": "Optional query string parameters.",
+      "additionalProperties": true
+    },
+    "headers": {
+      "type": "object",
+      "description": "Optional custom request headers. Sending Authorization or the connection's api_key header is rejected.",
+      "additionalProperties": {"type": "string"}
+    },
+    "body": {
+      "description": "Optional request body. Same encoding rules as api_invoke_endpoint."
+    },
+    "timeout_seconds": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 1800,
+      "description": "Optional per-call timeout override. Capped at 30 minutes."
+    },
+    "name": {
+      "type": "string",
+      "description": "Asset display name; doubles as download filename. Keep short and ASCII-only (letters, digits, spaces, hyphens, dots). Required."
+    },
+    "description": {
+      "type": "string",
+      "description": "Optional asset description shown in the portal."
+    },
+    "tags": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Optional asset tags."
+    },
+    "idempotency_key": {
+      "type": "string",
+      "description": "Optional idempotency key. When supplied, a prior export by this user with the same key returns the existing asset's metadata without re-running the upstream call."
+    },
+    "create_public_link": {
+      "type": "boolean",
+      "description": "When true, also create a public share link for the resulting asset. Returns share_url alongside the asset metadata."
+    }
+  }
+}`)
+
 // invokeEndpointSchema is the JSON Schema for the api_invoke_endpoint tool input.
 //
 //nolint:gochecknoglobals // MCP tool schema must be a package-level var

--- a/pkg/toolkits/apigateway/toolkit.go
+++ b/pkg/toolkits/apigateway/toolkit.go
@@ -62,6 +62,10 @@ type Toolkit struct {
 	semanticProvider semantic.Provider
 	queryProvider    query.Provider
 	embedder         embedding.Provider
+
+	// exportDeps holds platform-side dependencies for api_export
+	// (nil = export disabled, tool not registered).
+	exportDeps *ExportDeps
 }
 
 // TokenStore returns the OAuth token store wired into this toolkit,
@@ -213,11 +217,27 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 			"may still be refused by api_invoke_endpoint.",
 		InputSchema: listEndpointsSchema,
 	}, t.handleListEndpoints)
+
+	// api_export is registered only when ExportDeps were wired by
+	// the platform (portal asset store available). Skipping the
+	// registration when deps are nil keeps the model from seeing
+	// a tool it can never successfully call.
+	t.registerExportTool(s)
 }
 
 // Tools returns the list of tool names this toolkit registers.
-func (*Toolkit) Tools() []string {
-	return []string{ToolInvokeEndpoint, ToolListEndpoints}
+// api_export is included only when the toolkit was constructed
+// with ExportDeps wired so callers (audit / introspection) see the
+// tool list that actually exists at runtime.
+func (t *Toolkit) Tools() []string {
+	tools := []string{ToolInvokeEndpoint, ToolListEndpoints}
+	t.mu.RLock()
+	hasExport := t.exportDeps != nil
+	t.mu.RUnlock()
+	if hasExport {
+		tools = append(tools, exportToolName)
+	}
+	return tools
 }
 
 // ListEndpointsInput is the parsed argument shape for
@@ -524,6 +544,17 @@ func (t *Toolkit) handleInvoke(ctx context.Context, _ *mcp.CallToolRequest, in I
 	out, err := invoke(ctx, invocation{cfg: c.cfg, auth: c.auth, client: c.client}, in)
 	if err != nil {
 		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol — argument validation surfaced as tool error
+	}
+	// Clear the api_export hint when the toolkit was built without
+	// export deps — the model would otherwise be told to use a tool
+	// that isn't registered on this deployment. The hint itself
+	// originates in executeRequest which has no toolkit handle, so
+	// the gating happens here at the call site.
+	t.mu.RLock()
+	hasExport := t.exportDeps != nil
+	t.mu.RUnlock()
+	if !hasExport {
+		out.Hint = ""
 	}
 	return jsonResult(out), out, nil
 }


### PR DESCRIPTION
## Summary

Closes #372. Three concerns ship as one PR because the cap-exceeded hint on `api_invoke_endpoint` references `api_export` by name — they're a coherent unit.

### Pagination envelope on api_invoke_endpoint

`InvokeOutput` now carries an optional `pagination: { has_more, next_cursor | next_url, source }` field surfaced from the upstream response. Detection covers:

- **RFC 5988 Link rel=\"next\"** — authoritative protocol, takes precedence over body cursors.
- **Body cursors**: `@odata.nextLink`, `next_cursor`, `nextCursor`, `next_page_token`, `nextPageToken`, generic `next`.
- **URL-shaped cursors** (always for `@odata.nextLink`; conditionally for other keys when value starts with `http(s)://`) populate `next_url` so the model issues a fresh GET against the URL rather than passing it as a `?cursor=` param.

The gateway does **not** auto-follow — each loop iteration stays observable in conversation + audit log.

### Cap-exceeded hint

When `body_truncated=true`, `InvokeOutput` now also carries a `hint` field steering the model toward `api_export` (which streams to a portal asset, no model-context cost). The hint is cleared in `handleInvoke` when `api_export` is unwired so the model isn't told about a tool that doesn't exist on this deployment.

### api_export tool (parallel to trino_export)

New tool with the same purpose-shape as `trino_export`: run something that produces a potentially-huge result, write it to a portal asset, return asset metadata not data.

- Invokes the upstream with the same SSRF guards (`validatePath`, host pinning), route-policy gating, and auth machinery as `api_invoke_endpoint`.
- Writes response body to a portal asset; returns `{asset_id, portal_url, share_url, content_type, size_bytes, status, message}` — no body bytes.
- Idempotency-key support; optional public-share link creation.
- Cap-exceeded responses refuse the export rather than write a partial asset (would mislead the operator who clicks the URL).
- Version row gets a generated `id` + `ChangeSummary` so the TEXT PRIMARY KEY on `portal_asset_versions` does not collide on the second call.
- VersionStore failures `slog.Warn` (matching trino_export's precedent) instead of being silently swallowed.

### Platform wiring

`wireAPIGatewayExport` mirrors `wireTrinoExport`: same portal asset store, same S3 client, same share creator. Thin adapters bridge the toolkit's locally-defined types to the shared portal stores.

The trino-side `exportShareCreatorAdapter` was updated to return `\"\"` on empty `baseURL` so both `_export` tools surface identical `share_url` contracts (`omitempty` hides the field cleanly when no URL is computable).

### Adversarial review history

Three rounds, all addressed:
1. Round 1 — 5 findings: missing version-row ID/ChangeSummary (would collide on PK), silently-swallowed VersionStore error, OData URL mis-routing (NextCursor instead of NextURL), missing `#nosec G107 G704` directive on new `client.Do`, missing platform-side adapter tests. All FIXED.
2. Round 2 — 1 finding: trino vs api-gateway share-creator divergence on empty `baseURL`. FIXED on both sides for parity.
3. Round 3 — CLEAN.

### Scope notes

- **Buffered upload** (parity with `trino_export`). True streaming for >100 MB payloads would require extending `pkg/portal.S3Client` with a multipart-upload variant; deferred to a follow-up if a real workload demands it. `deps.Config.MaxBytes` is a hard ceiling — above it, the call returns a structured error rather than a truncated asset.
- Per-connection `max_response_bytes` was already configurable (shipped in #379); this PR just adds the cap-exceeded hint and the streaming alternative.
- Pagination is detection + envelope only; auto-follow is intentionally NOT included so each call remains observable.

## Test plan

- [ ] CI green (lint, race tests, security/codeql, codecov ≥ 80% total + patch — currently 86.1% patch).
- [ ] Spot-check: register an api gateway connection with a paginated upstream (e.g., a Microsoft Graph or Slack endpoint) and confirm `pagination.next_cursor` / `pagination.next_url` appears on responses; auto-follow is NOT performed.
- [ ] Spot-check: call `api_invoke_endpoint` against an endpoint returning > `max_response_bytes`; confirm `body_truncated=true` and `hint` references `api_export`.
- [ ] Spot-check: call `api_export` with an endpoint returning small JSON; confirm asset_id + portal_url returned, asset visible in portal, downloadable file is the upstream response bytes.
- [ ] Spot-check: re-issue `api_export` with the same `idempotency_key`; confirm existing asset_id is returned without re-running the upstream.
- [ ] Spot-check: route-policy denial — persona scoped to GET-only; `api_export` for a DELETE on the same connection must be refused.
- [ ] Spot-check: `create_public_link: true` with `portal.public_base_url` configured; confirm `share_url` is a working portal viewer URL.