### PR TITLE
fix(apigateway): distinguish upstream vs gateway failure semantics

### DIFF
--- a/pkg/gatewayhttp/handler.go
+++ b/pkg/gatewayhttp/handler.go
@@ -54,14 +54,20 @@ type Deps struct {
 // the HTTP status of the platform's own response only signals
 // platform-level outcomes:
 //
-//	200 — the platform performed the upstream call (outcome in body)
-//	400 — the request failed validation (method, path, body)
-//	401 — no credential, or the credential was rejected
-//	403 — persona or route policy denied the call
-//	404 — the named connection is not registered
+//	200 - the platform performed the upstream call (outcome in body)
+//	400 - the request failed validation (method, path, body)
+//	401 - no credential, or the credential was rejected
+//	403 - persona or route policy denied the call
+//	404 - the named connection is not registered
+//	502 - the gateway could not reach the upstream (DNS, TCP, TLS, reset)
+//	504 - the upstream call exceeded its deadline before responding
 //
-// Surfacing the upstream status in the body keeps platform-side and
-// upstream-side failures distinguishable for NiFi's response routing.
+// 502 and 504 represent gateway-level failures (issue #432): the
+// gateway tried to proxy and did not succeed. Upstream-level failures
+// (the upstream responded with 4xx or 5xx) still flow as wire HTTP
+// 200 with the upstream code embedded in InvokeOutput.Status, so HTTP
+// clients can distinguish "the gateway is broken" from "the upstream
+// is unhappy" using their built-in status-code routing.
 func NewHandler(deps Deps) (http.Handler, error) {
 	if deps.MCPServer == nil {
 		return nil, errors.New("gatewayhttp: MCPServer is required")
@@ -244,10 +250,22 @@ func firstTextContent(content []mcp.Content) (string, bool) {
 // classifyToolError inspects an MCP tool error envelope and picks an
 // HTTP status that best represents the failure. The matched patterns
 // are stable strings emitted by the apigateway toolkit and the MCP
-// auth/authz middleware: "authentication failed:", "not authorized:",
-// and "connection %q not found". Anything else is returned as 400 so
-// that a request the platform refused does not surface as a 5xx
-// (which would imply a platform fault).
+// auth/authz middleware. Categories, in order of evaluation:
+//
+//   - "authentication failed" → 401 (caller's token bad)
+//   - "not authorized"        → 403 (caller's persona denies)
+//   - timeout signatures      → 504 (gateway gave up waiting on upstream)
+//   - transport signatures    → 502 (gateway could not reach upstream)
+//   - "not found"             → 404 (connection name unknown to the toolkit)
+//   - anything else           → 400 (request the platform refused, NOT a
+//     platform fault; clients see 4xx so they don't trigger retry loops
+//     on what is essentially a malformed input).
+//
+// Order matters: timeout/transport patterns are evaluated AFTER auth
+// because auth errors are independent of the upstream and should
+// surface as auth failures, but BEFORE the "not found" pattern
+// because a transport error reading "no such host" must not be
+// mistaken for a connection-name lookup miss.
 func classifyToolError(payload string) (status int, message string) {
 	var env errorEnvelope
 	if err := json.Unmarshal([]byte(payload), &env); err != nil {
@@ -260,11 +278,42 @@ func classifyToolError(payload string) (status int, message string) {
 		return http.StatusUnauthorized, msg
 	case strings.Contains(lower, "not authorized"):
 		return http.StatusForbidden, msg
+	case isTimeoutSignature(lower):
+		return http.StatusGatewayTimeout, msg
+	case isTransportSignature(lower):
+		return http.StatusBadGateway, msg
 	case strings.Contains(lower, "not found"):
 		return http.StatusNotFound, msg
 	default:
 		return http.StatusBadRequest, msg
 	}
+}
+
+// isTimeoutSignature reports whether the lowercased error message
+// carries one of Go's stable timeout phrases. Mirrors the same set
+// used by pkg/toolkits/apigateway.isTimeoutErrorMessage so the
+// REST shim and the toolkit agree on what counts as a timeout.
+func isTimeoutSignature(lower string) bool {
+	return strings.Contains(lower, "context deadline exceeded") ||
+		strings.Contains(lower, "client.timeout exceeded") ||
+		strings.Contains(lower, "i/o timeout")
+}
+
+// isTransportSignature reports whether the lowercased error message
+// carries one of Go's stable non-timeout transport-error phrases:
+// DNS resolution, TCP refused, TLS handshake, broken stream, peer
+// reset. Each of these means the gateway could not successfully
+// proxy the call to the upstream, so the REST shim returns 502
+// Bad Gateway to its caller (NiFi / curl / etc.), which lets
+// those clients use their built-in retry semantics for 5xx instead
+// of having to inspect the JSON body.
+func isTransportSignature(lower string) bool {
+	return strings.Contains(lower, "connection refused") ||
+		strings.Contains(lower, "no such host") ||
+		strings.Contains(lower, "tls:") ||
+		strings.Contains(lower, "tls handshake") ||
+		strings.Contains(lower, "eof") ||
+		strings.Contains(lower, "connection reset")
 }
 
 func writeJSON(w http.ResponseWriter, status int, payload any) {

--- a/pkg/gatewayhttp/handler_test.go
+++ b/pkg/gatewayhttp/handler_test.go
@@ -198,6 +198,51 @@ func TestClassifyToolError(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
+			name:       "context deadline → 504 Gateway Timeout",
+			payload:    `{"error":"Get \"https://api.example.com/x\": context deadline exceeded"}`,
+			wantStatus: http.StatusGatewayTimeout,
+		},
+		{
+			name:       "Client.Timeout exceeded → 504 Gateway Timeout",
+			payload:    `{"error":"Get \"https://api.example.com/x\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)"}`,
+			wantStatus: http.StatusGatewayTimeout,
+		},
+		{
+			name:       "i/o timeout → 504 Gateway Timeout",
+			payload:    `{"error":"read tcp 10.0.0.1:443: i/o timeout"}`,
+			wantStatus: http.StatusGatewayTimeout,
+		},
+		{
+			name:       "DNS resolution failure → 502 Bad Gateway",
+			payload:    `{"error":"Get \"https://nope.invalid/x\": dial tcp: lookup nope.invalid: no such host"}`,
+			wantStatus: http.StatusBadGateway,
+		},
+		{
+			name:       "TCP connection refused → 502 Bad Gateway",
+			payload:    `{"error":"Get \"https://api.example.com/x\": dial tcp 10.0.0.1:443: connect: connection refused"}`,
+			wantStatus: http.StatusBadGateway,
+		},
+		{
+			name:       "TLS handshake failure → 502 Bad Gateway",
+			payload:    `{"error":"Get \"https://api.example.com/x\": tls: handshake failure"}`,
+			wantStatus: http.StatusBadGateway,
+		},
+		{
+			name:       "EOF mid-stream → 502 Bad Gateway",
+			payload:    `{"error":"Get \"https://api.example.com/x\": EOF"}`,
+			wantStatus: http.StatusBadGateway,
+		},
+		{
+			name:       "connection reset → 502 Bad Gateway",
+			payload:    `{"error":"read tcp 10.0.0.1:443: connection reset by peer"}`,
+			wantStatus: http.StatusBadGateway,
+		},
+		{
+			name:       "transport phrase 'no such host' does NOT mismatch as 404 not found",
+			payload:    `{"error":"dial tcp: lookup api.example.com: no such host"}`,
+			wantStatus: http.StatusBadGateway,
+		},
+		{
 			name:       "non-JSON payload → 500 with raw text",
 			payload:    `garbage`,
 			wantStatus: http.StatusInternalServerError,
@@ -407,6 +452,91 @@ func TestIntegration_UpstreamErrorIsBodyNotHTTP(t *testing.T) {
 	require.NoError(t, json.Unmarshal(respBody, &out))
 	assert.Equal(t, 500, out.Status,
 		"upstream HTTP status must be returned in InvokeOutput.Status")
+}
+
+// TestIntegration_UpstreamTimeoutIsGatewayTimeout proves that when
+// the apigateway's outbound call to the upstream exceeds its
+// CallTimeout, the REST shim returns HTTP 504 Gateway Timeout, NOT
+// 200 with a status=0 body, and NOT 500. This is the corrected gateway
+// semantics from issue #432: the gateway failed to proxy, so it
+// surfaces the failure at the wire layer so HTTP clients (NiFi,
+// Airflow, curl) can use their built-in retry / failure routing
+// instead of having to parse a JSON body to detect the failure.
+func TestIntegration_UpstreamTimeoutIsGatewayTimeout(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		// Sleep longer than the call_timeout configured in
+		// newGatewayHTTPServer's connection definition. The
+		// apigateway will cancel the request and produce a
+		// context-deadline-exceeded error which buildInvokeResult
+		// classifies as upstream_timeout.
+		time.Sleep(2 * time.Second)
+	}))
+	defer upstream.Close()
+
+	gateway := newGatewayHTTPServerWithTimeout(t, upstream.URL, "acme", "200ms")
+	defer gateway.Close()
+
+	status, respBody := postJSON(t, gateway.URL+"/api/v1/gateway/acme/invoke",
+		`{"method":"GET","path":"/v1/slow"}`)
+
+	require.Equal(t, http.StatusGatewayTimeout, status,
+		"upstream timeout must surface as 504 Gateway Timeout at the wire layer")
+	var env errorEnvelope
+	require.NoError(t, json.Unmarshal(respBody, &env))
+	assert.NotEmpty(t, env.Error, "504 response must include the scrubbed transport error message")
+}
+
+// TestIntegration_TransportErrorIsBadGateway proves that when the
+// upstream is unreachable (connection refused / TLS / DNS), the REST
+// shim returns HTTP 502 Bad Gateway. Confirms the gateway-side
+// failure path lands as a real 5xx that HTTP clients can route on.
+func TestIntegration_TransportErrorIsBadGateway(t *testing.T) {
+	// Stand up an httptest server then close it immediately so the
+	// URL is well-formed but the TCP connect attempt fails. This
+	// produces a "connect: connection refused" error from net/http
+	// which the apigateway scrubber preserves and the classifier
+	// maps to 502.
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	closedURL := upstream.URL
+	upstream.Close()
+
+	gateway := newGatewayHTTPServerWithTimeout(t, closedURL, "acme", "5s")
+	defer gateway.Close()
+
+	status, respBody := postJSON(t, gateway.URL+"/api/v1/gateway/acme/invoke",
+		`{"method":"GET","path":"/v1/anything"}`)
+
+	require.Equal(t, http.StatusBadGateway, status,
+		"unreachable upstream must surface as 502 Bad Gateway at the wire layer")
+	var env errorEnvelope
+	require.NoError(t, json.Unmarshal(respBody, &env))
+	assert.NotEmpty(t, env.Error, "502 response must include the scrubbed transport error message")
+}
+
+// newGatewayHTTPServerWithTimeout is a variant of newGatewayHTTPServer
+// that takes an explicit call_timeout string, used by the timeout
+// integration test to force a deterministic cancel without waiting
+// the default 5 seconds.
+func newGatewayHTTPServerWithTimeout(t *testing.T, upstreamURL, connName, callTimeout string) *httptest.Server {
+	t.Helper()
+	tk := apigatewaykit.New("apigateway")
+	if upstreamURL != "" {
+		require.NoError(t, tk.AddConnection(connName, map[string]any{
+			"base_url":        upstreamURL,
+			"auth_mode":       apigatewaykit.AuthModeNone,
+			"call_timeout":    callTimeout,
+			"connect_timeout": "2s",
+		}))
+	}
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "v1"}, nil)
+	tk.RegisterTools(mcpServer)
+	handler, err := NewHandler(Deps{MCPServer: mcpServer})
+	require.NoError(t, err)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(func() {
+		time.Sleep(10 * time.Millisecond)
+	})
+	return srv
 }
 
 // TestIntegration_ConnectionNotFound exercises the 404 path: the

--- a/pkg/middleware/mcp_audit.go
+++ b/pkg/middleware/mcp_audit.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/observability"
 )
 
 // MCPAuditMiddleware creates MCP protocol-level middleware that logs tool calls
@@ -83,14 +85,39 @@ func buildMCPAuditEvent(pc *PlatformContext, info auditCallInfo) AuditEvent {
 	success := info.Err == nil
 	errorMsg := ""
 	errorCategory := ""
+	callResult, _ := info.Result.(*mcp.CallToolResult)
 	if info.Err != nil {
 		errorMsg = info.Err.Error()
 		errorCategory = ErrorCategory(info.Err)
-	} else if callResult, ok := info.Result.(*mcp.CallToolResult); ok && callResult != nil && callResult.IsError {
+	} else if callResult != nil && callResult.IsError {
 		success = false
 		errorMsg = extractMCPErrorMessage(callResult)
 		if getErr := callResult.GetError(); getErr != nil {
 			errorCategory = ErrorCategory(getErr)
+		}
+	}
+
+	// Audit-outcome _meta override. Toolkits that proxy external
+	// services (apigateway) set this on every result so the audit row
+	// reflects the real upstream outcome rather than just "the MCP
+	// tool returned." When present and not 'ok', it overrides the
+	// IsError-derived success/category. Upstream 4xx/5xx come through
+	// here even though IsError stays false (correct gateway wire
+	// semantics: the gateway succeeded at proxying; the upstream
+	// returned what it returned). See issue #432.
+	//
+	// The meta message takes precedence over the IsError-branch's
+	// errorMsg because the IsError branch reads the full JSON-encoded
+	// tool result text, which for the apigateway is a multi-field
+	// JSON envelope ({"status":0,"duration_ms":...,"error":"..."}).
+	// The meta message is the concise scrubbed error string the
+	// toolkit explicitly stamped for audit consumption, preferable
+	// for grep/dashboards.
+	if outcome, message := readAuditOutcomeMeta(callResult); outcome != "" && outcome != observability.OutcomeOK {
+		success = false
+		errorCategory = outcome
+		if message != "" {
+			errorMsg = message
 		}
 	}
 
@@ -188,6 +215,20 @@ func calculateRequestSize(req mcp.Request) int {
 		return 0
 	}
 	return len(callParams.Arguments)
+}
+
+// readAuditOutcomeMeta extracts the audit outcome and (optional)
+// human-readable message from a CallToolResult's _meta map. Returns
+// empty strings when the result is nil, the Meta is nil, the keys
+// are absent, or the values are not strings, so the caller's check
+// for outcome == "" cleanly skips the override path.
+func readAuditOutcomeMeta(result *mcp.CallToolResult) (outcome, message string) {
+	if result == nil || result.Meta == nil {
+		return "", ""
+	}
+	outcome, _ = result.Meta[observability.MetaAuditOutcome].(string)
+	message, _ = result.Meta[observability.MetaAuditOutcomeMessage].(string)
+	return outcome, message
 }
 
 // extractMCPErrorMessage extracts the error message from an MCP CallToolResult.

--- a/pkg/middleware/mcp_audit_test.go
+++ b/pkg/middleware/mcp_audit_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/observability"
 )
 
 // Test constants for MCP audit tests.
