### PR TITLE
fix(auth): silence chain fallthrough noise and add request correlation

### DIFF
--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -2,12 +2,61 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 )
+
+// Log-field keys kept local to this package so we don't add a cross-
+// package import just for two string constants. Must match the keys
+// already used by pkg/middleware so operators can grep across the
+// stack consistently.
+const (
+	logKeyRequestID = "request_id"
+	logKeyTool      = "tool"
+)
+
+// correlationFields extracts request_id and tool name from any
+// PlatformContext present in ctx so chained-auth log lines can be
+// correlated with the upstream MCP request. Returns empty strings when
+// no PlatformContext is set (e.g. tools/list visibility filtering,
+// admin REST paths). The slog JSON handler renders empty values as
+// `"request_id":""` rather than omitting the key, which is acceptable
+// for the rare no-PC paths and keeps the call site branch-free.
+func correlationFields(ctx context.Context) (requestID, tool string) {
+	pc := middleware.GetPlatformContext(ctx)
+	if pc == nil {
+		return "", ""
+	}
+	return pc.RequestID, pc.ToolName
+}
+
+// ErrNotAJWT is the sentinel returned by JWT-based authenticators when
+// the supplied credential does not have the structural shape of a JWT
+// (three non-empty dot-separated segments). It is a fallthrough signal,
+// not a security event: the chained authenticator recognizes it and
+// silently advances to the next authenticator without logging.
+var ErrNotAJWT = errors.New("not a JWT")
+
+// LooksLikeJWT returns true when s has the structural shape of a JWT
+// (three non-empty dot-separated segments). This is a cheap pre-check
+// used by JWT-based authenticators to short-circuit non-JWT
+// credentials (e.g. API keys) without invoking the JWT library or
+// surfacing a low-level parse error to operators.
+func LooksLikeJWT(s string) bool {
+	if s == "" {
+		return false
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != jwtPartCount {
+		return false
+	}
+	return !slices.Contains(parts, "")
+}
 
 // ChainedAuthenticator tries multiple authenticators in order.
 type ChainedAuthenticator struct {
@@ -29,22 +78,40 @@ func NewChainedAuthenticator(cfg ChainedAuthConfig, authenticators ...middleware
 }
 
 // Authenticate tries each authenticator in order.
+//
+// An authenticator returning ErrNotAJWT is a structural fallthrough
+// (e.g. JWT authenticator handed an API key) and is NOT logged: it is
+// the chain's normal "this authenticator can't handle this credential
+// type, try the next one" path. Real verification failures (bad
+// signature, wrong issuer, expired token, no matching API key) are
+// logged at DEBUG with correlation context.
+//
+// lastErr tracks the most recent real (non-sentinel) error so a
+// failed-everywhere chain surfaces a meaningful reason instead of the
+// noisy ErrNotAJWT sentinel.
 func (c *ChainedAuthenticator) Authenticate(ctx context.Context) (*middleware.UserInfo, error) {
 	var lastErr error
+	reqID, tool := correlationFields(ctx)
 
 	for i, auth := range c.authenticators {
 		userInfo, err := auth.Authenticate(ctx)
 		if err == nil && userInfo != nil {
 			return userInfo, nil
 		}
-		if err != nil {
-			slog.Debug("chained auth: authenticator rejected",
-				"index", i,
-				"type", fmt.Sprintf("%T", auth),
-				"error", err.Error(),
-			)
-			lastErr = err
+		if err == nil {
+			continue
 		}
+		if errors.Is(err, ErrNotAJWT) {
+			continue
+		}
+		slog.Debug("chained auth: verification failed for this authenticator, trying next",
+			"index", i,
+			"type", fmt.Sprintf("%T", auth),
+			"error", err.Error(),
+			logKeyRequestID, reqID,
+			logKeyTool, tool,
+		)
+		lastErr = err
 	}
 
 	if c.allowAnonymous {

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -178,6 +179,116 @@ func TestAPIKeyExtractor(t *testing.T) {
 		}
 		if token != "api-key-123" {
 			t.Errorf("token = %q", token)
+		}
+	})
+}
+
+func TestLooksLikeJWT(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty", "", false},
+		{"plain api key", "nifi-etl", false},
+		{"hex api key", "abc123def456", false},
+		{"two segments", "header.payload", false},
+		{"three segments empty middle", "header..signature", false},
+		{"three segments empty header", ".payload.signature", false},
+		{"three segments empty signature", "header.payload.", false},
+		{"four segments", "a.b.c.d", false},
+		{"valid three segments", "header.payload.signature", true},
+		// Realistic-shaped JWT (not a real one — we never invoke the JWT
+		// library here, so we don't need valid base64 or signatures).
+		{"realistic shape", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.sig", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := LooksLikeJWT(tc.in)
+			if got != tc.want {
+				t.Errorf("LooksLikeJWT(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestChainedAuthenticator_NotAJWTSentinelFallsThrough(t *testing.T) {
+	// Models the production chain: two JWT-based authenticators that
+	// can't recognize an API key (return ErrNotAJWT) followed by an
+	// API-key authenticator that succeeds. The chain must return the
+	// API-key user without surfacing the JWT sentinel.
+	jwtAuth1 := &mockAuthenticator{err: ErrNotAJWT}
+	jwtAuth2 := &mockAuthenticator{err: fmt.Errorf("invalid token: %w", ErrNotAJWT)}
+	apiKeyAuth := &mockAuthenticator{
+		userInfo: &middleware.UserInfo{UserID: "apikey:svc", AuthType: "apikey"},
+	}
+
+	chained := NewChainedAuthenticator(ChainedAuthConfig{}, jwtAuth1, jwtAuth2, apiKeyAuth)
+
+	userInfo, err := chained.Authenticate(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if userInfo == nil || userInfo.UserID != "apikey:svc" {
+		t.Errorf("UserID = %v, want 'apikey:svc'", userInfo)
+	}
+}
+
+func TestChainedAuthenticator_AllSentinelNoLoudErrors(t *testing.T) {
+	// All authenticators return the not-a-JWT sentinel and no real
+	// authenticator matches: anonymous-disabled chain falls back to
+	// the generic "authentication failed" error rather than leaking
+	// the sentinel as the surface-level error.
+	jwt1 := &mockAuthenticator{err: ErrNotAJWT}
+	jwt2 := &mockAuthenticator{err: fmt.Errorf("invalid token: %w", ErrNotAJWT)}
+
+	chained := NewChainedAuthenticator(ChainedAuthConfig{}, jwt1, jwt2)
+
+	_, err := chained.Authenticate(context.Background())
+	if err == nil {
+		t.Fatal("expected error when all authenticators fall through")
+	}
+	if errors.Is(err, ErrNotAJWT) {
+		t.Errorf("error leaked sentinel ErrNotAJWT: %v", err)
+	}
+}
+
+func TestChainedAuthenticator_RealErrorPreservedAfterSentinel(t *testing.T) {
+	// When a real verification failure follows a sentinel, the chain
+	// should surface the real failure (not the sentinel and not nil)
+	// so operators see the actual reason in the WARN line emitted by
+	// the caller (MCPToolCallMiddleware).
+	jwt1 := &mockAuthenticator{err: ErrNotAJWT}
+	jwt2 := &mockAuthenticator{err: fmt.Errorf("verifying token: bad signature")}
+
+	chained := NewChainedAuthenticator(ChainedAuthConfig{}, jwt1, jwt2)
+
+	_, err := chained.Authenticate(context.Background())
+	if err == nil {
+		t.Fatal("expected error from chain")
+	}
+	if err.Error() != "verifying token: bad signature" {
+		t.Errorf("error = %q, want real verification failure", err.Error())
+	}
+}
+
+func TestCorrelationFields(t *testing.T) {
+	t.Run("no platform context", func(t *testing.T) {
+		reqID, tool := correlationFields(context.Background())
+		if reqID != "" || tool != "" {
+			t.Errorf("got (%q, %q), want empty pair", reqID, tool)
+		}
+	})
+
+	t.Run("platform context populated", func(t *testing.T) {
+		pc := &middleware.PlatformContext{RequestID: "req-abc123", ToolName: "trino_query"}
+		ctx := middleware.WithPlatformContext(context.Background(), pc)
+		reqID, tool := correlationFields(ctx)
+		if reqID != "req-abc123" {
+			t.Errorf("reqID = %q, want 'req-abc123'", reqID)
+		}
+		if tool != "trino_query" {
+			t.Errorf("tool = %q, want 'trino_query'", tool)
 		}
 	})
 }

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -104,7 +104,15 @@ func (a *OAuthJWTAuthenticator) Authenticate(ctx context.Context) (*middleware.U
 }
 
 // parseAndValidateToken parses and validates the JWT.
+//
+// Returns ErrNotAJWT (unwrapped) when the credential clearly isn't a
+// JWT, so ChainedAuthenticator can silently fall through to the next
+// authenticator without logging a misleading "rejected" line for what
+// is actually a normal API-key-handed-to-JWT-authenticator path.
 func (a *OAuthJWTAuthenticator) parseAndValidateToken(tokenString string) (map[string]any, error) {
+	if !LooksLikeJWT(tokenString) {
+		return nil, ErrNotAJWT
+	}
 	// Parse and verify the JWT signature
 	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (any, error) {
 		// Validate the algorithm is HMAC

--- a/pkg/auth/oauth_test.go
+++ b/pkg/auth/oauth_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -154,6 +155,19 @@ func TestOAuthJWTAuthenticator_Authenticate_EdgeCases(t *testing.T) {
 		_, err := authenticator.Authenticate(ctx)
 		if err == nil {
 			t.Error("expected error for invalid token format")
+		}
+	})
+
+	t.Run("api-key-shaped credential returns ErrNotAJWT sentinel", func(t *testing.T) {
+		// The chain hands every credential to every authenticator. An
+		// API key has zero dots and must surface as the sentinel so
+		// ChainedAuthenticator can fall through silently instead of
+		// logging "rejected" for what is a normal credential-type
+		// mismatch.
+		ctx := WithToken(context.Background(), "nifi-etl")
+		_, err := authenticator.Authenticate(ctx)
+		if !errors.Is(err, ErrNotAJWT) {
+			t.Errorf("err = %v, want ErrNotAJWT", err)
 		}
 	})
 

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -136,7 +136,16 @@ func (a *OIDCAuthenticator) Authenticate(ctx context.Context) (*middleware.UserI
 }
 
 // parseAndValidateToken parses and validates a JWT with signature verification.
+//
+// Returns ErrNotAJWT (unwrapped) when the credential clearly isn't a
+// JWT, so ChainedAuthenticator can silently fall through to the next
+// authenticator without logging a misleading "rejected" line for what
+// is actually a normal API-key-handed-to-JWT-authenticator path.
 func (a *OIDCAuthenticator) parseAndValidateToken(tokenString string) (map[string]any, error) {
+	if !LooksLikeJWT(tokenString) {
+		return nil, ErrNotAJWT
+	}
+
 	// If signature verification is disabled (testing only), use legacy parsing
 	if a.cfg.SkipSignatureVerification {
 		return a.parseTokenWithoutSignatureVerification(tokenString)

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
@@ -112,6 +113,35 @@ func TestOIDCAuthenticator_Authenticate(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for invalid JWT format")
 		}
+	})
+
+	t.Run("api-key-shaped credential returns ErrNotAJWT sentinel", func(t *testing.T) {
+		// Same chain-fallthrough contract as the OAuth JWT
+		// authenticator: a zero-dot credential (API key) must surface
+		// as the sentinel so ChainedAuthenticator can advance silently.
+		// Verified in skip-signature mode AND in verifying mode so the
+		// shape-check short-circuit runs before either branch.
+		t.Run("skip signature mode", func(t *testing.T) {
+			auth, _ := NewOIDCAuthenticator(OIDCConfig{
+				Issuer:                    "https://issuer.example.com",
+				SkipSignatureVerification: true,
+			})
+			ctx := WithToken(context.Background(), "nifi-etl")
+			_, err := auth.Authenticate(ctx)
+			if !errors.Is(err, ErrNotAJWT) {
+				t.Errorf("err = %v, want ErrNotAJWT", err)
+			}
+		})
+		t.Run("verifying mode", func(t *testing.T) {
+			auth, _ := NewOIDCAuthenticator(OIDCConfig{
+				Issuer: "https://issuer.example.com",
+			})
+			ctx := WithToken(context.Background(), "nifi-etl")
+			_, err := auth.Authenticate(ctx)
+			if !errors.Is(err, ErrNotAJWT) {
+				t.Errorf("err = %v, want ErrNotAJWT", err)
+			}
+		})
 	})
 
 	t.Run("invalid issuer", func(t *testing.T) {

--- a/pkg/middleware/mcp.go
+++ b/pkg/middleware/mcp.go
@@ -171,21 +171,23 @@ func populateToolkitMetadata(pc *PlatformContext, lookup ToolkitLookup, toolName
 // Streamable HTTP provides headers in RequestExtra on every POST.
 // MCPAuthGateway also bridges tokens at the HTTP level so they propagate via
 // the connection context; this function acts as a fallback.
+//
+// Intentionally silent on the no-op paths (token already present, no
+// extra headers, no token in headers). Those fire on every request and
+// produced uncorrelated noise that drowned out the audit trail; the
+// downstream authenticator emits "no token found in context" when the
+// outcome actually matters.
 func bridgeAuthToken(ctx context.Context, req mcp.Request) context.Context {
 	if GetToken(ctx) != "" {
-		slog.Debug("bridgeAuthToken: token already in context")
 		return ctx
 	}
 	extra := req.GetExtra()
 	if extra == nil || extra.Header == nil {
-		slog.Debug("bridgeAuthToken: no extra headers in request")
 		return ctx
 	}
 	if token := extractBearerOrAPIKey(extra.Header); token != "" {
-		slog.Debug("bridgeAuthToken: extracted token from request headers")
 		return WithToken(ctx, token)
 	}
-	slog.Debug("bridgeAuthToken: no token in request headers")
 	return ctx
 }
 


### PR DESCRIPTION
## Summary

The auth chain (`OAuthJWT` -> `OIDC` -> `APIKey`) emitted DEBUG lines on every API-key tool call that read like a security incident but were actually expected fallthrough behavior. Operators had no way to correlate those lines with the originating MCP request: `bridgeAuthToken` and the chain itself logged with zero `request_id`, `user_id`, or `tool` context.

This PR is a logging-only fix. No authentication semantics change.

## What operators were seeing

Real log fragment from a healthy `api_invoke_endpoint` call authenticated via the `nifi-etl` API key:

```
DEBUG tool call authorized tool=api_invoke_endpoint user_id=apikey:nifi-etl email=nifi-etl@apikey.local roles=[dp_etl] persona=etl-service auth_type=apikey request_id=req-1432cb7d...
DEBUG bridgeAuthToken: token already in context
DEBUG chained auth: authenticator rejected index=0 type=*auth.OAuthJWTAuthenticator error="invalid token: parsing token: token is malformed: token contains an invalid number of segments"
DEBUG chained auth: authenticator rejected index=1 type=*auth.OIDCAuthenticator error="invalid token: verifying token: token is malformed: token contains an invalid number of segments"
```

Reasonable reading of those last two lines: "an unparseable token reached two authenticators and was rejected." Actual mechanism: an API key (zero dots) was handed to two JWT-based authenticators (which require `header.payload.signature`); the chain advanced to the API-key authenticator (third in the chain), which matched and returned a user. Authentication succeeded. The noise was the JWT library's parse error bubbling up through the chain's "trying the next authenticator" path.

## Changes

### 1. `ErrNotAJWT` sentinel + `LooksLikeJWT` structural pre-check

`pkg/auth/middleware.go`

- New exported sentinel `ErrNotAJWT` and helper `LooksLikeJWT(s string) bool` (three non-empty dot-separated segments). Reuses the existing `jwtPartCount` constant.
- `OAuthJWTAuthenticator.parseAndValidateToken` and `OIDCAuthenticator.parseAndValidateToken` short-circuit with `ErrNotAJWT` before invoking `jwt.Parse`, so a non-JWT credential never produces a misleading library parse error.
- Returns are unwrapped sentinel; `Authenticate` then wraps with `%w` (`"invalid token: %w"`), so `errors.Is(err, ErrNotAJWT)` matches transitively at the chain.

### 2. `ChainedAuthenticator` recognizes the sentinel and adds correlation

`pkg/auth/middleware.go`

- Errors that match `errors.Is(err, ErrNotAJWT)` are silently skipped: structural fallthrough is not a security event and is not logged.
- Real verification failures (bad signature, wrong issuer, expired token, no matching API key) are still logged at DEBUG, now with `request_id` and `tool` pulled from `PlatformContext` via a new `correlationFields` helper.
- Message reworded from `"chained auth: authenticator rejected"` to `"chained auth: verification failed for this authenticator, trying next"` so the language matches the actual semantics (`pkg/auth/middleware.go:107`).
- `lastErr` skips sentinel errors, so a failed-everywhere chain surfaces a meaningful reason instead of leaking the sentinel string.

### 3. `bridgeAuthToken` no longer emits per-request DEBUG noise

`pkg/middleware/mcp.go`

- Deleted four DEBUG lines: `"token already in context"`, `"no extra headers in request"`, `"extracted token from request headers"`, `"no token in request headers"`. Every one of them fired on every request with no correlation.
- The downstream authenticator already emits `"no token found in context"` when the outcome actually matters, so the diagnostic signal is preserved without the per-call noise.

## What the same call now logs

```
DEBUG tool call authorized tool=api_invoke_endpoint user_id=apikey:nifi-etl ... request_id=req-1432cb7d...
```

Real verification failures still surface, now correlated:

```
DEBUG chained auth: verification failed for this authenticator, trying next index=0 type=*auth.OAuthJWTAuthenticator error="invalid token: verifying token: signature is invalid" request_id=req-abc tool=trino_query
```

## Security posture

Unchanged. Verified by reading the chain:

1. `ChainedAuthenticator.Authenticate` (`pkg/auth/middleware.go:95`) iterates authenticators in order, returning the first successful `UserInfo`.
2. Non-sentinel errors are recorded as `lastErr` (now also logged with correlation); sentinel errors are silent fallthrough.
3. After the loop, if no authenticator succeeded and `AllowAnonymous` is false (default), the chain returns `lastErr` or `"authentication failed"`.
4. `authenticateAndAuthorize` (`pkg/middleware/mcp.go:222-228`) then emits a WARN `"tool call authentication failed"` and short-circuits to a categorized error result. No tool runs. The auth gate holds.

A bogus token still results in no access. The only thing that changed is what gets logged on the success path.

## Tests

New tests in `pkg/auth/`:

| Test | What it proves |
|---|---|
| `TestLooksLikeJWT` (10 cases) | Structural classifier matches expected shape rules |
| `TestChainedAuthenticator_NotAJWTSentinelFallsThrough` | Chain advances silently from sentinel-returning authenticator to a real-matching one |
| `TestChainedAuthenticator_AllSentinelNoLoudErrors` | All-sentinel failure does not leak the sentinel string as the surface error |
| `TestChainedAuthenticator_RealErrorPreservedAfterSentinel` | A real signature failure following a sentinel surfaces as `lastErr` (sentinel is correctly skipped, not overwritten) |
| `TestCorrelationFields` | Returns empty pair when no `PlatformContext`; returns `RequestID`/`ToolName` when populated |
| `TestOAuthJWTAuthenticator_Authenticate_EdgeCases/api-key-shaped credential returns ErrNotAJWT sentinel` | OAuth path returns sentinel for non-JWT input |
| `TestOIDCAuthenticator_Authenticate/api-key-shaped credential returns ErrNotAJWT sentinel` (skip-signature + verifying subtests) | OIDC path returns sentinel for non-JWT input in both signature modes |

Coverage on new code:
- `LooksLikeJWT`: 100%
- `correlationFields`: 100%
- `ChainedAuthenticator.Authenticate`: 94.1%

## Test plan

- [x] `make verify` clean (tools-check, fmt, race tests, total + patch coverage >= 80%, lint, gosec, govulncheck, semgrep, codeql, doc-check, dead-code, mutation >= 60%, goreleaser dry-run)
- [x] Auth + middleware unit tests pass with `-race`
- [ ] Deploy and confirm `api_invoke_endpoint` via API key produces only the `tool call authorized` DEBUG line (no `bridgeAuthToken`, no `chained auth: authenticator rejected`)
- [ ] Confirm a real OIDC token with a bad signature still produces a DEBUG line carrying `request_id` and `tool`