### PR TITLE
fix(admin): tolerate nil tools slice from gateway-kind connections

### DIFF
--- a/pkg/admin/connection_handler.go
+++ b/pkg/admin/connection_handler.go
@@ -427,6 +427,16 @@ func mergeConnections(live []liveConnectionInfo, dbInstances []platform.Connecti
 	if result == nil {
 		result = []effectiveConnection{}
 	}
+	// Normalize Tools to a non-nil slice so the JSON wire shape is
+	// always [] for "no tools" instead of null. Some toolkits (notably
+	// the mcp gateway kind, which discovers tools per session) return
+	// a nil Tools() slice; without this, clients written against the
+	// documented []string shape break on the null.
+	for i := range result {
+		if result[i].Tools == nil {
+			result[i].Tools = []string{}
+		}
+	}
 	return result
 }
 

--- a/pkg/admin/connection_handler_test.go
+++ b/pkg/admin/connection_handler_test.go
@@ -604,6 +604,26 @@ func TestMergeConnections(t *testing.T) {
 		assert.NotNil(t, result)
 		assert.Len(t, result, 0)
 	})
+
+	t.Run("nil Tools from live connection normalizes to empty slice", func(t *testing.T) {
+		live := []liveConnectionInfo{
+			{kind: "mcp", name: "gateway", connection: "", tools: nil},
+		}
+		result := mergeConnections(live, nil)
+		require.Len(t, result, 1)
+		assert.NotNil(t, result[0].Tools, "Tools must not be nil after merge")
+		assert.Equal(t, []string{}, result[0].Tools)
+	})
+
+	t.Run("DB-only entries get empty Tools slice not nil", func(t *testing.T) {
+		db := []platform.ConnectionInstance{
+			{Kind: "trino", Name: "prod", Description: "DB"},
+		}
+		result := mergeConnections(nil, db)
+		require.Len(t, result, 1)
+		assert.NotNil(t, result[0].Tools, "DB-only Tools must not be nil")
+		assert.Equal(t, []string{}, result[0].Tools)
+	})
 }
 
 // --- Redaction ---

--- a/ui/src/pages/dashboard/DashboardPage.tsx
+++ b/ui/src/pages/dashboard/DashboardPage.tsx
@@ -302,7 +302,7 @@ export function DashboardPage({ onNavigate }: { onNavigate?: (path: string) => v
                   <span className="text-sm font-medium">{c.name}</span>
                 </div>
                 <p className="mt-1 text-xs text-muted-foreground">
-                  {c.tools.length} tools / {c.connection}
+                  {c.tools?.length ?? 0} tools / {c.connection}
                 </p>
               </div>
             ))}


### PR DESCRIPTION
## Summary

The admin dashboard rendered a blank page on any deployment that registered an mcp gateway connection. Two complementary fixes:

- Backend stops serializing `Tools` as `null` for the gateway-kind connection.
- Frontend stops assuming `Tools` is always an array.

## Root cause

`/api/v1/admin/connections` returns each connection with a `tools` field. Most toolkits register their static tool list at startup and return a populated slice. The mcp gateway kind discovers tools per session and therefore returns a nil slice from `Tools()`. Go's JSON encoder serializes nil as `null`. The TypeScript `ConnectionInfo` type declares `tools: string[]` (non-nullable), so `DashboardPage.tsx:305` read `c.tools.length` directly and threw:

> `Uncaught TypeError: Cannot read properties of null (reading 'length')`

`ConnectionsPanel.tsx:303` already guarded the same field, which is why the Connections settings page rendered correctly while the dashboard went blank.

## Changes

### Backend (`pkg/admin/connection_handler.go`)

`mergeConnections` now normalizes `Tools` to `[]string{}` before returning. The wire shape matches the documented type for every row, regardless of which toolkit produced it.

Two new subtests in `TestMergeConnections` cover:
- a live connection that reports nil tools (the gateway-kind path)
- a DB-only connection where `Tools` is never set

### Frontend (`ui/src/pages/dashboard/DashboardPage.tsx`)

`{c.tools.length}` becomes `{c.tools?.length ?? 0}`. Defensive even after the backend fix lands, so a future regression cannot blank the dashboard.

## Test plan

- [x] `make verify` passes (full suite: gofmt, race tests, lint, security, semgrep, codeql, coverage, dead-code, mutation, release-check)
- [x] Patch coverage 100% on changed lines
- [x] `go test ./pkg/admin/ -run TestMergeConnections` passes with both new subtests
- [x] `cd ui && npm run typecheck && npm run build` pass
- [ ] Live test on a deployment with an mcp gateway-kind connection: navigate to `/portal/admin`, confirm the dashboard renders and the gateway connection card shows `0 tools / `