@@ -553,6 +555,160 @@ func TestBuildMCPAuditEvent_WithProtocolError(t *testing.T) {
 	assert.Empty(t, event.ErrorCategory)
 	assert.Equal(t, 0, event.ResponseChars, "no response for protocol error")
 	assert.Equal(t, 0, event.ContentBlocks, "no content blocks for protocol error")
+}
+
+// TestBuildMCPAuditEvent_AuditOutcomeMetaOverride verifies the audit
+// middleware honors the _meta.audit_outcome / audit_outcome_message
+// hint that upstream-proxying toolkits (apigateway) populate on
+// every result. See issue #432: success cannot be derived from
+// IsError for the apigateway because upstream 4xx/5xx are NOT
+// gateway failures (gateway succeeded at proxying). They are
+// successful proxies of unsuccessful upstream calls, and the audit
+// row should reflect the latter.
+func TestBuildMCPAuditEvent_AuditOutcomeMetaOverride(t *testing.T) {
+	tests := []struct {
+		name             string
+		isError          bool
+		outcome          string
+		outcomeMessage   string
+		existingErrText  string
+		wantSuccess      bool
+		wantCategory     string
+		wantErrorMessage string
+	}{
+		{
+			name:             "outcome=ok leaves success true, no category",
+			isError:          false,
+			outcome:          observability.OutcomeOK,
+			wantSuccess:      true,
+			wantCategory:     "",
+			wantErrorMessage: "",
+		},
+		{
+			name:             "upstream_4xx with IsError false → success false, category set, message lifted",
+			isError:          false,
+			outcome:          observability.OutcomeUpstream4xx,
+			outcomeMessage:   "Not Found",
+			wantSuccess:      false,
+			wantCategory:     observability.OutcomeUpstream4xx,
+			wantErrorMessage: "Not Found",
+		},
+		{
+			name:             "upstream_5xx with IsError false → success false, category set",
+			isError:          false,
+			outcome:          observability.OutcomeUpstream5xx,
+			outcomeMessage:   "Service Unavailable",
+			wantSuccess:      false,
+			wantCategory:     observability.OutcomeUpstream5xx,
+			wantErrorMessage: "Service Unavailable",
+		},
+		{
+			name:             "transport_err with IsError true → success false, category overrides empty",
+			isError:          true,
+			existingErrText:  "Get \"https://x/\": dial tcp: connection refused",
+			outcome:          observability.OutcomeTransportErr,
+			outcomeMessage:   "Get \"https://x/\": dial tcp: connection refused",
+			wantSuccess:      false,
+			wantCategory:     observability.OutcomeTransportErr,
+			wantErrorMessage: "Get \"https://x/\": dial tcp: connection refused",
+		},
+		{
+			name:             "upstream_timeout with IsError true → category overrides",
+			isError:          true,
+			existingErrText:  "Get \"https://x/\": context deadline exceeded",
+			outcome:          observability.OutcomeUpstreamTimeout,
+			outcomeMessage:   "Get \"https://x/\": context deadline exceeded",
+			wantSuccess:      false,
+			wantCategory:     observability.OutcomeUpstreamTimeout,
+			wantErrorMessage: "Get \"https://x/\": context deadline exceeded",
+		},
+		{
+			name:             "no _meta hint → behavior unchanged (success result)",
+			isError:          false,
+			outcome:          "",
+			wantSuccess:      true,
+			wantCategory:     "",
+			wantErrorMessage: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pc := NewPlatformContext("req-outcome")
+			pc.ToolName = testAuditToolName
+
+			// Build Content to mirror what the apigateway's
+			// buildInvokeResult actually emits: a JSON-marshaled
+			// envelope when IsError is set. Without this, the
+			// IsError branch in buildMCPAuditEvent would receive
+			// the plain scrubbed error string and the test would
+			// give a false positive for the meta-message override
+			// logic (the override is supposed to REPLACE the
+			// JSON-blob extraction, not just fill an empty slot).
+			contentText := "{}"
+			if tc.isError && tc.existingErrText != "" {
+				body, err := json.Marshal(map[string]any{
+					"status":      0,
+					"duration_ms": 0,
+					"error":       tc.existingErrText,
+				})
+				require.NoError(t, err)
+				contentText = string(body)
+			}
+			result := &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: contentText}},
+				IsError: tc.isError,
+			}
+			if tc.outcome != "" {
+				result.Meta = mcp.Meta{
+					observability.MetaAuditOutcome: tc.outcome,
+				}
+				if tc.outcomeMessage != "" {
+					result.Meta[observability.MetaAuditOutcomeMessage] = tc.outcomeMessage
+				}
+			}
+
+			event := buildMCPAuditEvent(pc, auditCallInfo{
+				Request:   createAuditTestRequest(t, testAuditToolName, nil),
+				Result:    result,
+				StartTime: time.Now(),
+				Duration:  time.Millisecond,
+			})
+
+			assert.Equal(t, tc.wantSuccess, event.Success, "Success")
+			assert.Equal(t, tc.wantCategory, event.ErrorCategory, "ErrorCategory")
+			assert.Equal(t, tc.wantErrorMessage, event.ErrorMessage, "ErrorMessage")
+		})
+	}
+}
+
+// TestReadAuditOutcomeMeta covers the nil-safety and type-assertion
+// corners of the meta-reader so the audit middleware doesn't panic
+// on a malformed result.
+func TestReadAuditOutcomeMeta(t *testing.T) {
+	t.Run("nil result", func(t *testing.T) {
+		o, m := readAuditOutcomeMeta(nil)
+		assert.Empty(t, o)
+		assert.Empty(t, m)
+	})
+	t.Run("nil meta", func(t *testing.T) {
+		o, m := readAuditOutcomeMeta(&mcp.CallToolResult{})
+		assert.Empty(t, o)
+		assert.Empty(t, m)
+	})
+	t.Run("non-string outcome ignored", func(t *testing.T) {
+		r := &mcp.CallToolResult{Meta: mcp.Meta{observability.MetaAuditOutcome: 42}}
+		o, _ := readAuditOutcomeMeta(r)
+		assert.Empty(t, o)
+	})
+	t.Run("string values returned", func(t *testing.T) {
+		r := &mcp.CallToolResult{Meta: mcp.Meta{
+			observability.MetaAuditOutcome:        observability.OutcomeUpstream5xx,
+			observability.MetaAuditOutcomeMessage: "Service Unavailable",
+		}}
+		o, m := readAuditOutcomeMeta(r)
+		assert.Equal(t, observability.OutcomeUpstream5xx, o)
+		assert.Equal(t, "Service Unavailable", m)
+	})
 }
 
 // Helper to create ServerRequest for audit testing.

