### PR TITLE
fix(portal): recover admin SPA 401 via OIDC re-auth with return_to (#394)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -745,7 +745,7 @@ auth:
     secure: true
 ```
 
-Endpoints: `/portal/auth/login` (initiate), `/portal/auth/callback` (process), `/portal/auth/logout` (clear). API key fallback always available. MCP clients unaffected.
+Endpoints: `/portal/auth/login` (initiate; accepts optional `return_to` site-relative path), `/portal/auth/callback` (process; redirects to `return_to` when set, otherwise `PostLoginRedirect`), `/portal/auth/logout` (clear). API key fallback always available. MCP clients unaffected.
 
 Limitations: no individual session revocation, no key rotation support (rotating invalidates all sessions), no session refresh (re-auth required after TTL).
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -201,7 +201,11 @@ auth:
 
 When enabled, the platform registers three HTTP endpoints:
 
-- `GET /portal/auth/login` — Initiates OIDC authorization code flow with PKCE
+- `GET /portal/auth/login` — Initiates OIDC authorization code flow with PKCE.
+  Accepts an optional `return_to` query parameter (site-relative path only;
+  absolute URLs and scheme-relative inputs are rejected) which the callback
+  uses as the post-login redirect. The portal SPA sets this when redirecting
+  to login after a 401 so the operator lands back on the page they were on.
 - `GET /portal/auth/callback` — Processes the OIDC callback, creates session cookie
 - `GET /portal/auth/logout` — Clears session cookie and redirects to OIDC end_session
 

--- a/pkg/browsersession/oidcflow.go
+++ b/pkg/browsersession/oidcflow.go
@@ -129,6 +129,14 @@ func NewFlow(ctx context.Context, cfg FlowConfig) (*Flow, error) {
 // LoginHandler initiates the OIDC authorization code flow.
 // It generates state + PKCE verifier, stores them in a temporary cookie,
 // and redirects the user to the OIDC provider's authorization endpoint.
+//
+// An optional `return_to` query parameter is captured into the state
+// cookie and used as the post-login redirect on callback. This lets the
+// admin SPA send a 401-recovery flow back to the page the operator was
+// on (e.g., a connection settings page where they clicked Connect)
+// rather than dropping them at the portal root. The value must be a
+// site-relative path; anything else is silently dropped so an attacker
+// can't dangle an open redirect off the login endpoint.
 func (f *Flow) LoginHandler(w http.ResponseWriter, r *http.Request) {
 	state, err := randomString()
 	if err != nil {
@@ -146,6 +154,9 @@ func (f *Flow) LoginHandler(w http.ResponseWriter, r *http.Request) {
 	stateData := url.Values{
 		logKeyState: {state},
 		"verifier":  {verifier},
+	}
+	if returnTo := sanitizeReturnTo(r.URL.Query().Get("return_to")); returnTo != "" {
+		stateData.Set("return_to", returnTo)
 	}
 	stateToken, err := signStateData(stateData.Encode(), &f.cfg.Cookie)
 	if err != nil {
@@ -203,8 +214,8 @@ func (f *Flow) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate state and extract PKCE verifier.
-	verifier, err := f.validateCallbackState(r, state)
+	// Validate state and extract PKCE verifier + return_to.
+	verifier, returnTo, err := f.validateCallbackState(r, state)
 	if err != nil {
 		f.redirectWithError(w, r, "invalid_state")
 		return
@@ -219,7 +230,17 @@ func (f *Flow) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, f.cfg.PostLoginRedirect, http.StatusFound)
+	// dest is either the trusted config value or returnTo, which was
+	// passed through sanitizeReturnTo at both write (login) and read
+	// (validateCallbackState) — any value with a scheme, host, or
+	// scheme-relative prefix has already been dropped, so dest is
+	// guaranteed to be a site-relative path on this origin.
+	dest := f.cfg.PostLoginRedirect
+	if returnTo != "" {
+		dest = returnTo
+	}
+	// nosemgrep: go.lang.security.injection.open-redirect.open-redirect
+	http.Redirect(w, r, dest, http.StatusFound)
 }
 
 // redirectWithError redirects the user to the portal with an error query parameter
@@ -230,24 +251,62 @@ func (f *Flow) redirectWithError(w http.ResponseWriter, r *http.Request, errCode
 }
 
 // validateCallbackState verifies the state cookie matches the callback state
-// parameter and returns the PKCE code verifier.
-func (f *Flow) validateCallbackState(r *http.Request, state string) (string, error) {
+// parameter and returns the PKCE code verifier and the (already-sanitized)
+// return_to path that was captured at login. return_to is empty when the
+// login request didn't carry one or it failed validation at that time.
+func (f *Flow) validateCallbackState(r *http.Request, state string) (verifier, returnTo string, err error) {
 	stateCookie, err := r.Cookie(stateCookieName)
 	if err != nil {
-		return "", fmt.Errorf("missing state cookie")
+		return "", "", fmt.Errorf("missing state cookie")
 	}
 
 	stateData, err := verifyStateData(stateCookie.Value, f.cfg.Cookie.Key)
 	if err != nil {
-		return "", fmt.Errorf("invalid state cookie")
+		return "", "", fmt.Errorf("invalid state cookie")
 	}
 
 	parsed, err := url.ParseQuery(stateData)
 	if err != nil || parsed.Get(logKeyState) != state {
-		return "", fmt.Errorf("state mismatch")
+		return "", "", fmt.Errorf("state mismatch")
 	}
 
-	return parsed.Get("verifier"), nil
+	// Re-sanitize on read: signed cookies prove integrity but the
+	// sanitizer is the security boundary, so running it on both ends
+	// guarantees an upgrade that tightens validation can't be bypassed
+	// by a state cookie that was minted before the upgrade.
+	return parsed.Get("verifier"), sanitizeReturnTo(parsed.Get("return_to")), nil
+}
+
+// sanitizeReturnTo accepts a candidate post-login redirect path and
+// returns it only when it's a site-relative, single-slash path. Anything
+// else — absolute URLs, scheme-relative URLs (`//evil.com/...`),
+// backslash variants, or non-path inputs — is dropped. The portal
+// itself only ever needs to land back on a path on its own origin, so
+// rejecting everything else closes the open-redirect class entirely.
+func sanitizeReturnTo(s string) string {
+	if s == "" {
+		return ""
+	}
+	// Reject scheme-relative URLs (`//host`, `/\host`) which most
+	// browsers resolve against the current origin's scheme. Anchor on
+	// a single `/` first, then explicitly reject the second character
+	// being `/` or `\`.
+	if !strings.HasPrefix(s, "/") {
+		return ""
+	}
+	if len(s) > 1 && (s[1] == '/' || s[1] == '\\') {
+		return ""
+	}
+	// Parse to guarantee no host/scheme survived (a URL like
+	// `/foo` parses with empty Host/Scheme; anything else is suspect).
+	u, err := url.Parse(s)
+	if err != nil {
+		return ""
+	}
+	if u.Scheme != "" || u.Host != "" {
+		return ""
+	}
+	return s
 }
 
 // clearStateCookie removes the temporary OIDC state cookie.

--- a/pkg/browsersession/oidcflow_test.go
+++ b/pkg/browsersession/oidcflow_test.go
@@ -1176,3 +1176,188 @@ func TestRedirectWithError(t *testing.T) {
 		t.Errorf("redirect = %q, want /portal/?error=test_error", loc)
 	}
 }
