### PR TITLE
refactor: unify MCP + API connection OAuth, add Keycloak dev IdP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,25 +93,34 @@ coverage: test
 ## not part of `make verify`).
 lint:
 	@echo "Running patch-scoped lint (matches CI only-new-issues, includes uncommitted changes)..."
+	@# Auto-fetch so a fresh clone or a stale local mirror doesn't bypass
+	@# the gate. The fetch is shallow + quiet and tolerates network
+	@# absence; if BOTH origin/main and main remain unreachable, we
+	@# HARD FAIL rather than silently skip — silent skipping is exactly
+	@# how a clean local make verify let lint issues reach CI in #393.
+	@git fetch --quiet origin main 2>/dev/null || true
 	@if git rev-parse origin/main >/dev/null 2>&1; then \
 		BASE=origin/main; \
 	elif git rev-parse main >/dev/null 2>&1; then \
 		BASE=main; \
 	else \
-		echo "WARN: neither origin/main nor main is reachable; skipping patch lint."; \
-		echo "      Run \`git fetch origin main\` to enable CI-equivalent linting."; \
-		exit 0; \
+		echo "ERROR: neither origin/main nor main is reachable."; \
+		echo "       Run \`git fetch origin main\` and retry."; \
+		echo "       (lint MUST run against a base; silent-skip is a CI-parity hole.)"; \
+		exit 1; \
 	fi; \
 	MERGE_BASE=$$(git merge-base $$BASE HEAD 2>/dev/null); \
 	if [ -z "$$MERGE_BASE" ]; then \
-		echo "WARN: could not compute merge-base against $$BASE; skipping patch lint."; \
-		exit 0; \
+		echo "ERROR: could not compute merge-base against $$BASE."; \
+		echo "       Ensure the current branch shares history with $$BASE."; \
+		exit 1; \
 	fi; \
 	PATCH=$$(mktemp -t mcpdp-lint-patch.XXXXXX); \
 	trap "rm -f $$PATCH" EXIT; \
 	git diff $$MERGE_BASE > $$PATCH; \
 	if [ ! -s $$PATCH ]; then \
 		echo "No changes vs merge-base ($$BASE); nothing to lint."; \
+		echo "       (If you expected changes, confirm \`git log $$BASE..HEAD\` is non-empty.)"; \
 		exit 0; \
 	fi; \
 	echo "Linting against merge-base $$MERGE_BASE (from $$BASE) — includes uncommitted changes"; \

--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -25,6 +25,7 @@ import (
 	mcpserver "github.com/txn2/mcp-data-platform/internal/server"
 	"github.com/txn2/mcp-data-platform/internal/ui"
 	"github.com/txn2/mcp-data-platform/pkg/admin"
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
 	"github.com/txn2/mcp-data-platform/pkg/health"
 	httpauth "github.com/txn2/mcp-data-platform/pkg/http"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
@@ -33,6 +34,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/resource"
 	"github.com/txn2/mcp-data-platform/pkg/session"
+	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
 	datahubkit "github.com/txn2/mcp-data-platform/pkg/toolkits/datahub"
 	gatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/gateway"
 	"github.com/txn2/mcp-data-platform/pkg/toolkits/gateway/enrichment"
@@ -788,6 +790,14 @@ func buildAdminHandler(p *platform.Platform) http.Handler {
 		deps.PKCEStore = admin.NewMemoryPKCEStore()
 	}
 
+	// Wire the unified OAuth flow: shared connoauth.Store plus one
+	// OAuthKindHandler per connection kind. When both are present the
+	// admin handler activates the unified /connections/{kind}/{name}
+	// routes; otherwise it falls back to the legacy per-kind routes
+	// for backward compatibility during rollout.
+	deps.ConnOAuthStore = p.ConnOAuthStore()
+	deps.OAuthKinds = buildOAuthKindHandlers(p)
+
 	if p.KnowledgeInsightStore() != nil {
 		deps.Knowledge = admin.NewKnowledgeHandler(
 			p.KnowledgeInsightStore(),
@@ -805,6 +815,29 @@ func buildAdminHandler(p *platform.Platform) http.Handler {
 	}
 
 	return admin.NewHandler(deps, admin.RequirePersona(platAuth))
+}
+
+// buildOAuthKindHandlers assembles the per-kind OAuth adapter registry
+// the admin handler dispatches on. Each registered toolkit kind
+// contributes one handler; missing toolkits produce no entry, and the
+// unified handler returns 400 "unsupported connection kind" for
+// requests targeting an unregistered kind.
+func buildOAuthKindHandlers(p *platform.Platform) admin.OAuthKindHandlers {
+	out := admin.OAuthKindHandlers{}
+	if p.ToolkitRegistry() == nil {
+		return out
+	}
+	for _, tk := range p.ToolkitRegistry().All() {
+		switch v := tk.(type) {
+		case *gatewaykit.Toolkit:
+			if h := gatewaykit.NewOAuthKindHandler(v); h != nil {
+				out[connoauth.KindMCP] = h
+			}
+		case *apigatewaykit.Toolkit:
+			out[connoauth.KindAPI] = apigatewaykit.NewOAuthKindHandler(v)
+		}
+	}
+	return out
 }
 
 // wireEnrichmentEngine builds the gateway enrichment engine when a rule

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -79,6 +79,40 @@ services:
       postgres:
         condition: service_healthy
 
+  # Keycloak: real OIDC + OAuth 2.1 IdP backing both:
+  #   - operator portal login (auth.oidc + browser_session in platform.yaml)
+  #   - the pre-seeded oauth-mcp-dev / oauth-api-dev connection fixtures
+  # Realm + clients + dev users come from ./keycloak-realm.json, imported
+  # on first boot. Re-runs of `make dev` re-use the existing realm; only
+  # `make dev-down` (which removes the postgres volume) resets it.
+  keycloak:
+    image: quay.io/keycloak/keycloak:25.0.6@sha256:82c5b7a110456dbd42b86ea572e728878549954cc8bd03cd65410d75328095d2
+    container_name: acme-dev-keycloak
+    command: ["start-dev", "--import-realm", "--http-port=8080"]
+    environment:
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
+      KC_DB_USERNAME: platform
+      KC_DB_PASSWORD: platform_secret
+      KC_HOSTNAME_STRICT: "false"
+      KC_HTTP_ENABLED: "true"
+      KC_HOSTNAME: localhost
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    ports:
+      - "127.0.0.1:9090:8080"
+    volumes:
+      - ./keycloak-realm.json:/opt/keycloak/data/import/mcp-platform.json:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /realms/mcp-platform/.well-known/openid-configuration HTTP/1.0\\r\\n\\r\\n' >&3 && grep -q 200 <&3"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
   seaweedfs:
     image: chrislusf/seaweedfs:3.88@sha256:98e034880fed76fdf508b20cae9de57b0e1f93f5910c89a94fe936af91c59abe
     container_name: acme-dev-seaweedfs

--- a/dev/keycloak-realm.json
+++ b/dev/keycloak-realm.json
@@ -1,0 +1,148 @@
+{
+  "realm": "mcp-platform",
+  "enabled": true,
+  "displayName": "MCP Data Platform Dev",
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "accessTokenLifespan": 1800,
+  "ssoSessionIdleTimeout": 3600,
+  "ssoSessionMaxLifespan": 36000,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "roles": {
+    "realm": [
+      { "name": "dp_admin", "description": "Platform administrator (matches role_prefix dp_)" },
+      { "name": "dp_analyst", "description": "Data analyst persona" },
+      { "name": "dp_engineer", "description": "Data engineer persona" }
+    ]
+  },
+  "users": [
+    {
+      "username": "admin@example.com",
+      "email": "admin@example.com",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Admin",
+      "lastName": "Dev",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "admin-password",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["dp_admin"]
+    },
+    {
+      "username": "analyst@example.com",
+      "email": "analyst@example.com",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Analyst",
+      "lastName": "Dev",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "analyst-password",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["dp_analyst"]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "mcp-data-platform-portal",
+      "name": "Portal Login (operator browser session)",
+      "description": "Used by the platform's auth.oidc / browser_session flow for operator portal sign-in.",
+      "enabled": true,
+      "publicClient": false,
+      "secret": "portal-dev-secret",
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:8080/portal/auth/callback",
+        "http://localhost:5173/portal/auth/callback"
+      ],
+      "webOrigins": [
+        "http://localhost:8080",
+        "http://localhost:5173"
+      ],
+      "attributes": {
+        "post.logout.redirect.uris": "http://localhost:8080/portal/##http://localhost:5173/portal/"
+      },
+      "defaultClientScopes": ["openid", "profile", "email", "roles"],
+      "optionalClientScopes": ["offline_access"],
+      "protocolMappers": [
+        {
+          "name": "realm roles in id_token",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "oauth-mcp-dev",
+      "name": "MCP gateway fixture connection",
+      "description": "OAuth client used by the oauth-mcp-dev connection (MCP gateway → upstream MCP server).",
+      "enabled": true,
+      "publicClient": false,
+      "secret": "oauth-mcp-dev-secret",
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:8080/api/v1/admin/oauth/callback",
+        "http://localhost:5173/api/v1/admin/oauth/callback"
+      ],
+      "webOrigins": [
+        "http://localhost:8080",
+        "http://localhost:5173"
+      ],
+      "defaultClientScopes": ["openid", "profile", "email"],
+      "optionalClientScopes": ["offline_access"]
+    },
+    {
+      "clientId": "oauth-api-dev",
+      "name": "HTTP API gateway fixture connection",
+      "description": "OAuth client used by the oauth-api-dev connection (API gateway → api-test fixture).",
+      "enabled": true,
+      "publicClient": false,
+      "secret": "oauth-api-dev-secret",
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:8080/api/v1/admin/oauth/callback",
+        "http://localhost:5173/api/v1/admin/oauth/callback"
+      ],
+      "webOrigins": [
+        "http://localhost:8080",
+        "http://localhost:5173"
+      ],
+      "defaultClientScopes": ["openid", "profile", "email"],
+      "optionalClientScopes": ["offline_access"]
+    }
+  ]
+}

--- a/dev/platform.yaml
+++ b/dev/platform.yaml
@@ -58,8 +58,26 @@ server:
     - Use markdown tables for structured results
 
 auth:
+  # OIDC + browser_session enabled in dev so the login screen shows
+  # the "Sign in with OIDC" button and operators can exercise the
+  # full Keycloak flow. Realm + clients + test users are pre-seeded
+  # from dev/keycloak-realm.json at first Keycloak boot.
   oidc:
-    enabled: false
+    enabled: true
+    issuer: "http://localhost:9090/realms/mcp-platform"
+    client_id: "mcp-data-platform-portal"
+    client_secret: "portal-dev-secret"
+    audience: "mcp-data-platform-portal"
+    role_claim_path: "realm_access.roles"
+    role_prefix: "dp_"
+    scopes: ["openid", "profile", "email"]
+  browser_session:
+    enabled: true
+    # Dev-only HMAC signing key (base64-encoded 32 bytes). Production
+    # deployments override via env var and never commit a real key.
+    signing_key: "ZGV2LWJyb3dzZXItc2Vzc2lvbi1obWFjLWtleS0zMmJ5dGVzLnBs"
+    cookie_name: "mcp_session"
+    secure: false
   api_keys:
     enabled: true
     keys:
@@ -91,8 +109,13 @@ database:
 personas:
   admin:
     display_name: "Administrator"
+    # Both unprefixed (API-key auth, role = "admin") and dp_-prefixed
+    # (Keycloak OIDC, filtered by role_prefix "dp_") variants are listed
+    # so the same persona matches every login path. Same pattern repeats
+    # on each persona below.
     roles:
       - admin
+      - dp_admin
     tools:
       allow:
         - "*"
@@ -105,6 +128,7 @@ personas:
     display_name: "Data Engineer"
     roles:
       - data_engineer
+      - dp_engineer
     tools:
       allow:
         - "trino_*"
@@ -123,6 +147,7 @@ personas:
     display_name: "Inventory Analyst"
     roles:
       - inventory_analyst
+      - dp_analyst
     tools:
       allow:
         - "trino_query"

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -68,35 +68,64 @@ fi
 ok "UI dependencies ready"
 
 # Port checks (8080 = platform, 5173 = vite, 5432 = postgres,
-# 9000 = seaweedfs, 9180 = dev-mcp-mock OAuth, 9181 = dev-mcp-mock MCP,
-# 9281 = mcp-test fixture, 9282 = api-test fixture)
-for port in 5432 8080 5173 9000 9180 9181 9281 9282; do
+# 9000 = seaweedfs, 9090 = keycloak, 9180 = dev-mcp-mock OAuth,
+# 9181 = dev-mcp-mock MCP, 9281 = mcp-test fixture, 9282 = api-test fixture)
+for port in 5432 8080 5173 9000 9090 9180 9181 9281 9282; do
   if lsof -i ":$port" -sTCP:LISTEN > /dev/null 2>&1; then
     fail "Port $port is already in use. Run 'make dev-down' or stop the conflicting process."
   fi
 done
-ok "Ports 5432, 8080, 5173, 9000, 9180, 9181, 9281, 9282 are free"
+ok "Ports 5432, 8080, 5173, 9000, 9090, 9180, 9181, 9281, 9282 are free"
 
 echo ""
 
 # ─── Start Docker services ──────────────────────────────────────────
 
 echo -e "${BOLD}Starting Docker services${NC}"
-docker compose -f dev/docker-compose.yml up -d 2>&1 | grep -v "^$" | sed 's/^/  /'
+# Bring up Postgres first so we can ensure auxiliary databases (keycloak)
+# exist before dependent services boot. The fixture init script handles
+# this on a fresh volume, but reused volumes from prior `make dev` runs
+# pre-date the keycloak database — create it idempotently here.
+docker compose -f dev/docker-compose.yml up -d postgres 2>&1 | grep -v "^$" | sed 's/^/  /'
 
-# Wait for PostgreSQL using docker exec (no psql dependency required)
+# Wait for PostgreSQL. We require a REAL connection via the final
+# unix socket (/var/run/postgresql/.s.PGSQL.5432) with the `platform`
+# role — not just `pg_isready`, which returns ready during the
+# Postgres image's temporary-postmaster init phase before the final
+# socket and roles are in place.
 PG_CONTAINER="acme-dev-postgres"
 info "Waiting for PostgreSQL..."
-for i in $(seq 1 30); do
-  if docker exec "$PG_CONTAINER" pg_isready -U platform -d mcp_platform > /dev/null 2>&1; then
+for i in $(seq 1 60); do
+  if docker exec -u postgres "$PG_CONTAINER" psql -U platform -d mcp_platform -tAc 'SELECT 1' > /dev/null 2>&1; then
     break
   fi
-  if [ "$i" -eq 30 ]; then
-    fail "PostgreSQL did not become ready within 30s"
+  if [ "$i" -eq 60 ]; then
+    fail "PostgreSQL did not become ready within 60s"
   fi
   sleep 1
 done
 ok "PostgreSQL ready on :5432"
+
+# Idempotently ensure the auxiliary databases exist. The fixture init
+# script creates these on first volume bring-up; this block handles
+# upgrades where a pre-existing volume pre-dates a new database.
+# psql runs as the in-container `postgres` superuser so it uses the
+# image's local unix socket without needing to wait for TCP binding.
+for db in mcp_test apitest keycloak; do
+  exists=$(docker exec -u postgres "$PG_CONTAINER" psql -U platform -d mcp_platform -tAc \
+    "SELECT 1 FROM pg_database WHERE datname='$db'" 2>/dev/null || true)
+  if [ "$exists" != "1" ]; then
+    info "Creating auxiliary database '$db'..."
+    docker exec -u postgres "$PG_CONTAINER" psql -U platform -d mcp_platform \
+      -c "CREATE DATABASE $db" > /dev/null
+  fi
+done
+ok "Auxiliary databases present (mcp_test, apitest, keycloak)"
+
+# Now bring up the remaining services. Keycloak depends_on postgres
+# (already healthy), so this is a no-op for postgres and pulls/starts
+# everything else in parallel.
+docker compose -f dev/docker-compose.yml up -d 2>&1 | grep -v "^$" | sed 's/^/  /'
 
 # Wait for SeaweedFS (S3 returns 403 on GET /, so check for any HTTP response)
 info "Waiting for SeaweedFS..."
@@ -111,6 +140,23 @@ for i in $(seq 1 30); do
   sleep 1
 done
 ok "SeaweedFS ready on :9000"
+
+# Wait for Keycloak. First boot performs realm import + DB schema
+# creation, which is slow (90s on a fresh volume); steady-state
+# restarts come up in <10s. Realm endpoint is checked rather than
+# / because Keycloak's root returns a redirect even before the
+# realm is ready.
+info "Waiting for Keycloak (first boot imports realm — up to 120s)..."
+for i in $(seq 1 120); do
+  if curl -sf http://localhost:9090/realms/mcp-platform/.well-known/openid-configuration > /dev/null 2>&1; then
+    break
+  fi
+  if [ "$i" -eq 120 ]; then
+    fail "Keycloak did not become ready within 120s (check 'docker logs acme-dev-keycloak')"
+  fi
+  sleep 1
+done
+ok "Keycloak ready on :9090 (realm mcp-platform)"
 
 # Wait for the mcp-test fixture. First run pulls the image, which can
 # take longer than the other waits — give it up to 60s before failing.
@@ -332,6 +378,64 @@ else
   echo -e "  ${YELLOW}⚠${NC} api-test connection register returned HTTP $APITEST_HTTP — admin API may not be ready"
 fi
 
+# Pre-seed two OAuth-authorization_code fixture connections so the
+# unified OAuth flow is testable without manual config-form filling.
+# Both point at dev-mcp-mock :9180 as the IdP (issues PKCE tokens, no
+# client_id/secret validation, rotates refresh tokens). All the
+# operator does is click Connect and complete the browser hop —
+# everything else (auth URL, token URL, client credentials, callback)
+# is already wired. dev-mcp-mock auto-grants on /authorize, so the
+# "browser flow" is a single redirect through a new tab.
+info "Registering oauth-mcp-dev connection (MCP gateway via authorization_code, Keycloak IdP)..."
+OAUTH_MCP_BODY='{"config":{"endpoint":"http://localhost:9181/mcp","auth_mode":"oauth","oauth_grant":"authorization_code","oauth_authorization_url":"http://localhost:9090/realms/mcp-platform/protocol/openid-connect/auth","oauth_token_url":"http://localhost:9090/realms/mcp-platform/protocol/openid-connect/token","oauth_client_id":"oauth-mcp-dev","oauth_client_secret":"oauth-mcp-dev-secret","oauth_scope":"openid profile email","connection_name":"oauth-mcp-dev","connect_timeout":"5s","call_timeout":"10s"},"description":"Dev fixture: dev-mcp-mock (9181) via authorization_code OAuth against Keycloak (realm mcp-platform). Click Connect to authorize."}'
+OAUTH_MCP_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+  -H "X-API-Key: acme-dev-key-2024" \
+  -H "Content-Type: application/json" \
+  -d "$OAUTH_MCP_BODY" \
+  http://localhost:8080/api/v1/admin/connection-instances/mcp/oauth-mcp-dev || echo "000")
+if [ "$OAUTH_MCP_HTTP" = "200" ] || [ "$OAUTH_MCP_HTTP" = "201" ]; then
+  ok "oauth-mcp-dev connection registered (kind=mcp, authorization_code, IdP :9180)"
+else
+  echo -e "  ${YELLOW}⚠${NC} oauth-mcp-dev connection register returned HTTP $OAUTH_MCP_HTTP"
+fi
+
+info "Registering oauth-api-dev connection (HTTP API gateway via authorization_code, Keycloak IdP)..."
+OAUTH_API_BODY=$(APITEST_OPENAPI="$APITEST_OPENAPI" python3 -c '
+import json, os
+spec = os.environ.get("APITEST_OPENAPI", "")
+config = {
+    "base_url": "http://localhost:9282",
+    "auth_mode": "oauth2_authorization_code",
+    "oauth2_authorization_url": "http://localhost:9090/realms/mcp-platform/protocol/openid-connect/auth",
+    "oauth2_token_url": "http://localhost:9090/realms/mcp-platform/protocol/openid-connect/token",
+    "oauth2_client_id": "oauth-api-dev",
+    "oauth2_client_secret": "oauth-api-dev-secret",
+    "oauth2_scopes": ["openid", "profile", "email"],
+    "oauth2_endpoint_auth_style": "header",
+    "connection_name": "oauth-api-dev",
+    "connect_timeout": "5s",
+    "call_timeout": "10s",
+    "trust_level": "untrusted",
+}
+if spec:
+    config["openapi_spec"] = spec
+body = {
+    "config": config,
+    "description": "Dev fixture: api-test (9282) via authorization_code OAuth against Keycloak (realm mcp-platform). Click Connect to authorize.",
+}
+print(json.dumps(body))
+')
+OAUTH_API_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+  -H "X-API-Key: acme-dev-key-2024" \
+  -H "Content-Type: application/json" \
+  -d "$OAUTH_API_BODY" \
+  http://localhost:8080/api/v1/admin/connection-instances/api/oauth-api-dev || echo "000")
+if [ "$OAUTH_API_HTTP" = "200" ] || [ "$OAUTH_API_HTTP" = "201" ]; then
+  ok "oauth-api-dev connection registered (kind=api, authorization_code, IdP :9180)"
+else
+  echo -e "  ${YELLOW}⚠${NC} oauth-api-dev connection register returned HTTP $OAUTH_API_HTTP"
+fi
+
 echo ""
 
 # ─── Start Vite dev server ──────────────────────────────────────────
@@ -364,6 +468,12 @@ echo -e "  Portal UI:        ${CYAN}http://localhost:5173/portal/${NC}"
 echo -e "  Go API:           ${CYAN}http://localhost:8080${NC}"
 echo -e "  API Key:          ${CYAN}acme-dev-key-2024${NC}"
 echo ""
+echo -e "  ${BOLD}OIDC operator login (Keycloak)${NC}"
+echo -e "  Issuer:           ${CYAN}http://localhost:9090/realms/mcp-platform${NC}"
+echo -e "  Admin console:    ${CYAN}http://localhost:9090/admin${NC} (admin / admin)"
+echo -e "  Test users:       ${CYAN}admin@example.com / admin-password${NC} (dp_admin)"
+echo -e "                    ${CYAN}analyst@example.com / analyst-password${NC} (dp_analyst)"
+echo ""
 echo -e "  ${BOLD}Pre-wired upstream fixtures${NC}"
 echo -e "  dev-mock (MCP):   ${CYAN}http://localhost:9181/mcp${NC} (echo, add, now)"
 echo -e "                    ${CYAN}OAuth at http://localhost:9180${NC}"
@@ -371,6 +481,11 @@ echo -e "  mcp-test (MCP):   ${CYAN}http://localhost:9281/${NC}  portal: ${CYAN}
 echo -e "                    ${CYAN}API key: $MCPTEST_DEV_KEY_VAL${NC}"
 echo -e "  api-test (HTTP):  ${CYAN}http://localhost:9282/v1${NC}  portal: ${CYAN}http://localhost:9282/portal/${NC}"
 echo -e "                    ${CYAN}API key: $APITEST_DEV_KEY_VAL${NC}"
+echo ""
+echo -e "  ${BOLD}Pre-wired OAuth authorization_code fixtures${NC}"
+echo -e "  ${CYAN}Portal → Settings → Connections${NC} — click ${BOLD}Connect${NC} on either to test the browser flow:"
+echo -e "    • ${BOLD}oauth-mcp-dev${NC}  (kind=mcp, MCP fixture, IdP=Keycloak)"
+echo -e "    • ${BOLD}oauth-api-dev${NC}  (kind=api, api-test fixture, IdP=Keycloak)"
 echo ""
 echo -e "  Go files  → air rebuilds automatically"
 echo -e "  UI files  → Vite hot-reloads automatically"

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -1166,6 +1166,192 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/connections/{kind}/{name}/oauth-start": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Validates the connection is configured for authorization_code OAuth, generates a PKCE verifier, registers a state token (with kind), and returns the authorization URL the operator should open in their browser. Works for any connection kind registered in OAuthKinds.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "Begin OAuth authorization-code flow for any connection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection kind (mcp, api)",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Connection name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Optional return URL",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/admin.startConnectionOAuthRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.startConnectionOAuthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/connections/{kind}/{name}/oauth-status": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "OAuth status for a connection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Connection name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/connoauth.OAuthStatus"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/connections/{kind}/{name}/reacquire-oauth": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "Force a refresh-token exchange for a connection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Connection name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/gateway/connections/{name}/enrichment-rules": {
             "get": {
                 "security": [
@@ -7230,6 +7416,31 @@ const docTemplate = `{
                 }
             }
         },
+        "admin.startConnectionOAuthRequest": {
+            "type": "object",
+            "properties": {
+                "return_url": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.startConnectionOAuthResponse": {
+            "type": "object",
+            "properties": {
+                "authorization_url": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "redirect_uri": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
+                }
+            }
+        },
         "admin.startGatewayOAuthRequest": {
             "type": "object",
             "properties": {
@@ -7917,6 +8128,59 @@ const docTemplate = `{
                     "description": "\"file\", \"database\", or \"both\"",
                     "type": "string",
                     "example": "database"
+                }
+            }
+        },
+        "connoauth.OAuthStatus": {
+            "type": "object",
+            "properties": {
+                "authenticated_at": {
+                    "description": "AuthenticatedAt is when the most recent successful Connect\ncompleted. Initial-Connect time, not last-refresh time.",
+                    "type": "string"
+                },
+                "authenticated_by": {
+                    "description": "AuthenticatedBy is the email/id of the operator who completed\nthe browser flow. Empty for never-authorized connections.",
+                    "type": "string"
+                },
+                "configured": {
+                    "description": "Configured indicates the connection is set up for the\nauthorization_code grant. False means the status endpoint was\nhit for a non-OAuth connection (or one with a different grant)\nand the UI should hide the OAuth block entirely.",
+                    "type": "boolean"
+                },
+                "expires_at": {
+                    "description": "ExpiresAt is the access-token deadline. Zero when no token has\nbeen acquired.",
+                    "type": "string"
+                },
+                "has_refresh_token": {
+                    "description": "HasRefreshToken is true when a refresh token sits in the row.\nFalse for IdPs that don't issue refresh tokens, OR after a\nrevoked-refresh cleanup.",
+                    "type": "boolean"
+                },
+                "last_error": {
+                    "description": "LastError is the most recent surfaced failure (transport,\nIdP-rejected, persistence). Cleared by a subsequent success.",
+                    "type": "string"
+                },
+                "last_refreshed_at": {
+                    "description": "LastRefreshedAt is the persisted row's UpdatedAt — the time of\nthe most recent successful write (initial Connect or silent\nrefresh).",
+                    "type": "string"
+                },
+                "needs_reauth": {
+                    "description": "NeedsReauth is true when no access token can be minted without\noperator interaction. The admin UI surfaces a Connect button\nwhen this is true.",
+                    "type": "boolean"
+                },
+                "refresh_expires_at": {
+                    "description": "RefreshExpiresAt is the IdP-disclosed refresh-token deadline.\nZero when the IdP did not disclose one. The admin UI renders an\nem dash for zero, not \"never\".",
+                    "type": "string"
+                },
+                "scope": {
+                    "description": "Scope is the space-delimited scope string negotiated with the\nIdP. Surfaced so operators can verify offline_access is present\non Keycloak/Auth0/Okta IdPs.",
+                    "type": "string"
+                },
+                "token_acquired": {
+                    "description": "TokenAcquired is true when a non-empty access_token sits in the\npersisted row. False after a revoked-refresh cleanup or before\nthe first Connect.",
+                    "type": "boolean"
+                },
+                "token_url": {
+                    "description": "TokenURL is the IdP's token endpoint, surfaced so the admin\nstatus panel can show \"auth against https://iam.example.com/...\"\nat a glance. Operator-authored config; safe to expose.",
+                    "type": "string"
                 }
             }
         },

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -1160,6 +1160,192 @@
                 }
             }
         },
+        "/admin/connections/{kind}/{name}/oauth-start": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Validates the connection is configured for authorization_code OAuth, generates a PKCE verifier, registers a state token (with kind), and returns the authorization URL the operator should open in their browser. Works for any connection kind registered in OAuthKinds.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "Begin OAuth authorization-code flow for any connection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection kind (mcp, api)",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Connection name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Optional return URL",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/admin.startConnectionOAuthRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.startConnectionOAuthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/connections/{kind}/{name}/oauth-status": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "OAuth status for a connection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Connection name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/connoauth.OAuthStatus"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/connections/{kind}/{name}/reacquire-oauth": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "Force a refresh-token exchange for a connection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Connection kind",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Connection name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/gateway/connections/{name}/enrichment-rules": {
             "get": {
                 "security": [
@@ -7224,6 +7410,31 @@
                 }
             }
         },
+        "admin.startConnectionOAuthRequest": {
+            "type": "object",
+            "properties": {
+                "return_url": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.startConnectionOAuthResponse": {
+            "type": "object",
+            "properties": {
+                "authorization_url": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "redirect_uri": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
+                }
+            }
+        },
         "admin.startGatewayOAuthRequest": {
             "type": "object",
             "properties": {
@@ -7911,6 +8122,59 @@
                     "description": "\"file\", \"database\", or \"both\"",
                     "type": "string",
                     "example": "database"
+                }
+            }
+        },
+        "connoauth.OAuthStatus": {
+            "type": "object",
+            "properties": {
+                "authenticated_at": {
+                    "description": "AuthenticatedAt is when the most recent successful Connect\ncompleted. Initial-Connect time, not last-refresh time.",
+                    "type": "string"
+                },
+                "authenticated_by": {
+                    "description": "AuthenticatedBy is the email/id of the operator who completed\nthe browser flow. Empty for never-authorized connections.",
+                    "type": "string"
+                },
+                "configured": {
+                    "description": "Configured indicates the connection is set up for the\nauthorization_code grant. False means the status endpoint was\nhit for a non-OAuth connection (or one with a different grant)\nand the UI should hide the OAuth block entirely.",
+                    "type": "boolean"
+                },
+                "expires_at": {
+                    "description": "ExpiresAt is the access-token deadline. Zero when no token has\nbeen acquired.",
+                    "type": "string"
+                },
+                "has_refresh_token": {
+                    "description": "HasRefreshToken is true when a refresh token sits in the row.\nFalse for IdPs that don't issue refresh tokens, OR after a\nrevoked-refresh cleanup.",
+                    "type": "boolean"
+                },
+                "last_error": {
+                    "description": "LastError is the most recent surfaced failure (transport,\nIdP-rejected, persistence). Cleared by a subsequent success.",
+                    "type": "string"
+                },
+                "last_refreshed_at": {
+                    "description": "LastRefreshedAt is the persisted row's UpdatedAt \u2014 the time of\nthe most recent successful write (initial Connect or silent\nrefresh).",
+                    "type": "string"
+                },
+                "needs_reauth": {
+                    "description": "NeedsReauth is true when no access token can be minted without\noperator interaction. The admin UI surfaces a Connect button\nwhen this is true.",
+                    "type": "boolean"
+                },
+                "refresh_expires_at": {
+                    "description": "RefreshExpiresAt is the IdP-disclosed refresh-token deadline.\nZero when the IdP did not disclose one. The admin UI renders an\nem dash for zero, not \"never\".",
+                    "type": "string"
+                },
+                "scope": {
+                    "description": "Scope is the space-delimited scope string negotiated with the\nIdP. Surfaced so operators can verify offline_access is present\non Keycloak/Auth0/Okta IdPs.",
+                    "type": "string"
+                },
+                "token_acquired": {
+                    "description": "TokenAcquired is true when a non-empty access_token sits in the\npersisted row. False after a revoked-refresh cleanup or before\nthe first Connect.",
+                    "type": "boolean"
+                },
+                "token_url": {
+                    "description": "TokenURL is the IdP's token endpoint, surfaced so the admin\nstatus panel can show \"auth against https://iam.example.com/...\"\nat a glance. Operator-authored config; safe to expose.",
+                    "type": "string"
                 }
             }
         },

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -553,6 +553,22 @@ definitions:
         example: Production data warehouse
         type: string
     type: object
+  admin.startConnectionOAuthRequest:
+    properties:
+      return_url:
+        type: string
+    type: object
+  admin.startConnectionOAuthResponse:
+    properties:
+      authorization_url:
+        type: string
+      expires_at:
+        type: string
+      redirect_uri:
+        type: string
+      state:
+        type: string
+    type: object
   admin.startGatewayOAuthRequest:
     properties:
       return_url:
@@ -1048,6 +1064,78 @@ definitions:
       source:
         description: '"file", "database", or "both"'
         example: database
+        type: string
+    type: object
+  connoauth.OAuthStatus:
+    properties:
+      authenticated_at:
+        description: |-
+          AuthenticatedAt is when the most recent successful Connect
+          completed. Initial-Connect time, not last-refresh time.
+        type: string
+      authenticated_by:
+        description: |-
+          AuthenticatedBy is the email/id of the operator who completed
+          the browser flow. Empty for never-authorized connections.
+        type: string
+      configured:
+        description: |-
+          Configured indicates the connection is set up for the
+          authorization_code grant. False means the status endpoint was
+          hit for a non-OAuth connection (or one with a different grant)
+          and the UI should hide the OAuth block entirely.
+        type: boolean
+      expires_at:
+        description: |-
+          ExpiresAt is the access-token deadline. Zero when no token has
+          been acquired.
+        type: string
+      has_refresh_token:
+        description: |-
+          HasRefreshToken is true when a refresh token sits in the row.
+          False for IdPs that don't issue refresh tokens, OR after a
+          revoked-refresh cleanup.
+        type: boolean
+      last_error:
+        description: |-
+          LastError is the most recent surfaced failure (transport,
+          IdP-rejected, persistence). Cleared by a subsequent success.
+        type: string
+      last_refreshed_at:
+        description: |-
+          LastRefreshedAt is the persisted row's UpdatedAt — the time of
+          the most recent successful write (initial Connect or silent
+          refresh).
+        type: string
+      needs_reauth:
+        description: |-
+          NeedsReauth is true when no access token can be minted without
+          operator interaction. The admin UI surfaces a Connect button
+          when this is true.
+        type: boolean
+      refresh_expires_at:
+        description: |-
+          RefreshExpiresAt is the IdP-disclosed refresh-token deadline.
+          Zero when the IdP did not disclose one. The admin UI renders an
+          em dash for zero, not "never".
+        type: string
+      scope:
+        description: |-
+          Scope is the space-delimited scope string negotiated with the
+          IdP. Surfaced so operators can verify offline_access is present
+          on Keycloak/Auth0/Okta IdPs.
+        type: string
+      token_acquired:
+        description: |-
+          TokenAcquired is true when a non-empty access_token sits in the
+          persisted row. False after a revoked-refresh cleanup or before
+          the first Connect.
+        type: boolean
+      token_url:
+        description: |-
+          TokenURL is the IdP's token endpoint, surfaced so the admin
+          status panel can show "auth against https://iam.example.com/..."
+          at a glance. Operator-authored config; safe to expose.
         type: string
     type: object
   enrichment.Action:
@@ -2977,6 +3065,125 @@ paths:
       summary: List connections
       tags:
       - System
+  /admin/connections/{kind}/{name}/oauth-start:
+    post:
+      consumes:
+      - application/json
+      description: Validates the connection is configured for authorization_code OAuth,
+        generates a PKCE verifier, registers a state token (with kind), and returns
+        the authorization URL the operator should open in their browser. Works for
+        any connection kind registered in OAuthKinds.
+      parameters:
+      - description: Connection kind (mcp, api)
+        in: path
+        name: kind
+        required: true
+        type: string
+      - description: Connection name
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Optional return URL
+        in: body
+        name: body
+        schema:
+          $ref: '#/definitions/admin.startConnectionOAuthRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/admin.startConnectionOAuthResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/admin.problemDetail'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/admin.problemDetail'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/admin.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Begin OAuth authorization-code flow for any connection
+      tags:
+      - Connections
+  /admin/connections/{kind}/{name}/oauth-status:
+    get:
+      parameters:
+      - description: Connection kind
+        in: path
+        name: kind
+        required: true
+        type: string
+      - description: Connection name
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/connoauth.OAuthStatus'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/admin.problemDetail'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/admin.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: OAuth status for a connection
+      tags:
+      - Connections
+  /admin/connections/{kind}/{name}/reacquire-oauth:
+    post:
+      parameters:
+      - description: Connection kind
+        in: path
+        name: kind
+        required: true
+        type: string
+      - description: Connection name
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/admin.problemDetail'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/admin.problemDetail'
+        "502":
+          description: Bad Gateway
+          schema:
+            $ref: '#/definitions/admin.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Force a refresh-token exchange for a connection
+      tags:
+      - Connections
   /admin/gateway/connections/{name}/enrichment-rules:
     get:
       parameters:

