### PR TITLE
fix(admin): expand multi-connection toolkits in /connections so persona editor matches real connection names

### DIFF
--- a/pkg/admin/system.go
+++ b/pkg/admin/system.go
@@ -10,6 +10,7 @@ import (
 	mcpserver "github.com/txn2/mcp-data-platform/internal/server"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // systemInfoResponse is returned by GET /system/info.
@@ -298,12 +299,31 @@ func (h *Handler) listConnections(w http.ResponseWriter, _ *http.Request) {
 	if h.deps.ToolkitRegistry != nil {
 		for _, tk := range h.deps.ToolkitRegistry.All() {
 			tools := tk.Tools()
+			hidden := hiddenTools(tools, allow, deny)
+			// Multi-connection toolkits (apigateway, trino with multiple
+			// catalogs, etc.) must expand to one entry per real connection
+			// because that is what the persona filter authorizes against.
+			// Listing the single toolkit-level entry would make patterns
+			// like "blackbaud" unmatchable in the editor's live preview
+			// even though they work correctly at runtime.
+			if lister, ok := tk.(toolkit.ConnectionLister); ok {
+				for _, conn := range lister.ListConnections() {
+					conns = append(conns, connectionInfo{
+						Kind:        tk.Kind(),
+						Name:        conn.Name,
+						Connection:  conn.Name,
+						Tools:       tools,
+						HiddenTools: hidden,
+					})
+				}
+				continue
+			}
 			conns = append(conns, connectionInfo{
 				Kind:        tk.Kind(),
 				Name:        tk.Name(),
 				Connection:  tk.Connection(),
 				Tools:       tools,
-				HiddenTools: hiddenTools(tools, allow, deny),
+				HiddenTools: hidden,
 			})
 		}
 	}

--- a/pkg/admin/system_test.go
+++ b/pkg/admin/system_test.go
@@ -15,6 +15,7 @@ import (
 	mcpserver "github.com/txn2/mcp-data-platform/internal/server"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 func TestGetSystemInfo(t *testing.T) {
@@ -425,6 +426,62 @@ func TestListConnections(t *testing.T) {
 		var body map[string]any
 		require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
 		assert.Equal(t, float64(0), body["total"])
+	})
+
+	// A multi-connection toolkit (apigateway with N upstream connections,
+	// trino with multiple catalogs) must expand to one entry per real
+	// connection. The persona filter authorizes against the connection
+	// name (apigateway resolves "blackbaud" at call time), so listing the
+	// single toolkit-level entry makes patterns like "blackbaud"
+	// unmatchable in the editor's live preview even when they work
+	// correctly at runtime.
+	t.Run("multi-connection toolkit expands to one entry per connection", func(t *testing.T) {
+		mt := mockMultiConnectionToolkit{
+			mockToolkit: mockToolkit{
+				kind: "api", name: "apigateway", connection: "apigateway",
+				tools: []string{"api_invoke_endpoint", "api_list_endpoints"},
+			},
+			connections: []toolkit.ConnectionDetail{
+				{Name: "vendor-a", Description: "Vendor A REST API"},
+				{Name: "vendor-b", Description: "Vendor B REST API"},
+				{Name: "vendor-c", Description: "Vendor C REST API"},
+			},
+		}
+		single := mockToolkit{
+			kind: "knowledge", name: "knowledge", connection: "knowledge",
+			tools: []string{"capture_insight", "apply_knowledge"},
+		}
+		reg := &mockToolkitRegistry{
+			rawToolkits: []registry.Toolkit{mt, single},
+			allResult:   []mockToolkit{single},
+		}
+		h := NewHandler(Deps{ToolkitRegistry: reg}, nil)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/admin/connections", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var body connectionListResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+		assert.Equal(t, 4, body.Total, "3 expanded API connections + 1 single-connection knowledge toolkit")
+
+		byName := make(map[string]connectionInfo, len(body.Connections))
+		for _, c := range body.Connections {
+			byName[c.Name] = c
+		}
+		for _, name := range []string{"vendor-a", "vendor-b", "vendor-c"} {
+			c, ok := byName[name]
+			require.True(t, ok, "expected expanded connection %q in response", name)
+			assert.Equal(t, "api", c.Kind, "%s should inherit kind from parent toolkit", name)
+			assert.Equal(t, name, c.Connection, "%s authorization identifier must equal connection name", name)
+			assert.ElementsMatch(t, []string{"api_invoke_endpoint", "api_list_endpoints"}, c.Tools)
+		}
+		// Single-connection toolkit unchanged.
+		kn, ok := byName["knowledge"]
+		require.True(t, ok)
+		assert.Equal(t, "knowledge", kn.Kind)
+		assert.Equal(t, "knowledge", kn.Connection)
 	})
 
 	// A toolkit whose Tools() returns nil (e.g. gateway with no live


### PR DESCRIPTION
## Summary

Fixes a real UI bug: the persona editor's Connections tab showed a single placeholder entry "api" instead of the real upstream connections configured under an apigateway toolkit. An allow pattern like `salesforce` showed `0 allowed / 2 denied` in the live preview even though the same pattern authorized correctly at runtime.

## Root cause

`pkg/admin/system.go:listConnections` iterated `ToolkitRegistry.All()` and emitted one `connectionInfo` per toolkit. Multi-connection toolkits (apigateway, trino with multiple catalogs) expose a `toolkit.ConnectionLister` interface so callers can enumerate their real connections, but `listConnections` ignored it. The result was that an apigateway with N upstream connections shipped a single wire entry whose `name` was the toolkit's default placeholder (`apigateway`) instead of one entry per real connection name.

The parallel handler at `pkg/admin/connection_handler.go:collectLiveConnections` (used by the admin Connections page at `/portal/admin/connections`) already expands multi-connection toolkits the same way the `list_connections` MCP tool does. This PR brings `listConnections` into parity with that behavior.

## Why the runtime authorization was correct anyway

`pkg/persona/filter.go:IsConnectionAllowed` is invoked at MCP tool-call time with the connection name resolved by the toolkit at that moment. So a persona with `allow_connections: [salesforce]` correctly authorized calls all along. The bug was purely UI-visible:

- The persona editor's live preview computed `0 allowed` because none of the items in `useConnections()`'s response carried the connection name to match against.
- The resolution trace was empty for the same reason.
- The user could not tell from the editor whether their patterns were correct without testing them in production.

## What changes on the wire

`GET /api/v1/admin/connections` response, for a registry containing an apigateway toolkit with N connections:

**Before** (one entry per toolkit):
```json
{
  "connections": [
    {
      "kind": "api",
      "name": "apigateway",
      "connection": "apigateway",
      "tools": ["api_invoke_endpoint", "api_list_endpoints", ...],
      "hidden_tools": []
    }
  ]
}
```

**After** (one entry per connection):
```json
{
  "connections": [
    {
      "kind": "api",
      "name": "salesforce",
      "connection": "salesforce",
      "tools": ["api_invoke_endpoint", "api_list_endpoints", ...],
      "hidden_tools": []
    },
    {
      "kind": "api",
      "name": "stripe",
      "connection": "stripe",
      "tools": ["api_invoke_endpoint", "api_list_endpoints", ...],
      "hidden_tools": []
    },
    ...
  ]
}
```

Single-connection toolkits (knowledge, mcp, memory, portal, datahub with one instance, s3 with one instance) are emitted exactly as before.

## Edge case behavior

A multi-connection toolkit whose `ListConnections()` returns an empty slice (e.g. an apigateway instance registered but with no connections configured yet) now contributes ZERO entries to the response, where before it contributed one toolkit-level placeholder. This matches the existing behavior of `collectLiveConnections` and is intentional: there is nothing to authorize against until at least one real connection exists.

## Files changed

| File | Change |
|---|---|
| `pkg/admin/system.go` | When a toolkit implements `toolkit.ConnectionLister`, emit one `connectionInfo` per `ListConnections()` entry with `Name` and `Connection` set to the connection name. Single-connection toolkits unchanged. |
| `pkg/admin/system_test.go` | Regression test: a mock multi-connection toolkit with three connections plus one single-connection toolkit produces exactly four response entries, with kinds, names, and tool lists correctly attributed. |

## Test plan

- [x] `make verify` passes (fmt, race tests, lint, security, semgrep, codeql, coverage, dead-code, mutation, release dry-run)
- [x] New regression test passes: `TestListConnections/multi-connection_toolkit_expands_to_one_entry_per_connection`
- [x] Existing tests unchanged and passing (sort by Name, hidden_tools computation, empty registry, nil Tools() serialization)
- [x] Adversarial review against this branch: CLEAN
- [ ] Manual verification: open persona editor, switch to the Connections tab, verify the editor lists each apigateway connection by name instead of a single "api" entry

## No breaking changes for clients

- Existing `allow_connections` patterns in persona YAML keep working because the runtime authorization path was already correct.
- The `connectionInfo` JSON shape is unchanged (same fields, same types). Only the set of entries returned changes.
- TypeScript types in the UI already declare `ConnectionInfo` as the per-connection shape; the runtime now matches what the type already claimed.