### PR TITLE
fix(platform): late-registered OnStart callbacks fire immediately

### DIFF
--- a/pkg/platform/lifecycle.go
+++ b/pkg/platform/lifecycle.go
@@ -27,10 +27,23 @@ func NewLifecycle() *Lifecycle {
 }
 
 // OnStart registers a callback to run on startup.
+//
+// If the lifecycle has already been started, the callback is
+// invoked immediately with context.Background() and any error is
+// logged. This handles late-wiring paths (toolkit setup that
+// happens inside startHTTPServer, after platform.Start has
+// already run) which otherwise silently never fire.
 func (l *Lifecycle) OnStart(callback func(context.Context) error) {
 	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.startCallbacks = append(l.startCallbacks, callback)
+	if !l.started {
+		l.startCallbacks = append(l.startCallbacks, callback)
+		l.mu.Unlock()
+		return
+	}
+	l.mu.Unlock()
+	if err := callback(context.Background()); err != nil {
+		slog.Warn("lifecycle: late-registered OnStart callback failed", "error", err)
+	}
 }
 
 // OnStop registers a callback to run on shutdown.

--- a/pkg/platform/lifecycle_test.go
+++ b/pkg/platform/lifecycle_test.go
@@ -244,3 +244,67 @@ func TestLifecycle_StopWithError(t *testing.T) {
 		t.Error("Stop() expected error when callback fails")
 	}
 }
+
+// TestLifecycle_OnStartAfterStarted_FiresImmediately is the
+// regression test for v1.62.0's "embed jobs never run" bug.
+// Before the fix, OnStart called after Start silently dropped
+// the callback. The fix invokes the callback immediately.
+//
+// Production trigger: internal/server/server.go calls
+// platform.Start() inside platform.New's caller, then
+// cmd/mcp-data-platform/main.go's startHTTPServer wires the
+// embed-job worker via WireAPIGatewayEmbedJobsFromDB which
+// registers OnStart. That callback must fire even though the
+// lifecycle is already started.
+func TestLifecycle_OnStartAfterStarted_FiresImmediately(t *testing.T) {
+	t.Parallel()
+	lc := NewLifecycle()
+	if err := lc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	called := false
+	lc.OnStart(func(_ context.Context) error {
+		called = true
+		return nil
+	})
+	if !called {
+		t.Fatal("late-registered OnStart callback was not invoked")
+	}
+}
+
+// TestLifecycle_OnStartBeforeStarted_DeferredUntilStart proves
+// the pre-Start path still defers (does not eagerly invoke).
+func TestLifecycle_OnStartBeforeStarted_DeferredUntilStart(t *testing.T) {
+	t.Parallel()
+	lc := NewLifecycle()
+
+	called := false
+	lc.OnStart(func(_ context.Context) error {
+		called = true
+		return nil
+	})
+	if called {
+		t.Fatal("pre-Start callback should not have fired yet")
+	}
+	if err := lc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !called {
+		t.Fatal("pre-Start callback never fired after Start")
+	}
+}
+
+// TestLifecycle_OnStartAfterStarted_ErrorIsLogged confirms a
+// failing late-registered callback does not panic or deadlock
+// (it logs at warn level and returns to the caller).
+func TestLifecycle_OnStartAfterStarted_ErrorIsLogged(t *testing.T) {
+	t.Parallel()
+	lc := NewLifecycle()
+	if err := lc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	lc.OnStart(func(_ context.Context) error {
+		return errors.New("boom")
+	})
+}


### PR DESCRIPTION
## Summary

v1.62.0's embedding job queue (#421) shipped non-functional on live deployments. The `apiGatewayEmbedJobsStore` field on `Platform` was set, but no worker, reaper, reconciler, or listener goroutine ever ran. The API Catalogs UI rendered `0/N specs indexed` forever, and no `apigateway embed jobs: started` log appeared on pod boot.

This PR fixes the lifecycle ordering bug that caused it and adds three regression tests so the same class of bug cannot reappear silently.

## Root cause

Three pieces had to be true at once. They were:

1. **`Lifecycle.OnStart` did not check `started`.** Before this PR:
   ```go
   func (l *Lifecycle) OnStart(callback func(context.Context) error) {
       l.mu.Lock()
       defer l.mu.Unlock()
       l.startCallbacks = append(l.startCallbacks, callback)
   }
   ```
   Any callback registered after `Start()` was appended to a slice that was never iterated again. Silent drop.

