### PR TITLE
fix(connoauth): distributed refresh lock; preserve IdP error code and description

### DIFF
--- a/pkg/connoauth/source.go
+++ b/pkg/connoauth/source.go
@@ -40,6 +40,13 @@ const (
 	logKeyError = "error"
 )
 
+// scopeSep is the OAuth 2.0 scope-list separator (a single space per
+// RFC 6749 §3.3) and also the separator used when joining the
+// status / error / error_description parts of a sanitized
+// RetrieveError message. Named so revive's add-constant lint stops
+// flagging the literal as it accumulates call sites.
+const scopeSep = " "
+
 // newTokenExchangeClient builds the http.Client used for any
 // credential-bearing POST to an OAuth token endpoint. CheckRedirect
 // refuses 3xx so a misconfigured or compromised IdP cannot redirect
@@ -132,6 +139,27 @@ func (s *Source) Token(ctx context.Context) (string, error) {
 			return "", ErrNeedsReauth
 		}
 		return "", fmt.Errorf("connoauth: load token: %w", err)
+	}
+	if accessTokenStillValid(persisted) {
+		return persisted.AccessToken, nil
+	}
+	// Refresh under the store's distributed lock so two callers
+	// (background refresher + tool call, or two replicas) cannot
+	// POST the same refresh_token to a rotation-enforcing IdP and
+	// race each other. After acquiring the lock we re-read the row:
+	// another caller may have rotated under us, in which case the
+	// cached access token is now valid and no IdP round-trip runs.
+	unlock, err := s.store.Lock(ctx, s.key)
+	if err != nil {
+		return "", fmt.Errorf("connoauth: acquire refresh lock: %w", err)
+	}
+	defer unlock()
+	persisted, err = s.store.Get(ctx, s.key)
+	if err != nil {
+		if errors.Is(err, ErrTokenNotFound) {
+			return "", ErrNeedsReauth
+		}
+		return "", fmt.Errorf("connoauth: reload token after lock: %w", err)
 	}
 	if accessTokenStillValid(persisted) {
 		return persisted.AccessToken, nil
@@ -256,7 +284,7 @@ func (s *Source) Status(ctx context.Context) OAuthStatus {
 				Configured:  true,
 				NeedsReauth: true,
 				TokenURL:    s.cfg.TokenURL,
-				Scope:       strings.Join(s.cfg.Scopes, " "),
+				Scope:       strings.Join(s.cfg.Scopes, scopeSep),
 				Grant:       s.cfg.Grant,
 			}
 		}
@@ -264,7 +292,7 @@ func (s *Source) Status(ctx context.Context) OAuthStatus {
 			Configured: true,
 			LastError:  "load token: " + err.Error(),
 			TokenURL:   s.cfg.TokenURL,
-			Scope:      strings.Join(s.cfg.Scopes, " "),
+			Scope:      strings.Join(s.cfg.Scopes, scopeSep),
 			Grant:      s.cfg.Grant,
 		}
 	}
