### PR TITLE
feat(apigateway): incremental embed progress and configurable worker concurrency (#430)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2619,7 +2619,7 @@ The legacy `connection_instances.config.openapi_spec` JSONB key is no longer rea
 | `POST` | `/api/v1/admin/api-catalogs/{id}/specs/{spec}/refresh` | Re-fetch URL-sourced |
 | `POST` | `/api/v1/admin/api-catalogs/{id}/specs/{spec}/reembed` | Manual retry: enqueue a manual_retry embedding job |
 | `GET`  | `/api/v1/admin/api-catalogs/{id}/embedding-health` | Catalog-level roll-up (total / indexed / pending / running / failed) |
-| `GET`  | `/api/v1/admin/api-catalogs/{id}/embedding-status` | Per-spec embedding state (operation_count, embedding_count, last job state) |
+| `GET`  | `/api/v1/admin/api-catalogs/{id}/embedding-status` | Per-spec embedding state (operation_count, embedding_count, embedded_so_far, last job state). `embedded_so_far` is the worker's in-flight chunk counter that ticks up during a running embed pass; `embedding_count` jumps from 0 to N only on the final atomic upsert. |
 | `GET`  | `/api/v1/admin/api-catalogs/{id}/embedding-jobs` | Recent embedding job history (filterable by status / spec_name) |
 | `GET`  | `/api/v1/admin/embedding/status` | Platform-wide embedding provider status: `{kind, model, dimension, status}`. `status="unconfigured"` indicates the noop placeholder is in use (memory.embedding.provider unset); the portal renders an amber banner in this state and the apigateway embed-job queue refuses to start. |
 | `DELETE` | `/api/v1/admin/api-catalogs/{id}/specs/{spec}` | Delete one spec |

--- a/docs/server/api-catalogs.md
+++ b/docs/server/api-catalogs.md
@@ -90,7 +90,7 @@ Embedding work runs through a Postgres-backed job queue (`api_catalog_embedding_
 Four components run alongside the admin server:
 
 - **Producer** — every spec write (`upsert`, `upload`, `refresh`, `clone`) and the manual-retry admin action insert a row into `api_catalog_embedding_jobs`. A partial unique index on `(catalog_id, spec_name) WHERE status IN ('pending','running')` makes duplicate enqueues a no-op, so a spec edited twice in quick succession does not stack redundant work.
-- **Worker** — pulls one job at a time from the queue, fetches the current spec content, runs the embedding provider, persists vectors, marks the job succeeded. Lease default is 10 minutes; a pod that crashes mid-embed leaves its row in status=running and the reaper recovers it.
+- **Worker** claims one job per iteration, fetches the current spec content, runs the embedding provider, persists vectors, marks the job succeeded. Lease default is 10 minutes; a pod that crashes mid-embed leaves its row in status=running and the reaper recovers it. Each pod runs `apigateway.embed_jobs.workers` goroutines (default 1) that share the queue; the SKIP LOCKED predicate plus the lease guarantee mean two goroutines (in the same pod or across pods) never pick the same job. During a long embed the worker publishes `embedded_so_far` at every chunk boundary so the catalog status endpoint can render incremental progress before the final atomic upsert commits `embedding_count`.
 - **Reaper** — sweeps every 30 seconds: any row in status=running with `lease_expires_at <= NOW()` flips back to pending. Multiple pods, fast lease recovery.
 - **Reconciler** — periodic gap detector. Compares `api_catalog_specs.operation_count` (set at write time) against the actual count of rows in `api_catalog_operation_embeddings` and enqueues jobs for any spec where they disagree. Runs once on pod boot and every 5 minutes thereafter. This is the convergence backstop: a spec written before an embedder was configured, vectors lost to a partial restore, or any other gap is filled in without operator action.
 
@@ -100,7 +100,7 @@ Failure handling: retryable provider errors back off exponentially (5s, 10s, 20s
 
 The catalog editor renders the job queue's state directly:
 
-- **Per-spec badge** — `47/47 indexed` (green) when fully embedded, `indexing 12/47` (blue) while a worker is processing, `queued` (amber) while waiting for a worker, `failed` (red, tooltip carries the last error) after retries are exhausted.
+- **Per-spec badge.** `47/47 indexed` (green) when fully embedded, `indexing N/47` (blue) while a worker is processing where N is the chunk-progress counter that ticks up during the run, `queued` (amber) while waiting for a worker, `failed` (red, tooltip carries the last error) after retries are exhausted.
 - **Catalog header summary** — one-line roll-up: `All N specs indexed` (green) or `K indexed / M total (2 running, 1 failed)` (amber/red).
 - **Retry button** — visible only on failed rows; enqueues a `manual_retry` job. The reconciler's automatic path is the default; this is the escape hatch for "model changed externally."
 

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -696,6 +696,20 @@ memory:
 !!! note "Ollama batch endpoint"
     Batch embedding calls (API gateway spec indexing) issue a single `POST /api/embed` request per batch against modern Ollama servers. Servers that lack the batch endpoint (response: HTTP 404) are detected on the first call; the platform logs a WARN and transparently falls back to one `POST /api/embeddings` request per text. Upgrading the Ollama server is recommended for substantially faster batch indexing on multi-spec catalogs. Memory writes embed one record at a time and always use `/api/embeddings`.
 
+## API Gateway Configuration
+
+Cluster-wide tuning for the API gateway toolkit's background work. Connection-level configuration (`base_url`, `auth_mode`, credentials) lives in the connection store; this section is for knobs that apply to every API connection.
+
+```yaml
+apigateway:
+  embed_jobs:
+    workers: 1
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `embed_jobs.workers` | int | `1` | Number of embedding-worker goroutines per pod. Each goroutine independently claims and processes jobs; the lease + `SKIP LOCKED` predicate in the queue's claim path prevents two goroutines (in the same pod or across pods) from picking the same job. Increase to 2-4 for deployments with many specs and a fast embedder; CPU-only embedders typically saturate at 1 because the bottleneck is the embedding model. |
+
 ## MCP Apps Configuration
 
 MCP Apps provide interactive UI components that enhance tool results. The platform provides the infrastructure; you provide the HTML/JS/CSS apps.

--- a/pkg/admin/catalog_handler.go
+++ b/pkg/admin/catalog_handler.go
@@ -957,10 +957,20 @@ type embeddingStatusResponse struct {
 	SpecName       string `json:"spec_name"`
 	OperationCount int    `json:"operation_count"`
 	EmbeddingCount int    `json:"embedding_count"`
-	JobStatus      string `json:"job_status,omitempty"`
-	JobAttempts    int    `json:"job_attempts,omitempty"`
-	JobLastError   string `json:"job_last_error,omitempty"`
-	JobUpdatedAt   string `json:"job_updated_at,omitempty"`
+	// EmbeddedSoFar is the worker's in-flight chunk-progress counter.
+	// While JobStatus == "running" the portal renders this against
+	// OperationCount so a long embed pass shows incremental progress
+	// instead of staying at 0/N until the final atomic upsert commits
+	// EmbeddingCount in one tick (#430). Reset to 0 only when Claim
+	// picks the job up; terminal succeeded / failed rows and pending
+	// rows recovered from a lease expiry may still carry a prior
+	// attempt's value, which is why the portal gates its rendering
+	// on JobStatus == running.
+	EmbeddedSoFar int    `json:"embedded_so_far,omitempty"`
+	JobStatus     string `json:"job_status,omitempty"`
+	JobAttempts   int    `json:"job_attempts,omitempty"`
+	JobLastError  string `json:"job_last_error,omitempty"`
+	JobUpdatedAt  string `json:"job_updated_at,omitempty"`
 }
 
 func embeddingStatusResponseFromRow(row embedjobs.SpecStatusRow) embeddingStatusResponse {
@@ -968,6 +978,7 @@ func embeddingStatusResponseFromRow(row embedjobs.SpecStatusRow) embeddingStatus
 		SpecName:       row.SpecName,
 		OperationCount: row.OperationCount,
 		EmbeddingCount: row.EmbeddingCount,
+		EmbeddedSoFar:  row.EmbeddedSoFar,
 		JobStatus:      string(row.JobStatus),
 		JobAttempts:    row.JobAttempts,
 		JobLastError:   row.JobLastError,

--- a/pkg/database/migrate/migrate_unit_test.go
+++ b/pkg/database/migrate/migrate_unit_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	migrateTestFileCount    = 90
+	migrateTestFileCount    = 92
 	migrateTestSuccess      = "success"
 	migrateTestFactoryError = "factory error"
 )
@@ -98,6 +98,8 @@ func TestMigrationsEmbedded(t *testing.T) {
 		"000032_resources.down.sql",
 		"000041_drop_legacy_per_kind_oauth_token_tables.up.sql",
 		"000041_drop_legacy_per_kind_oauth_token_tables.down.sql",
+		"000046_api_catalog_embedding_jobs_progress.up.sql",
+		"000046_api_catalog_embedding_jobs_progress.down.sql",
 	}
 
 	fileNames := make(map[string]bool)

--- a/pkg/database/migrate/migrations/000046_api_catalog_embedding_jobs_progress.down.sql
+++ b/pkg/database/migrate/migrations/000046_api_catalog_embedding_jobs_progress.down.sql
@@ -1,0 +1,2 @@
+-- 000046: drop the embedded_so_far counter.
+ALTER TABLE api_catalog_embedding_jobs DROP COLUMN IF EXISTS embedded_so_far;

--- a/pkg/database/migrate/migrations/000046_api_catalog_embedding_jobs_progress.up.sql
+++ b/pkg/database/migrate/migrations/000046_api_catalog_embedding_jobs_progress.up.sql
@@ -1,0 +1,29 @@
+-- 000046: api_catalog_embedding_jobs.embedded_so_far
+--
+-- Adds the per-job in-flight progress counter the worker bumps at
+-- chunk boundaries during a long embed pass. Before this column the
+-- only progress signal a UI could read was COUNT(*) on
+-- api_catalog_operation_embeddings, which sits at 0 until the
+-- single worker transaction commits at the end of the run (the
+-- catalog store does DELETE ... ; INSERT ... ; COMMIT atomically
+-- to preserve the all-or-nothing rewrite semantic across a model
+-- swap). For a spec whose embedding pass takes minutes against a
+-- CPU-only embedder, the operator saw "indexing 0/N" the entire
+-- run and then a one-tick snap to "N/N" at completion (#430).
+--
+-- The counter is separate from embedding_count specifically so the
+-- atomicity of the final write stays intact. The worker writes
+-- embedded_so_far at every chunk boundary so the catalog status
+-- endpoint can render "running, 64/164" distinct from "queued,
+-- 0/164". The final UPSERT still happens in one transaction, and
+-- once it commits embedding_count == operation_count and this
+-- counter is irrelevant; reconciler / reaper logic does not depend
+-- on the value.
+--
+-- DEFAULT 0 so the column is populated for any pre-existing
+-- pending rows (a reconciler-enqueued backlog from before the
+-- upgrade). NOT NULL makes the worker's UPDATE path a simple SET
+-- without a coalesce.
+
+ALTER TABLE api_catalog_embedding_jobs
+    ADD COLUMN IF NOT EXISTS embedded_so_far INTEGER NOT NULL DEFAULT 0;

--- a/pkg/platform/apigateway_embed_jobs.go
+++ b/pkg/platform/apigateway_embed_jobs.go
@@ -63,11 +63,12 @@ func (p *Platform) WireAPIGatewayEmbedJobsFromDB() {
 	persister := &catalogEmbeddingPersister{store: catalogStore}
 
 	worker := embedjobs.NewWorker(embedjobs.WorkerConfig{
-		Store:     store,
-		Resolver:  resolver,
-		Computer:  computer,
-		Persister: persister,
-		Reloader:  &apigatewayConnectionReloader{registry: p.toolkitRegistry},
+		Store:       store,
+		Resolver:    resolver,
+		Computer:    computer,
+		Persister:   persister,
+		Reloader:    &apigatewayConnectionReloader{registry: p.toolkitRegistry},
+		Concurrency: p.config.APIGateway.EmbedJobs.Workers,
 	})
 	p.apiGatewayEmbedJobsWorker = worker
 
@@ -164,7 +165,7 @@ type embeddingProvider interface {
 // kit's ComputeOperationEmbeddings, and translates the result
 // back. The two intermediate types exist so embedjobs does not
 // import pgvector through every transitive consumer.
-func (c *apigatewayEmbeddingComputer) Compute(ctx context.Context, content, specName string, existing map[string]embedjobs.ExistingEmbedding) ([]embedjobs.ComputedEmbedding, error) {
+func (c *apigatewayEmbeddingComputer) Compute(ctx context.Context, content, specName string, existing map[string]embedjobs.ExistingEmbedding, progress func(int)) ([]embedjobs.ComputedEmbedding, error) {
 	catalogExisting := make(map[string]apigatewaycatalog.OperationEmbedding, len(existing))
 	for k, v := range existing {
 		catalogExisting[k] = apigatewaycatalog.OperationEmbedding{
@@ -175,7 +176,7 @@ func (c *apigatewayEmbeddingComputer) Compute(ctx context.Context, content, spec
 			Dim:         v.Dim,
 		}
 	}
-	rows, err := apigatewaykit.ComputeOperationEmbeddings(ctx, c.embedder, content, specName, catalogExisting)
+	rows, err := apigatewaykit.ComputeOperationEmbeddings(ctx, c.embedder, content, specName, catalogExisting, progress)
 	if err != nil {
 		return nil, fmt.Errorf("apigatewayEmbeddingComputer: %w", err)
 	}

--- a/pkg/platform/apigateway_embed_jobs_test.go
+++ b/pkg/platform/apigateway_embed_jobs_test.go
@@ -107,7 +107,7 @@ info:
 paths: {}
 `
 	c := &apigatewayEmbeddingComputer{embedder: &fakeEmbedder{dim: 8}}
-	rows, err := c.Compute(context.Background(), spec, "spec1", nil)
+	rows, err := c.Compute(context.Background(), spec, "spec1", nil, nil)
 	if err != nil {
 		t.Fatalf("Compute: %v", err)
 	}
@@ -145,7 +145,7 @@ paths:
 			Dim:         4,
 		},
 	}
-	rows, err := c.Compute(context.Background(), spec, "spec1", existing)
+	rows, err := c.Compute(context.Background(), spec, "spec1", existing, nil)
 	if err != nil {
 		t.Fatalf("Compute: %v", err)
 	}
@@ -163,7 +163,7 @@ paths:
 func TestApigatewayEmbeddingComputer_ParseError(t *testing.T) {
 	t.Parallel()
 	c := &apigatewayEmbeddingComputer{embedder: &fakeEmbedder{dim: 4}}
-	_, err := c.Compute(context.Background(), "this is not yaml at all: [", "spec1", nil)
+	_, err := c.Compute(context.Background(), "this is not yaml at all: [", "spec1", nil, nil)
 	if err == nil {
 		t.Fatal("expected parse error")
 	}

--- a/pkg/platform/apigateway_embed_jobs_wiring_test.go
+++ b/pkg/platform/apigateway_embed_jobs_wiring_test.go
@@ -6,6 +6,9 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	"github.com/txn2/mcp-data-platform/pkg/embedding"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
+	apigatewaycatalog "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway/catalog"
 )
 
 // TestWireAPIGatewayEmbedJobsFromDB_NoopEmbedderSkips proves the
@@ -60,5 +63,54 @@ func TestWireAPIGatewayEmbedJobsFromDB_NilEmbedderSkips(t *testing.T) {
 	p.WireAPIGatewayEmbedJobsFromDB()
 	if p.apiGatewayEmbedJobsStore != nil {
 		t.Errorf("nil embedder must not wire the job store")
+	}
+}
+
+// TestWireAPIGatewayEmbedJobsFromDB_WiresWorkerWithConfiguredConcurrency
+// proves the production-path branch (real DB + real embedder + real
+// catalog store): the store, worker, reaper, and reconciler all get
+// wired. The Concurrency value flows from APIGateway.EmbedJobs.Workers
+// into the WorkerConfig (#430). lifecycle.OnStart hooks are registered
+// but not invoked here so the goroutines never spawn.
+func TestWireAPIGatewayEmbedJobsFromDB_WiresWorkerWithConfiguredConcurrency(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	cfg := &Config{}
+	cfg.APIGateway.EmbedJobs.Workers = 3
+
+	reg := registry.NewRegistry()
+	// APIGatewayCatalogStore() reads through the registered
+	// apigateway toolkit, so register one before wiring the store.
+	if err := reg.Register(apigatewaykit.New("test")); err != nil {
+		t.Fatalf("register apigateway toolkit: %v", err)
+	}
+	p := &Platform{
+		db:              db,
+		embeddingProv:   embedding.NewOllamaProvider(embedding.OllamaConfig{}),
+		config:          cfg,
+		toolkitRegistry: reg,
+		lifecycle:       &Lifecycle{},
+	}
+	p.WireAPIGatewayCatalogStore(apigatewaycatalog.NewMemoryStore())
+	p.WireAPIGatewayEmbedJobsFromDB()
+
+	if p.apiGatewayEmbedJobsStore == nil {
+		t.Fatal("real embedder + DB + catalog store must wire the job store")
+	}
+	if p.apiGatewayEmbedJobsWorker == nil {
+		t.Fatal("worker must be constructed")
+	}
+	if got := p.apiGatewayEmbedJobsWorker.Concurrency(); got != 3 {
+		t.Errorf("Concurrency = %d; want 3 (the value flowed from apigateway.embed_jobs.workers)", got)
+	}
+	if p.apiGatewayEmbedJobsReaper == nil {
+		t.Fatal("reaper must be constructed")
+	}
+	if p.apiGatewayEmbedJobsReconciler == nil {
+		t.Fatal("reconciler must be constructed")
 	}
 }

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -116,6 +116,7 @@ type Config struct {
 	Elicitation   ElicitationConfig   `yaml:"elicitation"`
 	Workflow      WorkflowConfig      `yaml:"workflow"`
 	SessionGate   SessionGateConfig   `yaml:"session_gate"`
+	APIGateway    APIGatewayConfig    `yaml:"apigateway"`
 
 	// runtimeMu guards fields that can be mutated at runtime via the admin
 	// API (Tools.DescriptionOverrides, Tools.Deny). Other fields are
@@ -789,6 +790,30 @@ type SessionGateConfig struct {
 
 	// ExemptTools lists tool names that bypass the gate (e.g., "list_connections").
 	ExemptTools []string `yaml:"exempt_tools"`
+}
+
+// APIGatewayConfig holds platform-level tuning for the api-kind toolkit.
+// Connection-level configuration (base_url, auth_mode, credentials, etc.)
+// lives in the connection store; this struct is for cluster-wide knobs that
+// affect every api connection, primarily the embedding-job queue's
+// concurrency.
+type APIGatewayConfig struct {
+	// EmbedJobs tunes the api-gateway embedding job queue.
+	EmbedJobs APIGatewayEmbedJobsConfig `yaml:"embed_jobs"`
+}
+
+// APIGatewayEmbedJobsConfig tunes the per-pod embedding worker.
+type APIGatewayEmbedJobsConfig struct {
+	// Workers is the number of goroutines per pod that claim and
+	// process jobs in parallel. Multiple goroutines share the queue;
+	// the lease + SKIP LOCKED predicate in Claim prevents two
+	// goroutines (in the same pod or across pods) from picking the
+	// same job. Zero or negative falls back to 1, which preserves
+	// the pre-#430 single-goroutine behavior. Production deployments
+	// with many specs and a fast embedder benefit from 2-4; CPU-only
+	// embedders typically saturate at 1 because the bottleneck is
+	// the embedding model, not the gateway. See #430.
+	Workers int `yaml:"workers"`
 }
 
 // isExplicitlyDisabled returns true only when the pointer is non-nil and false.

--- a/pkg/platform/integration_embedjobs_progress_test.go
+++ b/pkg/platform/integration_embedjobs_progress_test.go
@@ -1,0 +1,177 @@
+//go:build integration
+
+package platform_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/txn2/mcp-data-platform/pkg/database/migrate"
+	"github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway/embedjobs"
+)
+
+// slowEmbedComputer drives the worker through several chunk
+// boundaries so the progress publish path exercises real DB writes
+// against the integration container. Each Compute call invokes the
+// supplied progress callback once per synthetic "chunk" with a small
+// sleep between them so the test can observe embedded_so_far moving
+// before the final Complete commits.
+type slowEmbedComputer struct {
+	chunkDelay  time.Duration
+	chunkCounts []int
+	finalRows   []embedjobs.ComputedEmbedding
+}
+
+func (c *slowEmbedComputer) Compute(ctx context.Context, _, _ string, _ map[string]embedjobs.ExistingEmbedding, progress func(int)) ([]embedjobs.ComputedEmbedding, error) {
+	for _, n := range c.chunkCounts {
+		select {
+		case <-time.After(c.chunkDelay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		if progress != nil {
+			progress(n)
+		}
+	}
+	return c.finalRows, nil
+}
+
+// noopReloader satisfies the ConnectionReloader interface without
+// touching a real toolkit registry: this integration test does not
+// boot the api-gateway toolkit, only the job queue.
+type noopReloader struct{}
+
+func (*noopReloader) ReloadConnectionsByCatalog(_ string) {}
+
+// inMemoryPersister substitutes for the real catalog persister.
+// The integration test asserts on embedded_so_far (which lives on
+// api_catalog_embedding_jobs); the embedding-vector rows themselves
+// are not exercised here.
+type inMemoryPersister struct{}
+
+func (*inMemoryPersister) ListExisting(_ context.Context, _, _ string) (map[string]embedjobs.ExistingEmbedding, error) {
+	return nil, nil
+}
+
+func (*inMemoryPersister) Upsert(_ context.Context, _, _ string, _ []embedjobs.ComputedEmbedding) error {
+	return nil
+}
+
+func (*inMemoryPersister) StampOperationCount(_ context.Context, _, _ string, _ int) error {
+	return nil
+}
+
+// staticResolver returns a fixed content blob for the (catalog,
+// spec) the test enqueues.
+type staticResolver struct{}
+
+func (*staticResolver) GetSpecContent(_ context.Context, _, _ string) (string, error) {
+	return "spec content (unused; slowEmbedComputer ignores it)", nil
+}
+
+// TestEmbedJobsProgress_EndToEnd verifies the wiring of the
+// embedded_so_far counter from worker chunk callback through the
+// Postgres UPDATE to the SpecStatuses read path used by the admin
+// UI (#430).
+func TestEmbedJobsProgress_EndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+
+	pgContainer, err := postgres.Run(ctx,
+		"pgvector/pgvector:pg16",
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("test"),
+		postgres.WithPassword("test"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(5*time.Minute),
+		),
+	)
+	require.NoError(t, err)
+	defer func() { _ = pgContainer.Terminate(ctx) }()
+
+	dsn, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+	require.NoError(t, migrate.Run(db))
+
+	// A spec row is required for the FK on api_catalog_embedding_jobs.
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO api_catalogs (id, name, display_name, version, description, created_at, updated_at)
+		VALUES ('c1', 'c1', 'c1', 'v1', '', NOW(), NOW())
+	`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO api_catalog_specs (catalog_id, spec_name, source_kind, content, operation_count, created_at, updated_at)
+		VALUES ('c1', 's1', 'inline', 'irrelevant', 12, NOW(), NOW())
+	`)
+	require.NoError(t, err)
+
+	store := embedjobs.NewPostgresStore(db)
+	_, err = store.Enqueue(ctx, embedjobs.SpecKey{CatalogID: "c1", SpecName: "s1"}, embedjobs.KindSpecWrite)
+	require.NoError(t, err)
+
+	computer := &slowEmbedComputer{
+		chunkDelay:  100 * time.Millisecond,
+		chunkCounts: []int{4, 8, 12},
+	}
+	w := embedjobs.NewWorker(embedjobs.WorkerConfig{
+		Store:     store,
+		Resolver:  &staticResolver{},
+		Computer:  computer,
+		Persister: &inMemoryPersister{},
+		Reloader:  &noopReloader{},
+		WorkerID:  "test-worker",
+		PollEvery: 25 * time.Millisecond,
+	})
+	w.Start(ctx)
+	defer w.Stop()
+
+	// Poll SpecStatuses while the worker runs. Assert embedded_so_far
+	// is strictly increasing across at least two observations before
+	// the job completes.
+	var observations []int
+	deadline := time.Now().Add(2 * time.Second)
+	var lastJobStatus embedjobs.Status
+	for time.Now().Before(deadline) {
+		rows, statusErr := store.SpecStatuses(ctx, "c1")
+		require.NoError(t, statusErr)
+		require.Len(t, rows, 1)
+		row := rows[0]
+		if row.JobStatus == embedjobs.StatusRunning && row.EmbeddedSoFar > 0 {
+			if len(observations) == 0 || observations[len(observations)-1] != row.EmbeddedSoFar {
+				observations = append(observations, row.EmbeddedSoFar)
+			}
+		}
+		lastJobStatus = row.JobStatus
+		if row.JobStatus == embedjobs.StatusSucceeded {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	assert.Equal(t, embedjobs.StatusSucceeded, lastJobStatus, "job should reach succeeded")
+	if len(observations) < 2 {
+		t.Fatalf("expected at least 2 distinct embedded_so_far observations during running; got %v", observations)
+	}
+	// Each observation must be greater than the prior one: the
+	// counter only moves forward inside a single Claim.
+	for i := 1; i < len(observations); i++ {
+		assert.Greater(t, observations[i], observations[i-1],
+			"embedded_so_far must be strictly increasing during running: %v", observations)
+	}
+}

--- a/pkg/toolkits/apigateway/embed_spec.go
+++ b/pkg/toolkits/apigateway/embed_spec.go
@@ -14,20 +14,32 @@ import (
 // walks its operations, and returns one catalog.OperationEmbedding
 // per operation. For an operation whose text hashes to a value
 // already present in existing, the existing row's Embedding is
-// reused — skipping the provider call for unchanged operations on
-// a spec refresh. Returns nil when embedder is nil (embedding-less
-// deployment) or when the spec parses to zero operations.
+// reused (no provider call) on a spec refresh. Returns nil when
+// embedder is nil (embedding-less deployment) or when the spec
+// parses to zero operations.
 //
 // The embed text is built with an empty base path so a base_path
 // change does not invalidate every vector. Operators tweaking the
 // per-spec prefix shouldn't trigger a full re-embed pass.
+//
+// progress is invoked at chunk boundaries during the fresh-embed
+// pass with the cumulative number of operations whose vectors are
+// ready (reused rows are counted up front; freshly-embedded rows
+// are added per chunk). The embed-jobs worker uses this to publish
+// embedded_so_far to the job row so the catalog status endpoint
+// can render incremental progress while the final atomic upsert is
+// still pending (#430). nil progress disables the callback for
+// non-worker call sites (admin handler invocations that never see
+// the long-running path).
 //
 // Called by the admin handler after every spec upsert / upload /
 // refresh / clone. Failures are non-fatal at the call site: the
 // spec write has already succeeded; an embedding compute failure
 // just means semantic ranking falls back to lexical until the
 // operator runs the re-embed admin endpoint.
-func ComputeOperationEmbeddings(ctx context.Context, embedder embedding.Provider, content, specName string, existing map[string]catalog.OperationEmbedding) ([]catalog.OperationEmbedding, error) {
+//
+//nolint:revive // argument-limit: orchestration entry point; each arg is atomic (ctx, embedder, two distinct strings, dedup map, progress callback) and bundling would only push the same surface into a struct.
+func ComputeOperationEmbeddings(ctx context.Context, embedder embedding.Provider, content, specName string, existing map[string]catalog.OperationEmbedding, progress func(completed int)) ([]catalog.OperationEmbedding, error) {
 	if embedder == nil {
 		return nil, nil
 	}
@@ -42,7 +54,14 @@ func ComputeOperationEmbeddings(ctx context.Context, embedder embedding.Provider
 	model := providerModel(embedder)
 	dim := embedder.Dimension()
 	rows, toEmbedIdx, toEmbedTexts := planEmbeddingRows(ops, texts, existing, model, dim)
-	if err := fillFreshEmbeddings(ctx, embedder, rows, toEmbedIdx, toEmbedTexts); err != nil {
+	reused := len(rows) - len(toEmbedIdx)
+	// Publish the initial reused-count so a refresh on a fully
+	// cached spec ticks straight to operation_count without waiting
+	// for the embedding pass (which has nothing to do).
+	if progress != nil {
+		progress(reused)
+	}
+	if err := fillFreshEmbeddings(ctx, embedder, rows, toEmbedIdx, toEmbedTexts, reused, progress); err != nil {
 		return nil, err
 	}
 	return rows, nil
@@ -83,11 +102,24 @@ func planEmbeddingRows(ops []OperationSummary, texts []string, existing map[stri
 // fillFreshEmbeddings calls embedder for the deltas only and
 // writes each vector back into its row. No-op when toEmbedTexts
 // is empty (every operation's vector was reused from existing).
-func fillFreshEmbeddings(ctx context.Context, embedder embedding.Provider, rows []catalog.OperationEmbedding, toEmbedIdx []int, toEmbedTexts []string) error {
+//
+// reusedBase is the count of operations whose vectors were reused
+// from the existing map (and therefore already published via the
+// initial progress callback). The per-chunk progress publish adds
+// the count of freshly-embedded operations to this base so the
+// caller sees a cumulative "operations ready" counter across the
+// whole spec, not just the fresh-embed portion.
+//
+//nolint:revive // argument-limit: internal helper called from one site; splitting would either duplicate the (rows, toEmbedIdx, toEmbedTexts) trio that ComputeOperationEmbeddings already produces together, or move the worker-progress wiring further from its consumer. Each arg is distinct.
+func fillFreshEmbeddings(ctx context.Context, embedder embedding.Provider, rows []catalog.OperationEmbedding, toEmbedIdx []int, toEmbedTexts []string, reusedBase int, progress func(completed int)) error {
 	if len(toEmbedTexts) == 0 {
 		return nil
 	}
-	vectors, err := embedInBatches(ctx, embedder, toEmbedTexts, embedBatchSize)
+	vectors, err := embedInBatches(ctx, embedder, toEmbedTexts, embedBatchSize, func(freshDone int) {
+		if progress != nil {
+			progress(reusedBase + freshDone)
+		}
+	})
 	if err != nil {
 		return fmt.Errorf("embed operation batch: %w", err)
 	}

--- a/pkg/toolkits/apigateway/embed_spec_test.go
+++ b/pkg/toolkits/apigateway/embed_spec_test.go
@@ -13,7 +13,7 @@ import (
 // unconditionally without guarding on the embedder.
 func TestComputeOperationEmbeddings_NilEmbedderReturnsNil(t *testing.T) {
 	t.Parallel()
-	rows, err := ComputeOperationEmbeddings(context.Background(), nil, persistedEmbedTestSpec, "default", nil)
+	rows, err := ComputeOperationEmbeddings(context.Background(), nil, persistedEmbedTestSpec, "default", nil, nil)
 	if err != nil {
 		t.Fatalf("nil embedder should not error; got %v", err)
 	}
@@ -27,7 +27,7 @@ func TestComputeOperationEmbeddings_NilEmbedderReturnsNil(t *testing.T) {
 // "parse spec" error so the admin handler logs the right cause.
 func TestComputeOperationEmbeddings_UnparseableSpecErrors(t *testing.T) {
 	t.Parallel()
-	_, err := ComputeOperationEmbeddings(context.Background(), newFakeEmbedder(8), "::not yaml::", "default", nil)
+	_, err := ComputeOperationEmbeddings(context.Background(), newFakeEmbedder(8), "::not yaml::", "default", nil, nil)
 	if err == nil {
 		t.Fatal("expected error on malformed spec")
 	}
@@ -44,7 +44,7 @@ func TestComputeOperationEmbeddings_ZeroOperationsReturnsNil(t *testing.T) {
 	emptySpec := `openapi: 3.0.0
 info: {title: t, version: "1"}
 paths: {}`
-	rows, err := ComputeOperationEmbeddings(context.Background(), newFakeEmbedder(8), emptySpec, "default", nil)
+	rows, err := ComputeOperationEmbeddings(context.Background(), newFakeEmbedder(8), emptySpec, "default", nil, nil)
 	if err != nil {
 		t.Fatalf("zero-op spec should not error; got %v", err)
 	}
@@ -61,7 +61,7 @@ func TestComputeOperationEmbeddings_BatchErrorPropagates(t *testing.T) {
 	t.Parallel()
 	emb := newFakeEmbedder(8)
 	emb.failBatch.Store(true)
-	_, err := ComputeOperationEmbeddings(context.Background(), emb, persistedEmbedTestSpec, "default", nil)
+	_, err := ComputeOperationEmbeddings(context.Background(), emb, persistedEmbedTestSpec, "default", nil, nil)
 	if err == nil {
 		t.Fatal("expected error from failing batch")
 	}
@@ -79,7 +79,7 @@ func TestComputeOperationEmbeddings_BatchErrorPropagates(t *testing.T) {
 // refactor bypassing embedInBatches.
 func TestComputeOperationEmbeddings_CountMismatchPropagates(t *testing.T) {
 	t.Parallel()
-	_, err := ComputeOperationEmbeddings(context.Background(), countMismatchEmbedder{returnCount: 1}, persistedEmbedTestSpec, "default", nil)
+	_, err := ComputeOperationEmbeddings(context.Background(), countMismatchEmbedder{returnCount: 1}, persistedEmbedTestSpec, "default", nil, nil)
 	if err == nil {
 		t.Fatal("expected error from vector count mismatch")
 	}
@@ -106,6 +106,35 @@ func (e countMismatchEmbedder) EmbedBatch(_ context.Context, _ []string) ([][]fl
 	return out, nil
 }
 
+// TestComputeOperationEmbeddings_ProgressCallback proves the
+// progress callback is invoked with the initial reused count up
+// front (so a fully-cached spec ticks straight to operation_count)
+// AND at every chunk boundary during the fresh-embed pass. The
+// callback is the path the embed-jobs worker uses to publish
+// embedded_so_far on the job row (#430).
+func TestComputeOperationEmbeddings_ProgressCallback(t *testing.T) {
+	t.Parallel()
+	emb := newFakeEmbedder(8)
+	var calls []int
+	progress := func(n int) { calls = append(calls, n) }
+	rows, err := ComputeOperationEmbeddings(context.Background(), emb, persistedEmbedTestSpec, "default", nil, progress)
+	if err != nil {
+		t.Fatalf("ComputeOperationEmbeddings: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d; want 2", len(rows))
+	}
+	// At minimum: one initial publish (reused=0) and one chunk-done
+	// publish (fresh=2). The final cumulative count must equal the
+	// number of operations.
+	if len(calls) < 2 {
+		t.Fatalf("progress called %d times; want >= 2 (initial + chunk-done): %v", len(calls), calls)
+	}
+	if calls[len(calls)-1] != 2 {
+		t.Errorf("final progress = %d; want 2 (all operations ready)", calls[len(calls)-1])
+	}
+}
+
 // TestComputeOperationEmbeddings_AllReusedSkipsFreshEmbed covers
 // fillFreshEmbeddings's early-return: when every operation's text
 // hash + dim + model already match the existing set, the embedder
@@ -115,7 +144,7 @@ func TestComputeOperationEmbeddings_AllReusedSkipsFreshEmbed(t *testing.T) {
 	t.Parallel()
 	emb := newTrackingEmbedder()
 	// First pass writes the existing set.
-	rows, err := ComputeOperationEmbeddings(context.Background(), emb, persistedEmbedTestSpec, "default", nil)
+	rows, err := ComputeOperationEmbeddings(context.Background(), emb, persistedEmbedTestSpec, "default", nil, nil)
 	if err != nil {
 		t.Fatalf("first compute: %v", err)
 	}
@@ -130,7 +159,7 @@ func TestComputeOperationEmbeddings_AllReusedSkipsFreshEmbed(t *testing.T) {
 	// Second pass with identical content + identical model. Nothing
 	// to re-embed, so fillFreshEmbeddings returns without calling
 	// the provider.
-	if _, err := ComputeOperationEmbeddings(context.Background(), emb, persistedEmbedTestSpec, "default", existing); err != nil {
+	if _, err := ComputeOperationEmbeddings(context.Background(), emb, persistedEmbedTestSpec, "default", existing, nil); err != nil {
 		t.Fatalf("second compute: %v", err)
 	}
 	if got := emb.batchCalls.Load(); got != firstBatch {

--- a/pkg/toolkits/apigateway/embedjobs/store_postgres.go
+++ b/pkg/toolkits/apigateway/embedjobs/store_postgres.go
@@ -142,11 +142,12 @@ func (s *PostgresStore) Claim(ctx context.Context, workerID string) (*Job, error
 		       worker_id = $2,
 		       attempts = attempts + 1,
 		       started_at = NOW(),
-		       lease_expires_at = NOW() + ($3 || ' seconds')::INTERVAL
+		       lease_expires_at = NOW() + ($3 || ' seconds')::INTERVAL,
+		       embedded_so_far = 0
 		 WHERE id = $1
 		 RETURNING id, catalog_id, spec_name, kind, status, attempts,
 		           last_error, next_run_at, worker_id, lease_expires_at,
-		           created_at, started_at, completed_at
+		           created_at, started_at, completed_at, embedded_so_far
 	`
 	leaseSeconds := int(LeaseDuration / time.Second)
 	row := tx.QueryRowContext(ctx, upd, id, workerID, leaseSeconds)
@@ -186,6 +187,32 @@ func (s *PostgresStore) Complete(ctx context.Context, id int64, workerID string)
 	}
 	if n == 0 {
 		return ErrNotFound
+	}
+	return nil
+}
+
+// UpdateProgress publishes the worker's chunk-boundary progress
+// counter to the row. The (id, worker_id, status='running')
+// predicate enforces lease ownership: if the lease has rotated to
+// another worker, the UPDATE matches zero rows and returns nil so
+// the calling worker carries on toward its next chunk without
+// caring whose count the row will surface (the new lease holder
+// will publish its own count on its next chunk).
+//
+// Best-effort: an error from the DB itself (network, pool
+// exhaustion) is returned for the worker to log, but the worker
+// does NOT retry or fail the job on a progress write error. The
+// final Complete is the authoritative success signal.
+func (s *PostgresStore) UpdateProgress(ctx context.Context, id int64, workerID string, embeddedSoFar int) error {
+	const q = `
+		UPDATE api_catalog_embedding_jobs
+		   SET embedded_so_far = $3
+		 WHERE id = $1
+		   AND status = 'running'
+		   AND worker_id = $2
+	`
+	if _, err := s.db.ExecContext(ctx, q, id, workerID, embeddedSoFar); err != nil {
+		return fmt.Errorf("embedjobs: update_progress: %w", err)
 	}
 	return nil
 }
@@ -365,7 +392,7 @@ func (s *PostgresStore) Get(ctx context.Context, id int64) (*Job, error) {
 	const q = `
 		SELECT id, catalog_id, spec_name, kind, status, attempts,
 		       last_error, next_run_at, worker_id, lease_expires_at,
-		       created_at, started_at, completed_at
+		       created_at, started_at, completed_at, embedded_so_far
 		  FROM api_catalog_embedding_jobs
 		 WHERE id = $1
 	`
@@ -396,7 +423,7 @@ func (s *PostgresStore) List(ctx context.Context, filter ListFilter) ([]Job, err
 	args = append(args, limit)
 	q := `SELECT id, catalog_id, spec_name, kind, status, attempts,
 	             last_error, next_run_at, worker_id, lease_expires_at,
-	             created_at, started_at, completed_at
+	             created_at, started_at, completed_at, embedded_so_far
 	        FROM api_catalog_embedding_jobs` + predicates +
 		` ORDER BY id DESC LIMIT $` + intToStr(len(args)) // #nosec G202 -- predicates are closed-set literal fragments; only $N placeholders are dynamic
 	rows, err := s.db.QueryContext(ctx, q, args...)
@@ -435,7 +462,8 @@ func (s *PostgresStore) SpecStatuses(ctx context.Context, catalogID string) ([]S
 		       COALESCE(j.status, '')             AS job_status,
 		       COALESCE(j.attempts, 0)            AS job_attempts,
 		       COALESCE(j.last_error, '')         AS job_last_error,
-		       GREATEST(j.completed_at, j.started_at, j.created_at) AS job_updated_at
+		       GREATEST(j.completed_at, j.started_at, j.created_at) AS job_updated_at,
+		       COALESCE(j.embedded_so_far, 0)     AS embedded_so_far
 		  FROM api_catalog_specs s
 		  LEFT JOIN (
 		    SELECT catalog_id, spec_name, COUNT(*) AS embedded
@@ -444,7 +472,7 @@ func (s *PostgresStore) SpecStatuses(ctx context.Context, catalogID string) ([]S
 		  ) e USING (catalog_id, spec_name)
 		  LEFT JOIN LATERAL (
 		    SELECT status, attempts, last_error,
-		           created_at, started_at, completed_at
+		           created_at, started_at, completed_at, embedded_so_far
 		      FROM api_catalog_embedding_jobs
 		     WHERE catalog_id = s.catalog_id
 		       AND spec_name = s.spec_name
@@ -465,7 +493,8 @@ func (s *PostgresStore) SpecStatuses(ctx context.Context, catalogID string) ([]S
 		var status string
 		var updatedAt sql.NullTime
 		if err := rows.Scan(&r.CatalogID, &r.SpecName, &r.OperationCount,
-			&r.EmbeddingCount, &status, &r.JobAttempts, &r.JobLastError, &updatedAt); err != nil {
+			&r.EmbeddingCount, &status, &r.JobAttempts, &r.JobLastError, &updatedAt,
+			&r.EmbeddedSoFar); err != nil {
 			return nil, fmt.Errorf("embedjobs: spec statuses scan: %w", err)
 		}
 		r.JobStatus = Status(status)
@@ -544,7 +573,8 @@ func scanJob(r rowScanner) (*Job, error) {
 	)
 	if err := r.Scan(&j.ID, &j.CatalogID, &j.SpecName, &kind, &status,
 		&j.Attempts, &j.LastError, &j.NextRunAt, &j.WorkerID,
-		&leaseExpiresAt, &j.CreatedAt, &startedAt, &completedAt); err != nil {
+		&leaseExpiresAt, &j.CreatedAt, &startedAt, &completedAt,
+		&j.EmbeddedSoFar); err != nil {
 		return nil, fmt.Errorf("embedjobs: scan job row: %w", err)
 	}
 	j.Kind = Kind(kind)

--- a/pkg/toolkits/apigateway/embedjobs/store_postgres_test.go
+++ b/pkg/toolkits/apigateway/embedjobs/store_postgres_test.go
@@ -106,9 +106,9 @@ func TestClaim_HappyPath(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "catalog_id", "spec_name", "kind", "status", "attempts",
 			"last_error", "next_run_at", "worker_id", "lease_expires_at",
-			"created_at", "started_at", "completed_at",
+			"created_at", "started_at", "completed_at", "embedded_so_far",
 		}).AddRow(int64(42), "petstore", "default", "spec_write", "running", 1,
-			"", now, "worker-x", lease, now, now, nil))
+			"", now, "worker-x", lease, now, now, nil, 0))
 	mock.ExpectCommit()
 	job, err := store.Claim(context.Background(), "worker-x")
 	if err != nil {
@@ -163,6 +163,53 @@ func TestComplete_LeaseRotated(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	if err := store.Complete(context.Background(), 42, "stale-worker"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err=%v want ErrNotFound", err)
+	}
+}
+
+// TestUpdateProgress_HappyPath verifies the worker's chunk-progress
+// publish writes embedded_so_far on the matching (id, worker_id,
+// status='running') row. The catalog status endpoint reads this
+// column to render incremental progress before the final commit
+// (#430).
+func TestUpdateProgress_HappyPath(t *testing.T) {
+	t.Parallel()
+	store, mock, done := newMockStore(t)
+	defer done()
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE api_catalog_embedding_jobs`)).
+		WithArgs(int64(42), "worker-x", 17).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	if err := store.UpdateProgress(context.Background(), 42, "worker-x", 17); err != nil {
+		t.Fatalf("UpdateProgress: %v", err)
+	}
+}
+
+// TestUpdateProgress_LeaseRotatedIsNoop proves a stale worker
+// whose lease has been recovered by the reaper writes nothing AND
+// returns no error, so a write race between an old and new holder
+// cannot fail the entire embed pass.
+func TestUpdateProgress_LeaseRotatedIsNoop(t *testing.T) {
+	t.Parallel()
+	store, mock, done := newMockStore(t)
+	defer done()
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE api_catalog_embedding_jobs`)).
+		WithArgs(int64(42), "stale-worker", 9).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	if err := store.UpdateProgress(context.Background(), 42, "stale-worker", 9); err != nil {
+		t.Errorf("UpdateProgress on rotated lease must not error; got %v", err)
+	}
+}
+
+// TestUpdateProgress_DBError surfaces a transport-layer failure so
+// the worker can log it; the worker itself does not abort the job
+// on a progress write error (see process()).
+func TestUpdateProgress_DBError(t *testing.T) {
+	t.Parallel()
+	store, mock, done := newMockStore(t)
+	defer done()
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE api_catalog_embedding_jobs`)).
+		WillReturnError(errors.New("conn pool exhausted"))
+	if err := store.UpdateProgress(context.Background(), 1, "w", 1); err == nil {
+		t.Fatal("expected wrapped DB error")
 	}
 }
 
@@ -399,9 +446,9 @@ func TestGet_Success(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "catalog_id", "spec_name", "kind", "status", "attempts",
 			"last_error", "next_run_at", "worker_id", "lease_expires_at",
-			"created_at", "started_at", "completed_at",
+			"created_at", "started_at", "completed_at", "embedded_so_far",
 		}).AddRow(int64(42), "petstore", "default", "spec_write", "running",
-			1, "", now, "w1", now, now, now, nil))
+			1, "", now, "w1", now, now, now, nil, 0))
 	j, err := store.Get(context.Background(), 42)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
@@ -445,7 +492,7 @@ func TestList_Empty(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "catalog_id", "spec_name", "kind", "status", "attempts",
 			"last_error", "next_run_at", "worker_id", "lease_expires_at",
-			"created_at", "started_at", "completed_at",
+			"created_at", "started_at", "completed_at", "embedded_so_far",
 		}))
 	jobs, err := store.List(context.Background(), ListFilter{})
 	if err != nil {
@@ -468,9 +515,9 @@ func TestList_WithFilters(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "catalog_id", "spec_name", "kind", "status", "attempts",
 			"last_error", "next_run_at", "worker_id", "lease_expires_at",
-			"created_at", "started_at", "completed_at",
+			"created_at", "started_at", "completed_at", "embedded_so_far",
 		}).AddRow(int64(7), "petstore", "default", "reconciler", "failed",
-			5, "boom", now, "", nil, now, now, now))
+			5, "boom", now, "", nil, now, now, now, 0))
 	jobs, err := store.List(context.Background(), ListFilter{
 		CatalogID: "petstore", SpecName: "default",
 		Status: StatusFailed, Kind: KindReconciler, Limit: 5,
@@ -507,9 +554,10 @@ func TestSpecStatuses_HappyPath(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{
 			"catalog_id", "spec_name", "operation_count", "embedding_count",
 			"job_status", "job_attempts", "job_last_error", "job_updated_at",
+			"embedded_so_far",
 		}).
-			AddRow("petstore", "users", 3, 3, "succeeded", 1, "", now).
-			AddRow("petstore", "orders", 5, 2, "running", 1, "", now))
+			AddRow("petstore", "users", 3, 3, "succeeded", 1, "", now, 3).
+			AddRow("petstore", "orders", 5, 2, "running", 1, "", now, 4))
 	rows, err := store.SpecStatuses(context.Background(), "petstore")
 	if err != nil {
 		t.Fatalf("SpecStatuses: %v", err)

--- a/pkg/toolkits/apigateway/embedjobs/types.go
+++ b/pkg/toolkits/apigateway/embedjobs/types.go
@@ -172,6 +172,18 @@ type Job struct {
 	CreatedAt      time.Time
 	StartedAt      *time.Time
 	CompletedAt    *time.Time
+	// EmbeddedSoFar is the worker's in-flight progress counter,
+	// bumped at every chunk boundary inside a long embed pass so
+	// the catalog status endpoint can render "running, N/M" while
+	// the final UPSERT transaction is still pending. Reset to 0
+	// only by Claim on the next pickup, which means a pending row
+	// recovered by Retry / ReleaseExpiredLeases, a terminal
+	// succeeded / failed row, or any other non-running state may
+	// still carry a non-zero value from a prior attempt. Callers
+	// gate the display on Status == running rather than on this
+	// counter; the value is meaningful only while a worker holds
+	// the lease. See #430.
+	EmbeddedSoFar int
 }
 
 // SpecKey is the composite (catalog_id, spec_name) reference
@@ -209,6 +221,13 @@ type SpecStatusRow struct {
 	JobAttempts    int
 	JobLastError   string
 	JobUpdatedAt   *time.Time
+	// EmbeddedSoFar mirrors Job.EmbeddedSoFar on the most recent
+	// job row. Reset to 0 only by Claim; a terminal succeeded /
+	// failed row or a pending row recovered from a lease expiry
+	// may still carry a prior attempt's value. The portal gates
+	// its "running, N/M" rendering on JobStatus == running so the
+	// stale value never reaches the UI. See #430.
+	EmbeddedSoFar int
 }
 
 // CatalogHealth is the per-catalog roll-up the catalog header
@@ -259,6 +278,16 @@ type Store interface {
 	// Complete on a job whose lease has rotated is a no-op
 	// (returns ErrNotFound).
 	Complete(ctx context.Context, id int64, workerID string) error
+
+	// UpdateProgress sets embedded_so_far on a running job's row.
+	// Called by the worker at chunk boundaries inside a long embed
+	// pass so the status endpoint can render incremental progress
+	// before the final UPSERT transaction commits. Best-effort:
+	// a write that misses (because the lease rotated and a foreign
+	// worker now holds the job) is silently dropped; the new
+	// holder will re-publish its own count. Returns nil on success
+	// even when zero rows match the (id, worker_id) filter.
+	UpdateProgress(ctx context.Context, id int64, workerID string, embeddedSoFar int) error
 
 	// Retry releases the lease and reschedules the job with an
 	// exponential backoff (5 * 2^attempts seconds). Used for

--- a/pkg/toolkits/apigateway/embedjobs/worker.go
+++ b/pkg/toolkits/apigateway/embedjobs/worker.go
@@ -48,8 +48,17 @@ type SpecResolver interface {
 // EmbeddingComputer is the worker's bridge to the embedding
 // provider. The implementation calls
 // apigateway.ComputeOperationEmbeddings (or a test stub).
+//
+// progress is called by the implementation at chunk boundaries
+// inside a long embed pass with the cumulative number of operations
+// whose vectors are ready (reused-from-existing plus freshly
+// computed). The worker publishes the value to api_catalog_embedding_jobs
+// .embedded_so_far so the catalog status endpoint can render
+// incremental progress while the final atomic upsert is still
+// pending (#430). nil progress is acceptable; the implementation
+// skips the callback in that case.
 type EmbeddingComputer interface {
-	Compute(ctx context.Context, content, specName string, existing map[string]ExistingEmbedding) ([]ComputedEmbedding, error)
+	Compute(ctx context.Context, content, specName string, existing map[string]ExistingEmbedding, progress func(int)) ([]ComputedEmbedding, error)
 }
 
 // ExistingEmbedding is the subset of catalog.OperationEmbedding
@@ -115,6 +124,15 @@ type WorkerConfig struct {
 	Reloader  ConnectionReloader // optional
 	WorkerID  string             // empty -> auto-generated
 	PollEvery time.Duration      // fallback poll interval; default 30s
+
+	// Concurrency is the number of goroutines that share the queue.
+	// Each goroutine independently calls Claim, so a flood of new
+	// specs can be embedded in parallel up to this cap. The lease +
+	// SKIP LOCKED machinery in Claim already prevents two goroutines
+	// (in the same pod or across pods) from picking the same job.
+	// Zero or negative falls back to 1, preserving the pre-#430
+	// single-goroutine behavior.
+	Concurrency int
 }
 
 // Worker drains the job queue. One Worker instance per pod is
@@ -139,6 +157,9 @@ func NewWorker(cfg WorkerConfig) *Worker {
 	if cfg.PollEvery <= 0 {
 		cfg.PollEvery = defaultPollEvery
 	}
+	if cfg.Concurrency <= 0 {
+		cfg.Concurrency = 1
+	}
 	return &Worker{
 		cfg:    cfg,
 		wakeup: make(chan struct{}, 1),
@@ -158,14 +179,32 @@ func (w *Worker) Notify() {
 	}
 }
 
+// Concurrency reports the number of goroutines this worker will
+// spawn (or has spawned) on Start. Exposed so platform wiring tests
+// can assert the configured value flowed from
+// apigateway.embed_jobs.workers through WorkerConfig into the
+// Worker without exporting the cfg field itself.
+func (w *Worker) Concurrency() int { return w.cfg.Concurrency }
+
 // Start begins the worker loop. Safe to call multiple times;
-// only the first call spawns the goroutine.
+// only the first call spawns goroutines.
+//
+// One run() goroutine per WorkerConfig.Concurrency unit; each
+// shares the wakeup channel + stopCh and races for jobs through
+// Claim's SKIP LOCKED predicate. The lease guarantee at the DB
+// level keeps two goroutines from racing on the same (catalog,
+// spec) pair, so the only coordination needed inside the pod is
+// the wakeup-channel buffering (one slot; a flurry of NOTIFYs
+// coalesces into a single wake, which is fine because every
+// goroutine drains the queue independently after waking).
 func (w *Worker) Start(_ context.Context) {
 	if !w.started.CompareAndSwap(false, true) {
 		return
 	}
-	w.wg.Add(1)
-	go w.run() // #nosec G118 -- background goroutine intentionally uses its own context per iteration
+	for i := 0; i < w.cfg.Concurrency; i++ {
+		w.wg.Add(1)
+		go w.run() // #nosec G118 -- background goroutine intentionally uses its own context per iteration
+	}
 }
 
 // Stop signals shutdown and waits for the goroutine to exit.
@@ -217,6 +256,13 @@ func (w *Worker) drainQueue() {
 			cancel()
 			return
 		}
+		// Fan out to sibling goroutines: a successful claim implies
+		// the queue had at least one runnable job, so another idle
+		// goroutine may have more to do. Notify is buffered to size
+		// 1 so this coalesces with an already-pending wake. Placed
+		// after the error check so a DB outage that storms Claim
+		// errors does not also storm sibling-warn logs.
+		w.Notify()
 		w.process(ctx, job)
 		cancel()
 	}
@@ -263,7 +309,19 @@ func (w *Worker) process(ctx context.Context, job *Job) {
 		}
 	}
 
-	rows, err := w.cfg.Computer.Compute(ctx, content, job.SpecName, existing)
+	progress := func(completed int) {
+		// Best-effort progress publish. Errors are logged at debug
+		// level only; a missed update just delays the UI tick by
+		// one chunk and the next call (or the final Complete which
+		// sets embedding_count) corrects it. UpdateProgress already
+		// no-ops when the lease has rotated, so a stale write can
+		// not clobber a new holder's count.
+		if perr := w.cfg.Store.UpdateProgress(ctx, job.ID, w.cfg.WorkerID, completed); perr != nil {
+			slog.Debug("embedjobs: update_progress failed",
+				logKeyJobID, job.ID, "embedded_so_far", completed, logKeyError, perr)
+		}
+	}
+	rows, err := w.cfg.Computer.Compute(ctx, content, job.SpecName, existing, progress)
 	if err != nil {
 		w.retryOrFail(ctx, job, fmt.Sprintf("compute failed: %v", err))
 		return

--- a/pkg/toolkits/apigateway/embedjobs/worker_test.go
+++ b/pkg/toolkits/apigateway/embedjobs/worker_test.go
@@ -3,6 +3,7 @@ package embedjobs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"maps"
 	"sync"
 	"sync/atomic"
@@ -26,6 +27,9 @@ type fakeStore struct {
 
 	releasedTotal int
 	reconcileFunc func() (int, error)
+
+	progressByID       map[int64]int
+	lastProgressWorker string
 }
 
 func newFakeStore() *fakeStore { return &fakeStore{} }
@@ -181,6 +185,19 @@ func (*fakeStore) Health(_ context.Context, catalogID string) (*CatalogHealth, e
 	return &CatalogHealth{CatalogID: catalogID}, nil
 }
 
+func (s *fakeStore) UpdateProgress(_ context.Context, id int64, workerID string, embeddedSoFar int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.progressByID == nil {
+		s.progressByID = make(map[int64]int)
+	}
+	if s.progressByID[id] < embeddedSoFar {
+		s.progressByID[id] = embeddedSoFar
+	}
+	s.lastProgressWorker = workerID
+	return nil
+}
+
 // fakeResolver is the test SpecResolver: returns a fixed
 // content for the (catalog, spec) keys the test enqueues.
 type fakeResolver struct {
@@ -204,8 +221,13 @@ type fakeComputer struct {
 	rows  []ComputedEmbedding
 }
 
-func (c *fakeComputer) Compute(_ context.Context, _, _ string, _ map[string]ExistingEmbedding) ([]ComputedEmbedding, error) {
+func (c *fakeComputer) Compute(_ context.Context, _, _ string, _ map[string]ExistingEmbedding, progress func(int)) ([]ComputedEmbedding, error) {
 	c.calls.Add(1)
+	// Honor the progress callback so the worker's update path is
+	// exercised even in tests with no real chunking.
+	if progress != nil {
+		progress(len(c.rows))
+	}
 	if c.err != nil {
 		return nil, c.err
 	}
@@ -488,6 +510,159 @@ func TestWorker_NotifyWakesIdleWorker(t *testing.T) {
 	if computer.calls.Load() == 0 {
 		t.Error("Notify did not wake the worker (computer never called)")
 	}
+}
+
+// TestWorker_PublishesChunkProgress proves the worker's progress
+// callback path: the Computer invokes the supplied progress function
+// during its work, and the worker translates each call into a
+// Store.UpdateProgress write keyed by (job.ID, workerID, count).
+// The catalog status endpoint reads embedded_so_far from that
+// column so a long embed pass renders incremental progress before
+// the final atomic upsert (#430).
+func TestWorker_PublishesChunkProgress(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	_, _ = store.Enqueue(context.Background(), SpecKey{CatalogID: "c", SpecName: "x"}, KindSpecWrite)
+	resolver := &fakeResolver{contents: map[string]string{"c/x": "spec"}}
+	// fakeComputer.Compute calls progress(len(rows)) before returning.
+	// With three synthetic rows the worker should publish 3.
+	computer := &fakeComputer{rows: []ComputedEmbedding{
+		{OperationID: "a", Dim: 4, Embedding: []float32{1, 0, 0, 0}},
+		{OperationID: "b", Dim: 4, Embedding: []float32{0, 1, 0, 0}},
+		{OperationID: "c", Dim: 4, Embedding: []float32{0, 0, 1, 0}},
+	}}
+	w := NewWorker(WorkerConfig{
+		Store: store, Resolver: resolver, Computer: computer, Persister: &fakePersister{},
+		WorkerID: "wp", PollEvery: 50 * time.Millisecond,
+	})
+	w.Start(context.Background())
+	defer w.Stop()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		store.mu.Lock()
+		done := store.completeCalls.Load() >= 1
+		store.mu.Unlock()
+		if done {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if got := store.progressByID[1]; got != 3 {
+		t.Errorf("UpdateProgress observed %d for job 1; want 3", got)
+	}
+	if store.lastProgressWorker != "wp" {
+		t.Errorf("UpdateProgress workerID=%q; want %q", store.lastProgressWorker, "wp")
+	}
+}
+
+// TestWorker_ConcurrencyProcessesJobsInParallel proves multiple
+// goroutines share the queue: with Concurrency=4 and four pending
+// jobs against a Computer that sleeps 50ms, total wall time is
+// well under the serial 200ms baseline (#430).
+func TestWorker_ConcurrencyProcessesJobsInParallel(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	for _, spec := range []string{"a", "b", "c", "d"} {
+		_, _ = store.Enqueue(context.Background(), SpecKey{CatalogID: "c", SpecName: spec}, KindSpecWrite)
+	}
+	resolver := &fakeResolver{contents: map[string]string{
+		"c/a": "spec", "c/b": "spec", "c/c": "spec", "c/d": "spec",
+	}}
+	const perJob = 50 * time.Millisecond
+	computer := &slowComputer{delay: perJob, rows: []ComputedEmbedding{
+		{OperationID: "op", Dim: 4, Embedding: []float32{1, 0, 0, 0}},
+	}}
+	w := NewWorker(WorkerConfig{
+		Store: store, Resolver: resolver, Computer: computer, Persister: &fakePersister{},
+		WorkerID: "wc", PollEvery: 200 * time.Millisecond, Concurrency: 4,
+	})
+	start := time.Now()
+	w.Start(context.Background())
+	defer w.Stop()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if store.completeCalls.Load() >= 4 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	elapsed := time.Since(start)
+	if store.completeCalls.Load() != 4 {
+		t.Fatalf("completed %d jobs; want 4", store.completeCalls.Load())
+	}
+	// Serial baseline is 4 * 50ms = 200ms; with 4 workers the
+	// pessimistic wall clock should be well under 150ms even with
+	// scheduler jitter. Use 175ms as the gate so the test is
+	// stable on CI runners without burning headroom.
+	if elapsed >= 175*time.Millisecond {
+		t.Errorf("4 jobs * %v with 4 workers took %v; expected parallel execution under 175ms", perJob, elapsed)
+	}
+}
+
+// TestWorker_ProgressWriteFailureIsLogged proves the worker keeps
+// running when Store.UpdateProgress errors mid-pass: the chunk
+// callback's log-debug-and-continue path exists specifically so a
+// transient DB hiccup on the progress column does not abort the
+// embed (the column is best-effort; the final Complete is the
+// authoritative signal).
+func TestWorker_ProgressWriteFailureIsLogged(t *testing.T) {
+	t.Parallel()
+	store := &progressFailStore{fakeStore: newFakeStore()}
+	_, _ = store.Enqueue(context.Background(), SpecKey{CatalogID: "c", SpecName: "x"}, KindSpecWrite)
+	resolver := &fakeResolver{contents: map[string]string{"c/x": "spec"}}
+	computer := &fakeComputer{rows: []ComputedEmbedding{{OperationID: "op", Dim: 4, Embedding: []float32{1, 0, 0, 0}}}}
+	w := NewWorker(WorkerConfig{
+		Store: store, Resolver: resolver, Computer: computer, Persister: &fakePersister{},
+		WorkerID: "wpf", PollEvery: 50 * time.Millisecond,
+	})
+	w.Start(context.Background())
+	defer w.Stop()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if store.completeCalls.Load() >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if store.completeCalls.Load() != 1 {
+		t.Errorf("Complete called %d times; want 1 (job must finish despite progress write error)", store.completeCalls.Load())
+	}
+	if store.updateProgressErrors.Load() == 0 {
+		t.Error("UpdateProgress was never called; cannot prove the error path was exercised")
+	}
+}
+
+// progressFailStore wraps fakeStore so UpdateProgress always
+// returns an error, exercising the worker's debug-log branch.
+type progressFailStore struct {
+	*fakeStore
+	updateProgressErrors atomic.Int32
+}
+
+func (s *progressFailStore) UpdateProgress(_ context.Context, _ int64, _ string, _ int) error {
+	s.updateProgressErrors.Add(1)
+	return errors.New("simulated progress write failure")
+}
+
+// slowComputer adds a configurable delay so concurrency tests can
+// measure parallel speedup without depending on a real embedder.
+type slowComputer struct {
+	delay time.Duration
+	rows  []ComputedEmbedding
+}
+
+func (c *slowComputer) Compute(ctx context.Context, _, _ string, _ map[string]ExistingEmbedding, _ func(int)) ([]ComputedEmbedding, error) {
+	select {
+	case <-time.After(c.delay):
+	case <-ctx.Done():
+		return nil, fmt.Errorf("slowComputer: %w", ctx.Err())
+	}
+	return c.rows, nil
 }
 
 // TestReaper_ReleasesExpiredLease proves a job whose

--- a/pkg/toolkits/apigateway/persisted_embeddings_test.go
+++ b/pkg/toolkits/apigateway/persisted_embeddings_test.go
@@ -82,7 +82,7 @@ func seedCatalogWithEmbeddings(t *testing.T, store catalog.Store, embedder *trac
 	}); err != nil {
 		t.Fatalf("UpsertSpec: %v", err)
 	}
-	rows, err := ComputeOperationEmbeddings(ctx, embedder, persistedEmbedTestSpec, specName, nil)
+	rows, err := ComputeOperationEmbeddings(ctx, embedder, persistedEmbedTestSpec, specName, nil, nil)
 	if err != nil {
 		t.Fatalf("ComputeOperationEmbeddings: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestRestartPreservesEmbeddings(t *testing.T) {
 	_ = store.UpsertSpec(ctx, "shared", catalog.SpecEntry{
 		SpecName: "default", Content: persistedEmbedTestSpec, SourceKind: catalog.SourceInline,
 	})
-	rows, err := ComputeOperationEmbeddings(ctx, emb, persistedEmbedTestSpec, "default", nil)
+	rows, err := ComputeOperationEmbeddings(ctx, emb, persistedEmbedTestSpec, "default", nil, nil)
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -362,7 +362,7 @@ func TestAddParsedConnection_VectorLookupSurvivesBasePathOverride(t *testing.T) 
 		SpecName: "default", Content: noOperationIDSpec, SourceKind: catalog.SourceInline,
 		BasePath: "/v2", // operator override, non-empty
 	})
-	rows, err := ComputeOperationEmbeddings(ctx, emb, noOperationIDSpec, "default", nil)
+	rows, err := ComputeOperationEmbeddings(ctx, emb, noOperationIDSpec, "default", nil, nil)
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}

--- a/pkg/toolkits/apigateway/ranking.go
+++ b/pkg/toolkits/apigateway/ranking.go
@@ -287,7 +287,7 @@ func indexOf(ops []OperationSummary, target OperationSummary) int {
 // model's context window, or hitting an HTTP body cap. The caller's
 // ctx is honored across all batches; the first batch error short-
 // circuits the rest.
-func embedInBatches(ctx context.Context, embedder embedding.Provider, texts []string, batchSize int) ([][]float32, error) {
+func embedInBatches(ctx context.Context, embedder embedding.Provider, texts []string, batchSize int, chunkDone func(completed int)) ([][]float32, error) {
 	if batchSize <= 0 {
 		batchSize = len(texts)
 	}
@@ -304,6 +304,9 @@ func embedInBatches(ctx context.Context, embedder embedding.Provider, texts []st
 				start, end, len(vectors), len(chunk))
 		}
 		out = append(out, vectors...)
+		if chunkDone != nil {
+			chunkDone(len(out))
+		}
 	}
 	return out, nil
 }

--- a/pkg/toolkits/apigateway/ranking_test.go
+++ b/pkg/toolkits/apigateway/ranking_test.go
@@ -707,7 +707,7 @@ func TestEmbedInBatches_ChunksAtBatchSize(t *testing.T) {
 		texts[i] = fmt.Sprintf("text-%d", i)
 	}
 
-	vectors, err := embedInBatches(context.Background(), emb, texts, 32)
+	vectors, err := embedInBatches(context.Background(), emb, texts, 32, nil)
 	if err != nil {
 		t.Fatalf("embedInBatches: %v", err)
 	}
@@ -737,7 +737,7 @@ func TestEmbedInBatches_PropagatesError(t *testing.T) {
 	for i := range texts {
 		texts[i] = fmt.Sprintf("text-%d", i)
 	}
-	_, err := embedInBatches(context.Background(), emb, texts, 32)
+	_, err := embedInBatches(context.Background(), emb, texts, 32, nil)
 	if err == nil {
 		t.Fatal("expected error from failing batch")
 	}

--- a/test/e2e/helpers/admin.go
+++ b/test/e2e/helpers/admin.go
@@ -718,14 +718,16 @@ func baseAdminConfig() *platform.Config {
 			PathPrefix: "/api/v1/admin",
 		},
 		Audit: platform.AuditConfig{
-			Enabled:      true,
+			Enabled:      boolPtr(true),
 			LogToolCalls: true,
 		},
 		Knowledge: platform.KnowledgeConfig{
-			Enabled: true,
+			Enabled: boolPtr(true),
 		},
 	}
 }
+
+func boolPtr(v bool) *bool { return &v }
 
 // StandaloneAdminConfig returns a config for standalone mode (no database).
 func StandaloneAdminConfig() *platform.Config {

--- a/ui/src/api/admin/hooks.ts
+++ b/ui/src/api/admin/hooks.ts
@@ -1048,6 +1048,12 @@ export interface APICatalogEmbeddingSpecStatus {
   spec_name: string;
   operation_count: number;
   embedding_count: number;
+  // embedded_so_far is the worker's in-flight chunk-progress counter.
+  // While job_status is "running" the badge renders this against
+  // operation_count so a long embed pass shows incremental progress
+  // instead of staying at 0/N until the final atomic upsert commits
+  // embedding_count in one tick. See #430.
+  embedded_so_far?: number;
   job_status?: string;
   job_attempts?: number;
   job_last_error?: string;

--- a/ui/src/pages/settings/CatalogsPanel.tsx
+++ b/ui/src/pages/settings/CatalogsPanel.tsx
@@ -902,12 +902,17 @@ function EmbeddingStatusBadge({ status }: { status?: APICatalogEmbeddingSpecStat
     );
   }
   if (jobStatus === "running") {
+    // While the spec's UPSERT transaction is still pending, embedding_count
+    // sits at 0 (or the previous run's value). The worker publishes
+    // embedded_so_far at every chunk boundary so the badge ticks up
+    // before the final commit. See #430.
+    const progress = status.embedded_so_far ?? status.embedding_count;
     return (
       <span
         title={`Worker is embedding this spec (attempt ${status.job_attempts ?? 1})`}
         className="inline-flex items-center gap-1 rounded bg-sky-100 px-1.5 py-0.5 text-xs text-sky-900 dark:bg-sky-950/30 dark:text-sky-200"
       >
-        indexing {status.embedding_count}/{status.operation_count}
+        indexing {progress}/{status.operation_count}
       </span>
     );
   }


### PR DESCRIPTION
## Summary

Closes #430.

A 164-operation spec on a CPU-only Ollama deployment took ~10 minutes to index while the UI sat at `indexing 0/164` the entire run and snapped to `164/164` at the end. From an operator's perspective the run looked frozen. Two independent gaps surfaced by that workflow, both fixed in this PR. The third half of #430 (Ollama batch endpoint) was closed earlier by #435.

## Approach

### Progress visibility

Migration `000046` adds `embedded_so_far INTEGER NOT NULL DEFAULT 0` to `api_catalog_embedding_jobs`. The worker publishes the counter at every chunk boundary via a new `Store.UpdateProgress` call. The catalog status endpoint reads the column. The portal's `EmbeddingStatusBadge` renders `indexing N/M` from `embedded_so_far` while `JobStatus == running`, distinct from `pending` (queued, 0) and `succeeded` (the green `N/N indexed` state).

The atomic all-or-nothing semantic of the spec's vector upsert is preserved: the existing `DELETE+INSERT` transaction is unchanged. `embedded_so_far` is a separate column on the job row, populated by best-effort writes. A DB error on the progress write is logged at debug level but does not abort the embed pass: the final `Complete` is the authoritative success signal.

`ComputeOperationEmbeddings` gains an optional `progress func(int)` callback that fires once with the reused-row count up front (so a fully-cached refresh ticks straight to operation_count without waiting for a no-op embed pass) and again after every `embedInBatches` chunk. The embed-jobs `Computer` adapter wires the callback to `Store.UpdateProgress` keyed by `(id, worker_id, status='running')` so a stale worker whose lease was rotated cannot clobber the new lease-holder's count.

The counter resets to 0 only on `Claim`. Terminal rows (`succeeded` / `failed`) and pending rows recovered from a lease expiry may still carry a prior attempt's value; callers gate display on `Status == running` so the stale value never reaches the UI. The doc comments and the JSON response struct both call this out explicitly.

### Worker concurrency

New `apigateway.embed_jobs.workers` config (default 1, preserves prior single-goroutine behavior). `Worker.Start` spawns N goroutines that share one wakeup channel and one stopCh. The existing `FOR UPDATE SKIP LOCKED LIMIT 1` predicate in `Claim` plus the 10-minute lease guarantee keep two goroutines (in the same pod or across pods) from picking the same job.

After each successful `Claim` the worker also calls `Notify` once so a sibling goroutine can drain the next pending job in parallel; the buffered wakeup channel coalesces redundant Notifies. The Notify-after-Claim is placed after the error check so a DB outage that storms `Claim` errors does not also storm sibling-wakeup attempts.

`Worker` gains a `Concurrency() int` accessor so the wiring test can prove the value flowed from config through `WorkerConfig` without exporting the `cfg` field itself.

## Wire-format change

`GET /api/v1/admin/api-catalogs/{id}/embedding-status` response gains one new field:

```json
{
  "spec_name": "users",
  "operation_count": 47,
  "embedding_count": 0,
  "embedded_so_far": 12,
  "job_status": "running",
  "job_attempts": 1,
  "job_last_error": "",
  "job_updated_at": "2026-05-19T11:42:03Z"
}
```

`embedded_so_far` is `omitempty` so existing consumers that ignore unknown fields see no change in shape when the counter is zero.

## Tests

### Unit

- `TestUpdateProgress_HappyPath` / `_LeaseRotatedIsNoop` / `_DBError` against `PostgresStore` via sqlmock.
- `TestWorker_PublishesChunkProgress` proves the worker hooks the chunk callback into `Store.UpdateProgress` keyed by `(id, worker_id)`.
- `TestWorker_ProgressWriteFailureIsLogged` proves a DB error on the progress write does not abort the job.
- `TestWorker_ConcurrencyProcessesJobsInParallel` proves 4 jobs at 50ms each run in well under the 200ms serial baseline with `Concurrency=4` (typical wall time ~60ms).
- `TestComputeOperationEmbeddings_ProgressCallback` asserts the initial reused-publish and the chunk-done publishes happen and that the cumulative count reaches `operation_count`.
- `TestWireAPIGatewayEmbedJobsFromDB_WiresWorkerWithConfiguredConcurrency` asserts `apigateway.embed_jobs.workers: 3` produces a `Worker` reporting `Concurrency() == 3`.

### Integration (build tag `integration`)

`pkg/platform/integration_embedjobs_progress_test.go` starts `pgvector/pgvector:pg16`, enqueues a job against a slow stub Computer that publishes 4/8/12 across three 100ms chunks, polls `SpecStatuses` while running, asserts `embedded_so_far` is strictly increasing across observations and terminal status is `succeeded`. Runtime ~5s.

## Verification

- `make verify` clean: tools-check, gofmt, race tests, total + patch coverage above gate (patch coverage 100%), golangci-lint (patch-scoped against `origin/main`), gosec, govulncheck, semgrep, codeql, doc-check, dead-code, mutation testing, goreleaser dry-run.
- `make test-integration` clean against pgvector.
- Adversarial sub-agent review: 3 rounds. Round 1 surfaced a doc-vs-code mismatch on the EmbeddedSoFar lifecycle (only `Claim` resets it, comments claimed `Retry` did too) plus em dashes; both fixed. Round 2 surfaced a dead `slowComputer.calls` field reintroducing a round-1 pattern, plus a wiring test whose name promised more than it asserted; both fixed (drop field, add `Worker.Concurrency()` + assertion). Round 3 returned CLEAN.

## Drive-by fix

`test/e2e/helpers/admin.go` was failing the `integration` build because `AuditConfig.Enabled` and `KnowledgeConfig.Enabled` had drifted to `*bool`. The helper now wraps with a local `boolPtr`.

## Test plan

- [x] `make verify` passes locally.
- [x] `make test-integration` passes locally against pgvector.
- [x] Adversarial review verdict CLEAN.
- [ ] CI green.
- [ ] Manual: deploy with `apigateway.embed_jobs.workers: 2`, save two API specs back to back, confirm both worker goroutines pick a different spec (lease + SKIP LOCKED in action), confirm both spec badges tick `indexing N/M` upward before flipping to green.
- [ ] Manual: with a slow embedder (CPU-only Ollama on a multi-op spec), confirm the catalog editor badge ticks past `0/N` before completion instead of staying at 0 until the final commit.