### PR TITLE
fix(apigateway): surface oneOf/anyOf/allOf, response headers, and const in api_get_endpoint_schema

### DIFF
--- a/pkg/toolkits/apigateway/schema_lookup.go
+++ b/pkg/toolkits/apigateway/schema_lookup.go
@@ -62,11 +62,22 @@ type RequestBodyDetail struct {
 
 // ResponseDetail describes one response status's shape.
 type ResponseDetail struct {
-	Status       string         `json:"status"`
-	Description  string         `json:"description,omitempty"`
-	ContentTypes []string       `json:"content_types,omitempty"`
-	Schema       any            `json:"schema,omitempty"`
-	Examples     map[string]any `json:"examples,omitempty"`
+	Status       string                  `json:"status"`
+	Description  string                  `json:"description,omitempty"`
+	ContentTypes []string                `json:"content_types,omitempty"`
+	Headers      map[string]HeaderDetail `json:"headers,omitempty"`
+	Schema       any                     `json:"schema,omitempty"`
+	Examples     map[string]any          `json:"examples,omitempty"`
+}
+
+// HeaderDetail is the slim shape used to surface response headers
+// (Location on redirects, Retry-After on rate-limited responses,
+// Link/ETag on cache-aware endpoints) so callers know which headers
+// to read off the upstream response.
+type HeaderDetail struct {
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+	Schema      any    `json:"schema,omitempty"`
 }
 
 // schemaCandidate is the disambiguation record returned when an
@@ -344,7 +355,35 @@ func buildResponseDetail(status string, r *openapi3.Response) ResponseDetail {
 			}
 		}
 	}
+	detail.Headers = flattenResponseHeaders(r.Headers)
 	return detail