--- a/pkg/observability/status.go
+++ b/pkg/observability/status.go
@@ -14,6 +14,46 @@ const (
 	StatusInternalErr   = "internal_err"
 )
 
+// Audit outcome categories for upstream-proxying toolkits (e.g. the
+// apigateway). These are bounded labels that distinguish gateway-level
+// failure (the gateway could not reach the upstream) from
+// upstream-level failure (the upstream responded with an error
+// status). The two are fundamentally different operational concerns
+// and should not share a status code or a success boolean:
+//   - The gateway returning 502 means the gateway broke.
+//   - The upstream returning 502 (proxied through the gateway as wire
+//     200 with the upstream code in the body) means the upstream
+//     broke. The gateway did its job.
+//
+// audit_logs.error_category and the Phase 1 status_category label
+// adopt these constants so dashboards can alert on each independently.
+const (
+	OutcomeOK              = "ok"
+	OutcomeUpstream4xx     = "upstream_4xx"
+	OutcomeUpstream5xx     = "upstream_5xx"
+	OutcomeTransportErr    = "transport_err"
+	OutcomeUpstreamTimeout = "upstream_timeout"
+)
+
+// Well-known CallToolResult Meta keys read by the audit middleware to
+// override its success / error_category derivation. Toolkits that
+// proxy external services populate these so the audit row reflects
+// the real upstream outcome instead of just "the MCP tool ran." Keys
+// are namespaced under "audit_" to keep them out of the way of other
+// _meta consumers.
+const (
+	// MetaAuditOutcome carries one of the Outcome* string constants
+	// above. When present and not OutcomeOK, the audit middleware
+	// sets success=false and uses the value as error_category.
+	MetaAuditOutcome = "audit_outcome"
+
+	// MetaAuditOutcomeMessage carries an optional human-readable
+	// summary of the outcome (typically the upstream status text or
+	// the scrubbed transport error). Used to populate
+	// audit_logs.error_message when no other source is available.
+	MetaAuditOutcomeMessage = "audit_outcome_message"
+)
+
 // HTTP status class labels for outbound calls. The "other" bucket
 // covers transport-level failures (status code 0) and the rarely-seen
 // 1xx informational range. Recording the raw status code as a label

