### PR TITLE
fix(apigateway): warm embeddings at AddConnection, off the request path

### DIFF
--- a/pkg/toolkits/apigateway/ranking.go
+++ b/pkg/toolkits/apigateway/ranking.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/txn2/mcp-data-platform/pkg/embedding"
 )
@@ -28,6 +29,31 @@ const embedBatchSize = 32
 // can phrase the cause correctly: this is operator configuration,
 // not an upstream failure.
 var errEmbedderNotWired = errors.New("embedding provider not configured on this connection")
+
+// Embedding-state sentinels returned by checkEmbeddingsReady. Each
+// one carries enough context for the operator to act:
+//
+//   - errEmbeddingsNoOps: nothing to embed (the connection has no
+//     operations; semantic ranking is meaningless).
+//   - errEmbeddingsFailed: a prior warmer attempt failed with a
+//     definitive error (not a transient cancel); reload the
+//     connection or restart the platform to retry.
+//   - errEmbeddingsWarming: the background warmer is in flight;
+//     fall back to lexical for this call and retry shortly.
+//   - errEmbeddingsNotStarted: no warmer ever ran (typically
+//     because the embedding provider was wired AFTER the
+//     connection registered and the toolkit was never told to
+//     start one); operator should reload the connection.
+//   - errEmbeddingsZeroVector: the provider returned a zero vector
+//     for the query, which produces meaningless cosine similarity;
+//     points at a misconfigured embedding model.
+var (
+	errEmbeddingsNoOps      = errors.New("connection has no operations to embed")
+	errEmbeddingsFailed     = errors.New("operation-embedding warm-up failed; reload the connection to retry")
+	errEmbeddingsWarming    = errors.New("operation embeddings still warming; falling back to lexical until ready")
+	errEmbeddingsNotStarted = errors.New("operation-embedding warm-up has not started; reload the connection")
+	errEmbeddingsZeroVector = errors.New("query embedding is the zero vector (misconfigured embedding model)")
+)
 
 // RankingMode selects the algorithm api_list_endpoints uses to score
 // candidate operations against the model's query.
