### PR TITLE
fix(admin): unblock persona editor connections tab and lock null-array wire invariant

### DIFF
--- a/pkg/admin/persona_handler.go
+++ b/pkg/admin/persona_handler.go
@@ -13,6 +13,10 @@ import (
 )
 
 // personaSummary is a lightweight persona representation for list responses.
+//
+// Roles is declared []string and ships as a JSON array, NEVER null. The
+// UI iterates p.roles directly (RolesPage, PersonasPanel) so a wire-level
+// null crashes the persona list. MarshalJSON enforces this invariant.
 type personaSummary struct {
 	Name        string   `json:"name" example:"data-engineer"`
 	DisplayName string   `json:"display_name" example:"Data Engineer"`
@@ -20,6 +24,16 @@ type personaSummary struct {
 	Roles       []string `json:"roles" example:"data_engineer"`
 	ToolCount   int      `json:"tool_count" example:"19"`
 	Source      string   `json:"source,omitempty" example:"file"` // "file", "database", or "both"
+}
+
+// MarshalJSON enforces the non-nil wire invariant for Roles.
+func (p personaSummary) MarshalJSON() ([]byte, error) {
+	type alias personaSummary
+	v := alias(p)
+	if v.Roles == nil {
+		v.Roles = []string{}
+	}
+	return json.Marshal(v) //nolint:wrapcheck // value struct of basic types cannot fail to marshal
 }
 
 // personaContextDetail holds context override fields nested under "context" in JSON.
@@ -31,6 +45,12 @@ type personaContextDetail struct {
 }
 
 // personaDetail includes resolved tool lists.
+//
+// Roles, AllowTools, DenyTools, and Tools ship as JSON arrays, NEVER
+// null. The PersonaEditor UI accesses .length / .filter on these
+// directly. AllowConnections / DenyConnections have omitempty so they
+// are absent when nil rather than null. MarshalJSON enforces the
+// non-nil invariant for the required arrays.
 type personaDetail struct {
 	Name             string                `json:"name" example:"data-engineer"`
 	DisplayName      string                `json:"display_name" example:"Data Engineer"`
@@ -44,6 +64,25 @@ type personaDetail struct {
 	Tools            []string              `json:"tools" example:"trino_query,trino_describe_table,datahub_search"`
 	Context          *personaContextDetail `json:"context,omitempty"`
 	Source           string                `json:"source,omitempty" example:"file"` // "file", "database", or "both"
+}
+
+// MarshalJSON enforces the non-nil wire invariant for the required arrays.
+func (p personaDetail) MarshalJSON() ([]byte, error) {
+	type alias personaDetail
+	v := alias(p)
+	if v.Roles == nil {
+		v.Roles = []string{}
+	}
+	if v.AllowTools == nil {
+		v.AllowTools = []string{}
+	}
+	if v.DenyTools == nil {
+		v.DenyTools = []string{}
+	}
+	if v.Tools == nil {
+		v.Tools = []string{}
+	}
+	return json.Marshal(v) //nolint:wrapcheck // value struct of basic types cannot fail to marshal
 }
 
 // personaCreateRequest is the request body for creating/updating a persona.

--- a/pkg/admin/persona_handler_test.go
+++ b/pkg/admin/persona_handler_test.go
@@ -87,6 +87,27 @@ func TestListPersonas(t *testing.T) {
 		require.True(t, ok, "first persona should be a map")
 		assert.Equal(t, float64(0), first["tool_count"])
 	})
+
+	// A persona registered with nil Roles (e.g. a YAML config without the
+	// roles: key) must serialize as "roles":[], not "roles":null, or the
+	// RolesPage / PersonasPanel UI crashes when iterating p.roles.
+	t.Run("nil Roles serializes as empty array, not null", func(t *testing.T) {
+		pReg := &mockPersonaRegistry{
+			allResult: []*persona.Persona{
+				{Name: "minimal", DisplayName: "Minimal", Roles: nil},
+			},
+		}
+		h := NewHandler(Deps{PersonaRegistry: pReg}, nil)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/admin/personas", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		raw := w.Body.String()
+		assert.Contains(t, raw, `"roles":[]`, "roles must be []; got: %s", raw)
+		assert.NotContains(t, raw, `"roles":null`, "roles must never be null on the wire")
+	})
 }
 
 func TestGetPersona(t *testing.T) {
@@ -225,6 +246,33 @@ func TestGetPersona(t *testing.T) {
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
 		_, hasContext := raw["context"]
 		assert.False(t, hasContext, "context key should be omitted when empty")
+	})
+
+	// A persona built from a YAML config that omits roles/allow_tools/
+	// deny_tools must still serialize the required array fields as [].
+	// The PersonaEditor UI does draft.allowTools.filter(...) and the
+	// like; a null on the wire crashes the editor on open.
+	t.Run("nil slice fields serialize as empty arrays, not null", func(t *testing.T) {
+		p := &persona.Persona{
+			Name:        "minimal",
+			DisplayName: "Minimal",
+			Roles:       nil,
+			Tools:       persona.ToolRules{Allow: nil, Deny: nil},
+		}
+		pReg := &mockPersonaRegistry{allResult: []*persona.Persona{p}}
+		h := NewHandler(Deps{PersonaRegistry: pReg}, nil)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/admin/personas/minimal", http.NoBody)
+		req.SetPathValue("name", "minimal")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		raw := w.Body.String()
+		for _, field := range []string{"roles", "allow_tools", "deny_tools", "tools"} {
+			assert.Contains(t, raw, fmt.Sprintf("%q:[]", field), "%s must be []; got: %s", field, raw)
+			assert.NotContains(t, raw, fmt.Sprintf("%q:null", field), "%s must never be null on the wire", field)
+		}
 	})
 }
 