--- a/pkg/toolkits/apigateway/invoke.go
+++ b/pkg/toolkits/apigateway/invoke.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/txn2/mcp-data-platform/pkg/observability"
 )
 
 // supportedMethods is the closed set of HTTP methods api_invoke_endpoint
@@ -67,11 +69,26 @@ type InvokeInput struct {
 	TimeoutSeconds int               `json:"timeout_seconds,omitempty"`
 }
 
-// InvokeOutput is the structured result returned to the model. Errors
-// reaching the upstream (DNS, connection refused, TLS failure,
-// timeout) are surfaced via Error rather than as MCP tool errors so
-// the model can branch on them without losing the rest of the
-// response envelope.
+// InvokeOutput is the structured result returned to the model and to
+// the REST gateway shim. Outcomes are distinguished at the MCP-result
+// layer (see buildInvokeResult and issue #432):
+//
+//   - Upstream responded with anything (2xx-5xx): the gateway
+//     succeeded at proxying. Status carries the upstream HTTP code,
+//     Error is normally empty, and the wrapping CallToolResult has
+//     IsError=false. Wire-level HTTP status from the REST shim stays
+//     200; HTTP clients read the upstream code from Status and
+//     branch on it.
+//   - Upstream responded with a status but the body could not be
+//     read in full (mid-stream drop, body exceeded the buffer
+//     allocator): Status carries the upstream code, Error carries
+//     the read-failure text, IsError stays false. The partial body
+//     is still returned in Body so callers can inspect what arrived.
+//   - Gateway could not reach upstream OR the upstream call timed
+//     out: gateway-level failure. Status is 0, Error carries the
+//     scrubbed transport-error text, the wrapping CallToolResult
+//     has IsError=true, and the REST shim maps this to wire 502
+//     (transport) or 504 (timeout).
 type InvokeOutput struct {
 	Status        int                 `json:"status"`
 	Headers       map[string][]string `json:"headers,omitempty"`
@@ -385,6 +402,70 @@ func buildRequest(ctx context.Context, spec requestSpec) (*http.Request, error) 
 		req.Header.Set("Accept", "application/json, */*;q=0.5")
 	}
 	return req, nil
