### PR TITLE
feat(dev): add mcp-test and api-test fixtures to make dev

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -27,7 +27,9 @@ This starts:
 | SeaweedFS (S3) | `:9000` | Portal asset storage |
 | Go API server | `http://localhost:8080` | Hot-reloads on `.go` file changes via air |
 | Vite UI | `http://localhost:5173/portal/` | Hot module replacement |
-| dev-mcp-mock | `:9180` (OAuth) / `:9181` (MCP) | Local mock for exercising the MCP gateway feature |
+| dev-mcp-mock | `:9180` (OAuth) / `:9181` (MCP) | In-process mock — exercises the MCP gateway + OAuth grants |
+| mcp-test fixture | `http://localhost:9281/` | `ghcr.io/plexara/mcp-test` — 12-tool deterministic MCP upstream + portal at `/portal/` |
+| api-test fixture | `http://localhost:9282` | `ghcr.io/plexara/api-test` — 9 deterministic `/v1/*` paths (14 operations — `/echo` accepts all 6 HTTP methods) + OpenAPI at `/openapi.yaml` + portal at `/portal/` |
 
 On first run, seed data (~5K audit events, 8 knowledge insights) is automatically loaded.
 
@@ -53,6 +55,38 @@ Switching the `dev-mock` connection to OAuth in the portal lets you
 walk the full PKCE flow against the in-process mock — no external
 provider needed. See [Gateway Toolkit](../docs/server/gateway.md) for
 the connection-config reference and OAuth grant types.
+
+### mcp-test and api-test fixtures
+
+In addition to the in-process `dev-mcp-mock`, `make dev` brings up two
+prebuilt fixture containers and registers them as platform connections:
+
+- **`mcp-test-fixture`** (kind `mcp`) — `ghcr.io/plexara/mcp-test` on
+  `http://localhost:9281/`. A 12-tool deterministic MCP server across
+  four groups (`identity`, `data`, `failure`, `streaming`) for
+  exercising the MCP gateway against a realistic upstream. Its own
+  portal at `http://localhost:9281/portal/` shows every call the
+  platform made (full request/response payloads + headers).
+- **`api-test-fixture`** (kind `api`) — `ghcr.io/plexara/api-test` on
+  `http://localhost:9282`. Nine deterministic HTTP paths under `/v1`
+  (`/whoami`, `/headers`, `/fixed/{key}`, `/sized?bytes=N`, `/lorem`,
+  `/status/{code}`, `/slow?ms=N`, `/flaky`, `/echo`) — 14 operations
+  total because `/v1/echo` accepts all six HTTP methods (GET, POST,
+  PUT, PATCH, DELETE, HEAD). Exercises the apigateway tools
+  (`api_invoke_endpoint`, `api_list_endpoints`, `api_export`). The
+  fixture publishes an OpenAPI 3.1 spec at `/openapi.yaml`;
+  `dev/start.sh` fetches it at registration time and inlines it into
+  the connection config, so `api_list_endpoints` returns the full
+  catalog. Portal at `http://localhost:9282/portal/`.
+
+Both fixtures use the shared `acme-dev-postgres` instance (databases
+`mcp_test` and `apitest`, created on first volume init via
+`dev/fixtures/postgres-init.sql`). Fixture configs live under
+`dev/fixtures/`.
+
+Both fixtures run in anonymous mode at the HTTP level; the platform
+authenticates outbound with `X-API-Key`. Their own portals therefore
+require no login — open them directly.
 
 Press **Ctrl-C** to stop all services.
 

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -19,11 +19,65 @@ services:
       - "5432:5432"
     volumes:
       - acme_postgres_data:/var/lib/postgresql/data
+      # Init script creates the mcp_test and apitest databases used by the
+      # mcp-test and api-test fixtures. Runs once on first startup against
+      # a fresh data volume; `make dev-down` removes the volume so the
+      # next `make dev` re-applies it.
+      - ./fixtures/postgres-init.sql:/docker-entrypoint-initdb.d/01-fixture-dbs.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U platform -d mcp_platform"]
       interval: 3s
       timeout: 3s
       retries: 10
