### PR TITLE
feat(portal): admin-portal form for kind=api connections

### DIFF
--- a/ui/src/api/admin/hooks.ts
+++ b/ui/src/api/admin/hooks.ts
@@ -750,6 +750,25 @@ export function useStartGatewayOAuth() {
   });
 }
 
+// useStartAPIGatewayOAuth kicks off the authorization_code flow for
+// an HTTP API gateway connection (kind=api). Mirrors useStartGatewayOAuth
+// but targets the api-gateway-specific admin route. Returns the
+// authorization URL the operator's browser should be redirected to;
+// the upstream IdP will redirect back to /api/v1/admin/api-gateway/oauth/callback
+// after authentication.
+export function useStartAPIGatewayOAuth() {
+  return useMutation({
+    mutationFn: ({ name, returnURL }: { name: string; returnURL?: string }) =>
+      apiFetch<import("./types").GatewayOAuthStartResponse>(
+        `/api-gateway/connections/${name}/oauth-start`,
+        {
+          method: "POST",
+          body: JSON.stringify({ return_url: returnURL ?? "" }),
+        },
+      ),
+  });
+}
+
 export function useEnrichmentRules(connection: string, enabled = true) {
   return useQuery({
     queryKey: ["enrichment-rules", connection],

--- a/ui/src/pages/settings/ConnectionsPanel.tsx
+++ b/ui/src/pages/settings/ConnectionsPanel.tsx
@@ -3,6 +3,7 @@ import {
   useEffectiveConnections,
   useSetConnectionInstance,
   useDeleteConnectionInstance,
+  useStartAPIGatewayOAuth,
   useSystemInfo,
 } from "@/api/admin/hooks";
 import type { EffectiveConnection } from "@/api/admin/types";
@@ -48,6 +49,7 @@ const KIND_COLORS: Record<string, string> = {
   datahub: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
   s3: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
   mcp: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400",
+  api: "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-400",
 };
 
 function kindColor(kind: string): string {
@@ -489,7 +491,7 @@ interface EditorProps {
   onDirtyChange: (dirty: boolean) => void;
 }
 
-const AVAILABLE_KINDS = ["trino", "s3", "mcp"];
+const AVAILABLE_KINDS = ["trino", "s3", "mcp", "api"];
 
 function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: EditorProps) {
   const isCreate = !connection;
@@ -664,6 +666,14 @@ function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: Edito
             )}
             {kind === "mcp" && (
               <GatewayConfigForm config={configObj} onChange={setConfigObj} />
+            )}
+            {kind === "api" && (
+              <ApiGatewayConfigForm
+                config={configObj}
+                onChange={setConfigObj}
+                connectionName={name}
+                isCreate={isCreate}
+              />
             )}
           </div>
         </div>
@@ -1184,6 +1194,317 @@ function GatewayConfigForm({ config, onChange }: ConfigFormProps) {
         </select>
         <p className="mt-1 text-xs text-muted-foreground">
           Reserved for future content-fencing of upstream responses. Leave at "untrusted" unless you control the upstream.
+        </p>
+      </div>
+    </>
+  );
+}
+
+// ApiGatewayConfigForm renders the editor for kind=api connections —
+// the HTTP API gateway. Field shape matches the apigateway toolkit
+// config (see pkg/toolkits/apigateway/config.go): base_url, optional
+// openapi_spec, the same auth_mode set the toolkit accepts (none,
+// bearer, api_key, oauth2_client_credentials, oauth2_authorization_code),
+// timeouts, max_response_bytes, and the OAuth Connect button when
+// authorization_code is selected.
+//
+// The Connect button is wired to the admin /api-gateway/connections/
+// {name}/oauth-start endpoint shipped in #381; clicking it opens the
+// IdP authorization URL in a new tab so the operator completes the
+// browser flow without losing the editor's unsaved state.
+function ApiGatewayConfigForm({
+  config,
+  onChange,
+  connectionName,
+  isCreate,
+}: ConfigFormProps & { connectionName: string; isCreate: boolean }) {
+  const startOAuth = useStartAPIGatewayOAuth();
+  const [oauthError, setOAuthError] = useState<string | null>(null);
+  const handleConnect = useCallback(() => {
+    setOAuthError(null);
+    if (!connectionName) {
+      setOAuthError("Save the connection first, then click Connect.");
+      return;
+    }
+    startOAuth.mutate(
+      { name: connectionName, returnURL: window.location.pathname },
+      {
+        onSuccess: (resp) => {
+          // Open the IdP authorization URL in a new tab so the
+          // editor's unsaved fields survive the round-trip; the
+          // callback handler redirects the new tab back to the
+          // portal after persisting tokens.
+          window.open(resp.authorization_url, "_blank", "noopener,noreferrer");
+        },
+        onError: (err) => {
+          setOAuthError(err instanceof Error ? err.message : "Connect failed");
+        },
+      },
+    );
+  }, [connectionName, startOAuth]);
+
+  return (
+    <>
+      <ConfigField
+        label="Base URL"
+        help="HTTPS URL of the upstream API (no trailing slash)."
+        value={String(config.base_url ?? "")}
+        onChange={(v) => onChange(update(config, "base_url", v))}
+        placeholder="https://api.vendor.example.com"
+        mono
+      />
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="mb-1 block text-xs font-medium">Auth mode</label>
+          <select
+            value={String(config.auth_mode ?? "none")}
+            onChange={(e) => onChange(update(config, "auth_mode", e.target.value))}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none ring-ring focus:ring-2"
+          >
+            <option value="none">None</option>
+            <option value="bearer">Bearer token</option>
+            <option value="api_key">API key</option>
+            <option value="oauth2_client_credentials">OAuth 2.1 — client_credentials</option>
+            <option value="oauth2_authorization_code">OAuth 2.1 — authorization_code (browser sign-in)</option>
+          </select>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Bearer sends Authorization; API key sends a header or query param. OAuth client_credentials is machine-to-machine; authorization_code requires a one-time browser sign-in via Connect.
+          </p>
+        </div>
+        <ConfigField
+          label="Connection name"
+          help="Optional override; defaults to the instance name above."
+          value={String(config.connection_name ?? "")}
+          onChange={(v) => onChange(update(config, "connection_name", v))}
+          placeholder={connectionName || "vendor"}
+          mono
+        />
+      </div>
+
+      {config.auth_mode === "bearer" && (
+        <ConfigField
+          label="Credential"
+          help="Bearer token. Encrypted at rest when ENCRYPTION_KEY is set. Use [REDACTED] when re-saving without changing it."
+          value={String(config.credential ?? "")}
+          onChange={(v) => onChange(update(config, "credential", v))}
+          sensitive
+        />
+      )}
+
+      {config.auth_mode === "api_key" && (
+        <div className="rounded-md border bg-muted/20 px-3 py-3 space-y-3">
+          <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            API key
+          </div>
+          <ConfigField
+            label="Credential"
+            help="The API key value. Encrypted at rest. Use [REDACTED] to keep an existing value when re-saving."
+            value={String(config.credential ?? "")}
+            onChange={(v) => onChange(update(config, "credential", v))}
+            sensitive
+          />
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="mb-1 block text-xs font-medium">Placement</label>
+              <select
+                value={String(config.api_key_placement ?? "header")}
+                onChange={(e) => onChange(update(config, "api_key_placement", e.target.value))}
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none ring-ring focus:ring-2"
+              >
+                <option value="header">Header</option>
+                <option value="query">Query string</option>
+              </select>
+            </div>
+            {config.api_key_placement === "query" ? (
+              <ConfigField
+                label="Query parameter name"
+                help="e.g. api_key, apikey, key."
+                value={String(config.api_key_param ?? "")}
+                onChange={(v) => onChange(update(config, "api_key_param", v))}
+                placeholder="api_key"
+                mono
+              />
+            ) : (
+              <ConfigField
+                label="Header name"
+                help="Defaults to X-API-Key."
+                value={String(config.api_key_header ?? "")}
+                onChange={(v) => onChange(update(config, "api_key_header", v))}
+                placeholder="X-API-Key"
+                mono
+              />
+            )}
+          </div>
+        </div>
+      )}
+
+      {(config.auth_mode === "oauth2_client_credentials" ||
+        config.auth_mode === "oauth2_authorization_code") && (
+        <div className="rounded-md border bg-muted/20 px-3 py-3 space-y-3">
+          <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            OAuth 2.1 — {config.auth_mode === "oauth2_authorization_code" ? "authorization_code" : "client_credentials"}
+          </div>
+          <ConfigField
+            label="Token URL"
+            help="OAuth token endpoint."
+            value={String(config.oauth2_token_url ?? "")}
+            onChange={(v) => onChange(update(config, "oauth2_token_url", v))}
+            placeholder="https://idp.example.com/oauth/token"
+            mono
+          />
+          {config.auth_mode === "oauth2_authorization_code" && (
+            <ConfigField
+              label="Authorization URL"
+              help="Where the browser is sent to sign in."
+              value={String(config.oauth2_authorization_url ?? "")}
+              onChange={(v) => onChange(update(config, "oauth2_authorization_url", v))}
+              placeholder="https://idp.example.com/oauth/authorize"
+              mono
+            />
+          )}
+          <div className="grid grid-cols-2 gap-3">
+            <ConfigField
+              label="Client ID"
+              value={String(config.oauth2_client_id ?? "")}
+              onChange={(v) => onChange(update(config, "oauth2_client_id", v))}
+              placeholder="platform-client"
+              mono
+            />
+            <ConfigField
+              label="Client Secret"
+              help="Encrypted at rest. Use [REDACTED] to keep the existing value when re-saving."
+              value={String(config.oauth2_client_secret ?? "")}
+              onChange={(v) => onChange(update(config, "oauth2_client_secret", v))}
+              sensitive
+            />
+          </div>
+          <ConfigField
+            label="Scopes"
+            help="Space-delimited scope string. Leave empty if the IdP does not require it."
+            value={String(
+              Array.isArray(config.oauth2_scopes)
+                ? (config.oauth2_scopes as string[]).join(" ")
+                : (config.oauth2_scopes ?? ""),
+            )}
+            onChange={(v) =>
+              onChange(update(config, "oauth2_scopes", v.trim() ? v.split(/\s+/) : []))
+            }
+            placeholder="read:users write:orders"
+            mono
+          />
+          <div>
+            <label className="mb-1 block text-xs font-medium">Endpoint auth style</label>
+            <select
+              value={String(config.oauth2_endpoint_auth_style ?? "header")}
+              onChange={(e) => onChange(update(config, "oauth2_endpoint_auth_style", e.target.value))}
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none ring-ring focus:ring-2"
+            >
+              <option value="header">Header (HTTP Basic) — OAuth 2.1 default</option>
+              <option value="params">Form params — some IdPs require this</option>
+            </select>
+          </div>
+          {config.auth_mode === "oauth2_authorization_code" && (
+            <>
+              <div>
+                <label className="mb-1 block text-xs font-medium">OIDC prompt</label>
+                <select
+                  value={String(config.oauth2_prompt ?? "")}
+                  onChange={(e) => onChange(update(config, "oauth2_prompt", e.target.value))}
+                  className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none ring-ring focus:ring-2"
+                >
+                  <option value="">(default — no prompt parameter)</option>
+                  <option value="login">login (force fresh credentials each Connect)</option>
+                  <option value="consent">consent (force consent screen)</option>
+                  <option value="select_account">select_account (force account picker)</option>
+                  <option value="none">none (silent auth)</option>
+                </select>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Leave default for non-OIDC OAuth providers that reject unknown parameters. Use <code>login</code> for Keycloak / Auth0 / Okta to defeat stale-form bugs by forcing a fresh credential prompt on every Connect.
+                </p>
+              </div>
+              <div className="rounded-md border border-dashed bg-background px-3 py-3 space-y-2">
+                <p className="text-xs">
+                  <strong>Connect</strong> opens the IdP sign-in page in a new tab. After the
+                  browser flow completes, the platform persists the refresh token (encrypted)
+                  so subsequent tool calls refresh access tokens silently.
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Save the connection first; Connect needs the connection registered before
+                  the IdP redirect can find it.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleConnect}
+                  disabled={isCreate || startOAuth.isPending || !connectionName}
+                  className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {startOAuth.isPending ? "Opening IdP…" : "Connect"}
+                </button>
+                {oauthError && (
+                  <p className="text-xs text-red-600 dark:text-red-400">{oauthError}</p>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      <div>
+        <label className="mb-1 block text-xs font-medium">OpenAPI spec (optional)</label>
+        <textarea
+          value={String(config.openapi_spec ?? "")}
+          onChange={(e) => onChange(update(config, "openapi_spec", e.target.value))}
+          placeholder="openapi: 3.0.0&#10;info:&#10;  title: Vendor API&#10;  version: '1'&#10;paths:&#10;  /v1/users:&#10;    get:&#10;      operationId: list-users&#10;      summary: List users&#10;      responses:&#10;        '200':&#10;          description: ok"
+          rows={8}
+          className="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono outline-none ring-ring focus:ring-2"
+        />
+        <p className="mt-1 text-xs text-muted-foreground">
+          Paste the upstream's OpenAPI 3.x document (YAML or JSON) to enable
+          <code className="mx-1">api_list_endpoints</code>. Without a spec the model can still call
+          <code className="mx-1">api_invoke_endpoint</code> with explicit method+path.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <ConfigField
+          label="Connect timeout"
+          help="Initial dial timeout (e.g. 10s, 1m)."
+          value={String(config.connect_timeout ?? "")}
+          onChange={(v) => onChange(update(config, "connect_timeout", v))}
+          placeholder="10s"
+          mono
+        />
+        <ConfigField
+          label="Call timeout"
+          help="Per-call upstream timeout (e.g. 60s)."
+          value={String(config.call_timeout ?? "")}
+          onChange={(v) => onChange(update(config, "call_timeout", v))}
+          placeholder="60s"
+          mono
+        />
+      </div>
+
+      <ConfigField
+        label="Max response bytes"
+        help="Cap on response body size returned through api_invoke_endpoint. Above this, the call sets body_truncated=true and hints the model toward api_export. Default 10485760 (10 MiB)."
+        type="number"
+        value={String(config.max_response_bytes ?? "")}
+        onChange={(v) => onChange(update(config, "max_response_bytes", v ? Number(v) : undefined))}
+        placeholder="10485760"
+      />
+
+      <div>
+        <label className="mb-1 block text-xs font-medium">Trust level</label>
+        <select
+          value={String(config.trust_level ?? "untrusted")}
+          onChange={(e) => onChange(update(config, "trust_level", e.target.value))}
+          className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none ring-ring focus:ring-2"
+        >
+          <option value="untrusted">Untrusted (default)</option>
+          <option value="trusted">Trusted</option>
+        </select>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Reserved for future content-fencing of upstream responses.
         </p>
       </div>
     </>


### PR DESCRIPTION
## Summary

Adds the portal connection-add UI for the HTTP API gateway (`kind=api`) so admins can register and edit api connections from Settings → Connections, including the OAuth authorization-code Connect flow.

## What ships

- **`api` in the connection kind dropdown**, alongside `trino`/`s3`/`mcp`. Indigo color badge in the connection list.
- **`ApiGatewayConfigForm`** — a per-kind editor matching every field the apigateway toolkit's `ParseConfig` accepts:
  - `base_url` (required)
  - `auth_mode` with all 5 modes: `none`, `bearer`, `api_key`, `oauth2_client_credentials`, `oauth2_authorization_code`
  - Per-mode credential sub-forms: bearer token, API key (header/query placement + header name/param name), OAuth2 (token URL, authorization URL, client ID/secret, scopes, endpoint auth style, OIDC prompt)
  - **Connect button** (authorization_code only) wired to `POST /api/v1/admin/api-gateway/connections/{name}/oauth-start` — opens the IdP authorization URL in a new tab so the editor's unsaved state survives the round-trip
  - `openapi_spec` textarea (optional; enables `api_list_endpoints`)
  - `connect_timeout`, `call_timeout`, `max_response_bytes`, `trust_level`, `connection_name`
- **`useStartAPIGatewayOAuth`** hook in `ui/src/api/admin/hooks.ts` mirrors `useStartGatewayOAuth` but targets the api-gateway-specific admin route.
- `[REDACTED]`-on-resave round-trip works for `credential` and `oauth2_client_secret` (both already in the backend's `connectionSensitiveKeys` list).

## Test plan

- [ ] `make verify` green; UI builds.
- [ ] In the portal: Settings → Connections → "Add Connection" — confirm "api" appears in the kind dropdown.
- [ ] Pick `api`, fill `base_url`, save with `auth_mode: none` — confirm the connection registers and `api_invoke_endpoint` works.
- [ ] Edit a saved api connection, switch to `auth_mode: oauth2_authorization_code`, fill OAuth2 fields, save, click **Connect** — confirm new tab opens IdP, callback completes, token persists.
- [ ] Edit again, change a non-secret field, save with `client_secret` left as `[REDACTED]` — confirm the existing secret is preserved.
- [ ] Add an `openapi_spec` to an existing connection — confirm `api_list_endpoints` returns the operations.