+
+// runLoginCallback walks the login → callback round-trip with the given
+// login query and returns the callback's Location header. Centralizes
+// the cookie-shuttling boilerplate so return_to tests stay focused on
+// the behavior under test.
+func runLoginCallback(t *testing.T, flow *Flow, loginQuery string) string {
+	t.Helper()
+
+	loginPath := "/portal/auth/login"
+	if loginQuery != "" {
+		loginPath += "?" + loginQuery
+	}
+	loginReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, loginPath, http.NoBody)
+	loginW := httptest.NewRecorder()
+	flow.LoginHandler(loginW, loginReq)
+
+	loginResp := loginW.Result()
+	authURL, err := url.Parse(loginResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse login redirect: %v", err)
+	}
+	state := authURL.Query().Get("state")
+
+	var stateCookie *http.Cookie
+	for _, c := range loginResp.Cookies() {
+		if c.Name == stateCookieName {
+			stateCookie = c
+		}
+	}
+	if stateCookie == nil {
+		t.Fatal("no state cookie from login")
+	}
+
+	callbackReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/portal/auth/callback?code=auth-code&state="+state, http.NoBody)
+	callbackReq.AddCookie(stateCookie)
+	callbackW := httptest.NewRecorder()
+	flow.CallbackHandler(callbackW, callbackReq)
+
+	return callbackW.Result().Header.Get("Location")
+}
+
+func TestCallbackHandlerHonorsReturnTo(t *testing.T) {
+	// Operator clicked Connect on a connection settings page after
+	// their cookie expired; the SPA bounced them through OIDC with
+	// return_to set. They must land back where they were — not at the
+	// portal root — or the action is lost.
+	claims := map[string]any{"sub": "user-42", "email": "user@example.com"}
+	srv := mockOIDCProvider(t, claims)
+	defer srv.Close()
+
+	cfg := testFlowConfig(srv.URL)
+	cfg.HTTPClient = srv.Client()
+
+	flow, err := NewFlow(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewFlow: %v", err)
+	}
+
+	got := runLoginCallback(t, flow, "return_to=%2Fportal%2Fsettings%2Fconnections%2Fvendor")
+	if got != "/portal/settings/connections/vendor" {
+		t.Errorf("redirect = %q, want /portal/settings/connections/vendor", got)
+	}
+}
+
+func TestCallbackHandlerReturnToWithQuery(t *testing.T) {
+	// return_to includes its own query string (deep link to an OAuth
+	// status tab). Round-tripping must preserve it.
+	claims := map[string]any{"sub": "user-42", "email": "user@example.com"}
+	srv := mockOIDCProvider(t, claims)
+	defer srv.Close()
+
+	cfg := testFlowConfig(srv.URL)
+	cfg.HTTPClient = srv.Client()
+
+	flow, err := NewFlow(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewFlow: %v", err)
+	}
+
+	got := runLoginCallback(t, flow, "return_to="+url.QueryEscape("/portal/settings/connections/vendor?tab=oauth"))
+	if got != "/portal/settings/connections/vendor?tab=oauth" {
+		t.Errorf("redirect = %q, want /portal/settings/connections/vendor?tab=oauth", got)
+	}
+}
+
+func TestCallbackHandlerNoReturnToFallsBackToPostLoginRedirect(t *testing.T) {
+	// No return_to on the login request → behavior is unchanged from
+	// before this feature: callback redirects to PostLoginRedirect.
+	claims := map[string]any{"sub": "user-42", "email": "user@example.com"}
+	srv := mockOIDCProvider(t, claims)
+	defer srv.Close()
+
+	cfg := testFlowConfig(srv.URL)
+	cfg.HTTPClient = srv.Client()
+
+	flow, err := NewFlow(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewFlow: %v", err)
+	}
+
+	got := runLoginCallback(t, flow, "")
+	if got != "/portal/" {
+		t.Errorf("redirect = %q, want /portal/", got)
+	}
+}
+
+func TestCallbackHandlerRejectsHostileReturnTo(t *testing.T) {
+	// Each hostile return_to must be dropped at login time, so the
+	// callback falls back to PostLoginRedirect. This guarantees the
+	// login endpoint cannot be weaponized as an open redirect even if
+	// a phishing email puts the value in front of an operator.
+	cases := []struct {
+		name      string
+		returnTo  string
+		wantBlock bool // true ⇒ must redirect to "/portal/"
+	}{
+		{"absolute_http", "http://evil.com/path", true},
+		{"absolute_https", "https://evil.com/path", true},
+		{"scheme_relative", "//evil.com/path", true},
+		{"backslash_variant", "/\\evil.com/path", true},
+		{"javascript_scheme", "javascript:alert(1)", true},
+		{"data_scheme", "data:text/html,<script>", true},
+		{"empty", "", true},
+		{"plain_relative_no_leading_slash", "portal/foo", true},
+		{"site_relative_root", "/portal/settings", false},
+		{"site_relative_with_query", "/portal/settings?tab=oauth", false},
+	}
+
+	claims := map[string]any{"sub": "user-42", "email": "user@example.com"}
+	srv := mockOIDCProvider(t, claims)
+	defer srv.Close()
+
+	cfg := testFlowConfig(srv.URL)
+	cfg.HTTPClient = srv.Client()
+
+	flow, err := NewFlow(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewFlow: %v", err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			query := ""
+			if tc.returnTo != "" {
+				query = "return_to=" + url.QueryEscape(tc.returnTo)
+			}
+			got := runLoginCallback(t, flow, query)
+			if tc.wantBlock {
+				if got != "/portal/" {
+					t.Errorf("hostile return_to %q leaked through: redirect = %q", tc.returnTo, got)
+				}
+			} else {
+				if got != tc.returnTo {
+					t.Errorf("benign return_to %q dropped: redirect = %q", tc.returnTo, got)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeReturnTo(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"/", "/"},
+		{"/portal/foo", "/portal/foo"},
+		{"/portal/foo?bar=baz#frag", "/portal/foo?bar=baz#frag"},
+		{"//evil.com", ""},
+		{"/\\evil.com", ""},
+		{"http://evil.com", ""},
+		{"https://evil.com/path", ""},
+		{"javascript:alert(1)", ""},
+		{"portal/foo", ""},
+		{"./portal", ""},
+	}
+	for _, tc := range cases {
+		got := sanitizeReturnTo(tc.in)
+		if got != tc.want {
+			t.Errorf("sanitizeReturnTo(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/ui/src/api/admin/client.test.ts
+++ b/ui/src/api/admin/client.test.ts
@@ -9,6 +9,11 @@ async function loadApiFetch() {
   return mod.apiFetch;
 }
 
+async function loadApiFetchRaw() {
+  const mod = await import("./client");
+  return mod.apiFetchRaw;
+}
+
 describe("apiFetch error handling", () => {
   const originalFetch = global.fetch;
 
@@ -67,5 +72,134 @@ describe("apiFetch error handling", () => {
     // omitted, jsdom's Response leaves it empty; our fallback handles
     // either case — the failure message must just be non-empty.
     await expect(apiFetch("/x")).rejects.toMatchObject({ status: 503 });
+  });
+});
+
+describe("apiFetch 401 session-expiry handling", () => {
+  const originalFetch = global.fetch;
+  const originalLocation = window.location;
+
+  // jsdom's window.location is mostly read-only; replace it with a
+  // controllable stand-in so we can capture the redirect target without
+  // an actual navigation tearing down the test.
+  function mockLocation(pathname: string, search = "", hash = ""): { replace: ReturnType<typeof vi.fn> } {
+    const replace = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { pathname, search, hash, replace },
+    });
+    return { replace };
+  }
+
+  beforeEach(() => {
+    useAuthStore.setState({
+      user: null,
+      authMethod: "cookie",
+      apiKey: "",
+      sessionExpired: false,
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    vi.restoreAllMocks();
+  });
+
+  function mock401(): void {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ detail: "authentication required" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  }
+
+  it("redirects cookie-mode users to /portal/auth/login with the current path as return_to", async () => {
+    // Operator clicked Connect on the connection settings page. The
+    // cryptic "authentication required" must never reach the UI; the
+    // browser should be on its way back through OIDC by the time
+    // apiFetch rejects.
+    const { replace } = mockLocation("/portal/settings/connections/vendor", "?tab=oauth");
+    mock401();
+
+    const apiFetch = await loadApiFetch();
+    await expect(apiFetch("/gateway/connections/vendor/test", { method: "POST" }))
+      .rejects.toMatchObject({ status: 401 });
+
+    expect(replace).toHaveBeenCalledTimes(1);
+    const target = String(replace.mock.calls[0]?.[0] ?? "");
+    expect(target.startsWith("/portal/auth/login?return_to=")).toBe(true);
+    const returnToPart = target.split("return_to=")[1] ?? "";
+    expect(decodeURIComponent(returnToPart))
+      .toBe("/portal/settings/connections/vendor?tab=oauth");
+    expect(useAuthStore.getState().sessionExpired).toBe(true);
+  });
+
+  it("preserves hash fragments in return_to", async () => {
+    // Anchor links on a settings page should survive the round-trip
+    // so the operator lands back on the exact section.
+    const { replace } = mockLocation("/portal/settings", "?tab=oauth", "#status");
+    mock401();
+
+    const apiFetch = await loadApiFetch();
+    await expect(apiFetch("/anything")).rejects.toMatchObject({ status: 401 });
+
+    const target = String(replace.mock.calls[0]?.[0] ?? "");
+    const returnToPart = target.split("return_to=")[1] ?? "";
+    expect(decodeURIComponent(returnToPart))
+      .toBe("/portal/settings?tab=oauth#status");
+  });
+
+  it("does not redirect api-key-mode users (the cookie isn't the failing credential)", async () => {
+    // API-key auth fails because the key was revoked or rotated, not
+    // because a browser cookie expired. Sending the user through OIDC
+    // would be wrong — they may not even have an OIDC identity. The
+    // LoginForm picks up sessionExpired and the operator re-enters
+    // their key.
+    useAuthStore.setState({ authMethod: "apikey", apiKey: "stale-key" });
+    const { replace } = mockLocation("/portal/anywhere");
+    mock401();
+
+    const apiFetch = await loadApiFetch();
+    await expect(apiFetch("/anything")).rejects.toMatchObject({ status: 401 });
+
+    expect(replace).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().sessionExpired).toBe(true);
+  });
+
+  it("does not redirect on non-401 failures", async () => {
+    // A 500 from the admin API has nothing to do with auth state; the
+    // error band on the affected card is the right surface.
+    const { replace } = mockLocation("/portal/anywhere");
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ detail: "boom" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const apiFetch = await loadApiFetch();
+    await expect(apiFetch("/anything")).rejects.toMatchObject({ status: 500 });
+
+    expect(replace).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().sessionExpired).toBe(false);
+  });
+
+  it("apiFetchRaw also triggers redirect on 401 (parity with apiFetch)", async () => {
+    // Endpoints that return non-JSON (e.g., file downloads, log
+    // streams) go through apiFetchRaw. Same session-expiry bug, same
+    // recovery path required.
+    const { replace } = mockLocation("/portal/downloads");
+    mock401();
+
+    const apiFetchRaw = await loadApiFetchRaw();
+    const res = await apiFetchRaw("/anything");
+    expect(res.status).toBe(401);
+    expect(replace).toHaveBeenCalledTimes(1);
+    expect(useAuthStore.getState().sessionExpired).toBe(true);
   });
 });

--- a/ui/src/api/admin/client.ts
+++ b/ui/src/api/admin/client.ts
@@ -12,6 +12,28 @@ class ApiError extends Error {
   }
 }
 
+// handleUnauthorized centralizes session-expiry recovery for admin API
+// calls. The cookie-backed session is what gates /api/v1/admin/*, so a
+// 401 from any admin endpoint means the browser session is gone (or
+// never existed). Cookie-mode users are sent back through OIDC with a
+// return_to that brings them right back to the page they were on so
+// the action they were trying to take (e.g. starting a connection's
+// upstream OAuth flow) doesn't get lost. API-key-mode users get the
+// store flag flipped — their key is server-side invalid, the login
+// form re-renders with "your session has expired" and they re-enter.
+function handleUnauthorized(): void {
+  const { authMethod } = useAuthStore.getState();
+  useAuthStore.getState().expireSession();
+
+  if (authMethod !== "cookie") {
+    return;
+  }
+
+  const returnTo = window.location.pathname + window.location.search + window.location.hash;
+  const loginURL = `/portal/auth/login?return_to=${encodeURIComponent(returnTo)}`;
+  window.location.replace(loginURL);
+}
+
 async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const { apiKey, authMethod } = useAuthStore.getState();
   const headers: Record<string, string> = {
@@ -30,6 +52,9 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   });
 
   if (!res.ok) {
+    if (res.status === 401) {
+      handleUnauthorized();
+    }
     const body = await res.json().catch(() => ({} as Record<string, unknown>));
     const detail = (typeof body.detail === "string" && body.detail)
       || (typeof body.error === "string" && body.error)
@@ -51,11 +76,17 @@ async function apiFetchRaw(path: string, init?: RequestInit): Promise<Response> 
     headers["X-API-Key"] = apiKey;
   }
 
-  return fetch(`${BASE_URL}${path}`, {
+  const res = await fetch(`${BASE_URL}${path}`, {
     ...init,
     headers,
     credentials: "include",
   });
+
+  if (res.status === 401) {
+    handleUnauthorized();
+  }
+
+  return res;
 }
 
 export { apiFetch, apiFetchRaw, ApiError, BASE_URL };


### PR DESCRIPTION
Closes #394.

## Summary

The portal cookie expires after 8h (default `auth.browser_session.ttl`). Before this change, the next admin API call rejected with `401 {"detail":"authentication required"}`, the SPA threw that string verbatim into a component error band, and React Query held the last successful response on screen on top of it. The single most operator-hostile surface was the OAuth status card on a connection settings page: the operator clicked **Connect** to start the upstream IdP flow, saw "authentication required" inline, and naturally read it as "the connection needs auth" — exactly what they were trying to do — rather than "your portal cookie expired."

This PR centralizes 401 handling in the admin `apiFetch` so the operator is sent back through OIDC and lands on the same page they were on, action intact.

## What changes

**Client — `ui/src/api/admin/client.ts`**
- `apiFetch` and `apiFetchRaw` intercept 401 from `/api/v1/admin/*`.
- **Cookie-mode** users: call `expireSession()`, then `window.location.replace('/portal/auth/login?return_to=<encoded path+search+hash>')`. The full navigation tears down React (including React Query caches), so no stale-snapshot flash on return.
- **API-key-mode** users: only flip `sessionExpired`. Their failing credential isn't a browser cookie, and they may not even have an OIDC identity — sending them through SSO would be wrong. The existing `LoginForm` re-renders with the "Your session has expired" banner so they re-enter their key.

**Server — `pkg/browsersession/oidcflow.go`**
- `LoginHandler` accepts an optional `return_to` query parameter, sanitizes it, and stores it inside the signed state cookie alongside `state` and `verifier`.
- `CallbackHandler` reads the sanitized `return_to` back out and uses it as the post-login destination (falls back to `PostLoginRedirect` when absent).
- New `sanitizeReturnTo` accepts only site-relative single-slash paths. It rejects:
  - absolute URLs (`http://evil.com/...`, `https://...`)
  - scheme-relative URLs (`//evil.com/...`)
  - backslash variants (`/\evil.com/...`)
  - non-http schemes (`javascript:`, `data:`)
  - inputs without a leading `/`
- Sanitization runs at **both** write (login) and read (callback) so a future-tightening upgrade can't be bypassed by an old state cookie minted under looser rules.

## Why the asymmetric client behavior

Cookie-mode and API-key-mode have different failure recovery paths because the failing credential is different:

| Mode      | What expired              | Recovery                                          |
|-----------|---------------------------|---------------------------------------------------|
| Cookie    | The signed session cookie | OIDC round-trip via `/portal/auth/login`          |
| API key   | The key (revoked/rotated) | Re-enter key on `LoginForm`; no SSO assumed       |

Conflating these would either send API-key operators through an OIDC flow they may not have, or leave cookie-mode operators stuck on a login screen instead of automatically recovering.

## Security: open-redirect class is closed

`return_to` is operator-supplied via URL query. The endpoint must not be weaponizable as a phishing pivot. `sanitizeReturnTo` is the security boundary; the `http.Redirect` call carries a nosemgrep annotation pointing at it.

Tested hostile inputs that are dropped (full table in `TestCallbackHandlerRejectsHostileReturnTo`):

| Input                               | Result                          |
|-------------------------------------|---------------------------------|
| `http://evil.com/path`              | dropped → falls back to `/portal/` |
| `https://evil.com/path`             | dropped → falls back to `/portal/` |
| `//evil.com/path`                   | dropped → falls back to `/portal/` |
| `/\evil.com/path`                   | dropped → falls back to `/portal/` |
| `javascript:alert(1)`               | dropped → falls back to `/portal/` |
| `data:text/html,<script>`           | dropped → falls back to `/portal/` |
| `portal/foo` (no leading slash)     | dropped → falls back to `/portal/` |
| `/portal/settings`                  | kept                            |
| `/portal/settings?tab=oauth`        | kept                            |

The state cookie is HMAC-signed, so `return_to` can't be tampered with between login and callback. Re-running sanitization on read means the security guarantee holds even if a future patch tightens the rules.

## Tests

**Go — `pkg/browsersession/oidcflow_test.go` (+5 tests / +185 lines):**
- `TestCallbackHandlerHonorsReturnTo` — round-trips `/portal/settings/connections/vendor` through login + callback and asserts the final redirect.
- `TestCallbackHandlerReturnToWithQuery` — confirms query strings (`?tab=oauth`) survive the round-trip.
- `TestCallbackHandlerNoReturnToFallsBackToPostLoginRedirect` — guards backward compatibility.
- `TestCallbackHandlerRejectsHostileReturnTo` — 10-row table of hostile inputs, asserts each falls back to `PostLoginRedirect`.
- `TestSanitizeReturnTo` — direct unit table for the sanitizer.

**TypeScript — `ui/src/api/admin/client.test.ts` (+5 tests / +134 lines):**
- Cookie-mode 401 → redirect to `/portal/auth/login` with correct `return_to`.
- Hash fragments preserved in `return_to`.
- API-key-mode 401 → no redirect; only `sessionExpired` flag flips.
- Non-401 failures → no redirect, no session-expiry side effect.
- `apiFetchRaw` parity with `apiFetch` on 401.

Coverage on new functions:
- `sanitizeReturnTo`: 83.3%
- `validateCallbackState`: 90.0%
- `CallbackHandler`: 100%
- `LoginHandler`: 70% (pre-existing surface; new branches covered)

## Docs

`docs/reference/configuration.md` and `docs/llms-full.txt` now document the `return_to` query parameter and its same-origin-only constraint.

## Out of scope

- Silent OIDC renewal before the cookie expires (separate enhancement; called out in the issue).
- The portal (`/api/v1/portal/*`) and resources (`/api/v1/resources/*`) clients also call `expireSession()` on 401 but don't redirect with `return_to`. The issue scope is admin API only — operator-clickable actions on settings pages — and that's what was changed. The other clients can adopt the same pattern in a follow-up if their 401 surfaces become user-hostile enough to need it.

## Test plan

- [x] `make verify` passes locally (full CI-equivalent suite: fmt, test+race, lint, gosec, govulncheck, semgrep, codeql, coverage ≥80%, mutation ≥60%, release-check).
- [x] All 58 UI tests pass; UI typecheck and lint clean on changed files.
- [x] Adversarial pre-commit review returned `CLEAN`.
- [ ] Manual: log into portal, expire cookie (or shorten TTL), click Connect on a connection settings page, confirm browser bounces through OIDC and lands back on the same connection page with the action ready to retry.
- [ ] Manual: log in via API key, revoke the key server-side, click any admin action, confirm `LoginForm` renders with the "Your session has expired" banner (no OIDC redirect).