### PR TITLE
fix(ui): OAuth status card no longer renders an empty error banner

### DIFF
--- a/ui/src/pages/settings/ConnectionOAuthStatusCard.test.tsx
+++ b/ui/src/pages/settings/ConnectionOAuthStatusCard.test.tsx
@@ -19,10 +19,12 @@ vi.mock("@/api/admin/hooks", () => ({
   })),
 }));
 
+import { ApiError } from "@/api/admin/client";
 import { useConnectionOAuthStatus } from "@/api/admin/hooks";
 import {
   ConnectionOAuthStatusCard,
   describeVerdictCode,
+  formatActionError,
   renderDetailHint,
   revocationHeadline,
 } from "./ConnectionOAuthStatusCard";
@@ -114,6 +116,56 @@ function makeEvent(overrides: Partial<ConnectionAuthEvent>): ConnectionAuthEvent
     ...overrides,
   };
 }
+
+describe("formatActionError", () => {
+  // The empty-red-box bug: clicking "Refresh now" produced a red
+  // banner with no text. Root cause was the catch block rendering
+  // err.message directly. Some failure paths surface an ApiError with
+  // an empty detail (HTTP/2 fetches return empty statusText, and
+  // server paths can write a problem+json body with detail: "")
+  // which left the banner visually empty. formatActionError must
+  // ALWAYS return a non-empty string the operator can act on.
+  it("returns ApiError detail when non-empty", () => {
+    const err = new ApiError(502, "refresh failed: connoauth: token fetch failed: status=500");
+    expect(formatActionError(err, "Refresh failed")).toBe(
+      "refresh failed: connoauth: token fetch failed: status=500",
+    );
+  });
+
+  it("falls back to '<label> (HTTP <status>)' when ApiError detail is empty", () => {
+    expect(formatActionError(new ApiError(502, ""), "Refresh failed")).toBe(
+      "Refresh failed (HTTP 502)",
+    );
+    expect(formatActionError(new ApiError(409, "   "), "Refresh failed")).toBe(
+      "Refresh failed (HTTP 409)",
+    );
+  });
+
+  it("returns Error.message when non-empty for non-ApiError throws", () => {
+    expect(formatActionError(new Error("network down"), "Refresh failed")).toBe(
+      "network down",
+    );
+  });
+
+  it("falls back to the label for an Error with an empty message", () => {
+    expect(formatActionError(new Error(""), "Refresh failed")).toBe(
+      "Refresh failed",
+    );
+    expect(formatActionError(new Error("  "), "Refresh failed")).toBe(
+      "Refresh failed",
+    );
+  });
+
+  it("falls back to the label for a non-Error throw", () => {
+    expect(formatActionError("a string", "Refresh failed")).toBe(
+      "Refresh failed",
+    );
+    expect(formatActionError(undefined, "Refresh failed")).toBe(
+      "Refresh failed",
+    );
+    expect(formatActionError(null, "Refresh failed")).toBe("Refresh failed");
+  });
+});
 
 describe("renderDetailHint", () => {
   it("translates idp_error_code=refresh_expired so the row doesn't blame the IdP", () => {

--- a/ui/src/pages/settings/ConnectionOAuthStatusCard.tsx
+++ b/ui/src/pages/settings/ConnectionOAuthStatusCard.tsx
@@ -11,6 +11,7 @@ import {
   useReacquireConnectionOAuth,
   useStartConnectionOAuth,
 } from "@/api/admin/hooks";
+import { ApiError } from "@/api/admin/client";
 import type { ConnectionAuthEvent, ConnectionOAuthStatus } from "@/api/admin/types";
 import { cn } from "@/lib/utils";
 import {
@@ -80,10 +81,7 @@ function Inner({ kind, name }: { kind: string; name: string }) {
       }
       window.location.href = res.authorization_url;
     } catch (err) {
-      setActionMsg({
-        ok: false,
-        text: err instanceof Error ? err.message : "Connect failed",
-      });
+      setActionMsg({ ok: false, text: formatActionError(err, "Connect failed") });
     }
   };
 
@@ -93,10 +91,7 @@ function Inner({ kind, name }: { kind: string; name: string }) {
       await reacquire.mutateAsync({ kind, name });
       setActionMsg({ ok: true, text: "Token refreshed" });
     } catch (err) {
-      setActionMsg({
-        ok: false,
-        text: err instanceof Error ? err.message : "Reacquire failed",
-      });
+      setActionMsg({ ok: false, text: formatActionError(err, "Refresh failed") });
     }
   };
 
@@ -151,7 +146,7 @@ function Inner({ kind, name }: { kind: string; name: string }) {
       {error && (
         <div className="rounded border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs text-destructive">
           <span className="font-medium">Status unavailable:</span>{" "}
-          {error instanceof Error ? error.message : "fetch failed"}
+          {formatActionError(error, "fetch failed")}
         </div>
       )}
 
@@ -168,13 +163,13 @@ function Inner({ kind, name }: { kind: string; name: string }) {
         </div>
       )}
 
-      {status?.last_error && (
+      {status?.last_error && status.last_error.trim() !== "" && (
         <div className="rounded border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs text-destructive">
           <span className="font-medium">Last error:</span> {status.last_error}
         </div>
       )}
 
-      {actionMsg && (
+      {actionMsg && actionMsg.text.trim() !== "" && (
         <div
           className={cn(
             "rounded border px-2 py-1 text-xs",
@@ -508,6 +503,28 @@ function StatusGrid({ status }: { status: ConnectionOAuthStatus }) {
       ))}
     </div>
   );
+}
+
+// formatActionError turns any thrown value into a non-empty,
+// operator-meaningful string. The previous render used
+// `err.message` directly, which produced an empty red box when an
+// ApiError carried an empty detail (some upstream paths return 502
+// with no body, and HTTP/2 fetches return empty statusText). An
+// empty error box is the worst of both worlds: the operator sees
+// something went wrong but learns nothing about what. Always fall
+// back to the caller's label, and append the HTTP status when
+// available so "Refresh failed (HTTP 502)" beats a blank box.
+export function formatActionError(err: unknown, fallback: string): string {
+  if (err instanceof ApiError) {
+    const detail = err.detail?.trim();
+    if (detail) return detail;
+    return err.status > 0 ? `${fallback} (HTTP ${err.status})` : fallback;
+  }
+  if (err instanceof Error) {
+    const msg = err.message?.trim();
+    if (msg) return msg;
+  }
+  return fallback;
 }
 
 // formatRelative renders an ISO-8601 timestamp as a coarse "in N


### PR DESCRIPTION
## Summary

Clicking "Refresh now" on a connection whose IdP refresh fails produced a red banner with no text. Reported with [screenshot from #412 follow-up]. Root cause is the catch block rendering ``err.message`` directly: some failure paths surface an ``ApiError`` whose ``detail`` is the empty string, leaving the banner visually empty.

An empty error banner is strictly worse than no banner at all: the operator sees that something went wrong and learns nothing about what. They cannot copy the error, cannot grep logs for it, and cannot tell whether the next click will produce the same result.

## How ``ApiError`` ends up with an empty detail

``ui/src/api/admin/client.ts:54-63`` reads the error detail like this:

```ts
const body = await res.json().catch(() => ({} as Record<string, unknown>));
const detail = (typeof body.detail === "string" && body.detail)
    || (typeof body.error === "string" && body.error)
    || (typeof body.message === "string" && body.message)
    || res.statusText;
throw new ApiError(res.status, detail);
```

``detail`` ends up the empty string when:

- the response body is empty or non-JSON (``body`` parses as ``{}``) AND
- ``res.statusText`` is empty (HTTP/2 has no reason phrase; the Fetch API exposes ``""``)

Or when the response body is JSON ``{"detail": "", ...}``. ``new ApiError(502, "")`` then propagates to the catch block as an ``Error`` with ``message === ""``, and the previous code rendered exactly that.

## Fix

``formatActionError(err, fallback)`` is the new helper that always returns a non-empty, operator-readable string. Resolution order:

1. ``ApiError`` with non-empty ``detail`` → ``detail``
2. ``ApiError`` with empty ``detail`` and ``status > 0`` → ``"<fallback> (HTTP <status>)"``
3. Any ``Error`` with non-empty ``message`` → ``message``
4. Anything else → ``fallback``

All three failure-display call sites route through it:

- ``handleConnect`` (start-OAuth failures)
- ``handleReacquire`` ("Refresh now" failures — the reported bug)
- The status-fetch error banner

Two render guards close the loop: ``actionMsg.text.trim() !== ""`` and ``status.last_error.trim() !== ""``. Even if a future regression produces an empty error string somewhere upstream, the banner refuses to render rather than showing a bare red box.

## What the user will see now

Before:
> _empty red box_

After (for an HTTP/2 502 with empty body):
> Refresh failed (HTTP 502)

After (for a 502 with a real upstream detail):
> refresh failed: connoauth: token fetch failed: status=500

## Tests

Five new tests in ``ConnectionOAuthStatusCard.test.tsx`` cover the helper:

- ``returns ApiError detail when non-empty``
- ``falls back to '<label> (HTTP <status>)' when ApiError detail is empty`` (the regression case)
- ``returns Error.message when non-empty for non-ApiError throws``
- ``falls back to the label for an Error with an empty message``
- ``falls back to the label for a non-Error throw``

The existing 18 tests pass unchanged.

## Out of scope

This PR makes the failure message readable. It does NOT fix the underlying refresh failures the screenshot showed (28 consecutive ``Refresh failed (transient)`` events for the same connection over 3 hours, then ``transient`` again on manual refresh). That is a separate investigation. Now that the message will surface, the next manual ``Refresh now`` will reveal the actual upstream code or transport error, which is the input I need to dig into the IdP-side cause.

## Test plan

- [ ] ``make verify`` passes
- [ ] ``npm test -- ConnectionOAuthStatusCard --run`` passes (23 tests)
- [ ] In the admin UI, click "Refresh now" on a connection whose upstream is unreachable or returning errors; confirm the banner shows a non-empty message (status code at minimum)
- [ ] Confirm a successful "Refresh now" still produces the green "Token refreshed" banner with no regression