@@ -135,16 +161,24 @@ func rankWithMode(ctx context.Context, r rankRequest) (ranked []OperationSummary
 // error describing why semantic ranking cannot proceed for this
 // call. Error returns drive the lexical fallback in rankWithMode
 // AND populate the operator-facing Note on the response so the
-// model (and the operator reading the log) knows whether the cause
-// was operator configuration (errEmbedderNotWired), an upstream
+// model and the operator reading the log know whether the cause
+// is operator configuration (errEmbedderNotWired), an upstream
 // embedding failure (provider Embed errors), a previously-cached
-// per-connection failure (c.embedFailed), or a zero-vector reply
-// from the provider (a misconfigured model or empty-prompt edge
-// case).
+// per-connection failure (c.embedFailed), an in-flight cold-start
+// warmer that has not yet populated this connection's operation
+// embeddings (errEmbeddingsWarming), or a zero-vector reply from
+// the provider (errEmbeddingsZeroVector).
+//
+// The operation-embedding population happens in a background
+// warmer kicked off at AddConnection / SetEmbeddingProvider time.
+// queryVectorFor never does that work inline. A request that
+// arrives before the warmer finishes returns
+// errEmbeddingsWarming so the caller falls back to lexical inside
+// the request budget instead of synchronously triggering a
+// multi-minute per-operation pass.
 //
 // Snapshots t.embedder under the read lock so a concurrent
-// SetEmbeddingProvider cannot race with the nil check or with the
-// dereference below.
+// SetEmbeddingProvider cannot race with the nil check below.
 func (t *Toolkit) queryVectorFor(ctx context.Context, c *conn, query string) ([]float32, error) {
 	t.mu.RLock()
 	embedder := t.embedder
@@ -152,17 +186,106 @@ func (t *Toolkit) queryVectorFor(ctx context.Context, c *conn, query string) ([]
 	if embedder == nil {
 		return nil, errEmbedderNotWired
 	}
-	if err := t.ensureEmbeddings(ctx, c, embedder); err != nil {
-		return nil, fmt.Errorf("operation embeddings unavailable: %w", err)
+	if err := checkEmbeddingsReady(c); err != nil {
+		return nil, err
 	}
 	vec, err := embedder.Embed(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("embed query: %w", err)
 	}
 	if zeroVector(vec) {
-		return nil, errors.New("query embedding is the zero vector (misconfigured embedding model)")
+		return nil, errEmbeddingsZeroVector
 	}
 	return vec, nil
+}
+
+// checkEmbeddingsReady reports whether the per-connection
+// operation embeddings are populated and usable. Returns a
+// distinct sentinel for every reason a non-lexical rank cannot
+// proceed so the operator-facing fallback Note names the actual
+// cause: warmer still in flight, prior warmer failed definitively,
+// or the connection has no operations to embed in the first place.
+func checkEmbeddingsReady(c *conn) error {
+	c.embedMu.Lock()
+	defer c.embedMu.Unlock()
+	if len(c.embedTexts) == 0 {
+		return errEmbeddingsNoOps
+	}
+	if len(c.embeddings) == len(c.embedTexts) {
+		return nil
+	}
+	if c.embedFailed {
+		return errEmbeddingsFailed
+	}
+	if c.embedInFlight {
+		return errEmbeddingsWarming
+	}
+	return errEmbeddingsNotStarted
+}
+
+// ensureEmbeddings is the synchronous worker that populates the
+// per-connection operation embeddings. Called by warmEmbeddings
+// (in a goroutine at AddConnection / SetEmbeddingProvider time)
+// and exposed at package scope so unit tests can drive the worker
+// with controlled contexts (e.g., a pre-canceled ctx to verify
+// the carve-out that keeps a transient cancellation from poisoning
+// the cache).
+//
+// Concurrent callers serialize through the embedInFlight guard:
+// the loser returns errEmbeddingsWarming so a second worker does
+// not double-hit the embedder for the same connection. Failures
+// fall into two buckets: transient (ctx.Canceled / DeadlineExceeded)
+// do not poison the cache so a later attempt can succeed; every
+// other provider error sets c.embedFailed so a misbehaving
+// embedder is not re-hammered on every subsequent call.
+func (*Toolkit) ensureEmbeddings(ctx context.Context, c *conn, embedder embedding.Provider) error {
+	c.embedMu.Lock()
+	if len(c.embedTexts) == 0 {
+		c.embedMu.Unlock()
+		return errEmbeddingsNoOps
+	}
+	if len(c.embeddings) == len(c.embedTexts) {
+		c.embedMu.Unlock()
+		return nil
+	}
+	if c.embedFailed {
+		c.embedMu.Unlock()
+		return errEmbeddingsFailed
+	}
+	if c.embedInFlight {
+		c.embedMu.Unlock()
+		return errEmbeddingsWarming
+	}
+	c.embedInFlight = true
+	textCount := len(c.embedTexts)
+	c.embedMu.Unlock()
+
+	start := time.Now()
+	slog.Info("apigateway: warming connection embeddings",
+		logKeyConnection, c.cfg.ConnectionName, "count", textCount)
+	vectors, err := embedInBatches(ctx, embedder, c.embedTexts, embedBatchSize)
+	c.embedMu.Lock()
+	c.embedInFlight = false
+	switch {
+	case err != nil:
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			c.embedFailed = true
+		}
+		c.embedMu.Unlock()
+		return fmt.Errorf("embed operation batch: %w", err)
+	case len(vectors) != len(c.embedTexts):
+		c.embedFailed = true
+		c.embedMu.Unlock()
+		return fmt.Errorf("embed operation batch: provider returned %d vectors for %d texts",
+			len(vectors), len(c.embedTexts))
+	default:
+		c.embeddings = vectors
+		c.embedMu.Unlock()
+		slog.Info("apigateway: embeddings warm-up complete",
+			logKeyConnection, c.cfg.ConnectionName,
+			"count", textCount, "duration", time.Since(start))
+		return nil
+	}
 }
 
 // scoreOperations builds the per-op score slice. Operations whose
@@ -237,65 +360,6 @@ func indexOf(ops []OperationSummary, target OperationSummary) int {
 		}
 	}
 	return -1
-}
-
-// ensureEmbeddings populates c.embeddings for the current spec set
-// if not already populated. Returns nil when c.embeddings is usable
-// on return (already populated by a prior call, or populated by this
-// one). Returns a non-nil error describing why semantic ranking
-// cannot proceed; the caller surfaces the error verbatim on the
-// fallback Note so operators see the real cause instead of a generic
-// "embedding pipeline unavailable" placeholder.
-//
-// Concurrent callers serialize through c.embedMu so the embedding
-// service is hit at most once per (connection, spec_set) lifecycle.
-//
-// Failure handling distinguishes transient from definitive:
-//   - ctx.Err() (caller-side cancellation, deadline exceeded) and a
-//     length-mismatched batch (provider misconfiguration that may
-//     resolve on a hot-reconfig) are NOT sticky — the next call
-//     re-attempts. Without this carve-out, a single MCP-client
-//     cancellation during a slow first embed would permanently
-//     disable semantic ranking until pod restart.
-//   - Any other provider error sets c.embedFailed so a misbehaving
-//     embedding service does not get re-hammered every call.
-//
-// embedder is taken as an explicit argument (rather than reading
-// t.embedder again) so the snapshot taken under t.mu.RLock in the
-// caller is the value used here too.
-func (*Toolkit) ensureEmbeddings(ctx context.Context, c *conn, embedder embedding.Provider) error {
-	c.embedMu.Lock()
-	defer c.embedMu.Unlock()
-	if len(c.embedTexts) == 0 {
-		return errors.New("connection has no operations to embed")
-	}
-	if len(c.embeddings) == len(c.embedTexts) {
-		return nil
-	}
-	if c.embedFailed {
-		return errors.New("a previous embedding attempt failed; restart the platform or reload the connection to retry")
-	}
-	vectors, err := embedInBatches(ctx, embedder, c.embedTexts, embedBatchSize)
-	if err != nil {
-		// Transient signals do NOT poison the cache. Definitive
-		// provider errors do, so a misconfigured embedder URL
-		// doesn't produce a fresh hit on every tool call.
-		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-			c.embedFailed = true
-			slog.Warn("apigateway: embedding batch failed (caching as definitive)",
-				logKeyConnection, c.cfg.ConnectionName,
-				"texts", len(c.embedTexts), logKeyError, err)
-		}
-		return fmt.Errorf("embed operation batch: %w", err)
-	}
-	if len(vectors) != len(c.embedTexts) {
-		// Length mismatch is a provider bug; treat as transient so
-		// a hot-reconfig of the provider can recover.
-		return fmt.Errorf("embed operation batch: provider returned %d vectors for %d texts",
-			len(vectors), len(c.embedTexts))
-	}
-	c.embeddings = vectors
-	return nil
 }
 
 // embedInBatches calls embedder.EmbedBatch in chunks of at most