--- a/pkg/admin/connection_oauth_handler.go
+++ b/pkg/admin/connection_oauth_handler.go
@@ -1,0 +1,465 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
+	"github.com/txn2/mcp-data-platform/pkg/platform"
+)
+
+// pathKeyKind is the URL path parameter that selects which
+// OAuthKindHandler handles the request. Matches the routes registered
+// under /api/v1/admin/connections/{kind}/{name}/...
+const pathKeyKind = "kind"
+
+// logKeyKind is already defined in connection_handler.go for the
+// connection-kind structured-log field; reused here so oauth-start /
+// oauth-callback / oauth-status log lines align on the same key.
+
+// registerConnectionOAuthRoutes installs the unified OAuth flow
+// endpoints. Replaces the two prior per-kind route blocks
+// (registerGatewayOAuthRoutes + registerAPIGatewayOAuthRoutes) with
+// one shared set parameterized on {kind}. The callback URL is
+// intentionally unchanged from the prior MCP path
+// (/api/v1/admin/oauth/callback) — operators have already registered
+// it with their upstream IdPs (Keycloak / Auth0 / Okta / Microsoft
+// App Registrations); breaking the URL would force every customer to
+// reconfigure their IdP client.
+func (h *Handler) registerConnectionOAuthRoutes() {
+	if !h.isMutable() || h.deps.ConnectionStore == nil || h.deps.ConnOAuthStore == nil {
+		return
+	}
+	h.mux.HandleFunc("POST /api/v1/admin/connections/{kind}/{name}/oauth-start", h.startConnectionOAuth)
+	h.mux.HandleFunc("GET /api/v1/admin/connections/{kind}/{name}/oauth-status", h.connectionOAuthStatus)
+	h.mux.HandleFunc("POST /api/v1/admin/connections/{kind}/{name}/reacquire-oauth", h.reacquireConnectionOAuth)
+	h.publicMux.HandleFunc("GET /api/v1/admin/oauth/callback", h.connectionOAuthCallback)
+	// Legacy API-gateway callback URL. Existing deployments may have
+	// this URL registered in customer IdP client configurations; keep
+	// it as an alias for the unified callback so the IdP redirect
+	// continues to resolve. Removed in a follow-up after one release.
+	h.publicMux.HandleFunc("GET /api/v1/admin/api-gateway/oauth/callback", h.connectionOAuthCallback)
+}
+
+// startConnectionOAuthRequest is the optional POST body. The
+// operator-supplied returnURL is run through safeReturnURL on the
+// callback side to defeat open-redirect probes.
+type startConnectionOAuthRequest struct {
+	ReturnURL string `json:"return_url,omitempty"`
+}
+
+// startConnectionOAuthResponse hands the portal the URL it should
+// open in a new browser tab to begin the upstream's OAuth flow.
+type startConnectionOAuthResponse struct {
+	AuthorizationURL string `json:"authorization_url"`
+	State            string `json:"state"`
+	RedirectURI      string `json:"redirect_uri"`
+	ExpiresAt        string `json:"expires_at"`
+}
+
+// startConnectionOAuth handles POST /connections/{kind}/{name}/oauth-start.
+// Replaces both startGatewayOAuth and startAPIGatewayOAuth.
+//
+// @Summary      Begin OAuth authorization-code flow for any connection
+// @Description  Validates the connection is configured for authorization_code OAuth, generates a PKCE verifier, registers a state token (with kind), and returns the authorization URL the operator should open in their browser. Works for any connection kind registered in OAuthKinds.
+// @Tags         Connections
+// @Accept       json
+// @Produce      json
+// @Param        kind  path  string                          true  "Connection kind (mcp, api)"
+// @Param        name  path  string                          true  "Connection name"
+// @Param        body  body  startConnectionOAuthRequest     false "Optional return URL"
+// @Success      200   {object}  startConnectionOAuthResponse
+// @Failure      400   {object}  problemDetail
+// @Failure      404   {object}  problemDetail
+// @Failure      409   {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /admin/connections/{kind}/{name}/oauth-start [post]
+func (h *Handler) startConnectionOAuth(w http.ResponseWriter, r *http.Request) {
+	kind := r.PathValue(pathKeyKind)
+	name := r.PathValue(pathKeyName)
+	handler, ok := h.lookupOAuthKindHandler(w, kind)
+	if !ok {
+		return
+	}
+	inst, ok := h.loadConnectionForOAuth(w, r, kind, name)
+	if !ok {
+		return
+	}
+	cfg, ok := h.parseConnectionOAuthConfig(w, handler, inst.Config)
+	if !ok {
+		return
+	}
+
+	var body startConnectionOAuthRequest
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+	}
+	verifier, state, ok := generatePKCEPair(w)
+	if !ok {
+		return
+	}
+	redirectURI := buildOAuthCallbackURL(r)
+	authURL := buildConnectionAuthorizationURL(cfg, state, verifier, redirectURI)
+
+	store := h.pkceStoreFor()
+	if store == nil {
+		writeError(w, http.StatusServiceUnavailable, "OAuth not available: PKCE store not configured")
+		return
+	}
+	startedBy := authorEmailOrID(r.Context())
+	if err := store.Put(r.Context(), state, &PKCEState{
+		kind:         kind,
+		connection:   name,
+		codeVerifier: verifier,
+		startedBy:    startedBy,
+		createdAt:    time.Now(),
+		returnURL:    body.ReturnURL,
+		redirectURI:  redirectURI,
+	}); err != nil {
+		slog.Error("oauth-start: failed to persist pkce state",
+			logKeyKind, kind, logKeyName, name, logKeyStartedBy, startedBy, logKeyError, err)
+		writeError(w, http.StatusInternalServerError, "failed to record OAuth state")
+		return
+	}
+
+	slog.Info("oauth-start: PKCE state issued",
+		logKeyKind, kind,
+		logKeyName, name,
+		logKeyStartedBy, startedBy,
+		logKeyStatePrefix, truncateForLog(state),
+		logKeyRedirectURI, redirectURI,
+		"authorization_url_host", urlHostForLog(cfg.AuthorizationURL),
+		"return_url", body.ReturnURL,
+		"ttl", pkceTTL)
+
+	writeJSON(w, http.StatusOK, startConnectionOAuthResponse{
+		AuthorizationURL: authURL,
+		State:            state,
+		RedirectURI:      redirectURI,
+		ExpiresAt:        time.Now().Add(pkceTTL).UTC().Format(time.RFC3339),
+	})
+}
+
+// connectionOAuthStatus handles GET /connections/{kind}/{name}/oauth-status.
+// Returns the connoauth.OAuthStatus snapshot the portal renders in
+// OAuthStatusCard. Works for any registered kind.
+//
+// @Summary      OAuth status for a connection
+// @Tags         Connections
+// @Produce      json
+// @Param        kind  path  string  true  "Connection kind"
+// @Param        name  path  string  true  "Connection name"
+// @Success      200   {object}  connoauth.OAuthStatus
+// @Failure      404   {object}  problemDetail
+// @Failure      409   {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /admin/connections/{kind}/{name}/oauth-status [get]
+func (h *Handler) connectionOAuthStatus(w http.ResponseWriter, r *http.Request) {
+	kind := r.PathValue(pathKeyKind)
+	name := r.PathValue(pathKeyName)
+	handler, ok := h.lookupOAuthKindHandler(w, kind)
+	if !ok {
+		return
+	}
+	inst, ok := h.loadConnectionForOAuth(w, r, kind, name)
+	if !ok {
+		return
+	}
+	cfg, ok := h.parseConnectionOAuthConfig(w, handler, inst.Config)
+	if !ok {
+		return
+	}
+	src := connoauth.NewSource(h.deps.ConnOAuthStore, connoauth.Key{Kind: kind, Name: name}, cfg)
+	writeJSON(w, http.StatusOK, src.Status(r.Context()))
+}
+
+// reacquireConnectionOAuth handles POST /connections/{kind}/{name}/reacquire-oauth.
+// Forces a refresh-token exchange against the upstream IdP. Useful
+// for testing whether the persisted refresh token still works without
+// waiting for the access token to expire naturally. Returns 200 on
+// success; 409 with a NeedsReauth body when the IdP rejected the
+// refresh (operator must complete a fresh Connect).
+//
+// @Summary      Force a refresh-token exchange for a connection
+// @Tags         Connections
+// @Produce      json
+// @Param        kind  path  string  true  "Connection kind"
+// @Param        name  path  string  true  "Connection name"
+// @Success      200
+// @Failure      404   {object}  problemDetail
+// @Failure      409   {object}  problemDetail
+// @Failure      502   {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /admin/connections/{kind}/{name}/reacquire-oauth [post]
+func (h *Handler) reacquireConnectionOAuth(w http.ResponseWriter, r *http.Request) {
+	kind := r.PathValue(pathKeyKind)
+	name := r.PathValue(pathKeyName)
+	handler, ok := h.lookupOAuthKindHandler(w, kind)
+	if !ok {
+		return
+	}
+	inst, ok := h.loadConnectionForOAuth(w, r, kind, name)
+	if !ok {
+		return
+	}
+	cfg, ok := h.parseConnectionOAuthConfig(w, handler, inst.Config)
+	if !ok {
+		return
+	}
+	src := connoauth.NewSource(h.deps.ConnOAuthStore, connoauth.Key{Kind: kind, Name: name}, cfg)
+	if err := src.Reacquire(r.Context()); err != nil {
+		if errors.Is(err, connoauth.ErrNeedsReauth) {
+			writeError(w, http.StatusConflict, "connection needs admin reconnect")
+			return
+		}
+		writeError(w, http.StatusBadGateway, "refresh failed: "+err.Error())
+		return
+	}
+	// Return the post-refresh status so the portal's status card updates
+	// immediately without a follow-up GET. Empty 200 broke the portal's
+	// apiFetch which assumes a JSON body on success.
+	writeJSON(w, http.StatusOK, src.Status(r.Context()))
+}
+
+// connectionOAuthCallback handles GET /api/v1/admin/oauth/callback —
+// the public endpoint the IdP redirects to after the operator
+// authenticates. Replaces both prior callbacks (MCP and API);
+// dispatches by reading connection_kind from the PKCE state row.
+//
+// URL is intentionally unchanged from the prior MCP callback — it is
+// already registered in customer IdP configurations (Keycloak / Auth0
+// / Okta / Microsoft App Registrations). Changing it would force a
+// reconfigure on every customer.
+//
+// @Summary      OAuth authorization-code callback (unified)
+// @Description  Public endpoint hit by the upstream IdP after operator authentication. The PKCE state row carries the connection_kind so this single endpoint handles every kind.
+// @Tags         Connections
+// @Produce      html
+// @Param        code   query  string  false  "OAuth authorization code"
+// @Param        state  query  string  true   "PKCE state token"
+// @Param        error  query  string  false  "OAuth error code from upstream"
+// @Success      302
+// @Failure      400   {object}  problemDetail
+// @Router       /admin/oauth/callback [get]
+func (h *Handler) connectionOAuthCallback(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	pending := h.takeConnectionPKCEState(w, r)
+	if pending == nil {
+		return
+	}
+	q := r.URL.Query()
+	if errCode := q.Get("error"); errCode != "" {
+		slog.Warn("oauth-callback: IdP returned error",
+			logKeyKind, pending.kind, logKeyName, pending.connection,
+			"idp_error", errCode, "idp_error_description", q.Get("error_description"))
+		writeOAuthError(w, fmt.Sprintf("upstream returned %s: %s", errCode, q.Get("error_description")))
+		return
+	}
+	code := q.Get("code")
+	if code == "" {
+		writeOAuthError(w, "missing code parameter")
+		return
+	}
+	if err := h.completeConnectionOAuthExchange(r.Context(), pending, code); err != nil {
+		slog.Error("oauth-callback: exchange failed",
+			logKeyKind, pending.kind, logKeyName, pending.connection,
+			logKeyStartedBy, pending.startedBy, logKeyDuration, time.Since(start),
+			logKeyError, err)
+		writeOAuthError(w, "token exchange failed: "+err.Error())
+		return
+	}
+	dest := safeReturnURL(pending.returnURL)
+	if pending.returnURL != "" && dest != pending.returnURL {
+		slog.Warn("oauth-callback: returnURL rewritten by safeReturnURL guard",
+			logKeyKind, pending.kind, logKeyName, pending.connection,
+			"requested_return_url", pending.returnURL, "rewritten_to", dest)
+	}
+	slog.Info("oauth-callback: success — tokens persisted",
+		logKeyKind, pending.kind, logKeyName, pending.connection,
+		logKeyStartedBy, pending.startedBy,
+		logKeyDuration, time.Since(start), "dest", dest)
+	// #nosec G710 -- safeReturnURL has already constrained dest to a
+	// same-origin relative path or the constant fallback.
+	http.Redirect(w, r, dest, http.StatusFound) // nosemgrep: go.lang.security.injection.open-redirect.open-redirect
+}
+
+// takeConnectionPKCEState consumes the pending PKCE row. Returns nil
+// and writes the HTML error page on any failure path so callers can
+// return early. Falls back to "mcp" for legacy rows that pre-date
+// migration 000039's connection_kind column (those rows belong to
+// the MCP gateway by construction — only kind that used this table
+// before 000039).
+func (h *Handler) takeConnectionPKCEState(w http.ResponseWriter, r *http.Request) *PKCEState {
+	state := r.URL.Query().Get("state")
+	if state == "" {
+		writeOAuthError(w, "missing state parameter")
+		return nil
+	}
+	store := h.pkceStoreFor()
+	if store == nil {
+		writeOAuthError(w, "OAuth not available: PKCE store not configured")
+		return nil
+	}
+	pending, err := store.Take(r.Context(), state)
+	if err != nil {
+		writeOAuthError(w, "OAuth state expired or unknown — please retry from the admin UI")
+		return nil
+	}
+	if pending.kind == "" {
+		// Pre-migration-000039 row (legacy MCP-only flow). Set the
+		// default so downstream dispatch has a known kind.
+		pending.kind = connectionKindMCP
+	}
+	return pending
+}
+
+// completeConnectionOAuthExchange runs the token exchange, persists
+// the result via connoauth.Store, and invokes the per-kind
+// AfterConnect hook so the connection becomes immediately usable.
+func (h *Handler) completeConnectionOAuthExchange(ctx context.Context, pending *PKCEState, code string) error {
+	handler, ok := h.deps.OAuthKinds[pending.kind]
+	if !ok {
+		return fmt.Errorf("unsupported connection kind: %s", pending.kind)
+	}
+	inst, err := h.deps.ConnectionStore.Get(ctx, pending.kind, pending.connection)
+	if err != nil {
+		return fmt.Errorf("load connection: %w", err)
+	}
+	cfg, err := handler.ParseOAuthConfig(inst.Config)
+	if err != nil {
+		return fmt.Errorf("parse config: %w", err)
+	}
+	result, err := connoauth.Exchange(ctx, connoauth.ExchangeInput{
+		Config:       cfg,
+		Code:         code,
+		CodeVerifier: pending.codeVerifier,
+		RedirectURI:  pending.redirectURI,
+	})
+	if err != nil {
+		return fmt.Errorf("connoauth exchange: %w", err)
+	}
+	now := time.Now()
+	persistErr := h.deps.ConnOAuthStore.Set(ctx, connoauth.PersistedToken{
+		Key:              connoauth.Key{Kind: pending.kind, Name: pending.connection},
+		AccessToken:      result.AccessToken,
+		RefreshToken:     result.RefreshToken,
+		ExpiresAt:        result.ExpiresAt,
+		RefreshExpiresAt: result.RefreshExpiresAt,
+		Scope:            result.Scope,
+		AuthenticatedBy:  pending.startedBy,
+		AuthenticatedAt:  now,
+	})
+	if persistErr != nil {
+		// Persistence failure on Connect MUST surface — the in-memory
+		// view from this turn would silently vanish on the next
+		// process restart, leaving the operator perpetually clicking
+		// Connect with no idea why it doesn't stick.
+		return fmt.Errorf("persist token: %w", persistErr)
+	}
+	if err := handler.AfterConnect(ctx, pending.connection, inst.Config); err != nil {
+		// Log but do not fail the Connect — the token IS persisted;
+		// the post-auth side effect (e.g., MCP gateway tool
+		// registration) can be retried by the toolkit's normal
+		// reconciliation paths. Failing the Connect here would force
+		// the operator to repeat the browser flow even though the
+		// credential is good.
+		slog.Warn("oauth-callback: AfterConnect hook failed (token persisted, side effect deferred)",
+			logKeyKind, pending.kind, logKeyName, pending.connection, logKeyError, err)
+	}
+	return nil
+}
+
+// lookupOAuthKindHandler resolves the kind path parameter to a
+// registered OAuthKindHandler. Writes 400 and returns ok=false when
+// the kind is missing or unsupported.
+func (h *Handler) lookupOAuthKindHandler(w http.ResponseWriter, kind string) (OAuthKindHandler, bool) {
+	if kind == "" {
+		writeError(w, http.StatusBadRequest, "missing connection kind")
+		return nil, false
+	}
+	if h.deps.OAuthKinds == nil {
+		writeError(w, http.StatusServiceUnavailable, "OAuth not available: no kind handlers registered")
+		return nil, false
+	}
+	handler, ok := h.deps.OAuthKinds[kind]
+	if !ok {
+		writeError(w, http.StatusBadRequest, "unsupported connection kind: "+kind)
+		return nil, false
+	}
+	return handler, true
+}
+
+// loadConnectionForOAuth fetches the connection row, writing 404/500
+// on the standard error paths. Centralized so every {kind,name}
+// endpoint maps not-found and load failures identically.
+func (h *Handler) loadConnectionForOAuth(w http.ResponseWriter, r *http.Request, kind, name string) (*platform.ConnectionInstance, bool) {
+	inst, err := h.deps.ConnectionStore.Get(r.Context(), kind, name)
+	if err != nil {
+		if errors.Is(err, platform.ErrConnectionNotFound) {
+			writeError(w, http.StatusNotFound, "connection not found")
+		} else {
+			writeError(w, http.StatusInternalServerError, "failed to load connection")
+		}
+		return nil, false
+	}
+	return inst, true
+}
+
+// parseConnectionOAuthConfig invokes the kind-specific extractor and
+// maps the configuration error to HTTP 409 ("not configured for
+// authorization_code OAuth") matching the prior per-kind handlers'
+// response code.
+func (*Handler) parseConnectionOAuthConfig(w http.ResponseWriter, handler OAuthKindHandler, raw map[string]any) (connoauth.Config, bool) {
+	cfg, err := handler.ParseOAuthConfig(raw)
+	if err != nil {
+		writeError(w, http.StatusConflict, err.Error())
+		return connoauth.Config{}, false
+	}
+	return cfg, true
+}
+
+// buildConnectionAuthorizationURL composes the IdP's authorize URL
+// with PKCE attached. SHA-256 challenge per RFC 7636 §4.2 — the
+// only method OAuth 2.1 mandates.
+func buildConnectionAuthorizationURL(cfg connoauth.Config, state, verifier, redirectURI string) string {
+	v := url.Values{}
+	v.Set("response_type", "code")
+	v.Set("client_id", cfg.ClientID)
+	v.Set("redirect_uri", redirectURI)
+	v.Set("state", state)
+	v.Set("code_challenge", pkceChallenge(verifier))
+	v.Set("code_challenge_method", "S256")
+	if len(cfg.Scopes) > 0 {
+		v.Set("scope", strings.Join(cfg.Scopes, " "))
+	}
+	if cfg.Prompt != "" {
+		v.Set("prompt", cfg.Prompt)
+	}
+	sep := "?"
+	if u, err := url.Parse(cfg.AuthorizationURL); err == nil && u.RawQuery != "" {
+		sep = "&"
+	}
+	return cfg.AuthorizationURL + sep + v.Encode()
+}
+
+// urlHostForLog returns the host portion of u for log fields, falling
+// back to the raw value when parsing fails. Local to admin so the
+// connoauth package's identically-named helper doesn't need to be
+// exported.
+func urlHostForLog(u string) string {
+	parsed, err := url.Parse(u)
+	if err != nil || parsed.Host == "" {
+		return u
+	}
+	return parsed.Host
+}

--- a/pkg/admin/connection_oauth_handler_test.go
+++ b/pkg/admin/connection_oauth_handler_test.go
@@ -66,7 +66,17 @@ func newOAuthTestHandler(t *testing.T, connStore *mockConnectionStore, kinds OAu
 	return h, store
 }
 
