### PR TITLE
fix(ui): land on saved connection instead of first listed

### DIFF
--- a/ui/src/pages/settings/ConnectionsPanel.tsx
+++ b/ui/src/pages/settings/ConnectionsPanel.tsx
@@ -195,7 +195,7 @@ function kindColor(kind: string): string {
 export function ConnectionsPanel() {
   const { data: systemInfo } = useSystemInfo();
   const isReadOnly = systemInfo?.config_mode === "file";
-  const { data: instances, isLoading } = useEffectiveConnections();
+  const { data: instances, isLoading, isFetching } = useEffectiveConnections();
   const connections = instances ?? [];
   // Bulk per-row OAuth health drives the connection-list health
   // badge. Polls every 10s in the hook so background-refresh
@@ -256,8 +256,13 @@ export function ConnectionsPanel() {
   );
 
   // Auto-select the first listed connection when none is selected
-  // (or the URL-restored one is stale).
+  // (or the URL-restored one is stale). Gate on !isFetching so the
+  // post-save refetch lands before we judge selectedKey stale —
+  // otherwise a freshly-created connection's setSelectedKey races
+  // the cache invalidation: the effect sees the pre-mutation list,
+  // can't find the new key, and snaps selection to firstListed.
   useEffect(() => {
+    if (isFetching) return;
     if (selectedKey) {
       // If the URL pointed at a connection that no longer exists,
       // fall through to first-listed.
@@ -267,7 +272,7 @@ export function ConnectionsPanel() {
     if (firstListed) {
       setSelectedKey(`${firstListed.kind}/${firstListed.name}`);
     }
-  }, [connections, selectedKey, firstListed]);
+  }, [connections, selectedKey, firstListed, isFetching]);
 
   // Mirror the selection back into the URL (without reloading) so a
   // round-trip through an OAuth callback's returnURL restores the
@@ -411,7 +416,8 @@ export function ConnectionsPanel() {
         {mode === "create" ? (
           <ConnectionEditor
             connection={null}
-            onSave={() => {
+            onSave={(savedKind, savedName) => {
+              setSelectedKey(`${savedKind}/${savedName}`);
               setMode("view");
               setDirty(false);
             }}
@@ -422,7 +428,8 @@ export function ConnectionsPanel() {
           mode === "edit" ? (
             <ConnectionEditor
               connection={selected}
-              onSave={() => {
+              onSave={(savedKind, savedName) => {
+                setSelectedKey(`${savedKind}/${savedName}`);
                 setMode("view");
                 setDirty(false);
               }}
@@ -675,7 +682,7 @@ function ConnectionViewer({
 
 interface EditorProps {
   connection: EffectiveConnection | null; // null = create mode
-  onSave: () => void;
+  onSave: (savedKind: string, savedName: string) => void;
   onCancel: () => void;
   onDirtyChange: (dirty: boolean) => void;
 }
@@ -751,7 +758,7 @@ function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: Edito
         onSuccess: () => {
           setSaveSuccess(true);
           setTimeout(() => setSaveSuccess(false), 2000);
-          onSave();
+          onSave(kind, name);
         },
         onError: (err) => {
           setSaveError(err instanceof Error ? err.message : "Failed to save");


### PR DESCRIPTION
## Summary

- After creating a connection in the settings panel, selection snapped to the first listed connection instead of the one just saved. Same class of bug as #458 fixed for catalogs.
- `ConnectionEditor` now passes `(kind, name)` to `onSave` so the panel sets `selectedKey` to the just-saved connection.
- The auto-correct effect gates on `!isFetching` so a freshly-set `selectedKey` survives the post-save refetch window instead of being reset to `firstListed` against the stale list.

## Test plan

- [ ] Open Settings to Connections. Click "Add Connection", fill in a `trino` connection with an identifier that does not sort first (e.g. `zzz-trino`), save. Panel should land on `zzz-trino`, not the alphabetically-first connection.
- [ ] Repeat with `api`, `s3`, and `mcp` kinds.
- [ ] Edit an existing connection (change description), save. Panel stays on the edited connection.
- [ ] Reload the page with `?kind=...&name=...` query params. Selection still restores from the URL on first render.
- [ ] `cd ui && npm run test` -> 86 passed.
- [ ] `cd ui && npx tsc --noEmit` -> clean.