### PR TITLE
feat(enrichment): semantic-similarity fallback for cross-toolkit injection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,6 +326,8 @@ injection:
   datahub_query_enrichment: true
   unwrap_json: true                # Auto-unwrap single-row VARCHAR-of-JSON results (default: true)
   column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
+  semantic_fallback: false         # Issue #444: fall back to similarity search on URN miss (default: false)
+  semantic_fallback_top_k: 1       # Suggested matches per URN miss (default: 1, clamped to [1,10])
 ```
 
 ### Managed Resources

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -257,6 +257,8 @@ injection:
   datahub_query_enrichment: true
   unwrap_json: true                # Auto-unwrap single-row VARCHAR-of-JSON (default: true)
   column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
+  semantic_fallback: false         # Fallback to similarity search on URN miss (default: false, issue #444)
+  semantic_fallback_top_k: 1       # Suggested matches per miss (default: 1, max: 10)
 ```
 
 ## Server Configuration
@@ -628,6 +630,12 @@ The `database` store requires `database.dsn`. Database-backed sessions survive r
 | `column_context_filtering` | bool | true | Limit column enrichment to SQL-referenced columns |
 | `search_schema_preview` | bool | true | Add bounded column-name+type preview to datahub_search query_context |
 | `schema_preview_max_columns` | int | 15 | Max columns per entity in schema preview |
+| `semantic_fallback` | bool | false | When a Trino-table URN lookup misses on the semantic provider, fall back to a similarity search and surface the top-K hits as SUGGESTED matches annotated with `match_kind: semantic`. Default off; operators opt in. Issue #444. |
+| `semantic_fallback_top_k` | int | 1 | Number of similarity-search hits surfaced per URN miss when `semantic_fallback` is on. Clamped to [1, 10]. |
+
+When `semantic_fallback` fires, the appended content carries `semantic_fallback.match_kind: semantic`, a human-readable note, the queried table identifier, and a list of suggested matches (urn, name, platform, description, tags, domain). The audit row's `enrichment_match_kind` column records `semantic` for these calls and `urn` for exact lookups, so operators can compute the false-positive rate of similarity-based suggestions with a SQL aggregate.
+
+The fallback fires only on the single-table enrichment path (e.g. `trino_describe_table`); multi-table SQL queries fall through with no suggestions until a follow-up extends the same hook to `enrichTrinoQueryResult`.
 
 ## URN Mapping Configuration
 

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -8136,6 +8136,11 @@ const docTemplate = `{
                     "type": "boolean",
                     "example": true
                 },
+                "enrichment_match_kind": {
+                    "description": "EnrichmentMatchKind records how the semantic enrichment matched\nthe target table or column: \"urn\" when the URN-equality lookup\nresolved exactly, \"semantic\" when an exact lookup missed and the\nplatform fell back to similarity search (suggested match, not\nasserted), or empty when no enrichment ran. Operators use this\nto measure the false-positive rate of similarity-based\nsuggestions (issue #444).",
+                    "type": "string",
+                    "example": "urn"
+                },
                 "enrichment_mode": {
                     "type": "string",
                     "example": "summary"

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -8130,6 +8130,11 @@
                     "type": "boolean",
                     "example": true
                 },
+                "enrichment_match_kind": {
+                    "description": "EnrichmentMatchKind records how the semantic enrichment matched\nthe target table or column: \"urn\" when the URN-equality lookup\nresolved exactly, \"semantic\" when an exact lookup missed and the\nplatform fell back to similarity search (suggested match, not\nasserted), or empty when no enrichment ran. Operators use this\nto measure the false-positive rate of similarity-based\nsuggestions (issue #444).",
+                    "type": "string",
+                    "example": "urn"
+                },
                 "enrichment_mode": {
                     "type": "string",
                     "example": "summary"

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -982,6 +982,17 @@ definitions:
       enrichment_applied:
         example: true
         type: boolean
+      enrichment_match_kind:
+        description: |-
+          EnrichmentMatchKind records how the semantic enrichment matched
+          the target table or column: "urn" when the URN-equality lookup
+          resolved exactly, "semantic" when an exact lookup missed and the
+          platform fell back to similarity search (suggested match, not
+          asserted), or empty when no enrichment ran. Operators use this
+          to measure the false-positive rate of similarity-based
+          suggestions (issue #444).
+        example: urn
+        type: string
       enrichment_mode:
         example: summary
         type: string

--- a/pkg/audit/event.go
+++ b/pkg/audit/event.go
@@ -126,6 +126,14 @@ func (e *Event) WithEnrichmentMode(mode string) *Event {
 	return e
 }
 
+// WithEnrichmentMatchKind records how enrichment matched its target:
+// "urn" for exact URN equality, "semantic" for similarity-fallback,
+// empty when no enrichment ran. See Event.EnrichmentMatchKind.
+func (e *Event) WithEnrichmentMatchKind(kind string) *Event {
+	e.EnrichmentMatchKind = kind
+	return e
+}
+
 // generateEventID generates a unique event ID.
 func generateEventID() string {
 	bytes := make([]byte, 16)

--- a/pkg/audit/logger.go
+++ b/pkg/audit/logger.go
@@ -44,7 +44,15 @@ type Event struct {
 	EnrichmentTokensFull  int            `json:"enrichment_tokens_full" example:"850"`
 	EnrichmentTokensDedup int            `json:"enrichment_tokens_dedup" example:"350"`
 	EnrichmentMode        string         `json:"enrichment_mode,omitempty" example:"summary"`
-	Authorized            bool           `json:"authorized" example:"true"`
+	// EnrichmentMatchKind records how the semantic enrichment matched
+	// the target table or column: "urn" when the URN-equality lookup
+	// resolved exactly, "semantic" when an exact lookup missed and the
+	// platform fell back to similarity search (suggested match, not
+	// asserted), or empty when no enrichment ran. Operators use this
+	// to measure the false-positive rate of similarity-based
+	// suggestions (issue #444).
+	EnrichmentMatchKind string `json:"enrichment_match_kind,omitempty" example:"urn"`
+	Authorized          bool   `json:"authorized" example:"true"`
 }
 
 // SortOrder defines sort direction.

--- a/pkg/audit/postgres/store.go
+++ b/pkg/audit/postgres/store.go
@@ -63,7 +63,7 @@ var auditColumns = []string{
 	"response_chars", "request_chars", "content_blocks",
 	"transport", "source", "enrichment_applied",
 	"enrichment_tokens_full", "enrichment_tokens_dedup",
-	"enrichment_mode", "authorized",
+	"enrichment_mode", "enrichment_match_kind", "authorized",
 }
 
 // Store implements audit.Logger using PostgreSQL.
@@ -99,8 +99,8 @@ func (s *Store) Log(ctx context.Context, event audit.Event) error {
 
 	query := `
 		INSERT INTO audit_logs
