### PR TITLE
feat(ui): tighten connections list and identifier input

### DIFF
--- a/ui/src/pages/settings/ConnectionsPanel.tsx
+++ b/ui/src/pages/settings/ConnectionsPanel.tsx
@@ -339,6 +339,11 @@ export function ConnectionsPanel() {
                 </div>
                 {items.map((c) => {
                   const key = `${c.kind}/${c.name}`;
+                  const health = oauthHealthByKey.get(key);
+                  const showHealth = Boolean(
+                    health?.has_oauth &&
+                      (health.needs_reauth || health.idp_error_code),
+                  );
                   return (
                     <button
                       key={key}
@@ -351,26 +356,21 @@ export function ConnectionsPanel() {
                           : "border-l-2 border-l-transparent hover:bg-muted/50",
                       )}
                     >
-                      <div className="flex items-center gap-1.5">
-                        <span className="text-sm font-medium truncate">{c.name}</span>
-                        <span className={cn(
-                          "shrink-0 rounded px-1 py-0 text-xs font-medium",
-                          c.source === "file" ? "bg-muted text-muted-foreground" :
-                          "bg-primary/10 text-primary",
-                        )}>
-                          {c.source === "file" ? "file" : "database"}
-                        </span>
-                        <ConnectionOAuthHealthBadge
-                          health={oauthHealthByKey.get(`${c.kind}/${c.name}`)}
-                        />
-                      </div>
+                      <span className="block truncate font-mono text-sm font-medium">
+                        {c.name}
+                      </span>
+                      {showHealth && (
+                        <div className="mt-1">
+                          <ConnectionOAuthHealthBadge health={health} />
+                        </div>
+                      )}
                       {c.description && (
-                        <span className="mt-0.5 text-xs text-muted-foreground truncate">
+                        <span className="mt-1 block truncate text-xs text-muted-foreground">
                           {c.description}
                         </span>
                       )}
                       {c.tools && c.tools.length > 0 && (
-                        <span className="mt-0.5 text-xs text-muted-foreground">
+                        <span className="mt-0.5 block text-xs text-muted-foreground">
                           {c.tools.length} tools
                         </span>
                       )}
@@ -685,6 +685,7 @@ function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: Edito
   const setMutation = useSetConnectionInstance();
   const [kind, setKind] = useState(connection?.kind ?? "trino");
   const [name, setName] = useState(connection?.name ?? "");
+  const nameValid = !isCreate || /^[a-z][a-z0-9_-]*$/.test(name);
   const [description, setDescription] = useState(
     connection?.description || (connection?.config?.description as string) || "",
   );
@@ -777,7 +778,7 @@ function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: Edito
           <button
             type="button"
             onClick={handleSave}
-            disabled={isPending || (isCreate && !name.trim())}
+            disabled={isPending || (isCreate && (!name.trim() || !nameValid))}
             className={cn(
               "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-all disabled:opacity-50",
               saveSuccess
@@ -832,18 +833,42 @@ function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: Edito
             </p>
           </div>
           <div>
-            <label className="mb-1 block text-xs font-medium">Name</label>
+            <label className="mb-1 block text-xs font-medium">
+              Identifier
+            </label>
             <input
               type="text"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => {
+                if (!isCreate) return;
+                const raw = e.target.value.toLowerCase();
+                const cleaned = raw.replace(/[^a-z0-9_-]/g, "");
+                setName(cleaned);
+              }}
               disabled={!isCreate}
-              placeholder="my-connection"
+              placeholder="prod-trino"
+              pattern="^[a-z][a-z0-9_-]*$"
+              maxLength={64}
+              autoComplete="off"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+              aria-describedby="connection-name-help"
               className="w-full rounded-md border bg-background px-3 py-2 text-sm font-mono outline-none ring-ring focus:ring-2 disabled:opacity-50 disabled:cursor-not-allowed"
             />
-            <p className="mt-1 text-xs text-muted-foreground">
-              Unique name within this kind. Cannot be changed after creation.
+            <p
+              id="connection-name-help"
+              className="mt-1 text-xs text-muted-foreground"
+            >
+              Machine identifier used in API routes and persona patterns.
+              Lowercase letters, digits, hyphens, underscores. Must start with
+              a letter. Cannot be changed after creation.
             </p>
+            {isCreate && name.length > 0 && !nameValid && (
+              <p className="mt-1 text-xs text-destructive">
+                Identifier must start with a lowercase letter.
+              </p>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Small UX cleanup of the **Connections** admin page, plus proper handling of the connection name as the machine identifier it actually is.

### Sidebar list

- **Removed the `database` / `file` source pill.** The distinction between database-managed and file-managed connections isn't an operationally useful piece of information at glance height — it just adds visual noise next to every name.
- **Connection name now sits on its own row.** Previously the name shared a row with the source pill and the OAuth health badge, which forced everything to truncate on narrow widths. Name now gets full row width in a monospace font.
- **OAuth health badge moved to its own row.** When a connection needs reauth or had a recent refresh failure, the badge shows on the line below the name (still red/amber to draw the eye). When nothing is wrong, no row renders — no empty spacing for the common case.

### Identifier field (create form)

The previous **Name** input accepted any text the user typed: spaces, uppercase, slashes, anything. But the value gets used as a path segment in `/api/admin/connections/{kind}/{name}`, as a literal in persona allow/deny patterns, and as a primary key in the connection store. There was no validation anywhere — backend or frontend.

Now:

- **Label**: `Name` → `Identifier`, with helper text explaining what it's actually for.
- **Live input filter**: keystrokes are coerced to lowercase and anything outside `[a-z0-9_-]` is stripped on the fly, so the user can never end up with a value the backend can't route.
- **Leading-letter enforcement**: HTML `pattern=\"^[a-z][a-z0-9_-]*$\"` plus a JS regex check that gates the Save button. A typed `1foo` is caught and a destructive-styled inline message reads \"Identifier must start with a lowercase letter.\"
- **Native form niceties**: `autocomplete=off`, `autocapitalize=off`, `autocorrect=off`, `spellcheck=false`, `maxLength=64`.

The `disabled={!isCreate}` behavior is preserved — the identifier remains read-only in edit mode.

### Backend status

The backend currently doesn't validate connection names. This PR only adds frontend validation. A follow-up could mirror the regex in the connection handler if defense-in-depth is wanted, but the live filter on the only user-facing path of entry closes the practical gap.

### Files touched

| File | Change |
| --- | --- |
| `ui/src/pages/settings/ConnectionsPanel.tsx` | Sidebar list row layout; Identifier input rename + validation + helper copy. |

## Test plan

- [ ] Open `/admin/connections`: sidebar items show name on its own row in mono font, no source pill.
- [ ] Find a connection that needs reauth (or simulate one): badge appears on its own row directly below the name.
- [ ] Find a healthy OAuth connection: no badge row, no empty gap.
- [ ] Click **+ New Connection**:
  - Try to type `My Cool Conn` → filter strips spaces and uppercase, result is `mycoolconn`.
  - Try to type `1foo` → input accepts the keystrokes but inline error appears and Save stays disabled.
  - Type `prod-trino` → no error, Save enables.
  - Type `_internal` → error appears (leading underscore), Save disabled.
- [ ] Existing connections still show their (potentially legacy) names in edit mode and the Identifier field is disabled.