### PR TITLE
fix(apigateway): rename invoke/export `query` field to `query_params` (#388)

### DIFF
--- a/pkg/toolkits/apigateway/export.go
+++ b/pkg/toolkits/apigateway/export.go
@@ -190,7 +190,7 @@ type exportInput struct {
 	Connection       string            `json:"connection"`
 	Method           string            `json:"method"`
 	Path             string            `json:"path"`
-	Query            map[string]any    `json:"query"`
+	Query            map[string]any    `json:"query_params"`
 	Headers          map[string]string `json:"headers"`
 	Body             any               `json:"body"`
 	TimeoutSeconds   int               `json:"timeout_seconds"`

--- a/pkg/toolkits/apigateway/invoke.go
+++ b/pkg/toolkits/apigateway/invoke.go
@@ -61,7 +61,7 @@ type InvokeInput struct {
 	Connection     string            `json:"connection"`
 	Method         string            `json:"method"`
 	Path           string            `json:"path"`
-	Query          map[string]any    `json:"query,omitempty"`
+	Query          map[string]any    `json:"query_params,omitempty"`
 	Headers        map[string]string `json:"headers,omitempty"`
 	Body           any               `json:"body,omitempty"`
 	TimeoutSeconds int               `json:"timeout_seconds,omitempty"`

--- a/pkg/toolkits/apigateway/schemas.go
+++ b/pkg/toolkits/apigateway/schemas.go
@@ -55,9 +55,9 @@ var apiExportInputSchema = json.RawMessage(`{
       "type": "string",
       "description": "Request path joined to the connection's base URL. Required. Must start with \"/\"."
     },
-    "query": {
+    "query_params": {
       "type": "object",
-      "description": "Optional query string parameters.",
+      "description": "Optional HTTP query-string parameters sent to the upstream. Distinct from api_list_endpoints's \"query\" field (which is search text).",
       "additionalProperties": true
     },
     "headers": {
@@ -118,9 +118,9 @@ var invokeEndpointSchema = json.RawMessage(`{
       "type": "string",
       "description": "Request path joined to the connection's base URL. Examples: \"/v1/users/123\", \"/api/items\". Required. Must start with \"/\"."
     },
-    "query": {
+    "query_params": {
       "type": "object",
-      "description": "Optional query string parameters. Values may be strings, numbers, or booleans; arrays send the parameter once per value.",
+      "description": "Optional HTTP query-string parameters sent to the upstream. Values may be strings, numbers, or booleans; arrays send the parameter once per value. Distinct from api_list_endpoints's \"query\" field (which is search text).",
       "additionalProperties": true
     },
     "headers": {

--- a/pkg/toolkits/apigateway/schemas_test.go
+++ b/pkg/toolkits/apigateway/schemas_test.go
@@ -1,0 +1,86 @@
+package apigateway
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestInvokeInputJSONTag_QueryParams locks in the rename from
+// `query` → `query_params` for api_invoke_endpoint. The schema name
+// must match the struct tag or the model's argument silently
+// disappears (the field stays zero) — exactly the failure mode
+// issue #388 reported.
+func TestInvokeInputJSONTag_QueryParams(t *testing.T) {
+	raw := []byte(`{"connection":"c","method":"GET","path":"/x","query_params":{"bytes":128}}`)
+	var in InvokeInput
+	if err := json.Unmarshal(raw, &in); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got, want := in.Query["bytes"], float64(128); got != want {
+		t.Errorf("query_params not decoded into Query: got %v (%T), want %v", got, got, want)
+	}
+
+	// The old `query` name must no longer populate the field — a
+	// caller that still passes `query` should get nothing through,
+	// not a silent fallback that masks the change.
+	raw = []byte(`{"connection":"c","method":"GET","path":"/x","query":{"bytes":128}}`)
+	in = InvokeInput{}
+	if err := json.Unmarshal(raw, &in); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if in.Query != nil {
+		t.Errorf("legacy `query` field should no longer populate Query; got %v", in.Query)
+	}
+}
+
+// TestExportInputJSONTag_QueryParams mirrors the invoke test for
+// api_export — same rename, same risk of a silent miss.
+func TestExportInputJSONTag_QueryParams(t *testing.T) {
+	raw := []byte(`{"connection":"c","method":"GET","path":"/x","name":"n","query_params":{"k":"v"}}`)
+	var in exportInput
+	if err := json.Unmarshal(raw, &in); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got, want := in.Query["k"], "v"; got != want {
+		t.Errorf("query_params not decoded into Query: got %v, want %v", got, want)
+	}
+
+	raw = []byte(`{"connection":"c","method":"GET","path":"/x","name":"n","query":{"k":"v"}}`)
+	in = exportInput{}
+	if err := json.Unmarshal(raw, &in); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if in.Query != nil {
+		t.Errorf("legacy `query` field should no longer populate Query; got %v", in.Query)
+	}
+}
+
+// TestSchemas_QueryParamsRename verifies the JSON Schema published
+// to the model matches the struct tag. A drift between the two is
+// what makes the rename load-bearing: the schema is what the
+// model's tool-call validator consults.
+func TestSchemas_QueryParamsRename(t *testing.T) {
+	invoke := string(invokeEndpointSchema)
+	if !strings.Contains(invoke, `"query_params"`) {
+		t.Error("invokeEndpointSchema missing query_params property")
+	}
+	if strings.Contains(invoke, `"query":`) {
+		t.Error("invokeEndpointSchema still defines a query property; should be query_params")
+	}
+
+	export := string(apiExportInputSchema)
+	if !strings.Contains(export, `"query_params"`) {
+		t.Error("apiExportInputSchema missing query_params property")
+	}
+	if strings.Contains(export, `"query":`) {
+		t.Error("apiExportInputSchema still defines a query property; should be query_params")
+	}
+
+	// list_endpoints intentionally keeps `query` (search text, not
+	// HTTP query params). Guard against an over-eager rename.
+	list := string(listEndpointsSchema)
+	if !strings.Contains(list, `"query":`) {
+		t.Error("listEndpointsSchema must keep the `query` search-text property")
+	}
+}


### PR DESCRIPTION
## Summary

- Renames the JSON field `query` → `query_params` in `api_invoke_endpoint` and `api_export`. `api_list_endpoints` keeps `query` (search text).
- Updates schema descriptions to explicitly contrast the two fields so the difference is visible in the tools/list output a model sees.
- Adds `schemas_test.go` locking the rename: round-trip JSON decode for both `InvokeInput` and `exportInput` (proves `query_params` populates `Query` and legacy `query` no longer does), plus a schema-text assertion guarding `listEndpointsSchema` against an over-eager rename.

## Why

The same field name carried two unrelated meanings (search text vs HTTP query-string params), and #388 caught the concrete failure: a typo'd field name was silently accepted, the param was dropped, and the upstream returned 400. The api-test fixture's audit log confirmed the gateway sent no query string upstream.

Closes #388.

## Breaking change

Callers passing `query: {...}` to `api_invoke_endpoint` or `api_export` will break — the field is now `query_params`. The apigateway is recent (#371, #372, #380, #383, #384), so blast radius is small. Worth a Release-notes mention.

## Test plan

- [x] `make verify` (full CI-equivalent suite, all gates green)
- [x] New tests in `pkg/toolkits/apigateway/schemas_test.go` pass
- [ ] Live test against `make dev` api-test fixture: `api_invoke_endpoint` with `query_params:{bytes:128}` returns 200; legacy `query:{bytes:128}` no longer routes