### PR TITLE
fix(embedding): use Ollama batch /api/embed with 404 fallback

### DIFF
--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -693,6 +693,9 @@ memory:
 !!! note "Prerequisites"
     Memory requires `database.dsn` to be configured and the pgvector PostgreSQL extension installed. Memory tools are opt-in per persona (`memory_*` in `tools.allow`).
 
+!!! note "Ollama batch endpoint"
+    Batch embedding calls (API gateway spec indexing) issue a single `POST /api/embed` request per batch against modern Ollama servers. Servers that lack the batch endpoint (response: HTTP 404) are detected on the first call; the platform logs a WARN and transparently falls back to one `POST /api/embeddings` request per text. Upgrading the Ollama server is recommended for substantially faster batch indexing on multi-spec catalogs. Memory writes embed one record at a time and always use `/api/embeddings`.
+
 ## MCP Apps Configuration
 
 MCP Apps provide interactive UI components that enhance tool results. The platform provides the infrastructure; you provide the HTML/JS/CSS apps.

--- a/pkg/embedding/ollama.go
+++ b/pkg/embedding/ollama.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
+	"sync/atomic"
 	"time"
 )
 
@@ -21,11 +23,20 @@ type OllamaConfig struct {
 const maxErrorBodyBytes = 4096
 
 // ollamaProvider generates embeddings via the Ollama API.
+//
+// batchUnsupported records whether the connected Ollama server returns
+// 404 for the batch endpoint (/api/embed, added in modern Ollama
+// releases). Once set, EmbedBatch skips the batch attempt and falls
+// straight back to N sequential /api/embeddings calls. Stored as an
+// atomic so the worker can call EmbedBatch concurrently without a
+// mutex; the worst case on first concurrent call against an old server
+// is a small number of redundant 404 hits before the flag settles.
 type ollamaProvider struct {
-	client *http.Client
-	url    string
-	model  string
-	dim    int
+	client           *http.Client
+	url              string
+	model            string
+	dim              int
+	batchUnsupported atomic.Bool
 }
 
 // NewOllamaProvider creates an embedding provider that calls Ollama.
@@ -57,6 +68,24 @@ type ollamaRequest struct {
 // ollamaResponse is the JSON body returned from Ollama's /api/embeddings endpoint.
 type ollamaResponse struct {
 	Embedding []float64 `json:"embedding"`
+}
+
+// ollamaBatchRequest is the JSON body sent to Ollama's batch /api/embed
+// endpoint. Note the field name shift: the singular endpoint uses
+// "prompt" with a string value, the batch endpoint uses "input" with
+// either a string OR an array of strings. We always send the array
+// form so a one-element batch and an N-element batch take the same
+// code path.
+type ollamaBatchRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+// ollamaBatchResponse is the JSON body returned from Ollama's batch
+// /api/embed endpoint. The vectors come back in the same order as the
+// input array.
+type ollamaBatchResponse struct {
+	Embeddings [][]float64 `json:"embeddings"`
 }
 
 // Embed generates an embedding for a single text input.
@@ -94,8 +123,84 @@ func (o *ollamaProvider) Embed(ctx context.Context, text string) ([]float32, err
 	return toFloat32(result.Embedding), nil
 }
 
-// EmbedBatch generates embeddings for multiple text inputs.
+// EmbedBatch generates embeddings for multiple text inputs in a single
+// HTTP call against Ollama's batch /api/embed endpoint. On servers
+// that predate the batch endpoint (HTTP 404), it transparently falls
+// back to N sequential /api/embeddings calls and records the
+// fallback so subsequent batches skip the batch attempt.
+//
+// The fallback path matches the prior (pre-fix) behavior exactly so
+// older Ollama deployments keep working unmodified; the win is that
+// modern deployments stop paying N round-trips per batch.
 func (o *ollamaProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	if o.batchUnsupported.Load() {
+		return o.embedBatchSequential(ctx, texts)
+	}
+	results, fallback, err := o.embedBatchOnce(ctx, texts)
+	if fallback {
+		return o.embedBatchSequential(ctx, texts)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// embedBatchOnce makes a single POST to /api/embed. Returns
+// (results, false, nil) on success, (nil, true, nil) when the batch
+// endpoint is unavailable on this server (caller should fall back),
+// and (nil, false, err) for any other failure.
+func (o *ollamaProvider) embedBatchOnce(ctx context.Context, texts []string) (results [][]float32, fallback bool, err error) {
+	body, err := json.Marshal(ollamaBatchRequest{Model: o.model, Input: texts})
+	if err != nil {
+		return nil, false, fmt.Errorf("marshaling batch request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.url+"/api/embed", bytes.NewReader(body))
+	if err != nil {
+		return nil, false, fmt.Errorf("creating batch request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return nil, false, fmt.Errorf("calling Ollama batch embed API: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup
+
+	if resp.StatusCode == http.StatusNotFound {
+		o.batchUnsupported.Store(true)
+		slog.Warn("ollama: /api/embed not available, falling back to sequential /api/embeddings calls (recommend upgrading the ollama server for substantially faster batch embedding)",
+			"url", o.url, "model", o.model,
+		)
+		return nil, true, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		return nil, false, fmt.Errorf("ollama batch API returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result ollamaBatchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, false, fmt.Errorf("decoding Ollama batch response: %w", err)
+	}
+	if len(result.Embeddings) != len(texts) {
+		return nil, false, fmt.Errorf("ollama batch returned %d embeddings for %d inputs", len(result.Embeddings), len(texts))
+	}
+
+	results = make([][]float32, len(result.Embeddings))
+	for i, emb := range result.Embeddings {
+		results[i] = toFloat32(emb)
+	}
+	return results, false, nil
+}
+
+// embedBatchSequential is the pre-fix code path: N round-trips to
+// /api/embeddings. Used as the 404 fallback for older Ollama servers
+// that lack the batch endpoint.
+func (o *ollamaProvider) embedBatchSequential(ctx context.Context, texts []string) ([][]float32, error) {
 	results := make([][]float32, len(texts))
 	for i, text := range texts {
 		emb, err := o.Embed(ctx, text)

--- a/pkg/embedding/ollama_test.go
+++ b/pkg/embedding/ollama_test.go
@@ -151,52 +151,162 @@ func TestOllamaProvider_Embed_CancelledContext(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestOllamaProvider_EmbedBatch_Success(t *testing.T) {
+func TestOllamaProvider_EmbedBatch_BatchEndpoint_SingleHTTPCall(t *testing.T) {
 	t.Parallel()
 
-	callCount := 0
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		callCount++
-		resp := ollamaResponse{Embedding: []float64{float64(callCount), 0.0}}
+	var (
+		batchCallCount    int
+		singularCallCount int
+		gotInput          []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embed":
+			batchCallCount++
+			var req ollamaBatchRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			gotInput = req.Input
+			out := ollamaBatchResponse{
+				Embeddings: make([][]float64, len(req.Input)),
+			}
+			for i := range req.Input {
+				out.Embeddings[i] = []float64{float64(i + 1), 0.0}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(out))
+		case "/api/embeddings":
+			singularCallCount++
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := NewOllamaProvider(OllamaConfig{URL: srv.URL, Model: "test-model"})
+
+	results, err := p.EmbedBatch(context.Background(), []string{"a", "b", "c"})
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+	assert.Equal(t, 1, batchCallCount, "EmbedBatch must make exactly one HTTP call against /api/embed for N texts")
+	assert.Zero(t, singularCallCount, "must not fall back to /api/embeddings on the happy path")
+	assert.Equal(t, []string{"a", "b", "c"}, gotInput)
+	assert.InDelta(t, float32(1.0), results[0][0], 0.0001)
+	assert.InDelta(t, float32(2.0), results[1][0], 0.0001)
+	assert.InDelta(t, float32(3.0), results[2][0], 0.0001)
+}
+
+func TestOllamaProvider_EmbedBatch_FallbackOn404(t *testing.T) {
+	t.Parallel()
+
+	var (
+		batchCallCount    int
+		singularCallCount int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embed":
+			batchCallCount++
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("404 page not found"))
+		case "/api/embeddings":
+			singularCallCount++
+			resp := ollamaResponse{Embedding: []float64{float64(singularCallCount)}}
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(resp))
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	p := NewOllamaProvider(OllamaConfig{URL: srv.URL})
+
+	// First EmbedBatch: try /api/embed (404), fall back to /api/embeddings sequential.
+	results, err := p.EmbedBatch(context.Background(), []string{"a", "b", "c"})
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+	assert.Equal(t, 1, batchCallCount, "first call probes /api/embed once")
+	assert.Equal(t, 3, singularCallCount, "fallback issues one /api/embeddings per text")
+
+	// Second EmbedBatch: must NOT re-probe /api/embed; goes straight to sequential.
+	results2, err := p.EmbedBatch(context.Background(), []string{"d", "e"})
+	require.NoError(t, err)
+	require.Len(t, results2, 2)
+	assert.Equal(t, 1, batchCallCount, "second call must skip /api/embed entirely")
+	assert.Equal(t, 5, singularCallCount, "second call adds two more /api/embeddings calls")
+}
+
+func TestOllamaProvider_EmbedBatch_FallbackPropagatesSequentialError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embed":
+			w.WriteHeader(http.StatusNotFound)
+		case "/api/embeddings":
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("bad request"))
+		}
+	}))
+	defer srv.Close()
+
+	p := NewOllamaProvider(OllamaConfig{URL: srv.URL})
+
+	results, err := p.EmbedBatch(context.Background(), []string{"x", "y"})
+	assert.Nil(t, results)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "embedding text[0]")
+}
+
+func TestOllamaProvider_EmbedBatch_LengthMismatch(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/embed", r.URL.Path)
+		// Protocol violation: server returns only 1 embedding for 3 inputs.
 		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(resp))
+		require.NoError(t, json.NewEncoder(w).Encode(ollamaBatchResponse{
+			Embeddings: [][]float64{{1.0, 2.0}},
+		}))
 	}))
 	defer srv.Close()
 
 	p := NewOllamaProvider(OllamaConfig{URL: srv.URL})
 
 	results, err := p.EmbedBatch(context.Background(), []string{"a", "b", "c"})
-	require.NoError(t, err)
-	require.Len(t, results, 3)
-	// Each call increments, so first embedding starts with 1.0
-	assert.InDelta(t, float32(1.0), results[0][0], 0.0001)
-	assert.InDelta(t, float32(2.0), results[1][0], 0.0001)
-	assert.InDelta(t, float32(3.0), results[2][0], 0.0001)
+	assert.Nil(t, results)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "returned 1 embeddings for 3 inputs")
 }
 
-func TestOllamaProvider_EmbedBatch_ErrorOnSecond(t *testing.T) {
+func TestOllamaProvider_EmbedBatch_BatchEndpoint_Non200NotFallback(t *testing.T) {
 	t.Parallel()
 
-	callCount := 0
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		callCount++
-		if callCount == 2 {
-			w.WriteHeader(http.StatusBadRequest)
-			_, _ = w.Write([]byte("bad request"))
-			return
+	var (
+		batchCallCount    int
+		singularCallCount int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embed":
+			batchCallCount++
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("model not loaded"))
+		case "/api/embeddings":
+			singularCallCount++
 		}
-		resp := ollamaResponse{Embedding: []float64{1.0}}
-		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(resp))
 	}))
 	defer srv.Close()
 
 	p := NewOllamaProvider(OllamaConfig{URL: srv.URL})
 
