### PR TITLE
fix(embedding): refuse to persist zero vectors under noop provider (#429)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2621,6 +2621,7 @@ The legacy `connection_instances.config.openapi_spec` JSONB key is no longer rea
 | `GET`  | `/api/v1/admin/api-catalogs/{id}/embedding-health` | Catalog-level roll-up (total / indexed / pending / running / failed) |
 | `GET`  | `/api/v1/admin/api-catalogs/{id}/embedding-status` | Per-spec embedding state (operation_count, embedding_count, last job state) |
 | `GET`  | `/api/v1/admin/api-catalogs/{id}/embedding-jobs` | Recent embedding job history (filterable by status / spec_name) |
+| `GET`  | `/api/v1/admin/embedding/status` | Platform-wide embedding provider status: `{kind, model, dimension, status}`. `status="unconfigured"` indicates the noop placeholder is in use (memory.embedding.provider unset); the portal renders an amber banner in this state and the apigateway embed-job queue refuses to start. |
 | `DELETE` | `/api/v1/admin/api-catalogs/{id}/specs/{spec}` | Delete one spec |
 
 ### Persisted operation embeddings + job queue

--- a/docs/memory/configuration.md
+++ b/docs/memory/configuration.md
@@ -24,7 +24,7 @@ memory:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `enabled` | bool | `true` (when database available) | Enable the memory layer. Set `false` to explicitly disable. |
-| `embedding.provider` | string | `noop` | Embedding provider: `ollama` for real embeddings, `noop` for zero vectors |
+| `embedding.provider` | string | `noop` | Embedding provider: `ollama` for real embeddings. Anything else (including unset) selects the noop placeholder; memory writes persist with `Embedding: nil` and the apigateway embed-job queue refuses to start. Semantic features stay off until a real provider is wired. |
 | `embedding.ollama.url` | string | `http://localhost:11434` | Ollama API base URL |
 | `embedding.ollama.model` | string | `nomic-embed-text` | Ollama model name (768-dim) |
 | `embedding.ollama.timeout` | duration | `30s` | HTTP timeout for embedding API calls |
@@ -55,6 +55,18 @@ personas:
 The memory layer generates 768-dimensional embeddings for semantic search using [Ollama](https://ollama.ai/) with the `nomic-embed-text` model.
 
 When Ollama is unavailable, memory records are stored without embeddings and a warning is logged. Semantic recall (`memory_recall` with `semantic` or `auto` strategy) requires embeddings to function. Entity and graph recall strategies work without embeddings.
+
+### Unconfigured State
+
+When `memory.embedding.provider` is unset or unrecognized, the platform substitutes a noop placeholder that returns zero vectors. This is the documented degraded state, not an error: the platform still boots so Trino, S3, DataHub, audit, OAuth, and every other non-embedding feature remains available.
+
+In this state:
+
+- Startup logs one `WARN` line naming `memory.embedding.provider` as the key to set.
+- `GET /api/v1/admin/embedding/status` returns `{ "kind": "noop", "status": "unconfigured", ... }`.
+- The portal renders an amber banner on the API Catalogs and Memory pages.
+- Memory writes persist `Embedding: nil` (symmetric with the recall-side guard that refuses to vector-search zero vectors).
+- The apigateway embed-job queue does not start, so spec saves do not produce zero-vector rows in `api_catalog_operation_embeddings`. Per-spec badges render "not indexed" honestly; `api_list_endpoints` falls back to lexical scoring.
 
 To set up Ollama:
 

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -1432,6 +1432,34 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/embedding/status": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the configured embedding provider's kind, model, dimension, and a status enum (ok / unconfigured). Used by the portal to surface a banner when semantic features are disabled.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System"
+                ],
+                "summary": "Get embedding provider status",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.embeddingProviderStatusResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/gateway/connections/{name}/enrichment-rules": {
             "get": {
                 "security": [
@@ -7119,6 +7147,31 @@ const docTemplate = `{
                 },
                 "id": {
                     "type": "string"
+                }
+            }
+        },
+        "admin.embeddingProviderStatusResponse": {
+            "type": "object",
+            "properties": {
+                "dimension": {
+                    "description": "Dimension is the embedding vector length.",
+                    "type": "integer",
+                    "example": 768
+                },
+                "kind": {
+                    "description": "Kind is the provider implementation identifier: \"ollama\", \"noop\",\nor a future kind. Empty string when no provider was wired.",
+                    "type": "string",
+                    "example": "ollama"
+                },
+                "model": {
+                    "description": "Model identifies the underlying embedding model when the provider\nexposes it (e.g., \"nomic-embed-text\" for Ollama). Empty for\nproviders whose backend has no model concept (noop).",
+                    "type": "string",
+                    "example": "nomic-embed-text"
+                },
+                "status": {
+                    "description": "Status is the operator-visible health enum:\n  - \"ok\": a real provider is configured; semantic features active.\n  - \"unconfigured\": no provider configured (or noop placeholder).\n    Semantic ranking falls back to lexical; memory writes persist\n    with Embedding: nil.",
+                    "type": "string",
+                    "example": "ok"
                 }
             }
         },

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -1426,6 +1426,34 @@
                 }
             }
         },
+        "/admin/embedding/status": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the configured embedding provider's kind, model, dimension, and a status enum (ok / unconfigured). Used by the portal to surface a banner when semantic features are disabled.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System"
+                ],
+                "summary": "Get embedding provider status",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.embeddingProviderStatusResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/gateway/connections/{name}/enrichment-rules": {
             "get": {
                 "security": [
@@ -7113,6 +7141,31 @@
                 },
                 "id": {
                     "type": "string"
+                }
+            }
+        },
+        "admin.embeddingProviderStatusResponse": {
+            "type": "object",
+            "properties": {
+                "dimension": {
+                    "description": "Dimension is the embedding vector length.",
+                    "type": "integer",
+                    "example": 768
+                },
+                "kind": {
+                    "description": "Kind is the provider implementation identifier: \"ollama\", \"noop\",\nor a future kind. Empty string when no provider was wired.",
+                    "type": "string",
+                    "example": "ollama"
+                },
+                "model": {
+                    "description": "Model identifies the underlying embedding model when the provider\nexposes it (e.g., \"nomic-embed-text\" for Ollama). Empty for\nproviders whose backend has no model concept (noop).",
+                    "type": "string",
+                    "example": "nomic-embed-text"
+                },
+                "status": {
+                    "description": "Status is the operator-visible health enum:\n  - \"ok\": a real provider is configured; semantic features active.\n  - \"unconfigured\": no provider configured (or noop placeholder).\n    Semantic ranking falls back to lexical; memory writes persist\n    with Embedding: nil.",
+                    "type": "string",
+                    "example": "ok"
                 }
             }
         },

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -293,6 +293,35 @@ definitions:
       id:
         type: string
     type: object
+  admin.embeddingProviderStatusResponse:
+    properties:
+      dimension:
+        description: Dimension is the embedding vector length.
+        example: 768
+        type: integer
+      kind:
+        description: |-
+          Kind is the provider implementation identifier: "ollama", "noop",
+          or a future kind. Empty string when no provider was wired.
+        example: ollama
+        type: string
+      model:
+        description: |-
+          Model identifies the underlying embedding model when the provider
+          exposes it (e.g., "nomic-embed-text" for Ollama). Empty for
+          providers whose backend has no model concept (noop).
+        example: nomic-embed-text
+        type: string
+      status:
+        description: |-
+          Status is the operator-visible health enum:
+            - "ok": a real provider is configured; semantic features active.
+            - "unconfigured": no provider configured (or noop placeholder).
+              Semantic ranking falls back to lexical; memory writes persist
+              with Embedding: nil.
+        example: ok
+        type: string
+    type: object
   admin.enrichmentRuleBody:
     properties:
       description:
@@ -3304,6 +3333,24 @@ paths:
       summary: Bulk OAuth health for all connections
       tags:
       - Connections
+  /admin/embedding/status:
+    get:
+      description: Returns the configured embedding provider's kind, model, dimension,
+        and a status enum (ok / unconfigured). Used by the portal to surface a banner
+        when semantic features are disabled.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/admin.embeddingProviderStatusResponse'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Get embedding provider status
+      tags:
+      - System
   /admin/gateway/connections/{name}/enrichment-rules:
     get:
       parameters:

--- a/pkg/admin/embedding.go
+++ b/pkg/admin/embedding.go
@@ -1,0 +1,75 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
+)
+
+// embeddingProviderStatusResponse is returned by GET /admin/embedding/status.
+// Reports which embedding provider is wired and whether it can produce
+// real vectors. The portal renders the unconfigured state as a banner
+// on the Catalogs and Memory panels so operators see the degraded
+// state instead of "N/N indexed" badges built from zero vectors (#429).
+type embeddingProviderStatusResponse struct {
+	// Kind is the provider implementation identifier: "ollama", "noop",
+	// or a future kind. Empty string when no provider was wired.
+	Kind string `json:"kind" example:"ollama"`
+	// Model identifies the underlying embedding model when the provider
+	// exposes it (e.g., "nomic-embed-text" for Ollama). Empty for
+	// providers whose backend has no model concept (noop).
+	Model string `json:"model" example:"nomic-embed-text"`
+	// Dimension is the embedding vector length.
+	Dimension int `json:"dimension" example:"768"`
+	// Status is the operator-visible health enum:
+	//   - "ok": a real provider is configured; semantic features active.
+	//   - "unconfigured": no provider configured (or noop placeholder).
+	//     Semantic ranking falls back to lexical; memory writes persist
+	//     with Embedding: nil.
+	Status string `json:"status" example:"ok"`
+}
+
+const (
+	embeddingStatusOK           = "ok"
+	embeddingStatusUnconfigured = "unconfigured"
+)
+
+// modelNamed mirrors the optional interface declared in
+// pkg/toolkits/apigateway/embed_spec.go. Repeated here so admin does
+// not import the apigateway package to read the model name.
+type modelNamed interface {
+	Model() string
+}
+
+// getEmbeddingStatus handles GET /api/v1/admin/embedding/status.
+//
+// @Summary      Get embedding provider status
+// @Description  Returns the configured embedding provider's kind, model, dimension, and a status enum (ok / unconfigured). Used by the portal to surface a banner when semantic features are disabled.
+// @Tags         System
+// @Produce      json
+// @Success      200  {object}  embeddingProviderStatusResponse
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /admin/embedding/status [get]
+func (h *Handler) getEmbeddingStatus(w http.ResponseWriter, _ *http.Request) {
+	prov := h.deps.Embedder
+	if prov == nil {
+		writeJSON(w, http.StatusOK, embeddingProviderStatusResponse{
+			Status: embeddingStatusUnconfigured,
+		})
+		return
+	}
+	resp := embeddingProviderStatusResponse{
+		Kind:      prov.Kind(),
+		Dimension: prov.Dimension(),
+	}
+	if m, ok := prov.(modelNamed); ok {
+		resp.Model = m.Model()
+	}
+	if embedding.IsConfigured(prov) {
+		resp.Status = embeddingStatusOK
+	} else {
+		resp.Status = embeddingStatusUnconfigured
+	}
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/pkg/admin/embedding_test.go
+++ b/pkg/admin/embedding_test.go
@@ -1,0 +1,97 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
+)
+
+// stubProvider is a minimal embedding.Provider that lets each test set
+// Kind, Dimension, and (optionally via the modelNamed assertion) Model
+// without depending on the ollama package.
+type stubProvider struct {
+	kind  string
+	model string
+	dim   int
+}
+
+func (s *stubProvider) Embed(_ context.Context, _ string) ([]float32, error) {
+	return make([]float32, s.dim), nil
+}
+
+func (s *stubProvider) EmbedBatch(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range out {
+		out[i] = make([]float32, s.dim)
+	}
+	return out, nil
+}
+
+func (s *stubProvider) Dimension() int { return s.dim }
+func (s *stubProvider) Kind() string   { return s.kind }
+func (s *stubProvider) Model() string  { return s.model }
+
+func TestGetEmbeddingStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		provider  embedding.Provider
+		wantKind  string
+		wantModel string
+		wantDim   int
+		wantStat  string
+	}{
+		{
+			name:     "nil provider",
+			provider: nil,
+			wantKind: "",
+			wantDim:  0,
+			wantStat: embeddingStatusUnconfigured,
+		},
+		{
+			name:     "noop provider",
+			provider: embedding.NewNoopProvider(768),
+			wantKind: embedding.KindNoop,
+			wantDim:  768,
+			wantStat: embeddingStatusUnconfigured,
+		},
+		{
+			name:      "real provider with model name",
+			provider:  &stubProvider{kind: embedding.KindOllama, model: "nomic-embed-text", dim: 768},
+			wantKind:  embedding.KindOllama,
+			wantModel: "nomic-embed-text",
+			wantDim:   768,
+			wantStat:  embeddingStatusOK,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewHandler(Deps{Embedder: tc.provider}, nil)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/admin/embedding/status", http.NoBody)
+			w := httptest.NewRecorder()
+			h.getEmbeddingStatus(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d; want 200", w.Code)
+			}
+			var got embeddingProviderStatusResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got.Kind != tc.wantKind {
+				t.Errorf("Kind = %q; want %q", got.Kind, tc.wantKind)
+			}
+			if got.Model != tc.wantModel {
+				t.Errorf("Model = %q; want %q", got.Model, tc.wantModel)
+			}
+			if got.Dimension != tc.wantDim {
+				t.Errorf("Dimension = %d; want %d", got.Dimension, tc.wantDim)
+			}
+			if got.Status != tc.wantStat {
+				t.Errorf("Status = %q; want %q", got.Status, tc.wantStat)
+			}
+		})
+	}
+}

--- a/pkg/admin/handler.go
+++ b/pkg/admin/handler.go
@@ -381,6 +381,7 @@ func (h *Handler) registerSystemRoutes() {
 		h.mux.HandleFunc("PUT /api/v1/admin/tools/{name}/visibility", h.setToolVisibility)
 	}
 	h.mux.HandleFunc("GET /api/v1/admin/connections", h.listConnections)
+	h.mux.HandleFunc("GET /api/v1/admin/embedding/status", h.getEmbeddingStatus)
 	h.publicMux.HandleFunc("GET /api/v1/admin/public/branding", h.getPublicBranding)
 	h.publicMux.Handle(docsPrefix, httpswagger.Handler(
 		httpswagger.URL(docsPrefix+"doc.json"),

--- a/pkg/embedding/kind_test.go
+++ b/pkg/embedding/kind_test.go
@@ -1,0 +1,31 @@
+package embedding
+
+import "testing"
+
+// TestKind verifies that each provider returns its declared kind. The
+// platform wiring and toolkit write paths use this signal to decide
+// whether to persist vectors; a misreported kind would silently
+// reintroduce the #429 defect.
+func TestKind(t *testing.T) {
+	if got := NewNoopProvider(768).Kind(); got != KindNoop {
+		t.Errorf("noop.Kind() = %q; want %q", got, KindNoop)
+	}
+	if got := NewOllamaProvider(OllamaConfig{}).Kind(); got != KindOllama {
+		t.Errorf("ollama.Kind() = %q; want %q", got, KindOllama)
+	}
+}
+
+// TestIsConfigured exercises the helper callers use as a one-liner
+// guard. nil and the noop placeholder are NOT configured; a real
+// provider is.
+func TestIsConfigured(t *testing.T) {
+	if IsConfigured(nil) {
+		t.Errorf("IsConfigured(nil) = true; want false")
+	}
+	if IsConfigured(NewNoopProvider(768)) {
+		t.Errorf("IsConfigured(noop) = true; want false")
+	}
+	if !IsConfigured(NewOllamaProvider(OllamaConfig{})) {
+		t.Errorf("IsConfigured(ollama) = false; want true")
+	}
+}

--- a/pkg/embedding/noop.go
+++ b/pkg/embedding/noop.go
@@ -35,5 +35,9 @@ func (n *noopProvider) Dimension() int {
 	return n.dim
 }
 
+// Kind returns the noop kind identifier so callers can recognize this
+// provider as the placeholder and refuse to persist its zero vectors.
+func (*noopProvider) Kind() string { return KindNoop }
+
 // Verify interface compliance.
 var _ Provider = (*noopProvider)(nil)

--- a/pkg/embedding/ollama.go
+++ b/pkg/embedding/ollama.go
@@ -227,6 +227,10 @@ func (o *ollamaProvider) Model() string {
 	return o.model
 }
 
+// Kind returns the Ollama kind identifier so callers can distinguish
+// this real, network-backed provider from the noop placeholder.
+func (*ollamaProvider) Kind() string { return KindOllama }
+
 // toFloat32 converts a float64 slice to float32.
 func toFloat32(f64 []float64) []float32 {
 	f32 := make([]float32, len(f64))

--- a/pkg/embedding/provider.go
+++ b/pkg/embedding/provider.go
@@ -9,6 +9,33 @@ const DefaultDimension = 768
 // DefaultTimeout is the default HTTP timeout in seconds for embedding API calls.
 const DefaultTimeout = 30
 
+// Kind values for Provider.Kind. Used by callers (platform wiring,
+// toolkit write paths) to distinguish a real, network-backed embedder
+// from the placeholder noop. A noop returns zero vectors with no
+// error, which is indistinguishable from a "real" embedding at the
+// Embed/EmbedBatch contract level; without an explicit kind, downstream
+// consumers cannot tell whether the vectors they hold are meaningful.
+const (
+	// KindNoop identifies the placeholder provider returned when no
+	// embedder is configured. Callers MUST treat KindNoop as
+	// "embedding unavailable" and refuse to persist vectors from it.
+	KindNoop = "noop"
+
+	// KindOllama identifies the Ollama-backed provider.
+	KindOllama = "ollama"
+)
+
+// IsConfigured reports whether p is a real, configured embedding
+// provider whose vectors are safe to persist. Returns false for nil
+// and for the noop placeholder. Used by the platform wiring layer
+// and toolkit write paths as a single-line guard.
+func IsConfigured(p Provider) bool {
+	if p == nil {
+		return false
+	}
+	return p.Kind() != KindNoop
+}
+
 // Provider generates vector embeddings from text.
 type Provider interface {
 	// Embed generates an embedding vector for a single text input.
@@ -19,4 +46,10 @@ type Provider interface {
 
 	// Dimension returns the dimensionality of the generated embeddings.
 	Dimension() int
+
+	// Kind returns a short identifier for the provider implementation
+	// (KindOllama, KindNoop, ...). Callers use this to refuse to
+	// persist vectors from the noop placeholder without depending on
+	// concrete type assertions.
+	Kind() string
 }

--- a/pkg/platform/apigateway_embed_jobs.go
+++ b/pkg/platform/apigateway_embed_jobs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
 	apigatewaycatalog "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway/catalog"
@@ -36,8 +37,16 @@ func (p *Platform) WireAPIGatewayEmbedJobsFromDB() {
 		slog.Info("apigateway embed jobs: skipped (no database)")
 		return
 	}
-	if p.embeddingProv == nil {
-		slog.Info("apigateway embed jobs: skipped (no embedding provider)")
+	if !embedding.IsConfigured(p.embeddingProv) {
+		// Either no provider wired at all, or the noop placeholder that
+		// returns zero vectors. Standing up the queue against the noop
+		// would fill api_catalog_operation_embeddings with [0,...,0]
+		// rows that the catalog health endpoint reports as "indexed"
+		// while semantic ranking quietly degrades to nonsense (#429).
+		// Lexical ranking via errEmbeddingsNotIndexed handles invokes
+		// in this state, and the UI surfaces the unconfigured signal
+		// via /api/v1/admin/embedding/status.
+		slog.Info("apigateway embed jobs: skipped (embedding provider not configured)")
 		return
 	}
 	catalogStore := p.APIGatewayCatalogStore()
@@ -147,6 +156,7 @@ type embeddingProvider interface {
 	Embed(ctx context.Context, text string) ([]float32, error)
 	EmbedBatch(ctx context.Context, texts []string) ([][]float32, error)
 	Dimension() int
+	Kind() string
 }
 
 // Compute translates the embedjobs-side dedup map into a

--- a/pkg/platform/apigateway_embed_jobs_test.go
+++ b/pkg/platform/apigateway_embed_jobs_test.go
@@ -41,6 +41,7 @@ func (f *fakeEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]floa
 }
 
 func (f *fakeEmbedder) Dimension() int { return f.dim }
+func (*fakeEmbedder) Kind() string     { return "fake" }
 
 // seedCatalogStore inserts a catalog and a single spec used by
 // the resolver and persister tests below.

--- a/pkg/platform/apigateway_embed_jobs_wiring_test.go
+++ b/pkg/platform/apigateway_embed_jobs_wiring_test.go
@@ -1,0 +1,64 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
+)
+
+// TestWireAPIGatewayEmbedJobsFromDB_NoopEmbedderSkips proves the
+// wiring-layer guard for #429: when the embedder is the noop
+// placeholder AND a database is available, the entire job queue
+// (store, worker, reaper, reconciler, listener) MUST NOT be wired.
+// Standing it up against the noop would fill
+// api_catalog_operation_embeddings with zero vectors that the catalog
+// health endpoint reports as "indexed" while semantic ranking quietly
+// degrades to nonsense.
+//
+// A non-nil sql.DB is required to bypass the earlier "no database"
+// branch and reach the noop guard itself.
+func TestWireAPIGatewayEmbedJobsFromDB_NoopEmbedderSkips(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	p := &Platform{
+		db:            db,
+		embeddingProv: embedding.NewNoopProvider(768),
+	}
+	p.WireAPIGatewayEmbedJobsFromDB()
+	if p.apiGatewayEmbedJobsStore != nil {
+		t.Errorf("noop embedder must not wire the job store; got %T", p.apiGatewayEmbedJobsStore)
+	}
+	if p.apiGatewayEmbedJobsWorker != nil {
+		t.Errorf("noop embedder must not start the worker")
+	}
+	if p.apiGatewayEmbedJobsReaper != nil {
+		t.Errorf("noop embedder must not start the reaper")
+	}
+	if p.apiGatewayEmbedJobsReconciler != nil {
+		t.Errorf("noop embedder must not start the reconciler")
+	}
+}
+
+// TestWireAPIGatewayEmbedJobsFromDB_NilEmbedderSkips covers the
+// existing nil-embedder branch, kept asserted alongside the noop
+// branch so a future refactor that collapses them does not lose
+// either guarantee.
+func TestWireAPIGatewayEmbedJobsFromDB_NilEmbedderSkips(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	p := &Platform{db: db, embeddingProv: nil}
+	p.WireAPIGatewayEmbedJobsFromDB()
+	if p.apiGatewayEmbedJobsStore != nil {
+		t.Errorf("nil embedder must not wire the job store")
+	}
+}

--- a/pkg/platform/integration_embedding_noop_test.go
+++ b/pkg/platform/integration_embedding_noop_test.go
@@ -1,0 +1,187 @@
+//go:build integration
+
+package platform_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/txn2/mcp-data-platform/pkg/admin"
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
+	"github.com/txn2/mcp-data-platform/pkg/platform"
+	apigatewaycatalog "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway/catalog"
+)
+
+// TestEmbeddingNoop_EndToEnd is the integration counterpart to the
+// unit-level guards added for #429. With a real Postgres (pgvector
+// enabled) and no memory.embedding.provider configured, the platform
+// MUST:
+//
+//  1. Start successfully so non-embedding features stay available.
+//  2. Wire a noop embedder (Kind() == KindNoop).
+//  3. Refuse to start the apigateway embed-job queue.
+//  4. Not write any rows to api_catalog_operation_embeddings even
+//     after a spec is upserted into the catalog store.
+//  5. Report status="unconfigured" from /api/v1/admin/embedding/status.
+//
+// This proves the structural property that no zero-vector row can
+// reach the embeddings table while in the unconfigured state.
+func TestEmbeddingNoop_EndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	// pgvector/pgvector:pg16 is required so migration 000044's
+	// `CREATE EXTENSION vector` succeeds. The base postgres:16-alpine
+	// image other integration tests use does not carry the extension.
+	pgContainer, err := postgres.Run(ctx,
+		"pgvector/pgvector:pg16",
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("test"),
+		postgres.WithPassword("test"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(5*time.Minute),
+		),
+	)
+	require.NoError(t, err, "start postgres container")
+	defer func() { _ = pgContainer.Terminate(ctx) }()
+
+	dsn, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	// Build a Platform with DB but NO memory.embedding block. The
+	// initMemory default branch picks the noop placeholder; the WARN
+	// logged here is the operator's signal that semantic features
+	// are off (see platform.go initMemory).
+	cfg := &platform.Config{
+		Server: platform.ServerConfig{Name: "integration-test"},
+		Database: platform.DatabaseConfig{
+			DSN:          dsn,
+			MaxOpenConns: 5,
+		},
+		// Memory.Embedding.Provider left as zero value → noop fallback.
+		// Memory layer is enabled implicitly when DB is available.
+	}
+
+	p, err := platform.New(platform.WithConfig(cfg))
+	require.NoError(t, err, "build platform")
+	defer p.Close()
+
+	// (1) Startup succeeded: the deferred Close above runs only if
+	//     New returned without error. Also assert that non-embedding
+	//     wiring is in place.
+	require.NotNil(t, p.MCPServer(), "MCP server must initialize even without an embedder")
+
+	// (2) Embedder is the noop placeholder.
+	prov := p.EmbeddingProvider()
+	require.NotNil(t, prov, "platform must wire some Provider; noop is the documented fallback")
+	assert.Equal(t, embedding.KindNoop, prov.Kind(), "default branch must select the noop placeholder")
+	assert.False(t, embedding.IsConfigured(prov), "noop must report as not configured")
+
+	// (3) Wire the apigateway catalog store from DB, then attempt to
+	//     wire the embed-job queue. The queue MUST refuse to start
+	//     because the embedder is noop.
+	p.WireAPIGatewayCatalogStoreFromDB()
+	p.WireAPIGatewayEmbedJobsFromDB()
+	assert.Nil(t, p.APIGatewayEmbedJobsStore(),
+		"embed-job queue must not start under noop embedder (#429)")
+
+	// (4) Insert a spec through the catalog store directly so the
+	//     test does not depend on the admin HTTP layer. If the
+	//     wiring guard at (3) is wrong, persisting a spec would
+	//     trigger the worker to write zero vectors into
+	//     api_catalog_operation_embeddings. Assert no rows appear.
+	catStore := p.APIGatewayCatalogStore()
+	require.NotNil(t, catStore, "catalog store must wire even when embedder is noop")
+
+	const (
+		catalogID = "test-catalog"
+		specName  = "petstore"
+		specYAML  = `openapi: 3.0.0
+info:
+  title: Petstore
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List pets
+      responses:
+        "200":
+          description: ok
+    post:
+      operationId: createPet
+      summary: Create pet
+      responses:
+        "201":
+          description: created
+`
+	)
+
+	require.NoError(t, catStore.CreateCatalog(ctx, apigatewaycatalog.Catalog{
+		ID: catalogID, Name: catalogID, Version: "v1",
+	}))
+	require.NoError(t, catStore.UpsertSpec(ctx, catalogID, apigatewaycatalog.SpecEntry{
+		SpecName:   specName,
+		Content:    specYAML,
+		SourceKind: "inline",
+	}))
+
+	// Give the (non-existent) worker a window to do anything it
+	// might be tempted to do. Under the bug, this is when zero
+	// vectors would land. Under the fix, the queue doesn't exist
+	// so this window is purely defensive.
+	time.Sleep(500 * time.Millisecond)
+
+	// (4 cont.) Query api_catalog_operation_embeddings directly.
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	var rowCount int
+	err = db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM api_catalog_operation_embeddings WHERE catalog_id = $1 AND spec_name = $2`,
+		catalogID, specName,
+	).Scan(&rowCount)
+	require.NoError(t, err, "query embeddings table")
+	assert.Equal(t, 0, rowCount,
+		"no zero-vector rows must reach api_catalog_operation_embeddings under noop (#429)")
+
+	// (5) /api/v1/admin/embedding/status reports unconfigured.
+	adminH := admin.NewHandler(admin.Deps{
+		Embedder: prov,
+	}, nil)
+	srv := httptest.NewServer(adminH)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/admin/embedding/status") //nolint:gosec,noctx // test server, fixed URL
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck // test cleanup
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var status struct {
+		Kind      string `json:"kind"`
+		Model     string `json:"model"`
+		Dimension int    `json:"dimension"`
+		Status    string `json:"status"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&status))
+	assert.Equal(t, embedding.KindNoop, status.Kind)
+	assert.Equal(t, "unconfigured", status.Status)
+}

--- a/pkg/platform/integration_test.go
+++ b/pkg/platform/integration_test.go
@@ -5,8 +5,6 @@ package platform_test
 import (
 	"context"
 	"database/sql"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -18,6 +16,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 	"github.com/txn2/mcp-data-platform/pkg/audit"
 	auditpostgres "github.com/txn2/mcp-data-platform/pkg/audit/postgres"
+	"github.com/txn2/mcp-data-platform/pkg/database/migrate"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
@@ -34,7 +33,7 @@ func TestAuditLogging_EndToEnd(t *testing.T) {
 
 	// Start PostgreSQL container
 	pgContainer, err := postgres.Run(ctx,
-		"postgres:16-alpine",
+		"pgvector/pgvector:pg16",
 		postgres.WithDatabase("testdb"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
@@ -55,8 +54,11 @@ func TestAuditLogging_EndToEnd(t *testing.T) {
 	require.NoError(t, err, "failed to open database")
 	defer db.Close()
 
-	// Run migrations
-	err = runMigrations(db)
+	// Run migrations via the platform's embedded migration set. The
+	// older runMigrations helper that scanned a sibling directory has
+	// been retired: its fallback schema diverged from the canonical
+	// migrations once new columns (session_id, partitioning) landed.
+	err = migrate.Run(db)
 	require.NoError(t, err, "failed to run migrations")
 
 	// Create audit store
@@ -106,7 +108,7 @@ func TestAuditAdapter_Integration(t *testing.T) {
 
 	// Start PostgreSQL container
 	pgContainer, err := postgres.Run(ctx,
-		"postgres:16-alpine",
+		"pgvector/pgvector:pg16",
 		postgres.WithDatabase("testdb"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
@@ -127,8 +129,11 @@ func TestAuditAdapter_Integration(t *testing.T) {
 	require.NoError(t, err, "failed to open database")
 	defer db.Close()
 
-	// Run migrations
-	err = runMigrations(db)
+	// Run migrations via the platform's embedded migration set. The
+	// older runMigrations helper that scanned a sibling directory has
+	// been retired: its fallback schema diverged from the canonical
+	// migrations once new columns (session_id, partitioning) landed.
+	err = migrate.Run(db)
 	require.NoError(t, err, "failed to run migrations")
 
 	// Create audit store and adapter
@@ -245,7 +250,7 @@ func TestPlatform_WithDatabase(t *testing.T) {
 
 	// Start PostgreSQL container
 	pgContainer, err := postgres.Run(ctx,
-		"postgres:16-alpine",
+		"pgvector/pgvector:pg16",
 		postgres.WithDatabase("testdb"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
@@ -261,12 +266,13 @@ func TestPlatform_WithDatabase(t *testing.T) {
 	dsn, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
 	require.NoError(t, err, "failed to get connection string")
 
-	// Connect to run migrations
-	db, err := sql.Open("postgres", dsn)
-	require.NoError(t, err)
-	err = runMigrations(db)
-	require.NoError(t, err, "failed to run migrations")
-	db.Close()
+	// The platform's initDatabase calls pkg/database/migrate.Run on the
+	// supplied DSN, so the migrations are applied as part of New. The
+	// older runMigrations helper that read .sql files from a sibling
+	// directory has been retired here: when findMigrationsDir cannot
+	// locate the dir (its hard-coded relative paths drift with test
+	// layouts), it fell through to a hand-written minimal schema that
+	// conflicted with migration 000001's partitioned audit_logs.
 
 	// Create platform with database config
 	cfg := &platform.Config{
@@ -279,7 +285,7 @@ func TestPlatform_WithDatabase(t *testing.T) {
 			MaxOpenConns: 5,
 		},
 		Audit: platform.AuditConfig{
-			Enabled:       true,
+			Enabled:       boolPtr(true),
 			LogToolCalls:  true,
 			RetentionDays: 30,
 		},
@@ -295,77 +301,7 @@ func TestPlatform_WithDatabase(t *testing.T) {
 	assert.NotNil(t, p.RuleEngine())
 }
 
-// runMigrations executes all SQL migrations in the migrations directory.
-func runMigrations(db *sql.DB) error {
-	// Find migrations directory
-	migrationsDir := findMigrationsDir()
-	if migrationsDir == "" {
-		// Create minimal migration for testing
-		_, err := db.Exec(`
-			CREATE TABLE IF NOT EXISTS audit_logs (
-				id              VARCHAR(32) NOT NULL,
-				timestamp       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-				duration_ms     INTEGER,
-				request_id      VARCHAR(255),
-				user_id         VARCHAR(255),
-				user_email      VARCHAR(255),
-				persona         VARCHAR(100),
-				tool_name       VARCHAR(255) NOT NULL,
-				toolkit_kind    VARCHAR(100),
-				toolkit_name    VARCHAR(100),
-				connection      VARCHAR(100),
-				parameters      JSONB,
-				success         BOOLEAN NOT NULL,
-				error_message   TEXT,
-				created_date    DATE NOT NULL DEFAULT CURRENT_DATE,
-				PRIMARY KEY (id, created_date)
-			)
-		`)
-		return err
-	}
-
-	// Read and execute migration files
-	files, err := os.ReadDir(migrationsDir)
-	if err != nil {
-		return err
-	}
-
-	for _, file := range files {
-		if filepath.Ext(file.Name()) != ".sql" {
-			continue
-		}
-
-		content, err := os.ReadFile(filepath.Join(migrationsDir, file.Name()))
-		if err != nil {
-			return err
-		}
-
-		_, err = db.Exec(string(content))
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// findMigrationsDir locates the migrations directory.
-func findMigrationsDir() string {
-	// Try common paths
-	paths := []string{
-		"../../migrations",
-		"migrations",
-		"../../../migrations",
-	}
-
-	for _, p := range paths {
-		if _, err := os.Stat(p); err == nil {
-			return p
-		}
-	}
-
-	return ""
-}
+func boolPtr(v bool) *bool { return &v }
 
 // floatPtr returns a pointer to a float64 value.
 func floatPtr(v float64) *float64 {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -355,6 +355,16 @@ func (p *Platform) initMemory() error {
 			Timeout: p.config.Memory.Embedding.Ollama.Timeout,
 		})
 	default:
+		// No embedder configured. The platform still boots so Trino,
+		// S3, DataHub, OAuth, audit, and every other non-embedding
+		// feature remains available; semantic ranking degrades to the
+		// lexical fallback and memory writes persist Embedding: nil
+		// (the toolkit guards see Kind() == KindNoop). One WARN here
+		// is the operator's only signal that semantic features are
+		// off, so make it specific enough to act on (#429).
+		slog.Warn("memory.embedding.provider not configured; semantic ranking disabled (set memory.embedding.provider to 'ollama' to enable)",
+			"config_key", "memory.embedding.provider",
+			"current_value", p.config.Memory.Embedding.Provider)
 		p.embeddingProv = embedding.NewNoopProvider(embedding.DefaultDimension)
 	}
 

--- a/pkg/toolkits/apigateway/embed_spec_test.go
+++ b/pkg/toolkits/apigateway/embed_spec_test.go
@@ -93,6 +93,7 @@ func TestComputeOperationEmbeddings_CountMismatchPropagates(t *testing.T) {
 type countMismatchEmbedder struct{ returnCount int }
 
 func (countMismatchEmbedder) Dimension() int { return 8 }
+func (countMismatchEmbedder) Kind() string   { return "fake" }
 func (countMismatchEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 	return []float32{1, 0, 0, 0, 0, 0, 0, 0}, nil
 }

--- a/pkg/toolkits/apigateway/persisted_embeddings_test.go
+++ b/pkg/toolkits/apigateway/persisted_embeddings_test.go
@@ -39,6 +39,7 @@ func (e *trackingEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]fl
 }
 
 func (e *trackingEmbedder) Dimension() int { return e.dim }
+func (*trackingEmbedder) Kind() string     { return "fake" }
 
 // persistedEmbedTestSpec is a two-operation spec used by the
 // acceptance tests. Exact ops don't matter; the tests assert on

--- a/pkg/toolkits/apigateway/ranking_test.go
+++ b/pkg/toolkits/apigateway/ranking_test.go
@@ -122,6 +122,7 @@ type fakeEmbedder struct {
 func newFakeEmbedder(dim int) *fakeEmbedder { return &fakeEmbedder{dim: dim} }
 
 func (f *fakeEmbedder) Dimension() int { return f.dim }
+func (*fakeEmbedder) Kind() string     { return "fake" }
 
 func (f *fakeEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
 	if f.failEmbed.Load() {
@@ -351,6 +352,8 @@ func TestRankWithMode_ZeroQueryVectorFallsBack(t *testing.T) {
 }
 
 type zeroEmbedder struct{}
+
+func (zeroEmbedder) Kind() string { return "fake" }
 
 func (zeroEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
 	return make([]float32, 8), nil
@@ -751,6 +754,7 @@ type batchCounter struct {
 }
 
 func (b *batchCounter) Dimension() int { return b.vectorDim }
+func (*batchCounter) Kind() string     { return "fake" }
 
 func (b *batchCounter) Embed(_ context.Context, _ string) ([]float32, error) {
 	out := make([]float32, b.vectorDim)

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -257,8 +257,11 @@ func (t *Toolkit) handleCaptureInsight(ctx context.Context, _ *mcp.CallToolReque
 		return errorResult("failed to save insight: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
 	}
 
-	// Generate embedding for the memory record if embedder is available.
-	if t.embedder != nil && t.memoryStore != nil {
+	// Generate embedding for the memory record only when a real
+	// provider is configured. Persisting a zero vector from the noop
+	// placeholder would falsely claim the row is semantically indexed
+	// and the recall side would later refuse to query it (#429).
+	if embedding.IsConfigured(t.embedder) && t.memoryStore != nil {
 		emb, err := t.embedder.Embed(ctx, insight.InsightText)
 		if err != nil {
 			slog.Warn("embedding generation failed for insight", "id", id, "error", err)

--- a/pkg/toolkits/knowledge/toolkit_test.go
+++ b/pkg/toolkits/knowledge/toolkit_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/txn2/mcp-datahub/pkg/types"
 
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 )
 
@@ -586,6 +587,29 @@ func TestHandleCaptureInsight_AllFieldsPopulated(t *testing.T) {
 	assert.Len(t, insight.RelatedColumns, 1)
 	assert.Len(t, insight.SuggestedActions, 1)
 	assert.Equal(t, testStatusVal, insight.Status)
+}
+
+// TestHandleCaptureInsight_NoopEmbedderSkipsMemoryUpdate proves the
+// write-path guard on the knowledge capture path: when the embedder
+// is the noop placeholder, capture_insight MUST NOT call memoryStore.
+// Update with a zero vector (#429).
+func TestHandleCaptureInsight_NoopEmbedderSkipsMemoryUpdate(t *testing.T) {
+	spy := &fullSpyStore{}
+	tk, err := New(testName, spy)
+	require.NoError(t, err)
+	memStore := &mockMemoryStore{}
+	tk.SetMemoryStore(memStore, embedding.NewNoopProvider(768))
+
+	ctx := ctxWithUser("user-1", "sess-1", "admin")
+	result, _, callErr := tk.handleCaptureInsight(ctx, nil, captureInsightInput{
+		Category:    "business_context",
+		InsightText: "MRR excludes trial accounts",
+		Confidence:  "high",
+	})
+	require.Nil(t, callErr)
+	require.False(t, result.IsError)
+	assert.False(t, memStore.updateCalled,
+		"noop embedder must skip the embedding-update call entirely")
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/toolkits/memory/manage.go
+++ b/pkg/toolkits/memory/manage.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
 	memstore "github.com/txn2/mcp-data-platform/pkg/memory"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 )
@@ -84,12 +85,18 @@ func (t *Toolkit) handleRemember(ctx context.Context, input manageInput) (*mcp.C
 		return errorResult("failed to generate ID"), nil, nil //nolint:nilerr // MCP protocol
 	}
 
-	// Generate embedding (graceful failure if Ollama unavailable).
+	// Generate embedding when a real provider is configured. Skip the
+	// call against the noop placeholder so we persist Embedding: nil
+	// instead of a zero vector, symmetric with the recall-side guard
+	// at recall.go:127 that refuses to query against zero vectors
+	// (#429).
 	var emb []float32
-	emb, err = t.embedder.Embed(ctx, input.Content)
-	if err != nil {
-		slog.Warn("embedding generation failed, storing without embedding", "error", err)
-		emb = nil
+	if embedding.IsConfigured(t.embedder) {
+		emb, err = t.embedder.Embed(ctx, input.Content)
+		if err != nil {
+			slog.Warn("embedding generation failed, storing without embedding", "error", err)
+			emb = nil
+		}
 	}
 
 	record := memstore.Record{
@@ -155,8 +162,11 @@ func (t *Toolkit) handleUpdate(ctx context.Context, input manageInput) (*mcp.Cal
 		Metadata:   input.Metadata,
 	}
 
-	// Re-embed if content changed.
-	if input.Content != "" {
+	// Re-embed if content changed. Symmetric with the handleRemember
+	// guard: skip the noop placeholder so an update on an unconfigured
+	// deployment does not overwrite a previously-real vector with a
+	// zero vector (#429).
+	if input.Content != "" && embedding.IsConfigured(t.embedder) {
 		emb, err := t.embedder.Embed(ctx, input.Content)
 		if err != nil {
 			slog.Warn("embedding generation failed on update", "error", err)

--- a/pkg/toolkits/memory/manage_test.go
+++ b/pkg/toolkits/memory/manage_test.go
@@ -147,6 +147,8 @@ func (m *mockEmbedder) Dimension() int {
 	return m.dim
 }
 
+func (*mockEmbedder) Kind() string { return "fake" }
+
 var _ embedding.Provider = (*mockEmbedder)(nil)
 
 // ---------------------------------------------------------------------------
@@ -298,6 +300,37 @@ func TestHandleRemember_Valid(t *testing.T) {
 	assert.Equal(t, "user", rec.Source)
 	assert.Equal(t, []float32{0.1, 0.2}, rec.Embedding)
 	assert.Equal(t, "sess-123", rec.Metadata["session_id"])
+}
+
+// TestHandleRemember_NoopEmbedderSkipsEmbed proves the write-path
+// guard for #429: when the embedder is the noop placeholder, the
+// stored record's Embedding MUST be nil and the embedder's Embed
+// method MUST NOT be called (otherwise we'd persist a zero vector
+// that the recall-side check at recall.go:127 would later refuse
+// to query).
+func TestHandleRemember_NoopEmbedderSkipsEmbed(t *testing.T) {
+	t.Parallel()
+
+	store := &mockStore{}
+	// Use the real noop provider so the kind/IsConfigured check
+	// exercises the production code path, not a test fake.
+	tk := newTestToolkit(store, embedding.NewNoopProvider(768))
+	ctx := ctxWithPC("user@example.com", "analyst")
+
+	result, _, err := tk.handleManage(ctx, nil, manageInput{
+		Command:    "remember",
+		Content:    "Valid content that is long enough for tests",
+		Dimension:  "knowledge",
+		Category:   "correction",
+		Confidence: "high",
+		Source:     "user",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	require.Len(t, store.insertedRecords, 1)
+	rec := store.insertedRecords[0]
+	assert.Nil(t, rec.Embedding, "noop embedder must not produce a stored vector")
 }
 
 func TestHandleRemember_MissingContent(t *testing.T) {
@@ -469,6 +502,37 @@ func TestHandleUpdate_Valid(t *testing.T) {
 	assert.Equal(t, "abc123", store.updatedID)
 	assert.Equal(t, "Updated content that is long enough for tests", store.updatedFields.Content)
 	assert.Equal(t, []float32{0.5, 0.6}, store.updatedFields.Embedding)
+}
+
+// TestHandleUpdate_NoopEmbedderSkipsEmbed is the symmetric guard test
+// for the update path: under the noop placeholder, re-embedding on
+// content change MUST NOT overwrite the stored vector with a zero
+// vector (#429).
+func TestHandleUpdate_NoopEmbedderSkipsEmbed(t *testing.T) {
+	t.Parallel()
+
+	store := &mockStore{
+		getResult: &memstore.Record{
+			ID:        "abc123",
+			CreatedBy: "user@example.com",
+		},
+	}
+	tk := newTestToolkit(store, embedding.NewNoopProvider(768))
+	ctx := ctxWithPC("user@example.com", "analyst")
+
+	result, _, err := tk.handleManage(ctx, nil, manageInput{
+		Command: "update",
+		ID:      "abc123",
+		Content: "Updated content that is long enough for tests",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	// Embedding must remain nil; the postgres store's update path
+	// writes the embedding column only when len(Embedding) > 0, so a
+	// zero-length nil here keeps the column untouched.
+	assert.Nil(t, store.updatedFields.Embedding,
+		"noop embedder must not produce a stored vector on update")
 }
 
 func TestHandleUpdate_MissingID(t *testing.T) {

--- a/ui/src/api/admin/hooks.ts
+++ b/ui/src/api/admin/hooks.ts
@@ -1002,6 +1002,29 @@ export function useAPICatalogEmbeddingHealth(catalogID: string, enabled = true) 
   });
 }
 
+// EmbeddingProviderStatus mirrors the server-side embeddingProviderStatusResponse:
+// the platform-wide embedding provider's kind, model, dimension, and a
+// health enum. status="unconfigured" indicates the noop placeholder is
+// in use and semantic features are disabled (the portal renders a
+// banner on the Catalogs and Memory panels in this state). See #429.
+export interface EmbeddingProviderStatus {
+  kind: string;
+  model: string;
+  dimension: number;
+  status: "ok" | "unconfigured";
+}
+
+// useEmbeddingProviderStatus polls the platform-wide embedding-provider
+// status. Used by the Catalogs panel and the Memory settings panel to
+// surface a banner when the provider is unconfigured.
+export function useEmbeddingProviderStatus() {
+  return useQuery({
+    queryKey: ["admin", "embedding", "status"],
+    queryFn: () => apiFetch<EmbeddingProviderStatus>("/embedding/status"),
+    refetchInterval: 30000,
+  });
+}
+
 // useAPICatalogEmbeddingStatuses returns one row per spec. The
 // portal renders these as per-spec badges in the CatalogsPanel.
 // Refetched on the same 5s cadence as the health roll-up so the

--- a/ui/src/pages/knowledge/MyKnowledgePage.tsx
+++ b/ui/src/pages/knowledge/MyKnowledgePage.tsx
@@ -5,6 +5,7 @@ import {
   useMyMemories,
   useMyMemoryStats,
 } from "@/api/portal/hooks";
+import { useEmbeddingProviderStatus } from "@/api/admin/hooks";
 import { StatCard } from "@/components/cards/StatCard";
 import { Lightbulb, ChevronLeft, ChevronRight } from "lucide-react";
 import type { Insight, MemoryRecord } from "@/api/portal/types";
@@ -345,6 +346,8 @@ function MyMemorySection() {
     limit: PAGE_SIZE,
     offset,
   });
+  const { data: embedStatus } = useEmbeddingProviderStatus();
+  const embedderUnconfigured = embedStatus?.status === "unconfigured";
 
   const s = stats.data;
   const totalItems = memories.data?.total ?? 0;
@@ -370,6 +373,22 @@ function MyMemorySection() {
 
   return (
     <>
+      {embedderUnconfigured && (
+        <div
+          role="status"
+          className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
+        >
+          <strong>Embedding provider not configured.</strong> New memories are
+          persisted without vectors and semantic recall is unavailable; keyword
+          and entity-URN lookup still work. Set{" "}
+          <code className="rounded bg-amber-100 px-1 py-0.5 font-mono text-xs dark:bg-amber-900/40">
+            memory.embedding.provider
+          </code>{" "}
+          (e.g., to <code className="font-mono">ollama</code>) and restart to
+          enable semantic features.
+        </div>
+      )}
+
       {/* Summary Cards */}
       <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
         <StatCard label="Total Memories" value={s?.total ?? 0} />

--- a/ui/src/pages/settings/CatalogsPanel.tsx
+++ b/ui/src/pages/settings/CatalogsPanel.tsx
@@ -25,6 +25,7 @@ import {
   useAPICatalogEmbeddingHealth,
   useAPICatalogEmbeddingStatuses,
   useDeleteAPICatalogSpec,
+  useEmbeddingProviderStatus,
   useManualRetryEmbedding,
   useRefreshAPICatalogSpec,
   useUpdateAPICatalog,
@@ -51,6 +52,8 @@ export function CatalogsPanel() {
   const { data: systemInfo } = useSystemInfo();
   const isReadOnly = systemInfo?.config_mode === "file";
   const { data: catalogs, isLoading } = useAPICatalogs();
+  const { data: embedStatus } = useEmbeddingProviderStatus();
+  const embedderUnconfigured = embedStatus?.status === "unconfigured";
 
   const initialSelection = useMemo(() => {
     if (typeof window === "undefined") return null;
@@ -120,6 +123,22 @@ export function CatalogsPanel() {
       {isReadOnly && (
         <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200">
           The platform is running in file config mode. Catalog edits are disabled.
+        </div>
+      )}
+
+      {embedderUnconfigured && (
+        <div
+          role="status"
+          className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
+        >
+          <strong>Embedding provider not configured.</strong> Semantic ranking is
+          disabled; spec saves will not produce per-operation embeddings and
+          api_list_endpoints falls back to lexical scoring. Set{" "}
+          <code className="rounded bg-amber-100 px-1 py-0.5 font-mono text-xs dark:bg-amber-900/40">
+            memory.embedding.provider
+          </code>{" "}
+          (e.g., to <code className="font-mono">ollama</code>) and restart to
+          enable.
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Closes #429.

The default fallback to the noop embedding provider was operator-invisible and downstream consumers wrote its zero vectors as if they were real enrichment, leaving N/N "indexed" badges over data that semantic ranking could never match. This PR adds defense-in-depth so a deployment without `memory.embedding.provider` set still boots cleanly but produces no zero-vector rows in any toolkit, surfaces the state in the admin API and portal, and logs one actionable WARN at startup.

## Approach

`embedding.Provider` gains `Kind() string` and a package-level `IsConfigured(p) bool` helper. Callers use the helper as a one-line guard. Five independent defenses, in increasing depth:

| Layer | File | Guard |
|---|---|---|
| Startup WARN | `pkg/platform/platform.go` initMemory default branch | Logs `memory.embedding.provider not configured; semantic ranking disabled (set memory.embedding.provider to 'ollama' to enable)` with the config key in a structured field. |
| Apigateway wiring | `pkg/platform/apigateway_embed_jobs.go` `WireAPIGatewayEmbedJobsFromDB` | Treats noop the same as nil. Store / worker / reaper / reconciler / listener never wire. Admin handler's `EmbedJobs` dep stays nil, so `enqueueEmbedJob` is a no-op on every spec save. |
| Memory write path (`remember`) | `pkg/toolkits/memory/manage.go` `handleRemember` | Skips the Embed call entirely; record persists with `Embedding: nil`. Symmetric with the existing recall-side guard at `recall.go:127`. |
| Memory write path (`update`) | `pkg/toolkits/memory/manage.go` `handleUpdate` | Same gate on content re-embed so an update under noop does not overwrite a previously real vector with zeros. |
| Knowledge `capture_insight` | `pkg/toolkits/knowledge/toolkit.go` | Skips the per-insight `memoryStore.Update` when the embedder is noop. |

## New admin surface

`GET /api/v1/admin/embedding/status` returns:

```json
{
  "kind": "ollama" | "noop" | "",
  "model": "nomic-embed-text" | "",
  "dimension": 768,
  "status": "ok" | "unconfigured"
}
```

The portal polls this every 30s. When `status` is `unconfigured`, an amber banner renders on:

- **API Catalogs panel:** "Embedding provider not configured. Semantic ranking is disabled; spec saves will not produce per-operation embeddings and api_list_endpoints falls back to lexical scoring."
- **Memory tab on My Knowledge:** "Embedding provider not configured. New memories are persisted without vectors and semantic recall is unavailable; keyword and entity-URN lookup still work."

Both banners name the config key (`memory.embedding.provider`) so an operator can act without grep.

## Why existing gates did not catch this

`TestNoopOnlyInterfaces` checks that every interface with a noop has a real sibling. The embedding package has both noop and ollama, so the gate passes. The defect is not "noop with no real sibling." It is "noop is the runtime default when config is absent, and downstream consumers accept it without complaint and write data that falsely claims to be enriched." That class of failure is now covered by the integration test below.

## Tests

### Unit

- `pkg/embedding/kind_test.go`: `Kind()` returns the declared kind for both providers; `IsConfigured` returns false for nil + noop, true for ollama.
- `pkg/admin/embedding_test.go`: `/embedding/status` table-driven over nil / noop / real provider, asserts kind / model / dimension / status.
- `pkg/toolkits/memory/manage_test.go`: `TestHandleRemember_NoopEmbedderSkipsEmbed` and `TestHandleUpdate_NoopEmbedderSkipsEmbed` use the real `embedding.NewNoopProvider` (not a fake) and assert `store.insertedRecords[0].Embedding == nil` / `store.updatedFields.Embedding == nil`.
- `pkg/toolkits/knowledge/toolkit_test.go`: `TestHandleCaptureInsight_NoopEmbedderSkipsMemoryUpdate` asserts the noop embedder skips `memoryStore.Update` entirely.
- `pkg/platform/apigateway_embed_jobs_wiring_test.go`: sqlmock-backed test proves the noop guard fires after the `db == nil` short-circuit (`apiGatewayEmbedJobsStore`, `Worker`, `Reaper`, `Reconciler` all nil).

### Integration (build tag `integration`)

`pkg/platform/integration_embedding_noop_test.go`:

1. Starts `pgvector/pgvector:pg16` via testcontainers.
2. Builds a full `Platform` with `Memory.Embedding.Provider` unset (default → noop).
3. Wires the catalog store and calls `WireAPIGatewayEmbedJobsFromDB`.
4. Inserts a catalog and a two-operation spec through the real catalog store (not through admin HTTP, to focus the test on the data path).
5. Sleeps 500ms (defensive window; under the bug, this is when zero vectors would land).
6. Asserts: startup succeeded, `Kind() == "noop"`, `APIGatewayEmbedJobsStore() == nil`, zero rows in `api_catalog_operation_embeddings`, and `/admin/embedding/status` returns `{kind: "noop", status: "unconfigured"}`.

Runtime against pgvector: ~5.6s.

### Pre-existing integration test bit-rot, fixed here

`pkg/platform/integration_test.go` had drifted:

- `AuditConfig.Enabled` became `*bool` while the test passed a bare `true`; build broke under `-tags=integration`.
- `runMigrations` scanned a sibling directory that did not exist at the test's working directory, fell through to a hand-written minimal schema that diverged from the canonical migrations (missing `session_id` column, unpartitioned `audit_logs`), and conflicted with the platform's own `migrate.Run` on the same DB.
- Image was `postgres:16-alpine`; migration 000044 needs the `vector` extension.

All three integration tests now use `pgvector/pgvector:pg16` and rely on the platform's embedded `migrate.Run`. The dead `runMigrations` / `findMigrationsDir` helpers are removed. Full integration suite passes in 9.5s.

## Verification

- `make verify` clean: tools-check, gofmt, race tests, total coverage 87.4%, patch coverage above gate, golangci-lint (patch-scoped against `origin/main`), gosec, govulncheck, semgrep, codeql, doc-check, dead-code, mutation testing, goreleaser dry-run.
- `make test-integration` clean (5 tests, 9.5s).
- Adversarial sub-agent review: 3 rounds. Round 1 surfaced the missing `handleUpdate` and `capture_insight` guards and remaining em dashes; round 2 returned CLEAN after the fixes; round 3 (post lint cleanup) CLEAN.

## Public-API note

`embedding.Provider.Kind() string` is an additive method on a public interface in `pkg/`. External implementers of `embedding.Provider` (if any) will need to add `Kind()`. The benefit is making the noop distinguishable from a real provider without type assertions; the alternative (optional `Kinder` interface) would have left the contract opaque and forced every consumer to do its own type-switch.

## Test plan

- [x] `make verify` passes locally.
- [x] `make test-integration` passes locally against pgvector.
- [x] Adversarial review verdict CLEAN.
- [ ] CI green.
- [ ] Manual: deploy with no `memory.embedding` block, observe one WARN at startup, confirm the amber banner renders on both panels, save an API spec and verify `api_catalog_operation_embeddings` stays empty for that spec.
- [ ] Manual: set `memory.embedding.provider: ollama`, restart, confirm the banner disappears and spec saves produce per-operation rows.