### PR TITLE
feat(apigateway): per-spec base path override

### DIFF
--- a/pkg/admin/catalog_handler.go
+++ b/pkg/admin/catalog_handler.go
@@ -324,6 +324,7 @@ func (h *Handler) copyCatalogSpecs(w http.ResponseWriter, r *http.Request, srcID
 			SourceKind:    s.SourceKind,
 			SourceURL:     s.SourceURL,
 			ETag:          s.ETag,
+			BasePath:      s.BasePath,
 			LastFetchedAt: s.LastFetchedAt,
 		}
 		if upErr := h.deps.APICatalogStore.UpsertSpec(r.Context(), dstID, clone); upErr != nil {
@@ -338,12 +339,20 @@ func (h *Handler) copyCatalogSpecs(w http.ResponseWriter, r *http.Request, srcID
 // specResponse is the JSON wire shape returned by spec routes.
 // Carries the operator-visible metadata; content is included only
 // on the explicit GET /specs/{spec} detail endpoint.
+//
+// BasePath is the operator-set override prefix applied to every
+// operation in this spec at api_list_endpoints and
+// api_invoke_endpoint time. Empty means "no override"; the toolkit
+// falls back to deriving the prefix from the spec's servers[0].url.
+// See catalog.NormalizeBasePath for the leading-slash / trailing-
+// slash / control-character rules enforced on write.
 type specResponse struct {
 	SpecName      string `json:"spec_name"`
 	Content       string `json:"content,omitempty"`
 	SourceKind    string `json:"source_kind"`
 	SourceURL     string `json:"source_url,omitempty"`
 	ETag          string `json:"etag,omitempty"`
+	BasePath      string `json:"base_path,omitempty"`
 	LastFetchedAt string `json:"last_fetched_at,omitempty"`
 	CreatedAt     string `json:"created_at,omitempty"`
 	UpdatedAt     string `json:"updated_at,omitempty"`
@@ -386,10 +395,17 @@ func (h *Handler) getCatalogSpec(w http.ResponseWriter, r *http.Request) {
 }
 
 // upsertCatalogSpecRequest is the body for the inline / URL save path.
+//
+// BasePath sets the operator-supplied per-spec URL prefix. Optional;
+// empty leaves it unset (the toolkit derives the prefix from the
+// spec's servers[0].url at registration time). Normalized via
+// catalog.NormalizeBasePath at write time: must start with "/",
+// must not contain CR/LF/NUL/?/#, trailing slash is stripped.
 type upsertCatalogSpecRequest struct {
 	SourceKind string `json:"source_kind"`
 	Content    string `json:"content,omitempty"`
 	SourceURL  string `json:"source_url,omitempty"`
+	BasePath   string `json:"base_path,omitempty"`
 }
 
 func (h *Handler) upsertCatalogSpec(w http.ResponseWriter, r *http.Request) {
@@ -447,6 +463,7 @@ func (*Handler) materializeSpec(ctx context.Context, specName string, req upsert
 			SpecName:   specName,
 			Content:    req.Content,
 			SourceKind: apicatalog.SourceInline,
+			BasePath:   req.BasePath,
 		}, nil
 	case apicatalog.SourceURL:
 		if req.SourceURL == "" {
@@ -462,6 +479,7 @@ func (*Handler) materializeSpec(ctx context.Context, specName string, req upsert
 			SourceKind:    apicatalog.SourceURL,
 			SourceURL:     req.SourceURL,
 			ETag:          res.ETag,
+			BasePath:      req.BasePath,
 			LastFetchedAt: res.FetchedAt,
 		}, nil
 	case apicatalog.SourceUpload:
@@ -489,6 +507,8 @@ func (*Handler) specErrorStatus(err error) int {
 	case errors.Is(err, apicatalog.ErrNotFound):
 		return http.StatusNotFound
 	case errors.Is(err, apicatalog.ErrInvalidSpecName):
+		return http.StatusBadRequest
+	case errors.Is(err, apicatalog.ErrInvalidBasePath):
 		return http.StatusBadRequest
 	case errors.Is(err, apicatalog.ErrSSRFBlocked):
 		return http.StatusBadRequest
@@ -552,6 +572,25 @@ func (h *Handler) uploadCatalogSpec(w http.ResponseWriter, r *http.Request) {
 		Content:    string(body),
 		SourceKind: apicatalog.SourceUpload,
 	}
+	// Base path precedence on upload:
+	//   1. Explicit ?base_path=... on the upload URL (operator sets
+	//      it during a new upload or changes it mid-stream)
+	//   2. The previously-stored value on an existing spec row (so
+	//      a routine re-upload of refreshed content does not blow
+	//      away the operator's override)
+	//   3. Empty (the migration default)
+	if explicit := r.URL.Query().Get("base_path"); explicit != "" {
+		entry.BasePath = explicit
+	} else if existing, err := h.deps.APICatalogStore.GetSpec(r.Context(), id, specName); err == nil && existing != nil {
+		entry.BasePath = existing.BasePath
+	} else if err != nil && !errors.Is(err, apicatalog.ErrNotFound) {
+		// Log the swallowed lookup error so an operator chasing a
+		// vanished BasePath has a breadcrumb. The upload still
+		// proceeds with BasePath="" so a transient lookup failure
+		// does not block the operator from saving the new content.
+		slog.Warn("apigateway: catalog spec base_path preserve lookup failed",
+			"catalog_id", id, "spec_name", specName, logKeyError, err)
+	}
 	if err := apicatalog.ValidateContent(entry.Content); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -596,6 +635,7 @@ func (h *Handler) refreshCatalogSpec(w http.ResponseWriter, r *http.Request) {
 		SourceKind:    apicatalog.SourceURL,
 		SourceURL:     existing.SourceURL,
 		ETag:          res.ETag,
+		BasePath:      existing.BasePath,
 		LastFetchedAt: res.FetchedAt,
 	}
 	if err := h.deps.APICatalogStore.UpsertSpec(r.Context(), id, entry); err != nil {
@@ -654,6 +694,7 @@ func specToResponse(s apicatalog.SpecEntry, includeContent bool) specResponse {
 		SourceKind:    s.SourceKind,
 		SourceURL:     s.SourceURL,
 		ETag:          s.ETag,
+		BasePath:      s.BasePath,
 		LastFetchedAt: formatTime(s.LastFetchedAt),
 		CreatedAt:     formatTime(s.CreatedAt),
 		UpdatedAt:     formatTime(s.UpdatedAt),

--- a/pkg/admin/catalog_handler_test.go
+++ b/pkg/admin/catalog_handler_test.go
@@ -175,6 +175,7 @@ func TestCatalog_Clone(t *testing.T) {
 	})
 	_ = store.UpsertSpec(context.Background(), "src", apicatalog.SpecEntry{
 		SpecName: "default", Content: "x", SourceKind: apicatalog.SourceInline,
+		BasePath: "/v3",
 	})
 	res := doJSON(t, h, http.MethodPost, "/api/v1/admin/api-catalogs/src/clone", map[string]any{
 		"id": "dst", "name": "petstore", "version": "2",
@@ -184,7 +185,10 @@ func TestCatalog_Clone(t *testing.T) {
 	}
 	specs, _ := store.ListSpecs(context.Background(), "dst")
 	if len(specs) != 1 {
-		t.Errorf("clone did not copy specs: %+v", specs)
+		t.Fatalf("clone did not copy specs: %+v", specs)
+	}
+	if specs[0].BasePath != "/v3" {
+		t.Errorf("clone did not preserve BasePath; got %q, want %q", specs[0].BasePath, "/v3")
 	}
 }
 
@@ -425,5 +429,113 @@ func TestValidateConnectionCatalog_HappyPath(t *testing.T) {
 		map[string]any{"catalog_id": "p"})
 	if !ok || msg != "" {
 		t.Errorf("happy path: ok=%v msg=%q", ok, msg)
+	}
+}
+
+// TestCatalog_UpsertSpecInlineWithBasePath proves the operator-set
+// per-spec BasePath round-trips through the JSON upsert path and
+// shows up on the GET response.
+func TestCatalog_UpsertSpecInlineWithBasePath(t *testing.T) {
+	t.Parallel()
+	h, store := newCatalogTestHandler(t)
+	doJSON(t, h, http.MethodPost, "/api/v1/admin/api-catalogs", map[string]any{
+		"id": "p", "name": "p", "display_name": "P",
+	})
+	res := doJSON(t, h, http.MethodPut, "/api/v1/admin/api-catalogs/p/specs/default", map[string]any{
+		"source_kind": "inline",
+		"content":     "openapi: 3.0.0\ninfo: {title: x, version: '1'}\npaths: {}\n",
+		"base_path":   "/v3",
+	})
+	if res.Code != http.StatusOK {
+		t.Fatalf("upsert: %d %s", res.Code, res.Body.String())
+	}
+	saved, _ := store.GetSpec(context.Background(), "p", "default")
+	if saved == nil || saved.BasePath != "/v3" {
+		t.Fatalf("expected stored BasePath=/v3, got %+v", saved)
+	}
+}
+
+// TestCatalog_UpsertSpecRejectsInvalidBasePath proves a malformed
+// base_path is rejected with HTTP 400 (not 500), so operator input
+// mistakes do not pollute alerts.
+func TestCatalog_UpsertSpecRejectsInvalidBasePath(t *testing.T) {
+	t.Parallel()
+	h, _ := newCatalogTestHandler(t)
+	doJSON(t, h, http.MethodPost, "/api/v1/admin/api-catalogs", map[string]any{
+		"id": "p", "name": "p", "display_name": "P",
+	})
+	res := doJSON(t, h, http.MethodPut, "/api/v1/admin/api-catalogs/p/specs/default", map[string]any{
+		"source_kind": "inline",
+		"content":     "openapi: 3.0.0\ninfo: {title: x, version: '1'}\npaths: {}\n",
+		"base_path":   "v3", // missing leading slash
+	})
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid base_path, got %d %s", res.Code, res.Body.String())
+	}
+}
+
+// TestCatalog_UploadWithBasePath proves the ?base_path= query
+// parameter is honored on multipart uploads (the operator can set
+// the prefix during the upload step instead of having to switch to
+// the paste tab afterwards).
+func TestCatalog_UploadWithBasePath(t *testing.T) {
+	t.Parallel()
+	h, store := newCatalogTestHandler(t)
+	doJSON(t, h, http.MethodPost, "/api/v1/admin/api-catalogs", map[string]any{
+		"id": "p", "name": "p", "display_name": "P",
+	})
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	part, err := w.CreateFormFile("file", "spec.yaml")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := part.Write([]byte("openapi: 3.0.0\ninfo: {title: x, version: '1'}\npaths: {}\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = w.Close()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut,
+		"/api/v1/admin/api-catalogs/p/specs/uploaded/upload?base_path=%2Fv1", body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("upload: %d %s", rec.Code, rec.Body.String())
+	}
+	saved, _ := store.GetSpec(context.Background(), "p", "uploaded")
+	if saved == nil || saved.BasePath != "/v1" {
+		t.Fatalf("expected uploaded spec BasePath=/v1, got %+v", saved)
+	}
+}
+
+// TestCatalog_UploadPreservesExistingBasePath proves a re-upload
+// without a ?base_path= query keeps the previously-stored value
+// instead of zeroing it out.
+func TestCatalog_UploadPreservesExistingBasePath(t *testing.T) {
+	t.Parallel()
+	h, store := newCatalogTestHandler(t)
+	_ = store.CreateCatalog(context.Background(), apicatalog.Catalog{
+		ID: "p", Name: "p", DisplayName: "P",
+	})
+	_ = store.UpsertSpec(context.Background(), "p", apicatalog.SpecEntry{
+		SpecName: "uploaded", Content: "openapi: 3.0.0\ninfo: {title: x, version: '1'}\npaths: {}\n",
+		SourceKind: apicatalog.SourceUpload, BasePath: "/preset/v1",
+	})
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	part, _ := w.CreateFormFile("file", "spec.yaml")
+	_, _ = part.Write([]byte("openapi: 3.0.0\ninfo: {title: x, version: '2'}\npaths: {}\n"))
+	_ = w.Close()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut,
+		"/api/v1/admin/api-catalogs/p/specs/uploaded/upload", body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("upload: %d %s", rec.Code, rec.Body.String())
+	}
+	saved, _ := store.GetSpec(context.Background(), "p", "uploaded")
+	if saved == nil || saved.BasePath != "/preset/v1" {
+		t.Fatalf("expected preserved BasePath=/preset/v1, got %+v", saved)
 	}
 }

--- a/pkg/database/migrate/migrate_unit_test.go
+++ b/pkg/database/migrate/migrate_unit_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	migrateTestFileCount    = 84
+	migrateTestFileCount    = 86
 	migrateTestSuccess      = "success"
 	migrateTestFactoryError = "factory error"
 )

--- a/pkg/database/migrate/migrations/000042_api_catalogs.up.sql
+++ b/pkg/database/migrate/migrations/000042_api_catalogs.up.sql
@@ -1,14 +1,14 @@
 -- 000042: api_catalogs + api_catalog_specs
 --
--- OpenAPI documentation is a property of the API itself (Blackbaud
--- RE NXT, Salesforce REST, Stripe, ...), not of any individual
--- connection that authenticates against it. An organization with N
--- Blackbaud nonprofit tenants has N connections sharing one set of
--- specs; per-connection inline specs duplicated the same content N
--- times and drifted independently.
+-- OpenAPI documentation is a property of the API itself (Salesforce
+-- REST, Stripe, GitHub, ...), not of any individual connection that
+-- authenticates against it. An organization with N tenants of the
+-- same vendor has N connections sharing one set of specs; per-
+-- connection inline specs duplicated the same content N times and
+-- drifted independently.
 --
 -- An API catalog is a versioned, named bundle of component OpenAPI
--- specs. Each (name, version) pair is its own row — cloning to a
+-- specs. Each (name, version) pair is its own row, so cloning to a
 -- new version creates a new row, leaving existing connections on
 -- the old one until the operator migrates them deliberately.
 --

--- a/pkg/database/migrate/migrations/000043_api_catalog_specs_base_path.down.sql
+++ b/pkg/database/migrate/migrations/000043_api_catalog_specs_base_path.down.sql
@@ -1,0 +1,3 @@
+-- 000043 down: drop the per-spec base_path override column.
+ALTER TABLE api_catalog_specs
+    DROP COLUMN IF EXISTS base_path;

--- a/pkg/database/migrate/migrations/000043_api_catalog_specs_base_path.up.sql
+++ b/pkg/database/migrate/migrations/000043_api_catalog_specs_base_path.up.sql
@@ -1,0 +1,28 @@
+-- 000043: api_catalog_specs.base_path
+--
+-- Operator-overridable per-spec base path. When set, the toolkit
+-- prepends this value to every operation path emitted in
+-- api_list_endpoints and api_get_endpoint_schema output, AND uses
+-- it at api_invoke_endpoint time. When empty (the default), the
+-- toolkit falls back to deriving the base path from the spec's
+-- servers[0].url and dedupes against the connection's base_url.
+--
+-- The explicit override is necessary for two real cases the
+-- auto-derivation does not handle:
+--   1. Specs that ship without a servers[] entry at all (any
+--      generator can produce these), where the toolkit otherwise
+--      has nothing to prepend.
+--   2. Specs whose servers[0].url points at the vendor's own
+--      production host but the operator is targeting a sandbox,
+--      proxy, or version-pinned alias whose path differs.
+--
+-- TEXT with no length cap: an HTTP path can be arbitrarily long.
+-- Validation (leading slash, no embedded control chars) happens in
+-- the catalog Go layer at write time. Empty string is the "no
+-- override" sentinel. The column is NOT NULL with DEFAULT '', so
+-- rows that existed before this migration backfill to '' and the
+-- toolkit's empty-string check covers both pre-migration and new
+-- never-set values uniformly.
+
+ALTER TABLE api_catalog_specs
+    ADD COLUMN base_path TEXT NOT NULL DEFAULT '';

--- a/pkg/toolkits/apigateway/catalog/catalog.go
+++ b/pkg/toolkits/apigateway/catalog/catalog.go
@@ -16,7 +16,9 @@ package catalog
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -32,6 +34,11 @@ var ErrConflict = errors.New("catalog: conflict")
 // shape required by the store. IDs are operator-supplied and
 // immutable after creation, so we validate aggressively up front.
 var ErrInvalidID = errors.New("catalog: invalid id")
+
+// ErrInvalidBasePath is returned when an operator-supplied per-spec
+// base path fails validation. Exported so callers can map it to a
+// 400 response without string-matching the error message.
+var ErrInvalidBasePath = errors.New("catalog: invalid base_path")
 
 // ErrInvalidSpecName is returned when a spec name doesn't match the
 // component-slug shape. Spec names appear in MCP tool output (the
@@ -68,12 +75,23 @@ type Catalog struct {
 // Content is plain text (YAML or JSON); the toolkit parses it at
 // connection-load time. SourceURL/ETag/LastFetchedAt populate when
 // SourceKind == SourceURL so the portal can offer a "Refresh" action.
+//
+// BasePath is the operator-supplied override for the URL path
+// segment prepended to every operation in this spec when the
+// connection invokes the upstream. Empty means "no override"; the
+// toolkit falls back to deriving the prefix from servers[0].url
+// in the spec content. Set this when the spec ships without a
+// servers[] entry, or when the operator's deployment targets a
+// path that does not match what the spec author wrote (sandbox,
+// proxy, version pin). Must start with "/" when non-empty;
+// trailing slash is stripped at validation time.
 type SpecEntry struct {
 	SpecName      string
 	Content       string
 	SourceKind    string
 	SourceURL     string
 	ETag          string
+	BasePath      string
 	LastFetchedAt time.Time
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
@@ -130,4 +148,31 @@ func ValidateSourceKind(s string) error {
 	default:
 		return errors.New("catalog: invalid source_kind (want inline|upload|url)")
 	}
+}
+
+// NormalizeBasePath validates and normalizes an operator-supplied
+// SpecEntry.BasePath. Empty input returns empty output (the "no
+// override" sentinel). Non-empty input is required to start with
+// "/", must not contain CR/LF/NUL (header-smuggling vector when
+// the path lands in a request line) and must not contain "?" or
+// "#" (those terminate the path component of an URL). A trailing
+// slash on a non-root value is stripped so the prepended segment
+// joins cleanly with operation paths that all start with "/".
+func NormalizeBasePath(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	if !strings.HasPrefix(s, "/") {
+		return "", fmt.Errorf("must start with leading slash: %w", ErrInvalidBasePath)
+	}
+	if strings.ContainsAny(s, "\r\n\x00") {
+		return "", fmt.Errorf("contains CR/LF/NUL: %w", ErrInvalidBasePath)
+	}
+	if strings.ContainsAny(s, "?#") {
+		return "", fmt.Errorf("must not contain query or fragment: %w", ErrInvalidBasePath)
+	}
+	if s != "/" {
+		s = strings.TrimSuffix(s, "/")
+	}
+	return s, nil
 }

--- a/pkg/toolkits/apigateway/catalog/catalog_test.go
+++ b/pkg/toolkits/apigateway/catalog/catalog_test.go
@@ -90,3 +90,35 @@ func TestValidateSourceKind(t *testing.T) {
 		t.Fatal("empty accepted")
 	}
 }
+
+func TestNormalizeBasePath(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"empty stays empty", "", "", false},
+		{"valid leading slash", "/v1", "/v1", false},
+		{"nested valid", "/api/v2", "/api/v2", false},
+		{"trailing slash stripped", "/v1/", "/v1", false},
+		{"root preserved", "/", "/", false},
+		{"missing leading slash", "v1", "", true},
+		{"CR injected", "/v1\r/admin", "", true},
+		{"LF injected", "/v1\n/admin", "", true},
+		{"NUL injected", "/v1\x00/admin", "", true},
+		{"query string component", "/v1?x=1", "", true},
+		{"fragment component", "/v1#anchor", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := NormalizeBasePath(c.in)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, c.wantErr)
+			}
+			if !c.wantErr && got != c.want {
+				t.Errorf("got %q want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/toolkits/apigateway/catalog/memory.go
+++ b/pkg/toolkits/apigateway/catalog/memory.go
@@ -148,6 +148,11 @@ func (s *MemoryStore) UpsertSpec(_ context.Context, catalogID string, spec SpecE
 	if err := ValidateSourceKind(spec.SourceKind); err != nil {
 		return err
 	}
+	normalizedBasePath, err := NormalizeBasePath(spec.BasePath)
+	if err != nil {
+		return err
+	}
+	spec.BasePath = normalizedBasePath
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.catalogs[catalogID]; !ok {

--- a/pkg/toolkits/apigateway/catalog/memory_test.go
+++ b/pkg/toolkits/apigateway/catalog/memory_test.go
@@ -238,3 +238,22 @@ func TestMemoryStore_CascadeOnCatalogDelete(t *testing.T) {
 		t.Fatalf("expected specs gone after catalog delete: err=%v", err)
 	}
 }
+
+// TestMemoryStore_UpsertSpec_RejectsInvalidBasePath proves the
+// MemoryStore enforces NormalizeBasePath at write time, matching
+// the PostgresStore behavior so both backends reject identical
+// operator-input mistakes.
+func TestMemoryStore_UpsertSpec_RejectsInvalidBasePath(t *testing.T) {
+	s := NewMemoryStore()
+	_ = s.CreateCatalog(context.Background(), Catalog{ID: "p", Name: "p", DisplayName: "P"})
+	err := s.UpsertSpec(context.Background(), "p", SpecEntry{
+		SpecName: "default", Content: "x", SourceKind: SourceInline,
+		BasePath: "no-leading-slash",
+	})
+	if err == nil {
+		t.Fatal("expected ErrInvalidBasePath for missing leading slash")
+	}
+	if !errors.Is(err, ErrInvalidBasePath) {
+		t.Errorf("err=%v want errors.Is ErrInvalidBasePath", err)
+	}
+}

--- a/pkg/toolkits/apigateway/catalog/store_postgres.go
+++ b/pkg/toolkits/apigateway/catalog/store_postgres.go
@@ -209,16 +209,21 @@ func (s *PostgresStore) UpsertSpec(ctx context.Context, catalogID string, spec S
 	if err := ValidateSourceKind(spec.SourceKind); err != nil {
 		return err
 	}
+	normalizedBasePath, err := NormalizeBasePath(spec.BasePath)
+	if err != nil {
+		return err
+	}
 	const q = `
 		INSERT INTO api_catalog_specs
 		    (catalog_id, spec_name, content, source_kind,
-		     source_url, etag, last_fetched_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		     source_url, etag, base_path, last_fetched_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		ON CONFLICT (catalog_id, spec_name) DO UPDATE
 		SET content         = EXCLUDED.content,
 		    source_kind     = EXCLUDED.source_kind,
 		    source_url      = EXCLUDED.source_url,
 		    etag            = EXCLUDED.etag,
+		    base_path       = EXCLUDED.base_path,
 		    last_fetched_at = EXCLUDED.last_fetched_at,
 		    updated_at      = NOW()
 	`
@@ -226,9 +231,9 @@ func (s *PostgresStore) UpsertSpec(ctx context.Context, catalogID string, spec S
 	if !spec.LastFetchedAt.IsZero() {
 		lastFetched = spec.LastFetchedAt
 	}
-	_, err := s.db.ExecContext(ctx, q,
+	_, err = s.db.ExecContext(ctx, q,
 		catalogID, spec.SpecName, spec.Content, spec.SourceKind,
-		spec.SourceURL, spec.ETag, lastFetched)
+		spec.SourceURL, spec.ETag, normalizedBasePath, lastFetched)
 	if isPGCode(err, pgForeignKeyViolation) {
 		return ErrNotFound
 	}
@@ -242,7 +247,7 @@ func (s *PostgresStore) UpsertSpec(ctx context.Context, catalogID string, spec S
 func (s *PostgresStore) GetSpec(ctx context.Context, catalogID, specName string) (*SpecEntry, error) {
 	const q = `
 		SELECT spec_name, content, source_kind, source_url, etag,
-		       last_fetched_at, created_at, updated_at
+		       base_path, last_fetched_at, created_at, updated_at
 		  FROM api_catalog_specs
 		 WHERE catalog_id = $1 AND spec_name = $2
 	`
@@ -252,7 +257,7 @@ func (s *PostgresStore) GetSpec(ctx context.Context, catalogID, specName string)
 	)
 	err := s.db.QueryRowContext(ctx, q, catalogID, specName).Scan(
 		&spec.SpecName, &spec.Content, &spec.SourceKind, &spec.SourceURL,
-		&spec.ETag, &fetchedAt, &spec.CreatedAt, &spec.UpdatedAt)
+		&spec.ETag, &spec.BasePath, &fetchedAt, &spec.CreatedAt, &spec.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -271,7 +276,7 @@ func (s *PostgresStore) GetSpec(ctx context.Context, catalogID, specName string)
 func (s *PostgresStore) ListSpecs(ctx context.Context, catalogID string) ([]SpecEntry, error) {
 	const q = `
 		SELECT spec_name, content, source_kind, source_url, etag,
-		       last_fetched_at, created_at, updated_at
+		       base_path, last_fetched_at, created_at, updated_at
 		  FROM api_catalog_specs
 		 WHERE catalog_id = $1
 		 ORDER BY spec_name ASC
@@ -288,7 +293,7 @@ func (s *PostgresStore) ListSpecs(ctx context.Context, catalogID string) ([]Spec
 			fetchedAt sql.NullTime
 		)
 		if err := rows.Scan(&spec.SpecName, &spec.Content, &spec.SourceKind,
-			&spec.SourceURL, &spec.ETag, &fetchedAt,
+			&spec.SourceURL, &spec.ETag, &spec.BasePath, &fetchedAt,
 			&spec.CreatedAt, &spec.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("catalog: list specs scan: %w", err)
 		}

--- a/pkg/toolkits/apigateway/catalog/store_postgres_test.go
+++ b/pkg/toolkits/apigateway/catalog/store_postgres_test.go
@@ -318,7 +318,7 @@ func TestUpsertSpec_Insert(t *testing.T) {
 	store, mock, done := newMockStore(t)
 	defer done()
 	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO api_catalog_specs`)).
-		WithArgs("petstore", "default", "openapi: 3.0", SourceInline, "", "", nil).
+		WithArgs("petstore", "default", "openapi: 3.0", SourceInline, "", "", "", nil).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	err := store.UpsertSpec(context.Background(), "petstore", SpecEntry{
 		SpecName:   "default",
@@ -337,7 +337,7 @@ func TestUpsertSpec_WithFetchedAt(t *testing.T) {
 	fetched := time.Now()
 	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO api_catalog_specs`)).
 		WithArgs("petstore", "default", "openapi: 3.0", SourceURL,
-			"https://petstore3.swagger.io/api/v3/openapi.json", "etag-xyz", fetched).
+			"https://petstore3.swagger.io/api/v3/openapi.json", "etag-xyz", "", fetched).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	err := store.UpsertSpec(context.Background(), "petstore", SpecEntry{
 		SpecName:      "default",
@@ -349,6 +349,44 @@ func TestUpsertSpec_WithFetchedAt(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("UpsertSpec: %v", err)
+	}
+}
+
+// TestUpsertSpec_WithBasePath proves the operator-supplied base
+// path round-trips through the INSERT (normalized at write time:
+// trailing slash stripped, leading slash required).
+func TestUpsertSpec_WithBasePath(t *testing.T) {
+	t.Parallel()
+	store, mock, done := newMockStore(t)
+	defer done()
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO api_catalog_specs`)).
+		WithArgs("petstore", "default", "openapi: 3.0", SourceInline, "", "", "/v1", nil).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	err := store.UpsertSpec(context.Background(), "petstore", SpecEntry{
+		SpecName:   "default",
+		Content:    "openapi: 3.0",
+		SourceKind: SourceInline,
+		BasePath:   "/v1/", // trailing slash should be stripped
+	})
+	if err != nil {
+		t.Fatalf("UpsertSpec: %v", err)
+	}
+}
+
+// TestUpsertSpec_RejectsInvalidBasePath proves the validator stops
+// a malformed base path before the SQL exec.
+func TestUpsertSpec_RejectsInvalidBasePath(t *testing.T) {
+	t.Parallel()
+	store, _, done := newMockStore(t)
+	defer done()
+	err := store.UpsertSpec(context.Background(), "petstore", SpecEntry{
+		SpecName:   "default",
+		Content:    "openapi: 3.0",
+		SourceKind: SourceInline,
+		BasePath:   "v1", // missing leading slash
+	})
+	if err == nil {
+		t.Fatal("expected error for missing leading slash")
 	}
 }
 
@@ -419,9 +457,9 @@ func TestGetSpec_Success(t *testing.T) {
 		WithArgs("petstore", "default").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"spec_name", "content", "source_kind", "source_url",
-			"etag", "last_fetched_at", "created_at", "updated_at",
+			"etag", "base_path", "last_fetched_at", "created_at", "updated_at",
 		}).AddRow("default", "openapi: 3.0", "url",
-			"https://x", "etag-1", now, now, now))
+			"https://x", "etag-1", "", now, now, now))
 	s, err := store.GetSpec(context.Background(), "petstore", "default")
 	if err != nil {
 		t.Fatalf("GetSpec: %v", err)
@@ -440,9 +478,9 @@ func TestGetSpec_NullFetchedAt(t *testing.T) {
 		WithArgs("petstore", "default").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"spec_name", "content", "source_kind", "source_url",
-			"etag", "last_fetched_at", "created_at", "updated_at",
+			"etag", "base_path", "last_fetched_at", "created_at", "updated_at",
 		}).AddRow("default", "openapi: 3.0", "inline",
-			"", "", nil, now, now))
+			"", "", "", nil, now, now))
 	s, err := store.GetSpec(context.Background(), "petstore", "default")
 	if err != nil {
 		t.Fatalf("GetSpec: %v", err)
@@ -460,7 +498,7 @@ func TestGetSpec_NotFound(t *testing.T) {
 		WithArgs("petstore", "missing").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"spec_name", "content", "source_kind", "source_url",
-			"etag", "last_fetched_at", "created_at", "updated_at",
+			"etag", "base_path", "last_fetched_at", "created_at", "updated_at",
 		}))
 	_, err := store.GetSpec(context.Background(), "petstore", "missing")
 	if !errors.Is(err, ErrNotFound) {
@@ -489,10 +527,10 @@ func TestListSpecs(t *testing.T) {
 		WithArgs("petstore").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"spec_name", "content", "source_kind", "source_url",
-			"etag", "last_fetched_at", "created_at", "updated_at",
+			"etag", "base_path", "last_fetched_at", "created_at", "updated_at",
 		}).
-			AddRow("constituent", "openapi: 3.0", "inline", "", "", nil, now, now).
-			AddRow("gift", "openapi: 3.0", "url", "https://x", "etag", now, now, now))
+			AddRow("users", "openapi: 3.0", "inline", "", "", "", nil, now, now).
+			AddRow("orders", "openapi: 3.0", "url", "https://x", "etag", "/v1", now, now, now))
 	specs, err := store.ListSpecs(context.Background(), "petstore")
 	if err != nil {
 		t.Fatalf("ListSpecs: %v", err)

--- a/pkg/toolkits/apigateway/openapi_test.go
+++ b/pkg/toolkits/apigateway/openapi_test.go
@@ -536,3 +536,96 @@ func TestFilterBySpec(t *testing.T) {
 		t.Errorf("no-match must return empty slice, got %d", len(got))
 	}
 }