+
+  # mcp-test: deterministic MCP fixture used by `make dev` to exercise
+  # the platform's mcp-gateway connector against a real upstream.
+  # dev/start.sh registers this as the `mcp-test-fixture` MCP connection
+  # so its 12 tools (identity / data / failure / streaming) appear in
+  # the platform's tools/list as `mcp-test-fixture__*`.
+  #
+  # Anonymous mode (no OIDC); the platform sends MCPTEST_DEV_KEY as
+  # X-API-Key. Open http://localhost:9281/portal/ to inspect every call
+  # the platform made (audit log + portal SPA).
+  mcp-test:
+    image: ghcr.io/plexara/mcp-test:v1.2.0@sha256:85b1d6af2b45a6a4dd9fc9d5278ad5bfdc642b258dfab52600851c26d77c74b7
+    container_name: acme-dev-mcp-test
+    environment:
+      MCPTEST_DATABASE_URL: postgres://platform:platform_secret@postgres:5432/mcp_test?sslmode=disable
+      MCPTEST_DEV_KEY: ${MCPTEST_DEV_KEY:-mcptest-dev-key-2024}
+      MCPTEST_COOKIE_SECRET: ${MCPTEST_COOKIE_SECRET:-mcptest-dev-cookie-secret-please-change-32b}
+    command: ["--config", "/app/configs/mcp-test.yaml"]
+    volumes:
+      - ./fixtures/mcp-test.yaml:/app/configs/mcp-test.yaml:ro
+    ports:
+      - "127.0.0.1:9281:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  # api-test: deterministic HTTP fixture for the platform's apigateway
+  # toolkit. dev/start.sh registers this as the `api-test-fixture` api
+  # connection so `api_invoke_endpoint` / `api_list_endpoints` /
+  # `api_export` have a working upstream out of the box.
+  #
+  # Anonymous mode (no OIDC); the platform sends APITEST_DEV_KEY as
+  # X-API-Key. Open http://localhost:9282/portal/ to inspect every call
+  # the platform made.
+  api-test:
+    image: ghcr.io/plexara/api-test:v1.1.0@sha256:0a2b5d255f54243525a49a6b5c62b88c52c9e34e157e160de97d303dddb4b19b
+    container_name: acme-dev-api-test
+    environment:
+      APITEST_DB_URL: postgres://platform:platform_secret@postgres:5432/apitest?sslmode=disable
+      APITEST_DEV_KEY: ${APITEST_DEV_KEY:-apitest-dev-key-2024}
+      APITEST_COOKIE_SECRET: ${APITEST_COOKIE_SECRET:-apitest-dev-cookie-secret-please-change-32b}
+    command: ["--config", "/app/configs/api-test.yaml"]
+    volumes:
+      - ./fixtures/api-test.yaml:/app/configs/api-test.yaml:ro
+    ports:
+      - "127.0.0.1:9282:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
 
   seaweedfs:
     image: chrislusf/seaweedfs:3.88@sha256:98e034880fed76fdf508b20cae9de57b0e1f93f5910c89a94fe936af91c59abe

--- a/dev/fixtures/api-test.yaml
+++ b/dev/fixtures/api-test.yaml
@@ -1,0 +1,63 @@
+# api-test fixture config for `make dev`.
+#
+# Anonymous mode: the platform's apigateway connects to this fixture
+# with auth_mode=api_key (X-API-Key), so the fixture itself doesn't
+# need to gate /v1/* behind OIDC. Anonymous keeps the dev/start.sh
+# health probe and admin-API registration trivial.
+#
+# Portal + audit are on so developers can open
+# http://localhost:9282/portal/ and see every call the platform's
+# api_invoke_endpoint / api_export tools made to this fixture.
+#
+# Env vars (set by docker-compose.yml):
+#   APITEST_DEV_KEY        API key the platform sends as X-API-Key
+#   APITEST_COOKIE_SECRET  Portal session cookie secret
+#   APITEST_DB_URL         Points at acme-dev-postgres, database apitest
+
+server:
+  name: api-test-fixture
+  address: ":8080"
+  base_url: "http://localhost:9282"
+
+oidc:
+  enabled: false
+
+api_keys:
+  file:
+    - name: dev-fixture
+      key: "${APITEST_DEV_KEY}"
+      description: "platform-side apigateway X-API-Key"
+  db:
+    enabled: true
+
+auth:
+  allow_anonymous: true
+  require_for_api: false
+  require_for_portal: false
+
+database:
+  url: "${APITEST_DB_URL}"
+
+audit:
+  enabled: true
+  retention_days: 7
+  capture_payloads: true
+  capture_headers: true
+  max_payload_bytes: 1048576
+
+portal:
+  enabled: true
+  cookie_name: api_test_fixture_session
+  cookie_secret: "${APITEST_COOKIE_SECRET}"
+  cookie_secure: false
+
+endpoints:
+  identity:   { enabled: true }
+  data:       { enabled: true }
+  failure:    { enabled: true }
+  echo:       { enabled: true }
+  streaming:  { enabled: false }
+  pagination: { enabled: false }
+  methods:    { enabled: false }
+  security:   { enabled: false }
+  export:     { enabled: false }