--- a/pkg/admin/system.go
+++ b/pkg/admin/system.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"encoding/json"
 	"net/http"
 	"sort"
 
@@ -240,12 +241,34 @@ func (h *Handler) buildToolTitleMap(r *http.Request) map[string]string {
 }
 
 // connectionInfo describes a toolkit connection.
+//
+// Tools and HiddenTools are declared as plain []string but ship as JSON
+// arrays, NEVER null. MarshalJSON enforces the non-nil invariant at
+// serialization time because the persona editor UI dereferences
+// .length / .map on the wire value, and several toolkits (notably
+// gateway with no live upstream) return nil from Tools().
 type connectionInfo struct {
 	Kind        string   `json:"kind" example:"trino"`
 	Name        string   `json:"name" example:"acme-warehouse"`
 	Connection  string   `json:"connection" example:"acme-warehouse"`
 	Tools       []string `json:"tools" example:"trino_query,trino_describe_table,trino_browse"`
 	HiddenTools []string `json:"hidden_tools"`
+}
+
+// MarshalJSON enforces the non-nil wire invariant for Tools and
+// HiddenTools no matter how the struct was constructed. This closes
+// the loophole where a future handler builds a connectionInfo by
+// struct literal and forgets to normalize.
+func (c connectionInfo) MarshalJSON() ([]byte, error) {
+	type alias connectionInfo
+	v := alias(c)
+	if v.Tools == nil {
+		v.Tools = []string{}
+	}
+	if v.HiddenTools == nil {
+		v.HiddenTools = []string{}
+	}
+	return json.Marshal(v) //nolint:wrapcheck // value struct of basic types cannot fail to marshal
 }
 
 // connectionListResponse wraps a list of connections.