+}
+
+// httpStatus4xxLo / httpStatus5xxLo / httpStatus6xxLo bound the
+// upstream status ranges used by ClassifyInvokeOutcome. They mirror
+// the constants in pkg/observability/status.go but live here so this
+// file's switch reads as plain numbers without an import alias gymnastics.
+const (
+	httpStatus4xxLo = 400
+	httpStatus5xxLo = 500
+	httpStatus6xxLo = 600
+)
+
+// ClassifyInvokeOutcome maps an InvokeOutput to one of the bounded
+// outcome categories defined in pkg/observability. The audit middleware
+// reads this category off the CallToolResult's _meta to populate
+// audit_logs.error_category and to derive success without relying on
+// the MCP IsError flag, which is reserved for gateway-level failures
+// (transport / timeout) per the corrected gateway semantics described
+// in issue #432.
+//
+// Mapping:
+//   - Status 0 with a timeout-like error message → upstream_timeout
+//   - Status 0 with any other transport error    → transport_err
+//   - 4xx upstream response                      → upstream_4xx
+//   - 5xx upstream response                      → upstream_5xx
+//   - 2xx / 3xx upstream response                → ok
+//
+// Pattern matching on the scrubbed error string is acceptable here
+// because scrubTransportError above normalizes the upstream error
+// shape; the substrings checked below are the stable phrases Go's
+// net/http and net/url error types produce.
+func ClassifyInvokeOutcome(out InvokeOutput) string {
+	if out.Status == 0 {
+		if isTimeoutErrorMessage(out.Error) {
+			return observability.OutcomeUpstreamTimeout
+		}
+		return observability.OutcomeTransportErr
+	}
+	if out.Status >= httpStatus5xxLo && out.Status < httpStatus6xxLo {
+		return observability.OutcomeUpstream5xx
+	}
+	if out.Status >= httpStatus4xxLo && out.Status < httpStatus5xxLo {
+		return observability.OutcomeUpstream4xx
+	}
+	return observability.OutcomeOK
+}
+
+// isTimeoutErrorMessage reports whether the scrubbed transport-error
+// string carries a timeout signature. Strings checked are the stable
+// phrases Go's net/http, context, and net/url error types emit:
+//   - "context deadline exceeded" for context.DeadlineExceeded
+//   - "Client.Timeout exceeded" for http.Client when its own Timeout fires
+//   - "i/o timeout" for net.OpError on read/write timeouts
+//
+// All three are case-insensitive so the message can come from any
+// wrapper layer. A plain "timeout" substring is intentionally NOT
+// matched because that word can appear in legitimate body content
+// surfaced via scrubTransportError; the more specific phrases above
+// are unambiguous.
+func isTimeoutErrorMessage(msg string) bool {
+	lower := strings.ToLower(msg)
+	return strings.Contains(lower, "context deadline exceeded") ||
+		strings.Contains(lower, "client.timeout exceeded") ||
+		strings.Contains(lower, "i/o timeout")
 }
 
 // scrubTransportError rewrites a transport-level error so its message