-		(id, timestamp, duration_ms, request_id, session_id, user_id, user_email, persona, tool_name, toolkit_kind, toolkit_name, connection, parameters, success, error_message, created_date, response_chars, request_chars, content_blocks, transport, source, enrichment_applied, enrichment_tokens_full, enrichment_tokens_dedup, enrichment_mode, authorized)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)
+		(id, timestamp, duration_ms, request_id, session_id, user_id, user_email, persona, tool_name, toolkit_kind, toolkit_name, connection, parameters, success, error_message, created_date, response_chars, request_chars, content_blocks, transport, source, enrichment_applied, enrichment_tokens_full, enrichment_tokens_dedup, enrichment_mode, enrichment_match_kind, authorized)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)
 	`
 
 	_, err = s.db.ExecContext(ctx, query,
@@ -129,6 +129,7 @@ func (s *Store) Log(ctx context.Context, event audit.Event) error {
 		event.EnrichmentTokensFull,
 		event.EnrichmentTokensDedup,
 		event.EnrichmentMode,
+		event.EnrichmentMatchKind,
 		event.Authorized,
 	)
 	if err != nil {
@@ -364,6 +365,7 @@ func (*Store) scanEvent(rows *sql.Rows) (audit.Event, error) {
 		&event.EnrichmentTokensFull,
 		&event.EnrichmentTokensDedup,
 		&event.EnrichmentMode,
+		&event.EnrichmentMatchKind,
 		&event.Authorized,
 	)
 	if err != nil {

--- a/pkg/audit/postgres/store_test.go
+++ b/pkg/audit/postgres/store_test.go
@@ -28,7 +28,7 @@ const (
 	testCountFiltered = 7
 )
 
-// selectColumns lists the 25 SELECT column names in scan order.
+// selectColumns lists the 26 SELECT column names in scan order.
 var selectColumns = []string{
 	"id", "timestamp", "duration_ms", "request_id", "session_id",
 	"user_id", "user_email", "persona", "tool_name", "toolkit_kind",
@@ -36,7 +36,7 @@ var selectColumns = []string{
 	"response_chars", "request_chars", "content_blocks",
 	"transport", "source", "enrichment_applied",
 	"enrichment_tokens_full", "enrichment_tokens_dedup",
-	"enrichment_mode", "authorized",
+	"enrichment_mode", "enrichment_match_kind", "authorized",
 }
 
 const (
@@ -128,6 +128,7 @@ func TestLog_Success(t *testing.T) {
 		event.EnrichmentTokensFull,
 		event.EnrichmentTokensDedup,
 		event.EnrichmentMode,
+		event.EnrichmentMatchKind,
 		event.Authorized,
 	).WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -157,7 +158,7 @@ func TestLog_NilParameters(t *testing.T) {
 		event.ResponseChars, event.RequestChars, event.ContentBlocks,
 		event.Transport, event.Source, event.EnrichmentApplied,
 		event.EnrichmentTokensFull, event.EnrichmentTokensDedup,
-		event.EnrichmentMode, event.Authorized,
+		event.EnrichmentMode, event.EnrichmentMatchKind, event.Authorized,
 	).WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err = store.Log(context.Background(), event)
@@ -198,7 +199,7 @@ func testEventRows(mock sqlmock.Sqlmock, events ...audit.Event) {
 			event.ResponseChars, event.RequestChars, event.ContentBlocks,
 			event.Transport, event.Source, event.EnrichmentApplied,
 			event.EnrichmentTokensFull, event.EnrichmentTokensDedup,
-			event.EnrichmentMode, event.Authorized,
+			event.EnrichmentMode, event.EnrichmentMatchKind, event.Authorized,
 		)
 	}
 	mock.ExpectQuery("SELECT .+ FROM audit_logs").WillReturnRows(rows)
@@ -256,7 +257,7 @@ func TestQuery_AllFilters(t *testing.T) {
 		event.ResponseChars, event.RequestChars, event.ContentBlocks,
 		event.Transport, event.Source, event.EnrichmentApplied,
 		event.EnrichmentTokensFull, event.EnrichmentTokensDedup,
-		event.EnrichmentMode, event.Authorized,
+		event.EnrichmentMode, event.EnrichmentMatchKind, event.Authorized,
 	)
 
 	mock.ExpectQuery("SELECT .+ FROM audit_logs").WithArgs(
@@ -390,6 +391,7 @@ func TestScanEvent_AllFields(t *testing.T) {
 		event.EnrichmentTokensFull,
 		event.EnrichmentTokensDedup,
 		event.EnrichmentMode,
+		event.EnrichmentMatchKind,
 		event.Authorized,
 	)
 	mock.ExpectQuery("SELECT .+ FROM audit_logs").WillReturnRows(rows)
@@ -708,7 +710,7 @@ func TestQuery_MultipleRows(t *testing.T) {
 			ev.ResponseChars, ev.RequestChars, ev.ContentBlocks,
 			ev.Transport, ev.Source, ev.EnrichmentApplied,
 			ev.EnrichmentTokensFull, ev.EnrichmentTokensDedup,
-			ev.EnrichmentMode, ev.Authorized,
+			ev.EnrichmentMode, ev.EnrichmentMatchKind, ev.Authorized,
 		)
 	}
 	mock.ExpectQuery("SELECT .+ FROM audit_logs").WillReturnRows(rows)
@@ -741,7 +743,7 @@ func TestQuery_EmptyParameters(t *testing.T) {
 		event.ResponseChars, event.RequestChars, event.ContentBlocks,
 		event.Transport, event.Source, event.EnrichmentApplied,
 		event.EnrichmentTokensFull, event.EnrichmentTokensDedup,
-		event.EnrichmentMode, event.Authorized,
+		event.EnrichmentMode, event.EnrichmentMatchKind, event.Authorized,
 	)
 	mock.ExpectQuery("SELECT .+ FROM audit_logs").WillReturnRows(rows)
 
@@ -829,7 +831,7 @@ func TestQuery_IDFilter(t *testing.T) {
 		event.ResponseChars, event.RequestChars, event.ContentBlocks,
 		event.Transport, event.Source, event.EnrichmentApplied,
 		event.EnrichmentTokensFull, event.EnrichmentTokensDedup,
-		event.EnrichmentMode, event.Authorized,
+		event.EnrichmentMode, event.EnrichmentMatchKind, event.Authorized,
 	)
 	mock.ExpectQuery("SELECT .+ FROM audit_logs").WithArgs("evt-specific").WillReturnRows(rows)
 

--- a/pkg/database/migrate/migrate_unit_test.go
+++ b/pkg/database/migrate/migrate_unit_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	migrateTestFileCount    = 92
+	migrateTestFileCount    = 94
 	migrateTestSuccess      = "success"
 	migrateTestFactoryError = "factory error"
 )

--- a/pkg/database/migrate/migrations/000047_audit_match_kind.down.sql
+++ b/pkg/database/migrate/migrations/000047_audit_match_kind.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE audit_logs DROP COLUMN IF EXISTS enrichment_match_kind;

--- a/pkg/database/migrate/migrations/000047_audit_match_kind.up.sql
+++ b/pkg/database/migrate/migrations/000047_audit_match_kind.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS enrichment_match_kind VARCHAR(20) DEFAULT '';

--- a/pkg/middleware/audit.go
+++ b/pkg/middleware/audit.go
@@ -37,7 +37,12 @@ type AuditEvent struct {
 	EnrichmentTokensFull  int            `json:"enrichment_tokens_full"`
 	EnrichmentTokensDedup int            `json:"enrichment_tokens_dedup"`
 	EnrichmentMode        string         `json:"enrichment_mode,omitempty"`
-	Authorized            bool           `json:"authorized"`
+	// EnrichmentMatchKind records how the enrichment matched its
+	// target: "urn" for exact, "semantic" for similarity-fallback,
+	// empty when no enrichment ran. See pkg/audit.Event for the
+	// operator-facing description.
+	EnrichmentMatchKind string `json:"enrichment_match_kind,omitempty"`
+	Authorized          bool   `json:"authorized"`
 }
 
 // NoopAuditLogger discards all audit events.

--- a/pkg/middleware/audit_adapter.go
+++ b/pkg/middleware/audit_adapter.go
@@ -42,6 +42,7 @@ func (a *auditStoreAdapter) Log(ctx context.Context, event AuditEvent) error {
 		WithEnrichment(event.EnrichmentApplied).
 		WithEnrichmentTokens(event.EnrichmentTokensFull, event.EnrichmentTokensDedup).
 		WithEnrichmentMode(event.EnrichmentMode).
+		WithEnrichmentMatchKind(event.EnrichmentMatchKind).
 		WithAuthorized(event.Authorized)
 
 	// Override timestamp from the event

--- a/pkg/middleware/context.go
+++ b/pkg/middleware/context.go
@@ -13,6 +13,22 @@ import (
 // EnrichmentModeFull is the enrichment mode value for full (non-dedup) enrichment.
 const EnrichmentModeFull = "full"
 
+// Enrichment match-kind values, recorded on PlatformContext and
+// surfaced in audit_logs.enrichment_match_kind so operators can
+// distinguish a confident URN-equality match from a similarity
+// suggestion produced by the semantic fallback path (issue #444).
+const (
+	// EnrichmentMatchURN means the platform resolved the target
+	// table or column by exact URN equality. High confidence.
+	EnrichmentMatchURN = "urn"
+
+	// EnrichmentMatchSemantic means the URN-equality lookup missed
+	// and the platform fell back to a similarity search. The
+	// enrichment payload is a SUGGESTED match, not an asserted one;
+	// operators measure false-positive rate from this value.
+	EnrichmentMatchSemantic = "semantic"
+)
+
 // contextKey is a private type for context keys.
 type contextKey int
 
@@ -57,6 +73,13 @@ type PlatformContext struct {
 	EnrichmentTokensFull  int    // estimated tokens for full enrichment
 	EnrichmentTokensDedup int    // estimated tokens for deduped enrichment (0 if full sent)
 	EnrichmentMode        string // "full", "summary", "reference", "none", or "" (not enriched)
+
+	// EnrichmentMatchKind distinguishes URN-equality matches from
+	// similarity-fallback matches. Set to EnrichmentMatchURN when
+	// the URN lookup succeeded, EnrichmentMatchSemantic when the
+	// platform fell back to a similarity search. Empty when no
+	// enrichment ran. See pkg/audit.Event.EnrichmentMatchKind.
+	EnrichmentMatchKind string
 
 	// Results (populated after handler)
 	Success      bool

--- a/pkg/middleware/mcp_audit.go
+++ b/pkg/middleware/mcp_audit.go
@@ -152,6 +152,7 @@ func buildMCPAuditEvent(pc *PlatformContext, info auditCallInfo) AuditEvent {
 		EnrichmentTokensFull:  pc.EnrichmentTokensFull,
 		EnrichmentTokensDedup: pc.EnrichmentTokensDedup,
 		EnrichmentMode:        pc.EnrichmentMode,
+		EnrichmentMatchKind:   pc.EnrichmentMatchKind,
 		Authorized:            pc.Authorized,
 	}
 }

--- a/pkg/middleware/middleware_chain_test.go
+++ b/pkg/middleware/middleware_chain_test.go
@@ -1337,12 +1337,30 @@ func TestMiddlewareChain_EnrichmentAppliedInAudit(t *testing.T) {
 	if trinoEvent.SessionID == "" {
 		t.Error("trino_describe_table: SessionID is empty")
 	}
+	// Issue #444: the URN-equality lookup succeeded for this fixture
+	// (mockSemanticProvider returns a non-nil TableContext), so the
+	// audit row must carry match_kind="urn". This proves the
+	// PlatformContext set-site inside enrichTrinoResult is reached
+	// through the real assembled middleware chain, not just exercised
+	// in isolation by the unit tests.
+	if trinoEvent.EnrichmentMatchKind != middleware.EnrichmentMatchURN {
+		t.Errorf("trino_describe_table: EnrichmentMatchKind = %q, want %q",
+			trinoEvent.EnrichmentMatchKind, middleware.EnrichmentMatchURN)
+	}
 
 	if infoEvent == nil {
 		t.Fatal("missing audit event for platform_info")
 	}
 	if infoEvent.EnrichmentApplied {
 		t.Error("platform_info: EnrichmentApplied = true, want false")
+	}
+	// Issue #444: when no enrichment runs (platform_info is not a
+	// Trino tool), match_kind must stay empty. Operators querying
+	// `WHERE enrichment_match_kind = ''` get the count of
+	// non-enriched calls.
+	if infoEvent.EnrichmentMatchKind != "" {
+		t.Errorf("platform_info: EnrichmentMatchKind = %q, want empty",
+			infoEvent.EnrichmentMatchKind)
 	}
 }
 

--- a/pkg/middleware/semantic.go
+++ b/pkg/middleware/semantic.go
@@ -126,6 +126,20 @@ type EnrichmentConfig struct {
 	// ConnectionsForURN returns connection names that can access the dataset
 	// identified by a DataHub URN, based on the URN's platform component.
 	ConnectionsForURN func(urn string) []string
+
+	// SemanticFallbackEnabled turns on the issue #444 fallback: when
+	// a URN-equality lookup misses on the semantic provider, the
+	// enricher calls SearchTables with Mode="semantic" and surfaces
+	// the top-K hits as SUGGESTED matches (annotated with
+	// match_kind=semantic so the model knows they are similarity-
+	// inferred rather than URN-resolved). Default off; operators opt
+	// in explicitly because similarity is heuristic.
+	SemanticFallbackEnabled bool
+
+	// SemanticFallbackTopK caps how many similarity-search results
+	// the fallback returns per miss. Caller is expected to clamp to
+	// a sane range (the platform-level config helper does this).
+	SemanticFallbackTopK int
 }
 
 // schemaPreviewColumn is a minimal column entry for search result schema previews.
@@ -199,7 +213,7 @@ func (e *semanticEnricher) enrichTrinoResultWithDedup(
 	if cache == nil {
 		slog.Debug("dedup: cache is nil, full enrichment")
 		pc.EnrichmentMode = EnrichmentModeFull
-		return e.enrichTrinoResult(ctx, result, request, catalogMapping)
+		return e.enrichTrinoResult(ctx, result, request, catalogMapping, pc)
 	}
 
 	// Identify tables from the request
@@ -210,7 +224,7 @@ func (e *semanticEnricher) enrichTrinoResultWithDedup(
 			keySessionID, pc.SessionID,
 			"has_params", request.Params != nil,
 		)
-		return e.enrichTrinoResult(ctx, result, request, catalogMapping)
+		return e.enrichTrinoResult(ctx, result, request, catalogMapping, pc)
 	}
 
 	slog.Debug("dedup: checking cache",
@@ -254,7 +268,7 @@ func (e *semanticEnricher) handleFullEnrichment(
 		_, catalogMapping = e.cfg.ForConnection(pc.Connection)
 	}
 
-	enrichedResult, err := e.enrichTrinoResult(ctx, result, request, catalogMapping)
+	enrichedResult, err := e.enrichTrinoResult(ctx, result, request, catalogMapping, pc)
 	if err != nil {
 		return enrichedResult, err
 	}
@@ -475,11 +489,15 @@ func applyCatalogMapping(table semantic.TableIdentifier, mapping map[string]stri
 
 // enrichTrinoResult adds semantic context to Trino tool results.
 // catalogMapping optionally remaps connection catalog names to DataHub catalog names.
+// pc may be nil in test paths; when non-nil, EnrichmentMatchKind is set to
+// EnrichmentMatchURN on exact resolution or EnrichmentMatchSemantic when the
+// issue #444 similarity fallback fires.
 func (e *semanticEnricher) enrichTrinoResult(
 	ctx context.Context,
 	result *mcp.CallToolResult,
 	request mcp.CallToolRequest,
 	catalogMapping map[string]string,
+	pc *PlatformContext,
 ) (*mcp.CallToolResult, error) {
 	// Check for SQL query first (multi-table support)
 	if sql := extractSQLFromRequest(request); sql != "" {
@@ -517,6 +535,18 @@ func (e *semanticEnricher) enrichTrinoResult(
 			"parsed_table", table.Table,
 			keyError, err,
 		)
+		// Issue #444: when URN-equality lookup misses and the
+		// operator opted into semantic_fallback, surface the top-K
+		// similarity hits as SUGGESTED matches so the model can
+		// still get a hint about likely-related entities. The
+		// match_kind tag on both the payload and the audit row
+		// makes it visible that this is heuristic, not asserted.
+		if suggestions := e.trySemanticFallback(ctx, table); len(suggestions) > 0 {
+			if pc != nil {
+				pc.EnrichmentMatchKind = EnrichmentMatchSemantic
+			}
+			return appendSemanticFallbackSuggestions(result, table, suggestions)
+		}
 		return result, nil
 	}
 
@@ -529,7 +559,118 @@ func (e *semanticEnricher) enrichTrinoResult(
 		)
 	}
 
+	if pc != nil {
+		pc.EnrichmentMatchKind = EnrichmentMatchURN
+	}
 	return appendSemanticContextWithColumns(result, semanticCtx, columnsCtx)
+}
+
+// fallbackSearchMode is the SearchFilter.Mode value the issue #444
+// fallback requests on the semantic provider. Named so the same
+// literal does not float between the caller and any future test
+// that needs to assert on the value the provider sees.
+const fallbackSearchMode = "semantic"
+
+// trySemanticFallback runs the issue #444 similarity-search path
+// when a URN-equality lookup for table misses. Returns nil when the
+// operator did not enable the fallback, when the provider is
+// unavailable, when the constructed query is empty, or when the
+// underlying search errors. A non-nil empty slice is treated as
+// "ran but no hits" and the caller suppresses the suggested-matches
+// payload.
+func (e *semanticEnricher) trySemanticFallback(ctx context.Context, table semantic.TableIdentifier) []semantic.TableSearchResult {
+	if !e.cfg.SemanticFallbackEnabled || e.semanticProvider == nil {
+		return nil
+	}
+	searchQuery := buildSemanticFallbackQuery(table)
+	if searchQuery == "" {
+		return nil
+	}
+	topK := e.cfg.SemanticFallbackTopK
+	if topK <= 0 {
+		topK = 1
+	}
+	results, err := e.semanticProvider.SearchTables(ctx, semantic.SearchFilter{
+		Query: searchQuery,
+		Mode:  fallbackSearchMode,
+		Limit: topK,
+	})
+	if err != nil {
+		slog.Debug("semantic fallback search failed",
+			keyTable, table.String(),
+			keyError, err,
+		)
+		return nil
+	}
+	return results
+}
+
+// buildSemanticFallbackQuery turns a TableIdentifier into the query
+// text the similarity search receives. Table name carries the most
+// information so it leads; schema follows to disambiguate
+// similarly-named tables across schemas. Catalog is intentionally
+// omitted because catalog names are often deployment-internal
+// identifiers ("hive", "rdbms") that add noise without recall.
+// Returns "" when no usable component is present.
+func buildSemanticFallbackQuery(table semantic.TableIdentifier) string {
+	parts := make([]string, 0, 2)
+	if table.Table != "" {
+		parts = append(parts, table.Table)
+	}
+	if table.Schema != "" {
+		parts = append(parts, table.Schema)
+	}
+	return strings.Join(parts, " ")
+}
+
+// appendSemanticFallbackSuggestions appends the suggested-matches
+// payload produced by trySemanticFallback to the result. The
+// payload is wrapped under "semantic_fallback" with a match_kind
+// tag and a human-readable note so the model can distinguish
+// these heuristic suggestions from URN-resolved enrichment.
+// Returns the result unchanged when suggestions is empty.
+func appendSemanticFallbackSuggestions(
+	result *mcp.CallToolResult,
+	table semantic.TableIdentifier,
+	suggestions []semantic.TableSearchResult,
+) (*mcp.CallToolResult, error) {
+	if len(suggestions) == 0 {
+		return result, nil
+	}
+	items := make([]map[string]any, 0, len(suggestions))
+	for _, s := range suggestions {
+		item := map[string]any{
+			keyURN:    s.URN,
+			fieldName: s.Name,
+		}
+		if s.Platform != "" {
+			item["platform"] = s.Platform
+		}
+		if s.Description != "" {
+			item[keyDescription] = s.Description
+		}
+		if len(s.Tags) > 0 {
+			item[keyTags] = s.Tags
+		}
+		if s.Domain != "" {
+			item[fieldDomain] = s.Domain
+		}
+		items = append(items, item)
+	}
+	payload := map[string]any{
+		"semantic_fallback": map[string]any{
+			"queried_table":     table.String(),
+			"match_kind":        EnrichmentMatchSemantic,
+			fieldNote:           "Exact URN lookup for the queried table missed. The following are SUGGESTED matches from a similarity search; verify before treating as authoritative.",
+			"suggested_matches": items,
+		},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return result, fmt.Errorf("marshal semantic fallback: %w", err)
+	}
+	result.Content = append(result.Content, &mcp.TextContent{Text: string(payloadJSON)})
+	return result, nil
 }
 
 // extractSQLFromRequest extracts SQL from request arguments.

--- a/pkg/middleware/semantic_fallback_test.go
+++ b/pkg/middleware/semantic_fallback_test.go
@@ -1,0 +1,335 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/semantic"
+)
+
+const (
+	fallbackTestSchema = "analytics"
+	fallbackTestTable  = "orders_v2"
+	fallbackTestQuery  = fallbackTestTable + " " + fallbackTestSchema
+	fallbackTestURN    = "urn:li:dataset:(urn:li:dataPlatform:trino,analytics.orders,PROD)"
+)
+
+// trinoDescribeRequest builds the minimal request shape that
+// enrichTrinoResult uses to pick a table identifier from a single-
+// table tool call (the path issue #444 targets first).
+func trinoDescribeRequest(t *testing.T, table string) mcp.CallToolRequest {
+	t.Helper()
+	args, err := json.Marshal(map[string]any{"table": table})
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	return mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      "trino_describe_table",
+			Arguments: args,
+		},
+	}
+}
+
+func TestBuildSemanticFallbackQuery(t *testing.T) {
+	cases := []struct {
+		name  string
+		table semantic.TableIdentifier
+		want  string
+	}{
+		{"table_and_schema", semantic.TableIdentifier{Schema: "s", Table: "t"}, "t s"},
+		{"table_only", semantic.TableIdentifier{Table: "t"}, "t"},
+		{"schema_only", semantic.TableIdentifier{Schema: "s"}, "s"},
+		{"empty_yields_empty_query", semantic.TableIdentifier{}, ""},
+		{"catalog_ignored_for_recall", semantic.TableIdentifier{Catalog: "hive", Schema: "s", Table: "t"}, "t s"},
+	}
+	for _, tc := range cases {
+		got := buildSemanticFallbackQuery(tc.table)
+		if got != tc.want {
+			t.Errorf("buildSemanticFallbackQuery(%+v) = %q; want %q", tc.table, got, tc.want)
+		}
+	}
+}
+
+// TestTrySemanticFallback_Disabled proves the fallback is opt-in.
+// With the config flag off, no SearchTables call must happen even
+// when the provider would gladly serve one. This is the "default
+// off" half of acceptance criterion #1 in issue #444.
+func TestTrySemanticFallback_Disabled(t *testing.T) {
+	called := false
+	provider := &mockSemanticProvider{
+		searchTablesFunc: func(_ context.Context, _ semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
+			called = true
+			return []semantic.TableSearchResult{{URN: fallbackTestURN, Name: fallbackTestTable}}, nil
+		},
+	}
+	enricher := &semanticEnricher{
+		semanticProvider: provider,
+		cfg:              EnrichmentConfig{SemanticFallbackEnabled: false, SemanticFallbackTopK: 3},
+	}
+	got := enricher.trySemanticFallback(context.Background(), semantic.TableIdentifier{Schema: fallbackTestSchema, Table: fallbackTestTable})
+	if got != nil {
+		t.Errorf("trySemanticFallback returned %v; want nil when disabled", got)
+	}
+	if called {
+		t.Error("SearchTables was called when fallback is disabled")
+	}
+}
+
+// TestTrySemanticFallback_EnabledHits proves the enabled path
+// queries with the expected mode (semantic) and respects top_k.
+func TestTrySemanticFallback_EnabledHits(t *testing.T) {
+	var seenFilter semantic.SearchFilter
+	provider := &mockSemanticProvider{
+		searchTablesFunc: func(_ context.Context, f semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
+			seenFilter = f
+			return []semantic.TableSearchResult{
+				{URN: fallbackTestURN, Name: "orders", Platform: "trino", Description: "Order facts"},
+				{URN: "urn:li:dataset:(urn:li:dataPlatform:trino,analytics.orders_old,PROD)", Name: "orders_old"},
+			}, nil
+		},
+	}
+	enricher := &semanticEnricher{
+		semanticProvider: provider,
+		cfg:              EnrichmentConfig{SemanticFallbackEnabled: true, SemanticFallbackTopK: 2},
+	}
+	got := enricher.trySemanticFallback(context.Background(), semantic.TableIdentifier{Schema: fallbackTestSchema, Table: fallbackTestTable})
+	if len(got) != 2 {
+		t.Fatalf("got %d results; want 2", len(got))
+	}
+	if seenFilter.Mode != fallbackSearchMode {
+		t.Errorf("filter.Mode = %q; want %q", seenFilter.Mode, fallbackSearchMode)
+	}
+	if seenFilter.Limit != 2 {
+		t.Errorf("filter.Limit = %d; want 2 (top_k)", seenFilter.Limit)
+	}
+	if seenFilter.Query != fallbackTestQuery {
+		t.Errorf("filter.Query = %q; want %q", seenFilter.Query, fallbackTestQuery)
+	}
+}
+
+// TestTrySemanticFallback_TopKClampsBelowOne protects against a
+// misconfigured EnrichmentConfig where SemanticFallbackTopK is 0
+// or negative. The fallback should still fire with at least one
+// result rather than asking the provider for zero rows.
+func TestTrySemanticFallback_TopKClampsBelowOne(t *testing.T) {
+	var seenLimit int
+	provider := &mockSemanticProvider{
+		searchTablesFunc: func(_ context.Context, f semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
+			seenLimit = f.Limit
+			return []semantic.TableSearchResult{{URN: fallbackTestURN, Name: "x"}}, nil
+		},
+	}
+	enricher := &semanticEnricher{
+		semanticProvider: provider,
+		cfg:              EnrichmentConfig{SemanticFallbackEnabled: true, SemanticFallbackTopK: 0},
+	}
+	_ = enricher.trySemanticFallback(context.Background(), semantic.TableIdentifier{Table: fallbackTestTable})
+	if seenLimit != 1 {
+		t.Errorf("filter.Limit = %d; want 1 (clamped)", seenLimit)
+	}
+}
+
+// TestTrySemanticFallback_ProviderError swallows the error per
+// the helper's contract: a failed similarity search must not
+// surface as an enrichment error, just as a URN miss does not.
+func TestTrySemanticFallback_ProviderError(t *testing.T) {
+	provider := &mockSemanticProvider{
+		searchTablesFunc: func(_ context.Context, _ semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
+			return nil, errors.New("upstream search 500")
+		},
+	}
+	enricher := &semanticEnricher{
+		semanticProvider: provider,
+		cfg:              EnrichmentConfig{SemanticFallbackEnabled: true, SemanticFallbackTopK: 1},
+	}
+	got := enricher.trySemanticFallback(context.Background(), semantic.TableIdentifier{Table: fallbackTestTable})
+	if got != nil {
+		t.Errorf("got %v; want nil when search errors", got)
+	}
+}
+
+// TestTrySemanticFallback_EmptyQuerySkipsSearch confirms that an
+// empty table identifier short-circuits before any provider call.
+// Without this, a malformed request could send "" to the upstream
+// and bloat its query logs.
+func TestTrySemanticFallback_EmptyQuerySkipsSearch(t *testing.T) {
+	called := false
+	provider := &mockSemanticProvider{
+		searchTablesFunc: func(_ context.Context, _ semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
+			called = true
+			return nil, nil
+		},
+	}
+	enricher := &semanticEnricher{
+		semanticProvider: provider,
+		cfg:              EnrichmentConfig{SemanticFallbackEnabled: true, SemanticFallbackTopK: 1},
+	}
+	if got := enricher.trySemanticFallback(context.Background(), semantic.TableIdentifier{}); got != nil {
+		t.Errorf("got %v; want nil for empty identifier", got)
+	}
+	if called {
+		t.Error("SearchTables was called for an empty identifier")
+	}
+}
+
+// TestAppendSemanticFallbackSuggestions_PayloadShape verifies the
+// shape of the appended content block: match_kind must equal
+// EnrichmentMatchSemantic so the model can distinguish the
+// suggestion from URN-resolved enrichment, and each suggested
+// match must carry urn+name at minimum.
+func TestAppendSemanticFallbackSuggestions_PayloadShape(t *testing.T) {
+	result := &mcp.CallToolResult{}
+	table := semantic.TableIdentifier{Schema: fallbackTestSchema, Table: fallbackTestTable}
+	suggestions := []semantic.TableSearchResult{
+		{URN: fallbackTestURN, Name: "orders", Platform: "trino", Description: "Orders facts", Tags: []string{"finance"}, Domain: "Sales"},
+	}
+	out, err := appendSemanticFallbackSuggestions(result, table, suggestions)
+	if err != nil {
+		t.Fatalf("appendSemanticFallbackSuggestions: %v", err)
+	}
+	if len(out.Content) != 1 {
+		t.Fatalf("expected 1 content item, got %d", len(out.Content))
+	}
+	text, ok := out.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("appended content is not TextContent: %T", out.Content[0])
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(text.Text), &decoded); err != nil {
+		t.Fatalf("payload not valid JSON: %v", err)
+	}
+	fallback, ok := decoded["semantic_fallback"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload missing semantic_fallback key: %s", text.Text)
+	}
+	if got := fallback["match_kind"]; got != EnrichmentMatchSemantic {
+		t.Errorf("match_kind = %v; want %q", got, EnrichmentMatchSemantic)
+	}
+	if got := fallback["queried_table"]; got != table.String() {
+		t.Errorf("queried_table = %v; want %q", got, table.String())
+	}
+	matches, ok := fallback["suggested_matches"].([]any)
+	if !ok || len(matches) != 1 {
+		t.Fatalf("suggested_matches malformed: %v", fallback["suggested_matches"])
+	}
+	first, ok := matches[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first match is not an object: %T", matches[0])
+	}
+	if first["urn"] != fallbackTestURN || first["name"] != "orders" {
+		t.Errorf("suggested match malformed: %v", first)
+	}
+}
+
+func TestAppendSemanticFallbackSuggestions_EmptyIsNoOp(t *testing.T) {
+	result := &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "original"}}}
+	out, err := appendSemanticFallbackSuggestions(result, semantic.TableIdentifier{Table: "x"}, nil)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(out.Content) != 1 {
+		t.Errorf("content len = %d; want 1 (no append for empty suggestions)", len(out.Content))
+	}
+}
+
+// TestEnrichTrinoResult_FallbackOnURNMissSetsMatchKind is the
+// end-to-end behavioral test for issue #444: a single-table
+// enrichment that misses on URN equality, with the fallback
+// enabled, produces a suggested-matches payload AND sets
+// pc.EnrichmentMatchKind to EnrichmentMatchSemantic so the audit
+// row records the heuristic match.
+func TestEnrichTrinoResult_FallbackOnURNMissSetsMatchKind(t *testing.T) {
+	provider := &mockSemanticProvider{
+		getTableContextFunc: func(_ context.Context, _ semantic.TableIdentifier) (*semantic.TableContext, error) {
+			return nil, errors.New("entity not found")
+		},
+		searchTablesFunc: func(_ context.Context, _ semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
+			return []semantic.TableSearchResult{{URN: fallbackTestURN, Name: "orders"}}, nil
+		},
+	}
+	enricher := &semanticEnricher{
+		semanticProvider: provider,
+		cfg:              EnrichmentConfig{SemanticFallbackEnabled: true, SemanticFallbackTopK: 1},
+	}
+	pc := &PlatformContext{}
+	result := &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "original"}}}
+	enriched, err := enricher.enrichTrinoResult(context.Background(), result, trinoDescribeRequest(t, fallbackTestSchema+"."+fallbackTestTable), nil, pc)
+	if err != nil {
+		t.Fatalf("enrichTrinoResult: %v", err)
+	}
+	if len(enriched.Content) != 2 {
+		t.Fatalf("content len = %d; want 2 (original + suggested matches)", len(enriched.Content))
+	}
+	if pc.EnrichmentMatchKind != EnrichmentMatchSemantic {
+		t.Errorf("pc.EnrichmentMatchKind = %q; want %q", pc.EnrichmentMatchKind, EnrichmentMatchSemantic)
+	}
+	text, _ := enriched.Content[1].(*mcp.TextContent)
+	if !strings.Contains(text.Text, EnrichmentMatchSemantic) {
+		t.Errorf("appended content missing match_kind marker: %s", text.Text)
+	}
+}
+
+// TestEnrichTrinoResult_URNHitSetsMatchKindURN covers the happy
+// path of acceptance criterion #5: a successful URN lookup tags
+// the audit row with match_kind=urn so operators can later compute
+// the URN-vs-semantic ratio.
+func TestEnrichTrinoResult_URNHitSetsMatchKindURN(t *testing.T) {
+	provider := &mockSemanticProvider{
+		getTableContextFunc: func(_ context.Context, _ semantic.TableIdentifier) (*semantic.TableContext, error) {
+			return &semantic.TableContext{URN: fallbackTestURN, Description: "orders facts"}, nil
+		},
+	}
+	enricher := &semanticEnricher{
+		semanticProvider: provider,
+		cfg:              EnrichmentConfig{}, // fallback off; URN lookup succeeds
+	}
+	pc := &PlatformContext{}
+	result := &mcp.CallToolResult{}
+	_, err := enricher.enrichTrinoResult(context.Background(), result, trinoDescribeRequest(t, fallbackTestSchema+"."+fallbackTestTable), nil, pc)
+	if err != nil {
+		t.Fatalf("enrichTrinoResult: %v", err)
+	}
+	if pc.EnrichmentMatchKind != EnrichmentMatchURN {
+		t.Errorf("pc.EnrichmentMatchKind = %q; want %q", pc.EnrichmentMatchKind, EnrichmentMatchURN)
+	}
+}
+
+// TestEnrichTrinoResult_FallbackDisabledLeavesMatchKindEmpty
+// guards the audit-row default: when the URN lookup misses and
+// the fallback is OFF, no enrichment runs, no payload is
+// appended, and match_kind stays empty. Operators querying for
+// match_kind=” get the count of "tried to enrich, found nothing,
+// fallback opted out" events.
+func TestEnrichTrinoResult_FallbackDisabledLeavesMatchKindEmpty(t *testing.T) {
+	provider := &mockSemanticProvider{
+		getTableContextFunc: func(_ context.Context, _ semantic.TableIdentifier) (*semantic.TableContext, error) {
+			return nil, errors.New("entity not found")
+		},
+		searchTablesFunc: func(_ context.Context, _ semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
+			t.Error("SearchTables was called despite fallback being disabled")
+			return nil, nil
+		},
+	}
+	enricher := &semanticEnricher{
+		semanticProvider: provider,
+		cfg:              EnrichmentConfig{SemanticFallbackEnabled: false},
+	}
+	pc := &PlatformContext{}
+	result := &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "original"}}}
+	enriched, err := enricher.enrichTrinoResult(context.Background(), result, trinoDescribeRequest(t, fallbackTestSchema+"."+fallbackTestTable), nil, pc)
+	if err != nil {
+		t.Fatalf("enrichTrinoResult: %v", err)
+	}
+	if len(enriched.Content) != 1 {
+		t.Errorf("content len = %d; want 1 (no append when fallback off)", len(enriched.Content))
+	}
+	if pc.EnrichmentMatchKind != "" {
+		t.Errorf("pc.EnrichmentMatchKind = %q; want empty", pc.EnrichmentMatchKind)
+	}
+}

--- a/pkg/middleware/semantic_test.go
+++ b/pkg/middleware/semantic_test.go
@@ -873,7 +873,7 @@ func TestEnrichTrinoResult(t *testing.T) {
 			Params: &mcp.CallToolParamsRaw{},
 		}
 
-		enriched, err := testEnricher(provider, false).enrichTrinoResult(context.Background(), result, request, nil)
+		enriched, err := testEnricher(provider, false).enrichTrinoResult(context.Background(), result, request, nil, nil)
 		requireNoErr(t, err)
 		requireContentLen(t, enriched, 1)
 	})
@@ -893,7 +893,7 @@ func TestEnrichTrinoResult(t *testing.T) {
 			Params: &mcp.CallToolParamsRaw{Arguments: args},
 		}
 
-		enriched, err := testEnricher(provider, false).enrichTrinoResult(context.Background(), result, request, nil)
+		enriched, err := testEnricher(provider, false).enrichTrinoResult(context.Background(), result, request, nil, nil)
 		requireNoErr(t, err)
 		requireContentLen(t, enriched, 2)
 	})
@@ -910,7 +910,7 @@ func TestEnrichTrinoResult(t *testing.T) {
 			Params: &mcp.CallToolParamsRaw{Arguments: args},
 		}
 
-		enriched, err := testEnricher(provider, false).enrichTrinoResult(context.Background(), result, request, nil)
+		enriched, err := testEnricher(provider, false).enrichTrinoResult(context.Background(), result, request, nil, nil)
 		requireNoErr(t, err)
 		// Should return original result without error
 		requireContentLen(t, enriched, 1)
@@ -933,7 +933,7 @@ func TestEnrichTrinoResult(t *testing.T) {
 			Params: &mcp.CallToolParamsRaw{Arguments: args},
 		}
 
-		enriched, err := testEnricher(provider, false).enrichTrinoResult(context.Background(), result, request, nil)
+		enriched, err := testEnricher(provider, false).enrichTrinoResult(context.Background(), result, request, nil, nil)
 		requireNoErr(t, err)
 		// Should have original + semantic context
 		requireContentLen(t, enriched, 2)
@@ -949,7 +949,7 @@ func TestEnrichTrinoResult(t *testing.T) {
 			Params: &mcp.CallToolParamsRaw{Arguments: args},
 		}
 
-		enriched, err := testEnricher(provider, false).enrichTrinoResult(context.Background(), result, request, nil)
+		enriched, err := testEnricher(provider, false).enrichTrinoResult(context.Background(), result, request, nil, nil)
 		requireNoErr(t, err)
 		// No tables found, no enrichment
 		requireContentLen(t, enriched, 1)
@@ -970,7 +970,7 @@ func TestEnrichTrinoResult(t *testing.T) {
 			Params: &mcp.CallToolParamsRaw{Arguments: args},
 		}
 
-		enriched, err := testEnricher(provider, false).enrichTrinoResult(context.Background(), result, request, nil)
+		enriched, err := testEnricher(provider, false).enrichTrinoResult(context.Background(), result, request, nil, nil)
 		requireNoErr(t, err)
 		// Should still have enrichment even if columns fail
 		requireContentLen(t, enriched, 2)
@@ -3642,7 +3642,7 @@ func TestEnrichTrinoResult_ColumnFiltering(t *testing.T) {
 		}
 		result := NewToolResultText("query result")
 
-		enriched, err := testEnricher(provider, true).enrichTrinoResult(context.Background(), result, request, nil)
+		enriched, err := testEnricher(provider, true).enrichTrinoResult(context.Background(), result, request, nil, nil)
 		requireNoErr(t, err)
 		requireContentLen(t, enriched, 2) //nolint:mnd // original + enrichment
 
@@ -3677,7 +3677,7 @@ func TestEnrichTrinoResult_ColumnFiltering(t *testing.T) {
 		}
 		result := NewToolResultText("query result")
 
-		enriched, err := testEnricher(provider, false).enrichTrinoResult(context.Background(), result, request, nil)
+		enriched, err := testEnricher(provider, false).enrichTrinoResult(context.Background(), result, request, nil, nil)
 		requireNoErr(t, err)
 		requireContentLen(t, enriched, 2) //nolint:mnd // original + enrichment
 
@@ -3702,7 +3702,7 @@ func TestEnrichTrinoResult_ColumnFiltering(t *testing.T) {
 		}
 		result := NewToolResultText("describe result")
 
-		enriched, err := testEnricher(provider, true).enrichTrinoResult(context.Background(), result, request, nil)
+		enriched, err := testEnricher(provider, true).enrichTrinoResult(context.Background(), result, request, nil, nil)
 		requireNoErr(t, err)
 		requireContentLen(t, enriched, 2) //nolint:mnd // original + enrichment
 

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -494,6 +494,24 @@ type InjectionConfig struct {
 	// SchemaPreviewMaxColumns caps how many columns appear in each
 	// schema preview. Defaults to 15 (nil = 15).
 	SchemaPreviewMaxColumns *int `yaml:"schema_preview_max_columns"`
+
+	// SemanticFallback enables the issue #444 fallback path: when a
+	// URN-equality lookup for a Trino table misses on the semantic
+	// provider, the platform calls SearchTables with Mode=semantic
+	// and surfaces the top hit as a SUGGESTED match (annotated with
+	// match_kind=semantic so the model knows it is similarity-
+	// inferred, not URN-resolved). Audit rows record
+	// enrichment_match_kind so operators can measure false-positive
+	// rate. Default off. Requires the semantic provider to support
+	// the "semantic" search mode (DataHub does as of v1.8.1).
+	SemanticFallback *bool `yaml:"semantic_fallback"`
+
+	// SemanticFallbackTopK is how many similarity-search hits the
+	// fallback surfaces per miss. Default 1. Caps at 10 to keep
+	// suggested-match output bounded; operators wanting broader
+	// recall should adjust persona scope or query patterns, not
+	// flood the response with low-rank suggestions.
+	SemanticFallbackTopK *int `yaml:"semantic_fallback_top_k"`
 }
 
 // IsUnwrapJSONEnabled returns whether unwrap_json defaults to true,
@@ -533,6 +551,43 @@ func (c *InjectionConfig) EffectiveSchemaPreviewMaxColumns() int {
 		return defaultSchemaPreviewMaxColumns
 	}
 	return *c.SchemaPreviewMaxColumns
+}
+
+// defaultSemanticFallbackTopK is the default number of similarity-
+// search results surfaced per URN miss when the semantic fallback
+// fires.
+const defaultSemanticFallbackTopK = 1
+
+// maxSemanticFallbackTopK caps the configurable top-K so a stray
+// large value cannot dominate a response with low-rank suggestions.
+const maxSemanticFallbackTopK = 10
+
+// IsSemanticFallbackEnabled returns whether the issue #444 fallback
+// is enabled. Defaults to false; operators opt in explicitly because
+// similarity matches are heuristic and may surface false positives.
+func (c *InjectionConfig) IsSemanticFallbackEnabled() bool {
+	if c.SemanticFallback == nil {
+		return false
+	}
+	return *c.SemanticFallback
+}
+
+// EffectiveSemanticFallbackTopK returns the configured top-K for the
+// semantic fallback, clamped to [1, maxSemanticFallbackTopK]. Returns
+// defaultSemanticFallbackTopK when unset; clamps to bounds when set
+// outside the valid range.
+func (c *InjectionConfig) EffectiveSemanticFallbackTopK() int {
+	if c.SemanticFallbackTopK == nil {
+		return defaultSemanticFallbackTopK
+	}
+	k := *c.SemanticFallbackTopK
+	if k < 1 {
+		return 1
+	}
+	if k > maxSemanticFallbackTopK {
+		return maxSemanticFallbackTopK
+	}
+	return k
 }
 
 // SessionDedupConfig configures session-level metadata deduplication.

--- a/pkg/platform/config_test.go
+++ b/pkg/platform/config_test.go
@@ -1489,6 +1489,77 @@ injection:
 	})
 }
 
+func TestInjectionConfig_IsSemanticFallbackEnabled(t *testing.T) {
+	t.Run("nil defaults to off", func(t *testing.T) {
+		cfg := &InjectionConfig{}
+		if cfg.IsSemanticFallbackEnabled() {
+			t.Error("default should be disabled per issue #444 acceptance criteria")
+		}
+	})
+	t.Run("explicit true", func(t *testing.T) {
+		v := true
+		cfg := &InjectionConfig{SemanticFallback: &v}
+		if !cfg.IsSemanticFallbackEnabled() {
+			t.Error("expected enabled when explicitly true")
+		}
+	})
+	t.Run("explicit false", func(t *testing.T) {
+		v := false
+		cfg := &InjectionConfig{SemanticFallback: &v}
+		if cfg.IsSemanticFallbackEnabled() {
+			t.Error("expected disabled when explicitly false")
+		}
+	})
+	t.Run("YAML loading", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+injection:
+  semantic_fallback: true
+`)
+		if !cfg.Injection.IsSemanticFallbackEnabled() {
+			t.Error("expected enabled from YAML")
+		}
+	})
+}
+
+func TestInjectionConfig_EffectiveSemanticFallbackTopK(t *testing.T) {
+	t.Run("nil defaults to 1", func(t *testing.T) {
+		cfg := &InjectionConfig{}
+		if cfg.EffectiveSemanticFallbackTopK() != defaultSemanticFallbackTopK {
+			t.Errorf("got %d, want %d", cfg.EffectiveSemanticFallbackTopK(), defaultSemanticFallbackTopK)
+		}
+	})
+	t.Run("explicit value", func(t *testing.T) {
+		v := 5
+		cfg := &InjectionConfig{SemanticFallbackTopK: &v}
+		if cfg.EffectiveSemanticFallbackTopK() != 5 {
+			t.Errorf("got %d, want 5", cfg.EffectiveSemanticFallbackTopK())
+		}
+	})
+	t.Run("clamps zero to 1", func(t *testing.T) {
+		v := 0
+		cfg := &InjectionConfig{SemanticFallbackTopK: &v}
+		if cfg.EffectiveSemanticFallbackTopK() != 1 {
+			t.Errorf("got %d, want 1 (clamped)", cfg.EffectiveSemanticFallbackTopK())
+		}
+	})
+	t.Run("clamps negative to 1", func(t *testing.T) {
+		v := -3
+		cfg := &InjectionConfig{SemanticFallbackTopK: &v}
+		if cfg.EffectiveSemanticFallbackTopK() != 1 {
+			t.Errorf("got %d, want 1 (clamped)", cfg.EffectiveSemanticFallbackTopK())
+		}
+	})
+	t.Run("clamps above max", func(t *testing.T) {
+		v := 999
+		cfg := &InjectionConfig{SemanticFallbackTopK: &v}
+		if cfg.EffectiveSemanticFallbackTopK() != maxSemanticFallbackTopK {
+			t.Errorf("got %d, want %d (clamped)", cfg.EffectiveSemanticFallbackTopK(), maxSemanticFallbackTopK)
+		}
+	})
+}
+
 func TestApplyDefaults_SessionGateConfig(t *testing.T) {
 	t.Run("defaults init tool to platform_info", func(t *testing.T) {
 		cfg := &Config{}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -2599,6 +2599,8 @@ func (p *Platform) buildEnrichmentConfig() middleware.EnrichmentConfig {
 		ColumnContextFiltering:      p.config.Injection.IsColumnContextFilteringEnabled(),
 		SearchSchemaPreview:         p.config.Injection.IsSearchSchemaPreviewEnabled(),
 		SchemaPreviewMaxColumns:     p.config.Injection.EffectiveSchemaPreviewMaxColumns(),
+		SemanticFallbackEnabled:     p.config.Injection.IsSemanticFallbackEnabled(),
+		SemanticFallbackTopK:        p.config.Injection.EffectiveSemanticFallbackTopK(),
 	}
 
 	// Wire connection source map lookups as closures to avoid import cycles.

--- a/scripts/codeql-baseline.txt
+++ b/scripts/codeql-baseline.txt
@@ -16,5 +16,5 @@
 # Triaging them out of scope; track separately if any becomes a real
 # concern.
 
-go/sql-injection pkg/audit/postgres/store.go:190
+go/sql-injection pkg/audit/postgres/store.go:191
 go/log-injection cmd/dev-mcp-mock/main.go:178


### PR DESCRIPTION
Closes #444 (acceptance criteria #1, #2, #5). Score-based thresholding (#3, #4) is documented as upstream-blocked in the issue thread; see "Scope and the deferred score" below.

## Summary

When a Trino-table URN-equality lookup misses on the semantic provider and the operator opts in via the new `injection.semantic_fallback` flag, the enrichment middleware now calls `SearchTables` with `Mode=semantic` and surfaces the top-K hits as **suggested** matches. The appended payload is wrapped under `semantic_fallback`, tagged with `match_kind: semantic`, and carries a human-readable note flagging the result as similarity-inferred rather than URN-resolved. Audit rows pick up a new `enrichment_match_kind` column recording `urn`, `semantic`, or empty, so operators can measure the false-positive rate of similarity-based suggestions with a SQL aggregate.

The fallback is off by default. It only fires on the single-table enrichment path (`trino_describe_table` and similar). Multi-table SQL-query enrichment is unchanged.

## Scope and the deferred score

Acceptance criteria #3 (similarity score in injected metadata) and #4 (score threshold configurable per pair) from the issue are **not** implemented. DataHub's GraphQL `SearchResult` type does not surface a per-result relevance score on any current version. Verified against:

- The bundled schema at `testdata/datahub-schema/search.graphql:675-695` in mcp-datahub
- DataHub master at `datahub-graphql-core/src/main/resources/search.graphql`

The only `score` in DataHub's search schema is on `SearchSuggestion` (edit distance for suggested query text, unrelated to result relevance). Attempting to request `score` on `SearchResult` would cause DataHub to reject every `searchAcrossEntities` call with a GraphQL validation error, regressing every consumer of mcp-datahub. This was verified empirically and documented in the closed mcp-datahub#147. Once DataHub upstream surfaces a per-result score, a follow-up adds the threshold gate; until then, top-K rank-based cutoff is the realistic substitute.

## Changes by file

### Config surface

`pkg/platform/config.go`
- `InjectionConfig` gains `SemanticFallback *bool` (yaml `semantic_fallback`, default false) and `SemanticFallbackTopK *int` (yaml `semantic_fallback_top_k`, default 1).
- `IsSemanticFallbackEnabled()` returns the flag, defaulting to false.
- `EffectiveSemanticFallbackTopK()` returns the clamped top-K, where unset defaults to 1 and out-of-range values are clamped to `[1, 10]` (`maxSemanticFallbackTopK = 10`).

`pkg/platform/platform.go`
- `buildEnrichmentConfig` forwards both helpers into the `middleware.EnrichmentConfig` struct.

### Enrichment middleware

`pkg/middleware/semantic.go`
- `EnrichmentConfig` gains `SemanticFallbackEnabled` and `SemanticFallbackTopK`.
- `enrichTrinoResult` now takes `pc *PlatformContext` so the URN-vs-semantic decision flows through to the audit layer. The three call sites (`enrichTrinoResultWithDedup` cache-nil, no-table-keys, and `handleFullEnrichment`) all forward `pc`.
- On `GetTableContext` miss, `trySemanticFallback` runs when the flag is on. On hits, `appendSemanticFallbackSuggestions` appends the wrapped payload. `pc.EnrichmentMatchKind` is set to `EnrichmentMatchSemantic` on fallback fire, `EnrichmentMatchURN` on exact-URN resolution.
- `buildSemanticFallbackQuery` produces `<table> <schema>` as the search query (catalog deliberately omitted; catalog names are often deployment-internal noise).

`pkg/middleware/context.go`
- New constants `EnrichmentMatchURN = "urn"` and `EnrichmentMatchSemantic = "semantic"`.
- `PlatformContext` gains `EnrichmentMatchKind string`.

`pkg/middleware/audit.go` and `pkg/middleware/mcp_audit.go`
- `AuditEvent` gains `EnrichmentMatchKind string` and the constructor in `mcp_audit.go` copies it from `pc`.

`pkg/middleware/audit_adapter.go`
- Adapter forwards `EnrichmentMatchKind` to the persistent `audit.Event` via the new `WithEnrichmentMatchKind` builder.

### Audit persistence

`pkg/database/migrate/migrations/000047_audit_match_kind.{up,down}.sql`
- `ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS enrichment_match_kind VARCHAR(20) DEFAULT ''`. Reversible. The down migration drops the column. `audit_logs` is a declarative-partitioned table so ALTER propagates to all partitions automatically.

`pkg/audit/logger.go`
- `Event` struct gains `EnrichmentMatchKind string` with a doc comment explaining the operator-facing semantics and a Swagger example.

`pkg/audit/event.go`
- New builder method `WithEnrichmentMatchKind(kind string)`.

`pkg/audit/postgres/store.go`
- `auditColumns`, the INSERT statement, and the SELECT scan all carry the new column.

### Tests

`pkg/middleware/semantic_fallback_test.go` (new, 332 lines)
- 11 tests covering `buildSemanticFallbackQuery` edge cases (empty, table-only, schema-only, catalog ignored), `trySemanticFallback` (disabled by default, hits respect mode and top-K, top-K clamps below 1, provider errors are swallowed, empty query skips the search), `appendSemanticFallbackSuggestions` (payload shape carries `match_kind: semantic` + queried table + suggested matches, empty input is a no-op), `enrichTrinoResult` (fallback on URN miss sets `EnrichmentMatchKind=semantic`, URN hit sets `EnrichmentMatchKind=urn`, fallback disabled leaves the field empty).

`pkg/middleware/middleware_chain_test.go`
- `TestMiddlewareChain_EnrichmentAppliedInAudit` extended with two new assertions: `trinoEvent.EnrichmentMatchKind == EnrichmentMatchURN` and `infoEvent.EnrichmentMatchKind == ""`. Proves the field propagates through the **real** assembled middleware chain (auth -> enrichment -> audit), not just through unit-tested hops. Satisfies CLAUDE.md item 5 for context-propagation features.

`pkg/middleware/semantic_test.go`
- 9 existing `enrichTrinoResult` call sites updated to pass `nil` for the new `pc` parameter (no behavior change; the nil-safe branches are exercised by the new fallback tests).

`pkg/audit/postgres/store_test.go`
- `selectColumns` and every row builder updated for the new column. All existing audit tests continue to pass.

`pkg/platform/config_test.go`
- New `TestInjectionConfig_IsSemanticFallbackEnabled` (nil/explicit-true/explicit-false/YAML) and `TestInjectionConfig_EffectiveSemanticFallbackTopK` (default/explicit/clamp-zero/clamp-negative/clamp-above-max).

`pkg/database/migrate/migrate_unit_test.go`
- Embedded-migration count bumped from 92 to 94 for the new pair of files.

### Docs

`docs/llms-full.txt`
- Added `semantic_fallback` and `semantic_fallback_top_k` rows to the cross-enrichment configuration table, plus a paragraph explaining the payload shape, the `enrichment_match_kind` audit field, and the scope (single-table path only for now).

`CLAUDE.md`
- The injection config example block now lists both new keys with their defaults.

### Generated and baseline files

`internal/apidocs/{docs.go,swagger.json,swagger.yaml}`
- `make swagger` regeneration to include the new `enrichment_match_kind` field on `audit.Event`.

`scripts/codeql-baseline.txt`
- One-line bump for the pre-existing `go/sql-injection` baseline entry on `pkg/audit/postgres/store.go` (line 190 -> 191; shifted by the new column insertion). The finding is the ORDER BY allowlist construction validated at line 185 via `audit.ValidSortColumns[filter.SortBy]`; behavior unchanged.

## Backward compatibility

- Default behavior is unchanged. With `semantic_fallback` left off (the default), the middleware preserves today's behavior character-for-character: URN miss returns the original result with no appended payload, no SearchTables call, no `match_kind` set.
- Existing audit rows have `enrichment_match_kind = ''` (the column default). All queries that filter or aggregate on existing audit columns work unchanged.
- The new `Event.EnrichmentMatchKind` field is `omitempty` in JSON, so audit API consumers that ignore unknown fields see no shape change for pre-migration rows.
- No tool input shapes, tool names, or wire-format identifiers changed.

## Verification

`make verify` PASS locally: fmt, race tests, lint clean against `origin/main`, gosec, govulncheck, semgrep, codeql with baseline line-bump, coverage, dead-code, mutation, release-check.

Adversarial review: two rounds, both CLEAN. Round 1 raised three non-blocking suggestions; suggestion #2 (extend the existing integration test to assert `EnrichmentMatchKind` propagation) was acted on in the same branch.

## Test plan

- [ ] CI is green
- [ ] On a deployment with `injection.semantic_fallback: true` and a real DataHub provider: call `trino_describe_table` with a table whose URN does not exist in DataHub. Confirm the response contains a `semantic_fallback` payload with `match_kind: semantic`, the queried table, and at least one suggested match.
- [ ] On the same deployment, call `trino_describe_table` with a table whose URN does exist. Confirm the standard `semantic_context` payload is appended and no `semantic_fallback` payload is present.
- [ ] Query the audit table: `SELECT enrichment_match_kind, COUNT(*) FROM audit_logs GROUP BY 1`. Confirm rows are tagged `urn` for hits, `semantic` for fallbacks, empty otherwise.
- [ ] With `injection.semantic_fallback: false` (default), repeat the URN-miss call. Confirm no `semantic_fallback` payload appears and the audit row's `enrichment_match_kind` is empty.