@@ -275,16 +298,12 @@ func (h *Handler) listConnections(w http.ResponseWriter, _ *http.Request) {
 	if h.deps.ToolkitRegistry != nil {
 		for _, tk := range h.deps.ToolkitRegistry.All() {
 			tools := tk.Tools()
-			if tools == nil {
-				tools = []string{}
-			}
-			hidden := hiddenTools(tools, allow, deny)
 			conns = append(conns, connectionInfo{
 				Kind:        tk.Kind(),
 				Name:        tk.Name(),
 				Connection:  tk.Connection(),
 				Tools:       tools,
-				HiddenTools: hidden,
+				HiddenTools: hiddenTools(tools, allow, deny),
 			})
 		}
 	}

--- a/pkg/admin/system.go
+++ b/pkg/admin/system.go
@@ -275,6 +275,9 @@ func (h *Handler) listConnections(w http.ResponseWriter, _ *http.Request) {
 	if h.deps.ToolkitRegistry != nil {
 		for _, tk := range h.deps.ToolkitRegistry.All() {
 			tools := tk.Tools()
+			if tools == nil {
+				tools = []string{}
+			}
 			hidden := hiddenTools(tools, allow, deny)
 			conns = append(conns, connectionInfo{
 				Kind:        tk.Kind(),

--- a/pkg/admin/system_test.go
+++ b/pkg/admin/system_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -424,5 +425,33 @@ func TestListConnections(t *testing.T) {
 		var body map[string]any
 		require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
 		assert.Equal(t, float64(0), body["total"])
+	})
+
+	// A toolkit whose Tools() returns nil (e.g. gateway with no live
+	// upstream connections) must serialize as "tools":[], not "tools":null,
+	// or the persona editor's connections scope crashes when it reads
+	// c.tools.length on the wire value.
+	t.Run("nil Tools() serializes as empty array, not null", func(t *testing.T) {
+		reg := &mockToolkitRegistry{
+			allResult: []mockToolkit{
+				{kind: "gateway", name: "vendor", connection: "vendor", tools: nil},
+			},
+		}
+		h := NewHandler(Deps{ToolkitRegistry: reg}, nil)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/admin/connections", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		raw := w.Body.String()
+		assert.Contains(t, raw, `"tools":[]`, "tools must be []; got: %s", raw)
+		assert.NotContains(t, raw, `"tools":null`, "tools must never be null on the wire")
+
+		var body connectionListResponse
+		require.NoError(t, json.NewDecoder(strings.NewReader(raw)).Decode(&body))
+		require.Len(t, body.Connections, 1)
+		assert.NotNil(t, body.Connections[0].Tools, "Tools slice must be non-nil after decode")
+		assert.Empty(t, body.Connections[0].Tools)
 	})
 }

--- a/pkg/admin/system_test.go
+++ b/pkg/admin/system_test.go
@@ -3,9 +3,9 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -428,10 +428,12 @@ func TestListConnections(t *testing.T) {
 	})
 
 	// A toolkit whose Tools() returns nil (e.g. gateway with no live
-	// upstream connections) must serialize as "tools":[], not "tools":null,
-	// or the persona editor's connections scope crashes when it reads
-	// c.tools.length on the wire value.
-	t.Run("nil Tools() serializes as empty array, not null", func(t *testing.T) {
+	// upstream connections) must serialize tools AND hidden_tools as [],
+	// not null. The persona editor's connections scope reads
+	// c.tools.length / c.hidden_tools.length on the wire value, and a
+	// null crashes the render. connectionInfo.MarshalJSON enforces the
+	// invariant for both fields no matter how the struct is constructed.
+	t.Run("nil Tools() serializes both tools and hidden_tools as empty arrays", func(t *testing.T) {
 		reg := &mockToolkitRegistry{
 			allResult: []mockToolkit{
 				{kind: "gateway", name: "vendor", connection: "vendor", tools: nil},
@@ -445,13 +447,9 @@ func TestListConnections(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		raw := w.Body.String()
-		assert.Contains(t, raw, `"tools":[]`, "tools must be []; got: %s", raw)
-		assert.NotContains(t, raw, `"tools":null`, "tools must never be null on the wire")
-
-		var body connectionListResponse
-		require.NoError(t, json.NewDecoder(strings.NewReader(raw)).Decode(&body))
-		require.Len(t, body.Connections, 1)
-		assert.NotNil(t, body.Connections[0].Tools, "Tools slice must be non-nil after decode")
-		assert.Empty(t, body.Connections[0].Tools)
+		for _, field := range []string{"tools", "hidden_tools"} {
+			assert.Contains(t, raw, fmt.Sprintf("%q:[]", field), "%s must be []; got: %s", field, raw)
+			assert.NotContains(t, raw, fmt.Sprintf("%q:null", field), "%s must never be null on the wire", field)
+		}
 	})
 }

--- a/ui/src/pages/audit/AuditLogPage.tsx
+++ b/ui/src/pages/audit/AuditLogPage.tsx
@@ -382,7 +382,7 @@ function EventsTab({ onNavigate }: { onNavigate?: (path: string) => void }) {
           className="rounded-md border bg-background px-3 py-1.5 text-sm outline-none ring-ring focus:ring-2"
         >
           <option value="">All Users</option>
-          {filters?.users.map((u) => (
+          {filters?.users?.map((u) => (
             <option key={u} value={u}>
               {filters.user_labels?.[u] || formatUser(u)}
             </option>
@@ -397,7 +397,7 @@ function EventsTab({ onNavigate }: { onNavigate?: (path: string) => void }) {
           className="rounded-md border bg-background px-3 py-1.5 text-sm outline-none ring-ring focus:ring-2"
         >
           <option value="">All Tools</option>
-          {filters?.tools.map((t) => (
+          {filters?.tools?.map((t) => (
             <option key={t} value={t}>
               {t}
             </option>

--- a/ui/src/pages/settings/PersonaEditor.tsx
+++ b/ui/src/pages/settings/PersonaEditor.tsx
@@ -272,19 +272,22 @@ export function PersonaEditor({
         kind: t.primaryKind,
       }));
     }
-    return connections.map((c) => ({
+    return connections.map((c) => {
       // The backend authorizes against toolkit.Connection() (see
       // pkg/registry/registry.go GetToolkitForTool → match.Connection,
       // consumed by pkg/persona/filter.go IsConnectionAllowed). The toolkit
       // instance "name" is unrelated and may diverge when connection_name
       // is configured explicitly, so allow/deny patterns must match against
       // the connection identifier, not the toolkit name.
-      key: c.connection,
-      primary: c.connection,
-      secondary: c.kind,
-      tertiary: `${c.tools.length} tools`,
-      kind: c.kind,
-    }));
+      const toolCount = c.tools?.length ?? 0;
+      return {
+        key: c.connection,
+        primary: c.connection,
+        secondary: c.kind,
+        tertiary: `${toolCount} tools`,
+        kind: c.kind,
+      };
+    });
   }, [scope, uniqueTools, connections]);
 
   const allowList = scope === "tools" ? draft.allowTools : draft.allowConnections;
@@ -536,9 +539,16 @@ export function PersonaEditor({
       )}
 
       {/* ─── MAIN: left identity/rules + tabbed right area ─── */}
-      <div className="grid min-h-0 flex-1 grid-cols-[300px_minmax(0,1fr)]">
+      {/*
+        Stack vertically below lg (1024px) so the scope tabs in the center
+        column remain reachable on narrow viewports — without this, the
+        fixed 300px left rail starves the right column of usable width and
+        users can't switch the Allow/Deny editor between tools and
+        connections scope.
+      */}
+      <div className="flex min-h-0 flex-1 flex-col lg:grid lg:grid-cols-[300px_minmax(0,1fr)]">
         {/* ── LEFT: Identity + Rules + Context ── */}
-        <aside className="overflow-y-auto border-r">
+        <aside className="border-b lg:overflow-y-auto lg:border-b-0 lg:border-r">
           <fieldset disabled={isReadOnly} className="contents">
           <Section title="Identity">
             <Field label="Name" required>
@@ -666,7 +676,7 @@ export function PersonaEditor({
         </aside>
 
         {/* ── RIGHT AREA: tabbed (Permissions / AI Assistant Behavior) ── */}
-        <div className="flex min-h-0 flex-col overflow-hidden">
+        <div className="flex flex-col lg:min-h-0 lg:overflow-hidden">
           <div className="flex shrink-0 border-b bg-muted/10 px-5">
             <MainTab
               active={mainTab === "permissions"}
@@ -722,10 +732,10 @@ export function PersonaEditor({
               </fieldset>
             </div>
           ) : (
-            <div className="grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)_340px]">
+            <div className="flex flex-1 flex-col xl:grid xl:min-h-0 xl:grid-cols-[minmax(0,1fr)_340px]">
 
         {/* ── CENTER: Tool / Connection explorer ── */}
-        <section className="flex min-h-0 flex-col overflow-hidden">
+        <section className="flex flex-col xl:min-h-0 xl:overflow-hidden">
           <div className="border-b bg-muted/10 px-5 pt-4 pb-3">
             <div className="mb-3">
               <h3 className="text-base font-semibold leading-tight">
@@ -813,7 +823,7 @@ export function PersonaEditor({
           </div>
 
           <fieldset disabled={isReadOnly} className="contents">
-          <div className="flex-1 overflow-y-auto px-5 py-3">
+          <div className="px-5 py-3 xl:flex-1 xl:overflow-y-auto">
             {grouped.length === 0 && (
               <div className="py-12 text-center text-xs text-muted-foreground">
                 No {scope} match
@@ -913,7 +923,7 @@ export function PersonaEditor({
         </section>
 
         {/* ── RIGHT: Summary + Trace + Templates ── */}
-        <aside className="flex flex-col overflow-y-auto border-l">
+        <aside className="flex flex-col border-t xl:overflow-y-auto xl:border-t-0 xl:border-l">
           <div className="grid grid-cols-2 border-b">
             <div className="border-r px-4 py-3">
               <div className="text-2xl font-semibold text-emerald-600 dark:text-emerald-400">


### PR DESCRIPTION
## Summary

Fixes two real bugs and one stale-cache hazard, all of the same class — backend handlers leaking `null` for slice fields the UI types as `string[]`, then the UI crashing on `.length` / `.map`.

### Bug 1 — Persona editor blanks when switching to the Connections tab

The `gateway` toolkit's `Tools()` returns a nil `[]string` when it has no live upstream connections. `pkg/admin/system.go:listConnections` was shipping that nil straight through `json.Marshal`, which writes `"tools": null` on the wire. The UI types `ConnectionInfo.tools` as `string[]` and the persona editor's items memo dereferences `c.tools.length` directly, so the page blanked.

```
Uncaught TypeError: Cannot read properties of null (reading 'length')
```

Fix: `connectionInfo` now has a `MarshalJSON` that normalizes both `Tools` and `HiddenTools` to `[]string{}` at serialization time, so the wire shape is guaranteed regardless of how the struct is constructed.

### Bug 2 — Same null-array crash in the adjacent persona endpoints

Reviewing the connections fix surfaced the same pattern in `pkg/admin/persona_handler.go`:

- `listPersonas` shipped `personaSummary.Roles` unchanged. A YAML persona without a `roles:` key produced `"roles": null`; `ui/src/pages/settings/RolesPage.tsx:28` iterates `p.roles` and `ui/src/pages/settings/PersonasPanel.tsx:218` reads `p.roles.length`, both unguarded.
- `getPersona` shipped `personaDetail.{Roles,AllowTools,DenyTools,Tools}` with the same shape — declared `[]string` without `omitempty`, no normalization on the path from `persona.Persona` into the response.

Fix: `personaSummary` and `personaDetail` each have a `MarshalJSON` that normalizes the required-non-null arrays. `AllowConnections` / `DenyConnections` retain `omitempty` and stay absent rather than `null`.

### Bug 3 — Audit page filter dropdowns guard only the outer optional

`AuditLogPage.tsx` did `filters?.users.map(...)` and `filters?.tools.map(...)`. The `?.` was only on `filters`, not on the array. The backend already normalizes these today, so this isn't a live crash — but a stale react-query cache from a pre-fix server would crash the page. Bring the field accesses into line with the sibling `filters?.toolkit_kinds?.map` / `filters?.sources?.map` pattern.

## Why MarshalJSON instead of inline normalization

The original fix was an inline `if tools == nil { tools = []string{} }` at the call site. That works but the invariant lives in prose, not on the type — any new handler that constructs a `connectionInfo` literal can silently regress the wire shape. Moving the normalization onto the type via `MarshalJSON` makes the contract impossible to bypass: every code path that calls `json.Marshal` on these structs gets non-nil arrays, no matter how the struct was built.

## Files changed

| File | Change |
|---|---|
| `pkg/admin/system.go` | `connectionInfo.MarshalJSON` normalizes `Tools` and `HiddenTools`; drop the now-redundant inline nil-check in `listConnections` |
| `pkg/admin/system_test.go` | Regression test: registers a toolkit with nil `Tools()`, asserts the raw response contains `"tools":[]` and `"hidden_tools":[]` and never `:null` |
| `pkg/admin/persona_handler.go` | `personaSummary.MarshalJSON` and `personaDetail.MarshalJSON` normalize the required-non-null arrays |
| `pkg/admin/persona_handler_test.go` | Two new subtests asserting the wire shape for `listPersonas` (nil Roles) and `getPersona` (nil Roles/AllowTools/DenyTools/Tools) |
| `ui/src/pages/audit/AuditLogPage.tsx` | `filters?.users?.map` and `filters?.tools?.map` — defensive guard parity with sibling fields |
| `ui/src/pages/settings/PersonaEditor.tsx` | Defensive `c.tools?.length ?? 0` in the connections items memo; stack the editor below `lg` so the scope tabs remain reachable on narrow viewports |

## Test plan

- [x] `make verify` passes (fmt, race tests, lint, security, semgrep, codeql, coverage, dead-code, mutation, release dry-run)
- [x] New regression tests added and passing:
  - [x] `TestListConnections/nil_Tools()_serializes_both_tools_and_hidden_tools_as_empty_arrays`
  - [x] `TestListPersonas/nil_Roles_serializes_as_empty_array,_not_null`
  - [x] `TestGetPersona/nil_slice_fields_serialize_as_empty_arrays,_not_null`
- [x] UI typecheck + production build pass
- [ ] Manual: open the persona editor, switch to the Connections tab — verify it renders the connection list instead of blanking
- [ ] Manual: with a YAML persona that omits `roles:`, load `/portal/admin/personas` and `/portal/admin/roles` — verify both pages render
- [ ] Manual: with audit data present, load `/portal/audit` — verify the Users and Tools dropdowns populate