### PR TITLE
fix(connoauth): emit honest event types for locally-decided revocations

### DIFF
--- a/pkg/admin/connection_auth_events_handler_test.go
+++ b/pkg/admin/connection_auth_events_handler_test.go
@@ -98,6 +98,45 @@ func TestLastRevocationForLatestRevoked(t *testing.T) {
 	}
 }
 
+// TestLastRevocationForSkippedLeads — the locally-decided revocation
+// lead types (TypeRefreshSkippedExpired, TypeRefreshSkippedNoToken)
+// must also surface in the banner. The TypeRefreshSkipped* events
+// carry no Detail payload — the reason is synthesized from the type
+// itself so the UI gets a consistent string regardless of whether
+// the lookup matched the lead or the trail event first.
+func TestLastRevocationForSkippedLeads(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		leadType   authevents.Type
+		wantReason string
+	}{
+		{"deadline reached", authevents.TypeRefreshSkippedExpired, "refresh_expired"},
+		{"no refresh token", authevents.TypeRefreshSkippedNoToken, "no_refresh_token"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := authevents.NewMemoryStore()
+			must(t, store.Insert(context.Background(), authevents.Event{
+				Kind: "api", Name: "test", Type: tc.leadType,
+				Actor: authevents.SystemBackgroundRefresh, IDPHost: "iam.example.io",
+			}))
+			h := &Handler{deps: Deps{AuthEventStore: store}}
+			got := h.lastRevocationFor(context.Background(), "api", "test")
+			if got == nil {
+				t.Fatalf("lastRevocationFor returned nil for %v", tc.leadType)
+			}
+			if got.Reason != tc.wantReason {
+				t.Errorf("Reason = %q, want %q", got.Reason, tc.wantReason)
+			}
+			if got.IDPHost != "iam.example.io" {
+				t.Errorf("IDPHost = %q, want iam.example.io", got.IDPHost)
+			}
+		})
+	}
+}
+
 func TestConnectionAuthEventsEndpointEmpty(t *testing.T) {
 	t.Parallel()
 	h := &Handler{}

--- a/pkg/admin/connection_oauth_handler.go
+++ b/pkg/admin/connection_oauth_handler.go
@@ -205,18 +205,56 @@ func (h *Handler) lastRevocationFor(ctx context.Context, kind, name string) *con
 		return nil
 	}
 	for _, ev := range events {
-		if ev.Type != authevents.TypeTokenDeletedRevoked &&
-			ev.Type != authevents.TypeRefreshFailedRevoked {
+		if !isRevocationLeadEvent(ev.Type) {
 			continue
 		}
-		reason := extractRevocationReason(ev)
 		return &connoauth.RevocationEvent{
 			OccurredAt: ev.OccurredAt,
-			Reason:     reason,
+			Reason:     reasonForRevocationLead(ev),
 			IDPHost:    ev.IDPHost,
 		}
 	}
 	return nil
+}
+
+// isRevocationLeadEvent reports whether an event type ends a
+// connection's credential lifecycle in a way the operator should see
+// on the status card. The lead types are:
+//
+//   - TypeTokenDeletedRevoked: trailing event of every revocation pair.
+//   - TypeRefreshFailedRevoked: IdP returned invalid_grant.
+//   - TypeRefreshSkippedExpired: IdP-disclosed deadline reached
+//     locally (no IdP call).
+//   - TypeRefreshSkippedNoToken: no refresh token was stored (no IdP
+//     call).
+//
+// All four are paired with a subsequent TypeTokenDeletedRevoked, so a
+// list query that returns multiple events in order will most commonly
+// match TypeTokenDeletedRevoked first.
+func isRevocationLeadEvent(t authevents.Type) bool {
+	switch t {
+	case authevents.TypeTokenDeletedRevoked,
+		authevents.TypeRefreshFailedRevoked,
+		authevents.TypeRefreshSkippedExpired,
+		authevents.TypeRefreshSkippedNoToken:
+		return true
+	}
+	return false
+}
+
+// reasonForRevocationLead derives a short reason string for the
+// revocation event. The TypeRefreshSkipped* events carry no detail
+// payload — their type alone names the cause, so we synthesize the
+// short string. TypeTokenDeletedRevoked and TypeRefreshFailedRevoked
+// have a payload and we extract it.
+func reasonForRevocationLead(ev authevents.Event) string {
+	switch ev.Type {
+	case authevents.TypeRefreshSkippedExpired:
+		return "refresh_expired"
+	case authevents.TypeRefreshSkippedNoToken:
+		return "no_refresh_token"
+	}
+	return extractRevocationReason(ev)
 }
 
 // extractRevocationReason pulls the reason field from a revocation

