### PR TITLE
fix(connoauth): classify client-auth failures as terminal, surface health on connection list

### DIFF
--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -1166,6 +1166,34 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/connections/oauth-health": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Single-shot per-connection OAuth health used by the connection-list view to render a per-row health badge. Returns has_oauth=false for non-OAuth connections so the UI doesn't have to filter client-side.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "Bulk OAuth health for all connections",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.connectionsOAuthHealthResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/connections/{kind}/{name}/auth-events": {
             "get": {
                 "security": [
@@ -7015,6 +7043,40 @@ const docTemplate = `{
                 "total": {
                     "type": "integer",
                     "example": 5
+                }
+            }
+        },
+        "admin.connectionOAuthHealthSummary": {
+            "type": "object",
+            "properties": {
+                "has_oauth": {
+                    "type": "boolean"
+                },
+                "idp_error_code": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "needs_reauth": {
+                    "type": "boolean"
+                },
+                "token_acquired": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "admin.connectionsOAuthHealthResponse": {
+            "type": "object",
+            "properties": {
+                "connections": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/admin.connectionOAuthHealthSummary"
+                    }
                 }
             }
         },

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -1160,6 +1160,34 @@
                 }
             }
         },
+        "/admin/connections/oauth-health": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Single-shot per-connection OAuth health used by the connection-list view to render a per-row health badge. Returns has_oauth=false for non-OAuth connections so the UI doesn't have to filter client-side.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "Bulk OAuth health for all connections",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.connectionsOAuthHealthResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/connections/{kind}/{name}/auth-events": {
             "get": {
                 "security": [
@@ -7009,6 +7037,40 @@
                 "total": {
                     "type": "integer",
                     "example": 5
+                }
+            }
+        },
+        "admin.connectionOAuthHealthSummary": {
+            "type": "object",
+            "properties": {
+                "has_oauth": {
+                    "type": "boolean"
+                },
+                "idp_error_code": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "needs_reauth": {
+                    "type": "boolean"
+                },
+                "token_acquired": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "admin.connectionsOAuthHealthResponse": {
+            "type": "object",
+            "properties": {
+                "connections": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/admin.connectionOAuthHealthSummary"
+                    }
                 }
             }
         },

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -243,6 +243,28 @@ definitions:
         example: 5
         type: integer
     type: object
+  admin.connectionOAuthHealthSummary:
+    properties:
+      has_oauth:
+        type: boolean
+      idp_error_code:
+        type: string
+      kind:
+        type: string
+      name:
+        type: string
+      needs_reauth:
+        type: boolean
+      token_acquired:
+        type: boolean
+    type: object
+  admin.connectionsOAuthHealthResponse:
+    properties:
+      connections:
+        items:
+          $ref: '#/definitions/admin.connectionOAuthHealthSummary'
+        type: array
+    type: object
   admin.dryRunEnrichmentRequest:
     properties:
       args:
@@ -3262,6 +3284,24 @@ paths:
       - ApiKeyAuth: []
       - BearerAuth: []
       summary: Force a refresh-token exchange for a connection
+      tags:
+      - Connections
+  /admin/connections/oauth-health:
+    get:
+      description: Single-shot per-connection OAuth health used by the connection-list
+        view to render a per-row health badge. Returns has_oauth=false for non-OAuth
+        connections so the UI doesn't have to filter client-side.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/admin.connectionsOAuthHealthResponse'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Bulk OAuth health for all connections
       tags:
       - Connections
   /admin/gateway/connections/{name}/enrichment-rules:

--- a/pkg/admin/connection_oauth_handler.go
+++ b/pkg/admin/connection_oauth_handler.go
@@ -42,6 +42,7 @@ func (h *Handler) registerConnectionOAuthRoutes() {
 	h.mux.HandleFunc("GET /api/v1/admin/connections/{kind}/{name}/oauth-status", h.connectionOAuthStatus)
 	h.mux.HandleFunc("GET /api/v1/admin/connections/{kind}/{name}/auth-events", h.connectionAuthEvents)
 	h.mux.HandleFunc("POST /api/v1/admin/connections/{kind}/{name}/reacquire-oauth", h.reacquireConnectionOAuth)
+	h.mux.HandleFunc("GET /api/v1/admin/connections/oauth-health", h.connectionsOAuthHealth)
 	h.publicMux.HandleFunc("GET /api/v1/admin/oauth/callback", h.connectionOAuthCallback)
 	// Legacy API-gateway callback URL. Existing deployments may have
 	// this URL registered in customer IdP client configurations; keep
@@ -187,6 +188,131 @@ func (h *Handler) connectionOAuthStatus(w http.ResponseWriter, r *http.Request) 
 	status := src.Status(r.Context())
 	status.LastRevocation = h.lastRevocationFor(r.Context(), kind, name)
 	writeJSON(w, http.StatusOK, status)
+}
+
+// connectionOAuthHealthSummary is the per-connection shape returned
+// by the bulk oauth-health endpoint. Sized to power the connection-
+// list badge: needs_reauth drives the red dot, idp_error_code feeds
+// the hover tooltip so the operator sees "invalid_client" without
+// clicking into the connection.
+type connectionOAuthHealthSummary struct {
+	Kind          string `json:"kind"`
+	Name          string `json:"name"`
+	HasOAuth      bool   `json:"has_oauth"`
+	NeedsReauth   bool   `json:"needs_reauth"`
+	TokenAcquired bool   `json:"token_acquired"`
+	IDPErrorCode  string `json:"idp_error_code,omitempty"`
+}
+
+type connectionsOAuthHealthResponse struct {
+	Connections []connectionOAuthHealthSummary `json:"connections"`
+}
+
+// connectionsOAuthHealth handles GET /api/v1/admin/connections/oauth-health.
+// Returns one summary per registered connection, including non-OAuth
+// connections (with has_oauth=false) so the UI can render the list in
+// one pass without a second "is this OAuth?" round-trip.
+//
+// @Summary      Bulk OAuth health for all connections
+// @Description  Single-shot per-connection OAuth health used by the connection-list view to render a per-row health badge. Returns has_oauth=false for non-OAuth connections so the UI doesn't have to filter client-side.
+// @Tags         Connections
+// @Produce      json
+// @Success      200  {object}  connectionsOAuthHealthResponse
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /admin/connections/oauth-health [get]
+func (h *Handler) connectionsOAuthHealth(w http.ResponseWriter, r *http.Request) {
+	if h.deps.ConnectionStore == nil {
+		writeJSON(w, http.StatusOK, connectionsOAuthHealthResponse{Connections: []connectionOAuthHealthSummary{}})
+		return
+	}
+	insts, err := h.deps.ConnectionStore.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list connections")
+		return
+	}
+	out := make([]connectionOAuthHealthSummary, 0, len(insts))
+	for _, inst := range insts {
+		out = append(out, h.connectionOAuthHealth(r.Context(), inst))
+	}
+	writeJSON(w, http.StatusOK, connectionsOAuthHealthResponse{Connections: out})
+}
+
+// connectionOAuthHealth derives one summary row. Connections without
+// an OAuth handler registered for their kind, or whose config does
+// not parse into an OAuth config (auth_mode != oauth2_*), get
+// has_oauth=false. The UI hides the badge for those.
+//
+// For OAuth connections, we read the latest refresh-failed event to
+// surface the IdP error code on the row tooltip. This is more
+// useful than scraping connoauth.Source.Status() alone because the
+// "needs_reauth=true, no clue why" case is exactly what the operator
+// is triaging.
+func (h *Handler) connectionOAuthHealth(ctx context.Context, inst platform.ConnectionInstance) connectionOAuthHealthSummary {
+	row := connectionOAuthHealthSummary{Kind: inst.Kind, Name: inst.Name}
+	if h.deps.OAuthKinds == nil {
+		return row
+	}
+	handler, ok := h.deps.OAuthKinds[inst.Kind]
+	if !ok {
+		return row
+	}
+	cfg, err := handler.ParseOAuthConfig(inst.Config)
+	if err != nil {
+		// Connection exists but is not configured for OAuth (e.g.,
+		// auth_mode=bearer on an api connection). has_oauth stays false.
+		return row
+	}
+	row.HasOAuth = true
+	if h.deps.ConnOAuthStore == nil {
+		return row
+	}
+	src := connoauth.NewSource(h.deps.ConnOAuthStore, connoauth.Key{Kind: inst.Kind, Name: inst.Name}, cfg)
+	status := src.Status(ctx)
+	row.NeedsReauth = status.NeedsReauth
+	row.TokenAcquired = status.TokenAcquired
+	row.IDPErrorCode = h.latestRefreshErrorCode(ctx, inst.Kind, inst.Name)
+	return row
+}
+
+// latestRefreshErrorCode reads the connection's most recent event
+// and, if it is a refresh-failed type, returns its idp_error_code.
+// Returns empty in every other case: events store unavailable, no
+// events at all, OR the most recent event is anything other than a
+// refresh-failed type (operator just reconnected, token was deleted
+// by admin, fresh connect_started, etc.).
+//
+// The "look at the single newest event" rule is load-bearing: an
+// older refresh failure followed by a newer success-shaped event
+// (connect_completed, refresh_succeeded, token_deleted_admin) is
+// NOT a current error and must not surface on the badge.
+func (h *Handler) latestRefreshErrorCode(ctx context.Context, kind, name string) string {
+	if h.deps.AuthEventStore == nil {
+		return ""
+	}
+	events, err := h.deps.AuthEventStore.List(ctx, authevents.Filter{Kind: kind, Name: name, Limit: 1})
+	if err != nil || len(events) == 0 {
+		return ""
+	}
+	switch events[0].Type {
+	case authevents.TypeRefreshFailedRevoked, authevents.TypeRefreshFailedTransient:
+		return refreshErrorCodeFromDetail(events[0].Detail)
+	}
+	return ""
+}
+
+// refreshErrorCodeFromDetail extracts idp_error_code from an
+// auth-event Detail blob. Returns empty on any parse failure so
+// callers can ignore the row safely.
+func refreshErrorCodeFromDetail(detail json.RawMessage) string {
+	if len(detail) == 0 {
+		return ""
+	}
+	var d authevents.RefreshDetail
+	if err := json.Unmarshal(detail, &d); err != nil {
+		return ""
+	}
+	return d.IDPErrorCode
 }
 
 // lastRevocationFor reads the most recent revocation event for the

--- a/pkg/admin/connection_oauth_handler_test.go
+++ b/pkg/admin/connection_oauth_handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
+	"github.com/txn2/mcp-data-platform/pkg/authevents"
 	"github.com/txn2/mcp-data-platform/pkg/connoauth"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
 )
@@ -27,14 +28,24 @@ type fakeOAuthKindHandler struct {
 	parseCfg connoauth.Config
 	parseErr error
 	afterErr error
+	// parseErrForAuthMode refuses to parse connections whose
+	// auth_mode matches this string. Lets the bulk-health test
+	// simulate a non-OAuth (bearer / api_key) connection in a list
+	// alongside OAuth ones, without standing up a second fake.
+	parseErrForAuthMode string
 	// captured args from AfterConnect for assertions:
 	afterCalled bool
 	afterName   string
 }
 
-func (f *fakeOAuthKindHandler) ParseOAuthConfig(_ map[string]any) (connoauth.Config, error) {
+func (f *fakeOAuthKindHandler) ParseOAuthConfig(raw map[string]any) (connoauth.Config, error) {
 	if f.parseErr != nil {
 		return connoauth.Config{}, f.parseErr
+	}
+	if f.parseErrForAuthMode != "" {
+		if mode, _ := raw["auth_mode"].(string); mode == f.parseErrForAuthMode {
+			return connoauth.Config{}, errors.New("connection is not configured for authorization_code OAuth")
+		}
 	}
 	return f.parseCfg, nil
 }
@@ -424,4 +435,326 @@ func TestURLHostForLog(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, "idp.example.com", urlHostForLog("https://idp.example.com/realms/x/token"))
 	assert.Equal(t, "not-a-url", urlHostForLog("not-a-url"))
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// connectionsOAuthHealth (bulk)
+// ────────────────────────────────────────────────────────────────────────
+
+// TestConnectionsOAuthHealth_EmptyStore confirms the endpoint returns
+// {connections: []} when no connections exist (not 500).
+func TestConnectionsOAuthHealth_EmptyStore(t *testing.T) {
+	t.Parallel()
+	srv := fakeIDPServer(t, func(http.ResponseWriter, *http.Request) {})
+	fx := setupOAuthFixture(t, srv)
+	fx.connStore.instances = []platform.ConnectionInstance{}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/api/v1/admin/connections/oauth-health", http.NoBody)
+	w := httptest.NewRecorder()
+	fx.handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp connectionsOAuthHealthResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.NotNil(t, resp.Connections)
+	assert.Empty(t, resp.Connections)
+}
+
+// TestConnectionsOAuthHealth_MixedKinds proves the endpoint returns
+// one row per connection regardless of OAuth eligibility, and sets
+// HasOAuth correctly. This is the contract the UI relies on to
+// render the badge only for OAuth connections without a second
+// round-trip per row.
+func TestConnectionsOAuthHealth_MixedKinds(t *testing.T) {
+	t.Parallel()
+	srv := fakeIDPServer(t, func(http.ResponseWriter, *http.Request) {})
+	fx := setupOAuthFixture(t, srv)
+	fx.connStore.instances = []platform.ConnectionInstance{
+		{
+			Kind: connoauth.KindMCP,
+			Name: "alpha",
+			Config: map[string]any{
+				"endpoint":                "http://upstream/mcp",
+				"auth_mode":               "oauth",
+				"oauth_grant":             "authorization_code",
+				"oauth_authorization_url": "https://idp.example/authorize",
+				"oauth_token_url":         srv.URL + "/token",
+				"oauth_client_id":         "test-client",
+				"oauth_client_secret":     "test-secret",
+			},
+		},
+		// Force the fake handler to refuse parsing this connection so
+		// it surfaces as has_oauth=false (the "bearer / api_key /
+		// none" case from a real connection).
+		{Kind: connoauth.KindMCP, Name: "beta", Config: map[string]any{"auth_mode": "bearer"}},
+	}
+	// fakeOAuthKindHandler ignores config and always returns the
+	// fixture's parseCfg, so without an override it would mark both
+	// rows as has_oauth=true. Flip that for "beta" by giving the fake
+	// a config-driven gate.
+	fx.kind.parseErrForAuthMode = "bearer"
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/api/v1/admin/connections/oauth-health", http.NoBody)
+	w := httptest.NewRecorder()
+	fx.handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var resp connectionsOAuthHealthResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp.Connections, 2)
+
+	byName := map[string]connectionOAuthHealthSummary{}
+	for _, c := range resp.Connections {
+		byName[c.Name] = c
+	}
+	assert.True(t, byName["alpha"].HasOAuth, "alpha should be has_oauth")
+	assert.True(t, byName["alpha"].NeedsReauth, "alpha has no token row so needs_reauth=true")
+	assert.False(t, byName["beta"].HasOAuth, "beta is bearer-auth, should be has_oauth=false")
+	assert.False(t, byName["beta"].NeedsReauth, "non-OAuth row should not set needs_reauth")
+}
+
+// TestConnectionsOAuthHealth_StoreError surfaces a 500 when the
+// connection store fails so the UI can show a degraded-state
+// banner rather than rendering all-green falsely.
+func TestConnectionsOAuthHealth_StoreError(t *testing.T) {
+	t.Parallel()
+	srv := fakeIDPServer(t, func(http.ResponseWriter, *http.Request) {})
+	fx := setupOAuthFixture(t, srv)
+	fx.connStore.listErr = errors.New("db down")
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/api/v1/admin/connections/oauth-health", http.NoBody)
+	w := httptest.NewRecorder()
+	fx.handler.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestConnectionsOAuthHealth_PopulatesIDPErrorCode proves the latest
+// refresh-failed event's idp_error_code flows into the bulk health
+// response. Without this, the connection-list badge could only show
+// "needs reauth" without the operator-actionable detail (which
+// distinguishes "fix the client_secret" from "click reconnect").
+func TestConnectionsOAuthHealth_PopulatesIDPErrorCode(t *testing.T) {
+	t.Parallel()
+	srv := fakeIDPServer(t, func(http.ResponseWriter, *http.Request) {})
+	connStore := &mockConnectionStore{
+		instances: []platform.ConnectionInstance{
+			{
+				Kind: connoauth.KindMCP,
+				Name: "alpha",
+				Config: map[string]any{
+					"auth_mode":               "oauth",
+					"oauth_grant":             "authorization_code",
+					"oauth_authorization_url": "https://idp.example/authorize",
+					"oauth_token_url":         srv.URL + "/token",
+					"oauth_client_id":         "test-client",
+					"oauth_client_secret":     "test-secret",
+				},
+			},
+		},
+	}
+	tokenStore := connoauth.NewMemoryStore()
+	eventStore := authevents.NewMemoryStore()
+	writer := authevents.NewWriter(eventStore, nil)
+	// Pre-seed a refresh_failed_revoked with a specific RFC 6749 code
+	// so the bulk endpoint must extract it through json.Unmarshal.
+	writer.RefreshFailedRevoked(context.Background(), connoauth.KindMCP, "alpha", "tester", srv.URL+"/token",
+		authevents.RefreshDetail{IDPErrorCode: "invalid_client"})
+
+	fakeKind := &fakeOAuthKindHandler{
+		parseCfg: connoauth.Config{
+			AuthorizationURL:  "https://idp.example/authorize",
+			TokenURL:          srv.URL + "/token",
+			ClientID:          "test-client",
+			ClientSecret:      "test-secret",
+			Scopes:            []string{"openid", "offline_access"},
+			EndpointAuthStyle: oauth2.AuthStyleInHeader,
+		},
+	}
+	h := NewHandler(Deps{
+		Config:          testConfig(),
+		ConnectionStore: connStore,
+		ConfigStore:     &mockConfigStore{mode: "database"},
+		PKCEStore:       NewMemoryPKCEStore(),
+		ConnOAuthStore:  tokenStore,
+		AuthEvents:      writer,
+		AuthEventStore:  eventStore,
+		OAuthKinds:      OAuthKindHandlers{connoauth.KindMCP: fakeKind},
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/api/v1/admin/connections/oauth-health", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	var resp connectionsOAuthHealthResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp.Connections, 1)
+	assert.Equal(t, "invalid_client", resp.Connections[0].IDPErrorCode)
+	assert.True(t, resp.Connections[0].HasOAuth)
+}
+
+// TestConnectionsOAuthHealth_RecentSuccessClearsErrorCode proves a
+// subsequent refresh_succeeded event clears the badge: the bulk
+// endpoint stops at the most-recent event, so a single successful
+// refresh removes the alert.
+func TestConnectionsOAuthHealth_RecentSuccessClearsErrorCode(t *testing.T) {
+	t.Parallel()
+	srv := fakeIDPServer(t, func(http.ResponseWriter, *http.Request) {})
+	connStore := &mockConnectionStore{
+		instances: []platform.ConnectionInstance{
+			{
+				Kind: connoauth.KindMCP,
+				Name: "alpha",
+				Config: map[string]any{
+					"auth_mode":               "oauth",
+					"oauth_grant":             "authorization_code",
+					"oauth_authorization_url": "https://idp.example/authorize",
+					"oauth_token_url":         srv.URL + "/token",
+					"oauth_client_id":         "test-client",
+					"oauth_client_secret":     "test-secret",
+				},
+			},
+		},
+	}
+	tokenStore := connoauth.NewMemoryStore()
+	eventStore := authevents.NewMemoryStore()
+	writer := authevents.NewWriter(eventStore, nil)
+	// Older failure, then newer success. The bulk endpoint should
+	// see "success is most recent" and return empty idp_error_code.
+	writer.RefreshFailedTransient(context.Background(), connoauth.KindMCP, "alpha", "tester", srv.URL+"/token",
+		authevents.RefreshDetail{IDPErrorCode: "server_error"})
+	writer.RefreshSucceeded(context.Background(), connoauth.KindMCP, "alpha", "tester", srv.URL+"/token",
+		authevents.RefreshDetail{})
+
+	fakeKind := &fakeOAuthKindHandler{
+		parseCfg: connoauth.Config{
+			AuthorizationURL:  "https://idp.example/authorize",
+			TokenURL:          srv.URL + "/token",
+			ClientID:          "test-client",
+			ClientSecret:      "test-secret",
+			Scopes:            []string{"openid", "offline_access"},
+			EndpointAuthStyle: oauth2.AuthStyleInHeader,
+		},
+	}
+	h := NewHandler(Deps{
+		Config:          testConfig(),
+		ConnectionStore: connStore,
+		ConfigStore:     &mockConfigStore{mode: "database"},
+		PKCEStore:       NewMemoryPKCEStore(),
+		ConnOAuthStore:  tokenStore,
+		AuthEvents:      writer,
+		AuthEventStore:  eventStore,
+		OAuthKinds:      OAuthKindHandlers{connoauth.KindMCP: fakeKind},
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/api/v1/admin/connections/oauth-health", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp connectionsOAuthHealthResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp.Connections, 1)
+	assert.Empty(t, resp.Connections[0].IDPErrorCode)
+}
+
+// TestRefreshErrorCodeFromDetail covers the parse-failure branch
+// (empty / malformed Detail JSON should not panic; returns empty).
+func TestRefreshErrorCodeFromDetail(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		detail string
+		want   string
+	}{
+		{"empty", "", ""},
+		{"malformed", "not-json", ""},
+		{"no field", `{}`, ""},
+		{"with code", `{"idp_error_code":"invalid_grant"}`, "invalid_grant"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := refreshErrorCodeFromDetail([]byte(tc.detail))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestConnectionsOAuthHealth_ReconnectClearsErrorCode is the
+// regression test for the "stale invalid_client survives reconnect"
+// finding. Before the fix, latestRefreshErrorCode walked past any
+// non-success event type (connect_completed, token_deleted_admin)
+// looking for an older refresh_succeeded. A connection that the
+// operator had just reconnected would still surface the old
+// invalid_client/invalid_grant code on the badge.
+//
+// The fix bails on whichever event type sits at events[0]. If the
+// newest event is anything other than a refresh_failed_*, the code
+// is empty regardless of what older events say.
+func TestConnectionsOAuthHealth_ReconnectClearsErrorCode(t *testing.T) {
+	t.Parallel()
+	srv := fakeIDPServer(t, func(http.ResponseWriter, *http.Request) {})
+	connStore := &mockConnectionStore{
+		instances: []platform.ConnectionInstance{
+			{
+				Kind: connoauth.KindMCP,
+				Name: "alpha",
+				Config: map[string]any{
+					"auth_mode":               "oauth",
+					"oauth_grant":             "authorization_code",
+					"oauth_authorization_url": "https://idp.example/authorize",
+					"oauth_token_url":         srv.URL + "/token",
+					"oauth_client_id":         "test-client",
+					"oauth_client_secret":     "test-secret",
+				},
+			},
+		},
+	}
+	tokenStore := connoauth.NewMemoryStore()
+	eventStore := authevents.NewMemoryStore()
+	writer := authevents.NewWriter(eventStore, nil)
+	// Older terminal failure, then a fresh operator-driven reconnect
+	// success. The badge must clear: the newest event is
+	// connect_completed, NOT a refresh failure.
+	writer.RefreshFailedRevoked(context.Background(), connoauth.KindMCP, "alpha", "tester", srv.URL+"/token",
+		authevents.RefreshDetail{IDPErrorCode: "invalid_client"})
+	writer.ConnectCompleted(context.Background(), connoauth.KindMCP, "alpha", "tester", srv.URL+"/token",
+		authevents.ConnectCompletedDetail{})
+
+	fakeKind := &fakeOAuthKindHandler{
+		parseCfg: connoauth.Config{
+			AuthorizationURL:  "https://idp.example/authorize",
+			TokenURL:          srv.URL + "/token",
+			ClientID:          "test-client",
+			ClientSecret:      "test-secret",
+			Scopes:            []string{"openid", "offline_access"},
+			EndpointAuthStyle: oauth2.AuthStyleInHeader,
+		},
+	}
+	h := NewHandler(Deps{
+		Config:          testConfig(),
+		ConnectionStore: connStore,
+		ConfigStore:     &mockConfigStore{mode: "database"},
+		PKCEStore:       NewMemoryPKCEStore(),
+		ConnOAuthStore:  tokenStore,
+		AuthEvents:      writer,
+		AuthEventStore:  eventStore,
+		OAuthKinds:      OAuthKindHandlers{connoauth.KindMCP: fakeKind},
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/api/v1/admin/connections/oauth-health", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp connectionsOAuthHealthResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Len(t, resp.Connections, 1)
+	assert.Empty(t, resp.Connections[0].IDPErrorCode,
+		"reconnect should clear the badge even when an older refresh failure exists")
 }

--- a/pkg/connoauth/errors.go
+++ b/pkg/connoauth/errors.go
@@ -22,13 +22,32 @@ var ErrTokenNotFound = errors.New("connoauth: token not found")
 var ErrNeedsReauth = errors.New("connoauth: connection needs admin reconnect")
 
 // errRefreshTokenRevoked wraps the underlying error when the IdP
-// definitively rejects a refresh_token grant — RFC 6749 §5.2
-// invalid_grant at HTTP 400. Internal sentinel that callers detect
-// with errors.Is to distinguish revoked refresh from transient
-// failures. Misclassifying a transient failure as revoked would
-// permanently invalidate a long-lived refresh token over a single
-// flaky-network event.
-var errRefreshTokenRevoked = errors.New("connoauth: refresh token rejected by IdP (invalid_grant)")
+// definitively rejects a refresh_token grant. Internal sentinel that
+// callers detect with errors.Is to distinguish revoked refresh from
+// transient failures. Misclassifying a transient failure as revoked
+// would permanently invalidate a long-lived refresh token over a
+// single flaky-network event.
+//
+// Wrapped responses are the terminal ones from RFC 6749 §5.2 that an
+// automated retry cannot recover. The token row is deleted and the
+// operator must reconnect (or, for client-credential failures, fix
+// the secret on the connection THEN reconnect):
+//
+//   - 400 invalid_grant: refresh_token is invalid, expired, revoked,
+//     or was issued to another client.
+//   - 400 invalid_client: client authentication failed. Common cause
+//     is a client_secret rotation on the IdP side; the operator must
+//     update the connection's stored secret.
+//   - 400 unauthorized_client: this client is not authorized to use
+//     the refresh_token grant type at all.
+//   - 400 unsupported_grant_type: server does not support refresh.
+//   - 401 (any error code): unauthenticated; same operator action as
+//     invalid_client.
+//
+// Network drops, 5xx responses, and request cancellations remain
+// transient (no row deletion, no reauth signal) so a flaky upstream
+// does not require an operator reconnect.
+var errRefreshTokenRevoked = errors.New("connoauth: refresh token rejected by IdP")
 
 // errNoRefreshToken / errRefreshExpired are sentinel locals for
 // pre-network checks. Both indicate state that won't recover without

--- a/pkg/connoauth/source.go
+++ b/pkg/connoauth/source.go
@@ -241,9 +241,19 @@ func (s *Source) emitRevokedLeadEvent(ctx context.Context, persisted *PersistedT
 // the short, machine-readable strings recorded in event details. The
 // strings are stable across releases — the History panel and any SIEM
 // dashboards consume them.
+//
+// For errRefreshTokenRevoked we look through the wrap chain for an
+// *oauth2.RetrieveError and surface the RFC 6749 `error` field
+// directly (e.g. "invalid_client", "invalid_grant", "unauthorized_client").
+// That way the History row distinguishes "refresh_token revoked"
+// from "client_secret no longer valid": operationally different
+// remediations.
 func classifyRevokedReason(err error) string {
 	switch {
 	case errors.Is(err, errRefreshTokenRevoked):
+		if code := idpErrorCodeOf(err); code != "" {
+			return code
+		}
 		return "invalid_grant"
 	case errors.Is(err, errNoRefreshToken):
 		return "no_refresh_token"
@@ -412,12 +422,20 @@ func (s *Source) refresh(ctx context.Context, persisted *PersistedToken) (*oauth
 		if !isRevokedRefresh(classified) {
 			// Transient: record it but do not delete the row. The
 			// revoked branch is handled by handleRevoked() in the
-			// caller, which also emits its own event.
+			// caller, which also emits its own event. IDPErrorCode
+			// surfaces the RFC 6749 `error` field (e.g.
+			// "server_error", "temporarily_unavailable") when the IdP
+			// did respond, so the History row shows what the IdP
+			// said instead of an empty detail box.
 			s.events.RefreshFailedTransient(ctx, s.key.Kind, s.key.Name, s.actor, s.cfg.TokenURL,
 				authevents.RefreshDetail{
 					BeforeExpiresAt:        persisted.ExpiresAt,
 					BeforeRefreshExpiresAt: persisted.RefreshExpiresAt,
 					DurationMS:             durationMS,
+					// sanitizeOAuthErrorField bounds length and
+					// strips URLs / control characters: same
+					// rationale as the terminal-classify path.
+					IDPErrorCode: sanitizeOAuthErrorField(idpErrorCodeOf(err)),
 				})
 		}
 		return nil, classified
@@ -511,23 +529,102 @@ func refreshDeadlineFromToken(tok *oauth2.Token, now time.Time) time.Time {
 	return now.Add(time.Duration(secs) * time.Second)
 }
 
-// classifyRefreshError distinguishes a definitively-revoked refresh
-// token (RFC 6749 §5.2 invalid_grant at HTTP 400) from transient
-// failures (network drops, 5xx, request cancellation). Wraps the
-// revoked case with errRefreshTokenRevoked so callers can detect it
-// via errors.Is; scrubs other errors via tokenFetchError so IdP
-// response bodies and embedded URL credentials cannot leak into
-// model output or logs.
+// terminalRefreshError is the wrapped sentinel returned by
+// classifyRefreshError for terminal IdP rejections. Carries the
+// sanitized operator-facing message AND the RFC 6749 error code
+// the IdP returned, so downstream callers (classifyRevokedReason,
+// idpErrorCodeOf, History event details) can show the specific
+// code instead of a generic "invalid_grant" stand-in.
+//
+// `code` is always run through sanitizeOAuthErrorField at
+// construction time (see classifyRefreshError) so a chatty or
+// hostile IdP cannot inject a 100KB blob, URL-shaped content, or
+// control characters into the auth_events JSONB column or the UI
+// tooltip surface.
+type terminalRefreshError struct {
+	msg  string
+	code string
+}
+
+func (e *terminalRefreshError) Error() string { return e.msg }
+
+// Unwrap reports errRefreshTokenRevoked so errors.Is on that
+// sentinel still works.
+func (*terminalRefreshError) Unwrap() error { return errRefreshTokenRevoked }
+
+// classifyRefreshError distinguishes definitively-terminal IdP
+// rejections from transient failures (network drops, 5xx, request
+// cancellation). The terminal set (see errors.go errRefreshTokenRevoked
+// docs) wraps with that sentinel so callers can detect it via
+// errors.Is and trigger handleRevoked. Everything else passes through
+// tokenFetchError so IdP response bodies and embedded URL credentials
+// cannot leak into model output or logs.
 func classifyRefreshError(err error) error {
 	var retrieve *oauth2.RetrieveError
-	if errors.As(err, &retrieve) &&
-		retrieve.Response != nil &&
-		retrieve.Response.StatusCode == http.StatusBadRequest &&
-		retrieve.ErrorCode == "invalid_grant" {
-		return fmt.Errorf("connoauth: refresh rejected by IdP: %s (%w)",
-			tokenFetchError(err).Error(), errRefreshTokenRevoked)
+	if errors.As(err, &retrieve) && isTerminalIDPRejection(retrieve) {
+		return &terminalRefreshError{
+			msg: fmt.Sprintf("connoauth: refresh rejected by IdP: %s (%s)",
+				tokenFetchError(err).Error(), errRefreshTokenRevoked.Error()),
+			// Sanitize at the boundary: this code lands in the
+			// auth_events.detail JSON blob, the bulk-health API
+			// response, and the UI badge tooltip. A hostile or
+			// chatty IdP could otherwise return a multi-KB blob
+			// with embedded URLs or control characters that would
+			// inflate storage and pollute logs.
+			code: sanitizeOAuthErrorField(retrieve.ErrorCode),
+		}
 	}
 	return tokenFetchError(err)
+}
+
+// terminalRefreshErrorCodes is the set of RFC 6749 §5.2 error codes
+// at HTTP 400 that an automated retry cannot recover. The classifier
+// treats them all as revoked so the connection moves to
+// needs_reauth instead of silent-retry-forever. HTTP 401 is treated
+// as terminal regardless of error code: by spec, 401 means client
+// authentication failed (same operator action as invalid_client).
+var terminalRefreshErrorCodes = map[string]struct{}{
+	"invalid_grant":          {},
+	"invalid_client":         {},
+	"unauthorized_client":    {},
+	"unsupported_grant_type": {},
+}
+
+// isTerminalIDPRejection reports whether an *oauth2.RetrieveError
+// represents a state the operator must intervene to clear. Extracted
+// so the predicate is testable in isolation and so the set of
+// terminal codes is maintained in one place.
+func isTerminalIDPRejection(re *oauth2.RetrieveError) bool {
+	if re.Response == nil {
+		return false
+	}
+	if re.Response.StatusCode == http.StatusUnauthorized {
+		return true
+	}
+	if re.Response.StatusCode != http.StatusBadRequest {
+		return false
+	}
+	_, ok := terminalRefreshErrorCodes[re.ErrorCode]
+	return ok
+}
+
+// idpErrorCodeOf extracts the RFC 6749 `error` field from an OAuth
+// library error, if present. Empty when the error is not a
+// RetrieveError (network drop, ctx cancel, etc.) so the caller can
+// distinguish "IdP said something" from "never reached the IdP."
+//
+// Looks through terminalRefreshError first (the post-classify path)
+// then through *oauth2.RetrieveError (the pre-classify path).
+func idpErrorCodeOf(err error) string {
+	var term *terminalRefreshError
+	if errors.As(err, &term) {
+		return term.code
+	}
+	var re *oauth2.RetrieveError
+	if errors.As(err, &re) {
+		return re.ErrorCode
+	}
+	return ""
 }
 
 // isRevokedRefresh reports whether the error is one of the

--- a/pkg/connoauth/source_test.go
+++ b/pkg/connoauth/source_test.go
@@ -849,3 +849,153 @@ func TestSanitizeOAuthErrorField(t *testing.T) {
 		})
 	}
 }
+
+// TestClassifyRefreshError_TerminalIdPCodes proves the classifier
+// treats the full RFC 6749 §5.2 terminal set as revoked, not just
+// invalid_grant. Pre-fix, a 400 invalid_client response was
+// classified transient: the refresher then retried every 5 minutes
+// forever while the connection silently dead-ended on every API
+// call. Regression for a real production 400 invalid_client hang.
+func TestClassifyRefreshError_TerminalIdPCodes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		status    int
+		errorCode string
+		wantRevkd bool
+	}{
+		{"400 invalid_grant", 400, "invalid_grant", true},
+		{"400 invalid_client", 400, "invalid_client", true},
+		{"400 unauthorized_client", 400, "unauthorized_client", true},
+		{"400 unsupported_grant_type", 400, "unsupported_grant_type", true},
+		{"401 with code", 401, "invalid_client", true},
+		{"401 without code", 401, "", true},
+		{"400 server_error", 400, "server_error", false},
+		{"500 (transient)", 500, "", false},
+		{"400 invalid_request", 400, "invalid_request", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			re := &oauth2.RetrieveError{
+				Response:  &http.Response{StatusCode: tc.status},
+				ErrorCode: tc.errorCode,
+			}
+			got := classifyRefreshError(re)
+			if isRevokedRefresh(got) != tc.wantRevkd {
+				t.Errorf("isRevokedRefresh=%v; want %v (status=%d error=%s)",
+					isRevokedRefresh(got), tc.wantRevkd, tc.status, tc.errorCode)
+			}
+		})
+	}
+}
+
+// TestClassifyRevokedReason_PreservesIdPCode proves the History
+// event detail carries the actual RFC 6749 error code that drove
+// the revocation, not a generic "invalid_grant". This is the bit
+// the operator reads when triaging "why is this connection
+// broken" without an IdP UI to cross-check.
+func TestClassifyRevokedReason_PreservesIdPCode(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		errorCode string
+		want      string
+	}{
+		{"invalid_client surfaces as invalid_client", "invalid_client", "invalid_client"},
+		{"unauthorized_client surfaces directly", "unauthorized_client", "unauthorized_client"},
+		{"invalid_grant surfaces as invalid_grant", "invalid_grant", "invalid_grant"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			re := &oauth2.RetrieveError{
+				Response:  &http.Response{StatusCode: 400},
+				ErrorCode: tc.errorCode,
+			}
+			classified := classifyRefreshError(re)
+			if got := classifyRevokedReason(classified); got != tc.want {
+				t.Errorf("classifyRevokedReason=%q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIdpErrorCodeOf returns the code when the error wraps an
+// oauth2.RetrieveError; empty otherwise. Both the raw library error
+// (pre-classify) and the terminal-classified wrap are supported so
+// callers don't need to remember which input is right.
+func TestIdpErrorCodeOf(t *testing.T) {
+	t.Parallel()
+	if got := idpErrorCodeOf(&oauth2.RetrieveError{ErrorCode: "server_error"}); got != "server_error" {
+		t.Errorf("idpErrorCodeOf(raw)=%q; want %q", got, "server_error")
+	}
+	if got := idpErrorCodeOf(errors.New("network down")); got != "" {
+		t.Errorf("idpErrorCodeOf(plain)=%q; want empty", got)
+	}
+	// Terminal-classified path: the typed terminalRefreshError
+	// preserves the code through sanitization so downstream emitters
+	// (RefreshFailedRevoked, classifyRevokedReason) see it.
+	terminal := &oauth2.RetrieveError{
+		Response:  &http.Response{StatusCode: 400},
+		ErrorCode: "invalid_client",
+	}
+	if got := idpErrorCodeOf(classifyRefreshError(terminal)); got != "invalid_client" {
+		t.Errorf("idpErrorCodeOf(terminal-classified)=%q; want %q", got, "invalid_client")
+	}
+}
+
+// TestTerminalRefreshError_ErrorMessage covers the Error() path so
+// the wrapped sentinel's operator-visible message survives the
+// fmt.Errorf chain.
+func TestTerminalRefreshError_ErrorMessage(t *testing.T) {
+	t.Parallel()
+	e := &terminalRefreshError{msg: "hello", code: "invalid_client"}
+	if e.Error() != "hello" {
+		t.Errorf("Error()=%q; want %q", e.Error(), "hello")
+	}
+	if !errors.Is(e, errRefreshTokenRevoked) {
+		t.Error("terminalRefreshError must unwrap to errRefreshTokenRevoked")
+	}
+}
+
+// TestIsTerminalIDPRejection_NilResponse covers the nil-response
+// guard. A library error with no Response (rare but possible on
+// transport-level failures) must not panic and must not be
+// classified as terminal: those are transient.
+func TestIsTerminalIDPRejection_NilResponse(t *testing.T) {
+	t.Parallel()
+	re := &oauth2.RetrieveError{ErrorCode: "invalid_client"}
+	if isTerminalIDPRejection(re) {
+		t.Error("nil Response must not classify as terminal")
+	}
+}
+
+// TestClassifyRefreshError_SanitizesHostileCode proves a hostile or
+// chatty IdP cannot inject a multi-KB blob or URL-shaped content
+// into terminalRefreshError.code. The same sanitization is applied
+// at the RefreshFailedRevoked / RefreshFailedTransient call sites,
+// so the value lands sanitized in auth_events.detail and the bulk
+// health API response.
+func TestClassifyRefreshError_SanitizesHostileCode(t *testing.T) {
+	t.Parallel()
+	huge := strings.Repeat("x", 5000)
+	re := &oauth2.RetrieveError{
+		Response:  &http.Response{StatusCode: 400},
+		ErrorCode: "invalid_grant " + huge,
+	}
+	got := classifyRefreshError(re)
+	code := idpErrorCodeOf(got)
+	if len(code) > 250 {
+		t.Errorf("code length = %d; sanitization should have bounded it", len(code))
+	}
+
+	urlBearing := &oauth2.RetrieveError{
+		Response:  &http.Response{StatusCode: 400},
+		ErrorCode: "see https://attacker.example/leak",
+	}
+	got = classifyRefreshError(urlBearing)
+	if c := idpErrorCodeOf(got); strings.Contains(c, "https://") {
+		t.Errorf("sanitized code still contains URL: %q", c)
+	}
+}

--- a/ui/src/api/admin/hooks.ts
+++ b/ui/src/api/admin/hooks.ts
@@ -1139,6 +1139,23 @@ export function useStartAPIGatewayOAuth() {
   return useStartConnectionOAuth("api");
 }
 
+// useConnectionsOAuthHealth polls the bulk OAuth-health endpoint on
+// a 10-second cadence. Returns one row per connection with the bits
+// the connection-list view needs to render a per-row badge without
+// fanning out N per-row /oauth-status calls. Polling interval
+// matches useConnectionOAuthStatus so a long-stale failure surface
+// is bounded the same way the per-connection card is.
+export function useConnectionsOAuthHealth() {
+  return useQuery({
+    queryKey: ["connections-oauth-health"],
+    queryFn: () =>
+      apiFetch<import("./types").ConnectionsOAuthHealthResponse>(
+        `/connections/oauth-health`,
+      ),
+    refetchInterval: 10000,
+  });
+}
+
 // useConnectionOAuthStatus returns the unified OAuth status snapshot
 // for ANY connection kind. Renders the status card in both the MCP
 // gateway and HTTP API gateway connection views.

--- a/ui/src/api/admin/types.ts
+++ b/ui/src/api/admin/types.ts
@@ -538,6 +538,31 @@ export interface GatewayOAuthStartResponse {
 // endpoint for any connection kind. Distinct from GatewayOAuthStatus
 // only because the backend type lives in a different package; the
 // fields are intentionally a superset for portal compatibility.
+// ConnectionOAuthHealthSummary is one row of the bulk
+// /connections/oauth-health endpoint. Powers the connection-list
+// health badge.
+//
+// has_oauth=false means the connection is not OAuth-configured at
+// all (bearer / api_key / none); the UI hides the badge for those.
+//
+// idp_error_code is the RFC 6749 `error` field from the latest
+// refresh_failed_* event, empty when the last refresh succeeded or
+// no events exist. Drives the tooltip text so the operator sees
+// "invalid_client" or "invalid_grant" without navigating away from
+// the connection list.
+export interface ConnectionOAuthHealthSummary {
+  kind: string;
+  name: string;
+  has_oauth: boolean;
+  needs_reauth: boolean;
+  token_acquired: boolean;
+  idp_error_code?: string;
+}
+
+export interface ConnectionsOAuthHealthResponse {
+  connections: ConnectionOAuthHealthSummary[];
+}
+
 export interface ConnectionOAuthStatus {
   configured: boolean;
   token_acquired: boolean;

--- a/ui/src/pages/settings/ConnectionsPanel.tsx
+++ b/ui/src/pages/settings/ConnectionsPanel.tsx
@@ -6,7 +6,9 @@ import {
   useDeleteConnectionInstance,
   useStartAPIGatewayOAuth,
   useSystemInfo,
+  useConnectionsOAuthHealth,
 } from "@/api/admin/hooks";
+import type { ConnectionOAuthHealthSummary } from "@/api/admin/types";
 import type { EffectiveConnection } from "@/api/admin/types";
 import { cn } from "@/lib/utils";
 import {
@@ -21,6 +23,58 @@ import {
 } from "lucide-react";
 import { GatewayActionBar, GatewayRulesDrawer } from "./GatewayActions";
 import { ConnectionOAuthStatusCard } from "./ConnectionOAuthStatusCard";
+
+// ConnectionOAuthHealthBadge renders the per-row health indicator
+// on the connection list. Visible only when the bulk health hook
+// has data AND the connection has OAuth configured. Three states:
+//
+//   - needs_reauth=true       → red dot, "needs reauth" tooltip
+//   - last refresh failed but not yet terminal → amber dot, code in tooltip
+//   - token_acquired && no recent failure → no badge (default)
+//
+// The operator sees the red dot from the connection list without
+// clicking in, addressing the "API calls are silently failing"
+// blind spot in the UI.
+function ConnectionOAuthHealthBadge({
+  health,
+}: {
+  health: ConnectionOAuthHealthSummary | undefined;
+}) {
+  if (!health || !health.has_oauth) return null;
+  if (health.needs_reauth) {
+    const code = health.idp_error_code;
+    const tooltip = code
+      ? `Reauth required (${code}). Click in to view details.`
+      : "Reauth required. Click in to view details.";
+    return (
+      <span
+        className="shrink-0 inline-flex items-center gap-1 rounded px-1 py-0 text-xs font-medium bg-destructive/10 text-destructive"
+        title={tooltip}
+        aria-label={tooltip}
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-destructive" />
+        reauth
+      </span>
+    );
+  }
+  if (health.idp_error_code) {
+    // Token still considered valid but the most recent refresh
+    // failed transiently. Surface so the operator notices before
+    // the access token actually expires.
+    const tooltip = `Last refresh failed (${health.idp_error_code}). Retrying.`;
+    return (
+      <span
+        className="shrink-0 inline-flex items-center gap-1 rounded px-1 py-0 text-xs font-medium bg-amber-500/10 text-amber-600 dark:text-amber-400"
+        title={tooltip}
+        aria-label={tooltip}
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+        refresh failing
+      </span>
+    );
+  }
+  return null;
+}
 
 // APICatalogPicker renders the dropdown that points an api-kind
 // connection at one of the globally-owned API catalogs. The model
@@ -141,6 +195,18 @@ export function ConnectionsPanel() {
   const isReadOnly = systemInfo?.config_mode === "file";
   const { data: instances, isLoading } = useEffectiveConnections();
   const connections = instances ?? [];
+  // Bulk per-row OAuth health drives the connection-list health
+  // badge. Polls every 10s in the hook so background-refresh
+  // failures (refresher runs every 5min) become visible within
+  // one tick. Keyed by `kind/name` for O(1) lookup in the row map.
+  const { data: oauthHealth } = useConnectionsOAuthHealth();
+  const oauthHealthByKey = useMemo(() => {
+    const m = new Map<string, ConnectionOAuthHealthSummary>();
+    for (const c of oauthHealth?.connections ?? []) {
+      m.set(`${c.kind}/${c.name}`, c);
+    }
+    return m;
+  }, [oauthHealth]);
 
   // Read initial selection from URL (?kind=...&name=...) so the OAuth
   // callback's returnURL can restore the connection the operator was
@@ -294,6 +360,9 @@ export function ConnectionsPanel() {
                         )}>
                           {c.source === "file" ? "file" : "database"}
                         </span>
+                        <ConnectionOAuthHealthBadge
+                          health={oauthHealthByKey.get(`${c.kind}/${c.name}`)}
+                        />
                       </div>
                       {c.description && (
                         <span className="mt-0.5 text-xs text-muted-foreground truncate">


### PR DESCRIPTION
## Summary

Three connected fixes for the "connection silently broken in background, no UI signal" class of bug. Surfaced by a production connection whose IdP returned `400 invalid_client` on every refresh: the platform retried every 5 minutes for ~6 hours with no visible signal to the operator, every API call against that connection failed, and the only way to discover the problem was to open the connection drawer and scroll the History panel.

PR #423 (this PR) hotfixes the three behaviors that produced that blind spot.

## 1. Terminal-error classifier was too narrow

`classifyRefreshError` previously wrapped only `400 invalid_grant` as definitively revoked. Every other RFC 6749 §5.2 error code was passed through as transient. The refresher retried indefinitely, the token row stayed in place, `needs_reauth` stayed false, and the operator-facing surface had nothing to show.

Pre-fix:

```go
if errors.As(err, &retrieve) &&
    retrieve.Response.StatusCode == http.StatusBadRequest &&
    retrieve.ErrorCode == "invalid_grant" {
    return fmt.Errorf("... (%w)", errRefreshTokenRevoked)
}
return tokenFetchError(err)
```

Post-fix, the terminal set is widened to match RFC 6749 §5.2 semantics:

| Response | Pre | Post |
| --- | --- | --- |
| 400 `invalid_grant` | terminal | terminal |
| 400 `invalid_client` | transient | **terminal** |
| 400 `unauthorized_client` | transient | **terminal** |
| 400 `unsupported_grant_type` | transient | **terminal** |
| 401 (any code) | transient | **terminal** |
| 400 `invalid_request`, `server_error` etc. | transient | transient |
| 5xx, network drop, ctx cancel | transient | transient |

All terminal responses route through `handleRevoked`: token row deleted, `needs_reauth=true`, `ErrNeedsReauth` surfaced to callers. The transient set is preserved so a flaky upstream does not force a reconnect.

`pkg/connoauth/source.go:521-595`, `pkg/connoauth/errors.go:24-51`.

## 2. History panel showed empty detail for transient and generic detail for revoked

A new typed sentinel `terminalRefreshError` (`pkg/connoauth/source.go:534-552`) preserves the RFC 6749 `error` field through the sanitization pass. Two downstream consumers benefit:

- `classifyRevokedReason` now returns the specific code (e.g. `invalid_client`) instead of always `invalid_grant`. The History panel can distinguish "refresh token was revoked" from "client_secret is no longer valid".
- `RefreshFailedTransient` event details now carry `IDPErrorCode` populated from the pre-classify error, so the History row says what the IdP returned instead of rendering an empty detail box.

Both call sites route the code through `sanitizeOAuthErrorField` at the boundary (`pkg/connoauth/source.go:534-552`, `:417-428`). A chatty or hostile IdP cannot inflate the `auth_events.detail` JSON column or inject URL-shaped content into the operator-facing tooltip surface.

## 3. Connection list had no health indicator

Pre-fix, an operator triaging "why is everything failing" had to open each connection one at a time and scroll its History panel. Post-fix:

- New bulk endpoint `GET /api/v1/admin/connections/oauth-health` returns one summary per connection:
  ```json
  {"connections":[{"kind":"api","name":"X","has_oauth":true,"needs_reauth":true,"token_acquired":false,"idp_error_code":"invalid_client"}, ...]}
  ```
  Non-OAuth connections appear with `has_oauth=false` so the UI does not have to filter client-side.
- New React hook `useConnectionsOAuthHealth` polls the endpoint every 10 seconds.
- New `ConnectionOAuthHealthBadge` component renders a per-row badge on the connection list:
  - red `reauth` badge when `needs_reauth=true`. Tooltip carries the IdP error code so the operator can decide between "fix the client_secret" and "click Reconnect" without leaving the list view.
  - amber `refresh failing` badge when the most recent refresh failed transiently but the access token has not yet expired. Tooltip shows the IdP error code.

The badge clears cleanly on reconnect. `latestRefreshErrorCode` (`pkg/admin/connection_oauth_handler.go:103-119`) reads only the single newest event: any non-failure event type (`connect_completed`, `refresh_succeeded`, `token_deleted_admin`, etc.) at events[0] means the code is empty. An older failure followed by a newer reconnect is not a current error.

## Files changed

| File | Change |
| --- | --- |
| `pkg/connoauth/errors.go` | Widened doc on `errRefreshTokenRevoked` to enumerate the full terminal set. |
| `pkg/connoauth/source.go` | New `terminalRefreshError` type, `isTerminalIDPRejection`, `idpErrorCodeOf`; wider classifier; sanitized code on both terminal and transient paths; `classifyRevokedReason` surfaces specific code. |
| `pkg/admin/connection_oauth_handler.go` | New `connectionsOAuthHealth` bulk endpoint, `connectionOAuthHealth` per-row deriver, `latestRefreshErrorCode`, `refreshErrorCodeFromDetail`. |
| `ui/src/api/admin/types.ts` | `ConnectionOAuthHealthSummary` and `ConnectionsOAuthHealthResponse`. |
| `ui/src/api/admin/hooks.ts` | `useConnectionsOAuthHealth` polling hook. |
| `ui/src/pages/settings/ConnectionsPanel.tsx` | `ConnectionOAuthHealthBadge` component, list rendering wired through. |
| `internal/apidocs/*` | Regenerated swagger. |

## Tests

| Test | Pins |
| --- | --- |
| `TestClassifyRefreshError_TerminalIdPCodes` | Full terminal set + representative transient cases (server_error, 500, invalid_request, 401-with-and-without-code). |
| `TestClassifyRevokedReason_PreservesIdPCode` | History detail surfaces the actual IdP code, not `invalid_grant`. |
| `TestIdpErrorCodeOf` | Extraction from both raw `*oauth2.RetrieveError` and the post-classify `terminalRefreshError`. |
| `TestIsTerminalIDPRejection_NilResponse` | Nil-Response guard against panic on transport-level failures. |
| `TestTerminalRefreshError_ErrorMessage` | Wrapped sentinel preserves message and unwraps to `errRefreshTokenRevoked`. |
| `TestClassifyRefreshError_SanitizesHostileCode` | 5KB hostile code is bounded; URL-shaped content stripped. |
| `TestConnectionsOAuthHealth_EmptyStore` | Endpoint returns `{connections: []}` (not 500) on no connections. |
| `TestConnectionsOAuthHealth_MixedKinds` | One row per connection, `has_oauth` set correctly for OAuth vs bearer/api_key. |
| `TestConnectionsOAuthHealth_StoreError` | List failure returns 500. |
| `TestConnectionsOAuthHealth_PopulatesIDPErrorCode` | Latest `refresh_failed_revoked`'s `idp_error_code` reaches the response. |
| `TestConnectionsOAuthHealth_RecentSuccessClearsErrorCode` | Newer `refresh_succeeded` clears the badge. |
| `TestConnectionsOAuthHealth_ReconnectClearsErrorCode` | Newer `connect_completed` clears the badge even with an older `refresh_failed_revoked` in history. |
| `TestRefreshErrorCodeFromDetail` | Empty / malformed / well-formed Detail JSON. |

`make verify` green locally (full suite, including patch-coverage and adversarial pre-commit review with two rounds: round 1 surfaced 5 substantive findings, all addressed; round 2 CLEAN).

## Adversarial-review findings, all fixed before commit

1. `latestRefreshErrorCode` walked past non-refresh-failure newer events. A reconnected connection still showed the old code on the badge. Fixed by reading only the single newest event.
2. Vendor brand name in a test comment scrubbed.
3. Three em dashes in new comments replaced with colons.
4. `Limit: 5` magic number reduced to `Limit: 1` (matches the single-newest read).
5. `retrieve.ErrorCode` flowed unsanitized into `auth_events.detail` JSON and the bulk-health API response. Now sanitized at construction time.

## Upgrade notes

- No schema change, no config change, no breaking API change.
- Connections previously stuck in silent-retry against `invalid_client` will, on next refresh attempt, have their token row deleted and surface `needs_reauth=true`. Operators see the red `reauth` badge immediately on the connection list, click Reconnect, and the connection recovers.
- The new bulk endpoint is read-only and adds one DB read per row per 10s poll. Acceptable for typical instance sizes; could be batched if a much larger connection count ever appears in profiles.

## Test plan

- [ ] CI gates pass (test/race, lint, security, coverage, dead-code, mutation, semgrep, codeql, GoReleaser).
- [ ] Deploy to staging.
- [ ] On a connection whose IdP returns `400 invalid_client`, confirm within one refresh tick: token row deleted, `needs_reauth=true` on `GET /oauth-status`, red `reauth` badge visible on the connection list.
- [ ] Click Reconnect, complete the authorize flow.
- [ ] Confirm the red badge clears within one bulk-health poll (10s).
- [ ] Trigger a transient 500 from the IdP and confirm an amber `refresh failing` badge appears with the IdP error code in the tooltip.
- [ ] Verify the History panel for a `refresh_failed_transient` event shows `idp_error_code` instead of an empty detail box.