--- a/pkg/toolkits/apigateway/outcome_test.go
+++ b/pkg/toolkits/apigateway/outcome_test.go
@@ -1,0 +1,159 @@
+package apigateway
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/observability"
+)
+
+func TestClassifyInvokeOutcome(t *testing.T) {
+	cases := []struct {
+		name string
+		in   InvokeOutput
+		want string
+	}{
+		{"2xx → ok", InvokeOutput{Status: 200}, observability.OutcomeOK},
+		{"3xx → ok", InvokeOutput{Status: 302}, observability.OutcomeOK},
+		{"4xx → upstream_4xx", InvokeOutput{Status: 404}, observability.OutcomeUpstream4xx},
+		{"4xx edge low", InvokeOutput{Status: 400}, observability.OutcomeUpstream4xx},
+		{"4xx edge high", InvokeOutput{Status: 499}, observability.OutcomeUpstream4xx},
+		{"5xx → upstream_5xx", InvokeOutput{Status: 503}, observability.OutcomeUpstream5xx},
+		{"5xx edge low", InvokeOutput{Status: 500}, observability.OutcomeUpstream5xx},
+		{"5xx edge high", InvokeOutput{Status: 599}, observability.OutcomeUpstream5xx},
+		{"status 0 + ctx deadline → upstream_timeout", InvokeOutput{Status: 0, Error: `Get "https://api.example.com/x": context deadline exceeded`}, observability.OutcomeUpstreamTimeout},
+		{"status 0 + Client.Timeout → upstream_timeout", InvokeOutput{Status: 0, Error: `Get "https://api.example.com/x": net/http: request canceled (Client.Timeout exceeded while awaiting headers)`}, observability.OutcomeUpstreamTimeout},
+		{"status 0 + i/o timeout → upstream_timeout", InvokeOutput{Status: 0, Error: `read tcp 10.0.0.1:443: i/o timeout`}, observability.OutcomeUpstreamTimeout},
+		{"status 0 + DNS → transport_err", InvokeOutput{Status: 0, Error: `Get "https://nope.invalid/x": dial tcp: lookup nope.invalid: no such host`}, observability.OutcomeTransportErr},
+		{"status 0 + connection refused → transport_err", InvokeOutput{Status: 0, Error: `Get "https://api.example.com/x": dial tcp 10.0.0.1:443: connect: connection refused`}, observability.OutcomeTransportErr},
+		{"status 0 + TLS → transport_err", InvokeOutput{Status: 0, Error: `Get "https://api.example.com/x": tls: handshake failure`}, observability.OutcomeTransportErr},
+		{"status 0 + EOF → transport_err", InvokeOutput{Status: 0, Error: `Get "https://api.example.com/x": EOF`}, observability.OutcomeTransportErr},
+		{"status 0 + connection reset → transport_err", InvokeOutput{Status: 0, Error: `read tcp 10.0.0.1:443: connection reset by peer`}, observability.OutcomeTransportErr},
+		{"status 0 + empty error → transport_err", InvokeOutput{Status: 0}, observability.OutcomeTransportErr},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyInvokeOutcome(tc.in); got != tc.want {
+				t.Errorf("ClassifyInvokeOutcome = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildInvokeResult(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          InvokeOutput
+		wantOutcome string
+		wantIsError bool
+		wantMsg     string
+	}{
+		{
+			name:        "2xx success leaves IsError false, ok outcome, no message",
+			in:          InvokeOutput{Status: 200, Body: map[string]any{"id": 1}},
+			wantOutcome: observability.OutcomeOK,
+			wantIsError: false,
+			wantMsg:     "",
+		},
+		{
+			name:        "upstream 404 leaves IsError false (gateway succeeded), upstream_4xx outcome, status text in meta",
+			in:          InvokeOutput{Status: 404, Body: map[string]any{"error": "not found"}},
+			wantOutcome: observability.OutcomeUpstream4xx,
+			wantIsError: false,
+			wantMsg:     "Not Found",
+		},
+		{
+			name:        "upstream 503 leaves IsError false (gateway succeeded), upstream_5xx outcome, status text in meta",
+			in:          InvokeOutput{Status: 503, Body: "Service Unavailable"},
+			wantOutcome: observability.OutcomeUpstream5xx,
+			wantIsError: false,
+			wantMsg:     "Service Unavailable",
+		},
+		{
+			name:        "upstream 500 with explicit Error prefers Error over status text",
+			in:          InvokeOutput{Status: 500, Error: "read body capped at 10MiB"},
+			wantOutcome: observability.OutcomeUpstream5xx,
+			wantIsError: false,
+			wantMsg:     "read body capped at 10MiB",
+		},
+		{
+			name:        "transport error → IsError true, transport_err outcome, message populated",
+			in:          InvokeOutput{Status: 0, Error: `Get "https://x.example.com/y": dial tcp: connection refused`},
+			wantOutcome: observability.OutcomeTransportErr,
+			wantIsError: true,
+			wantMsg:     `Get "https://x.example.com/y": dial tcp: connection refused`,
+		},
+		{
+			name:        "upstream timeout → IsError true, upstream_timeout outcome, message populated",
+			in:          InvokeOutput{Status: 0, Error: `Get "https://x.example.com/y": context deadline exceeded`},
+			wantOutcome: observability.OutcomeUpstreamTimeout,
+			wantIsError: true,
+			wantMsg:     `Get "https://x.example.com/y": context deadline exceeded`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := buildInvokeResult(tc.in)
+			if r.IsError != tc.wantIsError {
+				t.Errorf("IsError = %v, want %v", r.IsError, tc.wantIsError)
+			}
+			gotOutcome, _ := r.Meta[observability.MetaAuditOutcome].(string)
+			if gotOutcome != tc.wantOutcome {
+				t.Errorf("Meta[audit_outcome] = %q, want %q", gotOutcome, tc.wantOutcome)
+			}
+			gotMsg, _ := r.Meta[observability.MetaAuditOutcomeMessage].(string)
+			if gotMsg != tc.wantMsg {
+				t.Errorf("Meta[audit_outcome_message] = %q, want %q", gotMsg, tc.wantMsg)
+			}
+			// Every successful result still contains the JSON-encoded
+			// InvokeOutput as text content so MCP clients reading the
+			// body get the full upstream response shape regardless of
+			// whether IsError is set.
+			if len(r.Content) == 0 {
+				t.Errorf("Content is empty; expected JSON-encoded InvokeOutput payload")
+			}
+		})
+	}
+}
+
+// TestBuildInvokeResult_MetaPresentOnSuccess proves the audit_outcome
+// stamp lands on EVERY result, not just the failure paths. The audit
+// middleware uses this to populate audit_logs.error_category for
+// success rows too (with value "ok"), which lets a dashboard query
+// for "what fraction of calls have error_category != 'ok'" without
+// needing to special-case NULLs.
+func TestBuildInvokeResult_MetaPresentOnSuccess(t *testing.T) {
+	r := buildInvokeResult(InvokeOutput{Status: 200, Body: map[string]any{"id": 1}})
+	if r.Meta == nil {
+		t.Fatal("Meta is nil on success path")
+	}
+	v, ok := r.Meta[observability.MetaAuditOutcome].(string)
+	if !ok || v != observability.OutcomeOK {
+		t.Errorf("Meta[audit_outcome] = %v, want %q", r.Meta[observability.MetaAuditOutcome], observability.OutcomeOK)
+	}
+	// No message expected on the success path because InvokeOutput.Error is empty.
+	if _, present := r.Meta[observability.MetaAuditOutcomeMessage]; present {
+		t.Errorf("Meta[audit_outcome_message] should be absent on success path, got %v", r.Meta[observability.MetaAuditOutcomeMessage])
+	}
+}
+
+// TestBuildInvokeResult_PreservesJSONBody guards the structured-content
+// contract: even when IsError = true (transport / timeout), the JSON
+// body carrying the upstream status and scrubbed error MUST still be
+// present so MCP clients (and the REST shim's JSON unmarshal path) can
+// inspect the failure shape. Regression test for the temptation to
+// replace the content with a plain error string.
+func TestBuildInvokeResult_PreservesJSONBody(t *testing.T) {
+	r := buildInvokeResult(InvokeOutput{Status: 0, Error: `dial tcp: connection refused`})
+	if !r.IsError {
+		t.Fatal("expected IsError = true for transport error")
+	}
+	tc, ok := r.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("first content block is %T, want *mcp.TextContent", r.Content[0])
+	}
+	if tc.Text == "" {
+		t.Error("text content is empty; transport-error result must still carry the JSON body")
+	}
+}

