### PR TITLE
fix(portal): normalize asset tags so nil never blanks the portal

### DIFF
--- a/pkg/portal/store.go
+++ b/pkg/portal/store.go
@@ -101,6 +101,13 @@ func NewPostgresAssetStore(db *sql.DB) AssetStore {
 }
 
 func (s *postgresAssetStore) Insert(ctx context.Context, asset Asset) error { //nolint:revive // interface impl
+	// Normalize nil to empty slice so the column never holds JSON
+	// `null`. A nil tags slice serialized as JSON null is what blanked
+	// the portal: the React asset list does `asset.tags.slice(...)`
+	// and one null row kills the entire render tree.
+	if asset.Tags == nil {
+		asset.Tags = []string{}
+	}
 	tags, err := json.Marshal(asset.Tags)
 	if err != nil {
 		return fmt.Errorf("marshaling tags: %w", err)
@@ -963,6 +970,12 @@ func (*noopShareStore) IncrementAccess(_ context.Context, _ string) error { retu
 func unmarshalAssetJSON(asset *Asset, tags, prov []byte) error {
 	if err := json.Unmarshal(tags, &asset.Tags); err != nil {
 		return fmt.Errorf("unmarshaling tags: %w", err)
+	}
+	// Existing rows persisted from before the Insert normalization may
+	// hold literal JSON `null`. Always hand a concrete slice to the
+	// portal API so the JSON response is `[]`, never `null`.
+	if asset.Tags == nil {
+		asset.Tags = []string{}
 	}
 	if err := json.Unmarshal(prov, &asset.Provenance); err != nil {
 		return fmt.Errorf("unmarshaling provenance: %w", err)

--- a/pkg/portal/store_test.go
+++ b/pkg/portal/store_test.go
@@ -49,6 +49,73 @@ func TestPostgresAssetStoreInsert(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestPostgresAssetStoreInsertNilTags pins the normalization that a nil
+// Tags slice is persisted as JSON `[]` rather than `null`. Persisting
+// `null` is what blanked the portal: the React asset list calls
+// `asset.tags.slice(0, 3)` and one null tags row brings down the entire
+// React tree with no error boundary.
+func TestPostgresAssetStoreInsertNilTags(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	store := NewPostgresAssetStore(db)
+
+	asset := Asset{
+		ID:          "abc123",
+		OwnerID:     "user1",
+		Name:        "Untagged Export",
+		ContentType: "application/json",
+		S3Bucket:    "portal",
+		S3Key:       "user1/abc123/content.json",
+		SizeBytes:   42,
+		Tags:        nil, // simulate api_export with no tags supplied
+	}
+
+	mock.ExpectExec("INSERT INTO portal_assets").
+		WithArgs(
+			asset.ID, asset.OwnerID, asset.OwnerEmail, asset.Name, asset.Description,
+			asset.ContentType, asset.S3Bucket, asset.S3Key, asset.SizeBytes,
+			[]byte("[]"), sqlmock.AnyArg(), asset.SessionID, 0, nil,
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	require.NoError(t, store.Insert(context.Background(), asset))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestPostgresAssetStoreGetNullTags pins the read-side normalization:
+// rows that were persisted before the Insert fix may still hold the
+// literal JSON `null` for tags. The Get path must surface an empty
+// slice so the portal API response is always `"tags": []`.
+func TestPostgresAssetStoreGetNullTags(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	store := NewPostgresAssetStore(db)
+	now := time.Now()
+	prov, _ := json.Marshal(Provenance{})
+
+	rows := sqlmock.NewRows([]string{
+		"id", "owner_id", "owner_email", "name", "description", "content_type", "s3_bucket", "s3_key",
+		"thumbnail_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
+	}).AddRow(
+		"abc123", "user1", "user1@example.com", "Untagged", "", "application/json", "portal", "key1",
+		"", int64(42), []byte("null"), prov, "", 1, now, now, nil, "",
+	)
+
+	mock.ExpectQuery("SELECT .+ FROM portal_assets WHERE id").
+		WithArgs("abc123").
+		WillReturnRows(rows)
+
+	asset, err := store.Get(context.Background(), "abc123")
+	require.NoError(t, err)
+	assert.NotNil(t, asset.Tags, "stored JSON null must surface as a non-nil slice")
+	assert.Equal(t, []string{}, asset.Tags)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestPostgresAssetStoreGet(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/ui/src/pages/assets/MyAssetsPage.tsx
+++ b/ui/src/pages/assets/MyAssetsPage.tsx
@@ -193,7 +193,7 @@ export function MyAssetsPage({ onNavigate }: Props) {
                     >
                       {asset.content_type}
                     </span>
-                    {asset.tags.slice(0, 3).map((t) => (
+                    {(asset.tags ?? []).slice(0, 3).map((t) => (
                       <span
                         key={t}
                         className="text-xs px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground"
@@ -264,7 +264,7 @@ export function MyAssetsPage({ onNavigate }: Props) {
                     </td>
                     <td className="px-4 py-2.5 max-w-0">
                       <div className="flex flex-wrap gap-1">
-                        {asset.tags.slice(0, 3).map((t) => (
+                        {(asset.tags ?? []).slice(0, 3).map((t) => (
                           <span
                             key={t}
                             className="text-xs px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground truncate max-w-[100px]"
@@ -272,8 +272,8 @@ export function MyAssetsPage({ onNavigate }: Props) {
                             {t}
                           </span>
                         ))}
-                        {asset.tags.length > 3 && (
-                          <span className="text-xs text-muted-foreground">+{asset.tags.length - 3}</span>
+                        {(asset.tags ?? []).length > 3 && (
+                          <span className="text-xs text-muted-foreground">+{(asset.tags ?? []).length - 3}</span>
                         )}
                       </div>
                     </td>

--- a/ui/src/pages/collections/CollectionEditorPage.tsx
+++ b/ui/src/pages/collections/CollectionEditorPage.tsx
@@ -204,9 +204,9 @@ function AssetBrowserModal({
                   </td>
                   <td className="py-2 max-w-0">
                     <span className="font-medium truncate block">{a.name}</span>
-                    {a.tags.length > 0 && (
+                    {(a.tags ?? []).length > 0 && (
                       <div className="flex gap-1 mt-0.5">
-                        {a.tags.slice(0, 3).map((t) => (
+                        {(a.tags ?? []).slice(0, 3).map((t) => (
                           <span key={t} className="text-xs px-1 py-0.5 rounded bg-muted text-muted-foreground">{t}</span>
                         ))}
                       </div>

--- a/ui/src/pages/resources/ResourcesPage.tsx
+++ b/ui/src/pages/resources/ResourcesPage.tsx
@@ -250,13 +250,13 @@ export function ResourcesPage({ admin }: Props) {
                     <td className="px-4 py-2.5 text-xs text-muted-foreground truncate">{r.mime_type}</td>
                     <td className="px-4 py-2.5 max-w-0">
                       <div className="flex flex-wrap gap-1">
-                        {r.tags.slice(0, 3).map((t) => (
+                        {(r.tags ?? []).slice(0, 3).map((t) => (
                           <span key={t} className="text-xs px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground truncate max-w-[80px]">
                             {t}
                           </span>
                         ))}
-                        {r.tags.length > 3 && (
-                          <span className="text-xs text-muted-foreground">+{r.tags.length - 3}</span>
+                        {(r.tags ?? []).length > 3 && (
+                          <span className="text-xs text-muted-foreground">+{(r.tags ?? []).length - 3}</span>
                         )}
                       </div>
                     </td>

--- a/ui/src/pages/shared/SharedWithMePage.tsx
+++ b/ui/src/pages/shared/SharedWithMePage.tsx
@@ -250,7 +250,7 @@ export function SharedWithMePage({ onNavigate }: Props) {
                     >
                       {item.asset.content_type}
                     </span>
-                    {item.asset.tags.slice(0, 3).map((t) => (
+                    {(item.asset.tags ?? []).slice(0, 3).map((t) => (
                       <span
                         key={t}
                         className="text-xs px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground"
@@ -317,7 +317,7 @@ export function SharedWithMePage({ onNavigate }: Props) {
                     </td>
                     <td className="px-4 py-2.5 max-w-0">
                       <div className="flex flex-wrap gap-1">
-                        {item.asset.tags.slice(0, 3).map((t) => (
+                        {(item.asset.tags ?? []).slice(0, 3).map((t) => (
                           <span
                             key={t}
                             className="text-xs px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground truncate max-w-[100px]"
@@ -325,8 +325,8 @@ export function SharedWithMePage({ onNavigate }: Props) {
                             {t}
                           </span>
                         ))}
-                        {item.asset.tags.length > 3 && (
-                          <span className="text-xs text-muted-foreground">+{item.asset.tags.length - 3}</span>
+                        {(item.asset.tags ?? []).length > 3 && (
+                          <span className="text-xs text-muted-foreground">+{(item.asset.tags ?? []).length - 3}</span>
                         )}
                       </div>
                     </td>


### PR DESCRIPTION
## Summary

- A nil `[]string` Tags slice on `portal.Asset` was marshaled as JSON `null` into `portal_assets.tags` and returned to the FE as `"tags": null`. The React asset list calls `asset.tags.slice(0, 3).map(...)` with no guard, so a single bad row threw during render and — with no error boundary — blanked the entire portal.
- Backend normalizes at the store boundary: `Insert` coerces nil → `[]string{}` before marshaling (no new bad rows); `unmarshalAssetJSON` coerces decoded nil → `[]string{}` (masks existing bad rows on read, so the live portal recovers without a DB migration).
- Frontend adds `(x.tags ?? []).slice(...)` guards on every asset-list render site (My Assets, Shared With Me, Resources, Collection Editor) as defense-in-depth so a single malformed row can never blank the portal again.

## Test plan

- [x] `go test -race ./pkg/portal/...` — passes, including two new regression tests (`InsertNilTags` pins `[]` on the wire; `GetNullTags` pins non-nil slice surfacing from stored `null`)
- [x] `make verify` — green end-to-end (fmt, race tests, coverage, lint, gosec, govulncheck, semgrep, CodeQL, dead-code, mutate, goreleaser dry-run)
- [x] `npm run build` and `npm run lint` on touched UI files — no new findings
- [ ] After release + redeploy, confirm the live demo portal renders the asset list (3 `api_export` rows previously had `tags: null`)