--- a/pkg/toolkits/apigateway/ranking_test.go
+++ b/pkg/toolkits/apigateway/ranking_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -243,19 +244,25 @@ func TestRankWithMode_SemanticFallsBackWithoutEmbedder(t *testing.T) {
 // the whole point of #371.
 func TestRankWithMode_SemanticRanksByEmbedding(t *testing.T) {
 	tk := New("primary")
-	tk.SetEmbeddingProvider(newFakeEmbedder(32))
+	emb := newFakeEmbedder(32)
+	tk.SetEmbeddingProvider(emb)
 	c := buildTestConn(t, []testOp{
 		{id: "create-order", method: "POST", path: "/v1/orders", summary: "Place a new order", desc: "Submit an order to the fulfillment queue"},
 		{id: "list-orders", method: "GET", path: "/v1/orders", summary: "List orders"},
 		{id: "get-user", method: "GET", path: "/v1/users/{id}", summary: "Fetch user profile"},
 	})
+	// Populate embeddings synchronously: this test builds the
+	// conn directly via buildTestConn so the AddConnection-time
+	// warmer never ran. Inline warm matches what the warmer would
+	// have produced and keeps the test deterministic.
+	tk.warmEmbeddings(c, emb)
 	// Query intentionally lexically-overlapping with "create-order"
 	// to exercise the deterministic fakeEmbedder path. Real models
 	// would handle "place new order" or "submit order" too; that's
 	// captured in the corpus benchmark below.
 	got, fb := rankWithMode(context.Background(), rankRequest{tk: tk, conn: c, ops: c.operations, query: "place a new order", limit: 5, mode: RankingSemantic})
 	if fb != "" {
-		t.Fatal("semantic with embedder should not fallback")
+		t.Fatalf("semantic with embedder should not fallback; got reason %q", fb)
 	}
 	if len(got) == 0 || got[0].OperationID != "create-order" {
 		t.Errorf("top result = %v; want create-order first", topIDs(got))
@@ -264,17 +271,19 @@ func TestRankWithMode_SemanticRanksByEmbedding(t *testing.T) {
 
 func TestRankWithMode_HybridBlendsSignals(t *testing.T) {
 	tk := New("primary")
-	tk.SetEmbeddingProvider(newFakeEmbedder(32))
+	emb := newFakeEmbedder(32)
+	tk.SetEmbeddingProvider(emb)
 	c := buildTestConn(t, []testOp{
 		{id: "create-order", method: "POST", path: "/v1/orders", summary: "Place a new order"},
 		{id: "list-orders", method: "GET", path: "/v1/orders", summary: "List orders"},
 		{id: "get-user", method: "GET", path: "/v1/users/{id}", summary: "Fetch user profile"},
 	})
+	tk.warmEmbeddings(c, emb)
 	// Query has direct lexical match on /orders path. Hybrid should
 	// still surface order-related ops first.
 	got, fb := rankWithMode(context.Background(), rankRequest{tk: tk, conn: c, ops: c.operations, query: "orders", limit: 5, mode: RankingHybrid})
 	if fb != "" {
-		t.Fatal("hybrid with embedder should not fallback")
+		t.Fatalf("hybrid with embedder should not fallback; got reason %q", fb)
 	}
 	if len(got) < 2 {
 		t.Fatalf("want at least 2 results; got %v", topIDs(got))
@@ -300,12 +309,16 @@ func TestRankWithMode_SemanticEmbedFailureFallsBack(t *testing.T) {
 		{id: "a", method: "GET", path: "/a", summary: "alpha"},
 		{id: "b", method: "GET", path: "/b", summary: "beta"},
 	})
+	// Run the warmer synchronously: it will hit failBatch and
+	// set c.embedFailed, which is the state the subsequent
+	// rankWithMode call surfaces as a "warm-up failed" fallback.
+	tk.warmEmbeddings(c, emb)
+	if !c.embedFailed {
+		t.Fatal("c.embedFailed should be set after a batch failure")
+	}
 	_, fb := rankWithMode(context.Background(), rankRequest{tk: tk, conn: c, ops: c.operations, query: "alpha", limit: 5, mode: RankingSemantic})
 	if fb == "" {
 		t.Error("batch-embed failure should report fallback")
-	}
-	if !c.embedFailed {
-		t.Error("c.embedFailed should be sticky after a batch failure")
 	}
 	// Second call should also fall back without re-attempting embed.
 	emb.failBatch.Store(false) // would now succeed
@@ -388,7 +401,8 @@ func TestRankWithMode_QueryEmbedFailureFallsBack(t *testing.T) {
 	tk := New("primary")
 	tk.SetEmbeddingProvider(emb)
 	c := buildTestConn(t, []testOp{{id: "a", method: "GET", path: "/a", summary: "alpha"}})
-	emb.failEmbed.Store(true) // single Embed errors; EmbedBatch still works
+	tk.warmEmbeddings(c, emb) // populate before flipping failEmbed
+	emb.failEmbed.Store(true) // single Embed errors; EmbedBatch already ran
 	_, fb := rankWithMode(context.Background(), rankRequest{tk: tk, conn: c, ops: c.operations, query: "alpha", limit: 5, mode: RankingSemantic})
 	if fb == "" {
 		t.Error("query-embed failure should report fallback")
@@ -402,8 +416,10 @@ func TestRankWithMode_QueryEmbedFailureFallsBack(t *testing.T) {
 // itself succeeded.
 func TestRankWithMode_ZeroQueryVectorFallsBack(t *testing.T) {
 	tk := New("primary")
-	tk.SetEmbeddingProvider(zeroEmbedder{})
+	emb := zeroEmbedder{}
+	tk.SetEmbeddingProvider(emb)
 	c := buildTestConn(t, []testOp{{id: "a", method: "GET", path: "/a", summary: "alpha"}})
+	tk.warmEmbeddings(c, emb)
 	_, fb := rankWithMode(context.Background(), rankRequest{tk: tk, conn: c, ops: c.operations, query: "alpha", limit: 5, mode: RankingSemantic})
 	if fb == "" {
 		t.Error("zero-vector embedder should force fallback")
@@ -454,6 +470,7 @@ func TestRankWithMode_RehashOnSpecChange(t *testing.T) {
 	tk.mu.RLock()
 	connV1 := tk.connections["api"]
 	tk.mu.RUnlock()
+	waitForWarmerSettled(t, connV1)
 
 	got1, _ := rankWithMode(context.Background(), rankRequest{tk: tk, conn: connV1, ops: connV1.operations, query: "users", limit: 5, mode: RankingSemantic})
 	if len(got1) != 1 || got1[0].OperationID != "list-users" {
@@ -480,8 +497,10 @@ func TestRankWithMode_RehashOnSpecChange(t *testing.T) {
 	if connV2 == connV1 {
 		t.Error("ReloadConnection should produce a new conn instance")
 	}
-	if len(connV2.embeddings) != 0 {
-		t.Errorf("expected zero cached embeddings on the new conn, got %d", len(connV2.embeddings))
+	waitForWarmerSettled(t, connV2)
+	if len(connV2.embeddings) != len(connV2.embedTexts) {
+		t.Errorf("v2 embeddings should be rehashed, got %d vs %d",
+			len(connV2.embeddings), len(connV2.embedTexts))
 	}
 
 	got2, _ := rankWithMode(context.Background(), rankRequest{tk: tk, conn: connV2, ops: connV2.operations, query: "orders", limit: 5, mode: RankingSemantic})
@@ -562,6 +581,43 @@ func topIDs(ops []OperationSummary) []string {
 	return out
 }
 
+// warmerSettleTimeout is the deadline every test uses when
+// waiting for the background warmer to finish. Generous enough
+// for slow CI; tight enough that a hung warmer fails the test
+// loudly instead of stalling the whole suite.
+const warmerSettleTimeout = time.Second
+
+// waitForWarmerSettled polls c until the background warmer has
+// either populated the embeddings, marked the connection failed,
+// or has no work to do (empty embedTexts). Returns when the
+// warmer has settled so the caller can assert on the outcome
+// without racing. Tests that EXPECT success check
+// len(c.embeddings) after this returns; tests that EXPECT failure
+// check c.embedFailed.
+//
+// Required by tests that exercise the semantic / hybrid ranking
+// path: in production the warmer is kicked off at AddConnection
+// time and the first ranking call would otherwise race the
+// warmer. The helper makes tests deterministic without exposing
+// the warmer's internal coordination channel to production.
+func waitForWarmerSettled(t *testing.T, c *conn) {
+	t.Helper()
+	deadline := time.Now().Add(warmerSettleTimeout)
+	for time.Now().Before(deadline) {
+		c.embedMu.Lock()
+		inFlight := c.embedInFlight
+		populated := len(c.embeddings) == len(c.embedTexts) && len(c.embedTexts) > 0
+		failed := c.embedFailed
+		noWork := len(c.embedTexts) == 0
+		c.embedMu.Unlock()
+		if !inFlight && (populated || failed || noWork) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("warmer did not settle within %v", warmerSettleTimeout)
+}
+
 // minimalSpecWith wraps a YAML "paths" block in the smallest valid
 // OpenAPI 3.0 envelope the kin-openapi validator will accept. Each
 // operation in the caller-supplied paths block must declare its own
@@ -627,8 +683,15 @@ func TestSemanticRanking_BenchmarkCorpus(t *testing.T) {
 	}
 
 	tk := New("bench")
-	tk.SetEmbeddingProvider(newFakeEmbedder(64))
+	emb := newFakeEmbedder(64)
+	tk.SetEmbeddingProvider(emb)
 	c := buildTestConn(t, corpus)
+	// buildTestConn bypasses AddConnection so no warmer was
+	// spawned. Populate inline so hybrid actually scores
+	// semantically; without this, queryVectorFor would return
+	// errEmbeddingsNotStarted and hybrid would silently fall
+	// back to lexical, making the recall comparison meaningless.
+	tk.warmEmbeddings(c, emb)
 
 	type recall struct {
 		at1, at3 int
@@ -767,4 +830,109 @@ func TestLexicalScore_MultiTokenAndForHybridSignal(t *testing.T) {
 	if got := lexicalScore(op, ""); got != lexicalMatchAbsent {
 		t.Errorf("empty query should return absent; got %v", got)
 	}
+}
+
+// TestCheckEmbeddingsReady covers every state the embedding
+// readiness check can be in and confirms each maps to the right
+// operator-facing sentinel. The single hot-path on a ranking
+// request goes through this function; the sentinel choice
+// directly drives what shows up in the fallback Note operators
+// rely on.
+func TestCheckEmbeddingsReady(t *testing.T) {
+	t.Run("no ops to embed", func(t *testing.T) {
+		c := &conn{}
+		if err := checkEmbeddingsReady(c); !errors.Is(err, errEmbeddingsNoOps) {
+			t.Errorf("err=%v want errEmbeddingsNoOps", err)
+		}
+	})
+	t.Run("warmer in flight", func(t *testing.T) {
+		c := &conn{embedTexts: []string{"a"}, embedInFlight: true}
+		if err := checkEmbeddingsReady(c); !errors.Is(err, errEmbeddingsWarming) {
+			t.Errorf("err=%v want errEmbeddingsWarming", err)
+		}
+	})
+	t.Run("definitive failure", func(t *testing.T) {
+		c := &conn{embedTexts: []string{"a"}, embedFailed: true}
+		if err := checkEmbeddingsReady(c); !errors.Is(err, errEmbeddingsFailed) {
+			t.Errorf("err=%v want errEmbeddingsFailed", err)
+		}
+	})
+	t.Run("warmer never started", func(t *testing.T) {
+		c := &conn{embedTexts: []string{"a"}}
+		if err := checkEmbeddingsReady(c); !errors.Is(err, errEmbeddingsNotStarted) {
+			t.Errorf("err=%v want errEmbeddingsNotStarted", err)
+		}
+	})
+	t.Run("ready", func(t *testing.T) {
+		c := &conn{embedTexts: []string{"a"}, embeddings: [][]float32{{1, 0}}}
+		if err := checkEmbeddingsReady(c); err != nil {
+			t.Errorf("ready state should return nil; got %v", err)
+		}
+	})
+}
+
+// TestEnsureEmbeddings_RejectsProviderCountMismatch proves a
+// provider that returns the wrong number of vectors is rejected
+// definitively. The mismatch is a provider bug, not a transient
+// failure: c.embedFailed is set so subsequent calls fall back to
+// lexical with a clear reason instead of repeatedly hitting the
+// misbehaving provider.
+func TestEnsureEmbeddings_RejectsProviderCountMismatch(t *testing.T) {
+	tk := New("test")
+	c := &conn{embedTexts: []string{"alpha", "beta", "gamma"}}
+	emb := countMismatchEmbedder{returnCount: 2}
+	err := tk.ensureEmbeddings(context.Background(), c, emb)
+	if err == nil {
+		t.Fatal("expected error for vector count mismatch")
+	}
+	if !strings.Contains(err.Error(), "returned 2 vectors for 3 texts") {
+		t.Errorf("error should name the mismatch counts; got %q", err)
+	}
+	c.embedMu.Lock()
+	failed := c.embedFailed
+	c.embedMu.Unlock()
+	if !failed {
+		t.Error("count mismatch must set embedFailed (definitive provider bug)")
+	}
+}
+
+// countMismatchEmbedder returns fewer vectors than texts requested,
+// simulating a provider bug that drops items silently. Distinct from
+// failBatch (which errors) and zeroEmbedder (which returns the right
+// count with zero values).
+type countMismatchEmbedder struct{ returnCount int }
+
+func (countMismatchEmbedder) Dimension() int { return 4 }
+func (countMismatchEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return []float32{1, 0, 0, 0}, nil
+}
+
+func (e countMismatchEmbedder) EmbedBatch(_ context.Context, _ []string) ([][]float32, error) {
+	out := make([][]float32, e.returnCount)
+	for i := range out {
+		out[i] = []float32{1, 0, 0, 0}
+	}
+	return out, nil
+}
+
+// TestSetEmbeddingProvider_NilDoesNotPanic proves passing nil
+// is a no-op and never reaches the warmer spawn loop. Covers the
+// early-return branch.
+func TestSetEmbeddingProvider_NilDoesNotPanic(_ *testing.T) {
+	tk := New("test")
+	tk.SetEmbeddingProvider(nil)
+	tk.SetEmbeddingProvider(nil) // idempotent
+}
+
+// TestWarmEmbeddings_NoOpsReturnsImmediately proves the early
+// guards in warmEmbeddings short-circuit without spawning a
+// goroutine or hitting the provider when there is nothing to do.
+func TestWarmEmbeddings_NoOpsReturnsImmediately(_ *testing.T) {
+	tk := New("test")
+	// nil conn: short-circuit
+	tk.warmEmbeddings(nil, &fakeEmbedder{dim: 4})
+	// nil embedder: short-circuit
+	tk.warmEmbeddings(&conn{embedTexts: []string{"a"}}, nil)
+	// empty embedTexts: short-circuit
+	tk.warmEmbeddings(&conn{}, &fakeEmbedder{dim: 4})
 }

--- a/pkg/toolkits/apigateway/toolkit.go
+++ b/pkg/toolkits/apigateway/toolkit.go
@@ -211,23 +211,34 @@ type RoutePolicy interface {
 // parsed OpenAPI documents that api_get_endpoint_schema reads.
 //
 // embedTexts is the parallel-indexed text fed to the embedding
-// provider for semantic ranking; embeddings are populated lazily on
-// the first non-lexical api_list_endpoints call (so an unreachable
-// embedding service does not block platform startup). embedMu
-// serializes the lazy populate so concurrent calls embed once.
-// Invalidation is by full conn rebuild — ReloadConnection drops
-// the conn and re-creates it when a catalog mutates, so the
-// embedding cache is naturally fresh.
+// provider for semantic ranking. embeddings are populated by a
+// background warmer goroutine kicked off from addParsedConnection
+// (when an embedder is already wired) and from SetEmbeddingProvider
+// (when the provider is wired after the connection is registered).
+// Populating off the request path keeps the first ranking call
+// from synchronously blocking on a slow embedder and timing out
+// the MCP request budget. embedInFlight is the warmer presence
+// guard so concurrent triggers de-duplicate. embedFailed sticks
+// on definitive provider failures so a misbehaving embedder is
+// not re-hammered on every ranking call. Invalidation is by full
+// conn rebuild: ReloadConnection drops the conn and re-registers
+// it, which spawns a fresh warmer.
 type conn struct {
-	cfg         Config
-	auth        Authenticator
-	client      *http.Client
-	specs       map[string]*specState
-	operations  []OperationSummary
-	embedTexts  []string
-	embeddings  [][]float32
-	embedMu     sync.Mutex
-	embedFailed bool
+	cfg        Config
+	auth       Authenticator
+	client     *http.Client
+	specs      map[string]*specState
+	operations []OperationSummary
+	embedTexts []string
+	// embedMu guards every field below this line. Read paths
+	// (per-request) take the lock briefly to copy a snapshot and
+	// release; the write path (background warmer) holds it only
+	// while it swaps the populated slice in, never while the
+	// embedder is being called.
+	embedMu       sync.Mutex
+	embeddings    [][]float32
+	embedFailed   bool
+	embedInFlight bool
 }
 
 // specState retains the parsed OpenAPI document for a component
@@ -565,13 +576,25 @@ func (t *Toolkit) SetSemanticProvider(provider semantic.Provider) {
 // SetEmbeddingProvider wires the embedding model used by the
 // "semantic" and "hybrid" ranking modes of api_list_endpoints. nil
 // (the default) disables non-lexical ranking; calls that request
-// it fall back to lexical with a note. Per-connection embedding
-// vectors are computed lazily on the first non-lexical call so an
-// unreachable embedding service does not block platform startup.
+// it fall back to lexical with a note. When a non-nil provider is
+// wired, the toolkit kicks off a background warmer for every
+// already-registered connection so the first ranking call does
+// not pay the cold-start cost of embedding every operation
+// synchronously inside the request budget.
 func (t *Toolkit) SetEmbeddingProvider(p embedding.Provider) {
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	t.embedder = p
+	conns := make([]*conn, 0, len(t.connections))
+	for _, c := range t.connections {
+		conns = append(conns, c)
+	}
+	t.mu.Unlock()
+	if p == nil {
+		return
+	}
+	for _, c := range conns {
+		go t.warmEmbeddings(c, p)
+	}
 }
 
 // SetQueryProvider stores the query provider. Reserved for future
@@ -641,8 +664,8 @@ func (t *Toolkit) addParsedConnection(name string, cfg Config) error {
 		embedTexts: texts,
 	}
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	if _, exists := t.connections[name]; exists {
+		t.mu.Unlock()
 		return fmt.Errorf("apigateway: %s: %w", name, ErrConnectionExists)
 	}
 	// Wire the unified token store into authorization_code
@@ -659,8 +682,70 @@ func (t *Toolkit) addParsedConnection(name string, cfg Config) error {
 		}
 	}
 	t.connections[name] = c
+	embedder := t.embedder
+	t.mu.Unlock()
+	// Kick off the background embedding warmer when an embedder is
+	// already wired. SetEmbeddingProvider triggers it for the
+	// other-ordering case (provider wired after the connection
+	// registers). Either way the first ranking call finds the
+	// embeddings already populated and returns in milliseconds
+	// instead of timing out on a cold per-operation embedding pass.
+	if embedder != nil && len(c.embedTexts) > 0 {
+		go t.warmEmbeddings(c, embedder)
+	}
 	return nil
 }
+
+// warmEmbeddings populates c.embeddings in the background using the
+// supplied embedder. Runs once per connection lifecycle: subsequent
+// invocations short-circuit when embeddings are already populated,
+// when a prior warm-up failed definitively, or when another warmer
+// is already in flight. The result is that the FIRST
+// ranking=semantic|hybrid call against a connection finds
+// embeddings ready and returns inside the request budget rather
+// than triggering a multi-minute per-operation embedding pass
+// inside the MCP request and timing out.
+//
+// embedder is passed in rather than re-read from t.embedder so a
+// concurrent SetEmbeddingProvider(nil) does not race the loop.
+// The work itself runs on a 10-minute background context so a
+// genuinely unreachable embedder cannot leak a hung goroutine.
+func (t *Toolkit) warmEmbeddings(c *conn, embedder embedding.Provider) {
+	if c == nil || embedder == nil || len(c.embedTexts) == 0 {
+		return
+	}
+	// Panic recovery is mandatory in this entry point because the
+	// warmer is also called from a goroutine spawned by
+	// addParsedConnection and SetEmbeddingProvider. A misbehaving
+	// embedding provider that panics cannot crash the platform
+	// process. The recovered panic marks the warmer as definitively
+	// failed so subsequent ranking calls fall back to lexical with
+	// a clear reason instead of spawning another warmer that will
+	// panic the same way.
+	defer func() {
+		if rec := recover(); rec != nil {
+			c.embedMu.Lock()
+			c.embedInFlight = false
+			c.embedFailed = true
+			c.embedMu.Unlock()
+			slog.Error("apigateway: embeddings warm-up panicked",
+				logKeyConnection, c.cfg.ConnectionName, "panic", rec)
+		}
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), warmEmbeddingsTimeout)
+	defer cancel()
+	if err := t.ensureEmbeddings(ctx, c, embedder); err != nil {
+		slog.Warn("apigateway: embeddings warm-up failed",
+			logKeyConnection, c.cfg.ConnectionName, logKeyError, err)
+	}
+}
+
+// warmEmbeddingsTimeout caps how long the background embedding
+// warmer can run for a single connection. Generous enough for a
+// 1000-operation catalog against a slow embedder; bounded so a
+// genuinely unreachable embedder cannot leak a hung goroutine
+// across a long-lived platform process.
+const warmEmbeddingsTimeout = 10 * time.Minute
 
 // buildConnSpecs loads the connection's catalog (when configured),
 // parses each component spec, and returns the merged operation

--- a/pkg/toolkits/apigateway/toolkit_test.go
+++ b/pkg/toolkits/apigateway/toolkit_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -865,13 +866,17 @@ func TestHandleListEndpoints_FallbackNoteIncludesReason(t *testing.T) {
 	}
 }
 
-// TestHandleListEndpoints_PanicRecovery covers finding #3: a
-// runtime panic in the ranking pipeline must surface as an
-// operator-readable error result, not as the MCP SDK's generic
-// "Error occurred during tool execution". The follow-up assertion
-// proves the embed cache is marked failed so a misbehaving
-// embedder cannot be re-hit on every subsequent call.
-func TestHandleListEndpoints_PanicRecovery(t *testing.T) {
+// TestHandleListEndpoints_EmbedderPanicSurfacesAsFallback proves
+// a panicking embedding provider does NOT reach handleListEndpoints
+// (because warmEmbeddings owns the panic recovery in the background
+// warmer) and a subsequent semantic-mode call returns a clean
+// lexical fallback with a Note naming the warm-up failure. The
+// previous design ran the embedder synchronously inside the handler,
+// so a panic there had to be caught at the handler boundary; the
+// new design moves embedding population off the request path, so
+// the embedder panic is captured at warm time and surfaced as a
+// clear "warm-up failed" reason on every subsequent call.
+func TestHandleListEndpoints_EmbedderPanicSurfacesAsFallback(t *testing.T) {
 	tk := New("test")
 	tk.SetEmbeddingProvider(panicEmbedder{})
 	setupCatalogWithSpec(t, tk, "petstore", "default", validMinimalSpec)
@@ -881,57 +886,49 @@ func TestHandleListEndpoints_PanicRecovery(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("AddConnection: %v", err)
 	}
-	res, _, err := tk.handleListEndpoints(context.Background(), nil, ListEndpointsInput{
-		Connection: "c",
-		Query:      "users",
-		Ranking:    "semantic",
-	})
-	if err != nil {
-		t.Fatalf("handleListEndpoints returned go error: %v", err)
-	}
-	if !res.IsError {
-		t.Fatal("expected IsError result after panic")
-	}
-	msg := textContent(res)
-	if !strings.Contains(msg, "internal error") || !strings.Contains(msg, "connection=c") {
-		t.Errorf("error message should name internal error and connection name: %q", msg)
-	}
-	if strings.Contains(msg, "Error occurred during tool execution") {
-		t.Errorf("must NOT surface the MCP SDK generic panic message: %q", msg)
-	}
-
-	// After the panic, c.embedFailed must be set so the next
-	// semantic-mode call falls back to lexical instead of panicking
-	// again. Verify the flag, then prove the follow-up call returns
-	// a clean fallback result with a Note (no panic, no IsError).
 	tk.mu.RLock()
 	c := tk.connections["c"]
 	tk.mu.RUnlock()
+	waitForWarmerSettled(t, c)
 	c.embedMu.Lock()
 	failed := c.embedFailed
 	c.embedMu.Unlock()
 	if !failed {
-		t.Fatal("c.embedFailed should be set after a ranking panic")
+		t.Fatal("c.embedFailed should be set after the warmer recovered the panic")
 	}
-	res2, out2, err := tk.handleListEndpoints(context.Background(), nil, ListEndpointsInput{
+
+	res, out, err := tk.handleListEndpoints(context.Background(), nil, ListEndpointsInput{
 		Connection: "c",
 		Query:      "users",
 		Ranking:    "semantic",
 	})
 	if err != nil {
-		t.Fatalf("follow-up handleListEndpoints: %v", err)
+		t.Fatalf("handleListEndpoints: %v", err)
 	}
-	if res2.IsError {
-		t.Errorf("follow-up call should fall back to lexical, not error: %s", textContent(res2))
+	if res.IsError {
+		t.Fatalf("semantic mode after warmer panic should fall back to lexical, not error: %s", textContent(res))
 	}
-	o, _ := out2.(ListEndpointsOutput)
+	o, _ := out.(ListEndpointsOutput)
 	if o.Note == "" {
-		t.Error("follow-up call should carry a fallback Note")
+		t.Fatal("expected a fallback Note describing the warm-up failure")
+	}
+	if !strings.Contains(o.Note, "warm-up failed") {
+		t.Errorf("Note should name the warm-up failure; got: %q", o.Note)
+	}
+
+	// A second semantic call should produce the same lexical-with-Note
+	// outcome, NOT trigger another warmer (the embedFailed flag is
+	// sticky on definitive failures).
+	res2, _, _ := tk.handleListEndpoints(context.Background(), nil, ListEndpointsInput{
+		Connection: "c", Query: "users", Ranking: "semantic",
+	})
+	if res2.IsError {
+		t.Errorf("repeat call must continue to fall back cleanly: %s", textContent(res2))
 	}
 }
 
 // panicEmbedder panics on every call. Used to drive the
-// handleListEndpoints panic-recovery contract.
+// embedder-panic-recovery contract.
 type panicEmbedder struct{}
 
 func (panicEmbedder) Dimension() int { return 8 }
@@ -941,4 +938,121 @@ func (panicEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 
 func (panicEmbedder) EmbedBatch(_ context.Context, _ []string) ([][]float32, error) {
 	panic("simulated embedder batch panic")
+}
+
+// TestAddConnection_WarmsEmbeddingsInBackground proves the
+// per-connection embedding warmer kicks off when AddConnection
+// runs with an embedding provider already wired, populates the
+// embeddings WITHOUT blocking AddConnection, and finishes after
+// the embedder unblocks. Regression coverage for the "first
+// semantic call times out on a 350-op catalog" production
+// failure: the synchronous embed pass that used to run inside
+// the request budget is now done at registration time off the
+// request path.
+//
+// The slow embedder blocks on a release channel so AddConnection
+// must return BEFORE the embedder has produced any vectors. A
+// synchronous-blocking regression would not return until after
+// release() fires, so the duration assertion deterministically
+// catches it.
+func TestAddConnection_WarmsEmbeddingsInBackground(t *testing.T) {
+	tk := New("test")
+	emb := newSlowEmbedder(32)
+	tk.SetEmbeddingProvider(emb)
+	setupCatalogWithSpec(t, tk, "petstore", "default", validMinimalSpec)
+
+	addStart := time.Now()
+	if err := tk.AddConnection("c", map[string]any{
+		"base_url":   "https://x",
+		"catalog_id": "petstore",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	addDuration := time.Since(addStart)
+	// The embedder is still blocked. If the embed pass ran on the
+	// caller goroutine, AddConnection would not have returned.
+	// 50ms is well under the embedder's hold time.
+	if addDuration > 50*time.Millisecond {
+		t.Errorf("AddConnection took %v; warmer must not run on the caller goroutine", addDuration)
+	}
+
+	tk.mu.RLock()
+	c := tk.connections["c"]
+	tk.mu.RUnlock()
+	// Release the embedder so the warmer can complete.
+	emb.release()
+	waitForWarmerSettled(t, c)
+	if len(c.embeddings) != len(c.embedTexts) {
+		t.Fatalf("warmer should have populated %d embeddings, got %d",
+			len(c.embedTexts), len(c.embeddings))
+	}
+}
+
+// slowEmbedder is a deterministic embedder whose EmbedBatch
+// blocks on a release channel. Used to drive tests that must
+// prove a code path runs OFF the caller goroutine: if the
+// caller ran the embedder synchronously, the assertion would
+// fire before release() did.
+type slowEmbedder struct {
+	dim  int
+	wait chan struct{}
+}
+
+func newSlowEmbedder(dim int) *slowEmbedder {
+	return &slowEmbedder{dim: dim, wait: make(chan struct{})}
+}
+
+func (s *slowEmbedder) release()       { close(s.wait) }
+func (s *slowEmbedder) Dimension() int { return s.dim }
+
+func (s *slowEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	out := make([]float32, s.dim)
+	out[0] = 1
+	return out, nil
+}
+
+func (s *slowEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	select {
+	case <-s.wait:
+	case <-ctx.Done():
+		return nil, fmt.Errorf("slowEmbedder: %w", ctx.Err())
+	}
+	out := make([][]float32, len(texts))
+	for i := range out {
+		out[i] = make([]float32, s.dim)
+		out[i][0] = float32(i + 1)
+	}
+	return out, nil
+}
+
+// TestSetEmbeddingProvider_WarmsExistingConnections proves the
+// other ordering: when the embedding provider is wired AFTER
+// connections have been added, SetEmbeddingProvider triggers a
+// warmer for every already-registered connection. Without this,
+// startup ordering (toolkit configured before the embedder is
+// available) would leave operation embeddings unpopulated until
+// the operator manually reloaded the connection.
+func TestSetEmbeddingProvider_WarmsExistingConnections(t *testing.T) {
+	tk := New("test")
+	setupCatalogWithSpec(t, tk, "petstore", "default", validMinimalSpec)
+	// Register the connection BEFORE wiring the embedder.
+	if err := tk.AddConnection("c", map[string]any{
+		"base_url":   "https://x",
+		"catalog_id": "petstore",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	tk.mu.RLock()
+	c := tk.connections["c"]
+	tk.mu.RUnlock()
+	if len(c.embeddings) != 0 {
+		t.Fatalf("precondition: embeddings should be empty before embedder is wired; got %d", len(c.embeddings))
+	}
+
+	tk.SetEmbeddingProvider(newFakeEmbedder(32))
+	waitForWarmerSettled(t, c)
+	if len(c.embeddings) != len(c.embedTexts) {
+		t.Errorf("expected warmer to populate after SetEmbeddingProvider; got %d / %d",
+			len(c.embeddings), len(c.embedTexts))
+	}
 }


### PR DESCRIPTION
## Summary

``api_list_endpoints`` with ``ranking=semantic`` or ``ranking=hybrid`` against a multi-hundred-operation catalog timed out before the handler could return. The synchronous embedding population that ran on the first non-lexical call took 30+ seconds against a slow upstream embedder (Ollama with ``nomic-embed-text``, sequential per-text HTTP). The MCP request budget expired first and the client surfaced a generic ``Error occurred during tool execution`` with no Note.

The v1.61.9 release-note claim of "fallback Note describes the reason" was unreachable in production because the handler never got to return its result. This PR moves embedding population OFF the request path so the handler always completes inside the request budget, and the Note carries the actual cause when ranking cannot proceed.

## Root cause

Operation-embedding population was lazy: ``ensureEmbeddings`` ran synchronously on the first non-lexical request and held the caller until every operation's text had been embedded. For a 354-operation catalog against Ollama (one HTTP call per text, ~50-500ms each), that is well over typical MCP transport timeouts. The handler-level panic recovery and the fallback-Note logic shipped in v1.61.9 are correct, but the handler does not get to execute them when the request budget expires before ``ensureEmbeddings`` returns.

## Detail

### Background warmer

Operation embeddings now populate in a background goroutine kicked off at registration:

- ``addParsedConnection`` spawns the warmer when an embedding provider is already wired at the time the connection registers.
- ``SetEmbeddingProvider`` spawns warmers for every already-registered connection so the other startup ordering (toolkit before embedder) is covered too.
- ``ReloadConnection`` inherits the same path (it re-registers via ``addParsedConnection``), so a catalog edit produces a fresh warmer against the new operation set.

The warmer runs ``ensureEmbeddings`` under a 10-minute background context with mandatory panic recovery. A panicking embedder cannot crash the platform process; the recover marks the connection as definitively failed and subsequent ranking calls fall back to lexical with a clear Note.

### Request path

``queryVectorFor`` no longer does any embedding work. It calls a new ``checkEmbeddingsReady(c)`` that returns one of five distinct sentinels so the fallback Note names the exact cause:

| Sentinel | Operator meaning |
|---|---|
| ``errEmbeddingsNoOps`` | The connection has no operations; semantic ranking is meaningless. |
| ``errEmbeddingsFailed`` | A prior warmer attempt failed definitively; reload the connection to retry. |
| ``errEmbeddingsWarming`` | The warmer is in flight; falling back to lexical until ready. |
| ``errEmbeddingsNotStarted`` | No warmer ever ran (typically a configuration ordering bug). |
| ``errEmbeddingsZeroVector`` | Provider returned the zero vector; points at a misconfigured embedding model. |

### conn struct

``conn`` gains ``embedInFlight bool`` (guarded by the existing ``embedMu``). Read paths take the lock briefly to copy a snapshot and release; the writer holds it only while it swaps the populated slice in, never while the embedder is being called. The ``conn`` doc comment was rewritten to describe the warmer-at-registration model and remove the stale lazy-on-first-call narrative.

### Concurrency

``embedInFlight`` de-duplicates concurrent triggers. If ``AddConnection`` and ``SetEmbeddingProvider`` both spawn a warmer for the same connection in quick succession, the loser short-circuits at the ``embedInFlight`` check and returns immediately. The winner does the work once.

### Behavior unchanged

- ``ensureEmbeddings`` retains the same synchronous worker semantics it had before: transient ``ctx.Canceled`` / ``DeadlineExceeded`` do not poison the cache; every other provider error sets ``c.embedFailed``. Tests call it directly with controlled contexts.
- The handler-level ``recover`` in ``handleListEndpoints`` from v1.61.9 remains as defense-in-depth for any non-embedder panic. The embedder-panic path now ALSO has its own recovery at the warmer boundary.
- ``ranking=lexical`` is unaffected.

## Tests

| Test | What it proves |
|---|---|
| ``TestAddConnection_WarmsEmbeddingsInBackground`` | A ``slowEmbedder`` blocks on a release channel. AddConnection must return inside 50ms while the embedder is still blocked; a synchronous-blocking regression would not return until the embedder did, so the duration assertion deterministically catches it. |
| ``TestSetEmbeddingProvider_WarmsExistingConnections`` | Wiring the provider AFTER the connection is registered triggers a warmer so the operator does not have to reload. |
| ``TestHandleListEndpoints_EmbedderPanicSurfacesAsFallback`` | An embedder panic during the warmer is recovered, ``c.embedFailed`` is set, and subsequent ranking returns a clean lexical fallback with a Note naming the warm-up failure. No panic at the handler boundary, no repeated panics on retries. |
| ``TestCheckEmbeddingsReady`` | Every state branch of the readiness check maps to the right operator sentinel. |
| ``TestEnsureEmbeddings_RejectsProviderCountMismatch`` | A provider returning the wrong vector count is treated as a definitive failure (the mismatch is a provider bug, not a transient error). |
| ``waitForWarmerSettled`` helper | Tests that go through ``AddConnection`` wait deterministically for the warmer to finish. Tests using ``buildTestConn`` (which bypasses the warmer-spawn path) call ``tk.warmEmbeddings(c, emb)`` synchronously after construction. |

The ``TestSemanticRanking_BenchmarkCorpus`` recall benchmark now explicitly warms its synthetic conn so the hybrid path actually scores semantically instead of silently falling back to lexical under the new readiness contract.

## Behavior changes worth noting

- ``api_list_endpoints`` with ``ranking=semantic`` against a connection whose warmer is still in flight will now return lexical results with a Note saying ``"operation embeddings still warming; falling back to lexical until ready"``. This is the correct behavior for the cold-start window. Once the warmer settles (typically seconds for small catalogs, up to a few minutes for very large ones against a slow embedder), subsequent calls use the cached embeddings.
- AddConnection no longer blocks on the embedder. Startup time is unaffected by the embedder's speed.
- A panicking embedder no longer crashes the platform; it marks the affected connection as failed and the operator can reload the connection to retry.

## Test plan

- [x] ``make verify`` passes (full suite: fmt, race tests, lint, gosec, semgrep, codeql, coverage, dead-code, mutation, release-check)
- [ ] On the demo deployment, ``api_list_endpoints`` with ``ranking=semantic`` against a 350+ op catalog returns operations inside the request budget (no generic "Error occurred during tool execution")
- [ ] Calling ``ranking=semantic`` immediately after pod start (during the warmer window) returns lexical results with a Note containing ``"still warming"``
- [ ] Calling ``ranking=semantic`` after the warmer settles returns operations ranked by semantic similarity
- [ ] Pod logs show ``"warming connection embeddings"`` at startup and ``"embeddings warm-up complete"`` after settlement
- [ ] Restart the pod; same connection's first ``ranking=semantic`` call still returns inside the request budget (warmer is per-connection; restart re-warms)