### PR TITLE
fix(apigateway): tolerate PascalCase primitive type names in OpenAPI specs

### DIFF
--- a/pkg/toolkits/apigateway/catalog/fetch.go
+++ b/pkg/toolkits/apigateway/catalog/fetch.go
@@ -128,7 +128,7 @@ func ParseSpec(raw string) (*openapi3.T, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing: %w: %w", ErrInvalidContent, err)
 	}
-	normalizeArrayItems(doc)
+	normalizeSchemas(doc)
 	err = doc.Validate(loader.Context,
 		openapi3.DisableExamplesValidation(),
 		openapi3.DisableSchemaPatternValidation(),
@@ -140,17 +140,29 @@ func ParseSpec(raw string) (*openapi3.T, error) {
 	return doc, nil
 }
 
-// normalizeArrayItems walks the loaded document and injects a
-// permissive `items: {}` for every schema declared `type: array`
-// that omits an items clause. OpenAPI 3.0 requires items for an
-// array, but real vendor specs routinely omit it to mean "array of
-// unknown shape." Swagger UI, Postman, and Insomnia silently accept
-// this; kin-openapi's strict validator rejects with "when schema
-// type is 'array', schema 'items' must be non-null." The injection
-// happens in place after LoadFromData and before Validate so the
-// validator sees a structurally complete document while the
-// catalog still stores the operator's original spec text verbatim.
-func normalizeArrayItems(doc *openapi3.T) {
+// normalizeSchemas walks the loaded document and applies in-place
+// permissive fixes that vendor SDK generators routinely violate but
+// that Swagger UI, Postman, and Insomnia silently accept. Strict
+// kin-openapi validation runs after this so structural problems
+// (missing operation IDs, unresolved refs, invalid path templates)
+// still fail.
+//
+// Currently normalizes:
+//
+//   - Array schemas missing an `items` clause: injects `items: {}`.
+//     OpenAPI 3.0 requires items for an array, but vendor specs
+//     routinely omit it to mean "array of unknown shape." The
+//     validator would otherwise reject with "when schema type is
+//     'array', schema 'items' must be non-null."
+//   - PascalCase primitive type names: `String` -> `string`,
+//     `Integer` -> `integer`, etc. .NET-style SDK generators emit
+//     these. Only names that case-insensitively match a known
+//     OpenAPI primitive are lowercased, so `type: Strung` still
+//     fails validation.
+//
+// Both normalizations share one walk via the `seen` set so each
+// schema is visited once even with ref cycles.
+func normalizeSchemas(doc *openapi3.T) {
 	seen := map[*openapi3.Schema]bool{}
 	normalizeComponents(doc.Components, seen)
 	if doc.Paths != nil {
@@ -261,10 +273,39 @@ func normalizeSchemaRef(ref *openapi3.SchemaRef, seen map[*openapi3.Schema]bool)
 		return
 	}
 	seen[s] = true
+	normalizeSchemaTypeCase(s)
 	if s.Type != nil && s.Type.Is(openapi3.TypeArray) && s.Items == nil && len(s.PrefixItems) == 0 {
 		s.Items = &openapi3.SchemaRef{Value: &openapi3.Schema{}}
 	}
 	normalizeSchemaChildren(s, seen)
+}
+
+// normalizeSchemaTypeCase lowercases any entry in s.Type that
+// case-insensitively matches a known OpenAPI primitive. Only the
+// canonical 3.x primitive names are accepted; anything else is
+// left alone so strict validation can still flag it.
+func normalizeSchemaTypeCase(s *openapi3.Schema) {
+	if s == nil || s.Type == nil {
+		return
+	}
+	for i, t := range *s.Type {
+		if canonical, ok := canonicalPrimitiveType(t); ok && canonical != t {
+			(*s.Type)[i] = canonical
+		}
+	}
+}
+
+// canonicalPrimitiveType returns the OpenAPI 3.x canonical lowercase
+// form of t when t case-insensitively names a primitive (string,
+// number, integer, boolean, array, object, null). The second return
+// is false for any other value so callers leave it untouched.
+func canonicalPrimitiveType(t string) (string, bool) {
+	switch strings.ToLower(t) {
+	case openapi3.TypeString, openapi3.TypeNumber, openapi3.TypeInteger,
+		openapi3.TypeBoolean, openapi3.TypeArray, openapi3.TypeObject, "null":
+		return strings.ToLower(t), true
+	}
+	return "", false
 }
 
 func normalizeSchemaChildren(s *openapi3.Schema, seen map[*openapi3.Schema]bool) {

--- a/pkg/toolkits/apigateway/catalog/fetch_test.go
+++ b/pkg/toolkits/apigateway/catalog/fetch_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 // stubResolver lets tests pin a hostname to a chosen set of IPs
@@ -592,6 +594,108 @@ func TestParseSpec_AcceptsArrayWithoutItems_AllCallSites(t *testing.T) {
 	}
 }
 
+// TestParseSpec_AcceptsPascalCaseType reproduces the fourth
+// real-world drift pattern: vendor SDK generators (.NET-style)
+// emit PascalCase primitive type names ("String", "Integer") that
+// strict kin-openapi rejects with "unsupported 'type' value
+// 'String'." Swagger UI, Postman, and Insomnia accept these.
+// ParseSpec must match by lowercasing primitive names case-
+// insensitively before strict validation runs, in every place
+// schemas appear.
+func TestParseSpec_AcceptsPascalCaseType(t *testing.T) {
+	t.Parallel()
+	const spec = `{
+  "openapi": "3.0.1",
+  "info": {"title": "T", "version": "1.0"},
+  "paths": {
+    "/items": {
+      "post": {
+        "operationId": "createItem",
+        "parameters": [
+          {"name": "tag", "in": "query", "schema": {"type": "String"}}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {"$ref": "#/components/schemas/Item"}
+            }
+          }
+        },
+        "responses": {"200": {"description": "ok"}}
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Item": {
+        "type": "Object",
+        "properties": {
+          "id":     {"type": "Integer"},
+          "label":  {"type": "String"},
+          "active": {"type": "Boolean"},
+          "score":  {"type": "Number"},
+          "tags":   {"type": "Array", "items": {"type": "String"}}
+        }
+      }
+    }
+  }
+}`
+	doc, err := ParseSpec(spec)
+	if err != nil {
+		t.Fatalf("ParseSpec rejected a spec with PascalCase types: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("ParseSpec returned nil doc with nil error")
+	}
+
+	item := doc.Components.Schemas["Item"].Value
+	if !item.Type.Is(openapi3.TypeObject) {
+		t.Errorf("Item.Type = %v, want object", item.Type)
+	}
+	props := item.Properties
+	wantTypes := map[string]string{
+		"id":     openapi3.TypeInteger,
+		"label":  openapi3.TypeString,
+		"active": openapi3.TypeBoolean,
+		"score":  openapi3.TypeNumber,
+		"tags":   openapi3.TypeArray,
+	}
+	for name, want := range wantTypes {
+		if !props[name].Value.Type.Is(want) {
+			t.Errorf("Item.%s.Type = %v, want %s", name, props[name].Value.Type, want)
+		}
+	}
+}
+
+// TestCanonicalPrimitiveType verifies the case-insensitive
+// primitive lookup that backs PascalCase normalization. Only the
+// seven OpenAPI 3.x primitives are recognized; any other input
+// (including typos) is left alone for strict validation to flag.
+func TestCanonicalPrimitiveType(t *testing.T) {
+	t.Parallel()
+	primitives := []string{"string", "number", "integer", "boolean", "array", "object", "null"}
+	for _, p := range primitives {
+		variants := []string{p, strings.ToUpper(p[:1]) + p[1:], strings.ToUpper(p)}
+		for _, v := range variants {
+			got, ok := canonicalPrimitiveType(v)
+			if !ok {
+				t.Errorf("canonicalPrimitiveType(%q) ok=false, want true", v)
+				continue
+			}
+			if got != p {
+				t.Errorf("canonicalPrimitiveType(%q) = %q, want %q", v, got, p)
+			}
+		}
+	}
+	rejects := []string{"", "Strung", "stringy", "int", "bool", "Long", "Map", "List"}
+	for _, r := range rejects {
+		if got, ok := canonicalPrimitiveType(r); ok {
+			t.Errorf("canonicalPrimitiveType(%q) ok=true got=%q, want false", r, got)
+		}
+	}
+}
+
 // TestParseSpec_RejectsStructuralErrors guards against over-leniency:
 // structural problems (missing required field, malformed JSON) must
 // still fail. The disabled options are scoped to documentation
@@ -599,13 +703,14 @@ func TestParseSpec_AcceptsArrayWithoutItems_AllCallSites(t *testing.T) {
 func TestParseSpec_RejectsStructuralErrors(t *testing.T) {
 	t.Parallel()
 	cases := map[string]string{
-		"empty":           "",
-		"whitespace":      "   \n  ",
-		"not-json":        "not a spec",
-		"missing-openapi": `{"info": {"title": "T", "version": "1.0"}, "paths": {}}`,
-		"missing-info":    `{"openapi": "3.0.1", "paths": {}}`,
-		"truncated":       `{"openapi": "3.0.1", "info":`,
-		"invalid-ref":     `{"openapi":"3.0.1","info":{"title":"T","version":"1.0"},"paths":{"/x":{"get":{"responses":{"200":{"$ref":"#/components/responses/Missing"}}}}}}`,
+		"empty":                  "",
+		"whitespace":             "   \n  ",
+		"not-json":               "not a spec",
+		"missing-openapi":        `{"info": {"title": "T", "version": "1.0"}, "paths": {}}`,
+		"missing-info":           `{"openapi": "3.0.1", "paths": {}}`,
+		"truncated":              `{"openapi": "3.0.1", "info":`,
+		"invalid-ref":            `{"openapi":"3.0.1","info":{"title":"T","version":"1.0"},"paths":{"/x":{"get":{"responses":{"200":{"$ref":"#/components/responses/Missing"}}}}}}`,
+		"bad-type-not-primitive": `{"openapi":"3.0.1","info":{"title":"T","version":"1.0"},"paths":{},"components":{"schemas":{"X":{"type":"Strung"}}}}`,
 	}
 	for name, raw := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

The portal's "Add component spec" upload rejected a vendor OpenAPI spec with the error:

```
unsupported 'type' value "String"
```

.NET-based SDK generators emit PascalCase primitive type names (`type: String`, `type: Integer`, `type: Object`) in the OpenAPI schemas they ship. OpenAPI 3.x requires the canonical lowercase forms, and strict kin-openapi validation rejects on case. Swagger UI, Postman, and Insomnia silently accept the PascalCase variants. `ParseSpec` now matches that behavior. This is the fourth drift pattern accommodated by the v1.61.6 leniency work.

## Change

`pkg/toolkits/apigateway/catalog/fetch.go`

- New `normalizeSchemaTypeCase(s *openapi3.Schema)`: walks the entries in `s.Type` and lowercases any whose lowercased form matches a known OpenAPI primitive (`string`, `number`, `integer`, `boolean`, `array`, `object`, `null`). Anything else is left alone so strict validation still flags real errors.
- New `canonicalPrimitiveType(t string) (string, bool)`: the primitive lookup. Bounded to seven names so language-specific aliases like `Long`, `Map`, `List` are rejected.
- `normalizeSchemaRef` calls `normalizeSchemaTypeCase` before the array-items check, so a schema declared `type: Array` with no items gets lowercased to `array` first and then receives the permissive `items: {}` injection.
- `normalizeArrayItems` renamed to `normalizeSchemas` and its doc comment updated to list both normalizations that share the walk. One pass, one ref-cycle seen-set, no extra traversal cost.

## Tests

`pkg/toolkits/apigateway/catalog/fetch_test.go`

- `TestParseSpec_AcceptsPascalCaseType` reproduces the failing spec shape: every primitive name in PascalCase across query parameters, request body refs, and component-schema properties. Asserts the parsed doc reports canonical lowercase types after normalization.
- `TestCanonicalPrimitiveType` covers the primitive lookup positively (lowercase / PascalCase / UPPERCASE accepted) and negatively (typos like `Strung`, language-specific names like `Long` / `Map` / `List` rejected).
- `TestParseSpec_RejectsStructuralErrors` gains a `bad-type-not-primitive` case to guard against over-leniency. `type: Strung` must still fail validation.

## Verification

Parsed the real-world vendor spec that surfaced the bug (46 component schemas, multiple PascalCase types throughout). It now parses cleanly:

```
OK: title="Lists V2" paths=6 schemas=46
```

## Test plan

- [x] `make verify` passes (full suite: gofmt, race tests, lint, gosec, semgrep, codeql, coverage, dead-code, mutation, release-check)
- [x] Patch coverage 100% on changed lines (16/16)
- [x] `go test ./pkg/toolkits/apigateway/catalog/` passes including the new and updated tests
- [x] Real-world vendor spec (the one that triggered the bug report) now parses through `ParseSpec`
- [ ] Live test: re-upload the spec via the portal's "Add component spec" flow after this ships, confirm validation succeeds