### PR TITLE
fix(apigateway): ranking diagnostics, discovery filters, spec base paths, non-null operations

### DIFF
--- a/pkg/toolkits/apigateway/openapi.go
+++ b/pkg/toolkits/apigateway/openapi.go
@@ -2,6 +2,7 @@ package apigateway
 
 import (
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -9,6 +10,11 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway/catalog"
 )
+
+// pathSep is the URL path separator. Named so revive's add-constant
+// rule does not flag the repeated literal across the base-path
+// derivation and dedupe helpers.
+const pathSep = "/"
 
 // OperationSummary is the slim per-operation view returned by
 // api_list_endpoints. Designed to be cheap on context: the model gets
@@ -18,7 +24,7 @@ import (
 // api_get_endpoint_schema.
 //
 // Spec names the component spec inside the connection's catalog
-// (e.g. "constituent", "gift"). Omitted from JSON when empty so
+// (e.g. "users", "orders"). Omitted from JSON when empty so
 // connections with no catalog or a single anonymous spec stay slim
 // on context.
 type OperationSummary struct {
@@ -63,12 +69,12 @@ func parseOpenAPISpec(raw string) (*openapi3.T, error) {
 // Kept off OperationSummary so the JSON response shape stays slim
 // and the description (often paragraphs long) doesn't bloat the
 // model's context. nil when doc has no operations.
-func buildOperationIndex(doc *openapi3.T, specName string) (ops []OperationSummary, embedTexts []string) {
+func buildOperationIndex(doc *openapi3.T, specName, basePath string) (ops []OperationSummary, embedTexts []string) {
 	if doc == nil || doc.Paths == nil {
 		return nil, nil
 	}
 	for path, item := range doc.Paths.Map() {
-		ops, embedTexts = appendItemOperations(ops, embedTexts, path, item, specName)
+		ops, embedTexts = appendItemOperations(ops, embedTexts, basePath+path, item, specName)
 	}
 	indices := make([]int, len(ops))
 	for i := range indices {
@@ -165,41 +171,151 @@ func buildEmbedText(op OperationSummary, description string) string {
 	return strings.Join(parts, " ")
 }
 
-// rankOperations returns the subset of ops whose operation_id,
-// path, summary, or any tag contains the query (case-insensitive
-// substring match). When the query is empty the full slice is
-// returned in its existing order. The result is capped at limit
-// (or len(ops) if limit ≤ 0).
+// specBasePath returns the path component of the first declared
+// servers[].url, with any trailing slash stripped. Vendors that ship
+// each component spec under a distinct version segment (for example
+// a connection whose connection.base_url is the host and whose specs
+// each declare "https://host/foo/v1", "https://host/bar/v2") rely on
+// this so api_list_endpoints reports the full path the model should
+// pass to api_invoke_endpoint, not the spec-relative path that 404s
+// when the segment is missing from the connection's base_url.
 //
-// v1 ranking is deliberately lexical — semantic / embedding-based
-// ranking is deferred to issue #371 to keep this PR scoped.
-// Callers documenting the tool should set expectations accordingly:
-// the model should write queries in the API's own vocabulary
-// (paths, tags, summaries) rather than free-form intent.
+// Returns "" when doc has no servers entry, when the first entry's
+// URL fails to parse, or when the parsed path is empty or just "/".
+// In that case operations carry their spec-relative paths and the
+// connection's base_url is the only prefix the toolkit joins.
+//
+// Only the path component is extracted; the scheme and host on
+// servers[0].url are ignored because the connection's base_url is
+// the operator's authoritative choice of host (one spec author's
+// preferred host should not override an operator who pointed the
+// connection at a sandbox or proxied endpoint).
+func specBasePath(doc *openapi3.T) string {
+	if doc == nil || len(doc.Servers) == 0 {
+		return ""
+	}
+	raw := doc.Servers[0].URL
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	p := strings.TrimSuffix(u.Path, pathSep)
+	if p == "" {
+		return ""
+	}
+	// OpenAPI 3.0 explicitly allows relative server URLs whose path
+	// has no leading slash (e.g. servers: [{url: "v1"}]). The
+	// downstream invoke validator rejects paths that do not start
+	// with "/", so any synthesized OperationSummary.Path built from
+	// such a base would 400 at invoke time. Prepend the slash so
+	// the synthesized full path is a valid request path.
+	if !strings.HasPrefix(p, pathSep) {
+		return pathSep + p
+	}
+	return p
+}
+
+// computeEffectiveBasePath returns the prefix to apply to every
+// operation's spec-relative path so the toolkit's invoke-time URL
+// join produces the upstream URL without doubling segments. The
+// rule: drop the spec's servers[0] path component when the
+// connection's base_url path already contains it as a suffix
+// (which is exactly the case where an operator configured the
+// connection to point at the spec's documented base, then attached
+// the same spec to the connection). In every other case the
+// spec's base path is preserved.
+//
+// Examples:
+//
+//	conn=https://api.example.com         spec=/v1   -> "/v1"
+//	conn=https://api.example.com/v1      spec=/v1   -> ""
+//	conn=https://api.example.com/api/v2  spec=/api/v2 -> ""
+//	conn=https://api.example.com/legacy  spec=/v1   -> "/v1"
+//
+// Empty inputs short-circuit: an empty spec base means there is
+// nothing to prefix, an unparseable connection URL falls back to
+// the spec base verbatim (preserves the pre-existing behavior of
+// every connection that ships before this dedupe landed).
+func computeEffectiveBasePath(connBaseURL, specBase string) string {
+	if specBase == "" {
+		return ""
+	}
+	u, err := url.Parse(connBaseURL)
+	if err != nil {
+		return specBase
+	}
+	connPath := strings.TrimSuffix(u.Path, pathSep)
+	if connPath == "" {
+		return specBase
+	}
+	if strings.HasSuffix(connPath, specBase) {
+		return ""
+	}
+	return specBase
+}
+
+// rankOperations returns the subset of ops whose searchable fields
+// contain EVERY whitespace-separated token in query (case-insensitive
+// substring match per token; the tokens combine with AND). Searchable
+// fields are operation_id, path, summary, spec name, and tags. When
+// the query is empty the full slice is returned in its existing
+// order. The result is capped at limit (or len(ops) when limit ≤ 0).
+//
+// Always returns a non-nil slice so a zero-match query produces
+// "operations": [] in the JSON response rather than "operations":
+// null. Clients that switch on truthiness or array-length without
+// the null guard would otherwise have to handle two empty shapes.
+//
+// Per-token AND matches what operators expect when typing "gift
+// list" or "create user": each word should narrow the result, not be
+// treated as a single phrase that fails when the spec author wrote
+// the fields in a different order.
 func rankOperations(ops []OperationSummary, query string, limit int) []OperationSummary {
 	q := strings.ToLower(strings.TrimSpace(query))
 	if q == "" {
 		return capSlice(ops, limit)
 	}
-	var matched []OperationSummary
+	tokens := strings.Fields(q)
+	matched := make([]OperationSummary, 0, len(ops))
 	for _, op := range ops {
-		if operationMatches(op, q) {
+		if operationMatchesAllTokens(op, tokens) {
 			matched = append(matched, op)
 		}
 	}
 	return capSlice(matched, limit)
 }
 
-// operationMatches reports whether any of the searchable fields on
-// the operation contain the lowercased query string.
-func operationMatches(op OperationSummary, q string) bool {
-	if strings.Contains(strings.ToLower(op.OperationID), q) ||
-		strings.Contains(strings.ToLower(op.Path), q) ||
-		strings.Contains(strings.ToLower(op.Summary), q) {
+// operationMatchesAllTokens reports whether every token appears as
+// a substring of at least one of the operation's searchable fields.
+// Tokens are pre-lowercased by the caller; fields are lowercased
+// per check (cheap relative to alternatives like caching a struct
+// of lowercased fields per op).
+func operationMatchesAllTokens(op OperationSummary, tokens []string) bool {
+	for _, tok := range tokens {
+		if !operationFieldsContain(op, tok) {
+			return false
+		}
+	}
+	return true
+}
+
+// operationFieldsContain reports whether tok appears as a substring
+// of any one of the operation's searchable fields. Spec name is
+// included so operators can navigate a multi-spec catalog by
+// vendor-supplied section (e.g. "constituent", "gift") that does
+// not otherwise appear in the operation's id, path, or tags.
+func operationFieldsContain(op OperationSummary, tok string) bool {
+	if strings.Contains(strings.ToLower(op.OperationID), tok) ||
+		strings.Contains(strings.ToLower(op.Path), tok) ||
+		strings.Contains(strings.ToLower(op.Summary), tok) ||
+		strings.Contains(strings.ToLower(op.Spec), tok) {
 		return true
 	}
 	for _, tag := range op.Tags {
-		if strings.Contains(strings.ToLower(tag), q) {
+		if strings.Contains(strings.ToLower(tag), tok) {
 			return true
 		}
 	}

--- a/pkg/toolkits/apigateway/openapi_test.go
+++ b/pkg/toolkits/apigateway/openapi_test.go
@@ -136,7 +136,7 @@ func TestBuildOperationIndex_AllMethods(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseOpenAPISpec: %v", err)
 	}
-	ops, _ := buildOperationIndex(doc, "")
+	ops, _ := buildOperationIndex(doc, "", "")
 	if len(ops) != 5 {
 		t.Fatalf("expected 5 operations, got %d: %+v", len(ops), ops)
 	}
@@ -164,7 +164,7 @@ func TestBuildOperationIndex_SynthesizesMissingOperationID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseOpenAPISpec: %v", err)
 	}
-	ops, _ := buildOperationIndex(doc, "")
+	ops, _ := buildOperationIndex(doc, "", "")
 	if len(ops) != 1 {
 		t.Fatalf("expected 1 operation, got %+v", ops)
 	}
@@ -174,14 +174,14 @@ func TestBuildOperationIndex_SynthesizesMissingOperationID(t *testing.T) {
 }
 
 func TestBuildOperationIndex_NilDoc(t *testing.T) {
-	if ops, texts := buildOperationIndex(nil, ""); ops != nil || texts != nil {
+	if ops, texts := buildOperationIndex(nil, "", ""); ops != nil || texts != nil {
 		t.Errorf("buildOperationIndex(nil) = (%v, %v); want (nil, nil)", ops, texts)
 	}
 }
 
 func TestRankOperations_EmptyQueryReturnsAllUpToLimit(t *testing.T) {
 	doc, _ := parseOpenAPISpec(validMinimalSpec)
-	ops, _ := buildOperationIndex(doc, "")
+	ops, _ := buildOperationIndex(doc, "", "")
 
 	all := rankOperations(ops, "", 0)
 	if len(all) != len(ops) {
@@ -195,7 +195,7 @@ func TestRankOperations_EmptyQueryReturnsAllUpToLimit(t *testing.T) {
 
 func TestRankOperations_SubstringMatchesIDPathSummaryTags(t *testing.T) {
 	doc, _ := parseOpenAPISpec(validMinimalSpec)
-	ops, _ := buildOperationIndex(doc, "")
+	ops, _ := buildOperationIndex(doc, "", "")
 
 	cases := []struct {
 		name  string
@@ -340,5 +340,199 @@ func TestAddConnection_CatalogMissing_ZeroOps(t *testing.T) {
 	tk.mu.RUnlock()
 	if len(c.operations) != 0 {
 		t.Errorf("expected 0 ops when catalog missing, got %d", len(c.operations))
+	}
+}
+
+// TestRankOperations_MultiTokenAndMatch covers finding #4 (round 2):
+// a multi-token query previously failed because the substring check
+// treated the whole query as a single phrase. "gift list" should
+// match an operation whose summary is "List all gifts", since both
+// tokens appear in searchable fields (path/summary respectively).
+func TestRankOperations_MultiTokenAndMatch(t *testing.T) {
+	ops := []OperationSummary{
+		{OperationID: "listGifts", Method: "GET", Path: "/gifts", Summary: "List all gifts"},
+		{OperationID: "createGift", Method: "POST", Path: "/gifts", Summary: "Create a gift"},
+		{OperationID: "listUsers", Method: "GET", Path: "/users", Summary: "List all users"},
+	}
+	got := rankOperations(ops, "gift list", 10)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 match (listGifts), got %d: %+v", len(got), got)
+	}
+	if got[0].OperationID != "listGifts" {
+		t.Errorf("expected listGifts, got %s", got[0].OperationID)
+	}
+}
+
+// TestRankOperations_SpecNameSearchable covers finding #4: the spec
+// name must be a searchable field so an operator can navigate a
+// multi-spec catalog by vendor-supplied section.
+func TestRankOperations_SpecNameSearchable(t *testing.T) {
+	ops := []OperationSummary{
+		{OperationID: "list", Method: "GET", Path: "/things", Summary: "List things", Spec: "orders"},
+		{OperationID: "list2", Method: "GET", Path: "/things", Summary: "List things", Spec: "users"},
+	}
+	got := rankOperations(ops, "orders", 10)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 match in orders spec, got %d", len(got))
+	}
+	if got[0].Spec != "orders" {
+		t.Errorf("expected orders spec, got %s", got[0].Spec)
+	}
+}
+
+// TestRankOperations_ZeroMatchReturnsEmptySlice covers finding #6:
+// a no-match query must produce "operations": [] in the JSON
+// response, not "operations": null. Returning nil would force every
+// client to handle two empty shapes.
+func TestRankOperations_ZeroMatchReturnsEmptySlice(t *testing.T) {
+	ops := []OperationSummary{
+		{OperationID: "a", Method: "GET", Path: "/a"},
+	}
+	got := rankOperations(ops, "no-such-thing-anywhere", 10)
+	if got == nil {
+		t.Fatal("got nil; want empty []OperationSummary")
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty result, got %d", len(got))
+	}
+}
+
+// TestSpecBasePath covers finding #5: the path component of the
+// first declared servers[].url is extracted (with a trailing slash
+// stripped) and the scheme + host are ignored so the operator's
+// connection.base_url remains the authoritative host.
+func TestSpecBasePath(t *testing.T) {
+	cases := []struct {
+		name      string
+		serverURL string
+		want      string
+	}{
+		{"empty spec", "", ""},
+		{"host only", "https://api.example.com", ""},
+		{"host + path", "https://api.example.com/v1", "/v1"},
+		{"host + path + trailing slash", "https://api.example.com/v1/", "/v1"},
+		{"host + nested path", "https://api.example.com/foo/v2", "/foo/v2"},
+		{"path only", "/v1", "/v1"},
+		{"root only", "/", ""},
+		{"relative path no leading slash", "v1", "/v1"},
+		{"relative path nested no leading slash", "api/v2", "/api/v2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			specYAML := minimalSpecWith(`/widgets:
+    get:
+      operationId: listWidgets
+      responses:
+        "200": {description: ok}`)
+			if tc.serverURL != "" {
+				specYAML = "openapi: 3.0.3\ninfo:\n  title: T\n  version: \"1.0\"\nservers:\n  - url: " + tc.serverURL + "\npaths:\n  /widgets:\n    get:\n      operationId: listWidgets\n      responses:\n        \"200\": {description: ok}\n"
+			}
+			doc, err := parseOpenAPISpec(specYAML)
+			if err != nil {
+				t.Fatalf("parseOpenAPISpec: %v", err)
+			}
+			if got := specBasePath(doc); got != tc.want {
+				t.Errorf("specBasePath(%q) = %q; want %q", tc.serverURL, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildOperationIndex_AppliesBasePath proves the base path is
+// prepended to every operation's path so the model using
+// api_list_endpoints output as input to api_invoke_endpoint
+// receives the full upstream path, not the spec-relative path that
+// 404s when the segment is missing from the connection's base_url.
+func TestBuildOperationIndex_AppliesBasePath(t *testing.T) {
+	spec := `
+openapi: 3.0.3
+info:
+  title: Users
+  version: "1.0"
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      responses:
+        "200": {description: ok}
+  /users/{id}:
+    get:
+      operationId: getUser
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        "200": {description: ok}
+`
+	doc, err := parseOpenAPISpec(spec)
+	if err != nil {
+		t.Fatalf("parseOpenAPISpec: %v", err)
+	}
+	ops, _ := buildOperationIndex(doc, "users", "/v3")
+	wantPaths := map[string]bool{
+		"/v3/users":      true,
+		"/v3/users/{id}": true,
+	}
+	for _, op := range ops {
+		if !wantPaths[op.Path] {
+			t.Errorf("unexpected op path %q (want one of %v)", op.Path, wantPaths)
+		}
+		delete(wantPaths, op.Path)
+	}
+	if len(wantPaths) != 0 {
+		t.Errorf("missing expected paths: %v", wantPaths)
+	}
+}
+
+// TestComputeEffectiveBasePath covers finding #1: when an operator's
+// connection.base_url already contains the spec's servers[0] path
+// segment as a suffix, the toolkit must NOT prepend the segment to
+// the operation paths or the invoke-time URL join will double it.
+// Drives the dedupe rule from a tabulated set of operator inputs.
+func TestComputeEffectiveBasePath(t *testing.T) {
+	cases := []struct {
+		name     string
+		connURL  string
+		specBase string
+		want     string
+	}{
+		{"empty spec base", "https://api.example.com/v1", "", ""},
+		{"host-only conn", "https://api.example.com", "/v1", "/v1"},
+		{"trailing slash on conn", "https://api.example.com/", "/v1", "/v1"},
+		{"conn already includes spec base", "https://api.example.com/v1", "/v1", ""},
+		{"conn includes deeper spec base", "https://api.example.com/api/v2", "/api/v2", ""},
+		{"conn includes spec base as suffix", "https://api.example.com/foo/api/v2", "/api/v2", ""},
+		{"conn path is unrelated to spec base", "https://api.example.com/legacy", "/v1", "/v1"},
+		{"unparseable conn falls back to spec base", "://not-a-url", "/v1", "/v1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := computeEffectiveBasePath(tc.connURL, tc.specBase); got != tc.want {
+				t.Errorf("computeEffectiveBasePath(%q, %q) = %q; want %q",
+					tc.connURL, tc.specBase, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFilterBySpec covers finding #4: the new spec input filters
+// operations to the matching component spec; empty spec is a
+// passthrough.
+func TestFilterBySpec(t *testing.T) {
+	ops := []OperationSummary{
+		{OperationID: "a", Spec: "users"},
+		{OperationID: "b", Spec: "orders"},
+		{OperationID: "c", Spec: "users"},
+	}
+	if got := filterBySpec(ops, ""); len(got) != 3 {
+		t.Errorf("empty filter must passthrough, got %d ops", len(got))
+	}
+	if got := filterBySpec(ops, "users"); len(got) != 2 {
+		t.Errorf("users filter must return 2 ops, got %d", len(got))
+	}
+	if got := filterBySpec(ops, "nonexistent"); len(got) != 0 {
+		t.Errorf("no-match must return empty slice, got %d", len(got))
 	}
 }

--- a/pkg/toolkits/apigateway/ranking.go
+++ b/pkg/toolkits/apigateway/ranking.go
@@ -3,12 +3,31 @@ package apigateway
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log/slog"
 	"math"
 	"sort"
 	"strings"
 
 	"github.com/txn2/mcp-data-platform/pkg/embedding"
 )
+
+// embedBatchSize is the maximum number of texts fed to the
+// embedding provider's EmbedBatch in a single call. Bounded so a
+// connection with hundreds of operations does not POST one giant
+// batch that risks timing out the request context, exceeding an
+// upstream model's context window, or hitting an HTTP body cap.
+// 32 is small enough that a single timed-out batch only loses
+// progress for that chunk and large enough to amortize per-call
+// overhead.
+const embedBatchSize = 32
+
+// errEmbedderNotWired is the sentinel returned by queryVectorFor
+// when no embedding provider has been configured on the toolkit.
+// Kept distinct from generic embedder errors so the fallback note
+// can phrase the cause correctly: this is operator configuration,
+// not an upstream failure.
+var errEmbedderNotWired = errors.New("embedding provider not configured on this connection")
 
 // RankingMode selects the algorithm api_list_endpoints uses to score
 // candidate operations against the model's query.
@@ -85,18 +104,21 @@ type rankRequest struct {
 	mode  RankingMode
 }
 
-func rankWithMode(ctx context.Context, r rankRequest) (ranked []OperationSummary, fallback bool) {
+func rankWithMode(ctx context.Context, r rankRequest) (ranked []OperationSummary, fallbackReason string) {
 	q := strings.TrimSpace(r.query)
-	// Empty query has no semantic signal — the cosine of the
+	// Empty query has no semantic signal: the cosine of the
 	// embedding-of-empty-string is meaningless. Lexical's "return
 	// all up to limit" is the right answer for both empty-query
 	// and explicit-lexical-mode.
 	if r.mode == RankingLexical || q == "" {
-		return rankOperations(r.ops, r.query, r.limit), false
+		return rankOperations(r.ops, r.query, r.limit), ""
 	}
-	queryVec, ok := r.tk.queryVectorFor(ctx, r.conn, q)
-	if !ok {
-		return rankOperations(r.ops, r.query, r.limit), true
+	queryVec, err := r.tk.queryVectorFor(ctx, r.conn, q)
+	if err != nil {
+		slog.Warn("apigateway: semantic ranking fell back to lexical",
+			logKeyConnection, r.conn.cfg.ConnectionName,
+			"mode", string(r.mode), logKeyError, err)
+		return rankOperations(r.ops, r.query, r.limit), err.Error()
 	}
 	scored := scoreOperations(r.conn, r.ops, q, queryVec, r.mode)
 	sort.SliceStable(scored, func(i, j int) bool {
@@ -106,38 +128,41 @@ func rankWithMode(ctx context.Context, r rankRequest) (ranked []OperationSummary
 	for _, s := range scored {
 		out = append(out, s.op)
 	}
-	return capSlice(out, r.limit), false
+	return capSlice(out, r.limit), ""
 }
 
-// queryVectorFor centralizes the "do we have everything we need to
-// rank semantically?" check. Returns the embedded query vector and
-// true when an embedder is wired, the per-connection embeddings are
-// populated, and the query embedding itself is non-zero. Any of
-// those failing yields false → the caller falls back to lexical
-// and surfaces a note. Splits out of rankWithMode to keep its
-// cyclomatic complexity under the project's gocyclo ceiling.
-func (t *Toolkit) queryVectorFor(ctx context.Context, c *conn, query string) ([]float32, bool) {
-	// Snapshot t.embedder under the read lock so a concurrent
-	// SetEmbeddingProvider cannot race with the nil check + dereference
-	// below. SetEmbeddingProvider holds t.mu.Lock; without this read
-	// lock, -race would fire on any deployment that swapped providers
-	// at runtime. Production v1 only wires once at startup, so the
-	// race is latent today — but matching the file's existing
-	// TokenStore() / handleListEndpoints lock pattern keeps it that way.
+// queryVectorFor returns the query's embedding vector or a non-nil
+// error describing why semantic ranking cannot proceed for this
+// call. Error returns drive the lexical fallback in rankWithMode
+// AND populate the operator-facing Note on the response so the
+// model (and the operator reading the log) knows whether the cause
+// was operator configuration (errEmbedderNotWired), an upstream
+// embedding failure (provider Embed errors), a previously-cached
+// per-connection failure (c.embedFailed), or a zero-vector reply
+// from the provider (a misconfigured model or empty-prompt edge
+// case).
+//
+// Snapshots t.embedder under the read lock so a concurrent
+// SetEmbeddingProvider cannot race with the nil check or with the
+// dereference below.
+func (t *Toolkit) queryVectorFor(ctx context.Context, c *conn, query string) ([]float32, error) {
 	t.mu.RLock()
 	embedder := t.embedder
 	t.mu.RUnlock()
 	if embedder == nil {
-		return nil, false
+		return nil, errEmbedderNotWired
 	}
-	if !t.ensureEmbeddings(ctx, c, embedder) {
-		return nil, false
+	if err := t.ensureEmbeddings(ctx, c, embedder); err != nil {
+		return nil, fmt.Errorf("operation embeddings unavailable: %w", err)
 	}
 	vec, err := embedder.Embed(ctx, query)
-	if err != nil || zeroVector(vec) {
-		return nil, false
+	if err != nil {
+		return nil, fmt.Errorf("embed query: %w", err)
 	}
-	return vec, true
+	if zeroVector(vec) {
+		return nil, errors.New("query embedding is the zero vector (misconfigured embedding model)")
+	}
+	return vec, nil
 }
 
 // scoreOperations builds the per-op score slice. Operations whose
@@ -167,40 +192,63 @@ type scoredOp struct {
 
 // scoreFor returns the per-operation rank score under the given
 // mode. Pure semantic uses the normalized cosine (mapped to [0,1])
-// directly; hybrid blends with the lexical 0/1 signal.
+// directly; hybrid blends with the lexical signal computed by
+// lexicalScore.
 func scoreFor(mode RankingMode, query string, op OperationSummary, queryVec, opVec []float32) float64 {
 	cos := cosineSimilarity(queryVec, opVec)
-	semantic := (cos + 1) / 2 // map [-1, 1] → [0, 1]
+	semantic := (cos + 1) / 2 // map [-1, 1] to [0, 1]
 	if mode == RankingSemantic {
 		return semantic
 	}
-	// Hybrid.
-	lex := lexicalMatchAbsent
-	if operationMatches(op, strings.ToLower(query)) {
-		lex = lexicalMatchPresent
-	}
-	return hybridSemanticWeight*semantic + (1-hybridSemanticWeight)*lex
+	return hybridSemanticWeight*semantic + (1-hybridSemanticWeight)*lexicalScore(op, query)
 }
 
-// indexOf returns the position of op in ops by (Method, Path) — the
-// stable identity per the OpenAPI spec. -1 when not found.
+// lexicalScore returns lexicalMatchPresent (1.0) when every
+// whitespace-separated token of query appears as a substring of at
+// least one of the operation's searchable fields, else
+// lexicalMatchAbsent (0.0). Shared between rankOperations (the
+// pure-lexical filter) and scoreFor (the hybrid lexical signal) so
+// a multi-token query that narrows results under "ranking=lexical"
+// also gets credit under "ranking=hybrid". Without this sharing
+// the hybrid lexical component reverts to phrase-match and
+// systematically underweights every multi-token intent query.
+func lexicalScore(op OperationSummary, query string) float64 {
+	tokens := strings.Fields(strings.ToLower(query))
+	if len(tokens) == 0 {
+		return lexicalMatchAbsent
+	}
+	if operationMatchesAllTokens(op, tokens) {
+		return lexicalMatchPresent
+	}
+	return lexicalMatchAbsent
+}
+
+// indexOf returns the position of op in ops by (Method, Path, Spec).
+// Spec is part of the identity because multi-spec catalogs can
+// legitimately host the same (Method, Path) tuple in two specs
+// (e.g. a vendor that ships "GET /search" in every component spec
+// it publishes). Matching on (Method, Path) alone returned the
+// first-seen index and paired the visible op with whichever spec's
+// embedding happened to sort first. Returns -1 when not found.
 func indexOf(ops []OperationSummary, target OperationSummary) int {
 	for i, op := range ops {
-		if op.Method == target.Method && op.Path == target.Path {
+		if op.Method == target.Method && op.Path == target.Path && op.Spec == target.Spec {
 			return i
 		}
 	}
 	return -1
 }
 
-// ensureEmbeddings populates c.embeddings if not already done for
-// the current spec hash. Returns true when the conn has usable
-// embeddings after the call (either populated this call or already
-// populated by a prior call). Returns false on provider failure or
-// on a connection that has no operations to embed.
+// ensureEmbeddings populates c.embeddings for the current spec set
+// if not already populated. Returns nil when c.embeddings is usable
+// on return (already populated by a prior call, or populated by this
+// one). Returns a non-nil error describing why semantic ranking
+// cannot proceed; the caller surfaces the error verbatim on the
+// fallback Note so operators see the real cause instead of a generic
+// "embedding pipeline unavailable" placeholder.
 //
 // Concurrent callers serialize through c.embedMu so the embedding
-// service is hit at most once per (connection, spec_hash) lifecycle.
+// service is hit at most once per (connection, spec_set) lifecycle.
 //
 // Failure handling distinguishes transient from definitive:
 //   - ctx.Err() (caller-side cancellation, deadline exceeded) and a
@@ -214,31 +262,69 @@ func indexOf(ops []OperationSummary, target OperationSummary) int {
 //
 // embedder is taken as an explicit argument (rather than reading
 // t.embedder again) so the snapshot taken under t.mu.RLock in the
-// caller is the value used here too — no second unguarded read.
-func (*Toolkit) ensureEmbeddings(ctx context.Context, c *conn, embedder embedding.Provider) bool {
+// caller is the value used here too.
+func (*Toolkit) ensureEmbeddings(ctx context.Context, c *conn, embedder embedding.Provider) error {
 	c.embedMu.Lock()
 	defer c.embedMu.Unlock()
 	if len(c.embedTexts) == 0 {
-		return false
+		return errors.New("connection has no operations to embed")
 	}
 	if len(c.embeddings) == len(c.embedTexts) {
-		return true
+		return nil
 	}
 	if c.embedFailed {
-		return false
+		return errors.New("a previous embedding attempt failed; restart the platform or reload the connection to retry")
 	}
-	vectors, err := embedder.EmbedBatch(ctx, c.embedTexts)
-	if err != nil || len(vectors) != len(c.embedTexts) {
+	vectors, err := embedInBatches(ctx, embedder, c.embedTexts, embedBatchSize)
+	if err != nil {
 		// Transient signals do NOT poison the cache. Definitive
-		// provider errors do, so a misconfigured Ollama URL doesn't
-		// produce a fresh hit on every tool call.
-		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		// provider errors do, so a misconfigured embedder URL
+		// doesn't produce a fresh hit on every tool call.
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 			c.embedFailed = true
+			slog.Warn("apigateway: embedding batch failed (caching as definitive)",
+				logKeyConnection, c.cfg.ConnectionName,
+				"texts", len(c.embedTexts), logKeyError, err)
 		}
-		return false
+		return fmt.Errorf("embed operation batch: %w", err)
+	}
+	if len(vectors) != len(c.embedTexts) {
+		// Length mismatch is a provider bug; treat as transient so
+		// a hot-reconfig of the provider can recover.
+		return fmt.Errorf("embed operation batch: provider returned %d vectors for %d texts",
+			len(vectors), len(c.embedTexts))
 	}
 	c.embeddings = vectors
-	return true
+	return nil
+}
+
+// embedInBatches calls embedder.EmbedBatch in chunks of at most
+// batchSize texts. Returns a single flat vector slice in the same
+// order as the input. Bounded per-call batch size keeps a connection
+// with hundreds of operations from sending one giant request that
+// risks timing out the per-call context, exceeding the upstream
+// model's context window, or hitting an HTTP body cap. The caller's
+// ctx is honored across all batches; the first batch error short-
+// circuits the rest.
+func embedInBatches(ctx context.Context, embedder embedding.Provider, texts []string, batchSize int) ([][]float32, error) {
+	if batchSize <= 0 {
+		batchSize = len(texts)
+	}
+	out := make([][]float32, 0, len(texts))
+	for start := 0; start < len(texts); start += batchSize {
+		end := min(start+batchSize, len(texts))
+		chunk := texts[start:end]
+		vectors, err := embedder.EmbedBatch(ctx, chunk)
+		if err != nil {
+			return nil, fmt.Errorf("batch [%d:%d]: %w", start, end, err)
+		}
+		if len(vectors) != len(chunk) {
+			return nil, fmt.Errorf("batch [%d:%d]: provider returned %d vectors for %d texts",
+				start, end, len(vectors), len(chunk))
+		}
+		out = append(out, vectors...)
+	}
+	return out, nil
 }
 
 // cosineSimilarity returns the cosine of the angle between a and b.

--- a/pkg/toolkits/apigateway/ranking_test.go
+++ b/pkg/toolkits/apigateway/ranking_test.go
@@ -205,7 +205,7 @@ func TestRankWithMode_LexicalEmptyQueryReturnsAll(t *testing.T) {
 		{OperationID: "b", Method: "GET", Path: "/b"},
 	}}
 	got, fb := rankWithMode(context.Background(), rankRequest{tk: tk, conn: c, ops: c.operations, query: "", limit: 10, mode: RankingLexical})
-	if fb {
+	if fb != "" {
 		t.Error("lexical with empty query should not report fallback")
 	}
 	if len(got) != 2 {
@@ -228,7 +228,7 @@ func TestRankWithMode_SemanticFallsBackWithoutEmbedder(t *testing.T) {
 	// returning the lexical results, the model would see an empty
 	// list and assume the API has nothing relevant.
 	got, fb := rankWithMode(context.Background(), rankRequest{tk: tk, conn: c, ops: c.operations, query: "users", limit: 10, mode: RankingSemantic})
-	if !fb {
+	if fb == "" {
 		t.Error("semantic without embedder should fallback to lexical")
 	}
 	if len(got) == 0 {
@@ -254,7 +254,7 @@ func TestRankWithMode_SemanticRanksByEmbedding(t *testing.T) {
 	// would handle "place new order" or "submit order" too; that's
 	// captured in the corpus benchmark below.
 	got, fb := rankWithMode(context.Background(), rankRequest{tk: tk, conn: c, ops: c.operations, query: "place a new order", limit: 5, mode: RankingSemantic})
-	if fb {
+	if fb != "" {
 		t.Fatal("semantic with embedder should not fallback")
 	}
 	if len(got) == 0 || got[0].OperationID != "create-order" {
@@ -273,7 +273,7 @@ func TestRankWithMode_HybridBlendsSignals(t *testing.T) {
 	// Query has direct lexical match on /orders path. Hybrid should
 	// still surface order-related ops first.
 	got, fb := rankWithMode(context.Background(), rankRequest{tk: tk, conn: c, ops: c.operations, query: "orders", limit: 5, mode: RankingHybrid})
-	if fb {
+	if fb != "" {
 		t.Fatal("hybrid with embedder should not fallback")
 	}
 	if len(got) < 2 {
@@ -301,7 +301,7 @@ func TestRankWithMode_SemanticEmbedFailureFallsBack(t *testing.T) {
 		{id: "b", method: "GET", path: "/b", summary: "beta"},
 	})
 	_, fb := rankWithMode(context.Background(), rankRequest{tk: tk, conn: c, ops: c.operations, query: "alpha", limit: 5, mode: RankingSemantic})
-	if !fb {
+	if fb == "" {
 		t.Error("batch-embed failure should report fallback")
 	}
 	if !c.embedFailed {
@@ -310,7 +310,7 @@ func TestRankWithMode_SemanticEmbedFailureFallsBack(t *testing.T) {
 	// Second call should also fall back without re-attempting embed.
 	emb.failBatch.Store(false) // would now succeed
 	_, fb2 := rankWithMode(context.Background(), rankRequest{tk: tk, conn: c, ops: c.operations, query: "alpha", limit: 5, mode: RankingSemantic})
-	if !fb2 {
+	if fb2 == "" {
 		t.Error("subsequent call should still fallback (sticky)")
 	}
 }
@@ -332,17 +332,17 @@ func TestEnsureEmbeddings_CtxCancelDoesNotPoisonCache(t *testing.T) {
 
 	canceled, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel so EmbedBatch returns ctx.Err() immediately
-	if got := (*Toolkit)(nil).ensureEmbeddings(canceled, c, emb); got {
-		t.Error("ensureEmbeddings should return false when ctx is canceled")
+	if err := (*Toolkit)(nil).ensureEmbeddings(canceled, c, emb); err == nil {
+		t.Error("ensureEmbeddings should return an error when ctx is canceled")
 	}
 	if c.embedFailed {
 		t.Error("ctx cancellation must NOT set c.embedFailed (would permanently disable semantic ranking)")
 	}
 
-	// Subsequent call with a fresh ctx must retry — the conn was
+	// Subsequent call with a fresh ctx must retry. The conn was
 	// not poisoned. Provider now returns success.
-	if got := (*Toolkit)(nil).ensureEmbeddings(context.Background(), c, emb); !got {
-		t.Errorf("retry after ctx cancel should succeed; emb.batchCalls=%d", emb.batchCalls)
+	if err := (*Toolkit)(nil).ensureEmbeddings(context.Background(), c, emb); err != nil {
+		t.Errorf("retry after ctx cancel should succeed: %v (emb.batchCalls=%d)", err, emb.batchCalls)
 	}
 	if len(c.embeddings) != len(c.embedTexts) {
 		t.Errorf("embeddings not populated after retry: %d vs %d", len(c.embeddings), len(c.embedTexts))
@@ -390,7 +390,7 @@ func TestRankWithMode_QueryEmbedFailureFallsBack(t *testing.T) {
 	c := buildTestConn(t, []testOp{{id: "a", method: "GET", path: "/a", summary: "alpha"}})
 	emb.failEmbed.Store(true) // single Embed errors; EmbedBatch still works
 	_, fb := rankWithMode(context.Background(), rankRequest{tk: tk, conn: c, ops: c.operations, query: "alpha", limit: 5, mode: RankingSemantic})
-	if !fb {
+	if fb == "" {
 		t.Error("query-embed failure should report fallback")
 	}
 }
@@ -405,7 +405,7 @@ func TestRankWithMode_ZeroQueryVectorFallsBack(t *testing.T) {
 	tk.SetEmbeddingProvider(zeroEmbedder{})
 	c := buildTestConn(t, []testOp{{id: "a", method: "GET", path: "/a", summary: "alpha"}})
 	_, fb := rankWithMode(context.Background(), rankRequest{tk: tk, conn: c, ops: c.operations, query: "alpha", limit: 5, mode: RankingSemantic})
-	if !fb {
+	if fb == "" {
 		t.Error("zero-vector embedder should force fallback")
 	}
 }
@@ -662,5 +662,109 @@ func TestSemanticRanking_BenchmarkCorpus(t *testing.T) {
 	if hyb.at3 < lex.at3 {
 		t.Errorf("hybrid recall@3 (%d) < lexical recall@3 (%d) — blend regressed substring precision",
 			hyb.at3, lex.at3)
+	}
+}
+
+// TestEmbedInBatches_ChunksAtBatchSize proves the chunking
+// boundary: a 100-text input must produce 4 calls (chunks of 32,
+// 32, 32, 4) rather than one giant batch. Drives finding from the
+// adversarial review that the chunking claim was previously
+// unverified by tests using only small fixtures.
+func TestEmbedInBatches_ChunksAtBatchSize(t *testing.T) {
+	emb := &batchCounter{vectorDim: 4}
+	texts := make([]string, 100)
+	for i := range texts {
+		texts[i] = fmt.Sprintf("text-%d", i)
+	}
+
+	vectors, err := embedInBatches(context.Background(), emb, texts, 32)
+	if err != nil {
+		t.Fatalf("embedInBatches: %v", err)
+	}
+	if len(vectors) != 100 {
+		t.Fatalf("got %d vectors, want 100", len(vectors))
+	}
+	if emb.batchCalls != 4 {
+		t.Errorf("expected 4 EmbedBatch calls (32+32+32+4), got %d", emb.batchCalls)
+	}
+	wantSizes := []int{32, 32, 32, 4}
+	if len(emb.batchSizes) != len(wantSizes) {
+		t.Fatalf("got %d batches, want %d", len(emb.batchSizes), len(wantSizes))
+	}
+	for i, n := range wantSizes {
+		if emb.batchSizes[i] != n {
+			t.Errorf("batch %d: got %d, want %d", i, emb.batchSizes[i], n)
+		}
+	}
+}
+
+// TestEmbedInBatches_PropagatesError proves a batch error short-
+// circuits the remaining chunks. Caller must not see partial
+// results disguised as success.
+func TestEmbedInBatches_PropagatesError(t *testing.T) {
+	emb := &batchCounter{vectorDim: 4, failOnBatch: 2}
+	texts := make([]string, 100)
+	for i := range texts {
+		texts[i] = fmt.Sprintf("text-%d", i)
+	}
+	_, err := embedInBatches(context.Background(), emb, texts, 32)
+	if err == nil {
+		t.Fatal("expected error from failing batch")
+	}
+	if emb.batchCalls != 2 {
+		t.Errorf("expected 2 calls (first ok, second fail), got %d", emb.batchCalls)
+	}
+}
+
+type batchCounter struct {
+	vectorDim   int
+	batchCalls  int
+	batchSizes  []int
+	failOnBatch int // 1-indexed; 0 = never fail
+}
+
+func (b *batchCounter) Dimension() int { return b.vectorDim }
+
+func (b *batchCounter) Embed(_ context.Context, _ string) ([]float32, error) {
+	out := make([]float32, b.vectorDim)
+	out[0] = 1
+	return out, nil
+}
+
+func (b *batchCounter) EmbedBatch(_ context.Context, texts []string) ([][]float32, error) {
+	b.batchCalls++
+	b.batchSizes = append(b.batchSizes, len(texts))
+	if b.failOnBatch != 0 && b.batchCalls == b.failOnBatch {
+		return nil, fmt.Errorf("simulated batch %d failure", b.batchCalls)
+	}
+	out := make([][]float32, len(texts))
+	for i := range out {
+		out[i] = make([]float32, b.vectorDim)
+		out[i][0] = float32(i + 1)
+	}
+	return out, nil
+}
+
+// TestLexicalScore_MultiTokenAndForHybridSignal proves the hybrid
+// scorer's lexical signal honors per-token AND, matching the
+// rankOperations behavior. Previously hybrid mode treated the
+// query as a phrase and assigned lexicalMatchAbsent to multi-token
+// intent queries that rankOperations would have matched, defeating
+// the hybrid blend for exactly the queries it should help with.
+func TestLexicalScore_MultiTokenAndForHybridSignal(t *testing.T) {
+	op := OperationSummary{
+		OperationID: "listGifts",
+		Method:      "GET",
+		Path:        "/gifts",
+		Summary:     "List all gifts",
+	}
+	if got := lexicalScore(op, "gift list"); got != lexicalMatchPresent {
+		t.Errorf("multi-token AND match should return present (1.0); got %v", got)
+	}
+	if got := lexicalScore(op, "gift purchase"); got != lexicalMatchAbsent {
+		t.Errorf("token missing from any field should return absent (0.0); got %v", got)
+	}
+	if got := lexicalScore(op, ""); got != lexicalMatchAbsent {
+		t.Errorf("empty query should return absent; got %v", got)
 	}
 }

--- a/pkg/toolkits/apigateway/schema_lookup.go
+++ b/pkg/toolkits/apigateway/schema_lookup.go
@@ -168,19 +168,25 @@ func collectOperationMatches(c *conn, operationID, specFilter string) ([]*operat
 		if specFilter != "" && specName != specFilter {
 			continue
 		}
+		basePath := st.effectiveBasePath
 		walkOperations(st.doc, func(method, path string, op *openapi3.Operation) {
+			fullPath := basePath + path
 			id := op.OperationID
 			if id == "" {
-				id = method + " " + path
+				// Synthesized id must match what buildOperationIndex
+				// emits or the operationID returned by
+				// api_list_endpoints will not resolve here. Both
+				// sites use METHOD + " " + full upstream path.
+				id = method + " " + fullPath
 			}
 			if id != operationID {
 				return
 			}
 			matches = append(matches, &operationMatch{
-				specName: specName, method: method, path: path, op: op,
+				specName: specName, method: method, path: fullPath, op: op,
 			})
 			candidates = append(candidates, schemaCandidate{
-				Spec: specName, Method: method, Path: path,
+				Spec: specName, Method: method, Path: fullPath,
 			})
 		})
 	}
@@ -223,6 +229,11 @@ func walkOperations(doc *openapi3.T, fn func(method, path string, op *openapi3.O
 // buildEndpointSchemaOutput composes the response payload from the
 // resolved operation, stripping security/server metadata and
 // flattening schemas to a fixed depth.
+//
+// m.path is already the full upstream path (the spec's base path
+// prepended at collectOperationMatches time) so the output's Path
+// field agrees with the path reported by api_list_endpoints for
+// the same operation. Same for the synthesized OperationID.
 func buildEndpointSchemaOutput(m *operationMatch) EndpointSchemaOutput {
 	out := EndpointSchemaOutput{
 		Spec:        m.specName,

--- a/pkg/toolkits/apigateway/schema_lookup_test.go
+++ b/pkg/toolkits/apigateway/schema_lookup_test.go
@@ -135,7 +135,7 @@ func TestGetEndpointSchema_ListPets(t *testing.T) {
 		t.Fatalf("listPets: err=%v isError=%v body=%s", err, r.IsError, textContent(r))
 	}
 	out := parseSchemaResult(t, r)
-	if out.OperationID != "listPets" || out.Method != "GET" || out.Path != "/pets" {
+	if out.OperationID != "listPets" || out.Method != "GET" || out.Path != "/v1/pets" {
 		t.Fatalf("unexpected op: %+v", out)
 	}
 	if len(out.Parameters) != 1 || out.Parameters[0].Name != "limit" {

--- a/pkg/toolkits/apigateway/schemas.go
+++ b/pkg/toolkits/apigateway/schemas.go
@@ -15,7 +15,7 @@ var listEndpointsSchema = json.RawMessage(`{
     },
     "query": {
       "type": "string",
-      "description": "Optional case-insensitive substring search across operation_id, path, summary, and tags. Empty returns the full list (capped by limit)."
+      "description": "Optional case-insensitive search across operation_id, path, summary, spec name, and tags. Multiple whitespace-separated tokens combine with AND, so \"gift list\" matches operations containing both \"gift\" and \"list\" in any of those fields. Empty returns the full list (capped by limit)."
     },
     "limit": {
       "type": "integer",
@@ -23,10 +23,14 @@ var listEndpointsSchema = json.RawMessage(`{
       "maximum": 500,
       "description": "Optional cap on the number of operations returned. Defaults to 50. Pass a higher value when exploring large APIs."
     },
+    "spec": {
+      "type": "string",
+      "description": "Optional component-spec filter for multi-spec catalogs. Restricts results to operations whose spec field matches this value exactly. Pair with query to narrow to a section of a large catalog (e.g. spec=\"orders\" + query=\"refund\"). Values come from the spec field on operations in a prior api_list_endpoints response."
+    },
     "ranking": {
       "type": "string",
       "enum": ["lexical", "semantic", "hybrid"],
-      "description": "Optional ranking algorithm. \"lexical\" (default) is case-insensitive substring match — fast and deterministic but misses when your phrasing differs from the spec author's. \"semantic\" ranks by embedding cosine similarity, which finds endpoints by intent (\"create order\" → POST /v1/orders) even when no words overlap. \"hybrid\" blends both — best for free-form intent queries that may also share path/tag vocabulary. semantic and hybrid require an embedding provider; if unavailable they fall back to lexical and a note explains why."
+      "description": "Optional ranking algorithm. \"lexical\" (default) is per-token case-insensitive substring match: fast, deterministic, but misses when your phrasing differs from the spec author's. \"semantic\" ranks by embedding cosine similarity, which finds endpoints by intent (\"create order\" finds POST /v1/orders) even when no words overlap. \"hybrid\" blends both: best for free-form intent queries that may also share path/tag vocabulary. semantic and hybrid require an embedding provider; if unavailable they fall back to lexical and a note explains the reason."
     }
   }
 }`)

--- a/pkg/toolkits/apigateway/toolkit.go
+++ b/pkg/toolkits/apigateway/toolkit.go
@@ -233,14 +233,26 @@ type conn struct {
 // specState retains the parsed OpenAPI document for a component
 // spec alongside the catalog metadata the portal needs (source
 // kind, URL, etag, fetch time). The parsed doc is what
-// api_get_endpoint_schema walks to assemble per-endpoint detail —
-// without it, the toolkit would have to re-parse on every call.
+// api_get_endpoint_schema walks to assemble per-endpoint detail.
+// Without it, the toolkit would have to re-parse on every call.
+//
+// effectiveBasePath is the per-spec prefix applied to every
+// operation's spec-relative path so api_list_endpoints output, the
+// synthesized operationID in api_get_endpoint_schema, and the
+// stored OperationSummary.Path all agree on a single full path
+// the model passes to api_invoke_endpoint. The value is derived
+// once at registration time from servers[0].url and the connection's
+// base_url so callers downstream do not have to recompute or worry
+// about base_url-vs-spec-base-path overlap (when the operator's
+// connection.base_url already includes the spec's prefix, the
+// effective base path is empty and no doubling occurs).
 type specState struct {
-	doc           *openapi3.T
-	sourceKind    string
-	sourceURL     string
-	etag          string
-	lastFetchedAt time.Time
+	doc               *openapi3.T
+	sourceKind        string
+	sourceURL         string
+	etag              string
+	lastFetchedAt     time.Time
+	effectiveBasePath string
 }
 
 // New builds an empty toolkit. Connections are added later via
@@ -356,11 +368,21 @@ func (t *Toolkit) Tools() []string {
 
 // ListEndpointsInput is the parsed argument shape for
 // api_list_endpoints. Field names match the JSON schema.
+//
+// Spec restricts results to one component spec inside the
+// connection's catalog. For a multi-spec catalog (e.g. a vendor
+// shipping nine component specs under one connection) this is the
+// per-section filter operators reach for once the catalog passes
+// the size at which substring search across all 300+ operations
+// stops being useful. Spec values come from the spec field on each
+// operation in a prior api_list_endpoints response, so the model
+// can pass them back verbatim.
 type ListEndpointsInput struct {
 	Connection string `json:"connection"`
 	Query      string `json:"query,omitempty"`
 	Limit      int    `json:"limit,omitempty"`
 	Ranking    string `json:"ranking,omitempty"`
+	Spec       string `json:"spec,omitempty"`
 }
 
 // ListEndpointsOutput is the structured result. Empty + Note when
@@ -377,7 +399,29 @@ type ListEndpointsOutput struct {
 // model can request more by passing limit explicitly.
 const defaultListEndpointsLimit = 50
 
-func (t *Toolkit) handleListEndpoints(ctx context.Context, _ *mcp.CallToolRequest, in ListEndpointsInput) (*mcp.CallToolResult, any, error) {
+func (t *Toolkit) handleListEndpoints(ctx context.Context, _ *mcp.CallToolRequest, in ListEndpointsInput) (result *mcp.CallToolResult, _ any, _ error) {
+	// Panic recovery turns any unexpected runtime failure (a
+	// provider-impl bug, a nil-pointer, an out-of-range index) into
+	// an operator-readable error result instead of bubbling up as
+	// the MCP SDK's generic "Error occurred during tool execution"
+	// string that surfaced when the ranking path panicked against
+	// a multi-spec catalog. Logged at error level with the
+	// connection so the source is traceable from the pod log.
+	//
+	// When a panic interrupts a semantic or hybrid ranking call we
+	// also mark the connection's embed cache as failed so the next
+	// call short-circuits to lexical instead of re-triggering the
+	// same panic. Same definitive-failure semantics as the normal
+	// embedder-error path uses; without this guard a misbehaving
+	// embedding provider would panic on every subsequent call.
+	defer func() {
+		if rec := recover(); rec != nil {
+			slog.Error("apigateway: panic in handleListEndpoints",
+				logKeyConnection, in.Connection, "panic", rec)
+			t.markEmbedFailedOnPanic(in.Connection, in.Ranking)
+			result = errorResult(fmt.Sprintf("internal error in list_endpoints (connection=%s): %v", in.Connection, rec))
+		}
+	}()
 	if in.Connection == "" {
 		return errorResult("connection is required"), nil, nil
 	}
@@ -391,7 +435,7 @@ func (t *Toolkit) handleListEndpoints(ctx context.Context, _ *mcp.CallToolReques
 	if len(c.operations) == 0 {
 		out := ListEndpointsOutput{
 			Operations: []OperationSummary{},
-			Note:       "no catalog_id configured for this connection — call api_invoke_endpoint with method+path directly",
+			Note:       "no catalog_id configured for this connection; call api_invoke_endpoint with method+path directly",
 		}
 		return jsonResult(out), out, nil
 	}
@@ -401,6 +445,13 @@ func (t *Toolkit) handleListEndpoints(ctx context.Context, _ *mcp.CallToolReques
 	// listed and the model wastes a turn discovering the denial at
 	// invoke time.
 	visible := filterByRoutePolicy(ctx, policy, in.Connection, c.operations)
+	// Apply the operator-supplied spec filter (when set) before
+	// ranking, so the rank limit applies within the requested spec
+	// rather than to the unfiltered catalog. Pre-filtering also
+	// keeps the score computation small for the common case of an
+	// operator drilling into a known section of a multi-spec
+	// catalog.
+	visible = filterBySpec(visible, in.Spec)
 	limit := in.Limit
 	if limit <= 0 {
 		limit = defaultListEndpointsLimit
@@ -409,14 +460,59 @@ func (t *Toolkit) handleListEndpoints(ctx context.Context, _ *mcp.CallToolReques
 	if modeErr != nil {
 		return errorResult(modeErr.Error()), nil, nil
 	}
-	ranked, fellBack := rankWithMode(ctx, rankRequest{
+	ranked, fallbackReason := rankWithMode(ctx, rankRequest{
 		tk: t, conn: c, ops: visible, query: in.Query, limit: limit, mode: mode,
 	})
 	out := ListEndpointsOutput{Operations: ranked}
-	if fellBack {
-		out.Note = fmt.Sprintf("ranking %q fell back to lexical: embedding pipeline unavailable for this connection", mode)
+	if fallbackReason != "" {
+		out.Note = fmt.Sprintf("ranking %q fell back to lexical: %s", mode, fallbackReason)
 	}
 	return jsonResult(out), out, nil
+}
+
+// markEmbedFailedOnPanic sets c.embedFailed on the connection
+// when a semantic-or-hybrid ranking call panicked, so the next call
+// falls back to lexical instead of repeatedly triggering the same
+// panic. No-op for lexical-mode panics (which would not have
+// touched the embedder) and for unknown connection names. The
+// connection name and ranking mode are taken from the original
+// request input so the deferred recover does not depend on any
+// state we lose on panic.
+func (t *Toolkit) markEmbedFailedOnPanic(connName, ranking string) {
+	mode, err := parseRankingMode(ranking)
+	if err != nil || mode == RankingLexical {
+		return
+	}
+	t.mu.RLock()
+	c, ok := t.connections[connName]
+	t.mu.RUnlock()
+	if !ok {
+		return
+	}
+	c.embedMu.Lock()
+	c.embedFailed = true
+	c.embedMu.Unlock()
+	slog.Warn("apigateway: marked embed cache failed after ranking panic",
+		logKeyConnection, connName, "mode", string(mode))
+}
+
+// filterBySpec returns the subset of ops whose Spec exactly matches
+// spec. Empty spec is a passthrough (no filtering). The match is
+// case-sensitive because spec names are catalog-managed slugs the
+// catalog store validates against a fixed pattern; case insensitivity
+// would create false equivalences for catalogs that happen to host
+// distinct specs whose names differ only in case.
+func filterBySpec(ops []OperationSummary, spec string) []OperationSummary {
+	if spec == "" {
+		return ops
+	}
+	out := make([]OperationSummary, 0, len(ops))
+	for _, op := range ops {
+		if op.Spec == spec {
+			out = append(out, op)
+		}
+	}
+	return out
 }
 
 // parseRankingMode maps the input string to a RankingMode. Empty
@@ -535,7 +631,7 @@ func (t *Toolkit) addParsedConnection(name string, cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("apigateway: %s: %w", name, err)
 	}
-	specs, ops, texts := t.buildConnSpecs(name, cfg.CatalogID)
+	specs, ops, texts := t.buildConnSpecs(name, cfg.CatalogID, cfg.BaseURL)
 	c := &conn{
 		cfg:        cfg,
 		auth:       auth,
@@ -570,9 +666,19 @@ func (t *Toolkit) addParsedConnection(name string, cfg Config) error {
 // parses each component spec, and returns the merged operation
 // index alongside the per-spec retained state. A nil catalog
 // store, an empty catalog_id, or a load failure all return zero
-// values — the caller proceeds with no spec surface and logs the
+// values; the caller proceeds with no spec surface and logs the
 // reason.
-func (t *Toolkit) buildConnSpecs(connName, catalogID string) (
+//
+// connBaseURL is the connection's configured base URL. Its path
+// component is consulted when deriving each spec's effective base
+// path: if the connection's base_url already contains the spec's
+// servers[0] path segment, the spec base path is dropped so the
+// invoke-time URL join does not double the segment. The dedupe
+// makes both single-spec connections (where the operator typically
+// hard-codes the full vendor base) and multi-spec connections
+// (where the operator points at the bare host and each spec
+// declares its own versioned path) work without per-shape config.
+func (t *Toolkit) buildConnSpecs(connName, catalogID, connBaseURL string) (
 	specs map[string]*specState, operations []OperationSummary, texts []string,
 ) {
 	if catalogID == "" {
@@ -601,14 +707,16 @@ func (t *Toolkit) buildConnSpecs(connName, catalogID string) (
 				"spec_name", e.SpecName, logKeyError, perr)
 			continue
 		}
+		effectiveBasePath := computeEffectiveBasePath(connBaseURL, specBasePath(doc))
 		specs[e.SpecName] = &specState{
-			doc:           doc,
-			sourceKind:    e.SourceKind,
-			sourceURL:     e.SourceURL,
-			etag:          e.ETag,
-			lastFetchedAt: e.LastFetchedAt,
+			doc:               doc,
+			sourceKind:        e.SourceKind,
+			sourceURL:         e.SourceURL,
+			etag:              e.ETag,
+			lastFetchedAt:     e.LastFetchedAt,
+			effectiveBasePath: effectiveBasePath,
 		}
-		specOps, specTexts := buildOperationIndex(doc, e.SpecName)
+		specOps, specTexts := buildOperationIndex(doc, e.SpecName, effectiveBasePath)
 		operations = append(operations, specOps...)
 		texts = append(texts, specTexts...)
 	}

--- a/pkg/toolkits/apigateway/toolkit_test.go
+++ b/pkg/toolkits/apigateway/toolkit_test.go
@@ -788,3 +788,157 @@ func TestToolkit_SetConnOAuthStore_RethreadsAuthorizationCodeAuth(t *testing.T) 
 		t.Error("re-thread did not deliver the new store to the existing Authenticator")
 	}
 }
+
+// TestHandleListEndpoints_SpecFilter covers finding #4: the spec
+// input restricts results to one component spec of a multi-spec
+// catalog, applied before ranking so the rank limit acts within
+// the spec rather than against the unfiltered catalog.
+func TestHandleListEndpoints_SpecFilter(t *testing.T) {
+	tk := New("test")
+	store := setupCatalogWithSpec(t, tk, "vendor", "users",
+		minimalSpecWith(`/users:
+    `+pathOpYAML("get", "listUsers", "List users")))
+	if err := store.UpsertSpec(context.Background(), "vendor",
+		newSpecEntry("orders", minimalSpecWith(`/orders:
+    `+pathOpYAML("get", "listOrders", "List orders")))); err != nil {
+		t.Fatalf("UpsertSpec: %v", err)
+	}
+	if err := tk.AddConnection("c", map[string]any{
+		"base_url":   "https://x",
+		"catalog_id": "vendor",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	res, out, err := tk.handleListEndpoints(context.Background(), nil, ListEndpointsInput{
+		Connection: "c",
+		Spec:       "users",
+	})
+	if err != nil {
+		t.Fatalf("handleListEndpoints: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got error: %s", textContent(res))
+	}
+	o, _ := out.(ListEndpointsOutput)
+	if len(o.Operations) != 1 {
+		t.Fatalf("expected 1 op from users spec, got %d (%+v)", len(o.Operations), o.Operations)
+	}
+	if o.Operations[0].Spec != "users" {
+		t.Errorf("expected spec=users, got %q", o.Operations[0].Spec)
+	}
+}
+
+// TestHandleListEndpoints_FallbackNoteIncludesReason covers
+// finding #3: when semantic ranking falls back to lexical, the
+// fallback note must carry the real reason (e.g. embedder error
+// or "embedding provider not configured") so the operator can
+// fix the root cause without reading pod logs.
+func TestHandleListEndpoints_FallbackNoteIncludesReason(t *testing.T) {
+	tk := New("test")
+	// No embedding provider wired.
+	setupCatalogWithSpec(t, tk, "petstore", "default", validMinimalSpec)
+	if err := tk.AddConnection("c", map[string]any{
+		"base_url":   "https://x",
+		"catalog_id": "petstore",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	res, out, err := tk.handleListEndpoints(context.Background(), nil, ListEndpointsInput{
+		Connection: "c",
+		Query:      "users",
+		Ranking:    "semantic",
+	})
+	if err != nil {
+		t.Fatalf("handleListEndpoints: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success with fallback, got error: %s", textContent(res))
+	}
+	o, _ := out.(ListEndpointsOutput)
+	if o.Note == "" {
+		t.Fatal("expected non-empty Note describing the fallback reason")
+	}
+	// Note must name the actual cause; the generic v1 wording
+	// "embedding pipeline unavailable" was the regression.
+	if !strings.Contains(o.Note, "embedding provider not configured") {
+		t.Errorf("Note should name the real cause; got: %q", o.Note)
+	}
+}
+
+// TestHandleListEndpoints_PanicRecovery covers finding #3: a
+// runtime panic in the ranking pipeline must surface as an
+// operator-readable error result, not as the MCP SDK's generic
+// "Error occurred during tool execution". The follow-up assertion
+// proves the embed cache is marked failed so a misbehaving
+// embedder cannot be re-hit on every subsequent call.
+func TestHandleListEndpoints_PanicRecovery(t *testing.T) {
+	tk := New("test")
+	tk.SetEmbeddingProvider(panicEmbedder{})
+	setupCatalogWithSpec(t, tk, "petstore", "default", validMinimalSpec)
+	if err := tk.AddConnection("c", map[string]any{
+		"base_url":   "https://x",
+		"catalog_id": "petstore",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	res, _, err := tk.handleListEndpoints(context.Background(), nil, ListEndpointsInput{
+		Connection: "c",
+		Query:      "users",
+		Ranking:    "semantic",
+	})
+	if err != nil {
+		t.Fatalf("handleListEndpoints returned go error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError result after panic")
+	}
+	msg := textContent(res)
+	if !strings.Contains(msg, "internal error") || !strings.Contains(msg, "connection=c") {
+		t.Errorf("error message should name internal error and connection name: %q", msg)
+	}
+	if strings.Contains(msg, "Error occurred during tool execution") {
+		t.Errorf("must NOT surface the MCP SDK generic panic message: %q", msg)
+	}
+
+	// After the panic, c.embedFailed must be set so the next
+	// semantic-mode call falls back to lexical instead of panicking
+	// again. Verify the flag, then prove the follow-up call returns
+	// a clean fallback result with a Note (no panic, no IsError).
+	tk.mu.RLock()
+	c := tk.connections["c"]
+	tk.mu.RUnlock()
+	c.embedMu.Lock()
+	failed := c.embedFailed
+	c.embedMu.Unlock()
+	if !failed {
+		t.Fatal("c.embedFailed should be set after a ranking panic")
+	}
+	res2, out2, err := tk.handleListEndpoints(context.Background(), nil, ListEndpointsInput{
+		Connection: "c",
+		Query:      "users",
+		Ranking:    "semantic",
+	})
+	if err != nil {
+		t.Fatalf("follow-up handleListEndpoints: %v", err)
+	}
+	if res2.IsError {
+		t.Errorf("follow-up call should fall back to lexical, not error: %s", textContent(res2))
+	}
+	o, _ := out2.(ListEndpointsOutput)
+	if o.Note == "" {
+		t.Error("follow-up call should carry a fallback Note")
+	}
+}
+
+// panicEmbedder panics on every call. Used to drive the
+// handleListEndpoints panic-recovery contract.
+type panicEmbedder struct{}
+
+func (panicEmbedder) Dimension() int { return 8 }
+func (panicEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	panic("simulated embedder panic")
+}
+
+func (panicEmbedder) EmbedBatch(_ context.Context, _ []string) ([][]float32, error) {
+	panic("simulated embedder batch panic")
+}


### PR DESCRIPTION
## Summary

Four operator-visible issues against the api toolkit's discovery and ranking surface, addressed in one PR. Each one was reproducible against a real multi-spec catalog on the demo deployment and each one is now covered by a regression test that asserts observable behavior.

| # | Issue | Symptom |
|---|---|---|
| 1 | ``ranking=semantic`` and ``ranking=hybrid`` errored out | ``api_list_endpoints`` returned the MCP SDK's generic ``Error occurred during tool execution`` instead of useful diagnostics; the fallback Note said ``embedding pipeline unavailable`` regardless of the real cause |
| 2 | Discovery UX | Multi-token queries treated as a single phrase; spec name not searchable; no way to filter to one component spec of a multi-spec catalog |
| 3 | Spec base paths missing | ``api_list_endpoints`` returned spec-relative paths; the model invoked them and the upstream 404'd because the connection's ``base_url`` did not include the spec's version segment |
| 4 | ``operations: null`` | A zero-match query produced ``"operations": null`` in the JSON response (the catalog-less case produced ``"operations": []``); clients had to handle two empty shapes |

## Detail

### 1. Ranking diagnostics and resilience

The semantic and hybrid paths shipped with three independent weaknesses that compounded into the operator-reported ``Error occurred during tool execution``:

- ``rankWithMode``, ``queryVectorFor``, and ``ensureEmbeddings`` all dropped the embedder's error on the floor. A misconfigured Ollama URL, an upstream timeout, or a model with a context-window cap all surfaced as the same generic fallback Note.
- ``EmbedBatch`` was called once with every operation's text. A 354-operation catalog produced one large POST that risked timing out or hitting an upstream context-window cap.
- A panic anywhere in the ranking pipeline propagated up to the MCP SDK, which presented it as a generic tool-execution error with no traceability.
- ``indexOf`` keyed only on ``(Method, Path)``. Multi-spec catalogs where the same tuple legitimately exists in two specs received the first-seen spec's embedding for every match, producing silently wrong rankings.

Fixes:

- ``rankWithMode`` now returns ``(ranked, fallbackReason string)``. ``handleListEndpoints`` interpolates the reason into the Note: ``"ranking ""semantic"" fell back to lexical: embedding provider not configured on this connection"``, ``"... embed query: <provider error>"``, ``"... query embedding is the zero vector (misconfigured embedding model)"``, etc.
- ``ensureEmbeddings`` and ``queryVectorFor`` return errors. Errors are also logged with the connection name, mode, and the underlying error so the cause is traceable from the pod log.
- ``embedInBatches`` chunks at ``embedBatchSize = 32`` and short-circuits the loop on the first batch error.
- ``handleListEndpoints`` defers a recover that returns ``"internal error in list_endpoints (connection=<name>): <panic message>"`` and marks the connection's embed cache as failed via ``markEmbedFailedOnPanic`` so a misbehaving provider cannot be re-hit on every subsequent call. The follow-up call falls back cleanly to lexical with a Note.
- ``indexOf`` now keys on ``(Method, Path, Spec)``.

### 2. Discovery UX

The lexical filter was a single substring match against the whole query string. For a 354-operation catalog across 9 specs:

- ``"gift list"`` matched zero operations because no single field contains the phrase, even though plenty of operations contained both words.
- The spec name appeared in the output but was not a search target, so an operator who knew the vendor's section name (``orders``, ``billing``) could not navigate by it.
- There was no way to filter to one section. The model had to scan all 354 operations.

Fixes:

- ``rankOperations`` tokenizes the query on whitespace and requires every token to substring-match at least one searchable field. ``"gift list"`` now matches summary=``"List all gifts"`` path=``/gifts``.
- ``operationFieldsContain`` adds the spec name to the searched fields.
- ``ListEndpointsInput.Spec`` (new) restricts results to one component spec. Applied before ranking so the rank ``limit`` acts within the chosen spec.
- ``lexicalScore`` extracts the per-token AND check so the hybrid scorer's lexical signal uses the same multi-token semantics. Without this, hybrid systematically underweighted exactly the multi-token intent queries the discovery fix targets.

### 3. Spec base paths

Operation paths in ``api_list_endpoints`` were taken verbatim from each OpenAPI document's ``paths:`` map. Vendor specs that declare ``servers[]`` with a versioned base (``https://host/foo/v1``, ``https://host/bar/v2``) need that segment in front of every operation path or the invoke-time URL join produces a 404. The model had no way to know about the segment from the catalog metadata.

Fixes:

- ``specBasePath`` extracts the path component of ``servers[0].url`` and normalizes relative URLs to start with ``/``.
- ``computeEffectiveBasePath`` checks the connection's ``base_url``: if its path already contains the spec's base path as a suffix (the case where the operator typed the full vendor base into the connection config), the spec base path is dropped to avoid doubling the segment at invoke time.
- ``specState.effectiveBasePath`` stores the resolved value per spec. ``buildOperationIndex`` uses it at registration time so ``api_list_endpoints`` returns full paths. ``collectOperationMatches`` uses the same value at runtime so ``api_get_endpoint_schema`` returns the same path, and the synthesized operationID for endpoints without an explicit one is consistent across both tools.

### 4. Non-null operations

``rankOperations`` used ``var matched []OperationSummary``, producing ``"operations": null`` when no operations matched. The catalog-less branch in ``handleListEndpoints`` always returned ``"operations": []``. Clients now had two empty shapes to handle.

Fix: ``matched := make([]OperationSummary, 0, len(ops))``. Zero-match queries now produce ``"operations": []``.

## Behavior changes worth noting

- ``OperationSummary.Path`` now includes the spec's base path when ``servers[].url`` declares one. For connections whose ``base_url`` already contains the segment, the dedupe in ``computeEffectiveBasePath`` keeps the behavior unchanged. For connections that point at the bare host, paths in ``api_list_endpoints`` are now the full upstream paths the model should pass to ``api_invoke_endpoint`` directly.
- ``rankWithMode``'s signature changed from ``(ranked, fellBack bool)`` to ``(ranked, fallbackReason string)``. Internal to the package.
- ``ensureEmbeddings`` and ``queryVectorFor`` return ``error`` instead of ``bool``. Internal to the package.
- The ``ranking`` schema description now documents the multi-token AND semantics. The ``query`` description names spec name as a searched field. The new ``spec`` input is documented separately.

## Tests

| Test | What it proves |
|---|---|
| ``TestRankOperations_MultiTokenAndMatch`` | ``"gift list"`` matches ``summary="List all gifts"`` (token AND across fields), not ``createGift`` |
| ``TestRankOperations_SpecNameSearchable`` | Searching by spec name returns only ops in that spec |
| ``TestRankOperations_ZeroMatchReturnsEmptySlice`` | Zero-match query returns ``[]``, not nil |
| ``TestSpecBasePath`` | 9 cases covering empty, host-only, host+path, trailing slash, nested path, path-only, root-only, relative URLs with and without nested segments |
| ``TestBuildOperationIndex_AppliesBasePath`` | Op paths in the registered index include the spec base prefix |
| ``TestComputeEffectiveBasePath`` | 8 cases covering all dedupe combinations (overlap, no overlap, trailing slash, deep paths, unparseable conn URL) |
| ``TestFilterBySpec`` | Empty filter passes through; specific filter returns matching ops only; no-match returns ``[]`` |
| ``TestEmbedInBatches_ChunksAtBatchSize`` | 100 texts produce 4 EmbedBatch calls of sizes ``32, 32, 32, 4`` |
| ``TestEmbedInBatches_PropagatesError`` | A failing batch short-circuits the remaining chunks |
| ``TestLexicalScore_MultiTokenAndForHybridSignal`` | Multi-token AND match returns ``lexicalMatchPresent``; missing-token returns ``lexicalMatchAbsent``; empty query returns absent |
| ``TestHandleListEndpoints_SpecFilter`` | PUTting ``spec="users"`` on a 2-spec catalog returns only the ``users`` op |
| ``TestHandleListEndpoints_FallbackNoteIncludesReason`` | Note contains ``"embedding provider not configured"`` (not a generic placeholder) |
| ``TestHandleListEndpoints_PanicRecovery`` | Panic returns operator-readable error; embed cache is sticky-failed; follow-up call falls back to lexical instead of re-panicking |

The existing ``TestRankWithMode_*`` tests were updated to the new ``(ranked, fallbackReason)`` return signature; ``TestGetEndpointSchema_ListPets`` was updated to expect the now-prefixed path ``/v1/pets``.

## Test plan

- [x] ``make verify`` passes (full suite: fmt, race tests, lint, gosec, semgrep, codeql, coverage, dead-code, mutation, release-check)
- [ ] On the demo deployment, ``api_list_endpoints`` with ``ranking=semantic`` against a connection whose embedder is unreachable returns a Note that names the upstream cause (not a generic placeholder)
- [ ] ``api_list_endpoints`` with ``query="gift list"`` against a catalog whose only matching summary is ``"List all gifts"`` now returns that operation
- [ ] ``api_list_endpoints`` with ``spec=<name>`` filters to a single section of a multi-spec catalog
- [ ] For a connection whose spec declares ``servers[0].url=https://host/v1``, ``api_list_endpoints`` returns paths starting with ``/v1/...`` and ``api_invoke_endpoint`` with that path produces the right upstream URL
- [ ] For a connection whose ``base_url`` already contains the spec's base segment, ``api_list_endpoints`` returns the spec-relative path (no doubling) and invoke still works
- [ ] Re-running ``ranking=semantic`` after a deliberately-broken embedder no longer triggers repeated panics (the second call returns a lexical fallback with a Note)