--- a/dev/fixtures/mcp-test.yaml
+++ b/dev/fixtures/mcp-test.yaml
@@ -1,0 +1,60 @@
+# mcp-test fixture config for `make dev`.
+#
+# Anonymous mode: the platform's mcp-gateway connects to this fixture
+# with auth_mode=api_key (X-API-Key), so the fixture itself doesn't
+# need to gate its MCP endpoint behind OIDC. Anonymous makes the
+# `dev/start.sh` health probe and admin-API registration trivial.
+#
+# Portal + audit are on so developers can open
+# http://localhost:9281/portal/ and see every call the platform made
+# to this fixture (compare request_in vs request_out vs response).
+#
+# Env vars (set by docker-compose.yml):
+#   MCPTEST_DEV_KEY         API key the platform sends as X-API-Key
+#   MCPTEST_COOKIE_SECRET   Portal session cookie secret
+#   MCPTEST_DATABASE_URL    Points at acme-dev-postgres, database mcp_test
+
+server:
+  name: mcp-test-fixture
+  address: ":8080"
+  base_url: "http://localhost:9281"
+  streamable:
+    session_timeout: 30m
+
+oidc:
+  enabled: false
+
+api_keys:
+  file:
+    - name: dev-fixture
+      key: "${MCPTEST_DEV_KEY}"
+      description: "platform-side mcp-gateway X-API-Key"
+  db:
+    enabled: true
+
+auth:
+  allow_anonymous: true
+  require_for_mcp: false
+  require_for_portal: false
+
+database:
+  url: "${MCPTEST_DATABASE_URL}"
+
+audit:
+  enabled: true
+  capture_payloads: true
+  capture_headers: true
+  max_payload_bytes: 65536
+  max_notifications: 100
+
+portal:
+  enabled: true
+  cookie_name: mcp_test_fixture_session
+  cookie_secret: "${MCPTEST_COOKIE_SECRET}"
+  cookie_secure: false
+
+tools:
+  identity:  { enabled: true }
+  data:      { enabled: true }
+  failure:   { enabled: true }
+  streaming: { enabled: true }

--- a/dev/fixtures/postgres-init.sql
+++ b/dev/fixtures/postgres-init.sql
@@ -1,0 +1,14 @@
+-- Pre-create databases used by the mcp-test and api-test dev fixtures.
+-- Mounted into acme-dev-postgres at /docker-entrypoint-initdb.d/. Postgres
+-- runs everything in that directory once, on the very first container
+-- startup against a fresh data volume. `make dev-down` removes the
+-- volume (`docker compose down -v`), so the next `make dev` always
+-- starts clean and re-applies this file.
+--
+-- Note on grants: the platform's POSTGRES_USER ("platform") owns these
+-- databases. The fixture containers connect with the same credentials
+-- (see docker-compose.yml). If the fixtures ever move to a dedicated
+-- role, this file is the right place to CREATE ROLE + GRANT.
+
+CREATE DATABASE mcp_test;
+CREATE DATABASE apitest;

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -55,6 +55,11 @@ ok "Docker is running"
 which air > /dev/null 2>&1 || fail "air not found. Install: go install github.com/air-verse/air@latest"
 ok "air installed"
 