-	results, err := p.EmbedBatch(context.Background(), []string{"ok", "fail", "ok"})
+	results, err := p.EmbedBatch(context.Background(), []string{"a", "b"})
 	assert.Nil(t, results)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "embedding text[1]")
+	assert.Contains(t, err.Error(), "status 500")
+	assert.Equal(t, 1, batchCallCount)
+	assert.Zero(t, singularCallCount, "non-404 batch errors must not trigger sequential fallback")
 }
 
 func TestOllamaProvider_EmbedBatch_Empty(t *testing.T) {


### PR DESCRIPTION
Closes the slow half of #430.

## Background

`ollamaProvider.EmbedBatch` was named "batch" but did not batch. It issued one `POST /api/embeddings` per text in a sequential loop, paying a full HTTP round-trip and a separate model invocation for every input. On a CPU-only Ollama deployment, a 164-operation API gateway spec took ~10 minutes to index for that reason.

The actual Ollama batch endpoint is `POST /api/embed` (note: singular path, plural `input` field). It accepts the full array of texts in one request and returns the corresponding array of vectors. This PR switches `EmbedBatch` to use it, with a transparent fallback for servers that predate the endpoint.

## What ships

### One HTTP call per batch on modern Ollama

`EmbedBatch` now posts once to `/api/embed`:

```go
type ollamaBatchRequest struct {
    Model string   `json:""model""`
    Input []string `json:""input""`
}
```

Decodes:

```go
type ollamaBatchResponse struct {
    Embeddings [][]float64 `json:""embeddings""`
}
```

Verifies the returned count matches the input count (protocol violation if not). Empty input short-circuits with no HTTP call at all.

### Atomic 404 fallback for older Ollama

A new `atomic.Bool` on the provider records whether the connected server returned 404 for `/api/embed`. When it does:

1. The flag is set.
2. One WARN is logged with the URL and model: `"ollama: /api/embed not available, falling back to sequential /api/embeddings calls (recommend upgrading the ollama server for substantially faster batch embedding)"`.
3. The call falls through to N sequential `/api/embeddings` POSTs (the previous behavior, kept verbatim as `embedBatchSequential`).

Every subsequent `EmbedBatch` call on the same provider checks the flag first and goes straight to the sequential path. The probe is paid at most once per provider lifetime.

Non-404 errors from `/api/embed` (500, malformed JSON, length mismatch, etc.) are NOT fallback triggers. They surface as hard errors so a misconfigured server is not silently masked by the sequential path.

### What is NOT changed

- `Embed` (singular) still posts to `/api/embeddings` as before. Memory writes embed one record at a time and continue to use that path. No memory-side behavior change.
- The progress-visibility and worker-concurrency halves of #430 are still open. They each require a migration and config surface that warrant their own PRs.

## Performance impact

For the typical multi-spec catalog with N operations indexed per worker pass:

| | Before | After (modern Ollama) | After (old Ollama 404 path) |
|---|---|---|---|
| HTTP round-trips per batch of 32 | 32 | 1 | 32 (same as before) |
| Worst-case 164-op spec on CPU Ollama | ~10 min | dominated by model inference, not RTT | ~10 min (unchanged) |

The exact wall-clock win on modern Ollama depends on whether the server batches the inference internally; the elimination of 31 of every 32 HTTP round-trips is the floor.

## Tests

Replaced the two pre-fix `EmbedBatch` tests (they exercised the old sequential contract) with five that match the new behavior. Every test asserts on call counts per path so a future regression would fail loudly.

| Test | Asserts |
|---|---|
| `TestOllamaProvider_EmbedBatch_BatchEndpoint_SingleHTTPCall` | Exactly one POST to `/api/embed` for N=3 texts; zero hits on `/api/embeddings` |
| `TestOllamaProvider_EmbedBatch_FallbackOn404` | First call probes `/api/embed` once, falls back to 3 sequential `/api/embeddings` calls; second `EmbedBatch` call skips the probe entirely (1 batch + 5 singular over both calls) |
| `TestOllamaProvider_EmbedBatch_FallbackPropagatesSequentialError` | A 400 from `/api/embeddings` during the fallback path surfaces as `embedding text[i]: ...` |
| `TestOllamaProvider_EmbedBatch_LengthMismatch` | Server returns fewer embeddings than inputs: `returned N embeddings for M inputs` |
| `TestOllamaProvider_EmbedBatch_BatchEndpoint_Non200NotFallback` | 500 from `/api/embed` is a hard error; no fallback to `/api/embeddings` |
| `TestOllamaProvider_EmbedBatch_Empty` | Empty input returns without an HTTP call |

Coverage on the new code: `EmbedBatch` 100%, `embedBatchSequential` 100%, `embedBatchOnce` 85.2% (the uncovered lines are the `json.Marshal` and `http.NewRequestWithContext` error paths, which require dependency injection to trigger).

## Docs

`docs/server/configuration.md` Memory Layer section gains an admonition that:

- Spec indexing uses `/api/embed` on modern Ollama.
- Servers returning 404 are detected, WARN-logged, and transparently fall back.
- Memory writes are one-record-at-a-time and always use `/api/embeddings`.

## Test plan

- [x] `make verify` clean (tools-check, fmt, race tests, total + patch coverage >= 80%, lint, gosec, govulncheck, semgrep, codeql, doc-check, dead-code, mutation >= 60%, goreleaser dry-run)
- [x] All six `EmbedBatch_*` tests pass under `-race`
- [ ] Deploy to a cluster running an Ollama instance with `/api/embed` available; trigger a spec re-index; confirm exactly one outbound HTTP call per batch in the Ollama access log and a substantial wall-clock drop versus the pre-fix path
- [ ] Verify a single one-time WARN appears if pointed at an older Ollama and subsequent batches stay quiet (no repeated WARNs)