+
+// TestAddConnection_OverrideBasePath_WinsOverServers proves the
+// operator-set SpecEntry.BasePath is honored at registration time
+// even when the spec content also declares servers[0].url. Drives
+// the case where a vendor's published spec is wrong for the
+// operator's deployment (sandbox, proxy, version pin).
+func TestAddConnection_OverrideBasePath_WinsOverServers(t *testing.T) {
+	spec := `
+openapi: 3.0.3
+info: {title: x, version: "1.0"}
+servers:
+  - url: https://api.example.com/wrong-prefix
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      responses:
+        "200": {description: ok}
+`
+	tk := New("test")
+	store := catalog.NewMemoryStore()
+	tk.SetCatalogStore(store)
+	if err := store.CreateCatalog(context.Background(), catalog.Catalog{
+		ID: "vendor", Name: "vendor", DisplayName: "Vendor",
+	}); err != nil {
+		t.Fatalf("CreateCatalog: %v", err)
+	}
+	if err := store.UpsertSpec(context.Background(), "vendor", catalog.SpecEntry{
+		SpecName: "default", Content: spec, SourceKind: catalog.SourceInline,
+		BasePath: "/operator-override/v1",
+	}); err != nil {
+		t.Fatalf("UpsertSpec: %v", err)
+	}
+	if err := tk.AddConnection("c", map[string]any{
+		"base_url":   "https://api.example.com",
+		"catalog_id": "vendor",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	tk.mu.RLock()
+	c := tk.connections["c"]
+	tk.mu.RUnlock()
+	if c == nil || len(c.operations) != 1 {
+		t.Fatalf("expected 1 op, got %v", c)
+	}
+	if got, want := c.operations[0].Path, "/operator-override/v1/users"; got != want {
+		t.Errorf("op path = %q; want %q (operator override should win over servers[0])", got, want)
+	}
+}
+
+// TestAddConnection_OverrideBasePath_DedupesAgainstConnBaseURL
+// proves the dedupe rule still applies to operator-set values:
+// when the connection's base_url already contains the override as
+// a suffix, the override is dropped to prevent doubling at invoke
+// time. Same rule the auto-derived path uses.
+func TestAddConnection_OverrideBasePath_DedupesAgainstConnBaseURL(t *testing.T) {
+	spec := `
+openapi: 3.0.3
+info: {title: x, version: "1.0"}
+paths:
+  /things:
+    get:
+      operationId: listThings
+      responses:
+        "200": {description: ok}
+`
+	tk := New("test")
+	store := catalog.NewMemoryStore()
+	tk.SetCatalogStore(store)
+	if err := store.CreateCatalog(context.Background(), catalog.Catalog{
+		ID: "vendor", Name: "vendor", DisplayName: "Vendor",
+	}); err != nil {
+		t.Fatalf("CreateCatalog: %v", err)
+	}
+	if err := store.UpsertSpec(context.Background(), "vendor", catalog.SpecEntry{
+		SpecName: "default", Content: spec, SourceKind: catalog.SourceInline,
+		BasePath: "/v1",
+	}); err != nil {
+		t.Fatalf("UpsertSpec: %v", err)
+	}
+	if err := tk.AddConnection("c", map[string]any{
+		"base_url":   "https://api.example.com/v1",
+		"catalog_id": "vendor",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	tk.mu.RLock()
+	c := tk.connections["c"]
+	tk.mu.RUnlock()
+	if got, want := c.operations[0].Path, "/things"; got != want {
+		t.Errorf("op path = %q; want %q (dedupe should drop the duplicate /v1)", got, want)
+	}
+}

--- a/pkg/toolkits/apigateway/toolkit.go
+++ b/pkg/toolkits/apigateway/toolkit.go
@@ -239,13 +239,13 @@ type conn struct {
 // effectiveBasePath is the per-spec prefix applied to every
 // operation's spec-relative path so api_list_endpoints output, the
 // synthesized operationID in api_get_endpoint_schema, and the
-// stored OperationSummary.Path all agree on a single full path
-// the model passes to api_invoke_endpoint. The value is derived
-// once at registration time from servers[0].url and the connection's
-// base_url so callers downstream do not have to recompute or worry
-// about base_url-vs-spec-base-path overlap (when the operator's
-// connection.base_url already includes the spec's prefix, the
-// effective base path is empty and no doubling occurs).
+// stored OperationSummary.Path all agree on a single full path the
+// model passes to api_invoke_endpoint. Resolution order at
+// registration time: SpecEntry.BasePath (operator override) wins,
+// falling back to servers[0].url-derived value, with both sources
+// run through computeEffectiveBasePath so a connection.base_url
+// that already contains the prefix as a suffix gets the prefix
+// dropped and no doubling occurs at invoke time.
 type specState struct {
 	doc               *openapi3.T
 	sourceKind        string
@@ -707,7 +707,19 @@ func (t *Toolkit) buildConnSpecs(connName, catalogID, connBaseURL string) (
 				"spec_name", e.SpecName, logKeyError, perr)
 			continue
 		}
-		effectiveBasePath := computeEffectiveBasePath(connBaseURL, specBasePath(doc))
+		// Effective base path resolution: operator override on the
+		// spec entry wins over the servers[0]-derived value. Both
+		// sources route through computeEffectiveBasePath so the
+		// connection.base_url overlap dedupe applies uniformly. The
+		// override exists for specs that ship without a servers[]
+		// entry and for operators targeting a host whose path
+		// differs from what the spec author wrote (sandbox, proxy,
+		// version pin).
+		basePathSource := e.BasePath
+		if basePathSource == "" {
+			basePathSource = specBasePath(doc)
+		}
+		effectiveBasePath := computeEffectiveBasePath(connBaseURL, basePathSource)
 		specs[e.SpecName] = &specState{
 			doc:               doc,
 			sourceKind:        e.SourceKind,

--- a/ui/src/api/admin/hooks.ts
+++ b/ui/src/api/admin/hooks.ts
@@ -705,6 +705,12 @@ export interface APICatalogSpec {
   source_kind: "inline" | "upload" | "url";
   source_url?: string;
   etag?: string;
+  // Operator-set per-spec URL prefix applied at api_list_endpoints
+  // and api_invoke_endpoint time. Empty means "use whatever the
+  // spec's servers[0].url declares"; explicit non-empty overrides
+  // the derivation. See pkg/toolkits/apigateway/catalog
+  // NormalizeBasePath for the validation rules.
+  base_path?: string;
   last_fetched_at?: string;
   created_at?: string;
   updated_at?: string;
@@ -829,6 +835,7 @@ export function useUpsertAPICatalogSpec() {
       source_kind: "inline" | "url";
       content?: string;
       source_url?: string;
+      base_path?: string;
     }) =>
       apiFetch<APICatalogSpec>(
         `/api-catalogs/${catalogID}/specs/${specName}`,
@@ -850,15 +857,20 @@ export function useUploadAPICatalogSpec() {
       catalogID,
       specName,
       file,
+      base_path,
     }: {
       catalogID: string;
       specName: string;
       file: File;
+      base_path?: string;
     }) => {
       const form = new FormData();
       form.append("file", file);
+      const qs = base_path && base_path.trim() !== ""
+        ? `?base_path=${encodeURIComponent(base_path.trim())}`
+        : "";
       const res = await apiFetchRaw(
-        `/api-catalogs/${catalogID}/specs/${specName}/upload`,
+        `/api-catalogs/${catalogID}/specs/${specName}/upload${qs}`,
         { method: "PUT", body: form },
       );
       if (!res.ok) {

--- a/ui/src/pages/settings/CatalogsPanel.tsx
+++ b/ui/src/pages/settings/CatalogsPanel.tsx
@@ -848,6 +848,7 @@ function SpecModal({
   const [tab, setTab] = useState<SourceTab>("paste");
   const [content, setContent] = useState("");
   const [sourceURL, setSourceURL] = useState("");
+  const [basePath, setBasePath] = useState("");
   const [file, setFile] = useState<File | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -861,6 +862,7 @@ function SpecModal({
       setSourceURL(existing.source_url ?? "");
       setTab("url");
     }
+    setBasePath(existing.base_path ?? "");
   }, [existing]);
 
   const submit = useCallback(async () => {
@@ -876,6 +878,7 @@ function SpecModal({
           specName,
           source_kind: "inline",
           content,
+          base_path: basePath.trim(),
         });
       } else if (tab === "url") {
         await upsert.mutateAsync({
@@ -883,6 +886,7 @@ function SpecModal({
           specName,
           source_kind: "url",
           source_url: sourceURL,
+          base_path: basePath.trim(),
         });
       } else if (tab === "upload") {
         if (!file) {
@@ -893,13 +897,18 @@ function SpecModal({
           setError("file exceeds 10 MB limit");
           return;
         }
-        await upload.mutateAsync({ catalogID, specName, file });
+        await upload.mutateAsync({
+          catalogID,
+          specName,
+          file,
+          base_path: basePath.trim(),
+        });
       }
       onSaved();
     } catch (e) {
       setError(e instanceof Error ? e.message : "save failed");
     }
-  }, [catalogID, specName, tab, content, sourceURL, file, upsert, upload, onSaved]);
+  }, [catalogID, specName, tab, content, sourceURL, basePath, file, upsert, upload, onSaved]);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
@@ -991,6 +1000,15 @@ function SpecModal({
               mono
             />
           )}
+
+          <LabeledInput
+            label="Base path (optional)"
+            help="URL path segment prepended to every operation in this spec at invoke time. Set this when the spec ships without a servers[] entry, or when you need to override the spec author's value (sandbox, proxy, version pin). When empty, the toolkit derives the prefix from the spec's first servers[].url. Must start with '/'. Example: /v1 or /api/v2."
+            value={basePath}
+            onChange={setBasePath}
+            placeholder="/v1"
+            mono
+          />
 
           {error && (
             <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">


### PR DESCRIPTION
## Summary

Operators can now set the URL path prefix applied to every operation in a component spec, independent of what the spec author wrote in ``servers[]``. The auto-derivation from ``servers[0].url`` (shipped in #415) remains the fallback. The override addresses two real cases the auto-derivation cannot:

1. Specs that ship without a ``servers[]`` entry at all. The generator simply did not emit one and the operator has no way to inject a prefix today.
2. Specs whose ``servers[0].url`` points at the vendor's production host while the operator targets a sandbox, proxy, or version-pinned alias whose path differs. Without an override the model receives the wrong path and every invoke 404s.

Reported against a multi-spec catalog where one component spec's prefix did not match the upstream the operator was actually invoking.

## Detail

### Schema

Migration ``000043`` adds ``api_catalog_specs.base_path TEXT NOT NULL DEFAULT ''``. Existing rows backfill to ``''`` so the toolkit's empty-string check covers both pre-migration and never-set values uniformly. The column is ``NOT NULL`` so the Go scan binds into a plain ``string`` with no NULL handling.

### Catalog layer

``catalog.SpecEntry`` gains a ``BasePath string`` field. Both store implementations normalize on write through a new ``catalog.NormalizeBasePath`` helper:

- Empty is the explicit "no override" sentinel.
- Non-empty must start with ``/``.
- Must not contain CR, LF, NUL (header-smuggling vectors).
- Must not contain ``?`` or ``#`` (those terminate the path component).
- Trailing slash is stripped on non-root values so the prepended segment joins cleanly with operation paths that all start with ``/``.

``catalog.ErrInvalidBasePath`` is the exported sentinel so the admin handler maps operator-input failures to ``HTTP 400`` instead of the previous ``500``. The same routing pattern ``ErrInvalidSpecName`` already uses.

### Admin handler

- ``upsertCatalogSpecRequest`` accepts ``base_path`` on every source kind (``inline``, ``url``).
- The multipart upload endpoint accepts ``?base_path=`` as a query parameter so operators can set the prefix during the file upload.
- Re-upload without ``?base_path=`` preserves the previously-stored value so a routine refresh does not blow away the operator's override.
- ``GetSpec`` lookup failures during the preserve check are logged at ``WARN`` with the catalog ID and spec name so a vanished BasePath has a breadcrumb.
- ``refreshCatalogSpec`` carries ``BasePath`` through the refresh.
- Clone copies ``BasePath`` on every spec it copies into the destination catalog.
- ``specToResponse`` surfaces ``base_path`` on every read.

### Toolkit

``buildConnSpecs`` now resolves the effective base path with the operator override winning over ``servers[0]``. Both sources route through ``computeEffectiveBasePath`` so a ``connection.base_url`` that already contains the prefix as a suffix dedupes uniformly, preventing path doubling at invoke time regardless of where the prefix came from. ``specState.effectiveBasePath`` is the single source of truth used by ``buildOperationIndex`` (at registration time) and ``collectOperationMatches`` (at runtime) so ``api_list_endpoints`` and ``api_get_endpoint_schema`` agree on full paths.

### UI

The catalog spec editor exposes a "Base path" input on all three source tabs (Paste, Upload, URL). The input is pre-filled from the existing row when editing. The upload mutation appends ``?base_path=`` when the operator typed a value; the upsert mutation passes ``base_path`` in the JSON body.

### Companion cleanup

Migration ``000042`` carried a text-only example referencing a downstream client vendor. The example is now generic (``Salesforce``, ``Stripe``, ``GitHub``). The em dash in the same paragraph was replaced with a comma. No schema change; comments only.

## Resolution rules

| Override | servers[0].url | conn.base_url path contains spec base | Effective prefix |
|---|---|---|---|
| ``/v1`` | anything | no | ``/v1`` |
| ``/v1`` | anything | yes | ``""`` (dedupes) |
| ``""`` | ``https://host/v1`` | no | ``/v1`` |
| ``""`` | ``https://host/v1`` | yes | ``""`` (dedupes) |
| ``""`` | not declared | n/a | ``""`` |
| ``/v1`` | ``https://host/wrong`` | no | ``/v1`` (override wins) |

## Tests

| Test | What it proves |
|---|---|
| ``TestNormalizeBasePath`` | 11-case table covering empty, valid, nested, trailing slash, root, missing-leading-slash, CR/LF/NUL injection, query and fragment characters. |
| ``TestUpsertSpec_WithBasePath`` (Postgres) | Trailing slash is stripped and the value round-trips through the INSERT. |
| ``TestUpsertSpec_RejectsInvalidBasePath`` (Postgres) | Validator short-circuits before the SQL exec. |
| ``TestMemoryStore_UpsertSpec_RejectsInvalidBasePath`` | Parity with Postgres: same validator at the same point, same ``ErrInvalidBasePath`` sentinel. |
| ``TestCatalog_UpsertSpecInlineWithBasePath`` | Operator-supplied value round-trips through the admin handler and the JSON response. |
| ``TestCatalog_UpsertSpecRejectsInvalidBasePath`` | Malformed ``base_path`` is ``HTTP 400``, not ``500``. |
| ``TestCatalog_UploadWithBasePath`` | ``?base_path=`` query parameter is honored on multipart uploads. |
| ``TestCatalog_UploadPreservesExistingBasePath`` | Re-upload without ``?base_path=`` keeps the previously-stored value. |
| ``TestCatalog_Clone`` | ``BasePath`` is copied on clone. |
| ``TestAddConnection_OverrideBasePath_WinsOverServers`` | Operator override beats the spec's ``servers[0].url`` at registration time. |
| ``TestAddConnection_OverrideBasePath_DedupesAgainstConnBaseURL`` | Override flows through the same dedupe so a connection whose ``base_url`` already includes the prefix does not double the segment at invoke time. |

## Behavior changes worth noting

- ``Store.UpsertSpec`` now validates ``SpecEntry.BasePath`` before the write. Callers passing an invalid value receive ``catalog.ErrInvalidBasePath``.
- ``OperationSummary.Path`` and ``EndpointSchemaOutput.Path`` reflect the operator's chosen prefix when set, which can differ from what the spec content's ``servers[]`` declares. This is the point of the feature.
- The migration is additive and backfills to ``''``; no operator action is required to upgrade.

## Test plan

- [x] ``make verify`` passes (full suite: fmt, race tests, lint, gosec, semgrep, codeql, coverage, dead-code, mutation, release-check)
- [ ] On the demo deployment, open a catalog spec whose ``servers[0].url`` does not match the upstream you intend to invoke, set "Base path" in the Paste/URL editor, save, and confirm ``api_list_endpoints`` returns the new prefix.
- [ ] For an upload-sourced spec, ``PUT /api-catalogs/<id>/specs/<name>/upload?base_path=/v3`` and confirm the returned spec carries ``base_path: "/v3"``.
- [ ] Set a ``BasePath`` whose value is already a suffix of the connection's ``base_url``; confirm the operation paths are NOT doubled at invoke time.
- [ ] Try an invalid value (e.g. ``"v3"`` without a leading slash) and confirm the response is ``400`` with a message identifying ``base_path``.