### PR TITLE
feat(portal): add copy button to provenance query modal (#398)

### DIFF
--- a/ui/src/components/ProvenancePanel.tsx
+++ b/ui/src/components/ProvenancePanel.tsx
@@ -5,6 +5,8 @@ import {
   FileText,
   Info,
   Terminal,
+  Copy,
+  Check,
   type LucideIcon,
 } from "lucide-react";
 import * as Dialog from "@radix-ui/react-dialog";
@@ -142,10 +144,37 @@ function DetailModal({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
+  const [copied, setCopied] = useState(false);
+
   if (!call) return null;
   const Icon = getToolIcon(call.tool_name);
   const sql = extractSQL(call);
   const detail = sql ?? formatDetail(call.parameters);
+
+  const handleCopy = () => {
+    const writeFallback = () => {
+      const el = document.createElement("textarea");
+      el.value = detail;
+      document.body.appendChild(el);
+      el.select();
+      document.execCommand("copy");
+      document.body.removeChild(el);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    };
+
+    if (navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(detail).then(
+        () => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        },
+        writeFallback,
+      );
+    } else {
+      writeFallback();
+    }
+  };
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -161,9 +190,30 @@ function DetailModal({
           </Dialog.Description>
 
           <div className="mt-4">
-            <p className="mb-1.5 text-xs font-medium text-muted-foreground">
-              {sql ? "SQL Query" : "Parameters"}
-            </p>
+            <div className="mb-1.5 flex items-center justify-between">
+              <p className="text-xs font-medium text-muted-foreground">
+                {sql ? "SQL Query" : "Parameters"}
+              </p>
+              <button
+                type="button"
+                onClick={handleCopy}
+                className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+                title={sql ? "Copy SQL query" : "Copy parameters"}
+                aria-label={sql ? "Copy SQL query" : "Copy parameters"}
+              >
+                {copied ? (
+                  <>
+                    <Check className="h-3.5 w-3.5 text-green-500" />
+                    Copied
+                  </>
+                ) : (
+                  <>
+                    <Copy className="h-3.5 w-3.5" />
+                    Copy
+                  </>
+                )}
+              </button>
+            </div>
             <pre className="max-h-96 overflow-auto rounded-md bg-muted p-3 text-xs font-mono whitespace-pre-wrap break-words">
               {detail}
             </pre>


### PR DESCRIPTION
## Summary
- Adds a **Copy** button to the Provenance `DetailModal` so users can copy the full SQL query (or formatted parameters) without manual text selection
- Uses `navigator.clipboard.writeText` with a `document.execCommand("copy")` fallback (matches the pattern in `ShareDialog.tsx`)
- Shows a green ✓ "Copied" confirmation state for 2s after a successful copy
- Includes `aria-label` and `title` attributes for accessibility

Closes #398

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx eslint src/components/ProvenancePanel.tsx` — clean
- [x] `npm test` — 58/58 UI tests pass
- [x] `make verify` — all gates passed (fmt, race tests, coverage, lint, gosec, govulncheck, semgrep, codeql, dead-code, mutate, goreleaser dry-run)
- [ ] Manual: open a tool result with a `trino_*` provenance entry, click the entry to open the modal, click **Copy**, paste somewhere to confirm the full SQL is on the clipboard
- [ ] Manual: repeat for a non-SQL entry (e.g. `datahub_search`) and confirm the formatted JSON parameters are copied