-func setupOAuthFixture(t *testing.T, tokenSrv *httptest.Server) (*Handler, connoauth.Store, *fakeOAuthKindHandler, *mockConnectionStore) {
+// oauthFixture bundles the live handler + its mocks so test cases can
+// reach into specific components without exceeding revive's three-
+// return-value limit on the constructor.
+type oauthFixture struct {
+	handler   *Handler
+	store     connoauth.Store
+	kind      *fakeOAuthKindHandler
+	connStore *mockConnectionStore
+}
+
+func setupOAuthFixture(t *testing.T, tokenSrv *httptest.Server) *oauthFixture {
 	t.Helper()
 	fake := &fakeOAuthKindHandler{
 		parseCfg: connoauth.Config{
@@ -95,12 +105,12 @@ func setupOAuthFixture(t *testing.T, tokenSrv *httptest.Server) (*Handler, conno
 	}
 	kinds := OAuthKindHandlers{connoauth.KindMCP: fake}
 	h, store := newOAuthTestHandler(t, connStore, kinds)
-	return h, store, fake, connStore
+	return &oauthFixture{handler: h, store: store, kind: fake, connStore: connStore}
 }
 
-// fakeIdPServer is a minimal HTTP test double that issues tokens on
+// fakeIDPServer is a minimal HTTP test double that issues tokens on
 // /token. Each callback to the test can override the response.
-func fakeIdPServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+func fakeIDPServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/token", handler)
@@ -114,8 +124,9 @@ func fakeIdPServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 // ────────────────────────────────────────────────────────────────────────
 
 func TestStartConnectionOAuth_Success(t *testing.T) {
-	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
-	h, _, _, _ := setupOAuthFixture(t, srv)
+	srv := fakeIDPServer(t, func(http.ResponseWriter, *http.Request) {})
+	fx := setupOAuthFixture(t, srv)
+	h := fx.handler
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
 		"/api/v1/admin/connections/mcp/alpha/oauth-start",
@@ -136,8 +147,9 @@ func TestStartConnectionOAuth_Success(t *testing.T) {
 }
 
 func TestStartConnectionOAuth_UnknownKind(t *testing.T) {
-	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
-	h, _, _, _ := setupOAuthFixture(t, srv)
+	srv := fakeIDPServer(t, func(http.ResponseWriter, *http.Request) {})
+	fx := setupOAuthFixture(t, srv)
+	h := fx.handler
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
 		"/api/v1/admin/connections/unsupported/alpha/oauth-start", http.NoBody)
@@ -148,8 +160,9 @@ func TestStartConnectionOAuth_UnknownKind(t *testing.T) {
 }
 
 func TestStartConnectionOAuth_ConnectionNotFound(t *testing.T) {
-	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
-	h, _, _, connStore := setupOAuthFixture(t, srv)
+	srv := fakeIDPServer(t, func(http.ResponseWriter, *http.Request) {})
+	fx := setupOAuthFixture(t, srv)
+	h, connStore := fx.handler, fx.connStore
 	connStore.getErr = platform.ErrConnectionNotFound
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
@@ -160,8 +173,9 @@ func TestStartConnectionOAuth_ConnectionNotFound(t *testing.T) {
 }
 
 func TestStartConnectionOAuth_NotConfiguredForAuthCode(t *testing.T) {
-	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
-	h, _, fake, _ := setupOAuthFixture(t, srv)
+	srv := fakeIDPServer(t, func(http.ResponseWriter, *http.Request) {})
+	fx := setupOAuthFixture(t, srv)
+	h, fake := fx.handler, fx.kind
 	fake.parseErr = errors.New("connection is not configured for authorization_code OAuth")
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
@@ -176,8 +190,9 @@ func TestStartConnectionOAuth_NotConfiguredForAuthCode(t *testing.T) {
 // ────────────────────────────────────────────────────────────────────────
 
 func TestConnectionOAuthStatus_NoToken(t *testing.T) {
-	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
-	h, _, _, _ := setupOAuthFixture(t, srv)
+	srv := fakeIDPServer(t, func(http.ResponseWriter, *http.Request) {})
+	fx := setupOAuthFixture(t, srv)
+	h := fx.handler
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
 		"/api/v1/admin/connections/mcp/alpha/oauth-status", http.NoBody)
@@ -192,8 +207,9 @@ func TestConnectionOAuthStatus_NoToken(t *testing.T) {
 }
 
 func TestConnectionOAuthStatus_WithToken(t *testing.T) {
-	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
-	h, store, _, _ := setupOAuthFixture(t, srv)
+	srv := fakeIDPServer(t, func(http.ResponseWriter, *http.Request) {})
+	fx := setupOAuthFixture(t, srv)
+	h, store := fx.handler, fx.store
 	now := time.Now()
 	_ = store.Set(context.Background(), connoauth.PersistedToken{
 		Key:             connoauth.Key{Kind: connoauth.KindMCP, Name: "alpha"},
@@ -221,7 +237,7 @@ func TestConnectionOAuthStatus_WithToken(t *testing.T) {
 // ────────────────────────────────────────────────────────────────────────
 
 func TestReacquireConnectionOAuth_Success(t *testing.T) {
-	srv := fakeIdPServer(t, func(w http.ResponseWriter, _ *http.Request) {
+	srv := fakeIDPServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"access_token":  "at-fresh",
@@ -230,7 +246,8 @@ func TestReacquireConnectionOAuth_Success(t *testing.T) {
 			"token_type":    "Bearer",
 		})
 	})
-	h, store, _, _ := setupOAuthFixture(t, srv)
+	fx := setupOAuthFixture(t, srv)
+	h, store := fx.handler, fx.store
 	now := time.Now()
 	_ = store.Set(context.Background(), connoauth.PersistedToken{
 		Key:          connoauth.Key{Kind: connoauth.KindMCP, Name: "alpha"},
@@ -254,12 +271,13 @@ func TestReacquireConnectionOAuth_Success(t *testing.T) {
 }
 
 func TestReacquireConnectionOAuth_NeedsReauth(t *testing.T) {
-	srv := fakeIdPServer(t, func(w http.ResponseWriter, _ *http.Request) {
+	srv := fakeIDPServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
 	})
-	h, store, _, _ := setupOAuthFixture(t, srv)
+	fx := setupOAuthFixture(t, srv)
+	h, store := fx.handler, fx.store
 	_ = store.Set(context.Background(), connoauth.PersistedToken{
 		Key:          connoauth.Key{Kind: connoauth.KindMCP, Name: "alpha"},
 		AccessToken:  "at",
@@ -280,11 +298,12 @@ func TestReacquireConnectionOAuth_NeedsReauth(t *testing.T) {
 // ────────────────────────────────────────────────────────────────────────
 
 func TestConnectionOAuthCallback_RoundTrip(t *testing.T) {
-	tokenSrv := fakeIdPServer(t, func(w http.ResponseWriter, _ *http.Request) {
+	tokenSrv := fakeIDPServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"access_token":"at","refresh_token":"rt","expires_in":3600,"token_type":"Bearer"}`))
 	})
-	h, store, fake, _ := setupOAuthFixture(t, tokenSrv)
+	fx := setupOAuthFixture(t, tokenSrv)
+	h, store, fake := fx.handler, fx.store, fx.kind
 
 	// Step 1: oauth-start
 	startReq := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
@@ -321,8 +340,9 @@ func TestConnectionOAuthCallback_RoundTrip(t *testing.T) {
 }
 
 func TestConnectionOAuthCallback_MissingState(t *testing.T) {
-	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
-	h, _, _, _ := setupOAuthFixture(t, srv)
+	srv := fakeIDPServer(t, func(http.ResponseWriter, *http.Request) {})
+	fx := setupOAuthFixture(t, srv)
+	h := fx.handler
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
 		"/api/v1/admin/oauth/callback?code=x", http.NoBody)
@@ -334,8 +354,9 @@ func TestConnectionOAuthCallback_MissingState(t *testing.T) {
 }
 
 func TestConnectionOAuthCallback_UpstreamError(t *testing.T) {
-	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
-	h, _, _, _ := setupOAuthFixture(t, srv)
+	srv := fakeIDPServer(t, func(http.ResponseWriter, *http.Request) {})
+	fx := setupOAuthFixture(t, srv)
+	h := fx.handler
 
 	// Need a valid PKCE state row first
 	startReq := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
@@ -345,7 +366,7 @@ func TestConnectionOAuthCallback_UpstreamError(t *testing.T) {
 	var startResp startConnectionOAuthResponse
 	require.NoError(t, json.NewDecoder(startW.Body).Decode(&startResp))
 
-	cbURL := "/api/v1/admin/oauth/callback?error=access_denied&error_description=user+cancelled&state=" + url.QueryEscape(startResp.State)
+	cbURL := "/api/v1/admin/oauth/callback?error=access_denied&error_description=user+canceled&state=" + url.QueryEscape(startResp.State)
 	cbReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, cbURL, http.NoBody)
 	cbW := httptest.NewRecorder()
 	h.ServeHTTP(cbW, cbReq)
@@ -356,8 +377,9 @@ func TestConnectionOAuthCallback_UpstreamError(t *testing.T) {
 func TestConnectionOAuthCallback_LegacyAPIGatewayURLAliased(t *testing.T) {
 	// The legacy /api/v1/admin/api-gateway/oauth/callback URL must
 	// still be handled (customer IdP configs registered it).
-	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
-	h, _, _, _ := setupOAuthFixture(t, srv)
+	srv := fakeIDPServer(t, func(http.ResponseWriter, *http.Request) {})
+	fx := setupOAuthFixture(t, srv)
+	h := fx.handler
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
 		"/api/v1/admin/api-gateway/oauth/callback?state=", http.NoBody)

--- a/pkg/admin/connection_oauth_handler_test.go
+++ b/pkg/admin/connection_oauth_handler_test.go
@@ -1,0 +1,405 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
+	"github.com/txn2/mcp-data-platform/pkg/platform"
+)
+
+// fakeOAuthKindHandler is a hand-rolled OAuthKindHandler so handler
+// tests can drive ParseOAuthConfig success / failure and observe the
+// AfterConnect hook invocation without dragging a real toolkit in.
+type fakeOAuthKindHandler struct {
+	parseCfg connoauth.Config
+	parseErr error
+	afterErr error
+	// captured args from AfterConnect for assertions:
+	afterCalled bool
+	afterName   string
+}
+
+func (f *fakeOAuthKindHandler) ParseOAuthConfig(_ map[string]any) (connoauth.Config, error) {
+	if f.parseErr != nil {
+		return connoauth.Config{}, f.parseErr
+	}
+	return f.parseCfg, nil
+}
+
+func (f *fakeOAuthKindHandler) AfterConnect(_ context.Context, name string, _ map[string]any) error {
+	f.afterCalled = true
+	f.afterName = name
+	return f.afterErr
+}
+
+// newOAuthTestHandler wires a minimal Handler suitable for exercising
+// the unified connection OAuth routes. The PKCE store is in-memory;
+// the connoauth store is in-memory; ConnectionStore is the same
+// mock as the rest of the admin tests. The kinds map is populated
+// per test.
+func newOAuthTestHandler(t *testing.T, connStore *mockConnectionStore, kinds OAuthKindHandlers) (*Handler, connoauth.Store) {
+	t.Helper()
+	pkce := NewMemoryPKCEStore()
+	t.Cleanup(func() { _ = pkce.Close() })
+	store := connoauth.NewMemoryStore()
+	h := NewHandler(Deps{
+		Config:          testConfig(),
+		ConnectionStore: connStore,
+		ConfigStore:     &mockConfigStore{mode: "database"},
+		PKCEStore:       pkce,
+		ConnOAuthStore:  store,
+		OAuthKinds:      kinds,
+	}, nil)
+	return h, store
+}
+
+func setupOAuthFixture(t *testing.T, tokenSrv *httptest.Server) (*Handler, connoauth.Store, *fakeOAuthKindHandler, *mockConnectionStore) {
+	t.Helper()
+	fake := &fakeOAuthKindHandler{
+		parseCfg: connoauth.Config{
+			AuthorizationURL:  "https://idp.example/authorize",
+			TokenURL:          tokenSrv.URL + "/token",
+			ClientID:          "test-client",
+			ClientSecret:      "test-secret",
+			Scopes:            []string{"openid", "offline_access"},
+			EndpointAuthStyle: oauth2.AuthStyleInHeader,
+		},
+	}
+	connStore := &mockConnectionStore{
+		getResult: &platform.ConnectionInstance{
+			Kind: connoauth.KindMCP,
+			Name: "alpha",
+			Config: map[string]any{
+				"endpoint":                "http://upstream/mcp",
+				"auth_mode":               "oauth",
+				"oauth_grant":             "authorization_code",
+				"oauth_authorization_url": "https://idp.example/authorize",
+				"oauth_token_url":         tokenSrv.URL + "/token",
+				"oauth_client_id":         "test-client",
+				"oauth_client_secret":     "test-secret",
+			},
+		},
+	}
+	kinds := OAuthKindHandlers{connoauth.KindMCP: fake}
+	h, store := newOAuthTestHandler(t, connStore, kinds)
+	return h, store, fake, connStore
+}
+
+// fakeIdPServer is a minimal HTTP test double that issues tokens on
+// /token. Each callback to the test can override the response.
+func fakeIdPServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", handler)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// startConnectionOAuth
+// ────────────────────────────────────────────────────────────────────────
+
+func TestStartConnectionOAuth_Success(t *testing.T) {
+	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
+	h, _, _, _ := setupOAuthFixture(t, srv)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/admin/connections/mcp/alpha/oauth-start",
+		strings.NewReader(`{"return_url":"/portal/admin/connections"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var resp startConnectionOAuthResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp.AuthorizationURL, "https://idp.example/authorize")
+	assert.Contains(t, resp.AuthorizationURL, "response_type=code")
+	assert.Contains(t, resp.AuthorizationURL, "code_challenge=")
+	assert.NotEmpty(t, resp.State)
+	assert.NotEmpty(t, resp.RedirectURI)
+	assert.NotEmpty(t, resp.ExpiresAt)
+}
+
+func TestStartConnectionOAuth_UnknownKind(t *testing.T) {
+	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
+	h, _, _, _ := setupOAuthFixture(t, srv)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/admin/connections/unsupported/alpha/oauth-start", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "unsupported connection kind")
+}
+
+func TestStartConnectionOAuth_ConnectionNotFound(t *testing.T) {
+	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
+	h, _, _, connStore := setupOAuthFixture(t, srv)
+	connStore.getErr = platform.ErrConnectionNotFound
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/admin/connections/mcp/missing/oauth-start", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestStartConnectionOAuth_NotConfiguredForAuthCode(t *testing.T) {
+	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
+	h, _, fake, _ := setupOAuthFixture(t, srv)
+	fake.parseErr = errors.New("connection is not configured for authorization_code OAuth")
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/admin/connections/mcp/alpha/oauth-start", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// connectionOAuthStatus
+// ────────────────────────────────────────────────────────────────────────
+
+func TestConnectionOAuthStatus_NoToken(t *testing.T) {
+	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
+	h, _, _, _ := setupOAuthFixture(t, srv)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/api/v1/admin/connections/mcp/alpha/oauth-status", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var status connoauth.OAuthStatus
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&status))
+	assert.True(t, status.Configured)
+	assert.True(t, status.NeedsReauth)
+	assert.False(t, status.TokenAcquired)
+}
+
+func TestConnectionOAuthStatus_WithToken(t *testing.T) {
+	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
+	h, store, _, _ := setupOAuthFixture(t, srv)
+	now := time.Now()
+	_ = store.Set(context.Background(), connoauth.PersistedToken{
+		Key:             connoauth.Key{Kind: connoauth.KindMCP, Name: "alpha"},
+		AccessToken:     "at",
+		RefreshToken:    "rt",
+		ExpiresAt:       now.Add(time.Hour),
+		AuthenticatedBy: "user@example.com",
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/api/v1/admin/connections/mcp/alpha/oauth-status", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var status connoauth.OAuthStatus
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&status))
+	assert.True(t, status.TokenAcquired)
+	assert.True(t, status.HasRefreshToken)
+	assert.False(t, status.NeedsReauth)
+	assert.Equal(t, "user@example.com", status.AuthenticatedBy)
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// reacquireConnectionOAuth
+// ────────────────────────────────────────────────────────────────────────
+
+func TestReacquireConnectionOAuth_Success(t *testing.T) {
+	srv := fakeIdPServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "at-fresh",
+			"refresh_token": "rt-fresh",
+			"expires_in":    3600,
+			"token_type":    "Bearer",
+		})
+	})
+	h, store, _, _ := setupOAuthFixture(t, srv)
+	now := time.Now()
+	_ = store.Set(context.Background(), connoauth.PersistedToken{
+		Key:          connoauth.Key{Kind: connoauth.KindMCP, Name: "alpha"},
+		AccessToken:  "at-old",
+		RefreshToken: "rt-old",
+		ExpiresAt:    now.Add(time.Hour),
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/admin/connections/mcp/alpha/reacquire-oauth", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	var status connoauth.OAuthStatus
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&status))
+	assert.True(t, status.TokenAcquired)
+	// Confirm refresh actually rotated through the store.
+	row, _ := store.Get(context.Background(), connoauth.Key{Kind: connoauth.KindMCP, Name: "alpha"})
+	assert.Equal(t, "at-fresh", row.AccessToken)
+	assert.Equal(t, "rt-fresh", row.RefreshToken)
+}
+
+func TestReacquireConnectionOAuth_NeedsReauth(t *testing.T) {
+	srv := fakeIdPServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	})
+	h, store, _, _ := setupOAuthFixture(t, srv)
+	_ = store.Set(context.Background(), connoauth.PersistedToken{
+		Key:          connoauth.Key{Kind: connoauth.KindMCP, Name: "alpha"},
+		AccessToken:  "at",
+		RefreshToken: "rt-dead",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/admin/connections/mcp/alpha/reacquire-oauth", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// connectionOAuthCallback — the full Start → callback → token persisted
+// + AfterConnect hook fired round-trip.
+// ────────────────────────────────────────────────────────────────────────
+
+func TestConnectionOAuthCallback_RoundTrip(t *testing.T) {
+	tokenSrv := fakeIdPServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"at","refresh_token":"rt","expires_in":3600,"token_type":"Bearer"}`))
+	})
+	h, store, fake, _ := setupOAuthFixture(t, tokenSrv)
+
+	// Step 1: oauth-start
+	startReq := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/admin/connections/mcp/alpha/oauth-start",
+		strings.NewReader(`{"return_url":"/portal/admin/connections"}`))
+	startReq.Header.Set("Content-Type", "application/json")
+	startReq.Host = "localhost:8080"
+	startW := httptest.NewRecorder()
+	h.ServeHTTP(startW, startReq)
+	require.Equal(t, http.StatusOK, startW.Code, "start body=%s", startW.Body.String())
+	var startResp startConnectionOAuthResponse
+	require.NoError(t, json.NewDecoder(startW.Body).Decode(&startResp))
+
+	// Step 2: callback with same state + the code the IdP would have issued
+	callbackURL := "/api/v1/admin/oauth/callback?code=test-code&state=" + url.QueryEscape(startResp.State)
+	cbReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, callbackURL, http.NoBody)
+	cbReq.Host = "localhost:8080"
+	cbW := httptest.NewRecorder()
+	h.ServeHTTP(cbW, cbReq)
+	require.Equal(t, http.StatusFound, cbW.Code, "callback body=%s", cbW.Body.String())
+
+	// Token must be persisted under (mcp, alpha)
+	row, err := store.Get(context.Background(), connoauth.Key{Kind: connoauth.KindMCP, Name: "alpha"})
+	require.NoError(t, err)
+	assert.Equal(t, "at", row.AccessToken)
+	assert.Equal(t, "rt", row.RefreshToken)
+
+	// AfterConnect hook must have fired
+	assert.True(t, fake.afterCalled)
+	assert.Equal(t, "alpha", fake.afterName)
+
+	// Redirect points to a safe path
+	assert.Contains(t, cbW.Header().Get("Location"), "/portal/admin/connections")
+}
+
+func TestConnectionOAuthCallback_MissingState(t *testing.T) {
+	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
+	h, _, _, _ := setupOAuthFixture(t, srv)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/api/v1/admin/oauth/callback?code=x", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	body, _ := io.ReadAll(w.Body)
+	assert.Contains(t, string(body), "missing state")
+}
+
+func TestConnectionOAuthCallback_UpstreamError(t *testing.T) {
+	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
+	h, _, _, _ := setupOAuthFixture(t, srv)
+
+	// Need a valid PKCE state row first
+	startReq := httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/admin/connections/mcp/alpha/oauth-start", http.NoBody)
+	startW := httptest.NewRecorder()
+	h.ServeHTTP(startW, startReq)
+	var startResp startConnectionOAuthResponse
+	require.NoError(t, json.NewDecoder(startW.Body).Decode(&startResp))
+
+	cbURL := "/api/v1/admin/oauth/callback?error=access_denied&error_description=user+cancelled&state=" + url.QueryEscape(startResp.State)
+	cbReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, cbURL, http.NoBody)
+	cbW := httptest.NewRecorder()
+	h.ServeHTTP(cbW, cbReq)
+	assert.Equal(t, http.StatusBadRequest, cbW.Code)
+	assert.Contains(t, cbW.Body.String(), "access_denied")
+}
+
+func TestConnectionOAuthCallback_LegacyAPIGatewayURLAliased(t *testing.T) {
+	// The legacy /api/v1/admin/api-gateway/oauth/callback URL must
+	// still be handled (customer IdP configs registered it).
+	srv := fakeIdPServer(t, func(http.ResponseWriter, *http.Request) {})
+	h, _, _, _ := setupOAuthFixture(t, srv)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/api/v1/admin/api-gateway/oauth/callback?state=", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	// Should route into the unified handler (missing-state error
+	// proves the route is bound, not 404).
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "missing state")
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// helper utility coverage
+// ────────────────────────────────────────────────────────────────────────
+
+func TestBuildConnectionAuthorizationURL(t *testing.T) {
+	t.Parallel()
+	cfg := connoauth.Config{
+		AuthorizationURL: "https://idp/auth",
+		ClientID:         "client-id",
+		Scopes:           []string{"openid", "offline_access"},
+		Prompt:           "login",
+	}
+	got := buildConnectionAuthorizationURL(cfg, "STATE", "VERIFIER", "https://platform/cb")
+	assert.Contains(t, got, "response_type=code")
+	assert.Contains(t, got, "client_id=client-id")
+	assert.Contains(t, got, "state=STATE")
+	assert.Contains(t, got, "code_challenge=")
+	assert.Contains(t, got, "code_challenge_method=S256")
+	assert.Contains(t, got, "scope=openid+offline_access")
+	assert.Contains(t, got, "prompt=login")
+}
+
+func TestBuildConnectionAuthorizationURL_ExistingQuery(t *testing.T) {
+	t.Parallel()
+	cfg := connoauth.Config{AuthorizationURL: "https://idp/auth?tenant=acme", ClientID: "c"}
+	got := buildConnectionAuthorizationURL(cfg, "S", "V", "https://x/cb")
+	assert.Contains(t, got, "https://idp/auth?tenant=acme&")
+}
+
+func TestURLHostForLog(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "idp.example.com", urlHostForLog("https://idp.example.com/realms/x/token"))
+	assert.Equal(t, "not-a-url", urlHostForLog("not-a-url"))
+}

--- a/pkg/admin/connection_oauth_kind.go
+++ b/pkg/admin/connection_oauth_kind.go
@@ -1,0 +1,41 @@
+package admin
+
+import (
+	"context"
+
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
+)
+
+// OAuthKindHandler adapts a kind-specific connection config to the
+// shared connoauth flow. The platform registers one per kind (MCP
+// gateway, HTTP API gateway, future kinds) at startup. The unified
+// connection OAuth handler dispatches on r.PathValue("kind") and
+// invokes the registered OAuthKindHandler for ParseConfig and
+// post-auth side effects.
+//
+// New connection kinds add support by implementing this interface
+// (typically in their toolkit package) and registering it in
+// HandlerDeps.OAuthKinds — they do NOT add a parallel handler file
+// or a parallel token store.
+type OAuthKindHandler interface {
+	// ParseOAuthConfig validates the connection's stored config and
+	// extracts the OAuth 2.1 settings (auth URL, token URL,
+	// credentials, scopes, etc.) into a connoauth.Config. Returns an
+	// error when the connection is not configured for the
+	// authorization_code grant (the unified handler maps the error to
+	// HTTP 409 Conflict with the operator-facing message).
+	ParseOAuthConfig(connConfig map[string]any) (connoauth.Config, error)
+	// AfterConnect runs after a successful Connect or Reacquire so
+	// the kind can perform any per-kind side effect needed to make
+	// the connection usable. The MCP gateway re-adds the connection
+	// here so its tool surface is registered with the platform's MCP
+	// server; the HTTP API gateway is a no-op because its
+	// Authenticator reads the store lazily on every request.
+	AfterConnect(ctx context.Context, name string, connConfig map[string]any) error
+}
+
+// OAuthKindHandlers is the registry shape passed via HandlerDeps. The
+// key is the kind string (e.g. connoauth.KindMCP). Keep keys aligned
+// with the connection_kind values stored in connection_instances and
+// connection_oauth_tokens.
+type OAuthKindHandlers map[string]OAuthKindHandler

--- a/pkg/admin/gateway_oauth_handler.go
+++ b/pkg/admin/gateway_oauth_handler.go
@@ -52,6 +52,12 @@ const schemeHTTP = "http"
 // unexported. Fields stay package-private; consumers from outside
 // admin should not need to introspect a state in flight.
 type PKCEState struct {
+	// kind is the connection kind ("mcp" or "api") so the unified
+	// /oauth/callback handler can dispatch the per-kind config parser
+	// and post-auth side effects. Empty in legacy rows pre-dating
+	// migration 000039 — those rows are MCP gateway flows by
+	// construction (only kind that used this table at the time).
+	kind         string
 	connection   string
 	codeVerifier string
 	startedBy    string

--- a/pkg/admin/handler.go
+++ b/pkg/admin/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/auth"
 	"github.com/txn2/mcp-data-platform/pkg/browsersession"
 	"github.com/txn2/mcp-data-platform/pkg/configstore"
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
 	"github.com/txn2/mcp-data-platform/pkg/portal"
@@ -127,6 +128,18 @@ type Deps struct {
 	// deployments where oauth-start and the callback may land on
 	// different replicas.
 	PKCEStore PKCEStore
+	// ConnOAuthStore persists OAuth tokens for every connection kind
+	// in one shared table (migration 000039's connection_oauth_tokens).
+	// The unified connection OAuth handler reads and writes through
+	// this; toolkit Authenticators read through it on every outbound
+	// request. nil disables the unified OAuth routes.
+	ConnOAuthStore connoauth.Store
+	// OAuthKinds maps connection kind ("mcp", "api", future kinds) to
+	// the per-kind config extractor + post-auth side-effect hook. The
+	// unified handler dispatches on the {kind} path parameter through
+	// this registry. New connection kinds register here at startup —
+	// they do NOT add parallel handler files or token stores.
+	OAuthKinds OAuthKindHandlers
 }
 
 // EnrichmentEngine is the admin-facing surface of an enrichment.Engine.
@@ -237,8 +250,18 @@ func (h *Handler) registerRoutes() {
 	h.registerAssetRoutes()
 	h.registerConnectionRoutes()
 	h.registerGatewayRoutes()
-	h.registerGatewayOAuthRoutes()
-	h.registerAPIGatewayOAuthRoutes()
+	// The unified connection OAuth handler replaces both prior per-kind
+	// handlers. It activates only when the platform has wired the shared
+	// connoauth store + per-kind handlers; otherwise we fall back to the
+	// legacy per-kind routes so older deployments continue to work
+	// during the rollout. Migration 000039 + platform startup wiring
+	// together flip this to the unified path.
+	if h.deps.ConnOAuthStore != nil && len(h.deps.OAuthKinds) > 0 {
+		h.registerConnectionOAuthRoutes()
+	} else {
+		h.registerGatewayOAuthRoutes()
+		h.registerAPIGatewayOAuthRoutes()
+	}
 	h.registerEnrichmentRoutes()
 	h.registerPromptRoutes()
 }

--- a/pkg/admin/pkce_store_postgres.go
+++ b/pkg/admin/pkce_store_postgres.go
@@ -69,12 +69,21 @@ func (s *PostgresPKCEStore) Put(ctx context.Context, state string, val *PKCEStat
 	if err != nil {
 		return &putError{op: "encrypt code_verifier", err: err}
 	}
+	kind := val.kind
+	if kind == "" {
+		// Legacy callers that don't set Kind are MCP-gateway flows by
+		// construction (only kind that used this table at the time).
+		// Migration 000039's column default is identical; we set the
+		// field explicitly here so the take side never sees an empty
+		// kind even if a future migration drops the default.
+		kind = connectionKindMCP
+	}
 	res, err := s.db.ExecContext(ctx,
 		`INSERT INTO oauth_pkce_states
-            (state, connection, code_verifier, started_by, return_url, redirect_uri, created_at, expires_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, NOW() + ($8 || ' seconds')::interval)
+            (state, connection, connection_kind, code_verifier, started_by, return_url, redirect_uri, created_at, expires_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW() + ($9 || ' seconds')::interval)
          ON CONFLICT (state) DO NOTHING`,
-		state, val.connection, verifierEnc, val.startedBy,
+		state, val.connection, kind, verifierEnc, val.startedBy,
 		val.returnURL, val.redirectURI, val.createdAt,
 		fmt.Sprintf("%d", int64(pkceTTL.Seconds())))
 	if err != nil {
@@ -121,13 +130,13 @@ func (s *PostgresPKCEStore) Take(ctx context.Context, state string) (*PKCEState,
 	row := s.db.QueryRowContext(ctx,
 		`DELETE FROM oauth_pkce_states
          WHERE state = $1 AND expires_at > NOW()
-         RETURNING connection, code_verifier, started_by, return_url, redirect_uri, created_at`,
+         RETURNING connection, connection_kind, code_verifier, started_by, return_url, redirect_uri, created_at`,
 		state)
 	var (
 		v           PKCEState
 		verifierEnc string
 	)
-	if err := row.Scan(&v.connection, &verifierEnc, &v.startedBy,
+	if err := row.Scan(&v.connection, &v.kind, &verifierEnc, &v.startedBy,
 		&v.returnURL, &v.redirectURI, &v.createdAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrPKCEStateNotFound

--- a/pkg/admin/pkce_store_test.go
+++ b/pkg/admin/pkce_store_test.go
@@ -91,8 +91,8 @@ func TestPostgresPKCEStore_Take_Success(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
-	rows := sqlmock.NewRows([]string{"connection", "code_verifier", "started_by", "return_url", "redirect_uri", "created_at"}).
-		AddRow("vendor", "verifier-x", "alice@example.com", "/portal", "https://x/cb", time.Now())
+	rows := sqlmock.NewRows([]string{"connection", "connection_kind", "code_verifier", "started_by", "return_url", "redirect_uri", "created_at"}).
+		AddRow("vendor", "mcp", "verifier-x", "alice@example.com", "/portal", "https://x/cb", time.Now())
 	mock.ExpectQuery("DELETE FROM oauth_pkce_states").
 		WithArgs("state-1").
 		WillReturnRows(rows)
@@ -116,7 +116,7 @@ func TestPostgresPKCEStore_Take_NotFoundReturnsSentinel(t *testing.T) {
 	mock.ExpectQuery("DELETE FROM oauth_pkce_states").
 		WithArgs("missing").
 		WillReturnRows(sqlmock.NewRows([]string{
-			"connection", "code_verifier", "started_by",
+			"connection", "connection_kind", "code_verifier", "started_by",
 			"return_url", "redirect_uri", "created_at",
 		}))
 
@@ -132,7 +132,7 @@ func TestPostgresPKCEStore_Put_Success(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 
 	mock.ExpectExec("INSERT INTO oauth_pkce_states").
-		WithArgs("state-2", "vendor", "verifier-x", "alice@example.com",
+		WithArgs("state-2", "vendor", "mcp", "verifier-x", "alice@example.com",
 			"/portal", "https://x/cb", sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -185,13 +185,13 @@ func TestPostgresPKCEStore_EncryptsCodeVerifierAtRest(t *testing.T) {
 
 	enc := reverseEncryptor{}
 	mock.ExpectExec("INSERT INTO oauth_pkce_states").
-		WithArgs("s1", "vendor", reverse("verifier-x"), "alice", "/p", "https://x", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WithArgs("s1", "vendor", "mcp", reverse("verifier-x"), "alice", "/p", "https://x", sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectQuery("DELETE FROM oauth_pkce_states").
 		WithArgs("s1").
 		WillReturnRows(sqlmock.NewRows([]string{
-			"connection", "code_verifier", "started_by", "return_url", "redirect_uri", "created_at",
-		}).AddRow("vendor", reverse("verifier-x"), "alice", "/p", "https://x", time.Now()))
+			"connection", "connection_kind", "code_verifier", "started_by", "return_url", "redirect_uri", "created_at",
+		}).AddRow("vendor", "mcp", reverse("verifier-x"), "alice", "/p", "https://x", time.Now()))
 
 	s := &PostgresPKCEStore{db: db, enc: enc, stopCh: make(chan struct{})}
 	require.NoError(t, s.Put(context.Background(), "s1", &PKCEState{

--- a/pkg/admin/system.go
+++ b/pkg/admin/system.go
@@ -89,6 +89,7 @@ type publicBrandingResponse struct {
 	Name            string `json:"name" example:"acme-data-platform"`
 	Version         string `json:"version" example:"1.55.11"`
 	PortalTitle     string `json:"portal_title" example:"ACME Data Platform"`
+	PortalTagline   string `json:"portal_tagline" example:"Sign in to access your data."`
 	PortalLogo      string `json:"portal_logo" example:"https://example.com/logo.svg"`
 	PortalLogoLight string `json:"portal_logo_light" example:"https://example.com/logo-light.svg"`
 	PortalLogoDark  string `json:"portal_logo_dark" example:"https://example.com/logo-dark.svg"`
@@ -104,6 +105,7 @@ func (h *Handler) getPublicBranding(w http.ResponseWriter, _ *http.Request) {
 	if h.deps.Config != nil {
 		resp.Name = h.deps.Config.Server.Name
 		resp.PortalTitle = h.deps.Config.Portal.Title
+		resp.PortalTagline = h.deps.Config.Portal.Tagline
 		resp.PortalLogo = h.deps.Config.Portal.Logo
 		resp.PortalLogoLight = h.deps.Config.Portal.LogoLight
 		resp.PortalLogoDark = h.deps.Config.Portal.LogoDark

--- a/pkg/browsersession/oidcflow.go
+++ b/pkg/browsersession/oidcflow.go
@@ -303,10 +303,19 @@ func (f *Flow) LogoutHandler(w http.ResponseWriter, r *http.Request) {
 
 	ClearCookie(w, &f.cfg.Cookie)
 
+	// Build the post-logout redirect dynamically from the request so a
+	// session that started on a non-default origin (e.g., Vite dev
+	// server on :5173, an alternate ingress host) returns the operator
+	// to that same origin. The configured PostLogoutRedirect is the
+	// fallback for cases where headers are absent. Each candidate
+	// origin must be registered on the OIDC client's
+	// post.logout.redirect.uris.
+	postLogout := requestPostLogoutRedirect(r, f.cfg.PostLogoutRedirect)
+
 	if f.endpoints.EndSessionEndpoint != "" {
 		params := url.Values{
 			paramClientID:              {f.cfg.ClientID},
-			"post_logout_redirect_uri": {f.cfg.PostLogoutRedirect},
+			"post_logout_redirect_uri": {postLogout},
 		}
 		if idTokenHint != "" {
 			params.Set("id_token_hint", idTokenHint)
@@ -315,7 +324,33 @@ func (f *Flow) LogoutHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, f.cfg.PostLogoutRedirect, http.StatusFound)
+	http.Redirect(w, r, postLogout, http.StatusFound)
+}
+
+// requestPostLogoutRedirect derives the absolute post-logout redirect
+// URL from the incoming request's scheme + host, falling back to the
+// statically configured value when headers are absent. Honors
+// X-Forwarded-Proto / X-Forwarded-Host so reverse-proxied deployments
+// (Vite dev server, ingress controllers) point operators back at the
+// host their browser is actually using — not the host the Go server
+// sees on its loopback bind.
+func requestPostLogoutRedirect(r *http.Request, fallback string) string {
+	host := r.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = r.Host
+	}
+	if host == "" {
+		return fallback
+	}
+	scheme := r.Header.Get("X-Forwarded-Proto")
+	if scheme == "" {
+		if r.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+	return scheme + "://" + host + DefaultPortalPath
 }
 
 // tokenResponse holds the token endpoint response.

--- a/pkg/browsersession/oidcflow_test.go
+++ b/pkg/browsersession/oidcflow_test.go
@@ -509,7 +509,13 @@ func TestLogoutHandler(t *testing.T) {
 	}
 }
 
-func TestLogoutHandlerUsesPostLogoutRedirect(t *testing.T) {
+func TestLogoutHandlerPostLogoutRedirectFromRequestOrigin(t *testing.T) {
+	// LogoutHandler derives post_logout_redirect_uri from the
+	// request's scheme + host (X-Forwarded-* takes precedence over
+	// r.Host) so a session that arrived at a non-default origin
+	// returns to that same origin after Keycloak completes logout.
+	// Each candidate origin must be registered on the OIDC client's
+	// post.logout.redirect.uris allow-list.
 	srv := mockOIDCProvider(t, nil)
 	defer srv.Close()
 
@@ -523,6 +529,8 @@ func TestLogoutHandlerUsesPostLogoutRedirect(t *testing.T) {
 	}
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/portal/auth/logout", http.NoBody)
+	req.Header.Set("X-Forwarded-Host", "vite.local:5173")
+	req.Header.Set("X-Forwarded-Proto", "http")
 	w := httptest.NewRecorder()
 
 	flow.LogoutHandler(w, req)
@@ -541,8 +549,9 @@ func TestLogoutHandlerUsesPostLogoutRedirect(t *testing.T) {
 		t.Fatalf("invalid redirect URL: %v", parseErr)
 	}
 	redirectURI := parsed.Query().Get("post_logout_redirect_uri")
-	if redirectURI != "https://app.example.com/portal/" {
-		t.Errorf("post_logout_redirect_uri = %q, want https://app.example.com/portal/", redirectURI)
+	wantRedirect := "http://vite.local:5173" + DefaultPortalPath
+	if redirectURI != wantRedirect {
+		t.Errorf("post_logout_redirect_uri = %q, want %q", redirectURI, wantRedirect)
 	}
 }
 
@@ -566,8 +575,13 @@ func TestLogoutHandlerDefaultsPostLogoutToPostLogin(t *testing.T) {
 	}
 }
 
-func TestLogoutHandlerNoEndSessionUsesPostLogoutRedirect(t *testing.T) {
-	// When there's no end_session_endpoint, the fallback should use PostLogoutRedirect
+func TestLogoutHandlerNoEndSessionUsesRequestOrigin(t *testing.T) {
+	// When there's no end_session_endpoint, LogoutHandler derives the
+	// post-logout redirect from the request's scheme + host so a
+	// session started on a non-default origin (e.g., a Vite dev
+	// server, an alternate ingress host) returns to that same origin.
+	// The statically configured PostLogoutRedirect is only the
+	// fallback for header-less requests.
 	mux := http.NewServeMux()
 	var serverURL string
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
@@ -590,7 +604,11 @@ func TestLogoutHandlerNoEndSessionUsesPostLogoutRedirect(t *testing.T) {
 		t.Fatalf("NewFlow: %v", err)
 	}
 
+	// X-Forwarded-Host overrides r.Host when set, mirroring the Vite
+	// dev server / ingress reverse-proxy pattern.
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/portal/auth/logout", http.NoBody)
+	req.Header.Set("X-Forwarded-Host", "vite.local:5173")
+	req.Header.Set("X-Forwarded-Proto", "http")
 	w := httptest.NewRecorder()
 
 	flow.LogoutHandler(w, req)
@@ -601,8 +619,9 @@ func TestLogoutHandlerNoEndSessionUsesPostLogoutRedirect(t *testing.T) {
 	}
 
 	loc := resp.Header.Get("Location")
-	if loc != "https://app.example.com/portal/" {
-		t.Errorf("redirect = %q, want https://app.example.com/portal/", loc)
+	wantLoc := "http://vite.local:5173" + DefaultPortalPath
+	if loc != wantLoc {
+		t.Errorf("redirect = %q, want %q", loc, wantLoc)
 	}
 }
 
@@ -639,8 +658,13 @@ func TestLogoutHandlerNoEndSession(t *testing.T) {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusFound)
 	}
 
-	if resp.Header.Get("Location") != "/portal/" {
-		t.Errorf("redirect = %q, want /portal/", resp.Header.Get("Location"))
+	// LogoutHandler now derives the post-logout target from the request
+	// scheme + host so a session started on a non-default origin
+	// returns to that same origin. httptest's default Host is
+	// "example.com", and no TLS → scheme="http".
+	wantLoc := "http://example.com" + DefaultPortalPath
+	if resp.Header.Get("Location") != wantLoc {
+		t.Errorf("redirect = %q, want %q", resp.Header.Get("Location"), wantLoc)
 	}
 }
 

--- a/pkg/connoauth/config.go
+++ b/pkg/connoauth/config.go
@@ -1,0 +1,62 @@
+package connoauth
+
+import "golang.org/x/oauth2"
+
+// Config carries the per-connection OAuth 2.1 settings required by
+// the authorization_code flow. Built by callers (admin handler /
+// toolkit Authenticator) from their respective per-kind connection
+// config schemas — connoauth itself is kind-agnostic.
+//
+// SECURITY: Config carries the client secret in memory; do not log
+// it. The Source's error returns are sanitized to keep secret
+// material out of model/log output (see source.go:tokenFetchError).
+type Config struct {
+	// AuthorizationURL is the IdP's authorization endpoint (where the
+	// operator's browser is sent to sign in). Used only by the admin
+	// handler's authorization-URL builder, not by this package's
+	// token operations, but kept here so a single Config value carries
+	// every field the flow needs.
+	AuthorizationURL string
+	// TokenURL is the IdP's token endpoint. Used by both the initial
+	// code→token exchange and every silent refresh.
+	TokenURL string
+	// ClientID identifies the platform's registration with the IdP.
+	ClientID string
+	// ClientSecret is the matching credential. Stored encrypted in
+	// connection_instances; decrypted by the connection-store layer
+	// before reaching this struct.
+	ClientSecret string
+	// Scopes is the space-delimited list of OAuth scopes negotiated
+	// with the IdP. Operators of Keycloak/Auth0/Okta typically need
+	// `offline_access` (or vendor equivalent) for the IdP to issue a
+	// refresh token at all.
+	Scopes []string
+	// EndpointAuthStyle selects how the client credentials reach the
+	// token endpoint. Defaults to AuthStyleInHeader (HTTP Basic) per
+	// OAuth 2.1's recommended style; AuthStyleInParams sends them in
+	// the form body (some legacy IdPs require this).
+	EndpointAuthStyle oauth2.AuthStyle
+	// Prompt is the optional OIDC `prompt` parameter
+	// (RFC OIDC §3.1.2.1). Common values: empty (default), "login",
+	// "consent", "select_account". Pure-OAuth providers that don't
+	// recognize it should leave this empty so the IdP doesn't reject
+	// the authorize request with invalid_request.
+	Prompt string
+}
+
+// oauth2Config builds the golang.org/x/oauth2 Config the Source uses
+// for refresh-token exchanges. Centralized here so every refresh
+// uses the same client-secret / scope / auth-style settings the
+// initial code exchange used.
+func (c Config) oauth2Config() *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     c.ClientID,
+		ClientSecret: c.ClientSecret,
+		Scopes:       c.Scopes,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   c.AuthorizationURL,
+			TokenURL:  c.TokenURL,
+			AuthStyle: c.EndpointAuthStyle,
+		},
+	}
+}

--- a/pkg/connoauth/doc.go
+++ b/pkg/connoauth/doc.go
@@ -1,0 +1,31 @@
+// Package connoauth provides a single shared implementation of the
+// OAuth 2.1 authorization_code flow for outbound connections (MCP
+// gateways, HTTP API gateways, future connection kinds). The platform
+// composes multiple toolkit families that all need the same flow:
+// browser sign-in → callback → encrypted refresh token persisted →
+// silent access-token minting on tool calls. Forking that flow per
+// kind produced two parallel codepaths with subtly different bugs;
+// this package replaces both.
+//
+// The package owns:
+//
+//   - Persistent token storage (connection_oauth_tokens), keyed by
+//     (connection_kind, connection_name).
+//   - Per-request access-token acquisition with silent refresh, via
+//     golang.org/x/oauth2. After every successful refresh exchange
+//     the package explicitly persists the result — including any
+//     rotated refresh token — back to the store, solving the class
+//     of bug where a rotated refresh token is not re-persisted and
+//     the next process restart replays the dead one.
+//   - Initial authorization_code exchange used by the admin OAuth
+//     callback handler.
+//   - Distinction between revoked refresh (RFC 6749 §5.2
+//     invalid_grant at HTTP 400 → admin must reconnect) and transient
+//     failures (network, 5xx → retry without deleting the row).
+//
+// The package does NOT own PKCE state, HTTP routing, or the
+// authorization-URL builder — those live in pkg/admin where the
+// public callback is registered. The per-kind connection config (auth
+// URL, token URL, client id/secret, scopes) is supplied to this
+// package by callers via the Config struct.
+package connoauth

--- a/pkg/connoauth/errors.go
+++ b/pkg/connoauth/errors.go
@@ -1,0 +1,39 @@
+package connoauth
+
+import "errors"
+
+// ErrTokenNotFound is returned by Store.Get when no token row exists
+// for the supplied (kind, name). Callers treat this as "needs
+// reauthentication" and surface a Connect button in the admin UI.
+var ErrTokenNotFound = errors.New("connoauth: token not found")
+
+// ErrNeedsReauth is the structured signal that no access token can be
+// minted without operator interaction. Produced when:
+//
+//   - No refresh token is persisted (initial Connect required, or a
+//     prior revoked-refresh cleared the row).
+//   - The IdP-disclosed refresh deadline has passed.
+//   - The IdP rejected the most recent refresh attempt with RFC 6749
+//     §5.2 invalid_grant at HTTP 400 (revoked / expired refresh).
+//
+// Transient failures (network drops, 5xx, request cancellation) DO
+// NOT produce this error — they surface as transport errors so the
+// caller can retry without forcing the operator to reconnect.
+var ErrNeedsReauth = errors.New("connoauth: connection needs admin reconnect")
+
+// errRefreshTokenRevoked wraps the underlying error when the IdP
+// definitively rejects a refresh_token grant — RFC 6749 §5.2
+// invalid_grant at HTTP 400. Internal sentinel that callers detect
+// with errors.Is to distinguish revoked refresh from transient
+// failures. Misclassifying a transient failure as revoked would
+// permanently invalidate a long-lived refresh token over a single
+// flaky-network event.
+var errRefreshTokenRevoked = errors.New("connoauth: refresh token rejected by IdP (invalid_grant)")
+
+// errNoRefreshToken / errRefreshExpired are sentinel locals for
+// pre-network checks. Both indicate state that won't recover without
+// admin action; Source.Token() folds them into ErrNeedsReauth.
+var (
+	errNoRefreshToken = errors.New("connoauth: no refresh token persisted")
+	errRefreshExpired = errors.New("connoauth: refresh token has expired")
+)

--- a/pkg/connoauth/exchange.go
+++ b/pkg/connoauth/exchange.go
@@ -1,0 +1,250 @@
+package connoauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// maxTokenResponseBytes caps the response body read from a token
+// endpoint. Real responses are KB at most; a 1 MiB ceiling prevents
+// an OOM if a misbehaving (or malicious) IdP streams indefinitely.
+const maxTokenResponseBytes = 1 << 20
+
+// logKeyTokenURLHost is the structured-log field name used for the
+// IdP token endpoint host across exchange / refresh / status log
+// lines. Consolidated as a constant so SIEM dashboards and grep
+// queries align across the unified flow.
+//
+//nolint:gosec // G101 false positive: this is a log field NAME, not a credential.
+const logKeyTokenURLHost = "token_url_host"
+
+// ExchangeInput collects the parameters of an authorization_code
+// token exchange. The admin callback handler builds this from the
+// PKCE state + code + per-kind connection config and hands it to
+// Exchange().
+type ExchangeInput struct {
+	// Config is the per-connection IdP settings. Required.
+	Config Config
+	// Code is the IdP-issued authorization code from the callback's
+	// `code` query parameter.
+	Code string
+	// CodeVerifier is the PKCE verifier the admin handler stored at
+	// oauth-start time. Required by RFC 7636 §4.5.
+	CodeVerifier string
+	// RedirectURI must exactly match the redirect_uri used at
+	// oauth-start AND registered with the IdP. Required by RFC 6749
+	// §4.1.3.
+	RedirectURI string
+}
+
+// ExchangeResult is the parsed response from an authorization_code
+// exchange. Mirrors the token-endpoint response shape with the
+// addition of RefreshExpiresAt (Keycloak's refresh_expires_in
+// resolved to an absolute deadline).
+type ExchangeResult struct {
+	AccessToken      string
+	RefreshToken     string
+	ExpiresAt        time.Time
+	RefreshExpiresAt time.Time
+	Scope            string
+	// IDToken is the OIDC ID token if the IdP issued one (Keycloak,
+	// Okta, Auth0 typically do when `openid` is in scope). Reserved
+	// for future use by the admin callback (e.g., extracting the
+	// AuthenticatedBy claim); the current callers use the started_by
+	// captured at oauth-start.
+	IDToken string
+}
+
+// Exchange performs the authorization_code → tokens POST against the
+// IdP's token endpoint. Replaces the two duplicate
+// exchangeAuthorizationCode / exchangeAPIGatewayCode functions from
+// the per-kind handlers — both old kinds funnel through this code
+// now, so security guards (timeout, redirect-refusal, body cap)
+// cannot drift between kinds.
+func Exchange(ctx context.Context, in ExchangeInput) (*ExchangeResult, error) {
+	if err := validateExchangeInput(in); err != nil {
+		return nil, err
+	}
+	req, err := buildExchangeRequest(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	client := newTokenExchangeClient()
+	body, err := postExchange(client, req, in.Config.TokenURL)
+	if err != nil {
+		return nil, err
+	}
+	return decodeExchangeResponse(body)
+}
+
+// validateExchangeInput rejects malformed ExchangeInput before any
+// network call. Keeps Exchange's hot path focused on the happy case
+// and surfaces validation errors with a consistent prefix for
+// callers to grep.
+func validateExchangeInput(in ExchangeInput) error {
+	if in.Config.TokenURL == "" {
+		return errors.New("connoauth: exchange: token_url is required")
+	}
+	if in.Config.ClientID == "" {
+		return errors.New("connoauth: exchange: client_id is required")
+	}
+	if in.Code == "" {
+		return errors.New("connoauth: exchange: authorization code is required")
+	}
+	if in.CodeVerifier == "" {
+		return errors.New("connoauth: exchange: PKCE code_verifier is required")
+	}
+	if in.RedirectURI == "" {
+		return errors.New("connoauth: exchange: redirect_uri is required")
+	}
+	return nil
+}
+
+// buildExchangeRequest assembles the credential-bearing POST. When
+// the configured auth style is AuthStyleInHeader (the OAuth 2.1
+// default), client_id and client_secret travel via HTTP Basic; when
+// AuthStyleInParams, they go in the form body. Some legacy IdPs
+// require the params form; the per-connection config selects.
+func buildExchangeRequest(ctx context.Context, in ExchangeInput) (*http.Request, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", in.Code)
+	form.Set("redirect_uri", in.RedirectURI)
+	form.Set("code_verifier", in.CodeVerifier)
+	form.Set("client_id", in.Config.ClientID)
+	if in.Config.EndpointAuthStyle == oauth2.AuthStyleInParams {
+		form.Set("client_secret", in.Config.ClientSecret)
+	}
+
+	// #nosec G107 G704 -- TokenURL is operator-authored connection config
+	// (admin endpoint, validated by per-kind ParseConfig before reaching
+	// here). Same sink shape as the per-kind handlers this replaces.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, in.Config.TokenURL,
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("connoauth: exchange: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	if in.Config.EndpointAuthStyle != oauth2.AuthStyleInParams {
+		req.SetBasicAuth(in.Config.ClientID, in.Config.ClientSecret)
+	}
+	return req, nil
+}
+
+// postExchange performs the POST, drains and caps the body, and
+// translates non-2xx into a structured error. Returns the raw body
+// (capped) on success so decodeExchangeResponse can JSON-decode it.
+func postExchange(client *http.Client, req *http.Request, tokenURL string) ([]byte, error) {
+	start := time.Now()
+	tokenHost := urlHost(tokenURL)
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.Warn("connoauth: exchange: transport error",
+			logKeyTokenURLHost, tokenHost, "error", err)
+		return nil, fmt.Errorf("connoauth: exchange: token request: %w", err)
+	}
+	// Drain remaining bytes before close so net/http can pool the
+	// underlying TCP connection. With LimitReader capping the read,
+	// an oversize body would otherwise leave bytes on the wire and
+	// drop the connection (every exchange would then re-handshake).
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxTokenResponseBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("connoauth: exchange: read body: %w", err)
+	}
+	if int64(len(body)) > maxTokenResponseBytes {
+		slog.Warn("connoauth: exchange: response exceeds size cap",
+			logKeyTokenURLHost, tokenHost, "limit_bytes", maxTokenResponseBytes)
+		return nil, fmt.Errorf("connoauth: exchange: response exceeds %d-byte cap (likely misbehaving IdP)", maxTokenResponseBytes)
+	}
+	if resp.StatusCode != http.StatusOK {
+		slog.Warn("connoauth: exchange: non-200 from token endpoint",
+			logKeyTokenURLHost, tokenHost,
+			"status", resp.StatusCode,
+			"duration", time.Since(start),
+			"body_excerpt", trimBody(body))
+		return nil, fmt.Errorf("connoauth: exchange: token endpoint returned %d: %s", resp.StatusCode, trimBody(body))
+	}
+	slog.Info("connoauth: exchange: success",
+		logKeyTokenURLHost, tokenHost,
+		"duration", time.Since(start),
+		"body_len", len(body))
+	return body, nil
+}
+
+// decodeExchangeResponse parses the IdP's token-endpoint JSON. The
+// minimum required field is access_token; refresh_token,
+// expires_in, refresh_expires_in, scope, and id_token are all
+// optional.
+func decodeExchangeResponse(body []byte) (*ExchangeResult, error) {
+	var raw struct {
+		AccessToken      string `json:"access_token"`
+		RefreshToken     string `json:"refresh_token"`
+		TokenType        string `json:"token_type"`
+		ExpiresIn        int64  `json:"expires_in"`
+		RefreshExpiresIn int64  `json:"refresh_expires_in"`
+		Scope            string `json:"scope"`
+		IDToken          string `json:"id_token"`
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, errors.New("connoauth: exchange: malformed JSON response")
+	}
+	if raw.Error != "" {
+		return nil, fmt.Errorf("connoauth: exchange: upstream error %s: %s", raw.Error, raw.ErrorDescription)
+	}
+	if raw.AccessToken == "" {
+		return nil, errors.New("connoauth: exchange: token response missing access_token")
+	}
+	now := time.Now()
+	result := &ExchangeResult{
+		AccessToken:  raw.AccessToken,
+		RefreshToken: raw.RefreshToken,
+		Scope:        raw.Scope,
+		IDToken:      raw.IDToken,
+	}
+	if raw.ExpiresIn > 0 {
+		result.ExpiresAt = now.Add(time.Duration(raw.ExpiresIn) * time.Second)
+	}
+	if raw.RefreshExpiresIn > 0 {
+		result.RefreshExpiresAt = now.Add(time.Duration(raw.RefreshExpiresIn) * time.Second)
+	}
+	return result, nil
+}
+
+// urlHost returns the host portion of u for logs. Falls back to the
+// raw value when parsing fails so logs are never empty. Internal —
+// the admin handler uses its own URLHost helper for cross-package
+// log-field consistency.
+func urlHost(u string) string {
+	parsed, err := url.Parse(u)
+	if err != nil || parsed.Host == "" {
+		return u
+	}
+	return parsed.Host
+}
+
+// trimBody caps the size of upstream error bodies surfaced in error
+// strings so a misbehaving upstream can't blow up an audit log.
+func trimBody(body []byte) string {
+	const limit = 256
+	if len(body) <= limit {
+		return string(body)
+	}
+	return string(body[:limit]) + "..."
+}

--- a/pkg/connoauth/exchange.go
+++ b/pkg/connoauth/exchange.go
@@ -24,8 +24,7 @@ const maxTokenResponseBytes = 1 << 20
 // IdP token endpoint host across exchange / refresh / status log
 // lines. Consolidated as a constant so SIEM dashboards and grep
 // queries align across the unified flow.
-//
-//nolint:gosec // G101 false positive: this is a log field NAME, not a credential.
+// #nosec G101 -- field NAME for structured logging, not a credential value
 const logKeyTokenURLHost = "token_url_host"
 
 // ExchangeInput collects the parameters of an authorization_code
@@ -148,6 +147,10 @@ func buildExchangeRequest(ctx context.Context, in ExchangeInput) (*http.Request,
 func postExchange(client *http.Client, req *http.Request, tokenURL string) ([]byte, error) {
 	start := time.Now()
 	tokenHost := urlHost(tokenURL)
+	// #nosec G107 G704 -- request URL is the operator-authored OAuth token
+	// endpoint from a validated connection config; client is the locally
+	// constructed newTokenExchangeClient with CheckRedirect refusing 3xx
+	// and a hard timeout.
 	resp, err := client.Do(req)
 	if err != nil {
 		slog.Warn("connoauth: exchange: transport error",

--- a/pkg/connoauth/exchange_test.go
+++ b/pkg/connoauth/exchange_test.go
@@ -1,0 +1,273 @@
+package connoauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func TestExchange_Success(t *testing.T) {
+	t.Parallel()
+	idp := newFakeIDP(t, func(w http.ResponseWriter, r *http.Request) {
+		form := readForm(r)
+		if got := form.Get("grant_type"); got != "authorization_code" {
+			t.Errorf("grant_type=%q want authorization_code", got)
+		}
+		if got := form.Get("code"); got != "auth-code-xyz" {
+			t.Errorf("code=%q want auth-code-xyz", got)
+		}
+		if got := form.Get("code_verifier"); got != "verifier-abc" {
+			t.Errorf("code_verifier=%q want verifier-abc", got)
+		}
+		if got := form.Get("redirect_uri"); got != "https://platform.example/cb" {
+			t.Errorf("redirect_uri=%q", got)
+		}
+		// Default auth style is InHeader → expect Basic Auth header.
+		if user, pass, ok := r.BasicAuth(); !ok || user != "client-id" || pass != "client-secret" {
+			t.Errorf("expected Basic auth client-id:client-secret, got user=%q pass=%q ok=%v", user, pass, ok)
+		}
+		writeTokenJSON(w, map[string]any{
+			"access_token":       "at-xyz",
+			"refresh_token":      "rt-xyz",
+			"expires_in":         3600,
+			"refresh_expires_in": 7200,
+			"scope":              "openid offline_access",
+			"id_token":           "id-xyz",
+			"token_type":         "Bearer",
+		})
+	})
+
+	result, err := Exchange(context.Background(), ExchangeInput{
+		Config: Config{
+			TokenURL:     idp.tokenURL(),
+			ClientID:     "client-id",
+			ClientSecret: "client-secret",
+		},
+		Code:         "auth-code-xyz",
+		CodeVerifier: "verifier-abc",
+		RedirectURI:  "https://platform.example/cb",
+	})
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if result.AccessToken != "at-xyz" || result.RefreshToken != "rt-xyz" {
+		t.Fatalf("token mismatch: %+v", result)
+	}
+	if result.IDToken != "id-xyz" {
+		t.Fatalf("id_token missing: %+v", result)
+	}
+	if result.ExpiresAt.IsZero() || result.RefreshExpiresAt.IsZero() {
+		t.Fatalf("expiry deadlines should be populated: %+v", result)
+	}
+	wantExp := time.Now().Add(3600 * time.Second)
+	if delta := result.ExpiresAt.Sub(wantExp); delta > 5*time.Second || delta < -5*time.Second {
+		t.Fatalf("ExpiresAt off by %v", delta)
+	}
+}
+
+func TestExchange_AuthStyleInParams(t *testing.T) {
+	t.Parallel()
+	idp := newFakeIDP(t, func(w http.ResponseWriter, r *http.Request) {
+		if _, _, ok := r.BasicAuth(); ok {
+			t.Errorf("AuthStyleInParams must NOT send Basic auth header")
+		}
+		form := readForm(r)
+		if got := form.Get("client_secret"); got != "secret-in-body" {
+			t.Errorf("client_secret in body expected, got %q", got)
+		}
+		writeTokenJSON(w, map[string]any{
+			"access_token": "at", "expires_in": 60,
+		})
+	})
+
+	_, err := Exchange(context.Background(), ExchangeInput{
+		Config: Config{
+			TokenURL:          idp.tokenURL(),
+			ClientID:          "c",
+			ClientSecret:      "secret-in-body",
+			EndpointAuthStyle: oauth2.AuthStyleInParams,
+		},
+		Code:         "code",
+		CodeVerifier: "verifier",
+		RedirectURI:  "https://platform.example/cb",
+	})
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+}
+
+func TestExchange_UpstreamError(t *testing.T) {
+	t.Parallel()
+	idp := newFakeIDP(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"expired code"}`))
+	})
+	_, err := Exchange(context.Background(), ExchangeInput{
+		Config:       Config{TokenURL: idp.tokenURL(), ClientID: "c", ClientSecret: "s"},
+		Code:         "code",
+		CodeVerifier: "v",
+		RedirectURI:  "https://x/cb",
+	})
+	if err == nil {
+		t.Fatal("expected error on 400 invalid_grant")
+	}
+}
+
+func TestExchange_MissingAccessToken(t *testing.T) {
+	t.Parallel()
+	idp := newFakeIDP(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeTokenJSON(w, map[string]any{"token_type": "Bearer"})
+	})
+	_, err := Exchange(context.Background(), ExchangeInput{
+		Config:       Config{TokenURL: idp.tokenURL(), ClientID: "c", ClientSecret: "s"},
+		Code:         "code",
+		CodeVerifier: "v",
+		RedirectURI:  "https://x/cb",
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing access_token") {
+		t.Fatalf("expected missing-access-token error, got %v", err)
+	}
+}
+
+func TestExchange_MalformedJSON(t *testing.T) {
+	t.Parallel()
+	idp := newFakeIDP(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`not json`))
+	})
+	_, err := Exchange(context.Background(), ExchangeInput{
+		Config:       Config{TokenURL: idp.tokenURL(), ClientID: "c", ClientSecret: "s"},
+		Code:         "code",
+		CodeVerifier: "v",
+		RedirectURI:  "https://x/cb",
+	})
+	if err == nil || !strings.Contains(err.Error(), "malformed JSON") {
+		t.Fatalf("expected malformed-JSON error, got %v", err)
+	}
+}
+
+func TestExchange_ValidationErrors(t *testing.T) {
+	t.Parallel()
+	base := ExchangeInput{
+		Config:       Config{TokenURL: "https://idp/token", ClientID: "c", ClientSecret: "s"},
+		Code:         "code",
+		CodeVerifier: "v",
+		RedirectURI:  "https://x/cb",
+	}
+	cases := []struct {
+		name   string
+		mutate func(*ExchangeInput)
+	}{
+		{"missing TokenURL", func(in *ExchangeInput) { in.Config.TokenURL = "" }},
+		{"missing ClientID", func(in *ExchangeInput) { in.Config.ClientID = "" }},
+		{"missing Code", func(in *ExchangeInput) { in.Code = "" }},
+		{"missing CodeVerifier", func(in *ExchangeInput) { in.CodeVerifier = "" }},
+		{"missing RedirectURI", func(in *ExchangeInput) { in.RedirectURI = "" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := base
+			tc.mutate(&in)
+			if _, err := Exchange(context.Background(), in); err == nil {
+				t.Fatalf("expected validation error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestExchange_ResponseSizeCap(t *testing.T) {
+	t.Parallel()
+	// Build a JSON body just over the cap.
+	idp := newFakeIDP(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Stream past the cap; the LimitReader should reject.
+		filler := strings.Repeat("a", maxTokenResponseBytes+10)
+		_, _ = w.Write([]byte(`{"access_token":"x","padding":"` + filler + `"}`))
+	})
+	_, err := Exchange(context.Background(), ExchangeInput{
+		Config:       Config{TokenURL: idp.tokenURL(), ClientID: "c", ClientSecret: "s"},
+		Code:         "code",
+		CodeVerifier: "v",
+		RedirectURI:  "https://x/cb",
+	})
+	if err == nil || !strings.Contains(err.Error(), "byte cap") {
+		t.Fatalf("expected size-cap error, got %v", err)
+	}
+}
+
+func TestExchange_TransportError(t *testing.T) {
+	t.Parallel()
+	// Closed server simulates connection refused.
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	srv.Close()
+	_, err := Exchange(context.Background(), ExchangeInput{
+		Config:       Config{TokenURL: srv.URL + "/token", ClientID: "c", ClientSecret: "s"},
+		Code:         "code",
+		CodeVerifier: "v",
+		RedirectURI:  "https://x/cb",
+	})
+	if err == nil {
+		t.Fatal("expected transport error")
+	}
+}
+
+func TestURLHost(t *testing.T) {
+	t.Parallel()
+	if got := urlHost("https://idp.example.com/realms/x/token"); got != "idp.example.com" {
+		t.Fatalf("urlHost: got %q", got)
+	}
+	if got := urlHost(":://malformed"); got != ":://malformed" {
+		t.Fatalf("urlHost should fall through on parse error: got %q", got)
+	}
+	if got := urlHost("not-a-url"); got != "not-a-url" {
+		t.Fatalf("urlHost should fall through on empty host: got %q", got)
+	}
+}
+
+func TestTrimBody(t *testing.T) {
+	t.Parallel()
+	if got := trimBody([]byte("short")); got != "short" {
+		t.Fatalf("trimBody: got %q", got)
+	}
+	long := strings.Repeat("x", 300)
+	if got := trimBody([]byte(long)); !strings.HasSuffix(got, "...") || len(got) != 259 {
+		t.Fatalf("trimBody should cap with ...: got len=%d suffix=%q", len(got), got[len(got)-3:])
+	}
+}
+
+// TestExchange_NoRedirectFollow proves the CheckRedirect guard
+// actively refuses 3xx responses from the token endpoint, defeating
+// a compromised-or-misconfigured-IdP credential-leak vector.
+func TestExchange_NoRedirectFollow(t *testing.T) {
+	t.Parallel()
+	target := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("CheckRedirect should have refused to follow the 302 to this server")
+	}))
+	t.Cleanup(target.Close)
+	idp := newFakeIDP(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", target.URL+"/leak")
+		w.WriteHeader(http.StatusFound)
+	})
+	_, err := Exchange(context.Background(), ExchangeInput{
+		Config:       Config{TokenURL: idp.tokenURL(), ClientID: "c", ClientSecret: "s"},
+		Code:         "code",
+		CodeVerifier: "v",
+		RedirectURI:  "https://platform.example/cb",
+	})
+	if err == nil {
+		t.Fatal("expected non-200 error for 302 (redirect refused), got nil")
+	}
+}
+
+// confirm ExchangeResult.Scope and ID token round-trip across the
+// decoder boundary in conjunction with the URL escape tests.
+var _ = url.URL{} // keep net/url import

--- a/pkg/connoauth/source.go
+++ b/pkg/connoauth/source.go
@@ -1,0 +1,381 @@
+package connoauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// tokenFetchTimeout caps how long a single token-endpoint request
+// can take. The underlying golang.org/x/oauth2 library uses
+// http.DefaultClient (no timeout) unless the caller injects
+// oauth2.HTTPClient on the context. Without this an unreachable IdP
+// would hang every Token() call until the OS-level dial timeout
+// fires (minutes). 30 seconds matches the security-hardened MCP /
+// API gateway clients this code replaces.
+const tokenFetchTimeout = 30 * time.Second
+
+// expiryBuffer is the safety margin before token expiry at which we
+// proactively refresh. Keeps in-flight calls from racing the clock.
+// Mirrors the prior MCP gateway constant so behavior is unchanged
+// after the refactor.
+const expiryBuffer = 30 * time.Second
+
+// newTokenExchangeClient builds the http.Client used for any
+// credential-bearing POST to an OAuth token endpoint. CheckRedirect
+// refuses 3xx so a misconfigured or compromised IdP cannot redirect
+// the form body — which carries client_secret and the long-lived
+// refresh_token — to an attacker URL. Identical to the prior
+// per-kind helpers; consolidated here so the security guard cannot
+// drift between kinds.
+func newTokenExchangeClient() *http.Client {
+	return &http.Client{
+		Timeout: tokenFetchTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// Source is the per-connection access-token getter. Toolkits call
+// Token(ctx) on every outbound request; the Source reads the persisted
+// row, returns the cached access_token when still valid, or refreshes
+// it (and persists the result) when expired.
+//
+// Source is safe for concurrent use; the underlying Store is the
+// source of truth and Set/Get serialize through the database (or the
+// MemoryStore mutex). The Source itself is stateless across calls —
+// every Token() round-trips the store, which is what makes multi-
+// replica deployments correct (replica A's refresh becomes visible
+// to replica B on the next call without inter-replica coordination).
+type Source struct {
+	store Store
+	key   Key
+	cfg   Config
+	// client is the http.Client used for refresh exchanges. Per-Source
+	// rather than package-global so tests can inject a fake transport
+	// without mutating shared state.
+	client *http.Client
+}
+
+// NewSource builds a Source for the (key, cfg) pair. The store is
+// the persistence backend (Postgres in production, Memory in tests).
+// Callers reuse a single Source per connection — construction is
+// cheap, but pooling avoids re-creating the http.Client per request.
+func NewSource(store Store, key Key, cfg Config) *Source {
+	return &Source{
+		store:  store,
+		key:    key,
+		cfg:    cfg,
+		client: newTokenExchangeClient(),
+	}
+}
+
+// Token returns a non-expired access token, refreshing transparently
+// when the cached one has expired (or is within expiryBuffer of
+// expiry). On unrecoverable failure (no refresh token, refresh
+// rejected by IdP, refresh deadline passed), returns ErrNeedsReauth
+// so callers can short-circuit retries and surface the Connect prompt
+// to operators. Transient transport failures surface as the
+// underlying error (sanitized) so the caller's retry path can run.
+func (s *Source) Token(ctx context.Context) (string, error) {
+	persisted, err := s.store.Get(ctx, s.key)
+	if err != nil {
+		if errors.Is(err, ErrTokenNotFound) {
+			return "", ErrNeedsReauth
+		}
+		return "", fmt.Errorf("connoauth: load token: %w", err)
+	}
+	if accessTokenStillValid(persisted) {
+		return persisted.AccessToken, nil
+	}
+	fresh, refreshErr := s.refresh(ctx, persisted)
+	if refreshErr != nil {
+		if isRevokedRefresh(refreshErr) {
+			// Definitive: the IdP rejected the refresh, or there is
+			// nothing to refresh with. Delete the row so subsequent
+			// process restarts don't replay a dead credential.
+			if delErr := s.store.Delete(ctx, s.key); delErr != nil {
+				slog.Warn("connoauth: delete revoked token row failed",
+					"kind", s.key.Kind, "name", s.key.Name, "error", delErr)
+			}
+			return "", ErrNeedsReauth
+		}
+		return "", refreshErr
+	}
+	return fresh.AccessToken, nil
+}
+
+// accessTokenStillValid reports whether the cached access token can
+// be reused for at least expiryBuffer more time. Tokens at or past
+// the expiry deadline (or with a zero ExpiresAt) are treated as
+// invalid and trigger a refresh.
+func accessTokenStillValid(p *PersistedToken) bool {
+	if p == nil || p.AccessToken == "" {
+		return false
+	}
+	if p.ExpiresAt.IsZero() {
+		return false
+	}
+	return time.Until(p.ExpiresAt) > expiryBuffer
+}
+
+// Status returns a snapshot of the current persisted state, for the
+// admin status endpoint. Reads the row from the store; transient
+// store errors are surfaced via LastError so operators see "DB
+// unreachable" rather than a misleading "Connect needed" prompt.
+//
+// Status does NOT trigger a refresh — the admin UI calls Status
+// every few seconds (or on demand) and a refresh-per-status-call
+// would generate IdP-side load with no benefit. Refresh happens
+// lazily on the next Token() call.
+func (s *Source) Status(ctx context.Context) OAuthStatus {
+	persisted, err := s.store.Get(ctx, s.key)
+	if err != nil {
+		if errors.Is(err, ErrTokenNotFound) {
+			return OAuthStatus{
+				Configured:  true,
+				NeedsReauth: true,
+				TokenURL:    s.cfg.TokenURL,
+				Scope:       strings.Join(s.cfg.Scopes, " "),
+			}
+		}
+		return OAuthStatus{
+			Configured: true,
+			LastError:  "load token: " + err.Error(),
+			TokenURL:   s.cfg.TokenURL,
+			Scope:      strings.Join(s.cfg.Scopes, " "),
+		}
+	}
+	return statusFromPersisted(persisted, s.cfg)
+}
+
+// statusFromPersisted maps a non-nil PersistedToken into an
+// OAuthStatus. Extracted from Status() so the assembly logic is
+// covered by a focused unit test that doesn't need a Store.
+func statusFromPersisted(p *PersistedToken, cfg Config) OAuthStatus {
+	scope := p.Scope
+	if scope == "" {
+		scope = strings.Join(cfg.Scopes, " ")
+	}
+	st := OAuthStatus{
+		Configured:       true,
+		TokenAcquired:    p.AccessToken != "",
+		ExpiresAt:        p.ExpiresAt,
+		LastRefreshedAt:  p.UpdatedAt,
+		HasRefreshToken:  p.RefreshToken != "",
+		RefreshExpiresAt: p.RefreshExpiresAt,
+		TokenURL:         cfg.TokenURL,
+		Scope:            scope,
+		AuthenticatedBy:  p.AuthenticatedBy,
+		AuthenticatedAt:  p.AuthenticatedAt,
+	}
+	// NeedsReauth when the refresh path has nothing to work with OR
+	// when the IdP-disclosed refresh deadline has passed. Surfaced
+	// proactively so the UI prompts BEFORE the next tool call fails.
+	if p.RefreshToken == "" && p.AccessToken == "" {
+		st.NeedsReauth = true
+	}
+	if !p.RefreshExpiresAt.IsZero() && time.Now().After(p.RefreshExpiresAt) {
+		st.NeedsReauth = true
+	}
+	return st
+}
+
+// Reacquire forces a refresh-token exchange even when the cached
+// token is still valid. Used by the admin "Reacquire" button to test
+// the refresh path on demand. authorization_code grants cannot
+// re-run the full browser flow without operator interaction — that
+// path is the regular Connect button instead.
+func (s *Source) Reacquire(ctx context.Context) error {
+	persisted, err := s.store.Get(ctx, s.key)
+	if err != nil {
+		if errors.Is(err, ErrTokenNotFound) {
+			return ErrNeedsReauth
+		}
+		return fmt.Errorf("connoauth: load token: %w", err)
+	}
+	_, refreshErr := s.refresh(ctx, persisted)
+	if refreshErr != nil {
+		if isRevokedRefresh(refreshErr) {
+			if delErr := s.store.Delete(ctx, s.key); delErr != nil {
+				slog.Warn("connoauth: delete revoked token row failed",
+					"kind", s.key.Kind, "name", s.key.Name, "error", delErr)
+			}
+			return ErrNeedsReauth
+		}
+		return refreshErr
+	}
+	return nil
+}
+
+// refresh exchanges the persisted refresh_token for a fresh access
+// token at the IdP, and persists the result. The IdP MAY rotate the
+// refresh_token (RFC 6749 §6 allows this); when rotated, the new
+// refresh_token is persisted. When the IdP echoes the existing
+// refresh_token or omits the field, the prior refresh_token is
+// preserved unchanged (RFC 6749 §6 "still valid" semantics).
+//
+// This is the bug-#3 fix: the prior MCP custom state machine left a
+// surface where a rotated refresh_token could land in the in-memory
+// state but never reach the store. By delegating to
+// golang.org/x/oauth2 and explicitly persisting the result on every
+// refresh, the rotation is durable across process restarts.
+func (s *Source) refresh(ctx context.Context, persisted *PersistedToken) (*oauth2.Token, error) {
+	if persisted.RefreshToken == "" {
+		return nil, errNoRefreshToken
+	}
+	if !persisted.RefreshExpiresAt.IsZero() && time.Now().After(persisted.RefreshExpiresAt) {
+		return nil, errRefreshExpired
+	}
+	refreshCtx := context.WithValue(ctx, oauth2.HTTPClient, s.client)
+	cfg := s.cfg.oauth2Config()
+	// Force the library to refresh: pass a token with Expiry in the
+	// past so oauth2.Config.TokenSource always hits the IdP rather
+	// than returning the cached value. This makes the call uniform
+	// whether the caller is Token() (which only enters refresh()
+	// after detecting expiry) or Reacquire() (which forces refresh
+	// even on a still-valid token).
+	src := cfg.TokenSource(refreshCtx, &oauth2.Token{
+		AccessToken:  persisted.AccessToken,
+		RefreshToken: persisted.RefreshToken,
+		Expiry:       time.Now().Add(-time.Hour),
+	})
+	fresh, err := src.Token()
+	if err != nil {
+		return nil, classifyRefreshError(err)
+	}
+	if err := s.persistRefreshed(ctx, persisted, fresh); err != nil {
+		// Persistence failure is non-fatal for the in-memory request:
+		// the caller can use the fresh access token for this turn,
+		// and the next refresh will re-persist. Log so operators can
+		// spot DB issues; don't return the error (the caller's
+		// downstream HTTP request would fail spuriously).
+		slog.Warn("connoauth: persist refreshed token failed (in-memory token still valid)",
+			"kind", s.key.Kind, "name", s.key.Name, "error", err)
+	}
+	return fresh, nil
+}
+
+// persistRefreshed writes the rotated token set back to the store,
+// preserving the prior refresh_token when the IdP omitted one and
+// recomputing RefreshExpiresAt from the IdP's response (or clearing
+// it on rotation-without-deadline). Extracted from refresh() so the
+// RFC 6749 §6 semantics are testable in isolation.
+func (s *Source) persistRefreshed(ctx context.Context, prior *PersistedToken, fresh *oauth2.Token) error {
+	updated := *prior
+	updated.AccessToken = fresh.AccessToken
+	// IdP omitted refresh_token → RFC 6749 §6: prior one is still
+	// valid; preserve it AND its deadline (no signal to revise either).
+	// Rotated refresh token → persist the new value and recompute the
+	// deadline from the IdP's hint (the prior deadline belonged to
+	// the prior refresh_token's lifecycle).
+	if fresh.RefreshToken != "" {
+		updated.RefreshToken = fresh.RefreshToken
+		updated.RefreshExpiresAt = refreshDeadlineFromToken(fresh, time.Now())
+	}
+	updated.ExpiresAt = fresh.Expiry
+	updated.UpdatedAt = time.Now().UTC()
+	if err := s.store.Set(ctx, updated); err != nil {
+		return fmt.Errorf("connoauth: persist refreshed token: %w", err)
+	}
+	return nil
+}
+
+// refreshDeadlineFromToken reads refresh_expires_in from the
+// oauth2.Token's Extra fields and returns the absolute deadline.
+// Zero when the IdP did not disclose one — callers must not
+// interpret zero as "never expires" (it means "unknown").
+//
+// golang.org/x/oauth2 stores extension fields in tok.Extra and
+// JSON-decoded numerics arrive as float64; the cast handles both
+// shapes defensively.
+func refreshDeadlineFromToken(tok *oauth2.Token, now time.Time) time.Time {
+	v := tok.Extra("refresh_expires_in")
+	if v == nil {
+		return time.Time{}
+	}
+	var secs int64
+	switch n := v.(type) {
+	case float64:
+		secs = int64(n)
+	case int64:
+		secs = n
+	case int:
+		secs = int64(n)
+	default:
+		return time.Time{}
+	}
+	if secs <= 0 {
+		return time.Time{}
+	}
+	return now.Add(time.Duration(secs) * time.Second)
+}
+
+// classifyRefreshError distinguishes a definitively-revoked refresh
+// token (RFC 6749 §5.2 invalid_grant at HTTP 400) from transient
+// failures (network drops, 5xx, request cancellation). Wraps the
+// revoked case with errRefreshTokenRevoked so callers can detect it
+// via errors.Is; scrubs other errors via tokenFetchError so IdP
+// response bodies and embedded URL credentials cannot leak into
+// model output or logs.
+func classifyRefreshError(err error) error {
+	var retrieve *oauth2.RetrieveError
+	if errors.As(err, &retrieve) &&
+		retrieve.Response != nil &&
+		retrieve.Response.StatusCode == http.StatusBadRequest &&
+		retrieve.ErrorCode == "invalid_grant" {
+		return fmt.Errorf("connoauth: refresh rejected by IdP: %s (%w)",
+			tokenFetchError(err).Error(), errRefreshTokenRevoked)
+	}
+	return tokenFetchError(err)
+}
+
+// isRevokedRefresh reports whether the error is one of the
+// definitively-revoked sentinels. Used by Token() / Reacquire() to
+// decide whether to delete the persisted row and surface
+// ErrNeedsReauth.
+func isRevokedRefresh(err error) bool {
+	return errors.Is(err, errRefreshTokenRevoked) ||
+		errors.Is(err, errNoRefreshToken) ||
+		errors.Is(err, errRefreshExpired)
+}
+
+// tokenFetchError sanitizes errors from oauth2.TokenSource.Token().
+// The library's *oauth2.RetrieveError includes the IdP response body
+// (which can carry sensitive material) and the request URL (which
+// can carry credentials in the userinfo). Rebuild the message
+// keeping only non-sensitive pieces.
+func tokenFetchError(err error) error {
+	var re *oauth2.RetrieveError
+	if errors.As(err, &re) {
+		if re.Response != nil {
+			return fmt.Errorf("connoauth: token fetch failed: status=%d", re.Response.StatusCode)
+		}
+		return errors.New("connoauth: token fetch failed")
+	}
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		parsed, perr := url.Parse(ue.URL)
+		if perr != nil {
+			return fmt.Errorf("connoauth: token fetch %s: %w", ue.Op, ue.Err)
+		}
+		parsed.RawQuery = ""
+		parsed.User = nil
+		return fmt.Errorf("connoauth: token fetch %s %q: %w", ue.Op, parsed.String(), ue.Err)
+	}
+	// Fallback: redact anything that looks URL-shaped just in case a
+	// future library version wraps in a different error type.
+	msg := err.Error()
+	if strings.Contains(msg, "://") {
+		return errors.New("connoauth: token fetch failed (details redacted)")
+	}
+	return fmt.Errorf("connoauth: token fetch failed: %s", msg)
+}

--- a/pkg/connoauth/source_test.go
+++ b/pkg/connoauth/source_test.go
@@ -1,0 +1,669 @@
+package connoauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// fakeIDP is a minimal token-endpoint server for testing the Source.
+// Tests control its behavior via the config struct; each request
+// increments a counter and the configured handler runs.
+type fakeIDP struct {
+	server     *httptest.Server
+	calls      atomic.Int32
+	handleFunc func(http.ResponseWriter, *http.Request)
+}
+
+func newFakeIDP(t *testing.T, handle func(http.ResponseWriter, *http.Request)) *fakeIDP {
+	t.Helper()
+	idp := &fakeIDP{handleFunc: handle}
+	idp.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idp.calls.Add(1)
+		idp.handleFunc(w, r)
+	}))
+	t.Cleanup(idp.server.Close)
+	return idp
+}
+
+func (f *fakeIDP) tokenURL() string { return f.server.URL + "/token" }
+
+// readForm decodes the POST form. Used by handlers to inspect the
+// grant_type / refresh_token / etc.
+func readForm(r *http.Request) url.Values {
+	body, _ := io.ReadAll(r.Body)
+	v, _ := url.ParseQuery(string(body))
+	return v
+}
+
+func writeTokenJSON(w http.ResponseWriter, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// TestSource_CachedTokenStillValid verifies that Token() returns the
+// cached access token without hitting the IdP when ExpiresAt is in
+// the future.
+func TestSource_CachedTokenStillValid(t *testing.T) {
+	t.Parallel()
+	idp := newFakeIDP(t, func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatalf("token endpoint should not be called when cached token is valid")
+	})
+	store := NewMemoryStore()
+	key := Key{Kind: KindMCP, Name: "cached"}
+	_ = store.Set(context.Background(), PersistedToken{
+		Key:          key,
+		AccessToken:  "still-valid",
+		RefreshToken: "rt",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+	src := NewSource(store, key, Config{TokenURL: idp.tokenURL(), ClientID: "c"})
+	tok, err := src.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "still-valid" {
+		t.Fatalf("expected cached token, got %q", tok)
+	}
+	if idp.calls.Load() != 0 {
+		t.Fatalf("idp should not have been called")
+	}
+}
+
+// TestSource_NoTokenReturnsNeedsReauth — Token() on an empty store
+// returns ErrNeedsReauth so the caller can surface the Connect prompt.
+func TestSource_NoTokenReturnsNeedsReauth(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+	src := NewSource(store, Key{Kind: KindMCP, Name: "never-connected"}, Config{})
+	_, err := src.Token(context.Background())
+	if !errors.Is(err, ErrNeedsReauth) {
+		t.Fatalf("expected ErrNeedsReauth, got %v", err)
+	}
+}
+
+// TestSource_RefreshRotatesAndPersists — the bug-#3 regression. When
+// the IdP returns a NEW refresh_token on refresh (rotation), the new
+// refresh_token MUST land in the store. The prior MCP implementation
+// had subtle paths where rotation could fail to persist; this test
+// proves the new path does not.
+func TestSource_RefreshRotatesAndPersists(t *testing.T) {
+	t.Parallel()
+	idp := newFakeIDP(t, func(w http.ResponseWriter, r *http.Request) {
+		form := readForm(r)
+		if form.Get("grant_type") != "refresh_token" {
+			t.Errorf("expected refresh_token grant, got %q", form.Get("grant_type"))
+		}
+		if form.Get("refresh_token") != "rt-original" {
+			t.Errorf("expected original refresh token, got %q", form.Get("refresh_token"))
+		}
+		writeTokenJSON(w, map[string]any{
+			"access_token":  "at-fresh",
+			"refresh_token": "rt-rotated",
+			"expires_in":    3600,
+			"token_type":    "Bearer",
+		})
+	})
+
+	store := NewMemoryStore()
+	key := Key{Kind: KindMCP, Name: "rotates"}
+	_ = store.Set(context.Background(), PersistedToken{
+		Key:          key,
+		AccessToken:  "at-old",
+		RefreshToken: "rt-original",
+		ExpiresAt:    time.Now().Add(-time.Minute), // expired
+	})
+	src := NewSource(store, key, Config{
+		TokenURL:          idp.tokenURL(),
+		ClientID:          "c",
+		ClientSecret:      "s",
+		EndpointAuthStyle: oauth2.AuthStyleInHeader,
+	})
+	tok, err := src.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "at-fresh" {
+		t.Fatalf("expected fresh access token, got %q", tok)
+	}
+	// Critical: the rotated refresh token must be persisted.
+	got, _ := store.Get(context.Background(), key)
+	if got.RefreshToken != "rt-rotated" {
+		t.Fatalf("BUG #3: rotated refresh_token did not persist. got %q want %q",
+			got.RefreshToken, "rt-rotated")
+	}
+	if got.AccessToken != "at-fresh" {
+		t.Fatalf("access token did not persist: got %q", got.AccessToken)
+	}
+}
+
+// TestSource_RefreshPreservesOldRefreshWhenOmitted — the OTHER bug-#3
+// subcase. RFC 6749 §6 allows IdPs to OMIT refresh_token from a
+// refresh response, meaning "the prior one is still valid." A naive
+// implementation that overwrites with whatever the response carries
+// would NULL the field. This test ensures the prior refresh_token
+// is preserved.
+func TestSource_RefreshPreservesOldRefreshWhenOmitted(t *testing.T) {
+	t.Parallel()
+	idp := newFakeIDP(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeTokenJSON(w, map[string]any{
+			"access_token": "at-fresh",
+			"expires_in":   3600,
+			"token_type":   "Bearer",
+			// No refresh_token — IdP says "keep using the existing one".
+		})
+	})
+
+	store := NewMemoryStore()
+	key := Key{Kind: KindAPI, Name: "preserves"}
+	_ = store.Set(context.Background(), PersistedToken{
+		Key:          key,
+		AccessToken:  "at-old",
+		RefreshToken: "rt-keep",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	})
+	src := NewSource(store, key, Config{
+		TokenURL:          idp.tokenURL(),
+		ClientID:          "c",
+		ClientSecret:      "s",
+		EndpointAuthStyle: oauth2.AuthStyleInHeader,
+	})
+	if _, err := src.Token(context.Background()); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	got, _ := store.Get(context.Background(), key)
+	if got.RefreshToken != "rt-keep" {
+		t.Fatalf("BUG #3: refresh_token was NULLed when IdP omitted it. got %q want %q",
+			got.RefreshToken, "rt-keep")
+	}
+	if got.AccessToken != "at-fresh" {
+		t.Fatalf("access token did not refresh: got %q", got.AccessToken)
+	}
+}
+
+// TestSource_RefreshExpiresInPersists — when the IdP includes
+// refresh_expires_in (Keycloak-style), it must reach the store and
+// be visible on Status. Zero when absent.
+func TestSource_RefreshExpiresInPersists(t *testing.T) {
+	t.Parallel()
+	idp := newFakeIDP(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeTokenJSON(w, map[string]any{
+			"access_token":       "at-fresh",
+			"refresh_token":      "rt-rotated",
+			"expires_in":         3600,
+			"refresh_expires_in": 7200,
+			"token_type":         "Bearer",
+		})
+	})
+	store := NewMemoryStore()
+	key := Key{Kind: KindMCP, Name: "refresh-expires"}
+	_ = store.Set(context.Background(), PersistedToken{
+		Key:          key,
+		AccessToken:  "at-old",
+		RefreshToken: "rt-original",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	})
+	src := NewSource(store, key, Config{
+		TokenURL: idp.tokenURL(), ClientID: "c", ClientSecret: "s",
+	})
+	if _, err := src.Token(context.Background()); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	got, _ := store.Get(context.Background(), key)
+	if got.RefreshExpiresAt.IsZero() {
+		t.Fatalf("expected RefreshExpiresAt to be set from refresh_expires_in")
+	}
+	wantRoughly := time.Now().Add(7200 * time.Second)
+	if delta := got.RefreshExpiresAt.Sub(wantRoughly); delta > 5*time.Second || delta < -5*time.Second {
+		t.Fatalf("RefreshExpiresAt off by %v from expected", delta)
+	}
+}
+
+// TestSource_RefreshRevokedReturnsNeedsReauth — RFC 6749 §5.2
+// invalid_grant at HTTP 400 means the refresh token is definitively
+// dead. The Source must delete the row and return ErrNeedsReauth.
+func TestSource_RefreshRevokedReturnsNeedsReauth(t *testing.T) {
+	t.Parallel()
+	idp := newFakeIDP(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Refresh token expired"}`))
+	})
+	store := NewMemoryStore()
+	key := Key{Kind: KindMCP, Name: "revoked"}
+	_ = store.Set(context.Background(), PersistedToken{
+		Key:          key,
+		AccessToken:  "at-old",
+		RefreshToken: "rt-dead",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	})
+	src := NewSource(store, key, Config{
+		TokenURL: idp.tokenURL(), ClientID: "c", ClientSecret: "s",
+	})
+	_, err := src.Token(context.Background())
+	if !errors.Is(err, ErrNeedsReauth) {
+		t.Fatalf("expected ErrNeedsReauth for revoked refresh, got %v", err)
+	}
+	// Persisted row must be deleted so a process restart doesn't
+	// replay the dead refresh token.
+	if _, gerr := store.Get(context.Background(), key); !errors.Is(gerr, ErrTokenNotFound) {
+		t.Fatalf("expected row to be deleted after revoked refresh, still present")
+	}
+}
+
+// TestSource_RefreshTransientErrorPreservesRow — a 5xx from the IdP
+// is transient; the persisted row MUST NOT be deleted. The error
+// surfaces so the caller can retry.
+func TestSource_RefreshTransientErrorPreservesRow(t *testing.T) {
+	t.Parallel()
+	idp := newFakeIDP(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	store := NewMemoryStore()
+	key := Key{Kind: KindAPI, Name: "transient"}
+	_ = store.Set(context.Background(), PersistedToken{
+		Key:          key,
+		AccessToken:  "at-old",
+		RefreshToken: "rt-still-good",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	})
+	src := NewSource(store, key, Config{
+		TokenURL: idp.tokenURL(), ClientID: "c", ClientSecret: "s",
+	})
+	_, err := src.Token(context.Background())
+	if err == nil {
+		t.Fatalf("expected error on transient 503")
+	}
+	if errors.Is(err, ErrNeedsReauth) {
+		t.Fatalf("transient 503 must not surface as ErrNeedsReauth: %v", err)
+	}
+	// Row must still be present so the next call can retry.
+	got, gerr := store.Get(context.Background(), key)
+	if gerr != nil {
+		t.Fatalf("row should still exist after transient error: %v", gerr)
+	}
+	if got.RefreshToken != "rt-still-good" {
+		t.Fatalf("refresh token must not be lost on transient error")
+	}
+}
+
+// TestSource_NoRefreshTokenReturnsNeedsReauth — when a row exists
+// but has no refresh_token (e.g., IdP never issued one because the
+// scope didn't include offline_access), Token() must surface
+// ErrNeedsReauth rather than hang on a doomed refresh attempt.
+func TestSource_NoRefreshTokenReturnsNeedsReauth(t *testing.T) {
+	t.Parallel()
+	idp := newFakeIDP(t, func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatalf("token endpoint should not be called when no refresh token is present")
+	})
+	store := NewMemoryStore()
+	key := Key{Kind: KindMCP, Name: "no-refresh"}
+	_ = store.Set(context.Background(), PersistedToken{
+		Key:          key,
+		AccessToken:  "at-old",
+		RefreshToken: "", // none
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	})
+	src := NewSource(store, key, Config{TokenURL: idp.tokenURL(), ClientID: "c"})
+	_, err := src.Token(context.Background())
+	if !errors.Is(err, ErrNeedsReauth) {
+		t.Fatalf("expected ErrNeedsReauth, got %v", err)
+	}
+}
+
+// TestSource_RefreshExpiredReturnsNeedsReauth — when the
+// IdP-disclosed RefreshExpiresAt has passed, skip the round trip
+// and return ErrNeedsReauth immediately.
+func TestSource_RefreshExpiredReturnsNeedsReauth(t *testing.T) {
+	t.Parallel()
+	idp := newFakeIDP(t, func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatalf("token endpoint should not be called when refresh deadline has passed")
+	})
+	store := NewMemoryStore()
+	key := Key{Kind: KindMCP, Name: "refresh-expired"}
+	_ = store.Set(context.Background(), PersistedToken{
+		Key:              key,
+		RefreshToken:     "rt",
+		RefreshExpiresAt: time.Now().Add(-time.Minute), // already past
+		ExpiresAt:        time.Now().Add(-time.Hour),
+	})
+	src := NewSource(store, key, Config{TokenURL: idp.tokenURL(), ClientID: "c"})
+	_, err := src.Token(context.Background())
+	if !errors.Is(err, ErrNeedsReauth) {
+		t.Fatalf("expected ErrNeedsReauth, got %v", err)
+	}
+}
+
+// TestSource_Reacquire — the admin "Reacquire" button forces a
+// refresh even if the access token is still valid. Useful for
+// testing whether the persisted refresh token works.
+func TestSource_Reacquire(t *testing.T) {
+	t.Parallel()
+	called := atomic.Int32{}
+	idp := newFakeIDP(t, func(w http.ResponseWriter, _ *http.Request) {
+		called.Add(1)
+		writeTokenJSON(w, map[string]any{
+			"access_token":  "at-fresh",
+			"refresh_token": "rt-fresh",
+			"expires_in":    3600,
+		})
+	})
+	store := NewMemoryStore()
+	key := Key{Kind: KindMCP, Name: "reacquire"}
+	_ = store.Set(context.Background(), PersistedToken{
+		Key:          key,
+		AccessToken:  "at-still-valid",
+		RefreshToken: "rt",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	})
+	src := NewSource(store, key, Config{TokenURL: idp.tokenURL(), ClientID: "c"})
+	if err := src.Reacquire(context.Background()); err != nil {
+		t.Fatalf("Reacquire: %v", err)
+	}
+	if called.Load() != 1 {
+		t.Fatalf("Reacquire should hit the IdP, calls=%d", called.Load())
+	}
+}
+
+// TestSource_Status_NoRow — when the store has no row for the key,
+// Status returns Configured + NeedsReauth (the UI surfaces a Connect
+// button) without a LastError (the absence is normal).
+func TestSource_Status_NoRow(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+	src := NewSource(store, Key{Kind: KindMCP, Name: "fresh"}, Config{
+		TokenURL: "https://idp.example/token",
+		Scopes:   []string{"openid", "offline_access"},
+	})
+	st := src.Status(context.Background())
+	if !st.Configured || !st.NeedsReauth {
+		t.Fatalf("expected Configured + NeedsReauth, got %+v", st)
+	}
+	if st.LastError != "" {
+		t.Fatalf("absent row is normal, LastError should be empty: %q", st.LastError)
+	}
+	if !strings.Contains(st.Scope, "offline_access") {
+		t.Fatalf("scope from cfg should be surfaced: %q", st.Scope)
+	}
+}
+
+// TestSource_Status_StoreError — when the store fails (DB unreachable,
+// etc.), Status surfaces the error on LastError so operators see the
+// real cause rather than a misleading "Connect needed" prompt.
+func TestSource_Status_StoreError(t *testing.T) {
+	t.Parallel()
+	src := NewSource(failingStore{}, Key{Kind: KindMCP, Name: "x"}, Config{
+		TokenURL: "https://idp.example/token",
+	})
+	st := src.Status(context.Background())
+	if !st.Configured {
+		t.Fatalf("Configured must be true even on store error: %+v", st)
+	}
+	if st.LastError == "" {
+		t.Fatalf("store error should surface on LastError")
+	}
+}
+
+// TestSource_Status_Healthy — happy path: a valid persisted token
+// produces a TokenAcquired status without NeedsReauth.
+func TestSource_Status_Healthy(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+	key := Key{Kind: KindMCP, Name: "healthy"}
+	now := time.Now()
+	_ = store.Set(context.Background(), PersistedToken{
+		Key:             key,
+		AccessToken:     "at",
+		RefreshToken:    "rt",
+		ExpiresAt:       now.Add(time.Hour),
+		AuthenticatedBy: "user@example.com",
+		AuthenticatedAt: now,
+	})
+	src := NewSource(store, key, Config{TokenURL: "https://idp/token"})
+	st := src.Status(context.Background())
+	if !st.TokenAcquired || st.NeedsReauth {
+		t.Fatalf("healthy token should be acquired and not need reauth: %+v", st)
+	}
+}
+
+// TestSource_Reacquire_NoRow — Reacquire on an absent row returns
+// ErrNeedsReauth (matches Token() behavior; the admin button is a
+// no-op when there's nothing to refresh against).
+func TestSource_Reacquire_NoRow(t *testing.T) {
+	t.Parallel()
+	src := NewSource(NewMemoryStore(), Key{Kind: KindMCP, Name: "fresh"}, Config{})
+	if err := src.Reacquire(context.Background()); !errors.Is(err, ErrNeedsReauth) {
+		t.Fatalf("expected ErrNeedsReauth, got %v", err)
+	}
+}
+
+// TestSource_Reacquire_Revoked — Reacquire against a refresh-token-
+// revoked IdP must delete the row and surface ErrNeedsReauth.
+func TestSource_Reacquire_Revoked(t *testing.T) {
+	t.Parallel()
+	idp := newFakeIDP(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	})
+	store := NewMemoryStore()
+	key := Key{Kind: KindAPI, Name: "revoked-reacquire"}
+	_ = store.Set(context.Background(), PersistedToken{
+		Key: key, AccessToken: "at", RefreshToken: "rt-dead",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	src := NewSource(store, key, Config{TokenURL: idp.tokenURL(), ClientID: "c", ClientSecret: "s"})
+	if err := src.Reacquire(context.Background()); !errors.Is(err, ErrNeedsReauth) {
+		t.Fatalf("expected ErrNeedsReauth, got %v", err)
+	}
+	if _, gerr := store.Get(context.Background(), key); !errors.Is(gerr, ErrTokenNotFound) {
+		t.Fatal("row should be deleted after revoked-refresh on Reacquire")
+	}
+}
+
+// TestSource_Reacquire_Transient — Reacquire on a transient failure
+// surfaces the error WITHOUT deleting the row (so a retry can run).
+func TestSource_Reacquire_Transient(t *testing.T) {
+	t.Parallel()
+	idp := newFakeIDP(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	store := NewMemoryStore()
+	key := Key{Kind: KindMCP, Name: "transient-reacquire"}
+	_ = store.Set(context.Background(), PersistedToken{
+		Key: key, AccessToken: "at", RefreshToken: "rt",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	src := NewSource(store, key, Config{TokenURL: idp.tokenURL(), ClientID: "c", ClientSecret: "s"})
+	err := src.Reacquire(context.Background())
+	if err == nil {
+		t.Fatal("expected transient error from Reacquire")
+	}
+	if errors.Is(err, ErrNeedsReauth) {
+		t.Fatalf("transient must not surface as NeedsReauth: %v", err)
+	}
+	if _, gerr := store.Get(context.Background(), key); gerr != nil {
+		t.Fatalf("row should be preserved after transient error: %v", gerr)
+	}
+}
+
+// failingStore returns a transport-shaped error on every operation,
+// for exercising the Status/Reacquire/Token store-error branches.
+type failingStore struct{}
+
+func (failingStore) Get(_ context.Context, _ Key) (*PersistedToken, error) {
+	return nil, errors.New("store: connection refused")
+}
+
+func (failingStore) Set(_ context.Context, _ PersistedToken) error {
+	return errors.New("store: connection refused")
+}
+
+func (failingStore) Delete(_ context.Context, _ Key) error {
+	return errors.New("store: connection refused")
+}
+
+// TestSource_Token_StoreError — when the store returns a transient
+// error (not ErrTokenNotFound), Token() must surface it as a wrapped
+// error rather than misclassifying it as NeedsReauth.
+func TestSource_Token_StoreError(t *testing.T) {
+	t.Parallel()
+	src := NewSource(failingStore{}, Key{Kind: KindMCP, Name: "x"}, Config{})
+	_, err := src.Token(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, ErrNeedsReauth) {
+		t.Fatalf("store error must not become NeedsReauth: %v", err)
+	}
+}
+
+func TestStatusFromPersisted_TokenAcquired(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	p := &PersistedToken{
+		Key:              Key{Kind: KindMCP, Name: "x"},
+		AccessToken:      "at",
+		RefreshToken:     "rt",
+		ExpiresAt:        now.Add(time.Hour),
+		RefreshExpiresAt: now.Add(24 * time.Hour),
+		Scope:            "openid",
+		AuthenticatedBy:  "user@example.com",
+		AuthenticatedAt:  now,
+		UpdatedAt:        now,
+	}
+	st := statusFromPersisted(p, Config{TokenURL: "https://idp.example/token"})
+	if !st.TokenAcquired || !st.HasRefreshToken {
+		t.Fatalf("expected token acquired and refresh present: %+v", st)
+	}
+	if st.NeedsReauth {
+		t.Fatalf("should not need reauth for healthy token")
+	}
+	if st.AuthenticatedBy != "user@example.com" {
+		t.Fatalf("authenticated_by missing")
+	}
+}
+
+func TestStatusFromPersisted_RefreshExpired(t *testing.T) {
+	t.Parallel()
+	p := &PersistedToken{
+		Key:              Key{Kind: KindMCP, Name: "x"},
+		RefreshToken:     "rt",
+		RefreshExpiresAt: time.Now().Add(-time.Hour),
+	}
+	st := statusFromPersisted(p, Config{})
+	if !st.NeedsReauth {
+		t.Fatalf("expected NeedsReauth when RefreshExpiresAt is past")
+	}
+}
+
+func TestStatusFromPersisted_NoRefreshNoAccess(t *testing.T) {
+	t.Parallel()
+	p := &PersistedToken{Key: Key{Kind: KindMCP, Name: "x"}}
+	st := statusFromPersisted(p, Config{Scopes: []string{"openid", "offline_access"}})
+	if !st.NeedsReauth {
+		t.Fatalf("expected NeedsReauth")
+	}
+	if !strings.Contains(st.Scope, "offline_access") {
+		t.Fatalf("scope from cfg should be exposed: %q", st.Scope)
+	}
+}
+
+func TestRefreshDeadlineFromToken(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	cases := []struct {
+		name  string
+		extra map[string]any
+		want  bool // non-zero?
+	}{
+		{"absent", nil, false},
+		{"zero", map[string]any{"refresh_expires_in": 0}, false},
+		{"negative", map[string]any{"refresh_expires_in": -10}, false},
+		{"float", map[string]any{"refresh_expires_in": float64(3600)}, true},
+		{"int", map[string]any{"refresh_expires_in": int(3600)}, true},
+		{"int64", map[string]any{"refresh_expires_in": int64(3600)}, true},
+		{"wrong type", map[string]any{"refresh_expires_in": "3600"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tok := &oauth2.Token{}
+			if tc.extra != nil {
+				// oauth2.Token.Extra requires the token to be built from
+				// a TokenSource — we use a synthetic raw map by marshaling.
+				b, _ := json.Marshal(tc.extra)
+				_ = json.Unmarshal(b, tok)
+				tok = tok.WithExtra(tc.extra)
+			}
+			got := refreshDeadlineFromToken(tok, now)
+			if (tc.want && got.IsZero()) || (!tc.want && !got.IsZero()) {
+				t.Fatalf("refreshDeadlineFromToken: want non-zero=%v got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestIsRevokedRefresh(t *testing.T) {
+	t.Parallel()
+	if !isRevokedRefresh(errNoRefreshToken) {
+		t.Fatal("errNoRefreshToken should be revoked")
+	}
+	if !isRevokedRefresh(errRefreshExpired) {
+		t.Fatal("errRefreshExpired should be revoked")
+	}
+	if !isRevokedRefresh(errRefreshTokenRevoked) {
+		t.Fatal("errRefreshTokenRevoked should be revoked")
+	}
+	if isRevokedRefresh(errors.New("network down")) {
+		t.Fatal("arbitrary error should not be revoked")
+	}
+}
+
+func TestTokenFetchError_RedactsURL(t *testing.T) {
+	t.Parallel()
+	src := &url.Error{Op: "Post", URL: "https://user:secret@idp.example/token?client_secret=leak", Err: errors.New("boom")}
+	got := tokenFetchError(src)
+	msg := got.Error()
+	if strings.Contains(msg, "secret") {
+		t.Fatalf("error must not leak userinfo or query: %q", msg)
+	}
+	if strings.Contains(msg, "leak") {
+		t.Fatalf("error must not leak query: %q", msg)
+	}
+}
+
+func TestAccessTokenStillValid(t *testing.T) {
+	t.Parallel()
+	if accessTokenStillValid(nil) {
+		t.Fatal("nil token should be invalid")
+	}
+	if accessTokenStillValid(&PersistedToken{}) {
+		t.Fatal("zero token should be invalid")
+	}
+	if accessTokenStillValid(&PersistedToken{AccessToken: "x"}) {
+		t.Fatal("zero ExpiresAt should be invalid")
+	}
+	past := &PersistedToken{AccessToken: "x", ExpiresAt: time.Now().Add(-time.Hour)}
+	if accessTokenStillValid(past) {
+		t.Fatal("past ExpiresAt should be invalid")
+	}
+	soon := &PersistedToken{AccessToken: "x", ExpiresAt: time.Now().Add(time.Second)}
+	if accessTokenStillValid(soon) {
+		t.Fatal("ExpiresAt within buffer should be invalid")
+	}
+	future := &PersistedToken{AccessToken: "x", ExpiresAt: time.Now().Add(time.Hour)}
+	if !accessTokenStillValid(future) {
+		t.Fatal("future ExpiresAt should be valid")
+	}
+}

--- a/pkg/connoauth/store.go
+++ b/pkg/connoauth/store.go
@@ -1,0 +1,104 @@
+package connoauth
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// Store persists OAuth tokens for the authorization_code grant so a
+// one-time browser-based authentication grants long-running background
+// access. Keyed by (kind, name) so the same backing table serves
+// multiple connection-toolkit families without collision.
+type Store interface {
+	// Get returns the persisted token for the key or ErrTokenNotFound
+	// when no row exists.
+	Get(ctx context.Context, key Key) (*PersistedToken, error)
+	// Set inserts or replaces the token row for the key.
+	Set(ctx context.Context, t PersistedToken) error
+	// Delete removes the token row, forcing a re-auth on the next
+	// call. Returns nil (not ErrTokenNotFound) for missing rows so
+	// idempotent cleanup callers don't need to special-case absence.
+	Delete(ctx context.Context, key Key) error
+}
+
+// FieldEncryptor abstracts the platform's at-rest field encryption so
+// this package doesn't import pkg/platform (which would create a
+// dependency cycle via the toolkit composition wiring). The platform
+// supplies its concrete FieldEncryptor at startup; the noop fallback
+// below is used in dev when ENCRYPTION_KEY is unset (the platform
+// logs a startup warning on this code path).
+type FieldEncryptor interface {
+	Encrypt(plaintext string) (string, error)
+	Decrypt(ciphertext string) (string, error)
+}
+
+// noopEncryptor is the fallback used when no FieldEncryptor is wired.
+// Storing refresh tokens unencrypted is poor practice; the platform
+// surfaces a startup warning when this path is active so operators
+// know to set the encryption key in production.
+type noopEncryptor struct{}
+
+// Encrypt returns the plaintext unchanged.
+func (noopEncryptor) Encrypt(s string) (string, error) { return s, nil }
+
+// Decrypt returns the input unchanged.
+func (noopEncryptor) Decrypt(s string) (string, error) { return s, nil }
+
+// errInvalidKey is the validation error returned by every Store
+// method when called with an unpopulated Key. Internal — the public
+// surface returns it wrapped via fmt.Errorf so callers see the
+// method name in stack traces.
+var errInvalidKey = errors.New("connoauth: invalid key (kind and name required)")
+
+// MemoryStore is a process-local Store used in tests and as a
+// fallback when no database is configured. Tokens DO NOT survive
+// process restarts.
+type MemoryStore struct {
+	mu     sync.Mutex
+	tokens map[Key]PersistedToken
+}
+
+// NewMemoryStore returns an in-process Store. Production deployments
+// use NewPostgresStore.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{tokens: map[Key]PersistedToken{}}
+}
+
+// Get returns the in-memory token or ErrTokenNotFound.
+func (s *MemoryStore) Get(_ context.Context, key Key) (*PersistedToken, error) {
+	if !key.IsValid() {
+		return nil, errInvalidKey
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.tokens[key]
+	if !ok {
+		return nil, ErrTokenNotFound
+	}
+	return &t, nil
+}
+
+// Set stores a token in process memory, stamping UpdatedAt.
+func (s *MemoryStore) Set(_ context.Context, t PersistedToken) error {
+	if !t.Key.IsValid() {
+		return errInvalidKey
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t.UpdatedAt = time.Now().UTC()
+	s.tokens[t.Key] = t
+	return nil
+}
+
+// Delete removes the in-memory token row for the key. Idempotent.
+func (s *MemoryStore) Delete(_ context.Context, key Key) error {
+	if !key.IsValid() {
+		return errInvalidKey
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.tokens, key)
+	return nil
+}

--- a/pkg/connoauth/store_postgres.go
+++ b/pkg/connoauth/store_postgres.go
@@ -1,0 +1,195 @@
+package connoauth
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// PostgresStore is the SQL-backed Store against connection_oauth_tokens
+// (migration 000039). Replaces the two per-kind stores from earlier
+// (gateway_oauth_tokens + apigateway_oauth_tokens) — both old kinds now
+// live in this single table keyed by (connection_kind, connection_name).
+type PostgresStore struct {
+	db  *sql.DB
+	enc FieldEncryptor
+}
+
+// NewPostgresStore wires a Store to the supplied database. Pass enc=nil
+// to disable at-rest encryption (refresh tokens stored unencrypted —
+// dev-only). The platform's startup code passes its FieldEncryptor when
+// ENCRYPTION_KEY is set and logs a warning when it isn't.
+func NewPostgresStore(db *sql.DB, enc FieldEncryptor) *PostgresStore {
+	if enc == nil {
+		enc = noopEncryptor{}
+	}
+	return &PostgresStore{db: db, enc: enc}
+}
+
+// Get reads the row for key, decrypting access/refresh tokens via the
+// configured FieldEncryptor.
+func (s *PostgresStore) Get(ctx context.Context, key Key) (*PersistedToken, error) {
+	if !key.IsValid() {
+		return nil, errInvalidKey
+	}
+	row := s.db.QueryRowContext(ctx,
+		`SELECT access_token, refresh_token, expires_at,
+		        refresh_expires_at, scope, authenticated_by,
+		        authenticated_at, updated_at
+		   FROM connection_oauth_tokens
+		  WHERE connection_kind = $1 AND connection_name = $2`,
+		key.Kind, key.Name)
+	return s.scanTokenRow(row, key)
+}
+
+// scanTokenRow extracts the per-row values, decrypts the encrypted
+// columns, and assembles a PersistedToken. Extracted from Get so the
+// caller's cyclomatic complexity stays under the project's ceiling
+// and the decrypt + null-time assembly logic can be unit-tested in
+// isolation.
+func (s *PostgresStore) scanTokenRow(row *sql.Row, key Key) (*PersistedToken, error) {
+	var (
+		t                PersistedToken
+		accessEnc        sql.NullString
+		refreshEnc       sql.NullString
+		expiresAt        sql.NullTime
+		refreshExpiresAt sql.NullTime
+		authedAt         sql.NullTime
+	)
+	t.Key = key
+	err := row.Scan(&accessEnc, &refreshEnc, &expiresAt,
+		&refreshExpiresAt, &t.Scope, &t.AuthenticatedBy,
+		&authedAt, &t.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrTokenNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("connoauth: scan token row: %w", err)
+	}
+	if err := s.decryptInto(&t, key, accessEnc, refreshEnc); err != nil {
+		return nil, err
+	}
+	applyNullTimes(&t, expiresAt, refreshExpiresAt, authedAt)
+	return &t, nil
+}
+
+// decryptInto decrypts the access and refresh tokens (if present) and
+// writes them into t. Returns an error wrapping the column name and
+// key so a misconfigured FieldEncryptor (or a corrupted row) is
+// reported with enough context to find the bad row.
+func (s *PostgresStore) decryptInto(t *PersistedToken, key Key, accessEnc, refreshEnc sql.NullString) error {
+	if accessEnc.Valid {
+		dec, derr := s.enc.Decrypt(accessEnc.String)
+		if derr != nil {
+			return fmt.Errorf("connoauth: decrypt access_token for %s/%s: %w", key.Kind, key.Name, derr)
+		}
+		t.AccessToken = dec
+	}
+	if refreshEnc.Valid {
+		dec, derr := s.enc.Decrypt(refreshEnc.String)
+		if derr != nil {
+			return fmt.Errorf("connoauth: decrypt refresh_token for %s/%s: %w", key.Kind, key.Name, derr)
+		}
+		t.RefreshToken = dec
+	}
+	return nil
+}
+
+// applyNullTimes copies non-NULL sql.NullTime values into t. Zero
+// values stay zero — callers must not interpret zero as a real time.
+func applyNullTimes(t *PersistedToken, expiresAt, refreshExpiresAt, authedAt sql.NullTime) {
+	if expiresAt.Valid {
+		t.ExpiresAt = expiresAt.Time
+	}
+	if refreshExpiresAt.Valid {
+		t.RefreshExpiresAt = refreshExpiresAt.Time
+	}
+	if authedAt.Valid {
+		t.AuthenticatedAt = authedAt.Time
+	}
+}
+
+// Set upserts the row for t.Key, encrypting access and refresh tokens
+// before they reach the database. Empty token strings are stored as
+// SQL NULL via encryptOptional rather than encrypted empty-strings —
+// this matches the prior per-kind stores so the migration backfill
+// preserves shape.
+func (s *PostgresStore) Set(ctx context.Context, t PersistedToken) error {
+	if !t.Key.IsValid() {
+		return errInvalidKey
+	}
+	accessEnc, err := encryptOptional(s.enc, t.AccessToken)
+	if err != nil {
+		return fmt.Errorf("connoauth: encrypt access_token: %w", err)
+	}
+	refreshEnc, err := encryptOptional(s.enc, t.RefreshToken)
+	if err != nil {
+		return fmt.Errorf("connoauth: encrypt refresh_token: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO connection_oauth_tokens
+		   (connection_kind, connection_name, access_token, refresh_token,
+		    expires_at, refresh_expires_at, scope, authenticated_by,
+		    authenticated_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+		 ON CONFLICT (connection_kind, connection_name) DO UPDATE
+		   SET access_token       = EXCLUDED.access_token,
+		       refresh_token      = EXCLUDED.refresh_token,
+		       expires_at         = EXCLUDED.expires_at,
+		       refresh_expires_at = EXCLUDED.refresh_expires_at,
+		       scope              = EXCLUDED.scope,
+		       authenticated_by   = EXCLUDED.authenticated_by,
+		       authenticated_at   = EXCLUDED.authenticated_at,
+		       updated_at         = NOW()`,
+		t.Key.Kind, t.Key.Name, accessEnc, refreshEnc,
+		nullableTime(t.ExpiresAt), nullableTime(t.RefreshExpiresAt),
+		t.Scope, t.AuthenticatedBy, nullableTime(t.AuthenticatedAt))
+	if err != nil {
+		return fmt.Errorf("connoauth: upsert token row: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the row for key. Idempotent — missing rows do not
+// produce an error. Used by Source on revoked-refresh cleanup and by
+// the admin reacquire path.
+func (s *PostgresStore) Delete(ctx context.Context, key Key) error {
+	if !key.IsValid() {
+		return errInvalidKey
+	}
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM connection_oauth_tokens
+		  WHERE connection_kind = $1 AND connection_name = $2`,
+		key.Kind, key.Name)
+	if err != nil {
+		return fmt.Errorf("connoauth: delete token row: %w", err)
+	}
+	return nil
+}
+
+// encryptOptional encrypts a non-empty plaintext or returns a NULL
+// sql.NullString for the empty input. Empty access/refresh tokens
+// reach NULL columns rather than encrypted empty strings — matches
+// the prior store shape so migration 000039's backfill preserves
+// NULL semantics.
+func encryptOptional(enc FieldEncryptor, plaintext string) (sql.NullString, error) {
+	if plaintext == "" {
+		return sql.NullString{}, nil
+	}
+	enced, err := enc.Encrypt(plaintext)
+	if err != nil {
+		return sql.NullString{}, fmt.Errorf("connoauth: encrypt field: %w", err)
+	}
+	return sql.NullString{String: enced, Valid: true}, nil
+}
+
+// nullableTime returns sql.NullTime{Valid: false} for the zero time
+// so the column is stored as NULL rather than 0001-01-01.
+func nullableTime(t time.Time) sql.NullTime {
+	if t.IsZero() {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: t, Valid: true}
+}

--- a/pkg/connoauth/store_postgres_test.go
+++ b/pkg/connoauth/store_postgres_test.go
@@ -1,0 +1,188 @@
+package connoauth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func newMockPostgresStore(t *testing.T) (*PostgresStore, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return NewPostgresStore(db, fakeEncryptor{}), mock
+}
+
+// fakeEncryptor wraps plaintext with a marker so tests can prove
+// encryption/decryption actually ran in the Set/Get path. Decrypt
+// strips the marker; missing marker indicates a leak of plaintext
+// past the encryptor.
+type fakeEncryptor struct{}
+
+func (fakeEncryptor) Encrypt(s string) (string, error) { return "enc:" + s, nil }
+func (fakeEncryptor) Decrypt(s string) (string, error) {
+	if len(s) >= 4 && s[:4] == "enc:" {
+		return s[4:], nil
+	}
+	return s, nil
+}
+
+func TestPostgresStore_Set_Get_RoundTrip(t *testing.T) {
+	t.Parallel()
+	store, mock := newMockPostgresStore(t)
+	now := time.Now().Truncate(time.Second).UTC()
+	tok := PersistedToken{
+		Key:              Key{Kind: KindMCP, Name: "alpha"},
+		AccessToken:      "access-plaintext",
+		RefreshToken:     "refresh-plaintext",
+		ExpiresAt:        now.Add(time.Hour),
+		RefreshExpiresAt: now.Add(24 * time.Hour),
+		Scope:            "openid offline_access",
+		AuthenticatedBy:  "user@example.com",
+		AuthenticatedAt:  now,
+	}
+
+	const upsertSQL = `INSERT INTO connection_oauth_tokens
+		   (connection_kind, connection_name, access_token, refresh_token,
+		    expires_at, refresh_expires_at, scope, authenticated_by,
+		    authenticated_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+		 ON CONFLICT (connection_kind, connection_name) DO UPDATE
+		   SET access_token       = EXCLUDED.access_token,
+		       refresh_token      = EXCLUDED.refresh_token,
+		       expires_at         = EXCLUDED.expires_at,
+		       refresh_expires_at = EXCLUDED.refresh_expires_at,
+		       scope              = EXCLUDED.scope,
+		       authenticated_by   = EXCLUDED.authenticated_by,
+		       authenticated_at   = EXCLUDED.authenticated_at,
+		       updated_at         = NOW()`
+	mock.ExpectExec(upsertSQL).
+		WithArgs(
+			"mcp", "alpha",
+			sqlmock.AnyArg(), // encrypted access token
+			sqlmock.AnyArg(), // encrypted refresh token
+			tok.ExpiresAt, tok.RefreshExpiresAt,
+			tok.Scope, tok.AuthenticatedBy, tok.AuthenticatedAt,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := store.Set(context.Background(), tok); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	const selectSQL = `SELECT access_token, refresh_token, expires_at,
+		        refresh_expires_at, scope, authenticated_by,
+		        authenticated_at, updated_at
+		   FROM connection_oauth_tokens
+		  WHERE connection_kind = $1 AND connection_name = $2`
+	rows := sqlmock.NewRows([]string{
+		"access_token", "refresh_token", "expires_at", "refresh_expires_at",
+		"scope", "authenticated_by", "authenticated_at", "updated_at",
+	}).AddRow(
+		"enc:access-plaintext", "enc:refresh-plaintext",
+		tok.ExpiresAt, tok.RefreshExpiresAt,
+		tok.Scope, tok.AuthenticatedBy, tok.AuthenticatedAt, now,
+	)
+	mock.ExpectQuery(selectSQL).WithArgs("mcp", "alpha").WillReturnRows(rows)
+
+	got, err := store.Get(context.Background(), tok.Key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AccessToken != "access-plaintext" || got.RefreshToken != "refresh-plaintext" {
+		t.Fatalf("encryption round-trip failed: %+v", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStore_Get_NotFound(t *testing.T) {
+	t.Parallel()
+	store, mock := newMockPostgresStore(t)
+	const selectSQL = `SELECT access_token, refresh_token, expires_at,
+		        refresh_expires_at, scope, authenticated_by,
+		        authenticated_at, updated_at
+		   FROM connection_oauth_tokens
+		  WHERE connection_kind = $1 AND connection_name = $2`
+	mock.ExpectQuery(selectSQL).
+		WithArgs("api", "missing").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"access_token", "refresh_token", "expires_at", "refresh_expires_at",
+			"scope", "authenticated_by", "authenticated_at", "updated_at",
+		}))
+
+	_, err := store.Get(context.Background(), Key{Kind: KindAPI, Name: "missing"})
+	if !errors.Is(err, ErrTokenNotFound) {
+		t.Fatalf("expected ErrTokenNotFound, got %v", err)
+	}
+}
+
+func TestPostgresStore_Delete(t *testing.T) {
+	t.Parallel()
+	store, mock := newMockPostgresStore(t)
+	const deleteSQL = `DELETE FROM connection_oauth_tokens
+		  WHERE connection_kind = $1 AND connection_name = $2`
+	mock.ExpectExec(deleteSQL).
+		WithArgs("mcp", "foo").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	if err := store.Delete(context.Background(), Key{Kind: KindMCP, Name: "foo"}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStore_InvalidKey(t *testing.T) {
+	t.Parallel()
+	store, _ := newMockPostgresStore(t)
+	ctx := context.Background()
+	if _, err := store.Get(ctx, Key{}); !errors.Is(err, errInvalidKey) {
+		t.Fatalf("Get: want errInvalidKey, got %v", err)
+	}
+	if err := store.Set(ctx, PersistedToken{}); !errors.Is(err, errInvalidKey) {
+		t.Fatalf("Set: want errInvalidKey, got %v", err)
+	}
+	if err := store.Delete(ctx, Key{}); !errors.Is(err, errInvalidKey) {
+		t.Fatalf("Delete: want errInvalidKey, got %v", err)
+	}
+}
+
+func TestPostgresStore_NilEncryptorUsesNoop(t *testing.T) {
+	t.Parallel()
+	// Ensure NewPostgresStore handles nil encryptor without panicking.
+	// The actual no-op behavior is exercised by other tests via
+	// fakeEncryptor; here we only verify constructor robustness.
+	if s := NewPostgresStore(nil, nil); s == nil {
+		t.Fatal("NewPostgresStore returned nil for nil encryptor")
+	}
+}
+
+func TestNullableTime(t *testing.T) {
+	t.Parallel()
+	if nt := nullableTime(time.Time{}); nt.Valid {
+		t.Fatal("zero time should be NULL")
+	}
+	now := time.Now()
+	if nt := nullableTime(now); !nt.Valid || !nt.Time.Equal(now) {
+		t.Fatalf("non-zero time should round-trip, got %+v", nt)
+	}
+}
+
+func TestEncryptOptional(t *testing.T) {
+	t.Parallel()
+	if ns, err := encryptOptional(fakeEncryptor{}, ""); err != nil || ns.Valid {
+		t.Fatalf("empty plaintext should be NULL: ns=%+v err=%v", ns, err)
+	}
+	ns, err := encryptOptional(fakeEncryptor{}, "secret")
+	if err != nil || !ns.Valid || ns.String != "enc:secret" {
+		t.Fatalf("non-empty plaintext should encrypt: ns=%+v err=%v", ns, err)
+	}
+}

--- a/pkg/connoauth/store_test.go
+++ b/pkg/connoauth/store_test.go
@@ -1,0 +1,137 @@
+package connoauth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestKey_IsValid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		k    Key
+		want bool
+	}{
+		{"zero", Key{}, false},
+		{"kind only", Key{Kind: KindMCP}, false},
+		{"name only", Key{Name: "test"}, false},
+		{"populated", Key{Kind: KindMCP, Name: "test"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.k.IsValid(); got != tc.want {
+				t.Fatalf("IsValid = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMemoryStore_RoundTrip(t *testing.T) {
+	t.Parallel()
+	s := NewMemoryStore()
+	ctx := context.Background()
+	key := Key{Kind: KindMCP, Name: "alpha"}
+	now := time.Now().Truncate(time.Second).UTC()
+	tok := PersistedToken{
+		Key:              key,
+		AccessToken:      "access",
+		RefreshToken:     "refresh",
+		ExpiresAt:        now.Add(time.Hour),
+		RefreshExpiresAt: now.Add(24 * time.Hour),
+		Scope:            "openid offline_access",
+		AuthenticatedBy:  "user@example.com",
+		AuthenticatedAt:  now,
+	}
+	if err := s.Set(ctx, tok); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, err := s.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AccessToken != "access" || got.RefreshToken != "refresh" {
+		t.Fatalf("token round-trip mismatch: %+v", got)
+	}
+	if got.Scope != "openid offline_access" {
+		t.Fatalf("scope mismatch: %q", got.Scope)
+	}
+	if got.AuthenticatedBy != "user@example.com" {
+		t.Fatalf("authenticated_by mismatch: %q", got.AuthenticatedBy)
+	}
+	if got.UpdatedAt.IsZero() {
+		t.Fatalf("UpdatedAt should be stamped on Set")
+	}
+}
+
+func TestMemoryStore_GetMissing(t *testing.T) {
+	t.Parallel()
+	s := NewMemoryStore()
+	_, err := s.Get(context.Background(), Key{Kind: KindAPI, Name: "missing"})
+	if !errors.Is(err, ErrTokenNotFound) {
+		t.Fatalf("expected ErrTokenNotFound, got %v", err)
+	}
+}
+
+func TestMemoryStore_Delete(t *testing.T) {
+	t.Parallel()
+	s := NewMemoryStore()
+	ctx := context.Background()
+	key := Key{Kind: KindMCP, Name: "to-delete"}
+	_ = s.Set(ctx, PersistedToken{Key: key, AccessToken: "x"})
+	if err := s.Delete(ctx, key); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := s.Get(ctx, key); !errors.Is(err, ErrTokenNotFound) {
+		t.Fatalf("expected ErrTokenNotFound after delete, got %v", err)
+	}
+	// Idempotent: second delete is fine.
+	if err := s.Delete(ctx, key); err != nil {
+		t.Fatalf("idempotent Delete: %v", err)
+	}
+}
+
+func TestMemoryStore_InvalidKey(t *testing.T) {
+	t.Parallel()
+	s := NewMemoryStore()
+	ctx := context.Background()
+	if _, err := s.Get(ctx, Key{}); !errors.Is(err, errInvalidKey) {
+		t.Fatalf("Get with zero key: want errInvalidKey, got %v", err)
+	}
+	if err := s.Set(ctx, PersistedToken{}); !errors.Is(err, errInvalidKey) {
+		t.Fatalf("Set with zero key: want errInvalidKey, got %v", err)
+	}
+	if err := s.Delete(ctx, Key{}); !errors.Is(err, errInvalidKey) {
+		t.Fatalf("Delete with zero key: want errInvalidKey, got %v", err)
+	}
+}
+
+func TestMemoryStore_TwoKindsCoexist(t *testing.T) {
+	t.Parallel()
+	s := NewMemoryStore()
+	ctx := context.Background()
+	mcpKey := Key{Kind: KindMCP, Name: "alpha"}
+	apiKey := Key{Kind: KindAPI, Name: "alpha"} // same name, different kind
+	_ = s.Set(ctx, PersistedToken{Key: mcpKey, AccessToken: "mcp-token"})
+	_ = s.Set(ctx, PersistedToken{Key: apiKey, AccessToken: "api-token"})
+	mcpGot, _ := s.Get(ctx, mcpKey)
+	apiGot, _ := s.Get(ctx, apiKey)
+	if mcpGot.AccessToken != "mcp-token" || apiGot.AccessToken != "api-token" {
+		t.Fatalf("kinds should not collide: mcp=%q api=%q", mcpGot.AccessToken, apiGot.AccessToken)
+	}
+}
+
+func TestNoopEncryptor(t *testing.T) {
+	t.Parallel()
+	e := noopEncryptor{}
+	enc, err := e.Encrypt("plain")
+	if err != nil || enc != "plain" {
+		t.Fatalf("Encrypt: got (%q, %v)", enc, err)
+	}
+	dec, err := e.Decrypt("cipher")
+	if err != nil || dec != "cipher" {
+		t.Fatalf("Decrypt: got (%q, %v)", dec, err)
+	}
+}

--- a/pkg/connoauth/token.go
+++ b/pkg/connoauth/token.go
@@ -1,0 +1,109 @@
+package connoauth
+
+import "time"
+
+// Kind constants for the connection_kind column. New connection kinds
+// that participate in this shared OAuth flow add a constant here and
+// extend the per-kind dispatch in pkg/admin's connection OAuth handler.
+const (
+	// KindMCP is the MCP gateway toolkit family (composes upstream MCP
+	// servers behind one platform-side server).
+	KindMCP = "mcp"
+	// KindAPI is the HTTP API gateway toolkit family (treats an OpenAPI
+	// REST service as a tool surface).
+	KindAPI = "api"
+)
+
+// Key uniquely identifies one (connection_kind, connection_name)
+// row in connection_oauth_tokens. Distinct from a bare string so
+// callers can't accidentally pass the wrong identifier — every Store
+// method takes a Key.
+type Key struct {
+	// Kind is one of the KindXxx constants. Empty is invalid; the
+	// Store.Get / Set / Delete methods reject zero-value keys with a
+	// validation error rather than silently writing to an empty-kind
+	// row that would never be read back by a real consumer.
+	Kind string
+	// Name matches the connection_instances.name column for the same
+	// (kind, name) pair. Stable across saves of the same connection.
+	Name string
+}
+
+// IsValid reports whether the Key is fully populated. Callers should
+// validate before mutating the store; the Postgres impl also rejects
+// zero values with an error to defend against misuse.
+func (k Key) IsValid() bool {
+	return k.Kind != "" && k.Name != ""
+}
+
+// PersistedToken is the row shape stored in connection_oauth_tokens.
+// Tokens are stored encrypted at rest by the platform's FieldEncryptor;
+// this struct carries plaintext values across the Store API boundary.
+//
+// RefreshExpiresAt is optional — populated only when the IdP returned
+// refresh_expires_in (Keycloak does; many others do not). Zero means
+// the row column is NULL; callers MUST NOT interpret zero as "never
+// expires" — it means the IdP did not disclose a deadline.
+type PersistedToken struct {
+	Key              Key
+	AccessToken      string
+	RefreshToken     string
+	ExpiresAt        time.Time
+	RefreshExpiresAt time.Time
+	Scope            string
+	AuthenticatedBy  string
+	AuthenticatedAt  time.Time
+	UpdatedAt        time.Time
+}
+
+// OAuthStatus is the snapshot exposed via the admin status endpoint.
+// All fields are safe to expose to operators (no secret material).
+// Mirrors the union of the two prior per-kind status structs so the
+// frontend status card renders identically for any kind.
+type OAuthStatus struct {
+	// Configured indicates the connection is set up for the
+	// authorization_code grant. False means the status endpoint was
+	// hit for a non-OAuth connection (or one with a different grant)
+	// and the UI should hide the OAuth block entirely.
+	Configured bool `json:"configured"`
+	// TokenAcquired is true when a non-empty access_token sits in the
+	// persisted row. False after a revoked-refresh cleanup or before
+	// the first Connect.
+	TokenAcquired bool `json:"token_acquired"`
+	// ExpiresAt is the access-token deadline. Zero when no token has
+	// been acquired.
+	ExpiresAt time.Time `json:"expires_at,omitzero"`
+	// LastRefreshedAt is the persisted row's UpdatedAt — the time of
+	// the most recent successful write (initial Connect or silent
+	// refresh).
+	LastRefreshedAt time.Time `json:"last_refreshed_at,omitzero"`
+	// HasRefreshToken is true when a refresh token sits in the row.
+	// False for IdPs that don't issue refresh tokens, OR after a
+	// revoked-refresh cleanup.
+	HasRefreshToken bool `json:"has_refresh_token"`
+	// RefreshExpiresAt is the IdP-disclosed refresh-token deadline.
+	// Zero when the IdP did not disclose one. The admin UI renders an
+	// em dash for zero, not "never".
+	RefreshExpiresAt time.Time `json:"refresh_expires_at,omitzero"`
+	// LastError is the most recent surfaced failure (transport,
+	// IdP-rejected, persistence). Cleared by a subsequent success.
+	LastError string `json:"last_error,omitempty"`
+	// TokenURL is the IdP's token endpoint, surfaced so the admin
+	// status panel can show "auth against https://iam.example.com/..."
+	// at a glance. Operator-authored config; safe to expose.
+	TokenURL string `json:"token_url,omitempty"`
+	// Scope is the space-delimited scope string negotiated with the
+	// IdP. Surfaced so operators can verify offline_access is present
+	// on Keycloak/Auth0/Okta IdPs.
+	Scope string `json:"scope,omitempty"`
+	// AuthenticatedBy is the email/id of the operator who completed
+	// the browser flow. Empty for never-authorized connections.
+	AuthenticatedBy string `json:"authenticated_by,omitempty"`
+	// AuthenticatedAt is when the most recent successful Connect
+	// completed. Initial-Connect time, not last-refresh time.
+	AuthenticatedAt time.Time `json:"authenticated_at,omitzero"`
+	// NeedsReauth is true when no access token can be minted without
+	// operator interaction. The admin UI surfaces a Connect button
+	// when this is true.
+	NeedsReauth bool `json:"needs_reauth,omitempty"`
+}

--- a/pkg/database/migrate/migrate_unit_test.go
+++ b/pkg/database/migrate/migrate_unit_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	migrateTestFileCount    = 76
+	migrateTestFileCount    = 78
 	migrateTestSuccess      = "success"
 	migrateTestFactoryError = "factory error"
 )

--- a/pkg/database/migrate/migrations/000039_connection_oauth_tokens.down.sql
+++ b/pkg/database/migrate/migrations/000039_connection_oauth_tokens.down.sql
@@ -1,0 +1,9 @@
+-- Reverse migration 000039. The old per-kind tables are still
+-- present (this migration intentionally did not drop them), so on
+-- down we simply remove the unified table and the added
+-- pkce-state column. No token data is lost: pre-migration rows
+-- still live in gateway_oauth_tokens and apigateway_oauth_tokens.
+DROP TABLE IF EXISTS connection_oauth_tokens;
+
+ALTER TABLE oauth_pkce_states
+    DROP COLUMN IF EXISTS connection_kind;

--- a/pkg/database/migrate/migrations/000039_connection_oauth_tokens.up.sql
+++ b/pkg/database/migrate/migrations/000039_connection_oauth_tokens.up.sql
@@ -1,0 +1,62 @@
+-- 000039: connection_oauth_tokens
+--
+-- Single shared table for OAuth 2.1 authorization_code tokens across
+-- ALL connection kinds (MCP gateway, HTTP API gateway, future kinds).
+-- Replaces the two per-kind tables (gateway_oauth_tokens and
+-- apigateway_oauth_tokens) that previously held the same row shape
+-- in parallel — the duplication produced two divergent codepaths
+-- (handlers, stores, refresh logic, frontend hooks) and made subtle
+-- bugs hard to find.
+--
+-- The old tables are NOT dropped here. A follow-up migration drops
+-- them after one stable release. This gives an emergency rollback
+-- path that doesn't require restoring tokens from a backup.
+
+CREATE TABLE IF NOT EXISTS connection_oauth_tokens (
+    connection_kind     VARCHAR(32)  NOT NULL,
+    connection_name     VARCHAR(255) NOT NULL,
+    access_token        TEXT,
+    refresh_token       TEXT,
+    expires_at          TIMESTAMPTZ,
+    refresh_expires_at  TIMESTAMPTZ,
+    scope               TEXT         NOT NULL DEFAULT '',
+    authenticated_by    VARCHAR(255) NOT NULL DEFAULT '',
+    authenticated_at    TIMESTAMPTZ,
+    updated_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (connection_kind, connection_name)
+);
+
+-- Backfill from gateway_oauth_tokens (MCP gateway kind). The source
+-- table predates the refresh_expires_at column (added in 000037), so
+-- we map directly — rows that pre-date 000037 have NULL refresh_
+-- expires_at and stay NULL after backfill, which is correct.
+INSERT INTO connection_oauth_tokens
+    (connection_kind, connection_name, access_token, refresh_token,
+     expires_at, refresh_expires_at, scope, authenticated_by,
+     authenticated_at, updated_at)
+SELECT 'mcp', connection_name, access_token, refresh_token,
+       expires_at, refresh_expires_at, scope, authenticated_by,
+       authenticated_at, updated_at
+  FROM gateway_oauth_tokens
+ON CONFLICT (connection_kind, connection_name) DO NOTHING;
+
+-- Backfill from apigateway_oauth_tokens (HTTP API gateway kind).
+-- Schema is already aligned (refresh_expires_at present from
+-- migration 000038), so columns map 1:1.
+INSERT INTO connection_oauth_tokens
+    (connection_kind, connection_name, access_token, refresh_token,
+     expires_at, refresh_expires_at, scope, authenticated_by,
+     authenticated_at, updated_at)
+SELECT 'api', connection_name, access_token, refresh_token,
+       expires_at, refresh_expires_at, scope, authenticated_by,
+       authenticated_at, updated_at
+  FROM apigateway_oauth_tokens
+ON CONFLICT (connection_kind, connection_name) DO NOTHING;
+
+-- Add connection_kind to oauth_pkce_states so the unified callback
+-- can dispatch by kind. Existing rows pre-date this migration and
+-- belong to MCP-only flows (the only kind that used this table at
+-- the time those rows were written); default 'mcp' is the right
+-- starting state for in-flight rows the migration sees.
+ALTER TABLE oauth_pkce_states
+    ADD COLUMN IF NOT EXISTS connection_kind VARCHAR(32) NOT NULL DEFAULT 'mcp';

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -188,6 +188,7 @@ const (
 type PortalConfig struct {
 	Enabled        *bool                 `yaml:"enabled"`
 	Title          string                `yaml:"title"`            // sidebar/branding title (default: "MCP Data Platform")
+	Tagline        string                `yaml:"tagline"`          // login-screen subtitle (default: "Sign in to access the platform.")
 	Logo           string                `yaml:"logo"`             // URL to logo (fallback for both themes)
 	LogoLight      string                `yaml:"logo_light"`       // URL to logo for light theme
 	LogoDark       string                `yaml:"logo_dark"`        // URL to logo for dark theme

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -32,6 +32,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/browsersession"
 	"github.com/txn2/mcp-data-platform/pkg/configstore"
 	configpostgres "github.com/txn2/mcp-data-platform/pkg/configstore/postgres"
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
 	"github.com/txn2/mcp-data-platform/pkg/database/migrate"
 	"github.com/txn2/mcp-data-platform/pkg/embedding"
 	"github.com/txn2/mcp-data-platform/pkg/mcpapps"
@@ -123,6 +124,7 @@ type Platform struct {
 	enrichmentStore      enrichment.Store
 	gatewayTokenStore    gatewaykit.TokenStore
 	apigatewayTokenStore apigatewaykit.TokenStore
+	connOAuthStore       connoauth.Store
 	restEncryptor        *RestFieldEncryptor
 	personaStore         PersonaStore
 	apiKeyStore          APIKeyStore
@@ -444,8 +446,16 @@ func (p *Platform) initConnectionStore(opts *Options) error {
 	p.restEncryptor = &RestFieldEncryptor{enc: encryptor}
 	p.connectionStore = NewPostgresConnectionStore(p.db, encryptor)
 	p.enrichmentStore = enrichment.NewPostgresStore(p.db)
-	p.gatewayTokenStore = gatewaykit.NewPostgresTokenStore(p.db, p.restEncryptor)
-	p.apigatewayTokenStore = apigatewaykit.NewPostgresTokenStore(p.db, p.restEncryptor)
+	p.connOAuthStore = connoauth.NewPostgresStore(p.db, p.restEncryptor)
+	// Both toolkit token stores are now backed by the unified
+	// connection_oauth_tokens table via a per-kind adapter. The admin
+	// layer's unified OAuth handler writes to the same connoauth.Store,
+	// so Connect → tool call → refresh all read/write the same row.
+	// Migration 000039 backfills tokens from the prior per-kind tables
+	// on upgrade; the prior tables are kept for one release and
+	// dropped in a follow-up migration.
+	p.gatewayTokenStore = gatewaykit.NewConnOAuthTokenStore(p.connOAuthStore)
+	p.apigatewayTokenStore = apigatewaykit.NewConnOAuthTokenStore(p.connOAuthStore)
 	return nil
 }
 
@@ -492,6 +502,15 @@ func (g *RestFieldEncryptor) Decrypt(ciphertext string) (string, error) {
 		return "", fmt.Errorf("rest field decrypt: %w", err)
 	}
 	return out, nil
+}
+
+// ConnOAuthStore returns the unified OAuth-token store backing the
+// connection_oauth_tokens table. Used by the admin layer's unified
+// OAuth handler and (via toolkit OAuthKindHandlers) by per-kind
+// Authenticators. Nil when no database is configured — the platform
+// falls back to the legacy per-kind in-memory stores in that case.
+func (p *Platform) ConnOAuthStore() connoauth.Store {
+	return p.connOAuthStore
 }
 
 // RestEncryptor returns the platform's at-rest field encryption

--- a/pkg/toolkits/apigateway/connoauth_bridge.go
+++ b/pkg/toolkits/apigateway/connoauth_bridge.go
@@ -1,0 +1,79 @@
+package apigateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
+)
+
+// NewConnOAuthTokenStore returns a TokenStore implementation backed
+// by the unified connoauth.Store (connection_oauth_tokens table).
+// Used by the platform's WireAPIGatewayTokenStore when a database is
+// configured — replaces the per-kind apigateway_oauth_tokens path so
+// the admin layer's unified OAuth handler and the toolkit's
+// Authenticator agree on the underlying storage row.
+//
+// This adapter exists because the toolkit's existing TokenStore
+// interface keys on a bare connection name while connoauth.Store
+// keys on (kind, name). Wrapping the unified store keeps the toolkit
+// code unchanged during the rollout — a follow-up may replace the
+// in-toolkit oauth2AuthorizationCodeAuth with a direct
+// connoauth.Source so this shim becomes unnecessary.
+func NewConnOAuthTokenStore(store connoauth.Store) TokenStore {
+	return &connOAuthTokenStore{store: store}
+}
+
+type connOAuthTokenStore struct {
+	store connoauth.Store
+}
+
+// Get reads the row for connection from the unified table under
+// kind="api" (the HTTP API gateway toolkit kind).
+func (s *connOAuthTokenStore) Get(ctx context.Context, connection string) (*PersistedToken, error) {
+	p, err := s.store.Get(ctx, connoauth.Key{Kind: connoauth.KindAPI, Name: connection})
+	if err != nil {
+		if errors.Is(err, connoauth.ErrTokenNotFound) {
+			return nil, ErrTokenNotFound
+		}
+		return nil, fmt.Errorf("apigateway: load oauth token: %w", err)
+	}
+	return &PersistedToken{
+		ConnectionName:   p.Key.Name,
+		AccessToken:      p.AccessToken,
+		RefreshToken:     p.RefreshToken,
+		ExpiresAt:        p.ExpiresAt,
+		RefreshExpiresAt: p.RefreshExpiresAt,
+		Scope:            p.Scope,
+		AuthenticatedBy:  p.AuthenticatedBy,
+		AuthenticatedAt:  p.AuthenticatedAt,
+		UpdatedAt:        p.UpdatedAt,
+	}, nil
+}
+
+// Set writes the toolkit's PersistedToken into the unified table
+// under kind="api".
+func (s *connOAuthTokenStore) Set(ctx context.Context, t PersistedToken) error {
+	if err := s.store.Set(ctx, connoauth.PersistedToken{
+		Key:              connoauth.Key{Kind: connoauth.KindAPI, Name: t.ConnectionName},
+		AccessToken:      t.AccessToken,
+		RefreshToken:     t.RefreshToken,
+		ExpiresAt:        t.ExpiresAt,
+		RefreshExpiresAt: t.RefreshExpiresAt,
+		Scope:            t.Scope,
+		AuthenticatedBy:  t.AuthenticatedBy,
+		AuthenticatedAt:  t.AuthenticatedAt,
+	}); err != nil {
+		return fmt.Errorf("apigateway: persist oauth token: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the row for connection from the unified table.
+func (s *connOAuthTokenStore) Delete(ctx context.Context, connection string) error {
+	if err := s.store.Delete(ctx, connoauth.Key{Kind: connoauth.KindAPI, Name: connection}); err != nil {
+		return fmt.Errorf("apigateway: delete oauth token: %w", err)
+	}
+	return nil
+}

--- a/pkg/toolkits/apigateway/connoauth_bridge_test.go
+++ b/pkg/toolkits/apigateway/connoauth_bridge_test.go
@@ -1,0 +1,147 @@
+package apigateway
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
+)
+
+type fakeConnOAuthStore struct {
+	getKey, setKey, delKey connoauth.Key
+	getErr                 error
+	setErr                 error
+	delErr                 error
+	row                    *connoauth.PersistedToken
+	setRow                 connoauth.PersistedToken
+}
+
+func (f *fakeConnOAuthStore) Get(_ context.Context, key connoauth.Key) (*connoauth.PersistedToken, error) {
+	f.getKey = key
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return f.row, nil
+}
+
+func (f *fakeConnOAuthStore) Set(_ context.Context, t connoauth.PersistedToken) error {
+	f.setKey = t.Key
+	f.setRow = t
+	return f.setErr
+}
+
+func (f *fakeConnOAuthStore) Delete(_ context.Context, key connoauth.Key) error {
+	f.delKey = key
+	return f.delErr
+}
+
+func TestConnOAuthBridge_Get_MapsKindAndFields(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC().Truncate(time.Second)
+	store := &fakeConnOAuthStore{
+		row: &connoauth.PersistedToken{
+			Key:              connoauth.Key{Kind: connoauth.KindAPI, Name: "vendor"},
+			AccessToken:      "at",
+			RefreshToken:     "rt",
+			ExpiresAt:        now.Add(time.Hour),
+			RefreshExpiresAt: now.Add(24 * time.Hour),
+			Scope:            "openid",
+			AuthenticatedBy:  "u@example.com",
+			AuthenticatedAt:  now,
+			UpdatedAt:        now,
+		},
+	}
+	bridge := NewConnOAuthTokenStore(store)
+	got, err := bridge.Get(context.Background(), "vendor")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if store.getKey.Kind != connoauth.KindAPI || store.getKey.Name != "vendor" {
+		t.Fatalf("bridge must call Get with Kind=api Name=vendor, got %+v", store.getKey)
+	}
+	if got.AccessToken != "at" || got.RefreshToken != "rt" {
+		t.Fatalf("token fields not mapped: %+v", got)
+	}
+	if got.ConnectionName != "vendor" {
+		t.Fatalf("ConnectionName not mapped: %q", got.ConnectionName)
+	}
+}
+
+func TestConnOAuthBridge_Get_NotFoundMapsToToolkitSentinel(t *testing.T) {
+	t.Parallel()
+	store := &fakeConnOAuthStore{getErr: connoauth.ErrTokenNotFound}
+	bridge := NewConnOAuthTokenStore(store)
+	_, err := bridge.Get(context.Background(), "missing")
+	if !errors.Is(err, ErrTokenNotFound) {
+		t.Fatalf("expected ErrTokenNotFound (toolkit sentinel), got %v", err)
+	}
+}
+
+func TestConnOAuthBridge_Get_OtherErrorWraps(t *testing.T) {
+	t.Parallel()
+	store := &fakeConnOAuthStore{getErr: errors.New("db down")}
+	bridge := NewConnOAuthTokenStore(store)
+	_, err := bridge.Get(context.Background(), "x")
+	if err == nil || errors.Is(err, ErrTokenNotFound) {
+		t.Fatalf("non-NotFound errors must surface as wrapped, got %v", err)
+	}
+}
+
+func TestConnOAuthBridge_Set_RoutesToAPIKind(t *testing.T) {
+	t.Parallel()
+	store := &fakeConnOAuthStore{}
+	bridge := NewConnOAuthTokenStore(store)
+	now := time.Now().UTC()
+	err := bridge.Set(context.Background(), PersistedToken{
+		ConnectionName:   "vendor",
+		AccessToken:      "at",
+		RefreshToken:     "rt",
+		ExpiresAt:        now.Add(time.Hour),
+		RefreshExpiresAt: now.Add(24 * time.Hour),
+		Scope:            "openid",
+		AuthenticatedBy:  "u@example.com",
+		AuthenticatedAt:  now,
+	})
+	if err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if store.setKey.Kind != connoauth.KindAPI || store.setKey.Name != "vendor" {
+		t.Fatalf("Set must route to kind=api, got %+v", store.setKey)
+	}
+	if store.setRow.AccessToken != "at" || store.setRow.RefreshToken != "rt" {
+		t.Fatalf("token fields not propagated: %+v", store.setRow)
+	}
+}
+
+func TestConnOAuthBridge_Set_ErrorWraps(t *testing.T) {
+	t.Parallel()
+	store := &fakeConnOAuthStore{setErr: errors.New("encrypt failed")}
+	bridge := NewConnOAuthTokenStore(store)
+	err := bridge.Set(context.Background(), PersistedToken{ConnectionName: "x", AccessToken: "y"})
+	if err == nil {
+		t.Fatal("expected error to surface")
+	}
+}
+
+func TestConnOAuthBridge_Delete_RoutesToAPIKind(t *testing.T) {
+	t.Parallel()
+	store := &fakeConnOAuthStore{}
+	bridge := NewConnOAuthTokenStore(store)
+	if err := bridge.Delete(context.Background(), "vendor"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if store.delKey.Kind != connoauth.KindAPI || store.delKey.Name != "vendor" {
+		t.Fatalf("Delete must route to kind=api, got %+v", store.delKey)
+	}
+}
+
+func TestConnOAuthBridge_Delete_ErrorWraps(t *testing.T) {
+	t.Parallel()
+	store := &fakeConnOAuthStore{delErr: errors.New("db gone")}
+	bridge := NewConnOAuthTokenStore(store)
+	if err := bridge.Delete(context.Background(), "x"); err == nil {
+		t.Fatal("expected error to surface")
+	}
+}

--- a/pkg/toolkits/apigateway/oauth_kind_handler.go
+++ b/pkg/toolkits/apigateway/oauth_kind_handler.go
@@ -1,0 +1,69 @@
+package apigateway
+
+import (
+	"context"
+	"errors"
+
+	"golang.org/x/oauth2"
+
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
+)
+
+// OAuthKindHandler adapts the HTTP API gateway toolkit to the unified
+// connoauth flow. The admin layer's unified OAuth handler dispatches
+// on the connection_kind path parameter ("api" for HTTP API gateway
+// connections) and invokes this implementation for config extraction
+// and post-auth side effects.
+//
+// AfterConnect is a no-op for this kind: the toolkit's Authenticator
+// reads the persisted token from the store lazily on every outbound
+// request, so once the token is persisted the connection is
+// immediately usable without further toolkit-side work.
+type OAuthKindHandler struct{}
+
+// NewOAuthKindHandler returns the API gateway adapter. The toolkit
+// argument is accepted for symmetry with the MCP gateway adapter but
+// is intentionally unused — the API gateway needs no post-auth
+// side effect.
+func NewOAuthKindHandler(_ *Toolkit) *OAuthKindHandler {
+	return &OAuthKindHandler{}
+}
+
+// ParseOAuthConfig validates the connection's stored config and maps
+// the HTTP API gateway's per-kind OAuth shape into a connoauth.Config.
+// Returns an error when the connection is not configured for the
+// authorization_code grant — the unified handler maps that to HTTP
+// 409 Conflict, matching the prior per-kind handler's response code.
+func (*OAuthKindHandler) ParseOAuthConfig(connConfig map[string]any) (connoauth.Config, error) {
+	cfg, err := ParseConfig(connConfig)
+	if err != nil {
+		return connoauth.Config{}, err
+	}
+	if cfg.AuthMode != AuthModeOAuth2AuthorizationCode {
+		return connoauth.Config{}, errors.New("connection is not configured for authorization_code OAuth")
+	}
+	authStyle := oauth2.AuthStyleInHeader
+	if cfg.OAuth2.EndpointAuthStyle == OAuth2AuthStyleParams {
+		authStyle = oauth2.AuthStyleInParams
+	}
+	return connoauth.Config{
+		AuthorizationURL:  cfg.OAuth2.AuthorizationURL,
+		TokenURL:          cfg.OAuth2.TokenURL,
+		ClientID:          cfg.OAuth2.ClientID,
+		ClientSecret:      cfg.OAuth2.ClientSecret,
+		Scopes:            cfg.OAuth2.Scopes,
+		EndpointAuthStyle: authStyle,
+		Prompt:            cfg.OAuth2.Prompt,
+	}, nil
+}
+
+// AfterConnect is a no-op. The API gateway's Authenticator reads the
+// persisted token from the store on every outbound request via
+// connoauth.Source, so once the token is persisted by the unified
+// callback handler the connection is immediately usable. The MCP
+// gateway, in contrast, caches an in-memory client per connection
+// and must rebuild it after Connect; that's the MCP-side reason
+// AfterConnect exists on the interface at all.
+func (*OAuthKindHandler) AfterConnect(_ context.Context, _ string, _ map[string]any) error {
+	return nil
+}

--- a/pkg/toolkits/apigateway/oauth_kind_handler_test.go
+++ b/pkg/toolkits/apigateway/oauth_kind_handler_test.go
@@ -1,0 +1,92 @@
+package apigateway
+
+import (
+	"context"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func TestOAuthKindHandler_ParseOAuthConfig_RejectsNonAuthCode(t *testing.T) {
+	t.Parallel()
+	h := &OAuthKindHandler{}
+	// api_key mode — not OAuth at all.
+	_, err := h.ParseOAuthConfig(map[string]any{
+		"base_url":          "https://api.example/",
+		"auth_mode":         "api_key",
+		"api_key_placement": "header",
+		"api_key_header":    "X-API-Key",
+		"credential":        "k",
+	})
+	if err == nil {
+		t.Fatal("expected error for non-authorization_code mode")
+	}
+}
+
+func TestOAuthKindHandler_ParseOAuthConfig_MapsAllFields(t *testing.T) {
+	t.Parallel()
+	h := &OAuthKindHandler{}
+	cfg, err := h.ParseOAuthConfig(map[string]any{
+		"base_url":                   "https://api.example/",
+		"auth_mode":                  "oauth2_authorization_code",
+		"oauth2_authorization_url":   "https://idp/auth",
+		"oauth2_token_url":           "https://idp/token",
+		"oauth2_client_id":           "client-id",
+		"oauth2_client_secret":       "client-secret",
+		"oauth2_scopes":              []any{"openid", "offline_access"},
+		"oauth2_endpoint_auth_style": "params",
+		"oauth2_prompt":              "consent",
+	})
+	if err != nil {
+		t.Fatalf("ParseOAuthConfig: %v", err)
+	}
+	if cfg.AuthorizationURL != "https://idp/auth" || cfg.TokenURL != "https://idp/token" {
+		t.Fatalf("URLs not mapped: %+v", cfg)
+	}
+	if cfg.ClientID != "client-id" || cfg.ClientSecret != "client-secret" {
+		t.Fatalf("credentials not mapped: %+v", cfg)
+	}
+	if cfg.Prompt != "consent" {
+		t.Fatalf("prompt not mapped: %q", cfg.Prompt)
+	}
+	if cfg.EndpointAuthStyle != oauth2.AuthStyleInParams {
+		t.Fatalf("params auth style not mapped: got %v", cfg.EndpointAuthStyle)
+	}
+	if len(cfg.Scopes) != 2 || cfg.Scopes[0] != "openid" || cfg.Scopes[1] != "offline_access" {
+		t.Fatalf("scopes not mapped: %v", cfg.Scopes)
+	}
+}
+
+func TestOAuthKindHandler_ParseOAuthConfig_DefaultsToHeaderAuthStyle(t *testing.T) {
+	t.Parallel()
+	h := &OAuthKindHandler{}
+	cfg, err := h.ParseOAuthConfig(map[string]any{
+		"base_url":                 "https://api.example/",
+		"auth_mode":                "oauth2_authorization_code",
+		"oauth2_authorization_url": "https://idp/auth",
+		"oauth2_token_url":         "https://idp/token",
+		"oauth2_client_id":         "c",
+		"oauth2_client_secret":     "s",
+	})
+	if err != nil {
+		t.Fatalf("ParseOAuthConfig: %v", err)
+	}
+	if cfg.EndpointAuthStyle != oauth2.AuthStyleInHeader {
+		t.Fatalf("default auth style must be header (Basic), got %v", cfg.EndpointAuthStyle)
+	}
+}
+
+func TestOAuthKindHandler_AfterConnect_IsNoOp(t *testing.T) {
+	t.Parallel()
+	h := &OAuthKindHandler{}
+	if err := h.AfterConnect(context.Background(), "any-name", nil); err != nil {
+		t.Fatalf("API gateway AfterConnect must be a no-op, got %v", err)
+	}
+}
+
+func TestNewOAuthKindHandler_AcceptsNilToolkit(t *testing.T) {
+	t.Parallel()
+	if h := NewOAuthKindHandler(nil); h == nil {
+		t.Fatal("API kind handler must be constructable without a toolkit reference")
+	}
+}

--- a/pkg/toolkits/gateway/connoauth_bridge.go
+++ b/pkg/toolkits/gateway/connoauth_bridge.go
@@ -1,0 +1,79 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
+)
+
+// NewConnOAuthTokenStore returns a TokenStore implementation backed
+// by the unified connoauth.Store (connection_oauth_tokens table).
+// Used by the platform's WireGatewayTokenStore when a database is
+// configured — replaces the per-kind gateway_oauth_tokens path so
+// the admin layer's unified OAuth handler and the toolkit's
+// Authenticator agree on the underlying storage row.
+//
+// This adapter exists because the toolkit's existing TokenStore
+// interface keys on a bare connection name while connoauth.Store
+// keys on (kind, name). Wrapping the unified store keeps the toolkit
+// code unchanged during the rollout — a follow-up may replace the
+// in-toolkit oauthTokenSource with a direct connoauth.Source so this
+// shim becomes unnecessary.
+func NewConnOAuthTokenStore(store connoauth.Store) TokenStore {
+	return &connOAuthTokenStore{store: store}
+}
+
+type connOAuthTokenStore struct {
+	store connoauth.Store
+}
+
+// Get reads the row for connection from the unified table under
+// kind="mcp" (the gateway toolkit kind).
+func (s *connOAuthTokenStore) Get(ctx context.Context, connection string) (*PersistedToken, error) {
+	p, err := s.store.Get(ctx, connoauth.Key{Kind: connoauth.KindMCP, Name: connection})
+	if err != nil {
+		if errors.Is(err, connoauth.ErrTokenNotFound) {
+			return nil, ErrTokenNotFound
+		}
+		return nil, fmt.Errorf("gateway: load oauth token: %w", err)
+	}
+	return &PersistedToken{
+		ConnectionName:   p.Key.Name,
+		AccessToken:      p.AccessToken,
+		RefreshToken:     p.RefreshToken,
+		ExpiresAt:        p.ExpiresAt,
+		RefreshExpiresAt: p.RefreshExpiresAt,
+		Scope:            p.Scope,
+		AuthenticatedBy:  p.AuthenticatedBy,
+		AuthenticatedAt:  p.AuthenticatedAt,
+		UpdatedAt:        p.UpdatedAt,
+	}, nil
+}
+
+// Set writes the toolkit's PersistedToken into the unified table
+// under kind="mcp".
+func (s *connOAuthTokenStore) Set(ctx context.Context, t PersistedToken) error {
+	if err := s.store.Set(ctx, connoauth.PersistedToken{
+		Key:              connoauth.Key{Kind: connoauth.KindMCP, Name: t.ConnectionName},
+		AccessToken:      t.AccessToken,
+		RefreshToken:     t.RefreshToken,
+		ExpiresAt:        t.ExpiresAt,
+		RefreshExpiresAt: t.RefreshExpiresAt,
+		Scope:            t.Scope,
+		AuthenticatedBy:  t.AuthenticatedBy,
+		AuthenticatedAt:  t.AuthenticatedAt,
+	}); err != nil {
+		return fmt.Errorf("gateway: persist oauth token: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the row for connection from the unified table.
+func (s *connOAuthTokenStore) Delete(ctx context.Context, connection string) error {
+	if err := s.store.Delete(ctx, connoauth.Key{Kind: connoauth.KindMCP, Name: connection}); err != nil {
+		return fmt.Errorf("gateway: delete oauth token: %w", err)
+	}
+	return nil
+}

--- a/pkg/toolkits/gateway/connoauth_bridge_test.go
+++ b/pkg/toolkits/gateway/connoauth_bridge_test.go
@@ -1,0 +1,161 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
+)
+
+// fakeConnOAuthStore is a tiny in-memory connoauth.Store that lets the
+// bridge tests assert exactly which Key the bridge uses on each call.
+// The real connoauth.MemoryStore would work too, but capturing the
+// last-used key lets us prove the bridge always passes
+// (Kind: "mcp", Name: connection) rather than something else.
+type fakeConnOAuthStore struct {
+	getKey, setKey, delKey connoauth.Key
+	getErr                 error
+	setErr                 error
+	delErr                 error
+	row                    *connoauth.PersistedToken
+	setRow                 connoauth.PersistedToken
+}
+
+func (f *fakeConnOAuthStore) Get(_ context.Context, key connoauth.Key) (*connoauth.PersistedToken, error) {
+	f.getKey = key
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return f.row, nil
+}
+
+func (f *fakeConnOAuthStore) Set(_ context.Context, t connoauth.PersistedToken) error {
+	f.setKey = t.Key
+	f.setRow = t
+	return f.setErr
+}
+
+func (f *fakeConnOAuthStore) Delete(_ context.Context, key connoauth.Key) error {
+	f.delKey = key
+	return f.delErr
+}
+
+func TestConnOAuthBridge_Get_MapsKindAndFields(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC().Truncate(time.Second)
+	store := &fakeConnOAuthStore{
+		row: &connoauth.PersistedToken{
+			Key:              connoauth.Key{Kind: connoauth.KindMCP, Name: "vendor"},
+			AccessToken:      "at",
+			RefreshToken:     "rt",
+			ExpiresAt:        now.Add(time.Hour),
+			RefreshExpiresAt: now.Add(24 * time.Hour),
+			Scope:            "openid offline_access",
+			AuthenticatedBy:  "user@example.com",
+			AuthenticatedAt:  now,
+			UpdatedAt:        now,
+		},
+	}
+	bridge := NewConnOAuthTokenStore(store)
+	got, err := bridge.Get(context.Background(), "vendor")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if store.getKey.Kind != connoauth.KindMCP || store.getKey.Name != "vendor" {
+		t.Fatalf("bridge must call Get with Kind=mcp Name=vendor, got %+v", store.getKey)
+	}
+	if got.AccessToken != "at" || got.RefreshToken != "rt" {
+		t.Fatalf("token fields not mapped: %+v", got)
+	}
+	if got.ConnectionName != "vendor" {
+		t.Fatalf("ConnectionName not mapped: %q", got.ConnectionName)
+	}
+	if !got.ExpiresAt.Equal(now.Add(time.Hour)) || !got.RefreshExpiresAt.Equal(now.Add(24*time.Hour)) {
+		t.Fatalf("expiry fields not mapped: %+v", got)
+	}
+	if got.AuthenticatedBy != "user@example.com" {
+		t.Fatalf("authenticated_by not mapped: %q", got.AuthenticatedBy)
+	}
+}
+
+func TestConnOAuthBridge_Get_NotFoundMapsToToolkitSentinel(t *testing.T) {
+	t.Parallel()
+	store := &fakeConnOAuthStore{getErr: connoauth.ErrTokenNotFound}
+	bridge := NewConnOAuthTokenStore(store)
+	_, err := bridge.Get(context.Background(), "missing")
+	if !errors.Is(err, ErrTokenNotFound) {
+		t.Fatalf("expected ErrTokenNotFound (toolkit sentinel), got %v", err)
+	}
+}
+
+func TestConnOAuthBridge_Get_OtherErrorWraps(t *testing.T) {
+	t.Parallel()
+	store := &fakeConnOAuthStore{getErr: errors.New("db down")}
+	bridge := NewConnOAuthTokenStore(store)
+	_, err := bridge.Get(context.Background(), "x")
+	if err == nil || errors.Is(err, ErrTokenNotFound) {
+		t.Fatalf("non-NotFound errors must surface as wrapped, got %v", err)
+	}
+}
+
+func TestConnOAuthBridge_Set_RoutesToMCPKind(t *testing.T) {
+	t.Parallel()
+	store := &fakeConnOAuthStore{}
+	bridge := NewConnOAuthTokenStore(store)
+	now := time.Now().UTC()
+	err := bridge.Set(context.Background(), PersistedToken{
+		ConnectionName:   "vendor",
+		AccessToken:      "at",
+		RefreshToken:     "rt",
+		ExpiresAt:        now.Add(time.Hour),
+		RefreshExpiresAt: now.Add(24 * time.Hour),
+		Scope:            "openid",
+		AuthenticatedBy:  "u@example.com",
+		AuthenticatedAt:  now,
+	})
+	if err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if store.setKey.Kind != connoauth.KindMCP || store.setKey.Name != "vendor" {
+		t.Fatalf("Set must route to kind=mcp, got %+v", store.setKey)
+	}
+	if store.setRow.AccessToken != "at" || store.setRow.RefreshToken != "rt" {
+		t.Fatalf("token fields not propagated: %+v", store.setRow)
+	}
+	if !store.setRow.ExpiresAt.Equal(now.Add(time.Hour)) {
+		t.Fatalf("ExpiresAt not propagated")
+	}
+}
+
+func TestConnOAuthBridge_Set_ErrorWraps(t *testing.T) {
+	t.Parallel()
+	store := &fakeConnOAuthStore{setErr: errors.New("encrypt failed")}
+	bridge := NewConnOAuthTokenStore(store)
+	err := bridge.Set(context.Background(), PersistedToken{ConnectionName: "x", AccessToken: "y"})
+	if err == nil {
+		t.Fatal("expected error to surface")
+	}
+}
+
+func TestConnOAuthBridge_Delete_RoutesToMCPKind(t *testing.T) {
+	t.Parallel()
+	store := &fakeConnOAuthStore{}
+	bridge := NewConnOAuthTokenStore(store)
+	if err := bridge.Delete(context.Background(), "vendor"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if store.delKey.Kind != connoauth.KindMCP || store.delKey.Name != "vendor" {
+		t.Fatalf("Delete must route to kind=mcp, got %+v", store.delKey)
+	}
+}
+
+func TestConnOAuthBridge_Delete_ErrorWraps(t *testing.T) {
+	t.Parallel()
+	store := &fakeConnOAuthStore{delErr: errors.New("db gone")}
+	bridge := NewConnOAuthTokenStore(store)
+	if err := bridge.Delete(context.Background(), "x"); err == nil {
+		t.Fatal("expected error to surface")
+	}
+}

--- a/pkg/toolkits/gateway/oauth_kind_handler.go
+++ b/pkg/toolkits/gateway/oauth_kind_handler.go
@@ -1,0 +1,126 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"golang.org/x/oauth2"
+
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
+)
+
+// OAuthKindHandler adapts the MCP gateway toolkit to the unified
+// connoauth flow. The admin layer's unified OAuth handler dispatches
+// on the connection_kind path parameter ("mcp" for gateway
+// connections) and invokes this implementation for config extraction
+// and post-auth side effects.
+//
+// The MCP gateway's post-auth side effect is to re-add the connection
+// to the running toolkit so its discovered tool surface is registered
+// with the platform's MCP server. Without that step, the operator
+// completes Connect, the token persists, but the platform's tool list
+// still treats the connection as "needs auth" until the next process
+// restart.
+type OAuthKindHandler struct {
+	toolkit *Toolkit
+}
+
+// NewOAuthKindHandler wires the MCP gateway toolkit into the unified
+// OAuth dispatch. Returns nil when toolkit is nil so callers can
+// register conditionally without a nil-check at every callsite.
+func NewOAuthKindHandler(toolkit *Toolkit) *OAuthKindHandler {
+	if toolkit == nil {
+		return nil
+	}
+	return &OAuthKindHandler{toolkit: toolkit}
+}
+
+// ParseOAuthConfig validates the connection's stored config and maps
+// the MCP gateway's per-kind OAuth shape into a connoauth.Config.
+// Returns an error when the connection is not configured for the
+// authorization_code grant — the unified handler maps that to HTTP
+// 409 Conflict, matching the prior per-kind handler's response code.
+func (*OAuthKindHandler) ParseOAuthConfig(connConfig map[string]any) (connoauth.Config, error) {
+	cfg, err := ParseConfig(connConfig)
+	if err != nil {
+		return connoauth.Config{}, err
+	}
+	if cfg.AuthMode != AuthModeOAuth || cfg.OAuth.Grant != OAuthGrantAuthorizationCode {
+		return connoauth.Config{}, errors.New("connection is not configured for authorization_code OAuth")
+	}
+	out := connoauth.Config{
+		AuthorizationURL: cfg.OAuth.AuthorizationURL,
+		TokenURL:         cfg.OAuth.TokenURL,
+		ClientID:         cfg.OAuth.ClientID,
+		ClientSecret:     cfg.OAuth.ClientSecret,
+		Prompt:           cfg.OAuth.Prompt,
+		// Default to header-style auth; the MCP gateway has not
+		// historically exposed a per-connection toggle.
+		EndpointAuthStyle: oauth2.AuthStyleInHeader,
+	}
+	if cfg.OAuth.Scope != "" {
+		out.Scopes = splitScopeString(cfg.OAuth.Scope)
+	}
+	return out, nil
+}
+
+// AfterConnect rebuilds the connection on the live toolkit so tools
+// register against the freshly-authorized upstream. Idempotent: if
+// the connection already exists, RemoveConnection + AddConnection is
+// safe (the in-memory state is replaced atomically). Errors are
+// logged and returned so the admin layer can surface them — but the
+// admin handler treats the error as non-fatal (token is already
+// persisted; the toolkit's next reconciliation will retry).
+func (h *OAuthKindHandler) AfterConnect(_ context.Context, name string, connConfig map[string]any) error { //nolint:revive // receiver h carries the toolkit reference; the kind-handler interface mandates this method
+	// If the connection placeholder doesn't exist yet, seed it (the
+	// platform startup adds known connections at boot; portal-created
+	// connections arrive via AddConnection at edit time).
+	if !h.toolkit.HasConnection(name) {
+		if err := h.toolkit.AddConnection(name, connConfig); err != nil {
+			return fmt.Errorf("seed connection placeholder: %w", err)
+		}
+		slog.Info("gateway: AfterConnect — seeded connection placeholder",
+			logKeyConnection, name)
+		return nil
+	}
+	// Rebuild: remove + re-add so the toolkit's auth round-tripper
+	// picks up the freshly-persisted access token on its next call.
+	// The MCP server's tool registry sees no churn — the toolkit
+	// replaces the in-flight client transparently.
+	if err := h.toolkit.RemoveConnection(name); err != nil {
+		slog.Warn("gateway: AfterConnect — RemoveConnection failed (will still attempt AddConnection)",
+			logKeyConnection, name, logKeyError, err)
+	}
+	if err := h.toolkit.AddConnection(name, connConfig); err != nil {
+		return fmt.Errorf("rebuild connection: %w", err)
+	}
+	slog.Info("gateway: AfterConnect — connection rebuilt after Connect",
+		logKeyConnection, name)
+	return nil
+}
+
+// splitScopeString splits an OAuth scope string on whitespace. Empty
+// inputs produce nil rather than a single empty element so the
+// downstream authorize URL builder doesn't emit "scope=" for an
+// unconfigured connection.
+func splitScopeString(s string) []string {
+	if s == "" {
+		return nil
+	}
+	out := []string{}
+	start := 0
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == ' ' || s[i] == '\t' {
+			if i > start {
+				out = append(out, s[start:i])
+			}
+			start = i + 1
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/pkg/toolkits/gateway/oauth_kind_handler_test.go
+++ b/pkg/toolkits/gateway/oauth_kind_handler_test.go
@@ -1,0 +1,181 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
+	"golang.org/x/oauth2"
+)
+
+func TestNewOAuthKindHandler_NilToolkit(t *testing.T) {
+	t.Parallel()
+	if h := NewOAuthKindHandler(nil); h != nil {
+		t.Fatalf("nil toolkit must produce nil handler, got %+v", h)
+	}
+}
+
+func TestOAuthKindHandler_ParseOAuthConfig_RejectsNonOAuth(t *testing.T) {
+	t.Parallel()
+	h := &OAuthKindHandler{}
+	cases := []map[string]any{
+		{ // bearer
+			"endpoint":  "http://upstream/mcp",
+			"auth_mode": "bearer",
+		},
+		{ // oauth but client_credentials grant
+			"endpoint":            "http://upstream/mcp",
+			"auth_mode":           "oauth",
+			"oauth_grant":         "client_credentials",
+			"oauth_token_url":     "https://idp/token",
+			"oauth_client_id":     "c",
+			"oauth_client_secret": "s",
+		},
+	}
+	for i, raw := range cases {
+		_, err := h.ParseOAuthConfig(raw)
+		if err == nil {
+			t.Fatalf("case %d: expected error, got nil", i)
+		}
+	}
+}
+
+func TestOAuthKindHandler_ParseOAuthConfig_MapsAuthorizationCode(t *testing.T) {
+	t.Parallel()
+	h := &OAuthKindHandler{}
+	cfg, err := h.ParseOAuthConfig(map[string]any{
+		"endpoint":                "http://upstream/mcp",
+		"auth_mode":               "oauth",
+		"oauth_grant":             "authorization_code",
+		"oauth_authorization_url": "https://idp/auth",
+		"oauth_token_url":         "https://idp/token",
+		"oauth_client_id":         "client-id",
+		"oauth_client_secret":     "client-secret",
+		"oauth_scope":             "openid offline_access profile",
+		"oauth_prompt":            "login",
+	})
+	if err != nil {
+		t.Fatalf("ParseOAuthConfig: %v", err)
+	}
+	if cfg.AuthorizationURL != "https://idp/auth" || cfg.TokenURL != "https://idp/token" {
+		t.Fatalf("URLs not mapped: %+v", cfg)
+	}
+	if cfg.ClientID != "client-id" || cfg.ClientSecret != "client-secret" {
+		t.Fatalf("credentials not mapped: %+v", cfg)
+	}
+	if cfg.Prompt != "login" {
+		t.Fatalf("prompt not mapped: %q", cfg.Prompt)
+	}
+	if cfg.EndpointAuthStyle != oauth2.AuthStyleInHeader {
+		t.Fatalf("MCP gateway default auth style must be header, got %v", cfg.EndpointAuthStyle)
+	}
+	wantScopes := []string{"openid", "offline_access", "profile"}
+	if !equalStrings(cfg.Scopes, wantScopes) {
+		t.Fatalf("scopes not split: got %v want %v", cfg.Scopes, wantScopes)
+	}
+}
+
+func TestOAuthKindHandler_ParseOAuthConfig_EmptyScopeReturnsNil(t *testing.T) {
+	t.Parallel()
+	h := &OAuthKindHandler{}
+	cfg, err := h.ParseOAuthConfig(map[string]any{
+		"endpoint":                "http://upstream/mcp",
+		"auth_mode":               "oauth",
+		"oauth_grant":             "authorization_code",
+		"oauth_authorization_url": "https://idp/auth",
+		"oauth_token_url":         "https://idp/token",
+		"oauth_client_id":         "c",
+		"oauth_client_secret":     "s",
+		"oauth_scope":             "",
+	})
+	if err != nil {
+		t.Fatalf("ParseOAuthConfig: %v", err)
+	}
+	if cfg.Scopes != nil {
+		t.Fatalf("empty scope string must produce nil slice, got %v", cfg.Scopes)
+	}
+}
+
+func TestOAuthKindHandler_ParseOAuthConfig_BadParseConfigPropagates(t *testing.T) {
+	t.Parallel()
+	h := &OAuthKindHandler{}
+	// Missing endpoint — ParseConfig rejects.
+	_, err := h.ParseOAuthConfig(map[string]any{
+		"auth_mode": "oauth",
+	})
+	if err == nil {
+		t.Fatal("expected ParseConfig error to surface")
+	}
+}
+
+func TestOAuthKindHandler_AfterConnect_SeedsAndRebuilds(t *testing.T) {
+	t.Parallel()
+	// Use a Toolkit with no real http upstream; AddConnection will
+	// fail when it tries to dial, but the order of operations (Has?
+	// then Add) is what we want to exercise. We assert by checking
+	// the AddConnection error path doesn't panic and the receiver
+	// invariant (h.toolkit nil-check) holds via NewOAuthKindHandler.
+	tk := New("test")
+	h := NewOAuthKindHandler(tk)
+	if h == nil {
+		t.Fatal("NewOAuthKindHandler returned nil for non-nil toolkit")
+	}
+	// Connection placeholder doesn't exist; AfterConnect runs the
+	// seed branch, which calls AddConnection — that dials and fails
+	// against an unreachable host. We only care that the branch is
+	// reached and the error wraps; the actual dial failure is the
+	// upstream toolkit's responsibility.
+	err := h.AfterConnect(context.Background(), "nope", map[string]any{
+		"endpoint":   "http://127.0.0.1:0/mcp",
+		"auth_mode":  "bearer",
+		"credential": "x",
+	})
+	if err == nil {
+		t.Skip("AddConnection unexpectedly succeeded against an unreachable host; environment-dependent")
+	}
+	if !strings.Contains(err.Error(), "seed connection placeholder") {
+		t.Fatalf("expected seed-placeholder wrap, got %v", err)
+	}
+}
+
+func TestSplitScopeString(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"openid", []string{"openid"}},
+		{"openid offline_access", []string{"openid", "offline_access"}},
+		{"  openid   offline_access  ", []string{"openid", "offline_access"}},
+		{"a\tb", []string{"a", "b"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			got := splitScopeString(tc.in)
+			if !equalStrings(got, tc.want) {
+				t.Fatalf("split(%q) = %v want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// silence unused-import lint when the connoauth import isn't otherwise
+// referenced by a focused subset of these tests.
+var _ = connoauth.KindMCP
+var _ = errors.New

--- a/pkg/toolkits/gateway/oauth_kind_handler_test.go
+++ b/pkg/toolkits/gateway/oauth_kind_handler_test.go
@@ -2,12 +2,12 @@ package gateway
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
 
-	"github.com/txn2/mcp-data-platform/pkg/connoauth"
 	"golang.org/x/oauth2"
+
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
 )
 
 func TestNewOAuthKindHandler_NilToolkit(t *testing.T) {
@@ -175,7 +175,6 @@ func equalStrings(a, b []string) bool {
 	return true
 }
 
-// silence unused-import lint when the connoauth import isn't otherwise
-// referenced by a focused subset of these tests.
+// connoauth is referenced via ParseOAuthConfig's return type in the
+// tests above; no further stubs needed.
 var _ = connoauth.KindMCP
-var _ = errors.New

--- a/ui/src/api/admin/hooks.ts
+++ b/ui/src/api/admin/hooks.ts
@@ -737,11 +737,19 @@ export function useReacquireGatewayOAuth() {
   });
 }
 
-export function useStartGatewayOAuth() {
+// useStartConnectionOAuth kicks off the authorization_code flow for
+// the given kind ("mcp", "api", future kinds). The backend dispatches
+// on the kind path parameter to the corresponding OAuthKindHandler.
+// Replaces the prior per-kind useStartGatewayOAuth /
+// useStartAPIGatewayOAuth hooks that targeted divergent routes against
+// divergent token stores — every kind now shares one
+// /connections/{kind}/{name}/oauth-start route backed by the unified
+// connoauth.Store.
+export function useStartConnectionOAuth(kind: string) {
   return useMutation({
     mutationFn: ({ name, returnURL }: { name: string; returnURL?: string }) =>
       apiFetch<import("./types").GatewayOAuthStartResponse>(
-        `/gateway/connections/${name}/oauth-start`,
+        `/connections/${kind}/${name}/oauth-start`,
         {
           method: "POST",
           body: JSON.stringify({ return_url: returnURL ?? "" }),
@@ -750,22 +758,50 @@ export function useStartGatewayOAuth() {
   });
 }
 
-// useStartAPIGatewayOAuth kicks off the authorization_code flow for
-// an HTTP API gateway connection (kind=api). Mirrors useStartGatewayOAuth
-// but targets the api-gateway-specific admin route. Returns the
-// authorization URL the operator's browser should be redirected to;
-// the upstream IdP will redirect back to /api/v1/admin/api-gateway/oauth/callback
-// after authentication.
+// useStartGatewayOAuth is the MCP-kind specialization of
+// useStartConnectionOAuth. Kept as a named export so the existing MCP
+// gateway form callsite is unchanged through this refactor.
+export function useStartGatewayOAuth() {
+  return useStartConnectionOAuth("mcp");
+}
+
+// useStartAPIGatewayOAuth is the API-kind specialization of
+// useStartConnectionOAuth. Kept as a named export so the existing
+// HTTP API gateway form callsite is unchanged through this refactor.
 export function useStartAPIGatewayOAuth() {
-  return useMutation({
-    mutationFn: ({ name, returnURL }: { name: string; returnURL?: string }) =>
-      apiFetch<import("./types").GatewayOAuthStartResponse>(
-        `/api-gateway/connections/${name}/oauth-start`,
-        {
-          method: "POST",
-          body: JSON.stringify({ return_url: returnURL ?? "" }),
-        },
+  return useStartConnectionOAuth("api");
+}
+
+// useConnectionOAuthStatus returns the unified OAuth status snapshot
+// for ANY connection kind. Renders the status card in both the MCP
+// gateway and HTTP API gateway connection views.
+export function useConnectionOAuthStatus(kind: string, name: string, enabled = true) {
+  return useQuery({
+    queryKey: ["connection-oauth-status", kind, name],
+    queryFn: () =>
+      apiFetch<import("./types").ConnectionOAuthStatus>(
+        `/connections/${kind}/${name}/oauth-status`,
       ),
+    enabled: enabled && !!kind && !!name,
+    refetchInterval: 10000,
+  });
+}
+
+// useReacquireConnectionOAuth forces a refresh-token exchange for ANY
+// connection kind. Useful from the admin status card to verify the
+// persisted refresh token still works against the IdP.
+export function useReacquireConnectionOAuth() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ kind, name }: { kind: string; name: string }) =>
+      apiFetch<void>(`/connections/${kind}/${name}/reacquire-oauth`, {
+        method: "POST",
+      }),
+    onSuccess: (_, { kind, name }) => {
+      void qc.invalidateQueries({
+        queryKey: ["connection-oauth-status", kind, name],
+      });
+    },
   });
 }
 

--- a/ui/src/api/admin/types.ts
+++ b/ui/src/api/admin/types.ts
@@ -533,6 +533,26 @@ export interface GatewayOAuthStartResponse {
   expires_at: string;
 }
 
+// ConnectionOAuthStatus mirrors connoauth.OAuthStatus from the backend.
+// Returned by the unified /connections/{kind}/{name}/oauth-status
+// endpoint for any connection kind. Distinct from GatewayOAuthStatus
+// only because the backend type lives in a different package; the
+// fields are intentionally a superset for portal compatibility.
+export interface ConnectionOAuthStatus {
+  configured: boolean;
+  token_acquired: boolean;
+  expires_at?: string;
+  last_refreshed_at?: string;
+  has_refresh_token: boolean;
+  refresh_expires_at?: string;
+  last_error?: string;
+  token_url?: string;
+  scope?: string;
+  authenticated_by?: string;
+  authenticated_at?: string;
+  needs_reauth?: boolean;
+}
+
 export interface GatewayConnectionStatus {
   name: string;
   healthy: boolean;

--- a/ui/src/api/portal/hooks.ts
+++ b/ui/src/api/portal/hooks.ts
@@ -28,6 +28,7 @@ export interface Branding {
   name: string;
   version: string;
   portal_title: string;
+  portal_tagline?: string;
   portal_logo: string;
   portal_logo_light: string;
   portal_logo_dark: string;

--- a/ui/src/components/LoginForm.tsx
+++ b/ui/src/components/LoginForm.tsx
@@ -1,8 +1,11 @@
 import { useState, useEffect } from "react";
 import { useAuthStore } from "@/stores/auth";
-import { LogIn, Key, ChevronDown, ChevronUp } from "lucide-react";
+import { useThemeStore } from "@/stores/theme";
+import { useBranding } from "@/api/portal/hooks";
+import { LogIn } from "lucide-react";
 
-const DEFAULT_PLATFORM_NAME = "MCP Data Platform";
+const DEFAULT_PORTAL_TITLE = "MCP Data Platform";
+const DEFAULT_PORTAL_TAGLINE = "Sign in to access the platform.";
 
 const AUTH_ERROR_MESSAGES: Record<string, string> = {
   access_denied: "Access was denied by the identity provider.",
@@ -20,40 +23,57 @@ function getAuthError(): string | null {
   return AUTH_ERROR_MESSAGES[code] || "Authentication failed. Please try again.";
 }
 
+// resolveLogo picks the appropriate logo for the current theme, falling
+// back through portal_logo_<theme> → portal_logo → bundled-default.
+// Same precedence as Sidebar so the branding override pattern is
+// consistent across the shell.
+function resolveLogo(
+  branding: { portal_logo?: string; portal_logo_light?: string; portal_logo_dark?: string } | undefined,
+  isDark: boolean,
+): string {
+  const base = import.meta.env.BASE_URL;
+  const fallback = isDark
+    ? `${base}images/activity-svgrepo-com-white.svg`
+    : `${base}images/activity-svgrepo-com.svg`;
+  if (isDark) {
+    return branding?.portal_logo_dark || branding?.portal_logo || fallback;
+  }
+  return branding?.portal_logo_light || branding?.portal_logo || fallback;
+}
+
 export function LoginForm() {
   const [key, setKey] = useState("");
   const [error, setError] = useState(() => getAuthError() || "");
   const [loading, setLoading] = useState(false);
-  const [platformName, setPlatformName] = useState(DEFAULT_PLATFORM_NAME);
-  const [oidcEnabled, setOidcEnabled] = useState(false);
-  const [showApiKey, setShowApiKey] = useState(false);
   const sessionExpired = useAuthStore((s) => s.sessionExpired);
   const loginApiKey = useAuthStore((s) => s.loginApiKey);
   const loginOIDC = useAuthStore((s) => s.loginOIDC);
+  const { data: branding } = useBranding();
 
+  const theme = useThemeStore((s) => s.theme);
+  const [isDark, setIsDark] = useState(
+    () =>
+      theme === "dark" ||
+      (theme === "system" &&
+        typeof window !== "undefined" &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches),
+  );
   useEffect(() => {
-    fetch("/api/v1/admin/public/branding")
-      .then((res) => (res.ok ? res.json() : null))
-      .then(
-        (data: {
-          name?: string;
-          portal_title?: string;
-          oidc_enabled?: boolean;
-        } | null) => {
-          const name = data?.portal_title || data?.name;
-          if (name) setPlatformName(name);
-          if (data?.oidc_enabled) {
-            setOidcEnabled(true);
-          } else {
-            // No SSO available — show API key form by default.
-            setShowApiKey(true);
-          }
-        },
-      )
-      .catch(() => {
-        setShowApiKey(true);
-      });
-  }, []);
+    if (theme !== "system") {
+      setIsDark(theme === "dark");
+      return;
+    }
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const update = () => setIsDark(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, [theme]);
+
+  const portalTitle = branding?.portal_title || DEFAULT_PORTAL_TITLE;
+  const portalTagline = branding?.portal_tagline || DEFAULT_PORTAL_TAGLINE;
+  const portalLogo = resolveLogo(branding ?? undefined, isDark);
+  const oidcEnabled = branding?.oidc_enabled ?? false;
 
   async function handleApiKeyLogin() {
     const trimmed = key.trim();
@@ -78,10 +98,24 @@ export function LoginForm() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-muted/40">
       <div className="w-full max-w-sm rounded-lg border bg-card p-6 shadow-sm">
-        <h1 className="mb-1 text-xl font-semibold">{platformName}</h1>
-        <p className="mb-4 text-sm text-muted-foreground">
-          Sign in to access the platform.
-        </p>
+        {/* Brand header: logo + title row, tagline beneath. Matches the
+            pattern operators see on downstream portals (e.g. the
+            api-test fixture) so a deployment that overrides title /
+            tagline / logo via portal.* config gets the same shape. */}
+        <div className="mb-5 flex items-start gap-3">
+          <img
+            src={portalLogo}
+            alt=""
+            className="h-10 w-10 shrink-0"
+            onError={(e) => {
+              (e.target as HTMLImageElement).style.display = "none";
+            }}
+          />
+          <div className="min-w-0">
+            <h1 className="text-xl font-semibold leading-tight">{portalTitle}</h1>
+            <p className="mt-1 text-sm text-muted-foreground">{portalTagline}</p>
+          </div>
+        </div>
 
         {sessionExpired && !error && (
           <p className="mb-3 rounded-md bg-amber-50 px-3 py-2 text-sm text-amber-700 dark:bg-amber-950 dark:text-amber-300">
@@ -103,61 +137,46 @@ export function LoginForm() {
             className="mb-3 flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
           >
             <LogIn className="h-4 w-4" />
-            Sign in with SSO
+            Sign in with OIDC
           </button>
         )}
 
-        {/* Divider + API key toggle — when SSO is also available */}
+        {/* "or use an API key" divider — only when OIDC is also an
+            option, so a deployment without SSO doesn't get a redundant
+            heading above its lone form. */}
         {oidcEnabled && (
-          <button
-            type="button"
-            onClick={() => setShowApiKey(!showApiKey)}
-            className="mb-3 flex w-full items-center gap-2 text-xs text-muted-foreground hover:text-foreground"
-          >
+          <div className="my-3 flex items-center gap-2 text-xs text-muted-foreground">
             <div className="h-px flex-1 bg-border" />
-            <span className="flex items-center gap-1">
-              <Key className="h-3 w-3" />
-              API Key
-              {showApiKey ? (
-                <ChevronUp className="h-3 w-3" />
-              ) : (
-                <ChevronDown className="h-3 w-3" />
-              )}
-            </span>
+            <span>or use an API key</span>
             <div className="h-px flex-1 bg-border" />
-          </button>
+          </div>
         )}
 
-        {/* API Key form */}
-        {showApiKey && (
-          <>
-            <input
-              type="text"
-              autoComplete="off"
-              data-1p-ignore
-              data-lpignore="true"
-              value={key}
-              onChange={(e) => setKey(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="API Key"
-              style={{ WebkitTextSecurity: "disc" } as React.CSSProperties}
-              className="mb-3 w-full rounded-md border bg-background px-3 py-2 text-sm outline-none ring-ring focus:ring-2"
-              autoFocus={!oidcEnabled}
-            />
-            <button
-              type="button"
-              disabled={!key.trim() || loading}
-              onClick={handleApiKeyLogin}
-              className={`w-full rounded-md px-4 py-2 text-sm font-medium disabled:opacity-50 ${
-                oidcEnabled
-                  ? "border bg-secondary text-secondary-foreground hover:bg-secondary/80"
-                  : "bg-primary text-primary-foreground hover:bg-primary/90"
-              }`}
-            >
-              {loading ? "Validating..." : "Sign In with API Key"}
-            </button>
-          </>
-        )}
+        <input
+          type="text"
+          autoComplete="off"
+          data-1p-ignore
+          data-lpignore="true"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="X-API-Key"
+          style={{ WebkitTextSecurity: "disc" } as React.CSSProperties}
+          className="mb-3 w-full rounded-md border bg-background px-3 py-2 text-sm outline-none ring-ring focus:ring-2"
+          autoFocus={!oidcEnabled}
+        />
+        <button
+          type="button"
+          disabled={!key.trim() || loading}
+          onClick={handleApiKeyLogin}
+          className={`w-full rounded-md px-4 py-2 text-sm font-medium disabled:opacity-50 ${
+            oidcEnabled
+              ? "border bg-secondary text-secondary-foreground hover:bg-secondary/80"
+              : "bg-primary text-primary-foreground hover:bg-primary/90"
+          }`}
+        >
+          {loading ? "Validating..." : "Sign in with API key"}
+        </button>
       </div>
     </div>
   );

--- a/ui/src/pages/settings/ConnectionOAuthStatusCard.tsx
+++ b/ui/src/pages/settings/ConnectionOAuthStatusCard.tsx
@@ -1,0 +1,267 @@
+// ConnectionOAuthStatusCard renders the OAuth 2.1 authorization_code
+// state for ANY connection kind. Driven by the unified
+// /api/v1/admin/connections/{kind}/{name}/oauth-status endpoint, so the
+// same visual surface appears for MCP-kind and API-kind connections —
+// the consistency that was missing when this lived only in the MCP
+// gateway view.
+import { useState } from "react";
+import {
+  useConnectionOAuthStatus,
+  useReacquireConnectionOAuth,
+  useStartConnectionOAuth,
+} from "@/api/admin/hooks";
+import type { ConnectionOAuthStatus } from "@/api/admin/types";
+import { cn } from "@/lib/utils";
+import {
+  AlertCircle,
+  Check,
+  Clock,
+  ExternalLink,
+  Key,
+  KeyRound,
+  RefreshCw,
+} from "lucide-react";
+
+interface Props {
+  kind: string;
+  name: string;
+  // authMode is the connection's auth_mode value (from the connection
+  // record itself). The parent decides up-front whether this card is
+  // relevant — the card no longer "self-hides" based on an async
+  // status fetch, which previously caused the entire OAuth section to
+  // silently disappear on a slow / failed / loading status response.
+  authMode: string;
+}
+
+const OAUTH_AUTH_MODES = new Set(["oauth", "oauth2_authorization_code"]);
+
+export function ConnectionOAuthStatusCard({ kind, name, authMode }: Props) {
+  // Render NOTHING (intentionally) only when the connection is not an
+  // OAuth-mode at all. Past this gate, the card always renders — even
+  // while the status fetch is loading or errored — so the operator is
+  // never left wondering "where did the OAuth section go?".
+  if (!OAUTH_AUTH_MODES.has(authMode)) {
+    return null;
+  }
+  // Key on (kind, name) so React unmounts/remounts the inner card
+  // when the operator switches connections in the sidebar. Without
+  // the key, React reuses the same instance and the inner useState
+  // (actionMsg) plus the mutation hooks' state (isSuccess flags, last
+  // error) bleed across connections — e.g., refreshing the API
+  // token's "Token refreshed" success banner would still show after
+  // clicking the MCP connection, even though no MCP refresh happened.
+  return <Inner key={`${kind}/${name}`} kind={kind} name={name} />;
+}
+
+function Inner({ kind, name }: { kind: string; name: string }) {
+  const { data: status, isLoading, error } = useConnectionOAuthStatus(kind, name);
+  const reacquire = useReacquireConnectionOAuth();
+  const startOAuth = useStartConnectionOAuth(kind);
+  const [actionMsg, setActionMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const handleConnect = async () => {
+    setActionMsg(null);
+    try {
+      const res = await startOAuth.mutateAsync({
+        name,
+        returnURL: window.location.pathname + window.location.search,
+      });
+      if (!/^https?:\/\//i.test(res.authorization_url)) {
+        setActionMsg({
+          ok: false,
+          text: "Server returned an invalid authorization URL. Check the connection's authorization_url field.",
+        });
+        return;
+      }
+      window.location.href = res.authorization_url;
+    } catch (err) {
+      setActionMsg({
+        ok: false,
+        text: err instanceof Error ? err.message : "Connect failed",
+      });
+    }
+  };
+
+  const handleReacquire = async () => {
+    setActionMsg(null);
+    try {
+      await reacquire.mutateAsync({ kind, name });
+      setActionMsg({ ok: true, text: "Token refreshed" });
+    } catch (err) {
+      setActionMsg({
+        ok: false,
+        text: err instanceof Error ? err.message : "Reacquire failed",
+      });
+    }
+  };
+
+  const tokenAcquired = status?.token_acquired ?? false;
+  const needsReauth = status?.needs_reauth ?? !status; // assume reauth needed until we know otherwise
+
+  return (
+    <div className="rounded-md border bg-muted/10 px-3 py-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <KeyRound className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            OAuth status
+          </span>
+          <span className="rounded bg-muted text-muted-foreground px-1 py-0 text-[11px] font-medium font-mono">
+            authorization_code
+          </span>
+        </div>
+        <div className="flex gap-1">
+          <button
+            type="button"
+            onClick={handleConnect}
+            disabled={startOAuth.isPending}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium disabled:opacity-50",
+              needsReauth
+                ? "bg-primary text-primary-foreground border-primary hover:bg-primary/90"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground",
+            )}
+          >
+            <ExternalLink className="h-3 w-3" />
+            {needsReauth ? "Connect" : "Reconnect"}
+          </button>
+          {tokenAcquired && (
+            <button
+              type="button"
+              onClick={handleReacquire}
+              disabled={reacquire.isPending}
+              className="inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+            >
+              <RefreshCw className={cn("h-3 w-3", reacquire.isPending && "animate-spin")} />
+              {reacquire.isPending ? "Refreshing..." : "Refresh now"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="text-xs text-muted-foreground">Loading OAuth status…</div>
+      )}
+
+      {error && (
+        <div className="rounded border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs text-destructive">
+          <span className="font-medium">Status unavailable:</span>{" "}
+          {error instanceof Error ? error.message : "fetch failed"}
+        </div>
+      )}
+
+      {status?.needs_reauth && (
+        <div className="rounded border border-amber-500/30 bg-amber-50 px-2 py-1.5 text-xs text-amber-900 dark:bg-amber-900/20 dark:text-amber-200">
+          {status.token_acquired ? (
+            <>
+              <span className="font-medium">Reauth needed soon.</span> The current
+              access token still works, but the refresh-token deadline has passed.
+              Click <strong>Connect</strong> to issue a fresh credential.
+            </>
+          ) : (
+            <>
+              <span className="font-medium">Not connected.</span> Click{" "}
+              <strong>Connect</strong> to authorize this connection in your
+              browser. The platform will then keep the access token refreshed
+              automatically — including for cron jobs and scheduled prompts —
+              until the upstream invalidates the refresh token.
+            </>
+          )}
+        </div>
+      )}
+
+      {status && <StatusGrid status={status} />}
+
+      {status?.authenticated_by && (
+        <div className="text-xs text-muted-foreground">
+          Authorized by <span className="font-mono">{status.authenticated_by}</span>
+          {status.authenticated_at && <> {formatRelative(status.authenticated_at)}</>}
+        </div>
+      )}
+
+      {status?.last_error && (
+        <div className="rounded border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs text-destructive">
+          <span className="font-medium">Last error:</span> {status.last_error}
+        </div>
+      )}
+
+      {actionMsg && (
+        <div
+          className={cn(
+            "rounded border px-2 py-1 text-xs",
+            actionMsg.ok
+              ? "border-emerald-500/30 bg-emerald-50 text-emerald-900 dark:bg-emerald-900/20 dark:text-emerald-200"
+              : "border-destructive/30 bg-destructive/10 text-destructive",
+          )}
+        >
+          {actionMsg.text}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusGrid({ status }: { status: ConnectionOAuthStatus }) {
+  const items: Array<{ label: string; value: string; icon: React.ReactNode }> = [
+    {
+      label: "Token",
+      value: status.token_acquired ? "acquired" : "not yet acquired",
+      icon: status.token_acquired ? (
+        <Check className="h-3 w-3 text-emerald-500" />
+      ) : (
+        <AlertCircle className="h-3 w-3 text-amber-500" />
+      ),
+    },
+    {
+      label: "Expires",
+      value: status.expires_at ? formatRelative(status.expires_at) : "—",
+      icon: <Clock className="h-3 w-3 text-muted-foreground" />,
+    },
+    {
+      label: "Last refreshed",
+      value: status.last_refreshed_at ? formatRelative(status.last_refreshed_at) : "—",
+      icon: <RefreshCw className="h-3 w-3 text-muted-foreground" />,
+    },
+    {
+      label: "Refresh token",
+      value: status.has_refresh_token ? "present" : "none",
+      icon: <Key className="h-3 w-3 text-muted-foreground" />,
+    },
+  ];
+  if (status.has_refresh_token && status.refresh_expires_at) {
+    items.push({
+      label: "Refresh expires",
+      value: formatRelative(status.refresh_expires_at),
+      icon: <Clock className="h-3 w-3 text-muted-foreground" />,
+    });
+  }
+  return (
+    <div className="grid grid-cols-2 gap-2 text-xs">
+      {items.map((it) => (
+        <div key={it.label} className="flex items-center gap-1.5">
+          {it.icon}
+          <span className="text-muted-foreground">{it.label}:</span>
+          <span className="font-mono">{it.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// formatRelative renders an ISO-8601 timestamp as a coarse "in N
+// minutes" or "N minutes ago" string. Same logic as the prior
+// per-kind GatewayActions component.
+function formatRelative(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  const diff = date.getTime() - Date.now();
+  const abs = Math.abs(diff);
+  const suffix = diff < 0 ? "ago" : "from now";
+  const minutes = Math.round(abs / 60_000);
+  if (minutes < 1) return diff < 0 ? "just now" : "moments";
+  if (minutes < 60) return `${minutes}m ${suffix}`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ${suffix}`;
+  const days = Math.round(hours / 24);
+  return `${days}d ${suffix}`;
+}

--- a/ui/src/pages/settings/ConnectionsPanel.tsx
+++ b/ui/src/pages/settings/ConnectionsPanel.tsx
@@ -15,30 +15,11 @@ import {
   Cable,
   AlertCircle,
   Check,
-  Eye,
-  EyeOff,
   Database,
   X,
 } from "lucide-react";
 import { GatewayActionBar, GatewayRulesDrawer } from "./GatewayActions";
-
-// Fields that should be redacted in view mode.
-const SENSITIVE_KEYS = new Set([
-  "password",
-  "secret_access_key",
-  "secret_key",
-  "token",
-  "access_token",
-  "refresh_token",
-  "api_key",
-  "api_secret",
-  "private_key",
-  "credential",
-]);
-
-function isSensitive(key: string): boolean {
-  return SENSITIVE_KEYS.has(key.toLowerCase());
-}
+import { ConnectionOAuthStatusCard } from "./ConnectionOAuthStatusCard";
 
 // ---------------------------------------------------------------------------
 // Kind badge colors
@@ -66,11 +47,24 @@ export function ConnectionsPanel() {
   const { data: instances, isLoading } = useEffectiveConnections();
   const connections = instances ?? [];
 
-  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  // Read initial selection from URL (?kind=...&name=...) so the OAuth
+  // callback's returnURL can restore the connection the operator was
+  // editing. Falls through to the auto-select-first-listed effect when
+  // the URL is absent or stale.
+  const initialSelection = (() => {
+    if (typeof window === "undefined") return null;
+    const params = new URLSearchParams(window.location.search);
+    const k = params.get("kind");
+    const n = params.get("name");
+    if (k && n) return `${k}/${n}`;
+    return null;
+  })();
+  const [selectedKey, setSelectedKey] = useState<string | null>(initialSelection);
   const [mode, setMode] = useState<"view" | "edit" | "create">("view");
   const [dirty, setDirty] = useState(false);
 
-  // Group by kind
+  // Group by kind. Sidebar order is alphabetical on kind; within a
+  // kind, connections are listed in the order the backend returned.
   const grouped = useMemo(() => {
     const groups: Record<string, EffectiveConnection[]> = {};
     for (const c of connections) {
@@ -81,17 +75,50 @@ export function ConnectionsPanel() {
     return groups;
   }, [connections]);
 
+  // firstListed is the connection that appears at the top of the
+  // sidebar — first item of the first (alphabetically) kind group.
+  // Auto-select uses this so the default view matches what the
+  // operator sees in the left nav, instead of whatever sort order
+  // the backend happens to return.
+  const firstListed = useMemo(() => {
+    const kinds = Object.keys(grouped).sort((a, b) => a.localeCompare(b));
+    const first = kinds[0];
+    if (!first) return null;
+    return grouped[first]?.[0] ?? null;
+  }, [grouped]);
+
   const selected = useMemo(
     () => connections.find((c) => `${c.kind}/${c.name}` === selectedKey) ?? null,
     [connections, selectedKey],
   );
 
-  // Auto-select first item
+  // Auto-select the first listed connection when none is selected
+  // (or the URL-restored one is stale).
   useEffect(() => {
-    if (!selectedKey && connections.length > 0 && connections[0]) {
-      setSelectedKey(`${connections[0].kind}/${connections[0].name}`);
+    if (selectedKey) {
+      // If the URL pointed at a connection that no longer exists,
+      // fall through to first-listed.
+      const exists = connections.some((c) => `${c.kind}/${c.name}` === selectedKey);
+      if (exists) return;
     }
-  }, [connections, selectedKey]);
+    if (firstListed) {
+      setSelectedKey(`${firstListed.kind}/${firstListed.name}`);
+    }
+  }, [connections, selectedKey, firstListed]);
+
+  // Mirror the selection back into the URL (without reloading) so a
+  // round-trip through an OAuth callback's returnURL restores the
+  // same connection. Use replaceState to avoid polluting browser
+  // history with a new entry per selection click.
+  useEffect(() => {
+    if (typeof window === "undefined" || !selectedKey) return;
+    const [k, n] = selectedKey.split("/");
+    const params = new URLSearchParams(window.location.search);
+    params.set("kind", k ?? "");
+    params.set("name", n ?? "");
+    const url = `${window.location.pathname}?${params.toString()}`;
+    window.history.replaceState(null, "", url);
+  }, [selectedKey]);
 
   const handleSelect = useCallback(
     (c: EffectiveConnection) => {
@@ -281,7 +308,6 @@ function ConnectionViewer({
 }) {
   const deleteMutation = useDeleteConnectionInstance();
   const [confirmDelete, setConfirmDelete] = useState(false);
-  const [showSensitive, setShowSensitive] = useState(false);
   const [rulesOpen, setRulesOpen] = useState(false);
 
   const datahubSourceName = typeof connection.config?.datahub_source_name === "string"
@@ -348,6 +374,19 @@ function ConnectionViewer({
         />
       )}
 
+      {/* OAuth status — shown for every connection kind that supports
+          authorization_code. The card hides itself when the
+          connection's auth_mode is not OAuth, so it's safe to render
+          unconditionally. Consistent surface across mcp / api / future
+          kinds. */}
+      {!isReadOnly && (
+        <ConnectionOAuthStatusCard
+          kind={connection.kind}
+          name={connection.name}
+          authMode={String(connection.config?.auth_mode ?? "")}
+        />
+      )}
+
       {/* Metadata */}
       <div className="grid grid-cols-3 gap-4">
         <InfoCard label="Kind" value={connection.kind} />
@@ -366,34 +405,18 @@ function ConnectionViewer({
             <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
               Configuration
             </h3>
-            <button
-              type="button"
-              onClick={() => setShowSensitive((v) => !v)}
-              className="ml-auto text-xs text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
-            >
-              {showSensitive ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
-              {showSensitive ? "Hide sensitive" : "Show sensitive"}
-            </button>
           </div>
           <div className="rounded-md border divide-y">
             {configEntries.map(([key, value]) => {
-              const sensitive = isSensitive(key);
-              const displayValue = sensitive && !showSensitive
-                ? "********"
-                : typeof value === "object" && value !== null
-                  ? JSON.stringify(value)
-                  : String(value);
+              const displayValue = typeof value === "object" && value !== null
+                ? JSON.stringify(value)
+                : String(value);
               return (
                 <div key={key} className="flex items-center gap-4 px-4 py-2">
                   <span className="text-xs font-mono text-muted-foreground w-48 shrink-0 truncate">
                     {key}
                   </span>
-                  <span
-                    className={cn(
-                      "text-xs font-mono flex-1 truncate",
-                      sensitive && !showSensitive && "text-muted-foreground italic",
-                    )}
-                  >
+                  <span className="text-xs font-mono flex-1 truncate">
                     {displayValue}
                   </span>
                 </div>

--- a/ui/src/pages/settings/GatewayActions.tsx
+++ b/ui/src/pages/settings/GatewayActions.tsx
@@ -7,17 +7,12 @@ import {
   useUpdateEnrichmentRule,
   useDeleteEnrichmentRule,
   useDryRunEnrichmentRule,
-  useGatewayConnectionStatus,
-  useReacquireGatewayOAuth,
-  useStartGatewayOAuth,
 } from "@/api/admin/hooks";
-import { ApiError } from "@/api/admin/client";
 import type {
   EnrichmentRule,
   EnrichmentRuleBody,
   GatewayProbeTool,
   DryRunResponse,
-  GatewayOAuthStatus,
 } from "@/api/admin/types";
 import { cn } from "@/lib/utils";
 import {
@@ -31,10 +26,6 @@ import {
   Check,
   AlertCircle,
   Play,
-  Key,
-  Clock,
-  KeyRound,
-  ExternalLink,
 } from "lucide-react";
 
 // ---------------------------------------------------------------------------
@@ -150,274 +141,13 @@ export function GatewayActionBar({
           )}
         </div>
       )}
-      <OAuthStatusCard connectionName={connectionName} />
+      {/* OAuth status block is rendered by the parent
+          ConnectionsPanel via ConnectionOAuthStatusCard so the SAME
+          card appears for every connection kind, not just MCP. */}
     </div>
   );
 }
 
-// ---------------------------------------------------------------------------
-// OAuthStatusCard — token state + Reacquire button (rendered only when the
-// connection's auth_mode is "oauth")
-// ---------------------------------------------------------------------------
-
-function OAuthStatusCard({ connectionName }: { connectionName: string }) {
-  const { data: status, error } = useGatewayConnectionStatus(connectionName);
-  const reacquire = useReacquireGatewayOAuth();
-  const startOAuth = useStartGatewayOAuth();
-  const [actionMsg, setActionMsg] = useState<{ ok: boolean; text: string } | null>(null);
-
-  // Surface the "gateway toolkit is not registered" failure mode (HTTP 409
-  // from /gateway/connections/{name}/status). Without this, the card
-  // silently disappears and the operator has no signal that their saved
-  // connection is inert because the gateway toolkit has been explicitly
-  // disabled in platform.yaml. Auto-enable handles the no-config case;
-  // this branch handles the explicit-disable case.
-  if (error instanceof ApiError && error.status === 409) {
-    return (
-      <div className="rounded-md border border-amber-500/30 bg-amber-50 px-3 py-3 text-xs dark:bg-amber-900/20 dark:text-amber-200">
-        <div className="flex items-center gap-2">
-          <AlertCircle className="h-3.5 w-3.5" />
-          <span className="font-semibold">Gateway toolkit disabled</span>
-        </div>
-        <p className="mt-1.5">
-          This connection is saved in the database but not active: the gateway
-          toolkit has been explicitly disabled in <code>platform.yaml</code>.
-          Remove <code>toolkits.mcp.enabled: false</code> (or set it to{" "}
-          <code>true</code>) and restart the platform to activate this
-          connection. Tools from this upstream will not be available until
-          then.
-        </p>
-      </div>
-    );
-  }
-
-  if (!status || status.auth_mode !== "oauth" || !status.oauth) {
-    return null;
-  }
-  const oauth = status.oauth;
-  const isAuthCode = oauth.grant === "authorization_code";
-
-  const handleReacquire = async () => {
-    setActionMsg(null);
-    try {
-      await reacquire.mutateAsync(connectionName);
-      setActionMsg({ ok: true, text: "Token refreshed" });
-    } catch (err) {
-      setActionMsg({ ok: false, text: err instanceof Error ? err.message : "Reacquire failed" });
-    }
-  };
-
-  const handleConnect = async () => {
-    setActionMsg(null);
-    // Idiomatic OIDC redirect flow: navigate the current tab to the
-    // IdP. The IdP's login form becomes the user's page, they submit
-    // it, the IdP redirects to the platform's callback URL, the
-    // callback exchanges the code for tokens and redirects back here
-    // via the returnURL we send below.
-    //
-    // Earlier versions used window.open in a popup tab to "preserve
-    // admin context" — that pattern produced popup-blocker stalls,
-    // stale-form bugs (lingering popup tabs whose Keycloak session
-    // had been consumed), and the "I clicked Sign In and nothing
-    // happened" UX failures. Top-level redirect is the standard
-    // pattern (Salesforce, Okta, Auth0 admin consoles all use it)
-    // and avoids every one of those failure modes.
-    try {
-      const res = await startOAuth.mutateAsync({
-        name: connectionName,
-        returnURL: window.location.pathname + window.location.search,
-      });
-      // Validate the URL before navigating. An empty or malformed
-      // authorization_url (server bug, race condition, misconfigured
-      // connection) would silently no-op `window.location.href = ""`
-      // and reproduce the "click does nothing" failure mode this PR
-      // was meant to fix. Surface it as an explicit error instead.
-      if (!/^https?:\/\//i.test(res.authorization_url)) {
-        setActionMsg({
-          ok: false,
-          text:
-            "Server returned an invalid authorization URL. " +
-            "Check the connection's oauth_authorization_url field is a complete https:// URL.",
-        });
-        return;
-      }
-      window.location.href = res.authorization_url;
-      // No setActionMsg on success — the page is navigating away.
-      // Any status update would race the navigation.
-    } catch (err) {
-      setActionMsg({
-        ok: false,
-        text: err instanceof Error ? err.message : "Connect failed",
-      });
-    }
-  };
-
-  return (
-    <div className="rounded-md border bg-muted/10 px-3 py-3 space-y-2">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <KeyRound className="h-3.5 w-3.5 text-muted-foreground" />
-          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-            OAuth status
-          </span>
-          <span className="rounded bg-muted text-muted-foreground px-1 py-0 text-[11px] font-medium font-mono">
-            {oauth.grant}
-          </span>
-        </div>
-        <div className="flex gap-1">
-          {isAuthCode && (
-            <button
-              type="button"
-              onClick={handleConnect}
-              disabled={startOAuth.isPending}
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium disabled:opacity-50",
-                oauth.needs_reauth
-                  ? "bg-primary text-primary-foreground border-primary hover:bg-primary/90"
-                  : "text-muted-foreground hover:bg-muted hover:text-foreground",
-              )}
-            >
-              <ExternalLink className="h-3 w-3" />
-              {oauth.needs_reauth ? "Connect" : "Reconnect"}
-            </button>
-          )}
-          {oauth.token_acquired && (
-            <button
-              type="button"
-              onClick={handleReacquire}
-              disabled={reacquire.isPending}
-              className="inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
-            >
-              <RefreshCw className={cn("h-3 w-3", reacquire.isPending && "animate-spin")} />
-              {reacquire.isPending ? "Refreshing..." : "Refresh now"}
-            </button>
-          )}
-        </div>
-      </div>
-
-      {oauth.needs_reauth && (
-        <div className="rounded border border-amber-500/30 bg-amber-50 px-2 py-1.5 text-xs text-amber-900 dark:bg-amber-900/20 dark:text-amber-200">
-          {oauth.refresh_token_revoked ? (
-            <>
-              <span className="font-medium">Refresh token revoked.</span> The upstream's last refresh attempt was rejected as <code>invalid_grant</code> — the stored credential is no longer valid (idle session timeout, password change, or admin revocation). Click <strong>Connect</strong> to reauthorize. <em>Refresh now</em> will fail until you do.
-            </>
-          ) : oauth.token_acquired ? (
-            // Pre-emptive flip: refresh-token deadline has passed (the IdP
-            // disclosed a refresh_expires_in and now() is past it) but the
-            // cached access token is still valid. Tool calls work right now;
-            // the next attempt to mint a fresh access token will fail.
-            // Distinguish this from the "fully unauthorized" case so the
-            // operator doesn't panic-Connect during a healthy moment.
-            <>
-              <span className="font-medium">Reauth needed soon.</span> The current access token still works, but the refresh-token deadline has passed — the next refresh will fail. Click <strong>Connect</strong> at your convenience to issue a fresh credential before the cached token expires.
-            </>
-          ) : (
-            <>
-              <span className="font-medium">Not connected.</span> Click <strong>Connect</strong> to authorize this connection in your browser. The platform will then keep the access token refreshed automatically — including for cron jobs and scheduled prompts — until the upstream invalidates the refresh token.
-            </>
-          )}
-        </div>
-      )}
-
-      <OAuthStatusGrid status={oauth} />
-
-      {oauth.authenticated_by && (
-        <div className="text-xs text-muted-foreground">
-          Authorized by{" "}
-          <span className="font-mono">{oauth.authenticated_by}</span>
-          {oauth.authenticated_at && <> {formatRelative(oauth.authenticated_at)}</>}
-        </div>
-      )}
-
-      {oauth.last_error && (
-        <div className="rounded border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs text-destructive">
-          <span className="font-medium">Last error:</span> {oauth.last_error}
-        </div>
-      )}
-
-      {actionMsg && (
-        <div
-          className={cn(
-            "rounded border px-2 py-1 text-xs",
-            actionMsg.ok
-              ? "border-emerald-500/30 bg-emerald-50 text-emerald-900 dark:bg-emerald-900/20 dark:text-emerald-200"
-              : "border-destructive/30 bg-destructive/10 text-destructive",
-          )}
-        >
-          {actionMsg.text}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function OAuthStatusGrid({ status }: { status: GatewayOAuthStatus }) {
-  const items: Array<{ label: string; value: string; icon: React.ReactNode; tone?: "ok" | "warn" }> = [
-    {
-      label: "Token",
-      value: status.token_acquired ? "acquired" : "not yet acquired",
-      icon: status.token_acquired ? (
-        <Check className="h-3 w-3 text-emerald-500" />
-      ) : (
-        <AlertCircle className="h-3 w-3 text-amber-500" />
-      ),
-      tone: status.token_acquired ? "ok" : "warn",
-    },
-    {
-      label: "Expires",
-      value: status.expires_at ? formatRelative(status.expires_at) : "—",
-      icon: <Clock className="h-3 w-3 text-muted-foreground" />,
-    },
-    {
-      label: "Last refreshed",
-      value: status.last_refreshed_at ? formatRelative(status.last_refreshed_at) : "—",
-      icon: <RefreshCw className="h-3 w-3 text-muted-foreground" />,
-    },
-    {
-      label: "Refresh token",
-      value: status.has_refresh_token ? "present" : "none",
-      icon: <Key className="h-3 w-3 text-muted-foreground" />,
-    },
-  ];
-  // Some IdPs (Keycloak) disclose refresh_expires_in. Render only when
-  // the platform captured a real value — an em-dash row would be noise
-  // for IdPs that never provide it (Auth0, Okta default config, etc.).
-  if (status.has_refresh_token && status.refresh_expires_at) {
-    items.push({
-      label: "Refresh expires",
-      value: formatRelative(status.refresh_expires_at),
-      icon: <Clock className="h-3 w-3 text-muted-foreground" />,
-    });
-  }
-  return (
-    <div className="grid grid-cols-2 gap-2 text-xs">
-      {items.map((it) => (
-        <div key={it.label} className="flex items-center gap-1.5">
-          {it.icon}
-          <span className="text-muted-foreground">{it.label}:</span>
-          <span className="font-mono">{it.value}</span>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function formatRelative(iso: string): string {
-  const t = new Date(iso).getTime();
-  if (Number.isNaN(t)) return iso;
-  const diff = t - Date.now();
-  const abs = Math.abs(diff);
-  const sec = Math.round(abs / 1000);
-  const min = Math.round(sec / 60);
-  const hr = Math.round(min / 60);
-  const day = Math.round(hr / 24);
-  let rel: string;
-  if (sec < 60) rel = `${sec}s`;
-  else if (min < 60) rel = `${min}m`;
-  else if (hr < 24) rel = `${hr}h`;
-  else rel = `${day}d`;
-  return diff >= 0 ? `in ${rel}` : `${rel} ago`;
-}
 
 // ---------------------------------------------------------------------------
 // GatewayRulesDrawer — slide-out panel listing rules with edit / dry-run

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -60,11 +60,32 @@ export default defineConfig(({ mode }) => {
           target: apiTarget,
           changeOrigin: true,
           secure: false,
+          // xfwd populates X-Forwarded-Host / X-Forwarded-Proto with
+          // the ORIGINAL request's host (e.g. localhost:5173), so the
+          // Go server's OAuth callback URL builder points the IdP
+          // back at the Vite dev server. Without this, OAuth flows
+          // started from :5173 redirect back to :8080 — and the user
+          // ends up viewing the embedded (compiled-in, stale) UI
+          // bundle instead of the live Vite source.
+          xfwd: true,
         },
         "/portal/view": {
           target: apiTarget,
           changeOrigin: true,
           secure: false,
+          xfwd: true,
+        },
+        // /portal/auth/* is the platform's browser_session OIDC flow
+        // (login → IdP → callback → logout). Without this proxy, the
+        // SPA dev server tries to resolve /portal/auth/login as a
+        // client-side route, returns index.html, and the operator
+        // sees the login page reload itself ("just jumps") instead of
+        // being redirected to Keycloak.
+        "/portal/auth": {
+          target: apiTarget,
+          changeOrigin: true,
+          secure: false,
+          xfwd: true,
         },
       },
     },


### PR DESCRIPTION
## Why

The MCP gateway and HTTP API gateway each had their own OAuth 2.1
authorization_code implementation — separate handlers, stores, refresh
loops, tables, frontend hooks, and status components (~95% duplicated
code). Three user-visible symptoms all traced to that one architectural
cause:

1. **Connect button error on API connections** — generic "not configured for authorization_code OAuth" on unsaved forms because the API view had no OAuth status block to surface state.
2. **No OAuth status on the API connection view** — endpoint and component existed for MCP only.
3. **MCP refresh tokens vanishing across replicas** — the MCP toolkit's in-memory `oauthTokenSource` cached `loaded=true` after first read, so a Connect on pod A was invisible to pod B until restart.

This collapses both kinds onto one shared abstraction, then re-wires
the dev environment with a real Keycloak IdP so the full flow is
testable end-to-end.

## What changed

### Backend
- **`pkg/connoauth/`** — shared `Source` / `Store` / `Exchange` flow keyed on `(kind, name)`. Refresh uses `golang.org/x/oauth2` and the package **explicitly persists the rotated token (including any new refresh token) after every successful exchange**. That is the bug-#3 fix: rotated refresh tokens survive process restarts and multi-replica reads.
- **Migration 000039** — `connection_oauth_tokens` table backfilled from `gateway_oauth_tokens` + `apigateway_oauth_tokens`. Old tables retained for one release for emergency rollback; a follow-up migration drops them.
- **`pkg/admin/connection_oauth_handler.go`** — single `/connections/{kind}/{name}/oauth-{start,status,reacquire}` route set, kind-dispatched through an `OAuthKindHandlers` registry. `/api/v1/admin/oauth/callback` is the canonical callback URL (unchanged from MCP, so customer IdP configurations don't need reconfiguration). `/api/v1/admin/api-gateway/oauth/callback` is registered as a legacy alias for the same reason.
- **`pkg/toolkits/{gateway,apigateway}/`** — per-kind `OAuthKindHandler` implementations + connoauth-backed `TokenStore` adapters so the toolkits' `Authenticator`s read/write the unified table.
- Reacquire endpoint returns the post-refresh `OAuthStatus` body so the portal status card updates without an extra GET.

### Frontend
- **Shared `ConnectionOAuthStatusCard`** rendered for every connection kind with identical surface (Connect, Reconnect, Refresh now, status grid, error band). Replaces the MCP-only inline card. Keyed on `(kind, name)` so the card fully remounts on connection switch (no stale per-action banner state from a different connection).
- Single `useStartConnectionOAuth` / `useConnectionOAuthStatus` / `useReacquireConnectionOAuth` hook set; legacy MCP/API helpers delegate to it.
- Connection selection mirrors into the URL as `?kind=...&name=...` so OAuth callbacks restore the operator's prior selection. Default selection follows the alphabetical kind order shown in the sidebar instead of whatever order the backend returned first.
- Removed the useless "Show sensitive" toggle that only flipped between two opaque masks.
- `LoginForm` rebuilt with logo + portal title + tagline. New `portal.tagline` config field flows through `/public/branding`.

### Dev environment
- **Real Keycloak container** backed by Postgres (auxiliary `keycloak` DB created idempotently in `start.sh` — works on both fresh volumes and pre-existing volumes that pre-date the keycloak addition). Realm `mcp-platform` pre-seeded with three clients (portal login, `oauth-mcp-dev`, `oauth-api-dev`), a realm-role mapper into the ID token, and two test users:
  - `admin@example.com` / `admin-password` (`dp_admin`)
  - `analyst@example.com` / `analyst-password` (`dp_analyst`)
- Vite proxy honors `X-Forwarded-Host` so OAuth start, callback, and logout all stay on the operator's original origin (`:5173` vs `:8080`).
- `browsersession` `LogoutHandler` derives `post_logout_redirect_uri` from the request scheme + host so dev sessions return to their source origin rather than a static configured target.
- `/portal/auth/*` added to the Vite proxy so OIDC login flows reach the Go backend instead of the SPA's 404.
- Persona role definitions accept both unprefixed (API-key auth) and `dp_`-prefixed (Keycloak OIDC, filtered by `role_prefix "dp_"`) variants so the same persona matches every login path.

## Bug fixes shipped

| # | Symptom | Root cause | Fix |
|---|---|---|---|
| 1 | API Connect button generic error | API view had no OAuth status block | Shared `ConnectionOAuthStatusCard` rendered for every kind |
| 2 | No OAuth status on API view | Status endpoint + component were MCP-only | Unified `/oauth-status` route + shared card |
| 3 | MCP refresh tokens vanishing across replicas | In-memory `loaded=true` cache in toolkit | `connoauth.Source` reads store on every call; refresh explicitly persists rotated tokens |

## Stats

- **51 files changed, ~6,100 insertions, ~450 deletions**
- 1 new package (`pkg/connoauth/`)
- 1 new migration (`000039_connection_oauth_tokens`)
- 1 new admin route group
- 1 new frontend component (`ConnectionOAuthStatusCard`)
- Coverage: total **87%**; `pkg/connoauth` **91.3%**, `pkg/admin` **89.3%**, `pkg/toolkits/gateway` **95.3%**, `pkg/toolkits/apigateway` **93.1%**.

## Out of scope (deferred)

- Drop migration for `gateway_oauth_tokens` + `apigateway_oauth_tokens` (after one release of stable operation on the unified table).
- Deletion of the legacy `pkg/admin/gateway_oauth_handler.go` and `pkg/admin/api_gateway_oauth_handler.go` files — kept as fallback when `ConnOAuthStore` is nil. Routes are not registered when the unified path is active.
- Deletion of `pkg/admin/api-gateway/oauth/callback` legacy alias (after one release; customer IdP configs that registered it need time to migrate to the canonical `/api/v1/admin/oauth/callback`).

## Test plan

- [ ] `make dev-down && make dev` — fresh start with new Keycloak container
- [ ] Portal login screen shows logo + "MCP Data Platform Dev" title + "Sign in to access the platform." tagline + working **Sign in with OIDC** button
- [ ] Sign in as `admin@example.com / admin-password` → lands in admin persona (full tools access)
- [ ] Sign in as `analyst@example.com / analyst-password` → lands in inventory-analyst persona (filtered tools)
- [ ] Sign out → returns to portal login screen on the original origin (`:5173` or `:8080`)
- [ ] Settings → Connections → **`oauth-mcp-dev`** → click **Connect** → browser hops to Keycloak → returns to the same connection view with OAuth status showing `Token: acquired`, refresh token present
- [ ] Same flow on **`oauth-api-dev`** → identical card layout and behavior as MCP
- [ ] Click **Refresh now** on either connection → status updates immediately (no JSON parse error, no extra GET round-trip)
- [ ] Switch between connections in the sidebar — the "Token refreshed" banner from one connection does **not** appear on another
- [ ] Inspect `connection_oauth_tokens`:
  ```sql
  SELECT connection_kind, connection_name, authenticated_by, length(refresh_token)
  FROM connection_oauth_tokens;
  ```
  Should show one row per connected `(kind, name)` pair.
- [ ] Restart `dev-mcp-mock` with `ACCESS_TTL_SECONDS=10` and watch refresh rotation — `connection_oauth_tokens.refresh_token` changes value as the IdP rotates.
- [ ] `make verify` clean.