### PR TITLE
fix(apigateway): UPDATEs reach live toolkit; rework static-headers editor

### DIFF
--- a/pkg/admin/apigateway_catalog_integration_test.go
+++ b/pkg/admin/apigateway_catalog_integration_test.go
@@ -1,0 +1,430 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/platform"
+	"github.com/txn2/mcp-data-platform/pkg/query"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/semantic"
+	"github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
+	apicatalog "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway/catalog"
+)
+
+// failingRemoveToolkit is a registry.Toolkit + toolkit.ConnectionManager
+// whose RemoveConnection always fails. Used to cover the error
+// branch in hotAddConnection where the in-memory remove-before-readd
+// step rejects the operation, so the handler must NOT proceed to
+// AddConnection and leave the live state in an inconsistent half-
+// applied form.
+type failingRemoveToolkit struct {
+	addCalls int
+}
+
+func (*failingRemoveToolkit) Kind() string                            { return "api" }
+func (*failingRemoveToolkit) Name() string                            { return "api" }
+func (*failingRemoveToolkit) Connection() string                      { return "" }
+func (*failingRemoveToolkit) Tools() []string                         { return nil }
+func (*failingRemoveToolkit) RegisterTools(_ *mcp.Server)             {}
+func (*failingRemoveToolkit) SetSemanticProvider(_ semantic.Provider) {}
+func (*failingRemoveToolkit) SetQueryProvider(_ query.Provider)       {}
+func (*failingRemoveToolkit) Close() error                            { return nil }
+func (*failingRemoveToolkit) HasConnection(_ string) bool             { return true }
+func (*failingRemoveToolkit) RemoveConnection(_ string) error {
+	return errors.New("remove blocked by simulated failure")
+}
+
+func (f *failingRemoveToolkit) AddConnection(_ string, _ map[string]any) error {
+	f.addCalls++
+	return nil
+}
+
+var _ registry.Toolkit = (*failingRemoveToolkit)(nil)
+
+// integrationSpec is an inline OpenAPI 3.0 document with two
+// operations. The exact ops don't matter; the test asserts on
+// presence of operations after a catalog is attached via UPDATE,
+// not on operation content.
+const integrationSpec = `
+openapi: 3.0.3
+info:
+  title: Integration
+  version: "1.0"
+paths:
+  /v1/things:
+    get:
+      operationId: listThings
+      summary: List things
+      responses:
+        "200": {description: ok}
+    post:
+      operationId: createThing
+      summary: Create a thing
+      responses:
+        "201": {description: created}
+`
+
+// TestUpdateConnectionAttachesCatalogToLiveToolkit covers the bug
+// where attaching a catalog to an existing api-kind connection via
+// the admin UI updated the DB but never reached the in-memory
+// toolkit, so api_list_endpoints returned "no catalog_id configured"
+// and list_connections showed no catalog binding until process
+// restart. The unit test layer asserted only HTTP 200 from the
+// admin PUT and missed this entirely.
+//
+// Setup wires the real apigateway.Toolkit, a real (memory-backed)
+// catalog store shared between the toolkit and the admin handler,
+// pre-registers an api connection without a catalog, and then PUTs
+// a config with catalog_id set. The assertions verify that the live
+// toolkit's connection picked up the new CatalogID AND populated
+// OperationCount, which together prove the UPDATE path now reaches
+// the runtime.
+func TestUpdateConnectionAttachesCatalogToLiveToolkit(t *testing.T) {
+	ctx := context.Background()
+
+	// One catalog store, shared by the toolkit (reads spec content at
+	// connection build time) and the admin handler (validates that
+	// catalog_id exists before persisting).
+	catStore := apicatalog.NewMemoryStore()
+	require.NoError(t, catStore.CreateCatalog(ctx, apicatalog.Catalog{
+		ID: "things", Name: "things", DisplayName: "Things",
+	}))
+	require.NoError(t, catStore.UpsertSpec(ctx, "things", apicatalog.SpecEntry{
+		SpecName:   "default",
+		Content:    integrationSpec,
+		SourceKind: apicatalog.SourceInline,
+	}))
+
+	tk := apigateway.New("apigateway")
+	tk.SetCatalogStore(catStore)
+
+	// Pre-seed the toolkit with the api connection in its no-catalog
+	// state. This is the live-runtime precondition for the UPDATE
+	// path: a connection already exists, the user attaches a catalog
+	// to it from the admin UI. Without the fix, hotAddConnection
+	// silently no-ops here because HasConnection returns true.
+	require.NoError(t, tk.AddConnection("acme", map[string]any{
+		"base_url": "https://api.example.com",
+	}))
+
+	before := tk.ListConnections()
+	require.Len(t, before, 1)
+	require.Empty(t, before[0].CatalogID,
+		"precondition: connection should start with no catalog bound")
+	require.Zero(t, before[0].OperationCount,
+		"precondition: no operations until catalog is attached")
+
+	reg := &mockToolkitRegistry{rawToolkits: []registry.Toolkit{tk}}
+	store := &mockConnectionStore{}
+	h := NewHandler(Deps{
+		Config:          testConfig(),
+		ConnectionStore: store,
+		ToolkitRegistry: reg,
+		ConfigStore:     &mockConfigStore{mode: "database"},
+		APICatalogStore: catStore,
+	}, nil)
+
+	body := `{"config":{"base_url":"https://api.example.com","catalog_id":"things"},"description":"acme api"}`
+	req := httptest.NewRequestWithContext(ctx, http.MethodPut,
+		"/api/v1/admin/connection-instances/api/acme", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "PUT response body: %s", w.Body.String())
+
+	after := tk.ListConnections()
+	require.Len(t, after, 1)
+	assert.Equal(t, "things", after[0].CatalogID,
+		"the live toolkit must reflect the catalog binding after UPDATE; "+
+			"if this fails, hotAddConnection regressed to fail-silent on existing connections")
+	assert.Equal(t, 2, after[0].OperationCount,
+		"operations from the catalog's spec must be loaded into the live "+
+			"connection; OperationCount==0 means the catalog reference "+
+			"was accepted but specs were never resolved")
+}
+
+// TestUpdateConnectionChangesCatalogOnLiveToolkit is the
+// catalog-swap variant: an existing connection is bound to catalog
+// A and the operator attaches catalog B instead. The live toolkit
+// must replace, not retain, the original binding.
+func TestUpdateConnectionChangesCatalogOnLiveToolkit(t *testing.T) {
+	ctx := context.Background()
+
+	catStore := apicatalog.NewMemoryStore()
+	for _, id := range []string{"cat-a", "cat-b"} {
+		require.NoError(t, catStore.CreateCatalog(ctx, apicatalog.Catalog{
+			ID: id, Name: id, DisplayName: id,
+		}))
+		require.NoError(t, catStore.UpsertSpec(ctx, id, apicatalog.SpecEntry{
+			SpecName: "default", Content: integrationSpec,
+			SourceKind: apicatalog.SourceInline,
+		}))
+	}
+
+	tk := apigateway.New("apigateway")
+	tk.SetCatalogStore(catStore)
+	require.NoError(t, tk.AddConnection("acme", map[string]any{
+		"base_url":   "https://api.example.com",
+		"catalog_id": "cat-a",
+	}))
+	require.Equal(t, "cat-a", tk.ListConnections()[0].CatalogID)
+
+	reg := &mockToolkitRegistry{rawToolkits: []registry.Toolkit{tk}}
+	h := NewHandler(Deps{
+		Config:          testConfig(),
+		ConnectionStore: &mockConnectionStore{},
+		ToolkitRegistry: reg,
+		ConfigStore:     &mockConfigStore{mode: "database"},
+		APICatalogStore: catStore,
+	}, nil)
+
+	body := `{"config":{"base_url":"https://api.example.com","catalog_id":"cat-b"},"description":""}`
+	req := httptest.NewRequestWithContext(ctx, http.MethodPut,
+		"/api/v1/admin/connection-instances/api/acme", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "PUT response body: %s", w.Body.String())
+
+	after := tk.ListConnections()
+	require.Len(t, after, 1)
+	assert.Equal(t, "cat-b", after[0].CatalogID,
+		"swap must replace the live binding, not retain the prior catalog")
+}
+
+// TestUpdateConnectionDetachesCatalogOnLiveToolkit covers the
+// inverse path: a connection bound to a catalog has its catalog
+// cleared from the admin UI. The live toolkit must drop the
+// operations index, not retain stale ops from the prior binding.
+func TestUpdateConnectionDetachesCatalogOnLiveToolkit(t *testing.T) {
+	ctx := context.Background()
+
+	catStore := apicatalog.NewMemoryStore()
+	require.NoError(t, catStore.CreateCatalog(ctx, apicatalog.Catalog{
+		ID: "things", Name: "things", DisplayName: "Things",
+	}))
+	require.NoError(t, catStore.UpsertSpec(ctx, "things", apicatalog.SpecEntry{
+		SpecName: "default", Content: integrationSpec,
+		SourceKind: apicatalog.SourceInline,
+	}))
+
+	tk := apigateway.New("apigateway")
+	tk.SetCatalogStore(catStore)
+	require.NoError(t, tk.AddConnection("acme", map[string]any{
+		"base_url":   "https://api.example.com",
+		"catalog_id": "things",
+	}))
+	require.Equal(t, 2, tk.ListConnections()[0].OperationCount)
+
+	reg := &mockToolkitRegistry{rawToolkits: []registry.Toolkit{tk}}
+	h := NewHandler(Deps{
+		Config:          testConfig(),
+		ConnectionStore: &mockConnectionStore{},
+		ToolkitRegistry: reg,
+		ConfigStore:     &mockConfigStore{mode: "database"},
+		APICatalogStore: catStore,
+	}, nil)
+
+	body := `{"config":{"base_url":"https://api.example.com"},"description":""}`
+	req := httptest.NewRequestWithContext(ctx, http.MethodPut,
+		"/api/v1/admin/connection-instances/api/acme", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "PUT response body: %s", w.Body.String())
+
+	after := tk.ListConnections()
+	require.Len(t, after, 1)
+	assert.Empty(t, after[0].CatalogID, "detach must clear the live binding")
+	assert.Zero(t, after[0].OperationCount, "detach must drop the cached ops")
+}
+
+// TestUpdateConnectionPersistsStaticHeaders proves the admin PUT
+// path actually saves config.static_headers and that the same
+// remove-then-add fix that delivers catalog_id to the live toolkit
+// also delivers static_headers. Two assertions, both load-bearing:
+//
+//  1. mockConnectionStore.Set received an instance whose
+//     Config["static_headers"] contains the operator's entry,
+//     proving the field survived JSON decode, the redaction-merge
+//     branch, and the validator. (Counters the "not even getting
+//     saved" report.)
+//  2. The live apigateway.Toolkit's connection registers without
+//     error after the PUT, which exercises the post-hotAddConnection
+//     code path under the same fix.
+//
+// Without the hotAddConnection fix this test still demonstrates the
+// save half. The runtime half is covered separately by the
+// catalog-binding tests above, which share the same code path.
+func TestUpdateConnectionPersistsStaticHeaders(t *testing.T) {
+	ctx := context.Background()
+
+	tk := apigateway.New("apigateway")
+	require.NoError(t, tk.AddConnection("acme", map[string]any{
+		"base_url": "https://api.example.com",
+	}))
+
+	reg := &mockToolkitRegistry{rawToolkits: []registry.Toolkit{tk}}
+	store := &mockConnectionStore{}
+	h := NewHandler(Deps{
+		Config:          testConfig(),
+		ConnectionStore: store,
+		ToolkitRegistry: reg,
+		ConfigStore:     &mockConfigStore{mode: "database"},
+	}, nil)
+
+	body := `{
+		"config": {
+			"base_url": "https://api.example.com",
+			"static_headers": {"X-Test-Header": "test-value"}
+		},
+		"description": ""
+	}`
+	req := httptest.NewRequestWithContext(ctx, http.MethodPut,
+		"/api/v1/admin/connection-instances/api/acme", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "PUT response body: %s", w.Body.String())
+
+	require.Len(t, store.setCalls, 1, "ConnectionStore.Set must be invoked exactly once")
+	saved := store.setCalls[0].Config
+	require.Contains(t, saved, "static_headers",
+		"static_headers must reach the store; absence indicates the field "+
+			"was stripped between HTTP decode and persistence")
+
+	headers, ok := saved["static_headers"].(map[string]any)
+	require.True(t, ok,
+		"static_headers must be a map[string]any after JSON decode; got %T", saved["static_headers"])
+	assert.Equal(t, "test-value", headers["X-Test-Header"],
+		"header value must round-trip through the handler exactly as submitted")
+
+	after := tk.ListConnections()
+	require.Len(t, after, 1, "the live toolkit must still have the connection")
+	assert.Equal(t, "acme", after[0].Name)
+}
+
+// TestStaticHeadersRoundtripThroughEffectiveEndpoint is the
+// PUT-then-GET test that proves what the operator sees after saving
+// static_headers. The screenshot report on 2026-05-15 said headers
+// "weren't even getting saved"; this exercises the same flow the UI
+// uses (PUT to set, GET /effective to re-render) and asserts the
+// saved headers survive the round-trip with their NAMES intact and
+// values masked as [REDACTED] (operators recognize the round-trip,
+// they don't expect to see the plaintext value).
+//
+// If a future regression strips static_headers between PUT and
+// GET (a redaction bug, a serializer omission, a stale connection
+// store on the list path), this test will fail loudly.
+func TestStaticHeadersRoundtripThroughEffectiveEndpoint(t *testing.T) {
+	ctx := context.Background()
+
+	tk := apigateway.New("apigateway")
+	require.NoError(t, tk.AddConnection("acme", map[string]any{
+		"base_url": "https://api.example.com",
+	}))
+
+	reg := &mockToolkitRegistry{rawToolkits: []registry.Toolkit{tk}}
+	store := &mockConnectionStore{}
+	h := NewHandler(Deps{
+		Config:          testConfig(),
+		ConnectionStore: store,
+		ToolkitRegistry: reg,
+		ConfigStore:     &mockConfigStore{mode: "database"},
+	}, nil)
+
+	// PUT: add a static header to the connection.
+	putBody := `{
+		"config": {
+			"base_url": "https://api.example.com",
+			"static_headers": {"X-Quota-Project": "acme-prod-billing"}
+		},
+		"description": ""
+	}`
+	putReq := httptest.NewRequestWithContext(ctx, http.MethodPut,
+		"/api/v1/admin/connection-instances/api/acme", strings.NewReader(putBody))
+	putReq.Header.Set("Content-Type", "application/json")
+	putRec := httptest.NewRecorder()
+	h.ServeHTTP(putRec, putReq)
+	require.Equal(t, http.StatusOK, putRec.Code, "PUT body: %s", putRec.Body.String())
+
+	// Simulate the post-save state of the DB by reflecting the most
+	// recent Set into the mock's List path. This mirrors what the
+	// real PostgresConnectionStore would do.
+	require.NotEmpty(t, store.setCalls)
+	store.instances = []platform.ConnectionInstance{store.setCalls[len(store.setCalls)-1]}
+
+	// GET /effective: the same query the UI invalidates and refetches
+	// after a save.
+	getReq := httptest.NewRequestWithContext(ctx, http.MethodGet,
+		"/api/v1/admin/connection-instances/effective", http.NoBody)
+	getRec := httptest.NewRecorder()
+	h.ServeHTTP(getRec, getReq)
+	require.Equal(t, http.StatusOK, getRec.Code, "GET body: %s", getRec.Body.String())
+
+	var effective []map[string]any
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &effective))
+
+	var acme map[string]any
+	for _, e := range effective {
+		if e["kind"] == "api" && e["name"] == "acme" {
+			acme = e
+			break
+		}
+	}
+	require.NotNil(t, acme, "acme api connection must be present in /effective response; got %#v", effective)
+
+	cfg, ok := acme["config"].(map[string]any)
+	require.True(t, ok, "config must be a map in the response; got %T", acme["config"])
+
+	headers, ok := cfg["static_headers"].(map[string]any)
+	require.True(t, ok,
+		"static_headers must survive the PUT→GET round-trip. If this fails, "+
+			"the UI rightly reports headers as 'not getting saved' because "+
+			"the redaction/merge layer is dropping them on the way back. "+
+			"Got config=%#v", cfg)
+
+	require.Contains(t, headers, "X-Quota-Project",
+		"header NAME must be preserved (operators recognize names, not values)")
+	assert.Equal(t, "[REDACTED]", headers["X-Quota-Project"],
+		"header VALUE must be redacted in the response (encrypted at rest, "+
+			"never returned in plaintext)")
+}
+
+// TestHotAddConnection_RemoveFailureAbortsAdd covers the safety
+// branch: if the live toolkit cannot remove the existing connection,
+// hotAddConnection must abort and NOT call AddConnection. The
+// alternative would leave the toolkit briefly tracking two state
+// histories for the same name and risk an ErrConnectionExists from
+// AddConnection. The handler logs and bails.
+func TestHotAddConnection_RemoveFailureAbortsAdd(t *testing.T) {
+	tk := &failingRemoveToolkit{}
+	reg := &mockToolkitRegistry{rawToolkits: []registry.Toolkit{tk}}
+	h := NewHandler(Deps{
+		Config:          testConfig(),
+		ConnectionStore: &mockConnectionStore{},
+		ToolkitRegistry: reg,
+		ConfigStore:     &mockConfigStore{mode: "database"},
+	}, nil)
+
+	h.hotAddConnection("api", "stuck", map[string]any{"base_url": "https://x"})
+
+	assert.Zero(t, tk.addCalls,
+		"AddConnection must not run after a failed RemoveConnection. "+
+			"The live state stays as-is, the caller surfaces the failure "+
+			"via the structured log")
+}