+# python3 is used to build connection-registration JSON bodies safely
+# (no shell interpolation of model-supplied secrets / spec text).
+which python3 > /dev/null 2>&1 || fail "python3 not found. Required for fixture connection registration."
+ok "python3 available"
+
 # Node modules
 if [ ! -d ui/node_modules ]; then
   info "Installing UI dependencies..."
@@ -63,13 +68,14 @@ fi
 ok "UI dependencies ready"
 
 # Port checks (8080 = platform, 5173 = vite, 5432 = postgres,
-# 9000 = seaweedfs, 9180 = dev-mcp-mock OAuth, 9181 = dev-mcp-mock MCP)
-for port in 5432 8080 5173 9000 9180 9181; do
+# 9000 = seaweedfs, 9180 = dev-mcp-mock OAuth, 9181 = dev-mcp-mock MCP,
+# 9281 = mcp-test fixture, 9282 = api-test fixture)
+for port in 5432 8080 5173 9000 9180 9181 9281 9282; do
   if lsof -i ":$port" -sTCP:LISTEN > /dev/null 2>&1; then
     fail "Port $port is already in use. Run 'make dev-down' or stop the conflicting process."
   fi
 done
-ok "Ports 5432, 8080, 5173, 9000, 9180, 9181 are free"
+ok "Ports 5432, 8080, 5173, 9000, 9180, 9181, 9281, 9282 are free"
 
 echo ""
 
@@ -105,6 +111,33 @@ for i in $(seq 1 30); do
   sleep 1
 done
 ok "SeaweedFS ready on :9000"
+
+# Wait for the mcp-test fixture. First run pulls the image, which can
+# take longer than the other waits — give it up to 60s before failing.
+info "Waiting for mcp-test fixture..."
+for i in $(seq 1 60); do
+  if curl -sf http://localhost:9281/healthz > /dev/null 2>&1; then
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    fail "mcp-test fixture did not become healthy within 60s (check 'docker logs acme-dev-mcp-test')"
+  fi
+  sleep 1
+done
+ok "mcp-test fixture ready on :9281"
+
+# Wait for the api-test fixture.
+info "Waiting for api-test fixture..."
+for i in $(seq 1 60); do
+  if curl -sf http://localhost:9282/healthz > /dev/null 2>&1; then
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    fail "api-test fixture did not become healthy within 60s (check 'docker logs acme-dev-api-test')"
+  fi
+  sleep 1
+done
+ok "api-test fixture ready on :9282"
 
 # Create the portal-assets S3 bucket (requires aws CLI)
 if which aws > /dev/null 2>&1; then
@@ -201,6 +234,104 @@ else
   echo -e "  ${YELLOW}⚠${NC} dev-mock connection register returned HTTP $DEVMOCK_HTTP — admin API may not be ready"
 fi
 