2. **`platform.Start` runs inside `server.New`** (`internal/server/server.go:36`):
   ```go
   p, err := platform.New(platform.WithConfig(cfg))
   ...
   if err := p.Start(context.Background()); err != nil { ... }
   ```

3. **The api-gateway embed-jobs wire runs in `startHTTPServer`** (`cmd/mcp-data-platform/main.go:290`), which is called AFTER `server.New` returns. That wire function registers the worker/reaper/reconciler boot via `p.lifecycle.OnStart(...)`. Since the lifecycle is already started by the time we get here, the OnStart callback is appended to a slice that will never be read.

Result on the live pod (verified via kubectl logs against the deployed v1.62.0 image):

```
{"msg":"database migrations complete","version":45}
{"msg":"merged DB connection into toolkit config","kind":"api","name":"upstream-a"}
{"msg":"memory layer enabled","embedding_provider":"ollama"}
{"msg":"Starting HTTP server on :8080"}
```

No \`apigateway embed jobs: started\`. No \`apigateway embed jobs: skipped (...)\` either. The wire ran, all guards passed, the OnStart hook was registered, and then it was discarded.

## Fix

`Lifecycle.OnStart` now checks `started`. If false, it appends to the queue as before. If true, it invokes the callback immediately with `context.Background()` and logs any error at warn level.

```go
func (l *Lifecycle) OnStart(callback func(context.Context) error) {
    l.mu.Lock()
    if !l.started {
        l.startCallbacks = append(l.startCallbacks, callback)
        l.mu.Unlock()
        return
    }
    l.mu.Unlock()
    if err := callback(context.Background()); err != nil {
        slog.Warn("lifecycle: late-registered OnStart callback failed", "error", err)
    }
}
```

This addresses the entire bug class. Embed-jobs is the obvious victim today, but any future toolkit wired from `startHTTPServer` would have hit the same trap. The lock is released before calling the callback so the callback itself can register additional OnStop hooks without deadlocking.

## Why this slipped through

This is the honest accounting:

- **Every existing test calls `worker.Start(ctx)` directly.** None constructed a `Lifecycle`, called `Start`, then called `OnStart`, and verified the callback fired. The lifecycle path was unit-tested in pieces but never end-to-end in the production order.
- **The adversarial pre-commit review reads the diff.** It caught the three SQL/dedup bugs in #421 because those were visible in the code. It did not catch lifecycle ordering because that requires simulating the boot sequence.
- **No live verification before tagging v1.62.0.** A single hit against `/api/v1/admin/api-catalogs/{id}/embedding-health` after deploy would have shown `0/N indexed` immediately.

The structural fix is the new test below, which is the test that would have caught this.

## Tests added

`pkg/platform/lifecycle_test.go` gets three new cases:

- **`TestLifecycle_OnStartAfterStarted_FiresImmediately`** — the canonical regression. Constructs a lifecycle, calls `Start`, then registers an OnStart and asserts it ran. This is the test whose absence let v1.62.0 ship broken.
- **`TestLifecycle_OnStartBeforeStarted_DeferredUntilStart`** — proves the pre-Start path still defers (does not eagerly invoke).
- **`TestLifecycle_OnStartAfterStarted_ErrorIsLogged`** — confirms a failing late-registered callback does not panic or deadlock.

## Verification

- `make verify` green locally (full suite: fmt, test/race, lint, gosec, govulncheck, semgrep, codeql, coverage gates, dead-code, mutation, GoReleaser dry-run).
- Adversarial pre-commit review: CLEAN.

## Upgrade notes

- Tag `v1.62.1` after merge.
- Existing v1.62.0 deployments stay non-functional for api-gateway embedding until pods are rolled onto v1.62.1. Once rolled, the reconciler runs on the first 5-minute tick and converges any specs with `operation_count <> embedding_count`.
- No schema change. No config change. No API change.

## Test plan

- [ ] CI gates pass (test/race, lint, security, coverage, dead-code, mutation, semgrep, codeql, GoReleaser).
- [ ] Deploy v1.62.1 to a staging cluster.
- [ ] On a pod with at least one api catalog wired and `embedding.ollama.url` configured, confirm `apigateway embed jobs: started` appears in the startup logs.
- [ ] Upload an OpenAPI spec to an api catalog via the portal. Confirm the badge transitions `queued` then `indexing N/M` then `N/M indexed` within a few seconds, with no operator clicks.
- [ ] `GET /api/v1/admin/api-catalogs/{id}/embedding-health` returns non-zero `specs_indexed`.
- [ ] Kill the pod mid-embed; confirm the next pod's reaper releases the lease and another worker finishes the spec.