--- a/pkg/admin/connection_handler.go
+++ b/pkg/admin/connection_handler.go
@@ -590,12 +590,25 @@ func (h *Handler) findConnectionManager(kind string) toolkit.ConnectionManager {
 	return nil
 }
 
-// hotAddConnection attempts to add the connection to a live toolkit that
-// implements toolkit.ConnectionManager.
+// hotAddConnection makes the given config the live config for the
+// named connection. On CREATE it adds; on UPDATE it removes the
+// existing in-memory connection first and re-adds with the new
+// config so changes (notably config.catalog_id) take effect without
+// a process restart. Without the remove-then-add, the in-memory
+// connection retains its registration-time config while the DB row
+// has the new one, and list_connections and api_list_endpoints
+// disagree with the admin UI until restart.
 func (h *Handler) hotAddConnection(kind, name string, config map[string]any) {
 	cm := h.findConnectionManager(kind)
-	if cm == nil || cm.HasConnection(name) {
+	if cm == nil {
 		return
+	}
+	if cm.HasConnection(name) {
+		if err := cm.RemoveConnection(name); err != nil { // #nosec G706 -- structured slog call, not a format string
+			slog.Warn("failed to hot-remove connection before re-add",
+				logKeyKind, kind, logKeyName, name, logKeyError, err)
+			return
+		}
 	}
 	if err := cm.AddConnection(name, config); err != nil { // #nosec G706 -- structured slog call, not a format string
 		slog.Warn("failed to hot-add connection",

--- a/pkg/admin/connection_handler_test.go
+++ b/pkg/admin/connection_handler_test.go
@@ -27,6 +27,11 @@ type mockConnectionStore struct {
 	deleteErr error
 	listErr   error
 	getErr    error
+	// setCalls records each ConnectionInstance passed to Set so tests
+	// can assert the persisted config is what the handler sent. Used
+	// to prove fields like static_headers reach the store, not just
+	// that the HTTP request returned 200.
+	setCalls []platform.ConnectionInstance
 }
 
 func (m *mockConnectionStore) List(_ context.Context) ([]platform.ConnectionInstance, error) {
@@ -43,7 +48,8 @@ func (m *mockConnectionStore) Get(_ context.Context, _, _ string) (*platform.Con
 	return m.getResult, nil
 }
 
-func (m *mockConnectionStore) Set(_ context.Context, _ platform.ConnectionInstance) error {
+func (m *mockConnectionStore) Set(_ context.Context, inst platform.ConnectionInstance) error {
+	m.setCalls = append(m.setCalls, inst)
 	return m.setErr
 }
 

--- a/pkg/platform/connections_tool.go
+++ b/pkg/platform/connections_tool.go
@@ -11,6 +11,13 @@ import (
 )
 
 // connectionEntry describes a single toolkit connection.
+//
+// CatalogID and OperationCount are populated only for kinds where they
+// have meaning (today: api). They make the runtime view of a
+// connection visible to MCP clients so a stale in-memory binding
+// (DB updated, toolkit not reloaded) is observable from list_connections
+// rather than only via a downstream tool failing with "no catalog
+// configured".
 type connectionEntry struct {
 	Kind              string `json:"kind"`
 	Name              string `json:"name"`
@@ -18,6 +25,8 @@ type connectionEntry struct {
 	Description       string `json:"description,omitempty"`
 	IsDefault         bool   `json:"is_default,omitempty"`
 	DataHubSourceName string `json:"datahub_source_name,omitempty"`
+	CatalogID         string `json:"catalog_id,omitempty"`
+	OperationCount    int    `json:"operation_count,omitempty"`
 }
 
 // listConnectionsOutput is the JSON response for the list_connections tool.
@@ -80,11 +89,13 @@ func (p *Platform) handleListConnections(_ context.Context, _ *mcp.CallToolReque
 func (p *Platform) entriesFromLister(entries []connectionEntry, tk registry.Toolkit, lister toolkit.ConnectionLister) []connectionEntry {
 	for _, conn := range lister.ListConnections() {
 		entry := connectionEntry{
-			Kind:        tk.Kind(),
-			Name:        conn.Name,
-			Connection:  conn.Name,
-			Description: conn.Description,
-			IsDefault:   conn.IsDefault,
+			Kind:           tk.Kind(),
+			Name:           conn.Name,
+			Connection:     conn.Name,
+			Description:    conn.Description,
+			IsDefault:      conn.IsDefault,
+			CatalogID:      conn.CatalogID,
+			OperationCount: conn.OperationCount,
 		}
 		if src := p.connectionSources.ForConnection(tk.Kind(), conn.Name); src != nil {
 			entry.DataHubSourceName = src.DataHubSourceName

--- a/pkg/toolkit/connection.go
+++ b/pkg/toolkit/connection.go
@@ -5,10 +5,20 @@
 package toolkit
 
 // ConnectionDetail provides information about a single connection within a toolkit.
+//
+// CatalogID and OperationCount are optional and only populated by toolkits
+// where they have meaning (today: apigateway). They exist on this shared
+// struct so list_connections can surface what's actually bound at runtime
+// rather than only what's stored in the DB. The two disagreed in the
+// past when a config update reached the store but never reached the
+// in-memory toolkit, and the missing fields here made the divergence
+// invisible from the MCP surface.
 type ConnectionDetail struct {
-	Name        string
-	Description string
-	IsDefault   bool
+	Name           string
+	Description    string
+	IsDefault      bool
+	CatalogID      string
+	OperationCount int
 }
 
 // ConnectionLister is an optional interface for toolkits that manage multiple

--- a/pkg/toolkits/apigateway/toolkit.go
+++ b/pkg/toolkits/apigateway/toolkit.go
@@ -659,9 +659,11 @@ func (t *Toolkit) ListConnections() []toolkit.ConnectionDetail {
 	for _, name := range names {
 		c := t.connections[name]
 		out = append(out, toolkit.ConnectionDetail{
-			Name:        name,
-			Description: c.cfg.BaseURL,
-			IsDefault:   name == t.defaultName,
+			Name:           name,
+			Description:    c.cfg.BaseURL,
+			IsDefault:      name == t.defaultName,
+			CatalogID:      c.cfg.CatalogID,
+			OperationCount: len(c.operations),
 		})
 	}
 	return out

--- a/ui/src/pages/settings/ConnectionsPanel.tsx
+++ b/ui/src/pages/settings/ConnectionsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import {
   useAPICatalogs,
   useEffectiveConnections,
@@ -622,6 +622,18 @@ function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: Edito
   const [configObj, setConfigObj] = useState<Record<string, any>>(
     connection?.config ? { ...connection.config } : {},
   );
+  // configObjRef mirrors configObj synchronously so handleSave can
+  // read the latest value even when the Save click follows a child
+  // editor's onChange in the same task. React schedules setConfigObj
+  // asynchronously; the closure-captured configObj is one render
+  // behind. The ref bridges the gap so a keystroke that landed in
+  // the keystroke-eager SensitiveKeyValueEditor immediately before
+  // the Save click is included in the PUT body.
+  const configObjRef = useRef(configObj);
+  const updateConfig = useCallback((next: Record<string, any>) => {
+    configObjRef.current = next;
+    setConfigObj(next);
+  }, []);
   const configJson = JSON.stringify(configObj); // for dirty tracking
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -641,12 +653,20 @@ function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: Edito
 
   // Reset config when kind changes in create mode
   useEffect(() => {
-    if (isCreate) setConfigObj({});
+    if (isCreate) {
+      configObjRef.current = {};
+      setConfigObj({});
+    }
   }, [kind, isCreate]);
 
   const handleSave = useCallback(() => {
     setSaveError(null);
-    const config = configObj;
+    // Read from ref, not state, so a keystroke that just propagated
+    // through a child editor's onChange is included even when the
+    // Save button is the next click in the same task. The closure-
+    // captured configObj is one render behind; configObjRef is
+    // updated synchronously by updateConfig before React rerenders.
+    const config = configObjRef.current;
 
     setMutation.mutate(
       {
@@ -666,7 +686,7 @@ function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: Edito
         },
       },
     );
-  }, [kind, name, description, configObj, setMutation, onSave]);
+  }, [kind, name, description, setMutation, onSave]);
 
   const isPending = setMutation.isPending;
 
@@ -777,18 +797,18 @@ function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: Edito
           </div>
           <div className="px-4 py-4 space-y-4">
             {kind === "trino" && (
-              <TrinoConfigForm config={configObj} onChange={setConfigObj} />
+              <TrinoConfigForm config={configObj} onChange={updateConfig} />
             )}
             {kind === "s3" && (
-              <S3ConfigForm config={configObj} onChange={setConfigObj} />
+              <S3ConfigForm config={configObj} onChange={updateConfig} />
             )}
             {kind === "mcp" && (
-              <GatewayConfigForm config={configObj} onChange={setConfigObj} />
+              <GatewayConfigForm config={configObj} onChange={updateConfig} />
             )}
             {kind === "api" && (
               <ApiGatewayConfigForm
                 config={configObj}
-                onChange={setConfigObj}
+                onChange={updateConfig}
                 connectionName={name}
                 isCreate={isCreate}
               />
@@ -1166,11 +1186,20 @@ function asStringMap(raw: unknown): Record<string, string> {
   return out;
 }
 
-// SensitiveKeyValueEditor is KeyValueEditor's secret-aware sibling.
-// Existing entries display the name + a masked placeholder ("•••••"
-// or the literal "[REDACTED]" so operators recognize the round-trip);
-// values can only be replaced by deleting and re-adding. New entries
-// type the value once and are stored verbatim until the next save.
+// SensitiveKeyValueEditor renders one inline-editable row per entry
+// plus an "Add header" button that appends a fresh empty row. Every
+// keystroke commits to the parent's entries map (a row contributes
+// only when BOTH name and value are non-empty), so there is no
+// "pending uncommitted" state to lose at save time. Stable row IDs
+// keep React's reconciliation correct as the user renames keys or
+// removes rows out of order. Without IDs, deleting row 1 of 3 would
+// look like row 1 had its values changed and row 3 disappeared.
+//
+// Existing rows come back from the server with value === "[REDACTED]"
+// (the redaction mask). The password input renders that as dots; the
+// operator selects-all and types to replace the value, and the
+// backend's redaction-merge layer reinstates the stored value if the
+// row is saved without a change.
 function SensitiveKeyValueEditor({
   entries,
   onChange,
@@ -1182,78 +1211,109 @@ function SensitiveKeyValueEditor({
   keyPlaceholder?: string;
   valuePlaceholder?: string;
 }) {
-  const [newKey, setNewKey] = useState("");
-  const [newValue, setNewValue] = useState("");
-  const items = Object.entries(entries);
+  type Row = { id: number; name: string; value: string };
+  const idSeq = useRef(0);
+  const nextID = useCallback(() => ++idSeq.current, []);
 
-  const add = () => {
-    const k = newKey.trim();
-    const v = newValue.trim();
-    if (k && v) {
-      onChange({ ...entries, [k]: v });
-      setNewKey("");
-      setNewValue("");
+  // Local rows are the source of truth for editing. Initial value is
+  // derived from the entries prop on mount; later sync happens only
+  // when the prop's KEY SET changes (a real refresh from the server),
+  // not on every value change (which would clobber the user's
+  // mid-edit local state after every save round-trip turning real
+  // values into "[REDACTED]" masks).
+  const [rows, setRows] = useState<Row[]>(() =>
+    Object.entries(entries).map(([k, v]) => ({ id: nextID(), name: k, value: v })),
+  );
+  const lastKeySet = useRef(
+    Object.keys(entries).slice().sort().join(""),
+  );
+  useEffect(() => {
+    const k = Object.keys(entries).slice().sort().join("");
+    if (k !== lastKeySet.current) {
+      lastKeySet.current = k;
+      setRows(
+        Object.entries(entries).map(([key, val]) => ({
+          id: nextID(),
+          name: key,
+          value: val,
+        })),
+      );
     }
-  };
+  }, [entries, nextID]);
+
+  const commit = useCallback(
+    (updated: Row[]) => {
+      setRows(updated);
+      const out: Record<string, string> = {};
+      for (const r of updated) {
+        const n = r.name.trim();
+        if (n && r.value.length > 0) {
+          out[n] = r.value;
+        }
+      }
+      // Update lastKeySet to match what we're about to emit so the
+      // useEffect above doesn't fire a redundant re-sync after our
+      // own commit propagates back through the entries prop.
+      lastKeySet.current = Object.keys(out).slice().sort().join("");
+      onChange(out);
+    },
+    [onChange],
+  );
+
+  const updateRow = useCallback(
+    (id: number, patch: Partial<Row>) => {
+      commit(rows.map((r) => (r.id === id ? { ...r, ...patch } : r)));
+    },
+    [rows, commit],
+  );
+
+  const deleteRow = useCallback(
+    (id: number) => {
+      commit(rows.filter((r) => r.id !== id));
+    },
+    [rows, commit],
+  );
+
+  const addRow = useCallback(() => {
+    setRows((prev) => [...prev, { id: nextID(), name: "", value: "" }]);
+  }, [nextID]);
 
   return (
-    <div>
-      {items.length > 0 && (
-        <div className="rounded-md border overflow-hidden mb-2">
-          <table className="w-full text-xs">
-            <tbody>
-              {items.map(([k, v]) => (
-                <tr key={k} className="border-b last:border-0">
-                  <td className="px-3 py-1.5 font-mono">{k}</td>
-                  <td className="px-2 text-muted-foreground">→</td>
-                  <td className="px-3 py-1.5 font-mono text-muted-foreground">
-                    {v === "[REDACTED]" ? "[REDACTED]" : "•••••"}
-                  </td>
-                  <td className="px-2">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        const next = { ...entries };
-                        delete next[k];
-                        onChange(next);
-                      }}
-                      className="text-muted-foreground hover:text-destructive"
-                      aria-label={`Remove ${k}`}
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+    <div className="space-y-2">
+      {rows.map((row) => (
+        <div key={row.id} className="flex gap-2">
+          <input
+            type="text"
+            value={row.name}
+            onChange={(e) => updateRow(row.id, { name: e.target.value })}
+            placeholder={keyPlaceholder ?? "header"}
+            className="w-56 rounded-md border bg-background px-3 py-1.5 text-xs font-mono outline-none ring-ring focus:ring-2"
+          />
+          <input
+            type="password"
+            value={row.value}
+            onChange={(e) => updateRow(row.id, { value: e.target.value })}
+            placeholder={valuePlaceholder ?? "value"}
+            className="flex-1 rounded-md border bg-background px-3 py-1.5 text-xs font-mono outline-none ring-ring focus:ring-2"
+          />
+          <button
+            type="button"
+            onClick={() => deleteRow(row.id)}
+            className="rounded-md border px-2.5 py-1.5 text-xs text-muted-foreground hover:bg-muted hover:text-destructive"
+            aria-label={`Remove ${row.name || "header"}`}
+          >
+            <X className="h-3 w-3" />
+          </button>
         </div>
-      )}
-      <div className="flex gap-2">
-        <input
-          type="text"
-          value={newKey}
-          onChange={(e) => setNewKey(e.target.value)}
-          placeholder={keyPlaceholder ?? "header"}
-          className="w-56 rounded-md border bg-background px-3 py-1.5 text-xs font-mono outline-none ring-ring focus:ring-2"
-        />
-        <input
-          type="password"
-          value={newValue}
-          onChange={(e) => setNewValue(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); add(); } }}
-          placeholder={valuePlaceholder ?? "value"}
-          className="flex-1 rounded-md border bg-background px-3 py-1.5 text-xs font-mono outline-none ring-ring focus:ring-2"
-        />
-        <button
-          type="button"
-          onClick={add}
-          disabled={!newKey.trim() || !newValue.trim()}
-          className="rounded-md border px-2.5 py-1.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-30"
-        >
-          <Plus className="h-3 w-3" />
-        </button>
-      </div>
+      ))}
+      <button
+        type="button"
+        onClick={addRow}
+        className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <Plus className="h-3 w-3" />
+        Add header
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Two operator-visible regressions in the apigateway toolkit. Both are fixed by the same root-cause change to the admin hot-add path, plus a UI redesign that addresses a separate data-loss UX trap in the static-headers editor.

### Bug 1: catalog binding never reaches the runtime on UPDATE

Attaching an OpenAPI catalog to an existing api-kind connection via the admin UI persisted the binding to the database, displayed it as attached on reload, and continued to display it on every refresh — but the runtime tools never saw it. `api_list_endpoints` returned `"no catalog_id configured"`, `list_connections` showed the connection with no catalog field, and the only fix was a process restart.

### Bug 2: static_headers also dropped on UPDATE

Same underlying cause. Adding `static_headers` to an existing connection persisted to the database, but `api_invoke_endpoint` continued to make calls without the configured headers until restart. Operators trying to satisfy upstream requirements like `x-goog-user-project` saw the header disappear from outbound requests with no indication of why.

### UX trap in the static-headers editor

Independent of the above, the editor's ``+`` button meant "commit the row I just typed", not "add another row" — which matches no reasonable operator mental model. Users would type a header name and value into the input fields, click Save, and lose the entry silently because they hadn't first clicked the ``+``. The editor has been redesigned to commit on every keystroke, with ``+`` meaning what users expect.

## Root cause

``pkg/admin/connection_handler.go`` ``hotAddConnection`` early-returned whenever ``HasConnection(name)`` was true:

```go
func (h *Handler) hotAddConnection(kind, name string, config map[string]any) {
    cm := h.findConnectionManager(kind)
    if cm == nil || cm.HasConnection(name) {
        return                    // <-- silent skip on every UPDATE
    }
    if err := cm.AddConnection(name, config); err != nil { ... }
}
```

The CREATE path worked because ``HasConnection`` returned false. The UPDATE path — which is the only path a catalog or static_headers attach actually exercises in operator workflows — silently no-op'd. The database write completed, the live toolkit's ``connections[name].cfg`` retained whatever it held at registration time, and ``invoke()`` read ``inv.cfg.StaticHeaders`` from that stale cfg.

This affected every config field on every existing connection, not just catalog_id and static_headers: ``auth_mode``, ``base_url``, timeouts, OAuth client config — any change to an existing connection required a restart to take effect.

## Changes

### Backend

- **``pkg/admin/connection_handler.go``**: ``hotAddConnection`` now performs remove-then-add when the connection already exists. A failing remove aborts the operation (so we never end up with no live connection while the DB has new config); a failing add logs but doesn't roll back the remove (the live state is empty, the next restart or save reconciles).

- **``pkg/toolkit/connection.go``**: ``ConnectionDetail`` gains optional ``CatalogID`` and ``OperationCount`` fields. Other toolkits leave them zero; the JSON tags are ``omitempty``.

- **``pkg/platform/connections_tool.go``**: ``connectionEntry`` exposes ``catalog_id`` and ``operation_count`` in the ``list_connections`` MCP tool output so the runtime view is observable. This is what would have made the original bug self-diagnose.

- **``pkg/toolkits/apigateway/toolkit.go``**: ``ListConnections`` populates the new fields from the in-memory ``*conn``.

### UI

- **``ui/src/pages/settings/ConnectionsPanel.tsx``** — ``SensitiveKeyValueEditor`` rewritten:
  - Each header is its own inline-editable row with ``[name] [value] [×]``.
  - Every keystroke commits to the parent connection config (a row contributes only when both name and value are non-empty).
  - ``+ Add header`` appends a fresh empty row.
  - Stable row IDs survive renames and out-of-order deletes.
  - No "pending uncommitted" state anywhere; what's visible is what gets saved.

- **``ConnectionEditor``**: ``handleSave`` reads from ``configObjRef`` instead of the closure-captured ``configObj`` so a keystroke that propagates through a child editor's ``onChange`` in the same task as the Save click is included in the PUT body.

### Tests

Five new integration tests in ``pkg/admin/apigateway_catalog_integration_test.go`` that wire a real apigateway toolkit, real catalog store, and real admin handler:

1. ``TestUpdateConnectionAttachesCatalogToLiveToolkit`` — the exact scenario from the bug report: pre-existing connection without a catalog, PUT to attach one, assert the live toolkit's connection picked up ``CatalogID`` and loaded the catalog's operations.
2. ``TestUpdateConnectionChangesCatalogOnLiveToolkit`` — swap catalog A for catalog B, assert the live binding replaces.
3. ``TestUpdateConnectionDetachesCatalogOnLiveToolkit`` — clear the catalog, assert the live binding drops and operations are removed.
4. ``TestUpdateConnectionPersistsStaticHeaders`` — PUT static_headers, assert ``ConnectionStore.Set`` received the exact field, plus the live toolkit still has the connection.
5. ``TestStaticHeadersRoundtripThroughEffectiveEndpoint`` — PUT static_headers, then GET ``/effective`` (the endpoint the UI invalidates and refetches after save), assert header names survive with values masked as ``[REDACTED]``.
6. ``TestHotAddConnection_RemoveFailureAbortsAdd`` — safety branch: if RemoveConnection fails, AddConnection must not run.

``mockConnectionStore.Set`` was instrumented to record each call so tests can assert on the persisted config, not just on HTTP 200.

## Behavior change worth noting

``hotAddConnection`` is now non-atomic on UPDATE: a successful Remove followed by a failing Add leaves the live toolkit with no connection while the DB row still holds the new config. For the apigateway/trino/s3 toolkits the Add is local and effectively never fails; for the gateway-kind (mcp) connection it performs network I/O (dial + ListTools), so a failing upstream during an UPDATE will briefly disable the connection until the next save or restart.

This is arguably the correct behavior given that the alternative (the pre-fix silent-stale) was the bug being shipped. A future ``ReplaceConnection`` atomic operation on ``toolkit.ConnectionManager`` would close the gap cleanly.

## Test plan

- [ ] ``make verify`` passes
- [ ] In the admin UI, open an existing api connection and attach an OpenAPI catalog
- [ ] Without restart, call ``list_connections`` from any MCP client and confirm the connection entry shows ``"catalog_id"`` and a non-zero ``"operation_count"``
- [ ] Call ``api_list_endpoints`` against the connection and confirm operations are returned (no longer ``"no catalog_id configured"``)
- [ ] On the same connection, add a static header via the editor — type name and value, click Save without clicking ``+``, and confirm the header round-trips
- [ ] Add a second header by clicking ``+ Add header`` and typing in the new row
- [ ] Rename an existing header's name in place; confirm the old name is dropped and the new name is saved
- [ ] Remove a header via the ``×`` button; confirm it's gone after save
- [ ] Call ``api_invoke_endpoint`` and inspect the request the upstream receives; confirm the static headers are present