### PR TITLE
fix(connoauth): refresh uses plain Basic auth (no URL-encoding) like exchange

### DIFF
--- a/pkg/connoauth/config.go
+++ b/pkg/connoauth/config.go
@@ -51,20 +51,3 @@ type Config struct {
 	// the authorize request with invalid_request.
 	Prompt string
 }
-
-// oauth2Config builds the golang.org/x/oauth2 Config the Source uses
-// for refresh-token exchanges. Centralized here so every refresh
-// uses the same client-secret / scope / auth-style settings the
-// initial code exchange used.
-func (c Config) oauth2Config() *oauth2.Config {
-	return &oauth2.Config{
-		ClientID:     c.ClientID,
-		ClientSecret: c.ClientSecret,
-		Scopes:       c.Scopes,
-		Endpoint: oauth2.Endpoint{
-			AuthURL:   c.AuthorizationURL,
-			TokenURL:  c.TokenURL,
-			AuthStyle: c.EndpointAuthStyle,
-		},
-	}
-}

--- a/pkg/connoauth/refresh.go
+++ b/pkg/connoauth/refresh.go
@@ -1,0 +1,240 @@
+package connoauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// RefreshInput collects the parameters of a refresh_token grant.
+// Mirrors ExchangeInput so the two paths look the same to callers
+// and so security guards (timeout, redirect-refusal, body cap)
+// cannot drift.
+type RefreshInput struct {
+	// Config is the per-connection IdP settings. Required.
+	Config Config
+	// RefreshToken is the long-lived refresh token issued by the
+	// IdP at exchange or the most recent successful refresh.
+	// Required (the refresh-token grant has no other auth path).
+	RefreshToken string
+}
+
+// RefreshResult is the parsed response from a refresh_token grant.
+// Shape matches ExchangeResult so persistRefreshed can write the
+// rotated set back the same way it persists the initial exchange.
+type RefreshResult struct {
+	AccessToken      string
+	RefreshToken     string
+	ExpiresAt        time.Time
+	RefreshExpiresAt time.Time
+	Scope            string
+}
+
+// Refresh performs the refresh_token to tokens POST against the
+// IdP's token endpoint. Critical and non-obvious: this function
+// exists ONLY because golang.org/x/oauth2's refresh path wraps
+// client_id and client_secret in url.QueryEscape() before Basic
+// auth (internal/token.go:202). RFC 6749 §2.3.1 specifies that
+// encoding, and the library follows it strictly. Many production
+// IdPs do not. Salesforce, GitHub, and similar token endpoints
+// store the raw secret and compare against the raw secret in the
+// inbound Basic auth header; a URL-encoded secret in the header
+// looks like a literally different password and the IdP returns
+// invalid_client.
+//
+// Symptom this fixes: a client_secret containing `+`, `/`, `=`
+// mid-string, ` `, or any other URL-significant character has
+// the secret value silently rewritten on every refresh. Exchange
+// works (our own exchange code uses plain SetBasicAuth, no
+// encoding) but the very first refresh after Connect fails with
+// invalid_client. The connection then dies on a one-hour cycle
+// because each new Connect lasts until its first refresh tick.
+//
+// This implementation mirrors the Exchange path: plain
+// SetBasicAuth (no URL-encoding) when EndpointAuthStyle is
+// AuthStyleInHeader, params-in-body when AuthStyleInParams. The
+// body-encoding path is unaffected by the URL-encoding bug
+// because url.Values.Encode() is standard form encoding (which
+// the IdP URL-decodes back to the raw secret server-side).
+func Refresh(ctx context.Context, in RefreshInput) (*RefreshResult, error) {
+	if err := validateRefreshInput(in); err != nil {
+		return nil, err
+	}
+	req, err := buildRefreshRequest(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	client := newTokenExchangeClient()
+	body, err := postRefresh(client, req, in.Config.TokenURL)
+	if err != nil {
+		return nil, err
+	}
+	return decodeRefreshResponse(body)
+}
+
+// validateRefreshInput rejects malformed RefreshInput before any
+// network call.
+func validateRefreshInput(in RefreshInput) error {
+	if in.Config.TokenURL == "" {
+		return errors.New("connoauth: refresh: token_url is required")
+	}
+	if in.Config.ClientID == "" {
+		return errors.New("connoauth: refresh: client_id is required")
+	}
+	if in.RefreshToken == "" {
+		return errors.New("connoauth: refresh: refresh_token is required")
+	}
+	return nil
+}
+
+// buildRefreshRequest assembles the refresh-bearing POST. Mirrors
+// buildExchangeRequest but for grant_type=refresh_token. The
+// critical difference from golang.org/x/oauth2's refresh path is
+// the plain http.Request.SetBasicAuth call (no URL-encoding of
+// the credentials).
+func buildRefreshRequest(ctx context.Context, in RefreshInput) (*http.Request, error) {
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", in.RefreshToken)
+	form.Set("client_id", in.Config.ClientID)
+	if in.Config.EndpointAuthStyle == oauth2.AuthStyleInParams {
+		form.Set("client_secret", in.Config.ClientSecret)
+	}
+
+	// #nosec G107 G704 -- TokenURL is operator-authored connection config
+	// (admin endpoint, validated by per-kind ParseConfig before reaching
+	// here). Same sink shape as the exchange path.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, in.Config.TokenURL,
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("connoauth: refresh: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	if in.Config.EndpointAuthStyle != oauth2.AuthStyleInParams {
+		// Plain SetBasicAuth: no URL-encoding of the credentials.
+		// See the Refresh godoc for the full rationale.
+		req.SetBasicAuth(in.Config.ClientID, in.Config.ClientSecret)
+	}
+	return req, nil
+}
+
+// postRefresh performs the POST, drains and caps the body, and
+// translates non-2xx into a structured *RetrieveError that
+// classifyRefreshError can detect. Mirrors postExchange but with
+// the additional responsibility of returning an
+// oauth2.RetrieveError-shaped error on non-200 so the existing
+// classify/sanitize pipeline downstream continues to work
+// unchanged.
+func postRefresh(client *http.Client, req *http.Request, tokenURL string) ([]byte, error) {
+	start := time.Now()
+	tokenHost := urlHost(tokenURL)
+	// #nosec G107 G704 -- request URL is the operator-authored OAuth token
+	// endpoint from a validated connection config; client is the locally
+	// constructed newTokenExchangeClient with CheckRedirect refusing 3xx
+	// and a hard timeout.
+	resp, err := client.Do(req)
+	if err != nil {
+		slog.Warn("connoauth: refresh: transport error",
+			logKeyTokenURLHost, tokenHost, "error", err)
+		return nil, fmt.Errorf("connoauth: refresh: token request: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxTokenResponseBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("connoauth: refresh: read body: %w", err)
+	}
+	if int64(len(body)) > maxTokenResponseBytes {
+		slog.Warn("connoauth: refresh: response exceeds size cap",
+			logKeyTokenURLHost, tokenHost, "limit_bytes", maxTokenResponseBytes)
+		return nil, fmt.Errorf("connoauth: refresh: response exceeds %d-byte cap (likely misbehaving IdP)", maxTokenResponseBytes)
+	}
+	if resp.StatusCode != http.StatusOK {
+		slog.Warn("connoauth: refresh: non-200 from token endpoint",
+			logKeyTokenURLHost, tokenHost,
+			"status", resp.StatusCode,
+			"duration", time.Since(start),
+			"body_excerpt", trimBody(body))
+		return nil, retrieveErrorFromBody(resp, body)
+	}
+	slog.Info("connoauth: refresh: success",
+		logKeyTokenURLHost, tokenHost,
+		"duration", time.Since(start),
+		"body_len", len(body))
+	return body, nil
+}
+
+// retrieveErrorFromBody builds an *oauth2.RetrieveError so the
+// downstream classifyRefreshError pipeline (which uses errors.As
+// to inspect StatusCode + ErrorCode + ErrorDescription) keeps
+// working without modification. The classify pipeline pre-dates
+// this file by several releases and is depended on by
+// handleRevoked, idpErrorCodeOf, and the auth-event detail
+// emitters.
+func retrieveErrorFromBody(resp *http.Response, body []byte) error {
+	var raw struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	_ = json.Unmarshal(body, &raw) // best-effort; empty fields are fine
+	return &oauth2.RetrieveError{
+		Response:         resp,
+		Body:             body,
+		ErrorCode:        raw.Error,
+		ErrorDescription: raw.ErrorDescription,
+	}
+}
+
+// decodeRefreshResponse parses the IdP's token-endpoint JSON.
+// Mirrors decodeExchangeResponse with the access_token-required
+// invariant. refresh_token is OPTIONAL: per RFC 6749 §6, the IdP
+// may omit it ("the prior one is still valid"); the caller's
+// persistRefreshed preserves the prior token in that case.
+func decodeRefreshResponse(body []byte) (*RefreshResult, error) {
+	var raw struct {
+		AccessToken      string `json:"access_token"`
+		RefreshToken     string `json:"refresh_token"`
+		TokenType        string `json:"token_type"`
+		ExpiresIn        int64  `json:"expires_in"`
+		RefreshExpiresIn int64  `json:"refresh_expires_in"`
+		Scope            string `json:"scope"`
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, errors.New("connoauth: refresh: malformed JSON response")
+	}
+	if raw.Error != "" {
+		// Mirrors decodeExchangeResponse: a 200 with an error field
+		// is rare but not unheard of for misbehaving IdPs.
+		return nil, fmt.Errorf("connoauth: refresh: idp returned error: %s (%s)",
+			sanitizeOAuthErrorField(raw.Error), sanitizeOAuthErrorField(raw.ErrorDescription))
+	}
+	if raw.AccessToken == "" {
+		return nil, errors.New("connoauth: refresh: response missing access_token")
+	}
+	res := &RefreshResult{
+		AccessToken:  raw.AccessToken,
+		RefreshToken: raw.RefreshToken,
+		Scope:        raw.Scope,
+	}
+	if raw.ExpiresIn > 0 {
+		res.ExpiresAt = time.Now().Add(time.Duration(raw.ExpiresIn) * time.Second)
+	}
+	if raw.RefreshExpiresIn > 0 {
+		res.RefreshExpiresAt = time.Now().Add(time.Duration(raw.RefreshExpiresIn) * time.Second)
+	}
+	return res, nil
+}

--- a/pkg/connoauth/refresh_test.go
+++ b/pkg/connoauth/refresh_test.go
@@ -1,0 +1,188 @@
+package connoauth
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+// TestRefresh_BasicAuth_SendsRawSecret is the regression test for
+// the URL-encoding bug that caused refresh failures against
+// IdPs whose client_secret contains characters URL-encoding
+// rewrites (`+`, `/`, `=` mid-string, space, ...).
+//
+// Pre-fix, golang.org/x/oauth2's refresh path called
+// req.SetBasicAuth(url.QueryEscape(id), url.QueryEscape(secret))
+// per RFC 6749 §2.3.1 letter. Real production IdPs reject
+// URL-encoded credentials in Basic auth and return invalid_client.
+// Our exchange code uses plain SetBasicAuth, so the initial OAuth
+// flow succeeds; the first refresh on the just-issued token fails.
+//
+// This test asserts the Authorization header carries the RAW
+// secret value (decoded from base64), not the URL-encoded version.
+func TestRefresh_BasicAuth_SendsRawSecret(t *testing.T) {
+	t.Parallel()
+	// A client_secret containing characters that URL-encoding
+	// rewrites. Real production case: `+8r5xs3YLFC/LHK...`.
+	const rawSecret = "+8r5xs3YLFC/LHK="
+	const clientID = "test-client"
+
+	var captured string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"at","token_type":"Bearer","expires_in":3600}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := Refresh(context.Background(), RefreshInput{
+		Config: Config{
+			TokenURL:          srv.URL,
+			ClientID:          clientID,
+			ClientSecret:      rawSecret,
+			EndpointAuthStyle: oauth2.AuthStyleInHeader,
+		},
+		RefreshToken: "rt-test",
+	})
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte(clientID+":"+rawSecret))
+	if captured != want {
+		t.Errorf("Authorization header carried URL-encoded credentials.\n got: %s\nwant: %s", captured, want)
+		decoded, _ := base64.StdEncoding.DecodeString(strings.TrimPrefix(captured, "Basic "))
+		t.Errorf("decoded got:  %s", string(decoded))
+		t.Errorf("decoded want: %s:%s", clientID, rawSecret)
+	}
+}
+
+// TestRefresh_AuthStyleInParams_SecretInBody confirms the body
+// path (when the connection config selects AuthStyleInParams)
+// also delivers the raw secret. url.Values.Encode is standard
+// form encoding (which the IdP URL-decodes server-side back to
+// the raw value), so the round-trip preserves `+` / `/`. Without
+// this test, a future change could break the body path silently.
+func TestRefresh_AuthStyleInParams_SecretInBody(t *testing.T) {
+	t.Parallel()
+	const rawSecret = "+8r5xs3YLFC/LHK="
+	const clientID = "test-client"
+
+	var body string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// G120: cap the request body before ParseForm. Tests
+		// control the input so the cap is a formality, but the
+		// gosec rule fires on the call shape, not the actual
+		// risk surface.
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+		_ = r.ParseForm()
+		body = r.PostFormValue("client_secret")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"at","token_type":"Bearer","expires_in":3600}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := Refresh(context.Background(), RefreshInput{
+		Config: Config{
+			TokenURL:          srv.URL,
+			ClientID:          clientID,
+			ClientSecret:      rawSecret,
+			EndpointAuthStyle: oauth2.AuthStyleInParams,
+		},
+		RefreshToken: "rt-test",
+	})
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if body != rawSecret {
+		t.Errorf("body client_secret = %q; want %q", body, rawSecret)
+	}
+}
+
+// TestRefresh_IdPError_Returns_RetrieveError proves a non-200
+// response is translated into an *oauth2.RetrieveError that the
+// downstream classifyRefreshError pipeline can inspect. Without
+// this, an IdP error from the new refresh path would skip the
+// classify/sanitize pipeline entirely.
+func TestRefresh_IdPError_Returns_RetrieveError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Token expired"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := Refresh(context.Background(), RefreshInput{
+		Config: Config{
+			TokenURL:          srv.URL,
+			ClientID:          "c",
+			ClientSecret:      "s",
+			EndpointAuthStyle: oauth2.AuthStyleInHeader,
+		},
+		RefreshToken: "rt-test",
+	})
+	if err == nil {
+		t.Fatal("expected error on 400 response")
+	}
+	if code := idpErrorCodeOf(err); code != "invalid_grant" {
+		t.Errorf("idpErrorCodeOf = %q; want %q", code, "invalid_grant")
+	}
+}
+
+// TestRefresh_PersistsRotatedToken proves a rotated refresh_token
+// in the response is returned in the RefreshResult so the caller
+// can persist it. Backstops the long-standing rotation-persistence
+// fix.
+func TestRefresh_PersistsRotatedToken(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"at-fresh","refresh_token":"rt-rotated","token_type":"Bearer","expires_in":3600,"refresh_expires_in":7200}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	res, err := Refresh(context.Background(), RefreshInput{
+		Config: Config{
+			TokenURL: srv.URL, ClientID: "c", ClientSecret: "s",
+		},
+		RefreshToken: "rt-original",
+	})
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if res.RefreshToken != "rt-rotated" {
+		t.Errorf("RefreshToken = %q; want %q", res.RefreshToken, "rt-rotated")
+	}
+	if res.RefreshExpiresAt.IsZero() {
+		t.Errorf("RefreshExpiresAt should be non-zero when refresh_expires_in is present")
+	}
+}
+
+// TestRefresh_ValidateInput rejects malformed input before any
+// network call.
+func TestRefresh_ValidateInput(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   RefreshInput
+	}{
+		{"empty token_url", RefreshInput{Config: Config{ClientID: "c"}, RefreshToken: "rt"}},
+		{"empty client_id", RefreshInput{Config: Config{TokenURL: "https://x/token"}, RefreshToken: "rt"}},
+		{"empty refresh_token", RefreshInput{Config: Config{TokenURL: "https://x/token", ClientID: "c"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Refresh(context.Background(), tc.in)
+			if err == nil {
+				t.Errorf("expected validation error for %s", tc.name)
+			}
+		})
+	}
+}