--- a/pkg/toolkits/apigateway/toolkit.go
+++ b/pkg/toolkits/apigateway/toolkit.go
@@ -875,7 +875,57 @@ func (t *Toolkit) handleInvoke(ctx context.Context, _ *mcp.CallToolRequest, in I
 	if !hasExport {
 		out.Hint = ""
 	}
-	return jsonResult(out), out, nil
+	return buildInvokeResult(out), out, nil
+}
+
+// buildInvokeResult wraps an InvokeOutput in a CallToolResult,
+// classifies the outcome, and stamps the result for the audit
+// middleware and the REST shim:
+//
+//   - _meta.audit_outcome is set on EVERY call (including success)
+//     so the audit middleware can populate audit_logs.error_category
+//     for every row without parsing the JSON body.
+//   - _meta.audit_outcome_message carries a concise human-readable
+//     summary: the scrubbed transport-error text for gateway-level
+//     failures, or the canonical HTTP status reason phrase (via
+//     http.StatusText) for upstream 4xx/5xx. Empty on the success
+//     path.
+//   - IsError is set ONLY for gateway-level failures (transport
+//     error, upstream timeout, i.e. Status == 0). Upstream 4xx and
+//     5xx responses leave IsError = false because the gateway
+//     successfully proxied; the upstream returned what it returned.
+//     The REST shim's classifyToolError relies on this distinction
+//     to map gateway-level failures to 502 / 504 while letting
+//     successful proxies of upstream errors flow through as wire
+//     HTTP 200 with the upstream code embedded in the body.
+func buildInvokeResult(out InvokeOutput) *mcp.CallToolResult {
+	result := jsonResult(out)
+	outcome := ClassifyInvokeOutcome(out)
+	result.Meta = mcp.Meta{observability.MetaAuditOutcome: outcome}
+	if msg := auditOutcomeMessage(out); msg != "" {
+		result.Meta[observability.MetaAuditOutcomeMessage] = msg
+	}
+	if outcome == observability.OutcomeTransportErr || outcome == observability.OutcomeUpstreamTimeout {
+		result.IsError = true
+	}
+	return result
+}
+
+// auditOutcomeMessage returns the human-readable summary string the
+// audit middleware should record alongside the outcome category. For
+// gateway-level failures the scrubbed transport error is the most
+// specific signal; for upstream 4xx/5xx the canonical reason phrase
+// keeps the audit row grep-friendly without dragging the upstream's
+// arbitrary error body into the column. Empty string when the call
+// succeeded or no useful summary is available.
+func auditOutcomeMessage(out InvokeOutput) string {
+	if out.Error != "" {
+		return out.Error
+	}
+	if out.Status >= httpStatus4xxLo && out.Status < httpStatus6xxLo {
+		return http.StatusText(out.Status)
+	}
+	return ""
 }
 
 // checkRoutePolicy runs the optional per-(connection, method, path)


### PR DESCRIPTION
Closes #432.

The apigateway today returns wire HTTP 200 for every `api_invoke_endpoint` call no matter what the upstream did, and `audit_logs.success = true` for every row even when the upstream call failed. Two real-world consequences surfaced in production:

- **HTTP clients of the REST shim cannot use built-in status-code routing for gateway-level failures.** NiFi `InvokeHTTP`, curl, Airflow `HttpOperator`, and friends all branch on response code. With everything coming back as 200, a flowfile that hit a gateway-side timeout looks identical to one that hit a happy upstream. Operators have to add `EvaluateJsonPath` + `RouteOnAttribute` plumbing inside every flow.
- **`audit_logs.success` is useless as a per-upstream success-rate signal.** Dashboards built on it show a flat green line while real upstream failures happen in batches. This was the symptom that uncovered the bug in the first place: a production deployment showed 100% audit-success while the same window had 1.6% of calls failing at NiFi's read-timeout wall.