+}
+
+// flattenResponseHeaders coerces the kin-openapi Headers map (each
+// value is a HeaderRef whose Value embeds Parameter) into the slim
+// HeaderDetail shape. Returns nil when the response declares no
+// headers so the JSON omits the field entirely. Headers without a
+// resolved value are skipped rather than emitted as empty entries.
+func flattenResponseHeaders(headers openapi3.Headers) map[string]HeaderDetail {
+	if len(headers) == 0 {
+		return nil
+	}
+	out := make(map[string]HeaderDetail, len(headers))
+	for name, ref := range headers {
+		if ref == nil || ref.Value == nil {
+			continue
+		}
+		p := ref.Value.Parameter
+		out[name] = HeaderDetail{
+			Description: p.Description,
+			Required:    p.Required,
+			Schema:      schemaToValue(p.Schema, 0),
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // preferredContentType returns the content-type from sorted whose
@@ -394,9 +433,10 @@ func schemaToValue(ref *openapi3.SchemaRef, depth int) any {
 }
 
 // populateSchemaScalars copies the scalar-valued OpenAPI schema
-// fields (type, format, default, enum, required, example) into out.
-// Kept separate from compound (Properties, Items) walks so
-// schemaToValue stays under the cognitive-complexity gate.
+// fields (type, format, default, enum, const, required, example)
+// into out. Kept separate from compound (Properties, Items,
+// OneOf/AnyOf/AllOf) walks so schemaToValue stays under the
+// cognitive-complexity gate.
 func populateSchemaScalars(out map[string]any, s *openapi3.Schema) {
 	if types := s.Type.Slice(); len(types) > 0 {
 		if len(types) == 1 {
@@ -413,6 +453,9 @@ func populateSchemaScalars(out map[string]any, s *openapi3.Schema) {
 	if len(s.Enum) > 0 {
 		out["enum"] = s.Enum
 	}
+	if s.Const != nil {
+		out["const"] = s.Const
+	}
 	if len(s.Required) > 0 {
 		out["required"] = s.Required
 	}
@@ -421,8 +464,12 @@ func populateSchemaScalars(out map[string]any, s *openapi3.Schema) {
 	}
 }
 
-// populateSchemaCompounds recurses into Properties and Items at
-// depth+1 — the recursion that the maxSchemaDepth guard caps.
+// populateSchemaCompounds recurses into Properties, Items, and the
+// composition keywords (oneOf / anyOf / allOf / not) at depth+1.
+// Composition keywords are first-class in OpenAPI 3.1: the canonical
+// "nullable reference" pattern is oneOf: [$ref, {type: "null"}], and
+// polymorphic shapes lean on anyOf / allOf. Dropping them strips
+// substantial parts of the contract from the model's view.
 func populateSchemaCompounds(out map[string]any, s *openapi3.Schema, depth int) {
 	if len(s.Properties) > 0 {
 		props := make(map[string]any, len(s.Properties))
@@ -434,6 +481,33 @@ func populateSchemaCompounds(out map[string]any, s *openapi3.Schema, depth int) 
 	if s.Items != nil {
 		out["items"] = schemaToValue(s.Items, depth+1)
 	}
+	if branches := flattenSchemaRefs(s.OneOf, depth); branches != nil {
+		out["oneOf"] = branches
+	}
+	if branches := flattenSchemaRefs(s.AnyOf, depth); branches != nil {
+		out["anyOf"] = branches
+	}
+	if branches := flattenSchemaRefs(s.AllOf, depth); branches != nil {
+		out["allOf"] = branches
+	}
+	if s.Not != nil {
+		out["not"] = schemaToValue(s.Not, depth+1)
+	}
+}
+
+// flattenSchemaRefs walks a SchemaRefs slice (the underlying type
+// for OneOf/AnyOf/AllOf) and returns a []any of flattened branches.
+// Nil-or-empty input returns nil so the caller can omit the field
+// entirely from the marshaled JSON.
+func flattenSchemaRefs(refs openapi3.SchemaRefs, depth int) []any {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, schemaToValue(ref, depth+1))
+	}
+	return out
 }
 
 // addStringIfPresent skips zero values so the marshaled schema

--- a/pkg/toolkits/apigateway/schema_lookup_test.go
+++ b/pkg/toolkits/apigateway/schema_lookup_test.go
@@ -480,3 +480,309 @@ func TestFlattenExamples_Empty(t *testing.T) {
 		t.Errorf("nil examples should flatten to empty map, got %+v", got)
 	}
 }
+
+// oas31ResolverFixtureSpec exercises the three OpenAPI 3.1 patterns
+// the resolver historically dropped: oneOf with a $ref+null branch,
+// response headers, and const-valued discriminator fields. A single
+// fixture verifies all three because they appear together in real
+// JSON:API style specs.
+const oas31ResolverFixtureSpec = `
+openapi: 3.1.0
+info:
+  title: resolver-fixture
+  version: "1.0"
+paths:
+  /thing/:
+    get:
+      operationId: getThing
+      responses:
+        "200":
+          description: A thing.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    const: thing
+                  version:
+                    const: "1.0"
+                  status:
+                    type: string
+                    enum: [ok]
+                  parent:
+                    oneOf:
+                      - $ref: "#/components/schemas/Lite"
+                      - type: "null"
+                    description: Embedded lite reference.
+                  variants:
+                    type: array
+                    items:
+                      anyOf:
+                        - $ref: "#/components/schemas/Lite"
+                        - type: "null"
+                  envelope:
+                    allOf:
+                      - $ref: "#/components/schemas/Lite"
+        "301":
+          description: Redirect to the canonical URL.
+          headers:
+            Location:
+              description: Absolute path to the canonical URL.
+              schema:
+                type: string
+            X-Request-Id:
+              description: Echoed request id.
+              schema:
+                type: string
+components:
+  schemas:
+    Lite:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+`
+
+func setupOAS31FixtureTk(t *testing.T) *Toolkit {
+	t.Helper()
+	tk := New("api")
+	setupCatalogWithSpec(t, tk, "fixture", "default", oas31ResolverFixtureSpec)
+	if err := tk.AddConnection("c", map[string]any{
+		"base_url":   "https://example.com",
+		"catalog_id": "fixture",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	return tk
+}
+
+func getThingResponse200Props(t *testing.T, out EndpointSchemaOutput) map[string]any {
+	t.Helper()
+	var resp *ResponseDetail
+	for i := range out.Responses {
+		if out.Responses[i].Status == "200" {
+			resp = &out.Responses[i]
+			break
+		}
+	}
+	if resp == nil {
+		t.Fatalf("no 200 response in output: %+v", out.Responses)
+	}
+	schema, ok := resp.Schema.(map[string]any)
+	if !ok {
+		t.Fatalf("200 schema not map: %T", resp.Schema)
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("200 schema has no properties map: %+v", schema)
+	}
+	return props
+}
+
+func liteFromBranch(t *testing.T, branch any) map[string]any {
+	t.Helper()
+	m, ok := branch.(map[string]any)
+	if !ok {
+		t.Fatalf("branch not map: %T (%v)", branch, branch)
+	}
+	props, ok := m["properties"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return props
+}
+
+// Bug 1: oneOf: [$ref, {type: "null"}] previously dropped the $ref
+// entirely (and the type: "null" branch), surfacing parent as either
+// {} or an empty object with only the description preserved. The
+// resolver must now inline the referenced Lite schema and keep the
+// null-type branch so agents can see both shapes.
+func TestGetEndpointSchema_OneOfWithRefAndNullPreserved(t *testing.T) {
+	tk := setupOAS31FixtureTk(t)
+	r, _, err := tk.handleGetEndpointSchema(context.Background(), nil, GetEndpointSchemaInput{
+		Connection: "c", OperationID: "getThing",
+	})
+	if err != nil || r.IsError {
+		t.Fatalf("getThing: err=%v isError=%v body=%s", err, r.IsError, textContent(r))
+	}
+	out := parseSchemaResult(t, r)
+	props := getThingResponse200Props(t, out)
+	parent, ok := props["parent"].(map[string]any)
+	if !ok {
+		t.Fatalf("parent property missing or not map: %+v", props["parent"])
+	}
+	if parent["description"] != "Embedded lite reference." {
+		t.Errorf("parent description not preserved: %+v", parent)
+	}
+	branches, ok := parent["oneOf"].([]any)
+	if !ok {
+		t.Fatalf("parent missing oneOf array: %+v", parent)
+	}
+	if len(branches) != 2 {
+		t.Fatalf("expected 2 oneOf branches, got %d: %+v", len(branches), branches)
+	}
+	var sawLite, sawNull bool
+	for _, b := range branches {
+		bm, ok := b.(map[string]any)
+		if !ok {
+			t.Fatalf("branch not a map: %T", b)
+		}
+		if bm["type"] == "null" {
+			sawNull = true
+			continue
+		}
+		if liteProps := liteFromBranch(t, bm); liteProps != nil {
+			if _, hasID := liteProps["id"]; hasID {
+				sawLite = true
+			}
+		}
+	}
+	if !sawLite {
+		t.Errorf("expected Lite ref inlined into one oneOf branch: %+v", branches)
+	}
+	if !sawNull {
+		t.Errorf("expected null-type branch preserved: %+v", branches)
+	}
+}
+
+// Bug 1 sibling: anyOf with $ref+null nested under array items also
+// needs both branches surfaced. The variants property guards the
+// nested-recursion path.
+func TestGetEndpointSchema_AnyOfWithRefAndNullInsideArrayItems(t *testing.T) {
+	tk := setupOAS31FixtureTk(t)
+	r, _, _ := tk.handleGetEndpointSchema(context.Background(), nil, GetEndpointSchemaInput{
+		Connection: "c", OperationID: "getThing",
+	})
+	out := parseSchemaResult(t, r)
+	props := getThingResponse200Props(t, out)
+	variants, ok := props["variants"].(map[string]any)
+	if !ok {
+		t.Fatalf("variants property missing: %+v", props["variants"])
+	}
+	items, ok := variants["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("variants.items not a map: %+v", variants["items"])
+	}
+	branches, ok := items["anyOf"].([]any)
+	if !ok {
+		t.Fatalf("items.anyOf missing: %+v", items)
+	}
+	if len(branches) != 2 {
+		t.Fatalf("expected 2 anyOf branches, got %d", len(branches))
+	}
+}
+
+// Bug 1 sibling: allOf composition with a single $ref should inline
+// the referenced schema's properties (callers commonly use allOf to
+// extend a base schema).
+func TestGetEndpointSchema_AllOfWithRefInlined(t *testing.T) {
+	tk := setupOAS31FixtureTk(t)
+	r, _, _ := tk.handleGetEndpointSchema(context.Background(), nil, GetEndpointSchemaInput{
+		Connection: "c", OperationID: "getThing",
+	})
+	out := parseSchemaResult(t, r)
+	props := getThingResponse200Props(t, out)
+	envelope, ok := props["envelope"].(map[string]any)
+	if !ok {
+		t.Fatalf("envelope property missing: %+v", props["envelope"])
+	}
+	branches, ok := envelope["allOf"].([]any)
+	if !ok {
+		t.Fatalf("envelope.allOf missing: %+v", envelope)
+	}
+	if len(branches) != 1 {
+		t.Fatalf("expected 1 allOf branch, got %d", len(branches))
+	}
+	bm, ok := branches[0].(map[string]any)
+	if !ok {
+		t.Fatalf("allOf branch not a map: %T", branches[0])
+	}
+	bp, ok := bm["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("allOf branch missing inlined Lite properties: %+v", bm)
+	}
+	if _, hasID := bp["id"]; !hasID {
+		t.Errorf("Lite.id not inlined into allOf branch: %+v", bp)
+	}
+}
+
+// Bug 2: Response headers declared on the operation must surface in
+// the flattened response so callers know which headers to read on
+// redirects, rate-limited responses, etc.
+func TestGetEndpointSchema_ResponseHeadersPreserved(t *testing.T) {
+	tk := setupOAS31FixtureTk(t)
+	r, _, _ := tk.handleGetEndpointSchema(context.Background(), nil, GetEndpointSchemaInput{
+		Connection: "c", OperationID: "getThing",
+	})
+	out := parseSchemaResult(t, r)
+	var redirect *ResponseDetail
+	for i := range out.Responses {
+		if out.Responses[i].Status == "301" {
+			redirect = &out.Responses[i]
+			break
+		}
+	}
+	if redirect == nil {
+		t.Fatalf("no 301 response in output: %+v", out.Responses)
+	}
+	if len(redirect.Headers) != 2 {
+		t.Fatalf("expected 2 headers on 301, got %d: %+v", len(redirect.Headers), redirect.Headers)
+	}
+	loc, ok := redirect.Headers["Location"]
+	if !ok {
+		t.Fatalf("Location header missing: %+v", redirect.Headers)
+	}
+	if loc.Description != "Absolute path to the canonical URL." {
+		t.Errorf("Location description missing: %+v", loc)
+	}
+	locSchema, ok := loc.Schema.(map[string]any)
+	if !ok {
+		t.Fatalf("Location schema not map: %T", loc.Schema)
+	}
+	if locSchema["type"] != "string" {
+		t.Errorf("Location schema type lost: %+v", locSchema)
+	}
+}
+
+// Bug 3: const values on properties must surface so agents see the
+// expected literal — common on JSON:API style discriminator fields
+// (type: "thing", version: "1.0"). enum with a single value is
+// adjacent; both should pass through unchanged.
+func TestGetEndpointSchema_ConstAndEnumPreserved(t *testing.T) {
+	tk := setupOAS31FixtureTk(t)
+	r, _, _ := tk.handleGetEndpointSchema(context.Background(), nil, GetEndpointSchemaInput{
+		Connection: "c", OperationID: "getThing",
+	})
+	out := parseSchemaResult(t, r)
+	props := getThingResponse200Props(t, out)
+
+	typeProp, ok := props["type"].(map[string]any)
+	if !ok {
+		t.Fatalf("type property missing: %+v", props["type"])
+	}
+	if typeProp["const"] != "thing" {
+		t.Errorf("type.const not preserved (got %v): %+v", typeProp["const"], typeProp)
+	}
+
+	version, ok := props["version"].(map[string]any)
+	if !ok {
+		t.Fatalf("version property missing: %+v", props["version"])
+	}
+	if version["const"] != "1.0" {
+		t.Errorf("version.const not preserved (got %v): %+v", version["const"], version)
+	}
+
+	status, ok := props["status"].(map[string]any)
+	if !ok {
+		t.Fatalf("status property missing: %+v", props["status"])
+	}
+	statusEnum, ok := status["enum"].([]any)
+	if !ok || len(statusEnum) != 1 || statusEnum[0] != "ok" {
+		t.Errorf("status.enum not preserved (got %v): %+v", status["enum"], status)
+	}
+}


### PR DESCRIPTION
## Summary

The OpenAPI schema flattener that backs `api_get_endpoint_schema` walked only `properties` and `items`, silently dropping three patterns that are canonical in OpenAPI 3.1:

- **`oneOf: [$ref, {type: "null"}]`** (the 3.1 replacement for the 3.0 `nullable: true` keyword) collapsed to an empty object; both the inlined `$ref` and the null branch disappeared. Same for `anyOf` and `allOf`.
- **Response `headers`** blocks were stripped, so callers had no signal about `Location` on a 301, `Retry-After` on a 429, `ETag`/`Last-Modified` on cache-aware endpoints, etc.
- **`const`** values on properties (common as JSON:API discriminator fields, e.g. `type: "show"`) were dropped, leaving an unconstrained string. `enum` with a single value had the same problem because it followed the same code path.

This PR walks the missing keywords in the flattener so registered OpenAPI 3.1 specs surface their full contract.

## Changes

### `pkg/toolkits/apigateway/schema_lookup.go`

- `ResponseDetail` (schema_lookup.go:64) gains a `Headers map[string]HeaderDetail` field, marshaled as `headers` and `omitempty` so responses without declared headers stay slim.
- New `HeaderDetail` type with `Description`, `Required`, and `Schema` fields, mirroring `ParameterDetail` since kin-openapi's `Header` embeds `Parameter`.
- `buildResponseDetail` now calls `flattenResponseHeaders(r.Headers)` which iterates the kin-openapi `Headers` map and emits a slim entry per declared header.
- `populateSchemaScalars` (schema_lookup.go:440) now copies `s.Const` alongside the existing scalar keywords.
- `populateSchemaCompounds` (schema_lookup.go:473) now recurses into `OneOf`, `AnyOf`, `AllOf`, and `Not` via a new `flattenSchemaRefs` helper. Each branch is walked by the existing `schemaToValue` recursion, so `$ref` targets get inlined and `type: "null"` branches are preserved verbatim. The same `maxSchemaDepth` cap that protects against recursive schemas still applies.

### `pkg/toolkits/apigateway/schema_lookup_test.go`

Five new tests against a shared OpenAPI 3.1 fixture (`oas31ResolverFixtureSpec`) that exercises every reported pattern:

- `TestGetEndpointSchema_OneOfWithRefAndNullPreserved` — `parent: oneOf: [$ref Lite, {type: "null"}]` surfaces both branches and the description.
- `TestGetEndpointSchema_AnyOfWithRefAndNullInsideArrayItems` — nested case: `variants[].anyOf: [$ref Lite, null]`, guards the recursion through `items`.
- `TestGetEndpointSchema_AllOfWithRefInlined` — `envelope: allOf: [$ref Lite]` inlines the referenced properties.
- `TestGetEndpointSchema_ResponseHeadersPreserved` — `301` response with `Location` and `X-Request-Id` headers; asserts both surface with description and schema.
- `TestGetEndpointSchema_ConstAndEnumPreserved` — `type: { type: string, const: thing }`, `version: { const: "1.0" }`, `status: { enum: [ok] }`.

The fixture mirrors the JSON:API-style patterns commonly found in modern public OpenAPI 3.1 documents.

## Backward compatibility

- New `HeaderDetail` type and `headers` field are additive on the response payload; existing fields are unchanged. Clients that ignore unknown JSON fields are unaffected. Responses without declared headers do not emit the field.
- `oneOf` / `anyOf` / `allOf` / `not` / `const` are new keys on schema maps for specs that use them. Specs that don't are unaffected.
- No tool inputs, tool names, configuration, migrations, or wire-format identifiers changed.

## Verification

`make verify` passes (fmt, race tests, total coverage gate, golangci-lint, gosec, govulncheck, semgrep, codeql, dead-code, mutation testing, GoReleaser dry-run). Patch coverage 88.4%; new functions individually:

- `flattenSchemaRefs` 100%
- `populateSchemaCompounds` 93.3%
- `buildResponseDetail` 92.3%
- `populateSchemaScalars` 87.5%
- `flattenResponseHeaders` 81.8%

`golangci-lint run --new-from-rev=origin/main ./...` reports 0 issues.

## Test plan

- [x] Unit tests cover oneOf/anyOf/allOf with `$ref`+`null`, nested under array items
- [x] Unit tests cover response `headers` surfacing with description and schema
- [x] Unit tests cover `const` (typed and untyped) and single-value `enum`
- [x] `make verify` passes locally
- [ ] Manual smoke against a live OpenAPI 3.1 connection: call `api_get_endpoint_schema` on an operation that uses `oneOf: [$ref, null]`, confirm both branches appear in the response
- [ ] Manual smoke against a redirect endpoint: confirm the `headers` block lists `Location` with its schema