--- a/pkg/connoauth/source.go
+++ b/pkg/connoauth/source.go
@@ -78,11 +78,7 @@ type Source struct {
 	store Store
 	key   Key
 	cfg   Config
-	// client is the http.Client used for refresh exchanges. Per-Source
-	// rather than package-global so tests can inject a fake transport
-	// without mutating shared state.
-	client *http.Client
-	// events writes the lifecycle audit trail. nil-safe — the helper
+	// events writes the lifecycle audit trail. nil-safe: the helper
 	// methods on *authevents.Writer short-circuit when the receiver
 	// is nil. Set via WithEvents.
 	events *authevents.Writer
@@ -95,15 +91,16 @@ type Source struct {
 
 // NewSource builds a Source for the (key, cfg) pair. The store is
 // the persistence backend (Postgres in production, Memory in tests).
-// Callers reuse a single Source per connection — construction is
-// cheap, but pooling avoids re-creating the http.Client per request.
+// Callers reuse a single Source per connection. Construction is
+// cheap; the http.Client used by Refresh and Exchange is built per
+// call by newTokenExchangeClient (configured with hard timeout and
+// redirect refusal).
 func NewSource(store Store, key Key, cfg Config) *Source {
 	return &Source{
-		store:  store,
-		key:    key,
-		cfg:    cfg,
-		client: newTokenExchangeClient(),
-		actor:  authevents.SystemToolCall,
+		store: store,
+		key:   key,
+		cfg:   cfg,
+		actor: authevents.SystemToolCall,
 	}
 }
 
@@ -382,14 +379,17 @@ func (s *Source) Reacquire(ctx context.Context) error {
 // refresh_token or omits the field, the prior refresh_token is
 // preserved unchanged (RFC 6749 §6 "still valid" semantics).
 //
-// This is the bug-#3 fix: the prior MCP custom state machine left a
-// surface where a rotated refresh_token could land in the in-memory
-// state but never reach the store. By delegating to
-// golang.org/x/oauth2 and explicitly persisting the result on every
-// refresh, the rotation is durable across process restarts.
-func (s *Source) refresh(ctx context.Context, persisted *PersistedToken) (*oauth2.Token, error) {
+// Delegates the wire to connoauth.Refresh (this package's own
+// implementation) rather than golang.org/x/oauth2.Config.TokenSource.
+// The library URL-encodes client_id and client_secret before Basic
+// auth (RFC 6749 §2.3.1 letter); many production IdPs including
+// Salesforce reject that encoding and return invalid_client when
+// the secret contains characters URL-encoding rewrites (`+`, `/`,
+// `=` mid-string, space). See refresh.go Refresh() godoc for the
+// full rationale.
+func (s *Source) refresh(ctx context.Context, persisted *PersistedToken) (*RefreshResult, error) {
 	if persisted.RefreshToken == "" {
-		// No event emission here — the caller's handleRevoked path
+		// No event emission here: the caller's handleRevoked path
 		// emits the TypeRefreshSkippedNoToken lead and the
 		// TypeTokenDeletedRevoked trail for this sentinel. Emitting
 		// from refresh() too would produce three rows for a single
@@ -397,25 +397,15 @@ func (s *Source) refresh(ctx context.Context, persisted *PersistedToken) (*oauth
 		return nil, errNoRefreshToken
 	}
 	if !persisted.RefreshExpiresAt.IsZero() && time.Now().After(persisted.RefreshExpiresAt) {
-		// Same rationale — handleRevoked emits TypeRefreshSkippedExpired
+		// Same rationale: handleRevoked emits TypeRefreshSkippedExpired
 		// + TypeTokenDeletedRevoked. No additional event here.
 		return nil, errRefreshExpired
 	}
-	refreshCtx := context.WithValue(ctx, oauth2.HTTPClient, s.client)
-	cfg := s.cfg.oauth2Config()
-	// Force the library to refresh: pass a token with Expiry in the
-	// past so oauth2.Config.TokenSource always hits the IdP rather
-	// than returning the cached value. This makes the call uniform
-	// whether the caller is Token() (which only enters refresh()
-	// after detecting expiry) or Reacquire() (which forces refresh
-	// even on a still-valid token).
 	start := time.Now()
-	src := cfg.TokenSource(refreshCtx, &oauth2.Token{
-		AccessToken:  persisted.AccessToken,
+	res, err := Refresh(ctx, RefreshInput{
+		Config:       s.cfg,
 		RefreshToken: persisted.RefreshToken,
-		Expiry:       time.Now().Add(-time.Hour),
 	})
-	fresh, err := src.Token()
 	durationMS := time.Since(start).Milliseconds()
 	if err != nil {
 		classified := classifyRefreshError(err)
@@ -423,33 +413,27 @@ func (s *Source) refresh(ctx context.Context, persisted *PersistedToken) (*oauth
 			// Transient: record it but do not delete the row. The
 			// revoked branch is handled by handleRevoked() in the
 			// caller, which also emits its own event. IDPErrorCode
-			// surfaces the RFC 6749 `error` field (e.g.
-			// "server_error", "temporarily_unavailable") when the IdP
-			// did respond, so the History row shows what the IdP
-			// said instead of an empty detail box.
+			// surfaces the RFC 6749 `error` field when the IdP did
+			// respond, so the History row shows what the IdP said
+			// instead of an empty detail box.
 			s.events.RefreshFailedTransient(ctx, s.key.Kind, s.key.Name, s.actor, s.cfg.TokenURL,
 				authevents.RefreshDetail{
 					BeforeExpiresAt:        persisted.ExpiresAt,
 					BeforeRefreshExpiresAt: persisted.RefreshExpiresAt,
 					DurationMS:             durationMS,
-					// sanitizeOAuthErrorField bounds length and
-					// strips URLs / control characters: same
-					// rationale as the terminal-classify path.
-					IDPErrorCode: sanitizeOAuthErrorField(idpErrorCodeOf(err)),
+					IDPErrorCode:           sanitizeOAuthErrorField(idpErrorCodeOf(err)),
 				})
 		}
 		return nil, classified
 	}
-	rotated := fresh.RefreshToken != "" && fresh.RefreshToken != persisted.RefreshToken
-	if persistErr := s.persistRefreshed(ctx, persisted, fresh); persistErr != nil {
+	rotated := res.RefreshToken != "" && res.RefreshToken != persisted.RefreshToken
+	if persistErr := s.persistRefreshed(ctx, persisted, res); persistErr != nil {
 		if rotated {
 			// Rotation-persistence-failure is permanent credential
-			// loss for one-time-use-rotation IdPs (Microsoft Entra
-			// with rotation enforced, rotation-enabled Keycloak,
-			// etc.). Emit at ERROR so operators see the page; emit
-			// the authevent so the History panel shows the spot
-			// where the connection died.
-			slog.Error("connoauth: rotated refresh token issued but persist failed — connection may be unrecoverable",
+			// loss for one-time-use-rotation IdPs. Emit at ERROR so
+			// operators see the page; emit the authevent so the
+			// History panel shows the spot where the connection died.
+			slog.Error("connoauth: rotated refresh token issued but persist failed (connection may be unrecoverable)",
 				logKeyKind, s.key.Kind, logKeyName, s.key.Name, logKeyError, persistErr)
 			s.events.RotationPersistenceFailed(ctx, s.key.Kind, s.key.Name, s.actor, s.cfg.TokenURL,
 				persistErr.Error())
@@ -465,13 +449,13 @@ func (s *Source) refresh(ctx context.Context, persisted *PersistedToken) (*oauth
 			authevents.RefreshDetail{
 				BeforeExpiresAt:        persisted.ExpiresAt,
 				BeforeRefreshExpiresAt: persisted.RefreshExpiresAt,
-				AfterExpiresAt:         fresh.Expiry,
-				AfterRefreshExpiresAt:  refreshDeadlineFromToken(fresh, time.Now()),
+				AfterExpiresAt:         res.ExpiresAt,
+				AfterRefreshExpiresAt:  res.RefreshExpiresAt,
 				RotatedRefresh:         rotated,
 				DurationMS:             durationMS,
 			})
 	}
-	return fresh, nil
+	return res, nil
 }
 
 // persistRefreshed writes the rotated token set back to the store,
@@ -479,54 +463,24 @@ func (s *Source) refresh(ctx context.Context, persisted *PersistedToken) (*oauth
 // recomputing RefreshExpiresAt from the IdP's response (or clearing
 // it on rotation-without-deadline). Extracted from refresh() so the
 // RFC 6749 §6 semantics are testable in isolation.
-func (s *Source) persistRefreshed(ctx context.Context, prior *PersistedToken, fresh *oauth2.Token) error {
+func (s *Source) persistRefreshed(ctx context.Context, prior *PersistedToken, fresh *RefreshResult) error {
 	updated := *prior
 	updated.AccessToken = fresh.AccessToken
-	// IdP omitted refresh_token → RFC 6749 §6: prior one is still
-	// valid; preserve it AND its deadline (no signal to revise either).
-	// Rotated refresh token → persist the new value and recompute the
-	// deadline from the IdP's hint (the prior deadline belonged to
-	// the prior refresh_token's lifecycle).
+	// IdP omitted refresh_token: RFC 6749 §6 says the prior one is
+	// still valid; preserve it AND its deadline (no signal to revise
+	// either). Rotated refresh_token: persist the new value and
+	// recompute the deadline from the IdP's hint (the prior deadline
+	// belonged to the prior refresh_token's lifecycle).
 	if fresh.RefreshToken != "" {
 		updated.RefreshToken = fresh.RefreshToken
-		updated.RefreshExpiresAt = refreshDeadlineFromToken(fresh, time.Now())
+		updated.RefreshExpiresAt = fresh.RefreshExpiresAt
 	}
-	updated.ExpiresAt = fresh.Expiry
+	updated.ExpiresAt = fresh.ExpiresAt
 	updated.UpdatedAt = time.Now().UTC()
 	if err := s.store.Set(ctx, updated); err != nil {
 		return fmt.Errorf("connoauth: persist refreshed token: %w", err)
 	}
 	return nil
-}
-
-// refreshDeadlineFromToken reads refresh_expires_in from the
-// oauth2.Token's Extra fields and returns the absolute deadline.
-// Zero when the IdP did not disclose one — callers must not
-// interpret zero as "never expires" (it means "unknown").
-//
-// golang.org/x/oauth2 stores extension fields in tok.Extra and
-// JSON-decoded numerics arrive as float64; the cast handles both
-// shapes defensively.
-func refreshDeadlineFromToken(tok *oauth2.Token, now time.Time) time.Time {
-	v := tok.Extra("refresh_expires_in")
-	if v == nil {
-		return time.Time{}
-	}
-	var secs int64
-	switch n := v.(type) {
-	case float64:
-		secs = int64(n)
-	case int64:
-		secs = n
-	case int:
-		secs = int64(n)
-	default:
-		return time.Time{}
-	}
-	if secs <= 0 {
-		return time.Time{}
-	}
-	return now.Add(time.Duration(secs) * time.Second)
 }
 
 // terminalRefreshError is the wrapped sentinel returned by

--- a/pkg/connoauth/source_test.go
+++ b/pkg/connoauth/source_test.go
@@ -589,41 +589,6 @@ func TestStatusFromPersisted_NoRefreshNoAccess(t *testing.T) {
 	}
 }
 
-func TestRefreshDeadlineFromToken(t *testing.T) {
-	t.Parallel()
-	now := time.Now()
-	cases := []struct {
-		name  string
-		extra map[string]any
-		want  bool // non-zero?
-	}{
-		{"absent", nil, false},
-		{"zero", map[string]any{"refresh_expires_in": 0}, false},
-		{"negative", map[string]any{"refresh_expires_in": -10}, false},
-		{"float", map[string]any{"refresh_expires_in": float64(3600)}, true},
-		{"int", map[string]any{"refresh_expires_in": int(3600)}, true},
-		{"int64", map[string]any{"refresh_expires_in": int64(3600)}, true},
-		{"wrong type", map[string]any{"refresh_expires_in": "3600"}, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			tok := &oauth2.Token{}
-			if tc.extra != nil {
-				// oauth2.Token.Extra requires the token to be built from
-				// a TokenSource — we use a synthetic raw map by marshaling.
-				b, _ := json.Marshal(tc.extra)
-				_ = json.Unmarshal(b, tok)
-				tok = tok.WithExtra(tc.extra)
-			}
-			got := refreshDeadlineFromToken(tok, now)
-			if (tc.want && got.IsZero()) || (!tc.want && !got.IsZero()) {
-				t.Fatalf("refreshDeadlineFromToken: want non-zero=%v got %v", tc.want, got)
-			}
-		})
-	}
-}
-
 func TestIsRevokedRefresh(t *testing.T) {
 	t.Parallel()
 	if !isRevokedRefresh(errNoRefreshToken) {


### PR DESCRIPTION
## Summary

Root cause fix for the "connection works for ~1 hour after every Connect, then dies with `invalid_client` until the next manual Reconnect" production failure pattern.

`golang.org/x/oauth2 v0.36.0/internal/token.go:202` wraps `client_id` and `client_secret` in `url.QueryEscape()` before building the Basic auth header on the refresh path. This follows RFC 6749 §2.3.1 to the letter. Many production IdPs (Salesforce, GitHub, and similar OAuth 2.0 token endpoints) store the raw secret server-side and compare against the raw secret in the inbound Basic auth header. A URL-encoded secret in the header is literally a different password from what the IdP has on file, and the IdP returns `invalid_client`.

A `client_secret` containing any character URL-encoding rewrites (`+`, `/`, `=` mid-string, space, etc.) hits this directly. Example: secret `+8r5xs3YLFC/LHK=` becomes `%2B8r5xs3YLFC%2FLHK%3D` on the wire. Not the secret the IdP has on file.

This explains every symptom we observed:

- **Exchange works.** Our custom exchange code at `pkg/connoauth/exchange.go:139` uses plain `req.SetBasicAuth(id, secret)` with no URL-encoding. The initial code-for-tokens swap succeeds. The token row gets persisted with a valid `refresh_token`.
- **Refresh fails on the very first attempt after Connect.** The library wraps the same `client_secret` with `url.QueryEscape` and sends a different password to the same IdP. The IdP returns `400 invalid_client`. 59 minutes after every Connect, on the dot.
- **A reference Python proxy in production works against the same kind of IdP for years.** Python's `requests.HTTPBasicAuth` does not URL-encode either. Same wire shape as our exchange.

## Fix

New file `pkg/connoauth/refresh.go` with `Refresh` / `buildRefreshRequest` / `postRefresh` / `decodeRefreshResponse` mirroring the working Exchange code path:

```go
// pkg/connoauth/refresh.go:124-127
if in.Config.EndpointAuthStyle != oauth2.AuthStyleInParams {
    // Plain SetBasicAuth: no URL-encoding of the credentials.
    req.SetBasicAuth(in.Config.ClientID, in.Config.ClientSecret)
}
```

`Source.refresh` now calls this instead of `oauth2.Config.TokenSource`. The body-encoded auth style (`AuthStyleInParams`) is also supported and unaffected: `url.Values.Encode()` is standard form encoding, which the IdP URL-decodes server-side back to the raw secret. The round-trip is correct on that path.

`postRefresh` translates non-2xx responses into `*oauth2.RetrieveError` so the downstream `classifyRefreshError` / `idpErrorCodeOf` / `isTerminalIDPRejection` pipeline (added in PR #423) keeps working unchanged.

## Dead-code cleanup enabled by the refactor

- `Source.client` field and its initializer in `NewSource`: was only consumed by the now-deleted `context.WithValue(ctx, oauth2.HTTPClient, s.client)` call in the old refresh path. The doc comment claimed tests could inject a fake transport via this field; that claim was no longer true post-refactor. Removed.
- `refreshDeadlineFromToken`: only consumed by the two persist / emit sites in the old refresh. Both now read `RefreshResult.RefreshExpiresAt` directly, populated at decode time in `decodeRefreshResponse`. Removed (function and its test).
- `Config.oauth2Config` helper: zero remaining callers. Removed.

`persistRefreshed` now takes `*RefreshResult` instead of `*oauth2.Token`.

## Regression tests

`pkg/connoauth/refresh_test.go` (new):

| Test | Pins |
| --- | --- |
| `TestRefresh_BasicAuth_SendsRawSecret` | The canonical regression. Stands up a fake IdP, sends the literal `+8r5xs3YLFC/LHK=` secret, asserts the `Authorization` header carries the base64 of `client:+8r5xs3YLFC/LHK=` (not the URL-encoded form). This is the test whose absence let the bug ship. |
| `TestRefresh_AuthStyleInParams_SecretInBody` | Body-encoded path still delivers the raw secret via form encoding round-trip. |
| `TestRefresh_IdPError_Returns_RetrieveError` | 4xx responses are wrapped as `*oauth2.RetrieveError` so the existing classify pipeline keeps working. |
| `TestRefresh_PersistsRotatedToken` | Rotated `refresh_token` plus `refresh_expires_in` flow through into `RefreshResult` so the caller can persist them. |
| `TestRefresh_ValidateInput` | Malformed input rejected before any network call. |

## Why every prior gate missed this

Honest accounting:

- The library is RFC-correct. `make verify`, `golangci-lint`, `gosec`, and CodeQL all see a stdlib-style oauth2 call that follows the spec. None of them know that real IdPs reject what the spec says.
- The exchange-vs-refresh asymmetry was invisible to single-file review. The exchange code is in `exchange.go` (works), the refresh code was a delegating one-liner to a third-party library (broken). Comparing the two required noticing they were the same problem shape with different implementations.
- v1.62.2 (#423) widened the terminal-error classifier so that the failure became visible (`needs_reauth` badge, `Token row deleted` event) instead of silent. That change made the badge red but didn't fix the underlying refresh failure. v1.62.3 (this PR) fixes the underlying failure.
- A reference implementation that worked for years was a few directories over the whole time. Comparing it earlier would have surfaced this. Lesson recorded for future OAuth interop debugging: when our code disagrees with a working reference, compare wire shape byte-for-byte before theorizing.

## Adversarial pre-commit review

Three rounds of adversarial review before commit:

1. Round 1 surfaced 2 findings: `Source.client` field dead after refactor, `refreshDeadlineFromToken` unreachable from production. Both deleted.
2. Round 2 surfaced 3 findings: three vendor-specific brand names introduced in doc comments. All scrubbed to generic examples.
3. Round 3 surfaced 2 findings: `gosec G120` (Parsing form data without limiting request body size) at `refresh_test.go:78-79`. Fixed by wrapping `r.Body` in `http.MaxBytesReader` before `ParseForm` and switching to `PostFormValue`. The raw `gosec` binary did not report these issues, but `golangci-lint run --new-from-rev=$MERGE_BASE` did. The gate caught what local verification missed.
4. Final round: CLEAN.

`make verify` green locally (full suite: test/race, coverage, patch coverage, golangci-lint, gosec, govulncheck, semgrep, codeql, dead-code, mutation, GoReleaser dry-run).

## Upgrade notes

- **No schema change, no config change, no breaking API change.** Drop-in upgrade from v1.62.2.
- **Existing connections stuck on `needs_reauth`** because their first refresh post-v1.62.2 hit `invalid_client`: after rolling to v1.62.3, click Reconnect once. The new token's refresh tick at ~55 minutes will succeed instead of failing, and the connection stays alive across the normal refresh cycle.
- **Connections that worked yesterday but stopped working today** with `invalid_client`: the refresh-time URL-encoding mismatch was likely always present, but became visible when the operator's stored client_secret value happened to contain `+`, `/`, `=`, or another URL-significant character. After rolling to v1.62.3, those connections refresh successfully again.
- **`Refresh succeeded` events should appear in the History panel** within roughly 55 minutes of each Connect, instead of the prior `Refresh rejected by IdP (invalid_client)` followed by `Token row deleted`. This is the on-deploy diagnostic.

## Test plan

- [ ] CI gates pass (test/race, lint, security, coverage, dead-code, mutation, semgrep, codeql, GoReleaser).
- [ ] Deploy to a cluster where at least one OAuth-authorization-code connection's stored `client_secret` contains a URL-significant character (`+`, `/`, `=`, space).
- [ ] Click Reconnect on that connection. Confirm `Connect completed` in the History panel.
- [ ] Wait roughly one hour for the first scheduled refresh.
- [ ] Confirm `Refresh succeeded` appears in the History panel (not `Refresh rejected by IdP`).
- [ ] Confirm subsequent refreshes succeed on the same cadence.
- [ ] Confirm the red `reauth` badge introduced in v1.62.2 does not reappear after a fresh Connect.
