### PR TITLE
fix(middleware): close cross-user provenance leak on stateless HTTP transport

### DIFF
--- a/pkg/middleware/mcp.go
+++ b/pkg/middleware/mcp.go
@@ -20,25 +20,18 @@ import (
 const (
 	// defaultSessionID is the per-process session sentinel used by the stdio
 	// transport (one logical client per process). HTTP requests that cannot
-	// produce a real session ID get a per-principal synthetic ID once
-	// authenticated, or an empty string when the principal is anonymous or
-	// unidentified, via resolveSessionID and deriveAuthenticatedSessionID.
-	// They never inherit the stdio sentinel. Pooling stateless HTTP callers
-	// under "stdio" would let one caller's harvest tool return another
-	// caller's accumulated provenance.
+	// produce a real session ID get an empty SessionID instead, never the
+	// stdio sentinel. Stateless HTTP callers have no session by definition,
+	// so accumulating provenance, gate state, or dedup state across their
+	// calls would either be meaningless (one-shot calls) or pool unrelated
+	// callers into a shared bucket. Empty triggers the existing
+	// ProvenanceTracker.Record empty-skip and is documented as null in the
+	// audit schema.
 	defaultSessionID = "stdio"
 
 	// transportStdio is the cfg.Transport value that legitimately reuses
 	// defaultSessionID. Anything else (http, sse) clears the sentinel.
 	transportStdio = "stdio"
-
-	// synthSessionPrefix marks a session ID synthesized from an authenticated
-	// principal because the SDK didn't surface a real one. It buckets every
-	// stateless HTTP call by that principal's UserID, so provenance and
-	// session-scoped state can accumulate per-user instead of pooling
-	// across users. The "synth:" namespace keeps these IDs visually
-	// distinct from SDK-issued session IDs in logs and audit rows.
-	synthSessionPrefix = "synth:user:"
 
 	// methodToolsCall is the MCP method name for tool invocations.
 	methodToolsCall = "tools/call"
@@ -249,16 +242,6 @@ func authenticateAndAuthorize(
 		params.pc.Roles = userInfo.Roles
 	}
 
-	// Upgrade an empty SessionID to a per-principal synthetic ID. resolveSessionID
-	// leaves SessionID empty for stateless HTTP callers (no SDK session, no
-	// AwareHandler session); without this upgrade, every such caller would
-	// either be silently skipped by ProvenanceTracker.Record or, if any code
-	// path looked up state by the empty key, pool with other anonymous
-	// stateless callers. The synthetic ID buckets state per UserID so
-	// authenticated callers still get provenance accumulation and session
-	// gates while making cross-user pooling structurally impossible.
-	params.pc.SessionID = deriveAuthenticatedSessionID(params.pc.SessionID, params.pc.UserID)
-
 	authorized, personaName, reason := params.authorizer.IsAuthorized(ctx, params.pc.UserID, params.pc.Roles, params.toolName, params.pc.Connection)
 	params.pc.Authorized = authorized
 	params.pc.PersonaName = personaName
@@ -334,11 +317,11 @@ func extractSessionID(req mcp.Request) (id string) {
 //  3. For HTTP transport with neither of the above, the empty string.
 //     The stdio sentinel previously leaked into stateless HTTP, pooling
 //     every caller into one shared provenance bucket (and one shared
-//     session-gate, dedup, and workflow-tracker bucket). Empty here means
-//     "not yet known"; deriveAuthenticatedSessionID upgrades it to a
-//     per-principal synthetic ID once auth completes, so authenticated
-//     stateless callers still get per-user bucketing for provenance
-//     accumulation.
+//     session-gate, dedup, and workflow-tracker bucket).
+//     ProvenanceTracker.Record skips empty session IDs by design; the
+//     audit schema documents empty as null. Stateless HTTP callers
+//     simply do not accumulate session-scoped state, which is correct
+//     because they do not have a session.
 //  4. The stdio sentinel for the actual stdio transport (one logical
 //     client per process), the original design contract.
 func resolveSessionID(ctx context.Context, req mcp.Request, transport string) string {
@@ -353,39 +336,6 @@ func resolveSessionID(ctx context.Context, req mcp.Request, transport string) st
 		return ""
 	}
 	return sid
-}
-
-// deriveAuthenticatedSessionID returns a per-principal synthetic session ID
-// for stateless HTTP callers that completed authentication. Called from
-// authenticateAndAuthorize once pc.UserID is populated, so downstream
-// middleware (provenance tracker, audit, session gate, dedup cache,
-// workflow tracker) all see a bucket keyed on the authenticated user
-// instead of a shared value.
-//
-// Returns the existing sessionID unchanged when:
-//   - It's already non-empty (SDK session, AwareHandler session, or the
-//     stdio sentinel for the stdio transport).
-//   - No UserID is available.
-//   - The UserID is the anonymous sentinel set by ChainedAuthenticator
-//     when allowAnonymous is on (pkg/auth/middleware.go:119). Synthesizing
-//     "synth:user:anonymous" would pool every unauthenticated caller into
-//     one shared bucket, reintroducing the cross-caller mixing this
-//     function exists to prevent. Anonymous-allowed deployments accept
-//     that they have no identity to bucket on; downstream consumers see
-//     an empty SessionID and either skip (provenance) or use it as-is
-//     (audit, where empty is the documented null value).
-//
-// The synthSessionPrefix makes the synthesized IDs identifiable in logs
-// so an operator can tell at a glance whether a session ID came from a
-// real MCP session or was synthesized post-auth.
-func deriveAuthenticatedSessionID(sessionID, userID string) string {
-	if sessionID != "" {
-		return sessionID
-	}
-	if userID == "" || userID == userIDAnonymous {
-		return sessionID
-	}
-	return synthSessionPrefix + userID
 }
 
 // extractToolName extracts the tool name from a tools/call request.

--- a/pkg/middleware/mcp.go
+++ b/pkg/middleware/mcp.go
@@ -18,8 +18,27 @@ import (
 )
 
 const (
-	// defaultSessionID is used for stdio/SSE transports that don't provide a session ID.
+	// defaultSessionID is the per-process session sentinel used by the stdio
+	// transport (one logical client per process). HTTP requests that cannot
+	// produce a real session ID get a per-principal synthetic ID once
+	// authenticated, or an empty string when the principal is anonymous or
+	// unidentified, via resolveSessionID and deriveAuthenticatedSessionID.
+	// They never inherit the stdio sentinel. Pooling stateless HTTP callers
+	// under "stdio" would let one caller's harvest tool return another
+	// caller's accumulated provenance.
 	defaultSessionID = "stdio"
+
+	// transportStdio is the cfg.Transport value that legitimately reuses
+	// defaultSessionID. Anything else (http, sse) clears the sentinel.
+	transportStdio = "stdio"
+
+	// synthSessionPrefix marks a session ID synthesized from an authenticated
+	// principal because the SDK didn't surface a real one. It buckets every
+	// stateless HTTP call by that principal's UserID, so provenance and
+	// session-scoped state can accumulate per-user instead of pooling
+	// across users. The "synth:" namespace keeps these IDs visually
+	// distinct from SDK-issued session IDs in logs and audit rows.
+	synthSessionPrefix = "synth:user:"
 
 	// methodToolsCall is the MCP method name for tool invocations.
 	methodToolsCall = "tools/call"
@@ -88,14 +107,7 @@ func MCPToolCallMiddleware(authenticator Authenticator, authorizer Authorizer, t
 			// Build platform context and enrich the Go context.
 			pc := NewPlatformContext(generateRequestID())
 			pc.ToolName = toolName
-			pc.SessionID = extractSessionID(req)
-			// Fall back to AwareHandler-managed session ID when the MCP SDK
-			// doesn't propagate one (SSE returns "", stateless mode may vary).
-			if pc.SessionID == defaultSessionID {
-				if awareID := pkgsession.AwareSessionID(ctx); awareID != "" {
-					pc.SessionID = awareID
-				}
-			}
+			pc.SessionID = resolveSessionID(ctx, req, cfg.Transport)
 			pc.Transport = cfg.Transport
 			pc.Source = sourceMCP
 			ctx = buildToolCallContext(ctx, req, pc, toolkitLookup, toolName)
@@ -237,6 +249,16 @@ func authenticateAndAuthorize(
 		params.pc.Roles = userInfo.Roles
 	}
 
+	// Upgrade an empty SessionID to a per-principal synthetic ID. resolveSessionID
+	// leaves SessionID empty for stateless HTTP callers (no SDK session, no
+	// AwareHandler session); without this upgrade, every such caller would
+	// either be silently skipped by ProvenanceTracker.Record or, if any code
+	// path looked up state by the empty key, pool with other anonymous
+	// stateless callers. The synthetic ID buckets state per UserID so
+	// authenticated callers still get provenance accumulation and session
+	// gates while making cross-user pooling structurally impossible.
+	params.pc.SessionID = deriveAuthenticatedSessionID(params.pc.SessionID, params.pc.UserID)
+
 	authorized, personaName, reason := params.authorizer.IsAuthorized(ctx, params.pc.UserID, params.pc.Roles, params.toolName, params.pc.Connection)
 	params.pc.Authorized = authorized
 	params.pc.PersonaName = personaName
@@ -300,6 +322,70 @@ func extractSessionID(req mcp.Request) (id string) {
 		}
 	}
 	return id
+}
+
+// resolveSessionID picks the most accurate session identifier we can find
+// for the request, in order of preference:
+//
+//  1. The SDK's propagated session ID (Streamable HTTP Mcp-Session-Id header).
+//  2. The AwareHandler session ID stashed by the initialize hook (covers
+//     SSE and stateless HTTP that issue initialize but don't surface a
+//     session through the SDK request).
+//  3. For HTTP transport with neither of the above, the empty string.
+//     The stdio sentinel previously leaked into stateless HTTP, pooling
+//     every caller into one shared provenance bucket (and one shared
+//     session-gate, dedup, and workflow-tracker bucket). Empty here means
+//     "not yet known"; deriveAuthenticatedSessionID upgrades it to a
+//     per-principal synthetic ID once auth completes, so authenticated
+//     stateless callers still get per-user bucketing for provenance
+//     accumulation.
+//  4. The stdio sentinel for the actual stdio transport (one logical
+//     client per process), the original design contract.
+func resolveSessionID(ctx context.Context, req mcp.Request, transport string) string {
+	sid := extractSessionID(req)
+	if sid != defaultSessionID {
+		return sid
+	}
+	if awareID := pkgsession.AwareSessionID(ctx); awareID != "" {
+		return awareID
+	}
+	if transport != "" && transport != transportStdio {
+		return ""
+	}
+	return sid
+}
+
+// deriveAuthenticatedSessionID returns a per-principal synthetic session ID
+// for stateless HTTP callers that completed authentication. Called from
+// authenticateAndAuthorize once pc.UserID is populated, so downstream
+// middleware (provenance tracker, audit, session gate, dedup cache,
+// workflow tracker) all see a bucket keyed on the authenticated user
+// instead of a shared value.
+//
+// Returns the existing sessionID unchanged when:
+//   - It's already non-empty (SDK session, AwareHandler session, or the
+//     stdio sentinel for the stdio transport).
+//   - No UserID is available.
+//   - The UserID is the anonymous sentinel set by ChainedAuthenticator
+//     when allowAnonymous is on (pkg/auth/middleware.go:119). Synthesizing
+//     "synth:user:anonymous" would pool every unauthenticated caller into
+//     one shared bucket, reintroducing the cross-caller mixing this
+//     function exists to prevent. Anonymous-allowed deployments accept
+//     that they have no identity to bucket on; downstream consumers see
+//     an empty SessionID and either skip (provenance) or use it as-is
+//     (audit, where empty is the documented null value).
+//
+// The synthSessionPrefix makes the synthesized IDs identifiable in logs
+// so an operator can tell at a glance whether a session ID came from a
+// real MCP session or was synthesized post-auth.
+func deriveAuthenticatedSessionID(sessionID, userID string) string {
+	if sessionID != "" {
+		return sessionID
+	}
+	if userID == "" || userID == userIDAnonymous {
+		return sessionID
+	}
+	return synthSessionPrefix + userID
 }
 
 // extractToolName extracts the tool name from a tools/call request.

--- a/pkg/middleware/mcp_resources.go
+++ b/pkg/middleware/mcp_resources.go
@@ -21,6 +21,11 @@ const (
 
 	// mimeTypeJSON is the MIME type for JSON content.
 	mimeTypeJSON = "application/json"
+
+	// userIDAnonymous is the stable label used in log lines when no
+	// authenticated PlatformContext is available (auth failed or wasn't
+	// attempted). Keeps log queries groupable on user_id.
+	userIDAnonymous = "anonymous"
 )
 
 // ResourceListProvider loads managed resources for a given set of scope filters.
@@ -64,10 +69,8 @@ func MCPManagedResourceMiddleware(cfg ManagedResourceConfig) mcp.Middleware {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
 			switch method {
 			case methodListResources:
-				slog.Debug("managed resources middleware: intercepting resources/list")
 				return handleManagedList(ctx, next, method, req, cfg)
 			case methodReadResource:
-				slog.Debug("managed resources middleware: intercepting resources/read")
 				return handleManagedRead(ctx, next, method, req, cfg)
 			default:
 				return next(ctx, method, req)
@@ -80,35 +83,58 @@ func MCPManagedResourceMiddleware(cfg ManagedResourceConfig) mcp.Middleware {
 // scopes. Managed resources are registered with the SDK via AddResource for
 // discoverability, but the SDK returns ALL resources to every client. This
 // middleware removes resources the caller shouldn't see based on their auth.
+//
+// Logging philosophy: at DEBUG we emit one line per resources/list call when
+// filtering actually happens (with the user/persona that authorized the
+// filter and the in/out counts). Per-resource enumeration and no-op early
+// returns are intentionally silent: the resource list itself is the audit
+// surface for "what was visible", not infra logs.
 func handleManagedList(ctx context.Context, next mcp.MethodHandler, method string, req mcp.Request, cfg ManagedResourceConfig) (mcp.Result, error) {
 	result, err := next(ctx, method, req)
 	if err != nil {
-		slog.Debug("managed resources list: next handler error", logKeyError, err)
 		return result, err
 	}
 
 	listResult, ok := result.(*mcp.ListResourcesResult)
 	if !ok || cfg.Store == nil {
-		slog.Debug("managed resources list: skipping", "result_type_ok", ok, "store_nil", cfg.Store == nil)
 		return result, nil
-	}
-
-	slog.Debug("managed resources list: SDK returned resources", "count", len(listResult.Resources))
-	for i, r := range listResult.Resources {
-		slog.Debug("managed resources list: SDK resource", "index", i, logKeyURI, r.URI, "name", r.Name)
 	}
 
 	prefix := managedURIPrefix(cfg)
 	if !containsManagedResources(listResult.Resources, prefix) {
-		slog.Debug("managed resources list: no managed resources in SDK list, returning as-is", "prefix", prefix)
 		return result, nil
 	}
 
-	visibleURIs := resolveVisibleManagedURIs(ctx, req, cfg)
-	slog.Debug("managed resources list: resolved visible URIs", "count", len(visibleURIs), "visible", visibleURIs)
+	pc, visibleURIs := resolveVisibleManagedURIsWithPC(ctx, req, cfg)
+	before := len(listResult.Resources)
 	listResult.Resources = filterResources(listResult.Resources, prefix, visibleURIs)
-	slog.Debug("managed resources list: filtered result", "count", len(listResult.Resources))
+	slog.Debug("managed resources list: filtered",
+		"in", before,
+		"out", len(listResult.Resources),
+		logKeyUserID, userIDForLog(pc),
+		"persona", personaForLog(pc),
+	)
 	return listResult, nil
+}
+
+// userIDForLog returns a stable user attribution for the filter log line.
+// userIDAnonymous when no PlatformContext is present (auth failed or
+// skipped); concrete UserID otherwise. Keeps the log line shape stable
+// across the authenticated and anonymous paths so log queries can group
+// on user_id.
+func userIDForLog(pc *PlatformContext) string {
+	if pc == nil || pc.UserID == "" {
+		return userIDAnonymous
+	}
+	return pc.UserID
+}
+
+// personaForLog mirrors userIDForLog for the persona attribution column.
+func personaForLog(pc *PlatformContext) string {
+	if pc == nil || pc.PersonaName == "" {
+		return ""
+	}
+	return pc.PersonaName
 }
 
 // managedURIPrefix returns the URI prefix for managed resources.
@@ -130,25 +156,30 @@ func containsManagedResources(resources []*mcp.Resource, prefix string) bool {
 	return false
 }
 
-// resolveVisibleManagedURIs returns the set of managed resource URIs visible
-// to the authenticated caller. Returns nil if auth fails (all managed removed).
-func resolveVisibleManagedURIs(ctx context.Context, req mcp.Request, cfg ManagedResourceConfig) map[string]bool {
-	pc := getOrAuthenticatePC(ctx, req, cfg)
+// resolveVisibleManagedURIsWithPC returns the set of managed resource URIs
+// visible to the authenticated caller, along with the PlatformContext that
+// authorized the filter so callers can include user/persona attribution in
+// their log lines. Returns (nil, nil) when auth fails.
+func resolveVisibleManagedURIsWithPC(ctx context.Context, req mcp.Request, cfg ManagedResourceConfig) (pc *PlatformContext, visible map[string]bool) {
+	pc = getOrAuthenticatePC(ctx, req, cfg)
 	if pc == nil {
-		slog.Debug("resolveVisibleManagedURIs: no auth, returning nil (all managed will be removed)")
-		return nil
+		return nil, nil
 	}
 	scopes := scopesFromPlatformContext(pc, cfg)
 	managed, _, err := cfg.Store.List(ctx, resource.Filter{Scopes: scopes, Limit: 1000})
 	if err != nil {
-		slog.Warn("managed resources: scope filter failed, removing all managed", logKeyError, err)
-		return nil
+		slog.Warn("managed resources: scope filter failed, removing all managed",
+			logKeyError, err,
+			logKeyUserID, pc.UserID,
+			"persona", pc.PersonaName,
+		)
+		return pc, nil
 	}
-	visible := make(map[string]bool, len(managed))
+	visible = make(map[string]bool, len(managed))
 	for i := range managed {
 		visible[managed[i].URI] = true
 	}
-	return visible
+	return pc, visible
 }
 
 // filterResources keeps static resources and only visible managed resources.

--- a/pkg/middleware/mcp_test.go
+++ b/pkg/middleware/mcp_test.go
@@ -1072,14 +1072,21 @@ func TestMCPToolCallMiddleware_AwareSessionIDFallback(t *testing.T) {
 	// The AwareHandler → middleware integration test in middleware_chain_test.go
 	// covers this path through a real Streamable HTTP transport.
 
-	t.Run("falls back to default when no AwareHandler session", func(t *testing.T) {
+	t.Run("synthesizes per-principal SessionID for stateless http", func(t *testing.T) {
+		// HTTP transport with neither an SDK session nor an AwareHandler
+		// session: resolveSessionID returns "" before auth, and
+		// deriveAuthenticatedSessionID then upgrades to a synthetic
+		// "synth:user:<UserID>" once auth populates UserID. This is the
+		// boundary that prevents User A's harvest tool from returning
+		// User B's accumulated provenance.
 		next := func(ctx context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
 			pc := GetPlatformContext(ctx)
 			if pc == nil {
 				t.Fatal(mcpTestPCExpected)
 			}
-			if pc.SessionID != defaultSessionID {
-				t.Errorf("expected SessionID %q, got %q", defaultSessionID, pc.SessionID)
+			want := synthSessionPrefix + mcpTestUserID
+			if pc.SessionID != want {
+				t.Errorf("expected SessionID %q for stateless http after auth, got %q", want, pc.SessionID)
 			}
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
@@ -1089,12 +1096,127 @@ func TestMCPToolCallMiddleware_AwareSessionIDFallback(t *testing.T) {
 		handler := mw(next)
 		req := newMCPTestRequest(mcpTestToolName)
 
-		// No AwareHandler session in context
+		// No AwareHandler session in context.
 		_, err := handler(context.Background(), mcpTestMethod, req)
 		if err != nil {
 			t.Fatalf(mcpTestErrFmt, err)
 		}
 	})
+}
+
+// TestDeriveAuthenticatedSessionID covers the small helper directly. The
+// invariants are: (a) any non-empty incoming SessionID is preserved
+// verbatim, never silently rewritten over a real SDK session ID; (b)
+// empty + UserID -> synth:user:UserID; (c) empty + empty UserID -> empty;
+// (d) empty + the anonymous sentinel stays empty, so allowAnonymous
+// deployments don't pool every caller into synth:user:anonymous.
+func TestDeriveAuthenticatedSessionID(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		sessionID string
+		userID    string
+		want      string
+	}{
+		{"real SDK session preserved", "abc123", "user-1", "abc123"},
+		{"stdio sentinel preserved", defaultSessionID, "user-1", defaultSessionID},
+		{"empty + auth user -> synth", "", "apikey:nifi-etl", synthSessionPrefix + "apikey:nifi-etl"},
+		{"empty + empty user stays empty", "", "", ""},
+		{"empty + anonymous sentinel stays empty", "", userIDAnonymous, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got := deriveAuthenticatedSessionID(c.sessionID, c.userID)
+			if got != c.want {
+				t.Errorf("deriveAuthenticatedSessionID(%q, %q) = %q, want %q",
+					c.sessionID, c.userID, got, c.want)
+			}
+		})
+	}
+}
+
+// TestMCPToolCallMiddleware_StdioKeepsSentinel guards against an over-eager
+// fix: the stdio transport is allowed to keep the defaultSessionID because
+// there's exactly one logical client per process. Clearing it would break
+// provenance accumulation for stdio clients.
+func TestMCPToolCallMiddleware_StdioKeepsSentinel(t *testing.T) {
+	authenticator := &mcpTestAuthenticator{
+		userInfo: &UserInfo{UserID: mcpTestUserID, Roles: []string{mcpTestPersona}},
+	}
+	authorizer := &mcpTestAuthorizer{authorized: true, personaName: mcpTestPersona}
+
+	mw := MCPToolCallMiddleware(authenticator, authorizer, nil, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
+
+	var got string
+	next := func(ctx context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		pc := GetPlatformContext(ctx)
+		if pc == nil {
+			t.Fatal(mcpTestPCExpected)
+		}
+		got = pc.SessionID
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil
+	}
+
+	if _, err := mw(next)(context.Background(), mcpTestMethod, newMCPTestRequest(mcpTestToolName)); err != nil {
+		t.Fatalf(mcpTestErrFmt, err)
+	}
+	if got != defaultSessionID {
+		t.Errorf("stdio transport: expected SessionID %q, got %q", defaultSessionID, got)
+	}
+}
+
+// TestProvenanceNoCrossUserMixing_StatelessHTTP exercises the original
+// leak hazard end-to-end: two different stateless HTTP principals each
+// make tool calls against the same process. Before the fix, both pooled
+// into one shared "stdio" bucket and either user's harvest tool would
+// return the union of both users' provenance. After the fix each
+// principal lands in its own synth:user:<UserID> bucket, so HarvestA
+// returns only A's calls and HarvestB only B's. The stdio bucket
+// remains empty because no stdio caller is involved.
+func TestProvenanceNoCrossUserMixing_StatelessHTTP(t *testing.T) {
+	authorizer := &mcpTestAuthorizer{authorized: true, personaName: mcpTestPersona}
+	tracker := NewProvenanceTracker()
+	innerCount := 0
+	inner := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		innerCount++
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil
+	}
+	chain := MCPProvenanceMiddleware(tracker)(inner)
+
+	run := func(userID string, calls int) {
+		auth := &mcpTestAuthenticator{
+			userInfo: &UserInfo{UserID: userID, Roles: []string{mcpTestPersona}},
+		}
+		handler := MCPToolCallMiddleware(auth, authorizer, nil, ToolCallConfig{Transport: "http", AdminPersona: "admin"})(chain)
+		for range calls {
+			if _, err := handler(context.Background(), mcpTestMethod, newMCPTestRequest(mcpTestToolName)); err != nil {
+				t.Fatalf("handler(%s): %v", userID, err)
+			}
+		}
+	}
+
+	run("apikey:nifi-etl", 3)
+	run("apikey:other-client", 2)
+	if innerCount != 5 {
+		t.Fatalf("expected 5 inner calls, got %d", innerCount)
+	}
+
+	if got := tracker.Harvest(defaultSessionID); len(got) != 0 {
+		t.Errorf("stdio bucket should be empty for stateless http calls, got %d", len(got))
+	}
+	if got := tracker.Harvest(""); len(got) != 0 {
+		t.Errorf("empty bucket should be unreachable (record skips empty), got %d", len(got))
+	}
+
+	nifiCalls := tracker.Harvest(synthSessionPrefix + "apikey:nifi-etl")
+	if len(nifiCalls) != 3 {
+		t.Errorf("nifi-etl bucket should contain its 3 calls, got %d", len(nifiCalls))
+	}
+	otherCalls := tracker.Harvest(synthSessionPrefix + "apikey:other-client")
+	if len(otherCalls) != 2 {
+		t.Errorf("other-client bucket should contain its 2 calls, got %d", len(otherCalls))
+	}
 }
 
 func TestMCPToolCallMiddleware_PreAuthenticatedUser(t *testing.T) {

--- a/pkg/middleware/mcp_test.go
+++ b/pkg/middleware/mcp_test.go
@@ -1072,21 +1072,20 @@ func TestMCPToolCallMiddleware_AwareSessionIDFallback(t *testing.T) {
 	// The AwareHandler → middleware integration test in middleware_chain_test.go
 	// covers this path through a real Streamable HTTP transport.
 
-	t.Run("synthesizes per-principal SessionID for stateless http", func(t *testing.T) {
+	t.Run("clears SessionID for stateless http", func(t *testing.T) {
 		// HTTP transport with neither an SDK session nor an AwareHandler
-		// session: resolveSessionID returns "" before auth, and
-		// deriveAuthenticatedSessionID then upgrades to a synthetic
-		// "synth:user:<UserID>" once auth populates UserID. This is the
-		// boundary that prevents User A's harvest tool from returning
-		// User B's accumulated provenance.
+		// session: SessionID stays empty. Stateless HTTP has no session
+		// by definition; leaving the stdio sentinel would pool every
+		// caller into one shared provenance bucket, so empty is the
+		// correct value. ProvenanceTracker.Record skips empty session
+		// IDs, audit stores empty as null.
 		next := func(ctx context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
 			pc := GetPlatformContext(ctx)
 			if pc == nil {
 				t.Fatal(mcpTestPCExpected)
 			}
-			want := synthSessionPrefix + mcpTestUserID
-			if pc.SessionID != want {
-				t.Errorf("expected SessionID %q for stateless http after auth, got %q", want, pc.SessionID)
+			if pc.SessionID != "" {
+				t.Errorf("expected SessionID empty for stateless http, got %q", pc.SessionID)
 			}
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
@@ -1102,38 +1101,6 @@ func TestMCPToolCallMiddleware_AwareSessionIDFallback(t *testing.T) {
 			t.Fatalf(mcpTestErrFmt, err)
 		}
 	})
-}
-
-// TestDeriveAuthenticatedSessionID covers the small helper directly. The
-// invariants are: (a) any non-empty incoming SessionID is preserved
-// verbatim, never silently rewritten over a real SDK session ID; (b)
-// empty + UserID -> synth:user:UserID; (c) empty + empty UserID -> empty;
-// (d) empty + the anonymous sentinel stays empty, so allowAnonymous
-// deployments don't pool every caller into synth:user:anonymous.
-func TestDeriveAuthenticatedSessionID(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name      string
-		sessionID string
-		userID    string
-		want      string
-	}{
-		{"real SDK session preserved", "abc123", "user-1", "abc123"},
-		{"stdio sentinel preserved", defaultSessionID, "user-1", defaultSessionID},
-		{"empty + auth user -> synth", "", "apikey:nifi-etl", synthSessionPrefix + "apikey:nifi-etl"},
-		{"empty + empty user stays empty", "", "", ""},
-		{"empty + anonymous sentinel stays empty", "", userIDAnonymous, ""},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-			got := deriveAuthenticatedSessionID(c.sessionID, c.userID)
-			if got != c.want {
-				t.Errorf("deriveAuthenticatedSessionID(%q, %q) = %q, want %q",
-					c.sessionID, c.userID, got, c.want)
-			}
-		})
-	}
 }
 
 // TestMCPToolCallMiddleware_StdioKeepsSentinel guards against an over-eager
@@ -1170,10 +1137,10 @@ func TestMCPToolCallMiddleware_StdioKeepsSentinel(t *testing.T) {
 // leak hazard end-to-end: two different stateless HTTP principals each
 // make tool calls against the same process. Before the fix, both pooled
 // into one shared "stdio" bucket and either user's harvest tool would
-// return the union of both users' provenance. After the fix each
-// principal lands in its own synth:user:<UserID> bucket, so HarvestA
-// returns only A's calls and HarvestB only B's. The stdio bucket
-// remains empty because no stdio caller is involved.
+// return the union of both users' provenance. After the fix SessionID
+// stays empty for stateless HTTP, ProvenanceTracker.Record's empty-skip
+// guard fires, and no bucket accumulates anything. The stdio bucket
+// also stays empty because no stdio caller is involved.
 func TestProvenanceNoCrossUserMixing_StatelessHTTP(t *testing.T) {
 	authorizer := &mcpTestAuthorizer{authorized: true, personaName: mcpTestPersona}
 	tracker := NewProvenanceTracker()
@@ -1207,15 +1174,6 @@ func TestProvenanceNoCrossUserMixing_StatelessHTTP(t *testing.T) {
 	}
 	if got := tracker.Harvest(""); len(got) != 0 {
 		t.Errorf("empty bucket should be unreachable (record skips empty), got %d", len(got))
-	}
-
-	nifiCalls := tracker.Harvest(synthSessionPrefix + "apikey:nifi-etl")
-	if len(nifiCalls) != 3 {
-		t.Errorf("nifi-etl bucket should contain its 3 calls, got %d", len(nifiCalls))
-	}
-	otherCalls := tracker.Harvest(synthSessionPrefix + "apikey:other-client")
-	if len(otherCalls) != 2 {
-		t.Errorf("other-client bucket should contain its 2 calls, got %d", len(otherCalls))
 	}
 }
 


### PR DESCRIPTION
## Summary

`extractSessionID` returned the literal `"stdio"` sentinel whenever the SDK could not surface a session ID. On HTTP transport every stateless caller (no `Mcp-Session-Id` header, no `initialize` handshake) inherited that sentinel and pooled into one shared `"stdio"` bucket used by `ProvenanceTracker`, the session gate, the dedup cache, and the workflow tracker. `ProvenanceTracker.Record` guards against `""` to prevent cross-user mixing, but the `"stdio"` sentinel bypassed that guard, so a harvest tool (`save_artifact`, `trino_export`, `api_export`) called by any user would return whatever provenance the pool had accumulated regardless of who invoked it.

This PR closes the leak by leaving `SessionID` empty for stateless HTTP callers and reduces unrelated log noise in the managed-resources middleware.

## Why "clear to empty" and not "synthesize a per-user bucket"

The first version of this PR synthesized a per-principal session ID (`synth:user:UserID`) so authenticated stateless HTTP callers would still get provenance accumulation per individual. That was reverted in the second commit. Stateless HTTP callers have no session by definition; accumulating provenance, gate state, or dedup state across their calls would either be meaningless (one-shot calls) or invent a session contract the caller never asked for. The leak closure does not depend on the synthesis - `ProvenanceTracker.Record`'s existing empty-skip guard (`mcp_provenance.go:55`) fires once `SessionID` is empty, no bucket accumulates anything, no harvest can return another caller's calls. The simpler diff is 92 lines smaller and introduces no new wire format.

## Changes

### Session ID resolution (`pkg/middleware/mcp.go`)

- `extractSessionID` still returns the `"stdio"` sentinel as before. The behaviour change is in the new `resolveSessionID` helper, called from `MCPToolCallMiddleware` instead of inlined logic.
- `resolveSessionID` picks, in order: the SDK's propagated session ID, the `AwareHandler` session ID, then `""` for HTTP transport with neither, then the `"stdio"` sentinel for the actual stdio transport.
- The `transportStdio` constant pins the cfg.Transport value that legitimately keeps the sentinel. Any other transport ("http", "sse") clears it.
- No other consumer of `pc.SessionID` is modified. Audit handles empty SessionID (column default `''` in `000004_audit_schema_improvements.up.sql:5`). Memory and knowledge stores are scoped by persona/email and never bucket on session ID alone. The session gate, dedup cache, and workflow tracker still write to an empty-key bucket for stateless HTTP, which is a known cosmetic regression - they do not leak user data, only session-scoped state that did not belong to a real session anyway.

### Managed-resources middleware log noise (`pkg/middleware/mcp_resources.go`)

The middleware was emitting one DEBUG line per resource in every `resources/list` call, plus interception and no-op early-return messages, with no user attribution because `resources/list` does not go through `MCPToolCallMiddleware`.

- Removed the per-resource DEBUG fan-out (one line per resource).
- Removed the "intercepting resources/list" and "intercepting resources/read" pre-dispatch logs (redundant with the work itself).
- Removed the "no managed resources in SDK list, returning as-is" no-op log.
- Kept one DEBUG line on the actual filter path that now carries `user_id` and `persona`, so `resources/list` traffic against managed URIs is attributable.
- `resolveVisibleManagedURIsWithPC` is a new helper that returns the authenticated `PlatformContext` alongside the visible URIs so the log line can attribute the filter. The previous `resolveVisibleManagedURIs` function is removed; it would have been orphaned.

## Tests

- `TestMCPToolCallMiddleware_AwareSessionIDFallback/clears_SessionID_for_stateless_http` replaces the prior subtest that asserted the buggy `"stdio"` fallback.
- `TestMCPToolCallMiddleware_StdioKeepsSentinel` guards against an over-eager fix that would also clear the stdio bucket. Stdio is one logical client per process; keeping the sentinel there is correct.
- `TestProvenanceNoCrossUserMixing_StatelessHTTP` wires two distinct principals (`apikey:nifi-etl` and `apikey:other-client`) through the assembled middleware chain and asserts that `Harvest("stdio")` and `Harvest("")` both return zero entries. This is the actual leak-closure proof.

All new functions at 100% coverage. Total middleware-package coverage 95.2%.

## Verification

- `make verify` passes (fmt, race tests, total coverage gate, golangci-lint, gosec, govulncheck, semgrep, codeql, dead-code, mutation testing, GoReleaser dry-run)
- `golangci-lint run --new-from-rev=origin/main ./...` reports 0 issues

## Operator impact

### Existing installs

For HTTP-transport deployments, `pc.SessionID` for stateless callers changes from `"stdio"` to `""`. Downstream effects:

- **Audit logs**: `session_id` column on rows from stateless HTTP calls changes from `"stdio"` to `""` (column default). Queries grouping by `session_id = 'stdio'` lose those rows. Honest because those rows were never a real stdio session.
- **Provenance harvest**: stateless HTTP callers no longer accumulate provenance. Harvest tools called by them attach empty provenance. **This is the leak closure.** Previously a harvest tool would return whatever the pooled bucket held.
- **Session gate / dedup cache / workflow tracker**: still write to an empty-key bucket for stateless HTTP. No data leak (these stores hold table metadata, init flags, discovery flags - not user data). Cosmetic regression where multiple stateless HTTP callers may share an empty cache key.
- **stdio transport**: unchanged.
- **HTTP transport with `Mcp-Session-Id`**: unchanged.

### Rolling restart required to clear in-memory pool

The currently-running pod still has whatever it accumulated under `"stdio"` in memory from before this fix. A rolling restart clears it; the new behaviour applies to fresh sessions only.

## Test plan

- [x] Unit tests prove cross-user pooling is closed end-to-end through the assembled middleware
- [x] Stdio transport still uses the sentinel (regression guard)
- [x] `make verify` passes locally
- [x] `golangci-lint --new-from-rev=origin/main` is 0 issues
- [ ] Roll a deployment, confirm `provenance.record` log lines stop showing `session_id: "stdio"` for HTTP-transport callers; lines for stateless HTTP show `session_id: ""` (or are absent from `ProvenanceTracker.Record` because of the empty-skip)
- [ ] Confirm a `resources/list` against a deployment with managed resources emits one DEBUG line with `user_id` and `persona` attribution instead of the per-resource fan-out