+# Register the mcp-test fixture as an MCP-gateway connection. Same
+# rationale as dev-mock: go through the admin API so AddConnection
+# discovers the upstream's tools and registers them live. mcp-test
+# serves streamable HTTP at "/", so the endpoint includes a trailing
+# slash; api-key auth uses the X-API-Key header (matches the fixture's
+# api_keys.file entry, default placement).
+info "Registering mcp-test fixture connection..."
+MCPTEST_DEV_KEY_VAL="${MCPTEST_DEV_KEY:-mcptest-dev-key-2024}"
+MCPTEST_BODY=$(MCPTEST_DEV_KEY_VAL="$MCPTEST_DEV_KEY_VAL" python3 -c '
+import json, os
+key = os.environ.get("MCPTEST_DEV_KEY_VAL", "")
+body = {
+    "config": {
+        "endpoint": "http://localhost:9281/",
+        "auth_mode": "api_key",
+        "credential": key,
+        "connection_name": "mcp-test-fixture",
+        "connect_timeout": "5s",
+        "call_timeout": "10s",
+    },
+    "description": "Dev fixture: ghcr.io/plexara/mcp-test — identity, data, failure, streaming groups",
+}
+print(json.dumps(body))
+')
+MCPTEST_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+  -H "X-API-Key: acme-dev-key-2024" \
+  -H "Content-Type: application/json" \
+  -d "$MCPTEST_BODY" \
+  http://localhost:8080/api/v1/admin/connection-instances/mcp/mcp-test-fixture || echo "000")
+if [ "$MCPTEST_HTTP" = "200" ] || [ "$MCPTEST_HTTP" = "201" ]; then
+  ok "mcp-test fixture connection registered (tools: mcp-test-fixture__*)"
+else
+  echo -e "  ${YELLOW}⚠${NC} mcp-test connection register returned HTTP $MCPTEST_HTTP — admin API may not be ready"
+fi
+
+# Register the api-test fixture as an apigateway connection.
+#
+# api-test v1.1.0+ publishes its OpenAPI 3.1 spec at /openapi.yaml. We
+# pull it and inline it into the connection's openapi_spec field so
+# api_list_endpoints returns the 14 operations the fixture serves
+# (whoami, headers, fixed/{key}, sized, lorem, status/{code}, slow,
+# flaky, echo). Operations in the spec are pathed under /v1/..., so
+# base_url omits the /v1 suffix — the gateway joins base_url + the
+# operation path verbatim.
+#
+# The platform sends the api key as the X-API-Key header (default
+# placement). If the OpenAPI fetch fails (older image, transient
+# error), we still register the connection without a spec so
+# api_invoke_endpoint works against direct paths.
+info "Fetching api-test OpenAPI spec..."
+APITEST_OPENAPI=$(curl -sf http://localhost:9282/openapi.yaml || true)
+if [ -n "$APITEST_OPENAPI" ]; then
+  APITEST_OPENAPI_BYTES=${#APITEST_OPENAPI}
+  ok "api-test OpenAPI spec fetched (${APITEST_OPENAPI_BYTES} bytes)"
+else
+  echo -e "  ${YELLOW}⚠${NC} api-test /openapi.yaml unavailable — registering without spec (api_list_endpoints will be empty)"
+fi
+
+info "Registering api-test fixture connection..."
+APITEST_DEV_KEY_VAL="${APITEST_DEV_KEY:-apitest-dev-key-2024}"
+APITEST_BODY=$(APITEST_OPENAPI="$APITEST_OPENAPI" APITEST_DEV_KEY_VAL="$APITEST_DEV_KEY_VAL" python3 -c '
+import json, os
+spec = os.environ.get("APITEST_OPENAPI", "")
+key = os.environ.get("APITEST_DEV_KEY_VAL", "")
+config = {
+    "base_url": "http://localhost:9282",
+    "auth_mode": "api_key",
+    "credential": key,
+    "api_key_placement": "header",
+    "api_key_header": "X-API-Key",
+    "connection_name": "api-test-fixture",
+    "connect_timeout": "5s",
+    "call_timeout": "10s",
+    "trust_level": "untrusted",
+}
+if spec:
+    config["openapi_spec"] = spec
+body = {
+    "config": config,
+    "description": "Dev fixture: ghcr.io/plexara/api-test — identity, data, failure, echo endpoints",
+}
+print(json.dumps(body))
+')
+APITEST_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+  -H "X-API-Key: acme-dev-key-2024" \
+  -H "Content-Type: application/json" \
+  -d "$APITEST_BODY" \
+  http://localhost:8080/api/v1/admin/connection-instances/api/api-test-fixture || echo "000")
+if [ "$APITEST_HTTP" = "200" ] || [ "$APITEST_HTTP" = "201" ]; then
+  if [ -n "$APITEST_OPENAPI" ]; then
+    ok "api-test fixture connection registered with OpenAPI spec (api_list_endpoints will resolve)"
+  else
+    ok "api-test fixture connection registered (no OpenAPI spec)"
+  fi
+else
+  echo -e "  ${YELLOW}⚠${NC} api-test connection register returned HTTP $APITEST_HTTP — admin API may not be ready"
+fi
+
 echo ""
 
 # ─── Start Vite dev server ──────────────────────────────────────────
@@ -229,11 +360,17 @@ echo -e "${BOLD}${GREEN}══════════════════�
 echo -e "${BOLD}${GREEN}  Development environment ready${NC}"
 echo -e "${BOLD}${GREEN}══════════════════════════════════════════${NC}"
 echo ""
-echo -e "  Portal UI:    ${CYAN}http://localhost:5173/portal/${NC}"
-echo -e "  Go API:       ${CYAN}http://localhost:8080${NC}"
-echo -e "  API Key:      ${CYAN}acme-dev-key-2024${NC}"
-echo -e "  MCP gateway:  ${CYAN}dev-mock connection pre-wired to the local mock${NC}"
-echo -e "                ${CYAN}(http://localhost:9181/mcp + http://localhost:9180 OAuth)${NC}"
+echo -e "  Portal UI:        ${CYAN}http://localhost:5173/portal/${NC}"
+echo -e "  Go API:           ${CYAN}http://localhost:8080${NC}"
+echo -e "  API Key:          ${CYAN}acme-dev-key-2024${NC}"
+echo ""
+echo -e "  ${BOLD}Pre-wired upstream fixtures${NC}"
+echo -e "  dev-mock (MCP):   ${CYAN}http://localhost:9181/mcp${NC} (echo, add, now)"
+echo -e "                    ${CYAN}OAuth at http://localhost:9180${NC}"
+echo -e "  mcp-test (MCP):   ${CYAN}http://localhost:9281/${NC}  portal: ${CYAN}http://localhost:9281/portal/${NC}"
+echo -e "                    ${CYAN}API key: $MCPTEST_DEV_KEY_VAL${NC}"
+echo -e "  api-test (HTTP):  ${CYAN}http://localhost:9282/v1${NC}  portal: ${CYAN}http://localhost:9282/portal/${NC}"
+echo -e "                    ${CYAN}API key: $APITEST_DEV_KEY_VAL${NC}"
 echo ""
 echo -e "  Go files  → air rebuilds automatically"
 echo -e "  UI files  → Vite hot-reloads automatically"


### PR DESCRIPTION
## Summary

Wires two prebuilt fixture containers into `make dev` so the **MCP gateway** and **apigateway** features ship pre-explored against realistic upstreams. Closes the gap where the apigateway tools (#377/#371/#372/#380/#381/#383/#384) had no working dev fixture, and adds a richer alternative to `dev-mcp-mock` for the MCP gateway side.

| Fixture | Image | Host port | Registered as |
|---|---|---|---|
| **mcp-test** | `ghcr.io/plexara/mcp-test:v1.2.0` | `:9281` | `mcp-test-fixture` (kind `mcp`) — 12 tools across `identity` / `data` / `failure` / `streaming` groups |
| **api-test** | `ghcr.io/plexara/api-test:v1.1.0` | `:9282` | `api-test-fixture` (kind `api`) — 9 paths / 14 operations + OpenAPI 3.1 spec |

Both images are pinned by digest. `dev-mcp-mock` is unchanged; both upstream MCP fixtures coexist so the existing OAuth-grant exploration path still works.

## What changed

- **`dev/docker-compose.yml`** — two new compose services with digest-pinned images, mounted fixture configs, bound to `127.0.0.1` only.
- **`dev/fixtures/postgres-init.sql`** — pre-creates `mcp_test` and `apitest` databases in the shared `acme-dev-postgres` on first volume init.
- **`dev/fixtures/mcp-test.yaml`** / **`api-test.yaml`** — fixture configs (anonymous mode at the HTTP level, portal + audit on, points at shared postgres).
- **`dev/start.sh`** — adds pre-flight checks for ports `:9281` / `:9282` and `python3`, `/healthz` waits for both fixtures, and admin-API registration of both connections.
  - For `api-test`, the script fetches `/openapi.yaml` from the fixture at registration time and inlines it into the connection's `openapi_spec` field so `api_list_endpoints` returns the full catalog out of the box.
  - All registration bodies are constructed via `python3 json.dumps` — no shell interpolation of secrets / spec text into JSON.
- **`dev/README.md`** — new `### mcp-test and api-test fixtures` section documenting both, plus updates to the service table.

## Why this matters

Before this change, exercising the apigateway end-to-end required hand-curling a third-party HTTP API or writing a one-off fixture. With this change:

```
make dev
# → opens http://localhost:5173/portal/
# → tools/list returns 41 tools including:
#   - mcp-test-fixture__* (12 deterministic MCP tools)
#   - api_invoke_endpoint, api_list_endpoints, api_export
# → api_list_endpoints { connection: "api-test-fixture" } returns 14 operations
# → api_invoke_endpoint { connection: "api-test-fixture", method: "GET", path: "/v1/whoami" } returns 200
```

Both fixtures publish their own portal (`:9281/portal/` and `:9282/portal/`) so developers can compare what the platform sent vs. what the upstream received — full audit drill-down on the upstream side.

## Live verification

Tested end-to-end against the running platform via JSON-RPC against `/mcp`:

| Call | Result |
|---|---|
| `tools/list` | 41 tools total — 12 `mcp-test-fixture__*`, 3 `dev-mock__*`, 3 apigateway tools, plus the existing toolkit surface |
| `mcp-test-fixture__whoami` | 200 — identity `dev-fixture` (proves api-key auth forwarded) |
| `mcp-test-fixture__echo` | 200 — echoes payload |
| `mcp-test-fixture__fixed_response` | 200 — deterministic SHA256 |
| `api_list_endpoints` (api-test-fixture) | **14 operations** returned from inlined OpenAPI spec |
| `api_invoke_endpoint GET /v1/whoami` | 200, 2ms — identity `dev-fixture` |
| `api_invoke_endpoint GET /v1/fixed/demo` | 200 — deterministic hashed response |
| `api_invoke_endpoint POST /v1/echo` with JSON body | 200 — fixture echoes body + headers (with `X-Api-Key: [redacted]`) |
| `api_invoke_endpoint GET /v1/sized` with `query: {bytes: 128}` | 200 — 128-byte body |
| `api_invoke_endpoint GET /v1/flaky` with seed | 503 with `failed: true` — controlled failure reproducible |
| `api_invoke_endpoint GET /v1/status/418` | 418 "I'm a teapot" — full status passthrough |

`make verify` passes end-to-end (full CI-equivalent gate).

## Migration note

First `make dev` after merging this needs the postgres volume to be re-initialized so the `mcp_test` and `apitest` databases get created by the init script:

```bash
make dev-down   # removes the postgres volume
make dev        # re-init runs, fixtures come up healthy
```

Subsequent runs reuse the volume normally.

## Out of scope (filed for follow-up)

- **[#388](https://github.com/txn2/mcp-data-platform/issues/388)** — `apigateway`: rename `api_invoke_endpoint` / `api_export` `query` field to `query_params` to disambiguate from `api_list_endpoints` `query` (which means substring search). Discovered while testing this PR; a typo'd field name silently drops the query parameter at the upstream. Not blocking; tracked separately.
- `docker-compose.e2e.yml` integration of the same fixtures + a new `test/e2e/api_gateway_test.go` that exercises `api_invoke_endpoint` through the apigateway → api-test path. Deferred per the original review's "make dev only first" scope decision.
- Eventually replacing `cmd/dev-mcp-mock` with `mcp-test` once the apigateway OAuth grant flows (#368/#380/#381) are verified against `mcp-test`'s Keycloak path. Both upstream fixtures coexist for now.

## Test plan

- [ ] `make dev-down && make dev` — fixtures come up healthy, `dev/start.sh` registers both connections, banner shows both fixture URLs
- [ ] Open `http://localhost:9281/portal/` and `http://localhost:9282/portal/` — both portals load anonymously
- [ ] In the platform portal admin page, both `mcp-test-fixture` (kind `mcp`) and `api-test-fixture` (kind `api`) appear in the Connections list
- [ ] `tools/list` returns `mcp-test-fixture__*` tools alongside `dev-mock__*`
- [ ] `api_list_endpoints { connection: "api-test-fixture" }` returns 14 operations
- [ ] `api_invoke_endpoint { connection: "api-test-fixture", method: "GET", path: "/v1/whoami" }` returns 200
- [ ] `make verify` still passes