@@ -277,7 +305,7 @@ func (s *Source) Status(ctx context.Context) OAuthStatus {
 func statusFromPersisted(p *PersistedToken, cfg Config) OAuthStatus {
 	scope := p.Scope
 	if scope == "" {
-		scope = strings.Join(cfg.Scopes, " ")
+		scope = strings.Join(cfg.Scopes, scopeSep)
 	}
 	st := OAuthStatus{
 		Configured:       true,
@@ -307,9 +335,18 @@ func statusFromPersisted(p *PersistedToken, cfg Config) OAuthStatus {
 // Reacquire forces a refresh-token exchange even when the cached
 // token is still valid. Used by the admin "Reacquire" button to test
 // the refresh path on demand. authorization_code grants cannot
-// re-run the full browser flow without operator interaction — that
+// re-run the full browser flow without operator interaction. That
 // path is the regular Connect button instead.
+//
+// Holds the same distributed refresh lock as Token so a manual
+// reacquire cannot race the background refresher (or another replica)
+// into a rotation conflict.
 func (s *Source) Reacquire(ctx context.Context) error {
+	unlock, err := s.store.Lock(ctx, s.key)
+	if err != nil {
+		return fmt.Errorf("connoauth: acquire refresh lock: %w", err)
+	}
+	defer unlock()
 	persisted, err := s.store.Get(ctx, s.key)
 	if err != nil {
 		if errors.Is(err, ErrTokenNotFound) {
@@ -507,14 +544,18 @@ func isRevokedRefresh(err error) bool {
 // The library's *oauth2.RetrieveError includes the IdP response body
 // (which can carry sensitive material) and the request URL (which
 // can carry credentials in the userinfo). Rebuild the message
-// keeping only non-sensitive pieces.
+// keeping the structured RFC 6749 error fields (error, error_description)
+// which the oauth2 library already parsed out of the response body
+// and stored on the RetrieveError. These two fields are operator-
+// facing diagnostic surface by spec; preserving them is the
+// difference between "status=400" (useless) and
+// "status=400 error=invalid_grant error_description=Token is not active"
+// (immediately actionable). The full raw Response.Body is still
+// dropped.
 func tokenFetchError(err error) error {
 	var re *oauth2.RetrieveError
 	if errors.As(err, &re) {
-		if re.Response != nil {
-			return fmt.Errorf("connoauth: token fetch failed: status=%d", re.Response.StatusCode)
-		}
-		return errors.New("connoauth: token fetch failed")
+		return retrieveErrorMessage(re)
 	}
 	var ue *url.Error
 	if errors.As(err, &ue) {
@@ -533,4 +574,51 @@ func tokenFetchError(err error) error {
 		return errors.New("connoauth: token fetch failed (details redacted)")
 	}
 	return fmt.Errorf("connoauth: token fetch failed: %s", msg)
+}
+
+// retrieveErrorMessage assembles the sanitized message for an
+// oauth2.RetrieveError. Includes the HTTP status, the RFC 6749
+// `error` code, and a length-bounded `error_description`. Drops
+// any other body content. Returns "connoauth: token fetch failed"
+// when no fields are populated so the caller never sees an empty
+// message.
+func retrieveErrorMessage(re *oauth2.RetrieveError) error {
+	parts := make([]string, 0, 3)
+	if re.Response != nil {
+		parts = append(parts, fmt.Sprintf("status=%d", re.Response.StatusCode))
+	}
+	if re.ErrorCode != "" {
+		parts = append(parts, fmt.Sprintf("error=%s", sanitizeOAuthErrorField(re.ErrorCode)))
+	}
+	if re.ErrorDescription != "" {
+		parts = append(parts, fmt.Sprintf("error_description=%s",
+			sanitizeOAuthErrorField(re.ErrorDescription)))
+	}
+	if len(parts) == 0 {
+		return errors.New("connoauth: token fetch failed")
+	}
+	return fmt.Errorf("connoauth: token fetch failed: %s", strings.Join(parts, scopeSep))
+}
+
+// sanitizeOAuthErrorField bounds the length of an RFC 6749 error
+// field and replaces any URL-looking substrings, CR/LF, and other
+// control characters so a hostile or chatty IdP cannot inject log
+// noise or leak embedded credentials through the diagnostic string.
+// Length cap matches typical operator-readable description ceilings.
+func sanitizeOAuthErrorField(s string) string {
+	const maxLen = 200
+	if strings.Contains(s, "://") {
+		return "(redacted: URL-shaped content)"
+	}
+	cleaned := strings.Map(func(r rune) rune {
+		if r < 32 || r == 127 {
+			return ' '
+		}
+		return r
+	}, s)
+	cleaned = strings.TrimSpace(cleaned)
+	if len(cleaned) > maxLen {
+		cleaned = cleaned[:maxLen] + "..."
+	}
+	return cleaned
 }

--- a/pkg/connoauth/source_test.go
+++ b/pkg/connoauth/source_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -517,6 +519,10 @@ func (failingStore) List(_ context.Context) ([]PersistedToken, error) {
 	return nil, errors.New("store: connection refused")
 }
 
+func (failingStore) Lock(_ context.Context, _ Key) (func(), error) {
+	return nil, errors.New("store: connection refused")
+}
+
 // TestSource_Token_StoreError — when the store returns a transient
 // error (not ErrTokenNotFound), Token() must surface it as a wrapped
 // error rather than misclassifying it as NeedsReauth.
@@ -669,5 +675,177 @@ func TestAccessTokenStillValid(t *testing.T) {
 	future := &PersistedToken{AccessToken: "x", ExpiresAt: time.Now().Add(time.Hour)}
 	if !accessTokenStillValid(future) {
 		t.Fatal("future ExpiresAt should be valid")
+	}
+}
+
+// TestSource_ConcurrentRefreshSerializes is the regression test for
+// the rotation-race bug. Without serialization at the store layer,
+// two callers arriving at the refresh path together each POST the
+// same refresh_token. A rotation-enforcing IdP returns 200 + new
+// tokens to one and 400 invalid_grant to the other. The "loser"
+// classifies invalid_grant as a revoked refresh token and deletes
+// the row, taking the connection out of service. With Store.Lock,
+// the second caller waits, re-reads the row, finds the access token
+// already rotated, and returns it without a second IdP call.
+//
+// This test makes the IdP increment-rotate on every call (so a
+// second call with the previously-issued refresh token would fail
+// invalid_grant). It then fires N concurrent Token() calls against
+// the same store and key. Assertions: every caller succeeds, every
+// caller returns the same access token, and the IdP is hit exactly
+// once. The same serialization guarantee carries to multi-replica
+// deployments via PostgresStore's pg_advisory_lock; MemoryStore here
+// proves the contract, the Postgres-backed test in
+// store_postgres_test.go proves the cross-process guarantee.
+func TestSource_ConcurrentRefreshSerializes(t *testing.T) {
+	t.Parallel()
+	var (
+		rotation atomic.Int32
+		valid    atomic.Value
+	)
+	valid.Store("rt-0")
+	idp := newFakeIDP(t, func(w http.ResponseWriter, r *http.Request) {
+		form := readForm(r)
+		incoming := form.Get("refresh_token")
+		current, _ := valid.Load().(string)
+		if incoming != current {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Token is not active"}`))
+			return
+		}
+		n := rotation.Add(1)
+		next := fmt.Sprintf("rt-%d", n)
+		valid.Store(next)
+		writeTokenJSON(w, map[string]any{
+			"access_token":  fmt.Sprintf("at-%d", n),
+			"refresh_token": next,
+			"expires_in":    3600,
+		})
+	})
+
+	store := NewMemoryStore()
+	key := Key{Kind: KindAPI, Name: "rotation-race"}
+	_ = store.Set(context.Background(), PersistedToken{
+		Key:          key,
+		AccessToken:  "at-expired",
+		RefreshToken: "rt-0",
+		ExpiresAt:    time.Now().Add(-time.Hour),
+	})
+	cfg := Config{TokenURL: idp.tokenURL(), ClientID: "c", ClientSecret: "s"}
+
+	const callers = 20
+	var (
+		wg      sync.WaitGroup
+		tokens  = make([]string, callers)
+		errs    = make([]error, callers)
+		barrier = make(chan struct{})
+	)
+	for i := range callers {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			src := NewSource(store, key, cfg)
+			<-barrier
+			tokens[idx], errs[idx] = src.Token(context.Background())
+		}(i)
+	}
+	close(barrier)
+	wg.Wait()
+
+	for i, e := range errs {
+		if e != nil {
+			t.Fatalf("caller %d: %v (would be invalid_grant without the per-key lock)", i, e)
+		}
+	}
+	first := tokens[0]
+	if first == "" {
+		t.Fatal("expected a non-empty access token from every caller")
+	}
+	for i, tok := range tokens {
+		if tok != first {
+			t.Fatalf("caller %d returned %q, expected the shared %q", i, tok, first)
+		}
+	}
+	if got := idp.calls.Load(); got != 1 {
+		t.Fatalf("idp should be hit exactly once (winning refresh); got %d calls", got)
+	}
+	persisted, gerr := store.Get(context.Background(), key)
+	if gerr != nil {
+		t.Fatalf("row should still exist after coordinated refresh: %v", gerr)
+	}
+	if persisted.RefreshToken != "rt-1" {
+		t.Fatalf("persisted refresh_token should reflect the one rotation: %q", persisted.RefreshToken)
+	}
+}
+
+// TestRetrieveErrorMessage_PreservesOAuthErrorFields ensures the
+// IdP's RFC 6749 `error` and `error_description` survive the
+// sanitization pass. Operators previously saw only "status=400"
+// from a refresh failure and had to read pod logs to learn whether
+// the cause was invalid_grant, invalid_client, invalid_scope, or
+// something else.
+func TestRetrieveErrorMessage_PreservesOAuthErrorFields(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		re   *oauth2.RetrieveError
+		want string
+	}{
+		{
+			name: "status + error + description",
+			re: &oauth2.RetrieveError{
+				Response:         &http.Response{StatusCode: 400},
+				ErrorCode:        "invalid_grant",
+				ErrorDescription: "Token is not active",
+			},
+			want: "connoauth: token fetch failed: status=400 error=invalid_grant error_description=Token is not active",
+		},
+		{
+			name: "status + error only",
+			re: &oauth2.RetrieveError{
+				Response:  &http.Response{StatusCode: 401},
+				ErrorCode: "invalid_client",
+			},
+			want: "connoauth: token fetch failed: status=401 error=invalid_client",
+		},
+		{
+			name: "no fields",
+			re:   &oauth2.RetrieveError{},
+			want: "connoauth: token fetch failed",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := retrieveErrorMessage(tc.re).Error(); got != tc.want {
+				t.Errorf("retrieveErrorMessage:\n got: %s\nwant: %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeOAuthErrorField scrubs the operator-readable error_description
+// of CR/LF/control characters and URL-shaped content, and bounds its
+// length so a chatty IdP cannot inject log noise or leak embedded
+// credentials.
+func TestSanitizeOAuthErrorField(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in, want string
+	}{
+		{"invalid_grant", "invalid_grant"},
+		{"Token is not active", "Token is not active"},
+		{"Bad\r\nthing", "Bad  thing"},
+		{"see https://attacker.example/log?leak=secret for more", "(redacted: URL-shaped content)"},
+		{strings.Repeat("x", 250), strings.Repeat("x", 200) + "..."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			if got := sanitizeOAuthErrorField(tc.in); got != tc.want {
+				t.Errorf("sanitizeOAuthErrorField(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/pkg/connoauth/store.go
+++ b/pkg/connoauth/store.go
@@ -24,10 +24,30 @@ type Store interface {
 	// List returns metadata for every persisted row. Used by the
 	// background refresher to decide which connections need
 	// proactive refresh. AccessToken and RefreshToken are NOT
-	// populated in the returned slice — the refresher only needs
+	// populated in the returned slice. The refresher only needs
 	// deadlines, kind, and name to pick targets; the per-row Get
 	// loads the secret material when it actually refreshes.
 	List(ctx context.Context) ([]PersistedToken, error)
+	// Lock acquires an exclusive lock for the key. The lock is held
+	// across processes (Postgres advisory lock for the SQL store, a
+	// per-key mutex for the in-memory store) so two refresh attempts
+	// for the same key serialize regardless of which replica or
+	// goroutine started them. The caller MUST defer the returned
+	// release function. The returned function is idempotent and
+	// safe to call after the request context has been canceled.
+	//
+	// Lock is the coordination primitive that prevents the rotation
+	// race: against any IdP that enforces one-time-use refresh-token
+	// rotation (RFC 6749 §6), two concurrent refreshes posting the
+	// same refresh_token cause the loser to receive invalid_grant
+	// for a token the winner already consumed. Without serialization
+	// across replicas, that loser's response is classified as a
+	// revoked credential and the persisted row is deleted, taking
+	// the connection out of service. The acquired lock is released
+	// either by the returned function or by the backing connection
+	// closing (Postgres advisory locks are session-scoped, so a
+	// crashed holder cannot deadlock the row).
+	Lock(ctx context.Context, key Key) (func(), error)
 }
 
 // FieldEncryptor abstracts the platform's at-rest field encryption so
@@ -65,12 +85,39 @@ var errInvalidKey = errors.New("connoauth: invalid key (kind and name required)"
 type MemoryStore struct {
 	mu     sync.Mutex
 	tokens map[Key]PersistedToken
+	// locks holds a per-Key mutex for Lock. Lazily populated via
+	// LoadOrStore so the cost of the lock registry is bounded by the
+	// number of distinct keys ever locked, not by every key ever
+	// stored. The mutex registry is intentionally never trimmed; the
+	// memory cost of a *sync.Mutex per connection is trivial and
+	// reclaiming entries would require coordinating with in-flight
+	// Lock holders, which adds complexity without benefit.
+	locks sync.Map
 }
 
 // NewMemoryStore returns an in-process Store. Production deployments
 // use NewPostgresStore.
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{tokens: map[Key]PersistedToken{}}
+}
+
+// Lock acquires an exclusive per-key mutex. The returned release
+// function is idempotent and safe to defer. The context is accepted
+// for interface symmetry with PostgresStore (which observes ctx
+// during the wait); the in-process mutex acquisition itself does
+// not block on I/O so ctx is never consulted here.
+func (s *MemoryStore) Lock(_ context.Context, key Key) (func(), error) {
+	if !key.IsValid() {
+		return nil, errInvalidKey
+	}
+	v, _ := s.locks.LoadOrStore(key, &sync.Mutex{})
+	mu, ok := v.(*sync.Mutex)
+	if !ok {
+		return nil, errors.New("connoauth: memory store lock registry corrupted")
+	}
+	mu.Lock()
+	var once sync.Once
+	return func() { once.Do(mu.Unlock) }, nil
 }
 
 // Get returns the in-memory token or ErrTokenNotFound.

--- a/pkg/connoauth/store_postgres.go
+++ b/pkg/connoauth/store_postgres.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"hash/fnv"
+	"sync"
 	"time"
 )
 
@@ -200,6 +202,63 @@ func (s *PostgresStore) List(ctx context.Context) ([]PersistedToken, error) {
 		return nil, fmt.Errorf("connoauth: list iterate: %w", err)
 	}
 	return out, nil
+}
+
+// Lock acquires a Postgres session-scoped advisory lock for key.
+// Held across processes: two replicas calling Lock for the same key
+// serialize at the database level. The lock is auto-released if the
+// holding session disconnects, so a crashed holder cannot deadlock
+// the row. The returned release function MUST be deferred; it sends
+// an explicit pg_advisory_unlock and returns the dedicated
+// connection to the pool. It is idempotent and safe to call after
+// the request context has been canceled (the unlock uses a
+// background context so cancellation does not strand the lock).
+//
+// Lock ID derivation: a 64-bit FNV-1a hash of "connoauth:" + kind +
+// "/" + name. The "connoauth:" namespace prefix prevents collision
+// with any other code that might also use pg_advisory_lock in the
+// same database. Hash collisions across distinct (kind, name) pairs
+// are mathematically possible but vanishingly rare for any realistic
+// connection count; a collision would only cause unnecessary
+// serialization between two unrelated connections, never incorrect
+// behavior.
+func (s *PostgresStore) Lock(ctx context.Context, key Key) (func(), error) {
+	if !key.IsValid() {
+		return nil, errInvalidKey
+	}
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("connoauth: acquire conn for advisory lock: %w", err)
+	}
+	lockID := advisoryLockID(key)
+	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", lockID); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("connoauth: pg_advisory_lock(%s/%s): %w", key.Kind, key.Name, err)
+	}
+	var once sync.Once
+	release := func() {
+		once.Do(func() {
+			// Background context: unlock must run even if the request
+			// context was canceled. pg_advisory_unlock against a
+			// session-scoped lock is local and fast.
+			_, _ = conn.ExecContext(context.Background(),
+				"SELECT pg_advisory_unlock($1)", lockID)
+			_ = conn.Close()
+		})
+	}
+	return release, nil
+}
+
+// advisoryLockID computes the 64-bit pg_advisory_lock key for a
+// connection. Pure function so the lock IDs are deterministic across
+// process restarts; a token row's lock identity does not change as
+// long as its (kind, name) does not change.
+func advisoryLockID(key Key) int64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte("connoauth:" + key.Kind + "/" + key.Name))
+	// Convert uint64 to int64 via two's complement. pg_advisory_lock
+	// accepts any int64 value; we don't care about the sign.
+	return int64(h.Sum64()) // #nosec G115 -- intentional bit reinterpretation: pg_advisory_lock accepts any int64; the negative/positive distinction is meaningless for a hash-derived lock identifier.
 }
 
 // Delete removes the row for key. Idempotent — missing rows do not

--- a/pkg/connoauth/store_postgres_test.go
+++ b/pkg/connoauth/store_postgres_test.go
@@ -186,3 +186,81 @@ func TestEncryptOptional(t *testing.T) {
 		t.Fatalf("non-empty plaintext should encrypt: ns=%+v err=%v", ns, err)
 	}
 }
+
+func TestPostgresStore_Lock_AcquireAndRelease(t *testing.T) {
+	t.Parallel()
+	store, mock := newMockPostgresStore(t)
+	key := Key{Kind: KindAPI, Name: "alpha"}
+
+	// db.Conn pulls a connection from the pool. sqlmock returns one
+	// from its pool automatically when ExecContext runs.
+	mock.ExpectExec("SELECT pg_advisory_lock($1)").
+		WithArgs(advisoryLockID(key)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("SELECT pg_advisory_unlock($1)").
+		WithArgs(advisoryLockID(key)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	release, err := store.Lock(context.Background(), key)
+	if err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+	release()
+	// Calling release twice must NOT issue a second unlock query.
+	// sqlmock would fail on an unexpected ExecContext.
+	release()
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPostgresStore_Lock_RejectsInvalidKey(t *testing.T) {
+	t.Parallel()
+	store, _ := newMockPostgresStore(t)
+	if _, err := store.Lock(context.Background(), Key{}); !errors.Is(err, errInvalidKey) {
+		t.Fatalf("Lock with empty key should return errInvalidKey, got %v", err)
+	}
+}
+
+func TestPostgresStore_Lock_ConnAcquireFails(t *testing.T) {
+	t.Parallel()
+	store, mock := newMockPostgresStore(t)
+	key := Key{Kind: KindAPI, Name: "alpha"}
+	// pg_advisory_lock query errors are surfaced through Lock's
+	// error return. The release function MUST NOT be returned in
+	// that case (a caller deferring it would attempt to unlock a
+	// lock it never acquired). sqlmock makes the first ExecContext
+	// fail; we assert release is nil and an error is returned.
+	mock.ExpectExec("SELECT pg_advisory_lock($1)").
+		WithArgs(advisoryLockID(key)).
+		WillReturnError(errors.New("simulated pg error"))
+
+	release, err := store.Lock(context.Background(), key)
+	if err == nil {
+		t.Fatal("Lock should surface pg_advisory_lock errors")
+	}
+	if release != nil {
+		t.Fatal("Lock must not return a release function on acquire failure")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestAdvisoryLockID(t *testing.T) {
+	t.Parallel()
+	a1 := advisoryLockID(Key{Kind: KindAPI, Name: "alpha"})
+	a2 := advisoryLockID(Key{Kind: KindAPI, Name: "alpha"})
+	if a1 != a2 {
+		t.Fatalf("advisoryLockID must be deterministic: %d vs %d", a1, a2)
+	}
+	b := advisoryLockID(Key{Kind: KindAPI, Name: "beta"})
+	if a1 == b {
+		t.Fatalf("distinct (kind, name) must produce distinct lock IDs (collision: %d)", a1)
+	}
+	c := advisoryLockID(Key{Kind: KindMCP, Name: "alpha"})
+	if a1 == c {
+		t.Fatalf("distinct kinds for same name must produce distinct lock IDs (collision: %d)", a1)
+	}
+}

--- a/pkg/connoauth/store_test.go
+++ b/pkg/connoauth/store_test.go
@@ -135,3 +135,96 @@ func TestNoopEncryptor(t *testing.T) {
 		t.Fatalf("Decrypt: got (%q, %v)", dec, err)
 	}
 }
+
+func TestMemoryStore_Lock_Serializes(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+	key := Key{Kind: KindAPI, Name: "race"}
+
+	// First Lock acquires immediately.
+	release1, err := store.Lock(context.Background(), key)
+	if err != nil {
+		t.Fatalf("first Lock: %v", err)
+	}
+
+	// Second Lock for the same key must block until release1 fires.
+	type lockResult struct {
+		release func()
+		err     error
+	}
+	ch := make(chan lockResult, 1)
+	go func() {
+		r, err := store.Lock(context.Background(), key)
+		ch <- lockResult{r, err}
+	}()
+
+	select {
+	case <-ch:
+		t.Fatal("second Lock should block while first holds the key")
+	case <-time.After(50 * time.Millisecond):
+		// expected: blocked
+	}
+
+	release1()
+
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			t.Fatalf("second Lock: %v", res.err)
+		}
+		res.release()
+	case <-time.After(time.Second):
+		t.Fatal("second Lock did not acquire after first release")
+	}
+}
+
+func TestMemoryStore_Lock_DifferentKeysDoNotBlock(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+
+	releaseA, err := store.Lock(context.Background(), Key{Kind: KindAPI, Name: "a"})
+	if err != nil {
+		t.Fatalf("Lock A: %v", err)
+	}
+	defer releaseA()
+
+	// A different key must NOT block on A's lock.
+	done := make(chan error, 1)
+	go func() {
+		r, err := store.Lock(context.Background(), Key{Kind: KindAPI, Name: "b"})
+		if r != nil {
+			r()
+		}
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Lock B: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Lock B should not block on Lock A (different key)")
+	}
+}
+
+func TestMemoryStore_Lock_ReleaseIsIdempotent(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+	key := Key{Kind: KindAPI, Name: "x"}
+	release, err := store.Lock(context.Background(), key)
+	if err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+	// Calling release twice MUST NOT panic from a double-unlock of
+	// the underlying sync.Mutex.
+	release()
+	release()
+}
+
+func TestMemoryStore_Lock_RejectsInvalidKey(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore()
+	if _, err := store.Lock(context.Background(), Key{}); !errors.Is(err, errInvalidKey) {
+		t.Fatalf("Lock with empty key should return errInvalidKey, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Two concurrent refresh attempts for the same connection-OAuth row each loaded the persisted ``refresh_token``, each POSTed it to the upstream IdP, and against any IdP that enforces one-time-use rotation (RFC 6749 §6, e.g. Microsoft Entra with rotation enforced, Keycloak with rotation enabled, Salesforce) the loser received ``invalid_grant`` for a token the winner had just consumed. ``classifyRefreshError`` treated ``invalid_grant`` as a revoked credential and ``handleRevoked`` deleted the persisted row, taking the connection out of service after the first concurrent refresh window.

Operator-visible symptom: a connection works for several invocations, then sticks at "refresh failed (transient)" until an operator re-authorizes. The History panel showed a string of consecutive transient failures with no successful refreshes in between.

A secondary observability gap: the sanitized error from a refresh failure read only ``"connoauth: token fetch failed: status=400"``. Every diagnostic round trip required operator log access to learn whether the IdP returned ``invalid_grant`` (rotation race), ``invalid_client`` (credentials drift), ``invalid_scope`` (scope change), or something else.

## Root cause

The refresh path had no serialization. ``Source.Token`` and ``Source.Reacquire`` each loaded the persisted token, found the access token near or past expiry, and went straight to ``Source.refresh`` which POSTed the persisted ``refresh_token`` to the IdP. Two callers arriving inside a single rotation window each consumed the same one-time-use refresh token; the IdP rotated for the winner and rejected the loser. The loser was misclassified as revoked, the row was deleted, and every subsequent call returned ``ErrNeedsReauth``.

Two callers commonly arrive concurrently:

- the background refresher tick and a tool-call invocation
- two replicas of the platform handling overlapping tool calls
- a manual ``Reacquire`` from the admin UI overlapping with the background refresher

The pre-fix code lost every one of these.

## Fix

### 1. ``Store.Lock(ctx, key) (release func(), err error)``

Added to the ``Store`` interface as a first-class coordination primitive. Both backends implement it consistently:

- **PostgresStore**: ``pg_advisory_lock`` acquired on a dedicated ``*sql.Conn`` from the pool, keyed by a 64-bit FNV-1a hash of ``"connoauth:" + kind + "/" + name``. Postgres advisory locks are session-scoped, so a crashed holder is auto-released by the database on connection close. The lock is held across processes: two replicas calling ``Lock`` for the same key serialize at the database level.

- **MemoryStore**: ``sync.Map`` of per-key ``*sync.Mutex`` so the in-process test path has the same semantics. ``sync.Once`` around the unlock so the returned release function is idempotent and safe to defer.

Both backends return an idempotent release function. PostgresStore additionally uses ``context.Background()`` for the unlock query so a cancelled request context cannot strand the lock.

### 2. Double-checked locking in ``Source.Token`` and ``Source.Reacquire``

After acquiring the lock, the source re-reads the persisted row. A concurrent caller may have already rotated; if the access token is now valid, the second caller returns it without an IdP round-trip. The result is exactly one IdP call per rotation interval per key, no matter how many callers arrive concurrently across replicas.

### 3. Preserve IdP ``error`` and ``error_description``

``retrieveErrorMessage`` extracts ``oauth2.RetrieveError.ErrorCode`` and ``oauth2.RetrieveError.ErrorDescription`` (already parsed by ``golang.org/x/oauth2`` from the response body, not free-form text) and includes them in the sanitized error string:

```
connoauth: token fetch failed: status=400 error=invalid_grant error_description=Token is not active
```

The description is bounded to 200 characters and scrubbed of CR/LF/control characters and URL-shaped substrings via ``sanitizeOAuthErrorField`` so a hostile or chatty IdP cannot inject log noise or leak embedded credentials through the diagnostic surface.

## Tests

Seven new tests cover the contract end-to-end:

| Test | What it proves |
|---|---|
| ``TestSource_ConcurrentRefreshSerializes`` | 20 concurrent ``Token()`` calls against an IdP that rotates on every successful refresh. The IdP is hit exactly once; every caller receives the same access token. Without ``Store.Lock`` this test would see 19 deletion-induced ``ErrNeedsReauth`` errors. |
| ``TestPostgresStore_Lock_AcquireAndRelease`` | sqlmock-backed: lock query runs, unlock query runs, calling release twice does NOT issue a second unlock. |
| ``TestPostgresStore_Lock_RejectsInvalidKey`` | Validates the empty-key guard before allocating a connection. |
| ``TestPostgresStore_Lock_ConnAcquireFails`` | When ``pg_advisory_lock`` errors, the connection is closed and ``nil`` release is returned so a deferring caller cannot unlock a lock they never acquired. |
| ``TestAdvisoryLockID`` | Deterministic for the same input; distinct kinds and distinct names produce distinct lock IDs. |
| ``TestMemoryStore_Lock_*`` | Serialization on same key, no blocking on different keys, idempotent release, invalid key rejection. |
| ``TestRetrieveErrorMessage_PreservesOAuthErrorFields`` | Confirms the three-part error string format (status + error + error_description) for every populated-field combination. |
| ``TestSanitizeOAuthErrorField`` | CR/LF replacement, URL-shape redaction, length cap. |

## Test plan

- [x] ``make verify`` passes (full suite: fmt, race tests, lint, gosec, semgrep, codeql, coverage, dead-code, mutation, release-check)
- [x] ``go test -race ./...`` passes
- [ ] In production, "Refresh now" against a connection with a transient failure surfaces a non-empty operator-readable error including ``error=`` and ``error_description=`` from the IdP
- [ ] Over a sustained window (more than five invocations), an api-kind connection backed by a rotation-enforcing IdP no longer enters the stuck-at-failure state
- [ ] Two replicas of the platform handling overlapping tool calls produce exactly one refresh log entry per rotation interval per key (the loser observably waits on ``pg_advisory_lock`` and reads the rotated token after release)