--- a/pkg/authevents/event.go
+++ b/pkg/authevents/event.go
@@ -31,29 +31,27 @@ const (
 	// failure during refresh. The row is NOT deleted; the next attempt
 	// can succeed. Emitted at WARN level by both refresh paths.
 	TypeRefreshFailedTransient Type = "refresh_failed_transient"
-	// TypeRefreshFailedRevoked records a definitive refresh-token
-	// rejection (e.g. RFC 6749 §5.2 invalid_grant @ HTTP 400, local
-	// expiry of the IdP-disclosed refresh deadline, or absence of a
-	// refresh token in the persisted row). Paired with a subsequent
-	// TypeTokenDeletedRevoked event.
+	// TypeRefreshFailedRevoked records that the IdP was called and
+	// returned a definitive rejection (RFC 6749 §5.2 invalid_grant @
+	// HTTP 400). Paired with a subsequent TypeTokenDeletedRevoked
+	// event. Reserved strictly for IdP-returned rejections — the
+	// locally-decided cases use TypeRefreshSkippedExpired and
+	// TypeRefreshSkippedNoToken below so the History panel does not
+	// falsely attribute the verdict to the upstream IdP.
 	TypeRefreshFailedRevoked Type = "refresh_failed_revoked"
-	// TypeRefreshSkippedNoToken records a refresh attempt that found
-	// no refresh_token persisted. Reserved for future use by callers
-	// that want to record a "checked but skipped" signal WITHOUT also
-	// invoking the revoked-cleanup path. The current refresh paths
-	// in connoauth/source.go and apigateway/auth.go DO NOT emit this
-	// event — they fold the no-refresh-token case into the revoked
-	// cascade via IDPErrorCode="no_refresh_token" on
-	// TypeRefreshFailedRevoked so a single incident produces a
-	// single (RefreshFailedRevoked, TokenDeletedRevoked) event pair
-	// rather than three rows in the History panel.
+	// TypeRefreshSkippedNoToken records that the refresh attempt was
+	// aborted before any network call because no refresh_token was
+	// persisted. Paired with a subsequent TypeTokenDeletedRevoked
+	// event. Distinct from TypeRefreshFailedRevoked so the History
+	// panel can show that the IdP was NOT contacted on this tick.
 	TypeRefreshSkippedNoToken Type = "refresh_skipped_no_token"
-	// TypeRefreshSkippedExpired records a refresh attempt aborted
-	// before any network call because the IdP-disclosed refresh
-	// deadline had already passed. Same usage discipline as
-	// TypeRefreshSkippedNoToken: the cause is captured as
-	// IDPErrorCode="refresh_expired" on RefreshFailedRevoked rather
-	// than emitted as a separate row.
+	// TypeRefreshSkippedExpired records that the refresh attempt was
+	// aborted before any network call because the IdP-disclosed
+	// refresh deadline (refresh_expires_in from the most recent
+	// successful refresh response) had already passed. Paired with a
+	// subsequent TypeTokenDeletedRevoked event. Distinct from
+	// TypeRefreshFailedRevoked so the History panel does not falsely
+	// claim the IdP returned an error code on this tick.
 	TypeRefreshSkippedExpired Type = "refresh_skipped_expired"
 	// TypeRefreshRotationPersistenceFailed records the most serious
 	// failure class: the IdP issued a rotated token pair (the old

--- a/pkg/authevents/store.go
+++ b/pkg/authevents/store.go
@@ -65,9 +65,35 @@ const maxListLimit = 10000
 // MemoryStore is an in-process Store for tests and for dev
 // deployments without a database. Events DO NOT survive process
 // restarts. Concurrency-safe.
+//
+// List(...) returns newest-first by OccurredAt, with ties broken by a
+// monotonic insertion counter (seq) so back-to-back inserts that
+// produce identical OccurredAt values still yield a deterministic
+// order. Identical-timestamp ties happen on hardware where
+// time.Now()'s wall-clock granularity is coarser than the time
+// between two consecutive Insert calls — common on Apple Silicon when
+// tests run without -race.
+//
+// PostgresStore (store_postgres.go) does NOT have a comparable
+// tie-breaker — the table's primary key is a random UUID and List's
+// query is "ORDER BY occurred_at DESC" with no secondary sort. The
+// only production consumer of either backend that depends on this
+// ordering is admin.lastRevocationFor, which scans the most recent
+// few events for any revocation lead type and tolerates either order
+// (both the lead and the trail of a revocation pair carry the same
+// reason). Inside test code we still want determinism, hence the
+// counter here.
 type MemoryStore struct {
 	mu     sync.Mutex
-	events []Event
+	events []memEvent
+	seq    uint64
+}
+
+// memEvent wraps Event with the insertion sequence so List can break
+// ties on identical OccurredAt deterministically.
+type memEvent struct {
+	Event
+	seq uint64
 }
 
 // NewMemoryStore returns an in-process Store. The Postgres store is
@@ -91,7 +117,8 @@ func (s *MemoryStore) Insert(_ context.Context, ev Event) error {
 	if ev.ID == "" {
 		ev.ID = uuid.NewString()
 	}
-	s.events = append(s.events, ev)
+	s.seq++
+	s.events = append(s.events, memEvent{Event: ev, seq: s.seq})
 	return nil
 }
 
@@ -109,19 +136,28 @@ func (s *MemoryStore) List(_ context.Context, f Filter) ([]Event, error) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	matched := make([]Event, 0, f.Limit)
+	matched := make([]memEvent, 0, f.Limit)
 	for _, ev := range s.events {
-		if matchesFilter(ev, f) {
+		if matchesFilter(ev.Event, f) {
 			matched = append(matched, ev)
 		}
 	}
+	// Sort newest-first. OccurredAt is the primary key; seq breaks
+	// ties from identical wall-clock timestamps (see MemoryStore doc).
 	sort.Slice(matched, func(i, j int) bool {
+		if matched[i].OccurredAt.Equal(matched[j].OccurredAt) {
+			return matched[i].seq > matched[j].seq
+		}
 		return matched[i].OccurredAt.After(matched[j].OccurredAt)
 	})
 	if len(matched) > f.Limit {
 		matched = matched[:f.Limit]
 	}
-	return matched, nil
+	out := make([]Event, len(matched))
+	for i, m := range matched {
+		out[i] = m.Event
+	}
+	return out, nil
 }
 
 // matchesFilter returns true when ev satisfies every non-zero

--- a/pkg/connoauth/source.go
+++ b/pkg/connoauth/source.go
@@ -147,22 +147,32 @@ func (s *Source) Token(ctx context.Context) (string, error) {
 	return fresh.AccessToken, nil
 }
 
-// handleRevoked is the shared revoked-refresh cleanup used by Token()
-// and Reacquire(). The row is deleted (a dead credential must not be
-// replayed across process restarts) AND the deletion is observable:
-// an INFO log line replaces the previously silent `_ = Delete(...)`,
-// and an authevents row pair (refresh_failed_revoked +
-// token_deleted_revoked) lands in the History panel so operators see
-// the why and when on the connection's status card.
+// handleRevoked is the shared cleanup used by Token() and Reacquire()
+// when the persisted credential cannot be used to obtain a fresh
+// access token. The row is deleted (a dead credential must not be
+// replayed across process restarts) AND the deletion is observable
+// via an INFO log line and an authevents row pair in the History
+// panel.
+//
+// The leading event differs by cause and that distinction matters in
+// the History panel:
+//
+//   - errRefreshTokenRevoked: the IdP was called and returned RFC 6749
+//     §5.2 invalid_grant. Emits TypeRefreshFailedRevoked.
+//   - errRefreshExpired: the IdP-disclosed refresh deadline arrived;
+//     the platform skipped the refresh call entirely. Emits
+//     TypeRefreshSkippedExpired so the row does not falsely claim an
+//     IdP rejection.
+//   - errNoRefreshToken: no refresh token was persisted; nothing to
+//     exchange. Emits TypeRefreshSkippedNoToken.
+//
+// The trailing TypeTokenDeletedRevoked event is emitted in all three
+// branches because the end state is the same: the row is gone and the
+// operator must re-authorize.
 func (s *Source) handleRevoked(ctx context.Context, persisted *PersistedToken, refreshErr error) {
 	reason := classifyRevokedReason(refreshErr)
 	idpHost := urlHost(s.cfg.TokenURL)
-	s.events.RefreshFailedRevoked(ctx, s.key.Kind, s.key.Name, s.actor, s.cfg.TokenURL,
-		authevents.RefreshDetail{
-			BeforeExpiresAt:        persisted.ExpiresAt,
-			BeforeRefreshExpiresAt: persisted.RefreshExpiresAt,
-			IDPErrorCode:           reason,
-		})
+	s.emitRevokedLeadEvent(ctx, persisted, refreshErr, reason)
 	if delErr := s.store.Delete(ctx, s.key); delErr != nil {
 		slog.Warn("connoauth: delete revoked token row failed",
 			logKeyKind, s.key.Kind, logKeyName, s.key.Name, logKeyError, delErr)
@@ -172,10 +182,31 @@ func (s *Source) handleRevoked(ctx context.Context, persisted *PersistedToken, r
 	// is factually true. The prior ordering emitted the INFO line
 	// before attempting the delete, which produced a misleading
 	// audit trail when the delete itself failed.
-	slog.Info("connoauth: connection token row deleted: refresh rejected by IdP",
+	slog.Info("connoauth: connection token row deleted",
 		logKeyKind, s.key.Kind, logKeyName, s.key.Name,
 		"reason", reason, logKeyTokenURLHost, idpHost)
 	s.events.TokenDeletedRevoked(ctx, s.key.Kind, s.key.Name, s.actor, s.cfg.TokenURL, reason)
+}
+
+// emitRevokedLeadEvent emits the first event of the revocation pair,
+// choosing the type that accurately describes how the platform reached
+// the verdict. Extracted from handleRevoked so the dispatch is
+// testable in isolation and so handleRevoked stays under the gocognit
+// ceiling.
+func (s *Source) emitRevokedLeadEvent(ctx context.Context, persisted *PersistedToken, refreshErr error, reason string) {
+	switch {
+	case errors.Is(refreshErr, errRefreshExpired):
+		s.events.RefreshSkippedExpired(ctx, s.key.Kind, s.key.Name, s.actor, s.cfg.TokenURL)
+	case errors.Is(refreshErr, errNoRefreshToken):
+		s.events.RefreshSkippedNoToken(ctx, s.key.Kind, s.key.Name, s.actor, s.cfg.TokenURL)
+	default:
+		s.events.RefreshFailedRevoked(ctx, s.key.Kind, s.key.Name, s.actor, s.cfg.TokenURL,
+			authevents.RefreshDetail{
+				BeforeExpiresAt:        persisted.ExpiresAt,
+				BeforeRefreshExpiresAt: persisted.RefreshExpiresAt,
+				IDPErrorCode:           reason,
+			})
+	}
 }
 
 // classifyRevokedReason maps the sentinel errors used internally to
@@ -311,19 +342,16 @@ func (s *Source) Reacquire(ctx context.Context) error {
 // refresh, the rotation is durable across process restarts.
 func (s *Source) refresh(ctx context.Context, persisted *PersistedToken) (*oauth2.Token, error) {
 	if persisted.RefreshToken == "" {
-		// No event emission here. Caller treats this sentinel as
-		// "revoked" via isRevokedRefresh and calls handleRevoked,
-		// which records the cause as IDPErrorCode="no_refresh_token"
-		// in the RefreshFailedRevoked + TokenDeletedRevoked pair.
-		// Emitting RefreshSkippedNoToken in addition would make the
-		// History panel show three events for a single incident,
-		// contradicting the "distinct from RefreshFailedRevoked"
-		// contract on the Skipped types.
+		// No event emission here — the caller's handleRevoked path
+		// emits the TypeRefreshSkippedNoToken lead and the
+		// TypeTokenDeletedRevoked trail for this sentinel. Emitting
+		// from refresh() too would produce three rows for a single
+		// incident.
 		return nil, errNoRefreshToken
 	}
 	if !persisted.RefreshExpiresAt.IsZero() && time.Now().After(persisted.RefreshExpiresAt) {
-		// Same rationale: handleRevoked emits the cause via
-		// IDPErrorCode="refresh_expired"; no additional event here.
+		// Same rationale — handleRevoked emits TypeRefreshSkippedExpired
+		// + TypeTokenDeletedRevoked. No additional event here.
 		return nil, errRefreshExpired
 	}
 	refreshCtx := context.WithValue(ctx, oauth2.HTTPClient, s.client)

--- a/pkg/connoauth/source_events_test.go
+++ b/pkg/connoauth/source_events_test.go
@@ -27,50 +27,88 @@ func TestClassifyRevokedReason(t *testing.T) {
 	}
 }
 
-func TestHandleRevokedEmitsEventsAndDeletes(t *testing.T) {
+// TestHandleRevokedEmitsHonestLeadEvent — each revocation cause must
+// produce a lead event whose type accurately describes how the
+// verdict was reached. The IdP-rejected case stays on
+// TypeRefreshFailedRevoked. The locally-decided cases (deadline
+// reached, no refresh token) emit TypeRefreshSkippedExpired /
+// TypeRefreshSkippedNoToken so the History panel does not falsely
+// attribute the decision to the upstream IdP. All three cases share
+// the trailing TypeTokenDeletedRevoked — the credential is gone
+// regardless of how the verdict was reached.
+func TestHandleRevokedEmitsHonestLeadEvent(t *testing.T) {
 	t.Parallel()
-	tokenStore := NewMemoryStore()
-	eventStore := authevents.NewMemoryStore()
-	writer := authevents.NewWriter(eventStore, nil)
-	key := Key{Kind: KindMCP, Name: "alpha"}
-	persisted := PersistedToken{
-		Key: key, AccessToken: "at", RefreshToken: "rt",
+	cases := []struct {
+		name      string
+		cause     error
+		wantLead  authevents.Type
+		wantTrail authevents.Type
+	}{
+		{
+			name:      "invalid_grant from IdP",
+			cause:     errRefreshTokenRevoked,
+			wantLead:  authevents.TypeRefreshFailedRevoked,
+			wantTrail: authevents.TypeTokenDeletedRevoked,
+		},
+		{
+			name:      "local deadline reached",
+			cause:     errRefreshExpired,
+			wantLead:  authevents.TypeRefreshSkippedExpired,
+			wantTrail: authevents.TypeTokenDeletedRevoked,
+		},
+		{
+			name:      "no refresh token stored",
+			cause:     errNoRefreshToken,
+			wantLead:  authevents.TypeRefreshSkippedNoToken,
+			wantTrail: authevents.TypeTokenDeletedRevoked,
+		},
 	}
-	if err := tokenStore.Set(context.Background(), persisted); err != nil {
-		t.Fatalf("Set: %v", err)
-	}
-	src := NewSource(tokenStore, key, Config{TokenURL: "https://idp/token"}).
-		WithEvents(writer).
-		WithActor(authevents.SystemBackgroundRefresh)
-	src.handleRevoked(context.Background(), &persisted, errRefreshTokenRevoked)
-	// Token row is gone.
-	if _, err := tokenStore.Get(context.Background(), key); !errors.Is(err, ErrTokenNotFound) {
-		t.Errorf("token row should be gone, got %v", err)
-	}
-	// Two events emitted in order: refresh_failed_revoked, token_deleted_revoked.
-	got, _ := eventStore.List(context.Background(),
-		authevents.Filter{Kind: key.Kind, Name: key.Name, Limit: 10})
-	if len(got) != 2 {
-		t.Fatalf("len(got) = %d, want 2: %+v", len(got), got)
-	}
-	// Newest first ordering.
-	if got[0].Type != authevents.TypeTokenDeletedRevoked {
-		t.Errorf("got[0].Type = %v, want token_deleted_revoked", got[0].Type)
-	}
-	if got[1].Type != authevents.TypeRefreshFailedRevoked {
-		t.Errorf("got[1].Type = %v, want refresh_failed_revoked", got[1].Type)
-	}
-	if got[0].Actor != authevents.SystemBackgroundRefresh {
-		t.Errorf("actor = %q, want %q", got[0].Actor, authevents.SystemBackgroundRefresh)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tokenStore := NewMemoryStore()
+			eventStore := authevents.NewMemoryStore()
+			writer := authevents.NewWriter(eventStore, nil)
+			key := Key{Kind: KindMCP, Name: "alpha"}
+			persisted := PersistedToken{
+				Key: key, AccessToken: "at", RefreshToken: "rt",
+			}
+			if err := tokenStore.Set(context.Background(), persisted); err != nil {
+				t.Fatalf("Set: %v", err)
+			}
+			src := NewSource(tokenStore, key, Config{TokenURL: "https://idp/token"}).
+				WithEvents(writer).
+				WithActor(authevents.SystemBackgroundRefresh)
+			src.handleRevoked(context.Background(), &persisted, tc.cause)
+
+			if _, err := tokenStore.Get(context.Background(), key); !errors.Is(err, ErrTokenNotFound) {
+				t.Errorf("token row should be gone, got %v", err)
+			}
+			got, _ := eventStore.List(context.Background(),
+				authevents.Filter{Kind: key.Kind, Name: key.Name, Limit: 10})
+			if len(got) != 2 {
+				t.Fatalf("len(got) = %d, want 2: %+v", len(got), got)
+			}
+			// Newest first.
+			if got[0].Type != tc.wantTrail {
+				t.Errorf("got[0].Type = %v, want %v (trail)", got[0].Type, tc.wantTrail)
+			}
+			if got[1].Type != tc.wantLead {
+				t.Errorf("got[1].Type = %v, want %v (lead)", got[1].Type, tc.wantLead)
+			}
+			if got[0].Actor != authevents.SystemBackgroundRefresh {
+				t.Errorf("actor = %q, want %q", got[0].Actor, authevents.SystemBackgroundRefresh)
+			}
+		})
 	}
 }
 
 // TestRefreshSkippedNoTokenSilent: when refresh() encounters an empty
 // RefreshToken, it returns errNoRefreshToken WITHOUT emitting its own
-// event — the caller's handleRevoked path records the cause via
-// IDPErrorCode="no_refresh_token" on the RefreshFailedRevoked +
-// TokenDeletedRevoked pair. This avoids triple-emission for a
-// single operator-visible incident.
+// event — the caller's handleRevoked path emits the
+// TypeRefreshSkippedNoToken lead and the TypeTokenDeletedRevoked
+// trail. refresh() emitting on its own would produce a third row in
+// the History panel for a single incident.
 func TestRefreshSkippedNoTokenSilent(t *testing.T) {
 	t.Parallel()
 	tokenStore := NewMemoryStore()

--- a/ui/src/pages/settings/ConnectionOAuthStatusCard.test.tsx
+++ b/ui/src/pages/settings/ConnectionOAuthStatusCard.test.tsx
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type {
+  ConnectionAuthEvent,
+  ConnectionOAuthStatus,
+} from "@/api/admin/types";
+
+vi.mock("@/api/admin/hooks", () => ({
+  useConnectionOAuthStatus: vi.fn(),
+  useConnectionAuthEvents: vi.fn(() => ({ data: [], isLoading: false })),
+  useReacquireConnectionOAuth: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  })),
+  useStartConnectionOAuth: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  })),
+}));
+
+import { useConnectionOAuthStatus } from "@/api/admin/hooks";
+import {
+  ConnectionOAuthStatusCard,
+  describeVerdictCode,
+  renderDetailHint,
+  revocationHeadline,
+} from "./ConnectionOAuthStatusCard";
+
+const mockStatus = vi.mocked(useConnectionOAuthStatus);
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+function statusWithRevocation(
+  reason: string,
+  idp_host = "iam.example.io",
+): ConnectionOAuthStatus {
+  return {
+    configured: true,
+    token_acquired: false,
+    has_refresh_token: false,
+    needs_reauth: true,
+    last_revocation: {
+      occurred_at: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString(),
+      reason,
+      idp_host,
+    },
+  };
+}
+
+describe("revocationHeadline", () => {
+  it("returns the locally-decided headline for refresh_expired", () => {
+    // refresh_expired ONLY comes from the local short-circuit in
+    // pkg/connoauth/source.go — the IdP never returns this. The
+    // headline must not claim the IdP rejected anything.
+    expect(revocationHeadline("refresh_expired")).toBe(
+      "Session reached the IdP-disclosed maximum lifetime.",
+    );
+  });
+
+  it("returns the IdP-rejected headline for invalid_grant", () => {
+    expect(revocationHeadline("invalid_grant")).toBe(
+      "Upstream IdP rejected the refresh token.",
+    );
+  });
+
+  it("returns the no-refresh-token headline for no_refresh_token", () => {
+    expect(revocationHeadline("no_refresh_token")).toBe(
+      "No refresh token is stored for this connection.",
+    );
+  });
+
+  it("falls back to a neutral headline for an unknown reason", () => {
+    expect(revocationHeadline("rejected")).toBe("Previous session ended.");
+    expect(revocationHeadline(undefined)).toBe("Previous session ended.");
+  });
+});
+
+describe("describeVerdictCode", () => {
+  it("translates refresh_expired to a locally-decided phrase", () => {
+    // The string "refresh_expired" reads to operators as an IdP error
+    // code. It is not — the platform reached this verdict from a
+    // previously-disclosed deadline without calling the IdP again.
+    expect(describeVerdictCode("refresh_expired")).toBe(
+      "IdP-disclosed deadline reached",
+    );
+  });
+
+  it("translates no_refresh_token to a locally-decided phrase", () => {
+    expect(describeVerdictCode("no_refresh_token")).toBe(
+      "no refresh token stored",
+    );
+  });
+
+  it("passes invalid_grant through verbatim (the IdP did return it)", () => {
+    expect(describeVerdictCode("invalid_grant")).toBe("invalid_grant");
+  });
+
+  it("passes any unknown code through verbatim", () => {
+    expect(describeVerdictCode("server_error")).toBe("server_error");
+    expect(describeVerdictCode("")).toBe("");
+  });
+});
+
+function makeEvent(overrides: Partial<ConnectionAuthEvent>): ConnectionAuthEvent {
+  return {
+    id: "evt-1",
+    occurred_at: "2026-05-14T10:10:05Z",
+    event_type: "refresh_failed_revoked",
+    actor: "system:background-refresh",
+    ...overrides,
+  };
+}
+
+describe("renderDetailHint", () => {
+  it("translates idp_error_code=refresh_expired so the row doesn't blame the IdP", () => {
+    const hint = renderDetailHint(
+      makeEvent({ detail: { idp_error_code: "refresh_expired" } }),
+    );
+    expect(hint).toBe("(IdP-disclosed deadline reached)");
+  });
+
+  it("translates reason=refresh_expired on token_deleted_revoked rows", () => {
+    const hint = renderDetailHint(
+      makeEvent({
+        event_type: "token_deleted_revoked",
+        detail: { reason: "refresh_expired" },
+      }),
+    );
+    expect(hint).toBe("(IdP-disclosed deadline reached)");
+  });
+
+  it("preserves invalid_grant verbatim — that one came from the IdP", () => {
+    const hint = renderDetailHint(
+      makeEvent({ detail: { idp_error_code: "invalid_grant" } }),
+    );
+    expect(hint).toBe("(invalid_grant)");
+  });
+
+  it("renders rotated-refresh hint with duration", () => {
+    const hint = renderDetailHint(
+      makeEvent({
+        event_type: "refresh_succeeded",
+        detail: { rotated_refresh: true, duration_ms: 116 },
+      }),
+    );
+    expect(hint).toBe("(rotated refresh, 116ms)");
+  });
+
+  it("returns empty string when nothing notable is in detail", () => {
+    expect(renderDetailHint(makeEvent({ detail: {} }))).toBe("");
+    expect(renderDetailHint(makeEvent({}))).toBe("");
+  });
+});
+
+// Render-level tests prove the JSX assembly produces a banner whose
+// visible text matches what the wording function returned — the pure
+// unit tests above can't catch mistakes like wiring the headline to
+// the wrong branch or losing the host in the JSX.
+describe("ConnectionOAuthStatusCard banner rendering", () => {
+  it("for refresh_expired, the banner does NOT claim the IdP returned an error", () => {
+    mockStatus.mockReturnValue({
+      data: statusWithRevocation("refresh_expired", "iam.example.io"),
+      isLoading: false,
+    } as unknown as ReturnType<typeof useConnectionOAuthStatus>);
+
+    render(
+      <ConnectionOAuthStatusCard kind="api" name="Test API" authMode="oauth2_authorization_code" />,
+      { wrapper },
+    );
+
+    expect(
+      screen.getByText("Session reached the IdP-disclosed maximum lifetime."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Previous session rejected by the upstream IdP/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/returned refresh_expired/)).not.toBeInTheDocument();
+    expect(screen.getByText("iam.example.io")).toBeInTheDocument();
+  });
+
+  it("for invalid_grant, the banner attributes the rejection to the IdP", () => {
+    mockStatus.mockReturnValue({
+      data: statusWithRevocation("invalid_grant", "iam.example.io"),
+      isLoading: false,
+    } as unknown as ReturnType<typeof useConnectionOAuthStatus>);
+
+    render(
+      <ConnectionOAuthStatusCard kind="api" name="Test API" authMode="oauth2_authorization_code" />,
+      { wrapper },
+    );
+
+    expect(
+      screen.getByText("Upstream IdP rejected the refresh token."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("invalid_grant")).toBeInTheDocument();
+  });
+
+  it("for no_refresh_token, the banner names the local cause", () => {
+    mockStatus.mockReturnValue({
+      data: statusWithRevocation("no_refresh_token", "iam.example.io"),
+      isLoading: false,
+    } as unknown as ReturnType<typeof useConnectionOAuthStatus>);
+
+    render(
+      <ConnectionOAuthStatusCard kind="api" name="Test API" authMode="oauth2_authorization_code" />,
+      { wrapper },
+    );
+
+    expect(
+      screen.getByText("No refresh token is stored for this connection."),
+    ).toBeInTheDocument();
+  });
+});
+
+// renderDetailHint covers the parenthetical translation in isolation.
+// These two tests guard against an honest mistake elsewhere in the
+// History panel where someone might add a new locally-decided code
+// without translating it.
+describe("History row labels distinguish IdP-rejected from locally-decided", () => {
+  it("renders the refresh_failed_revoked label for an IdP rejection", () => {
+    const hint = renderDetailHint({
+      id: "1",
+      occurred_at: "2026-05-14T10:00:00Z",
+      event_type: "refresh_failed_revoked",
+      actor: "system:tool-call",
+      detail: { idp_error_code: "invalid_grant" },
+    });
+    expect(hint).toBe("(invalid_grant)");
+  });
+
+  it("renders honest text for refresh_skipped_expired", () => {
+    // refresh_skipped_expired events carry no detail payload — the type
+    // alone names the verdict. renderDetailHint returns "" in that case
+    // (no parenthetical), and EVENT_LABELS supplies the row's leading
+    // label "Refresh skipped — IdP-disclosed deadline reached".
+    const hint = renderDetailHint({
+      id: "1",
+      occurred_at: "2026-05-14T10:00:00Z",
+      event_type: "refresh_skipped_expired",
+      actor: "system:background-refresh",
+    });
+    expect(hint).toBe("");
+  });
+});

--- a/ui/src/pages/settings/ConnectionOAuthStatusCard.tsx
+++ b/ui/src/pages/settings/ConnectionOAuthStatusCard.tsx
@@ -199,24 +199,7 @@ function Inner({ kind, name }: { kind: string; name: string }) {
 // to reconnect"). See issue #395 Part 3.
 function ConnectionStatePrompt({ status }: { status: ConnectionOAuthStatus }) {
   if (status.last_revocation) {
-    const reason = status.last_revocation.reason || "rejected";
-    const host = status.last_revocation.idp_host;
-    return (
-      <div className="rounded border border-destructive/30 bg-destructive/10 px-2 py-1.5 text-xs text-destructive">
-        <div className="flex items-start gap-1.5">
-          <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0 mt-0.5" />
-          <div>
-            <span className="font-medium">Previous session rejected by the upstream IdP.</span>{" "}
-            {host && <>The token endpoint at <span className="font-mono">{host}</span> </>}
-            returned <span className="font-mono">{reason}</span>
-            {" "}({formatRelative(status.last_revocation.occurred_at)}).
-            Most common causes: the IdP's SSO session idled out, the operator
-            revoked consent, or the refresh token's wall-clock lifetime
-            expired. Click <strong>Connect</strong> to re-authorize.
-          </div>
-        </div>
-      </div>
-    );
+    return <RevocationPrompt revocation={status.last_revocation} />;
   }
   if (status.token_acquired) {
     return (
@@ -236,6 +219,112 @@ function ConnectionStatePrompt({ status }: { status: ConnectionOAuthStatus }) {
       until the upstream invalidates the refresh token.
     </div>
   );
+}
+
+// RevocationPrompt renders the explainer for a connection whose last
+// known state is "token deleted by the platform." The reason field
+// tells us how the verdict was reached, and the wording differs
+// substantially:
+//
+//   - refresh_expired: NO IdP call happened. The previous successful
+//     refresh response disclosed a hard deadline via refresh_expires_in
+//     (e.g., Keycloak SsoSessionMaxLifespan), the deadline arrived,
+//     and the platform stopped before contacting the IdP. Saying the
+//     IdP "returned refresh_expired" is wrong — the IdP wasn't asked.
+//
+//   - invalid_grant: the IdP was called and returned RFC 6749 §5.2
+//     invalid_grant. The session is genuinely terminated upstream
+//     (operator revoked consent, replay protection fired, etc.).
+//
+//   - no_refresh_token: there was no refresh token to exchange. Always
+//     a local determination — never reached the IdP.
+//
+// Each case gets its own headline and explanation so operators can
+// tell whether the IdP rejected something or the platform respected a
+// deadline.
+function RevocationPrompt({
+  revocation,
+}: {
+  revocation: NonNullable<ConnectionOAuthStatus["last_revocation"]>;
+}) {
+  const reason = revocation.reason;
+  const host = revocation.idp_host;
+  const occurred = formatRelative(revocation.occurred_at);
+  return (
+    <div className="rounded border border-destructive/30 bg-destructive/10 px-2 py-1.5 text-xs text-destructive">
+      <div className="flex items-start gap-1.5">
+        <AlertTriangle className="h-3.5 w-3.5 flex-shrink-0 mt-0.5" />
+        <div>
+          <span className="font-medium">{revocationHeadline(reason)}</span>{" "}
+          <RevocationBody reason={reason} host={host} />
+          {" "}
+          <span className="text-muted-foreground">({occurred})</span>
+          {" "}Click <strong>Connect</strong> to re-authorize.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// revocationHeadline returns the short, bold lead text for each
+// revocation reason. Exported via module scope so the test file can
+// assert exact wording without rendering.
+export function revocationHeadline(reason: string | undefined): string {
+  switch (reason) {
+    case "refresh_expired":
+      return "Session reached the IdP-disclosed maximum lifetime.";
+    case "invalid_grant":
+      return "Upstream IdP rejected the refresh token.";
+    case "no_refresh_token":
+      return "No refresh token is stored for this connection.";
+    default:
+      return "Previous session ended.";
+  }
+}
+
+function RevocationBody({
+  reason,
+  host,
+}: {
+  reason: string | undefined;
+  host: string | undefined;
+}) {
+  const idp = host ? (
+    <span className="font-mono">{host}</span>
+  ) : (
+    <>the upstream IdP</>
+  );
+  switch (reason) {
+    case "refresh_expired":
+      return (
+        <>
+          The previous successful refresh from {idp} disclosed this
+          deadline (typically the IdP's session-lifetime ceiling), so
+          the platform did not attempt another refresh.
+        </>
+      );
+    case "invalid_grant":
+      return (
+        <>
+          {idp} returned <span className="font-mono">invalid_grant</span>.
+          Common causes: the operator revoked consent, the IdP detected
+          replay of a rotated single-use refresh token, or the session
+          was administratively terminated.
+        </>
+      );
+    case "no_refresh_token":
+      return (
+        <>
+          The platform had no refresh token to exchange with {idp}.
+        </>
+      );
+    default:
+      return (
+        <>
+          {idp} could not extend the session.
+        </>
+      );
+  }
 }
 
 // AuthEventHistory is the collapsible History section under the OAuth
@@ -281,17 +370,23 @@ function AuthEventHistory({ kind, name }: { kind: string; name: string }) {
   );
 }
 
+// EVENT_LABELS is the operator-facing label for each event type. The
+// distinction between "failed (revoked)" and the two "skipped" types
+// matters: failed_revoked means the IdP was called and rejected the
+// refresh; the skipped types mean the platform reached the verdict
+// without contacting the IdP (deadline disclosed by a previous
+// successful refresh, or no refresh token was stored).
 const EVENT_LABELS: Record<ConnectionAuthEvent["event_type"], string> = {
   connect_started: "Connect started",
   connect_completed: "Connect completed",
   refresh_succeeded: "Refresh succeeded",
   refresh_failed_transient: "Refresh failed (transient)",
-  refresh_failed_revoked: "Refresh failed (revoked)",
-  refresh_skipped_no_token: "Refresh skipped — no refresh token",
-  refresh_skipped_expired: "Refresh skipped — refresh expired",
+  refresh_failed_revoked: "Refresh rejected by IdP",
+  refresh_skipped_no_token: "Refresh skipped — no refresh token stored",
+  refresh_skipped_expired: "Refresh skipped — IdP-disclosed deadline reached",
   refresh_rotation_persistence_failed: "Rotated token persistence failed",
-  token_deleted_revoked: "Token deleted — revoked",
-  token_deleted_admin: "Token deleted — admin",
+  token_deleted_revoked: "Token row deleted",
+  token_deleted_admin: "Token row deleted — admin",
 };
 
 const EVENT_TONE: Record<ConnectionAuthEvent["event_type"], string> = {
@@ -300,7 +395,7 @@ const EVENT_TONE: Record<ConnectionAuthEvent["event_type"], string> = {
   refresh_succeeded: "text-emerald-600 dark:text-emerald-400",
   refresh_failed_transient: "text-amber-600 dark:text-amber-400",
   refresh_failed_revoked: "text-destructive",
-  refresh_skipped_no_token: "text-muted-foreground",
+  refresh_skipped_no_token: "text-amber-600 dark:text-amber-400",
   refresh_skipped_expired: "text-amber-600 dark:text-amber-400",
   refresh_rotation_persistence_failed: "text-destructive font-medium",
   token_deleted_revoked: "text-destructive",
@@ -331,14 +426,14 @@ function AuthEventRow({ event }: { event: ConnectionAuthEvent }) {
 // pulling the most relevant detail fields per Type. Returns empty
 // string when the row has nothing extra worth showing (a clean
 // connect_started, for example).
-function renderDetailHint(ev: ConnectionAuthEvent): string {
+export function renderDetailHint(ev: ConnectionAuthEvent): string {
   if (!ev.detail) return "";
   const d = ev.detail as Record<string, unknown>;
   if (typeof d.idp_error_code === "string" && d.idp_error_code) {
-    return `(${d.idp_error_code})`;
+    return `(${describeVerdictCode(d.idp_error_code)})`;
   }
   if (typeof d.reason === "string" && d.reason) {
-    return `(${d.reason})`;
+    return `(${describeVerdictCode(d.reason)})`;
   }
   if (d.rotated_refresh === true) {
     const ms = typeof d.duration_ms === "number" ? `, ${d.duration_ms}ms` : "";
@@ -348,6 +443,24 @@ function renderDetailHint(ev: ConnectionAuthEvent): string {
     return `(${d.duration_ms}ms)`;
   }
   return "";
+}
+
+// describeVerdictCode translates the short reason codes stored in
+// event detail into honest one-line labels. The backend currently
+// stores `refresh_expired` and `no_refresh_token` for verdicts the
+// platform reached without contacting the IdP — surfacing the raw
+// code reads as "the IdP returned this," which is incorrect. The
+// IdP-returned code `invalid_grant` passes through verbatim because
+// it IS what the IdP returned.
+export function describeVerdictCode(code: string): string {
+  switch (code) {
+    case "refresh_expired":
+      return "IdP-disclosed deadline reached";
+    case "no_refresh_token":
+      return "no refresh token stored";
+    default:
+      return code;
+  }
 }
 
 function StatusGrid({ status }: { status: ConnectionOAuthStatus }) {


### PR DESCRIPTION
## TL;DR

The portal banner on a revoked connection said:

> "Previous session rejected by the upstream IdP. The token endpoint at iam.example.io returned `refresh_expired`."

But in the `refresh_expired` and `no_refresh_token` cases the IdP was never called on that tick. The verdict was reached locally from a deadline previously disclosed by the IdP (or from there being no refresh token at all). The banner was attributing platform decisions to the upstream IdP, and the underlying authevents row was emitting `TypeRefreshFailedRevoked` with a field literally named `IDPErrorCode` carrying a locally-computed value. This PR rewires both layers to be accurate.

## How the verdict is reached, per cause

| Cause sentinel | IdP called? | Lead event (new) | Trail event |
|---|---|---|---|
| `errRefreshTokenRevoked` (RFC 6749 §5.2 `invalid_grant` @ HTTP 400) | yes | `TypeRefreshFailedRevoked` | `TypeTokenDeletedRevoked` |
| `errRefreshExpired` (local deadline check at `source.go:355`) | no | `TypeRefreshSkippedExpired` | `TypeTokenDeletedRevoked` |
| `errNoRefreshToken` (empty `RefreshToken` at `source.go:344`) | no | `TypeRefreshSkippedNoToken` | `TypeTokenDeletedRevoked` |

The trailing `TypeTokenDeletedRevoked` is unchanged in all three branches — the credential row is gone regardless of how the verdict was reached.

The two `TypeRefreshSkipped*` types were already declared in `pkg/authevents/event.go` and already covered by writer tests, but had no production callers. The original doc-comments explicitly said "reserved for future use … current refresh paths DO NOT emit this event — they fold the cause into IDPErrorCode on TypeRefreshFailedRevoked." That folding is exactly the dishonest field-name behavior this PR removes; the doc-comments are rewritten to match.

## What changed

### Backend (`pkg/connoauth/source.go`)

- `handleRevoked` now calls `emitRevokedLeadEvent`, which switches on the sentinel error and emits the lead event type that accurately describes how the verdict was reached.
- Extracted `emitRevokedLeadEvent` keeps `handleRevoked` under the project's gocognit ceiling.
- The "row deleted: refresh rejected by IdP" INFO log line is reworded to "row deleted" — same caveat, the IdP isn't the only thing that can produce this state.
- Comments inside `refresh()` for the two sentinel-return branches are rewritten to describe the current emission contract (the agent caught these as stale in the adversarial review).

### Backend (`pkg/authevents/event.go`)

- Doc-comments on `TypeRefreshFailedRevoked`, `TypeRefreshSkippedExpired`, `TypeRefreshSkippedNoToken` rewritten. `TypeRefreshFailedRevoked` is now scoped strictly to IdP-returned rejections; the two Skipped types are the canonical lead events for locally-decided verdicts.

### Backend (`pkg/admin/connection_oauth_handler.go`)

- `lastRevocationFor` now matches against any of the four revocation-lead types via the new `isRevocationLeadEvent` predicate.
- `reasonForRevocationLead` synthesizes the short reason string for `TypeRefreshSkipped*` (which carry no Detail payload) and falls through to `extractRevocationReason` for the JSON-detail-bearing types.

### Backend (`pkg/authevents/store.go`)

- `MemoryStore.List` was nondeterministic when back-to-back inserts produced identical `OccurredAt` timestamps. This is the actual case on Apple Silicon when tests run without `-race`: clock granularity is coarser than the time between two consecutive `Insert` calls, both rows get the same nanosecond timestamp, and `sort.Slice` is not stable.
- Added a monotonic insertion counter (`seq`) that breaks ties. `TestMemoryStoreListFilters` previously failed deterministically under `go test` and passed only under `go test -race` (which slows execution enough for the clock to advance); now passes both.
- The Postgres backend has no comparable tie-breaker (UUID primary key, no secondary `ORDER BY`). The doc explicitly acknowledges this and notes that `admin.lastRevocationFor` — the only production consumer — tolerates either order because the lead and trail of a revocation pair both carry the same reason.

### UI (`ui/src/pages/settings/ConnectionOAuthStatusCard.tsx`)

- `RevocationPrompt` replaces the single-message banner with a switch on `last_revocation.reason`:
  - `refresh_expired` → "Session reached the IdP-disclosed maximum lifetime. The previous successful refresh from \<idp\> disclosed this deadline (typically the IdP's session-lifetime ceiling), so the platform did not attempt another refresh."
  - `invalid_grant` → "Upstream IdP rejected the refresh token. \<idp\> returned `invalid_grant`. Common causes: operator revoked consent, replay protection, administratively terminated."
  - `no_refresh_token` → "No refresh token is stored for this connection."
  - default → "Previous session ended."
- `EVENT_LABELS` revised: `refresh_failed_revoked` → "Refresh rejected by IdP"; the two `Skipped*` types get explicit "IdP-disclosed deadline reached" / "no refresh token stored" labels with amber tone.
- `renderDetailHint` calls `describeVerdictCode` to translate the parenthetical hint — `(refresh_expired)` becomes `(IdP-disclosed deadline reached)`, `(no_refresh_token)` becomes `(no refresh token stored)`, `(invalid_grant)` passes through verbatim. This handles legacy event rows still on disk from before this PR.

## Tests

- `TestHandleRevokedEmitsHonestLeadEvent` — table-driven over all three sentinel errors, asserts the lead+trail event-type pair is correct and the token row is deleted.
- `TestLastRevocationForSkippedLeads` — table-driven over `TypeRefreshSkippedExpired` and `TypeRefreshSkippedNoToken`, asserts the synthesized reason and host land on the banner-driving `RevocationEvent`.
- `ConnectionOAuthStatusCard.test.tsx` — 18 tests. Pure-function coverage for `revocationHeadline`, `describeVerdictCode`, `renderDetailHint`. Render-level coverage that the DOM no longer contains "Previous session rejected by the upstream IdP" or "returned refresh_expired" for the `refresh_expired` case, AND that the `invalid_grant` case still correctly attributes the rejection to the IdP.

## Verification

- `make verify` — green (fmt, race tests, ≥80% coverage, patch coverage, golangci-lint, gosec, govulncheck, semgrep, CodeQL, dead-code, mutation, goreleaser dry-run, swagger-check, doc-check).
- `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues.
- `go test ./...` without `-race` — green (the MemoryStore tie-breaker fix verified deterministically).
- Adversarial sub-agent review — round 2 verdict CLEAN. Round 1 surfaced two real doc-vs-code drift findings (stale `IDPErrorCode` references in `refresh()` comments after the wiring change; false BIGSERIAL parity claim in `MemoryStore` doc) — both fixed.

## Test plan

- [ ] On a Keycloak realm with a finite `SsoSessionMaxLifespan`, let the background refresher run a connection until the session ceiling is reached. Confirm the History panel now shows `Refresh skipped — IdP-disclosed deadline reached` (amber) followed by `Token row deleted` (red), not `Refresh rejected by IdP`. Confirm the banner reads "Session reached the IdP-disclosed maximum lifetime" with no "returned refresh_expired" wording.
- [ ] On a connection where the IdP genuinely revokes the refresh token (revoke consent in Keycloak admin UI, then trigger a tool call), confirm the History panel shows `Refresh rejected by IdP` followed by `Token row deleted` and the banner reads "Upstream IdP rejected the refresh token."
- [ ] On a connection that never issued a refresh token (scope without `offline_access`), trigger the access-token expiry path and confirm the History panel shows `Refresh skipped — no refresh token stored` followed by `Token row deleted` and the banner reads "No refresh token is stored for this connection."
- [ ] Verify a pre-existing `token_deleted_revoked` row (from before this PR) with `detail.reason = "refresh_expired"` still renders the honest parenthetical `(IdP-disclosed deadline reached)` in the History panel.