## What this PR changes

The corrected gateway semantics are split cleanly across three places:

### 1. The wire (HTTP status from the REST shim)

| Outcome | Wire status | Why |
|---|---|---|
| Upstream returned 2xx-5xx | `200` | Gateway successfully proxied; the upstream's status code lives in `InvokeOutput.Status` inside the body. RFC 7231/9110 idiomatic gateway behavior (cf. AWS API Gateway, Cloudflare, Kong). Passing an upstream 500 through as a gateway 500 would conflate "the upstream broke" with "the gateway broke." |
| Gateway-to-upstream transport error (DNS, TCP refused, TLS, EOF, reset) | **`502 Bad Gateway`** | The gateway failed to proxy. |
| Upstream call timed out (context deadline, `Client.Timeout`, `i/o timeout`) | **`504 Gateway Timeout`** | Same: gateway failed to proxy. |
| Auth, persona, validation, connection-not-found | `401`/`403`/`400`/`404` | Unchanged; these were already correct. |

The original proposal in the issue (set `IsError = true` on any non-2xx including upstream 4xx/5xx) was rejected in the comment thread for exactly this reason; the implementation is the corrected version.

### 2. Audit log

Audit grows a bounded `error_category` enum populated on every call, independent of `IsError`:

- `ok` (upstream 2xx/3xx)
- `upstream_4xx` (upstream 4xx, gateway succeeded at proxying)
- `upstream_5xx` (upstream 5xx, gateway succeeded at proxying)
- `transport_err` (gateway couldn't reach upstream)
- `upstream_timeout` (gateway timed out waiting for upstream)

`audit_logs.success` is now `false` for any non-`ok` outcome. `audit_logs.error_message` carries the scrubbed transport-error text for gateway failures or the canonical reason phrase (`Not Found`, `Service Unavailable`, etc.) for upstream 4xx/5xx, so the column stays grep-friendly.

### 3. The MCP `CallToolResult.IsError` flag

Only set to `true` for gateway-level failures (`transport_err`, `upstream_timeout`). Upstream 4xx/5xx leave `IsError = false` because the gateway succeeded at proxying. This is what drives the wire-status logic above.

## How the layers communicate

Toolkit → audit middleware coupling stays loose: a new `_meta.audit_outcome` (plus optional `_meta.audit_outcome_message`) is the contract.

- `pkg/observability/status.go` defines the bounded outcome constants and the well-known meta keys (`MetaAuditOutcome`, `MetaAuditOutcomeMessage`).
- `pkg/toolkits/apigateway` stamps these on every `api_invoke_endpoint` result via a new `buildInvokeResult` helper. `ClassifyInvokeOutcome` does the mapping; `auditOutcomeMessage` populates the message (scrubbed transport error for gateway failures, `http.StatusText(out.Status)` for upstream 4xx/5xx).
- `pkg/middleware/mcp_audit.go` reads the meta keys in `buildMCPAuditEvent` and uses them to override the `IsError`-derived success/category. The meta message **replaces** (not just fills) the JSON-blob `errorMessage` the `IsError` branch would otherwise extract, so the audit column carries the concise scrubbed text instead of `{"status":0,"duration_ms":...}`.
- `pkg/gatewayhttp/handler.go` `classifyToolError` gets new cases mapping timeout-shaped messages to 504 and transport-shaped messages to 502, ordered after auth/authz but before the existing `"not found"` pattern so a transport error reading `"no such host"` is not mistaken for a connection-name lookup miss.

## Test plan

- [x] Unit: `ClassifyInvokeOutcome` table tests (every outcome bucket incl. all timeout-signature phrases and all transport-signature phrases).
- [x] Unit: `buildInvokeResult` (every outcome, `IsError` flag set correctly, `_meta` stamped on every call, `http.StatusText` fallback for 4xx/5xx, explicit-`Error`-wins for the partial-body read-failure case).
- [x] Unit: `classifyToolError` (every new pattern + the `no-such-host` / `not-found` collision guard).
- [x] Unit: audit middleware override with a **realistic JSON-envelope Content fixture** so the test exercises production wiring rather than the bare-string fixture that would have given a false positive on the override path (this was a round-1 review finding).
- [x] Integration: end-to-end wire status for happy path, upstream-5xx-stays-200, upstream-timeout to 504 (driven by a deliberately-slow `httptest.Server`), and transport-error to 502 (driven by a closed `httptest.Server` URL).
- [x] `make verify` clean (race tests, coverage ≥80% with new functions at 100%, golangci-lint, gosec, govulncheck, semgrep, CodeQL, doc-check, dead-code, mutation testing, goreleaser dry-run).
- [ ] Post-merge: deploy and verify in a live deployment that audit `error_category` populates correctly for upstream tail latency and that HTTP pipeline clients see 504 for calls that exceed their read timeout (rather than an opaque timeout exception).

## What this PR deliberately does NOT do

- **Does not change `CallTimeout` defaults.** Still 60 s. Operators tune per connection.
- **Does not modify `api_export`.** Its return path is structurally different (errors flow as Go errors → `errorResult`), so it already surfaces gateway-level failures as `IsError = true`. Its audit category won't be as granular as `api_invoke_endpoint`'s after this PR, but bringing parity is a separate cleanup and is mentioned as out-of-scope in the issue.
- **Does not add Prometheus per-category labels.** The new `error_category` could become a label on `mcp_tool_calls_total` (added in #431) for parity with the audit table, but that's a small follow-up best done after this lands.

## Footprint

```
8 files changed, 724 insertions(+), 18 deletions(-)
```

Two review rounds were run pre-commit. Round 1 surfaced 3 substantive findings (audit override never replaced JSON-blob `errorMsg`; test fixture bypassed production Content shape; stale `InvokeOutput` doc) — all fixed before commit. Round 2 surfaced 2 doc-vs-code findings (missing 502/504 in the `NewHandler` enumeration; `InvokeOutput` doc claim "Error is empty" contradicted by the partial-body code path) — both fixed.