### PR TITLE
fix(portal): collection share revoke and shared thumbnail access

### DIFF
--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -5549,6 +5549,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/portal.problemDetail"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
                     "404": {
                         "description": "Not Found",
                         "schema": {
@@ -6268,7 +6274,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Revokes a share by its ID. Only the asset owner can revoke.",
+                "description": "Revokes a share by its ID. Only the owner can revoke.",
                 "produces": [
                     "application/json"
                 ],

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -5543,6 +5543,12 @@
                             "$ref": "#/definitions/portal.problemDetail"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
                     "404": {
                         "description": "Not Found",
                         "schema": {
@@ -6262,7 +6268,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Revokes a share by its ID. Only the asset owner can revoke.",
+                "description": "Revokes a share by its ID. Only the owner can revoke.",
                 "produces": [
                     "application/json"
                 ],

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -5988,6 +5988,10 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/portal.problemDetail'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
         "404":
           description: Not Found
           schema:
@@ -6443,7 +6447,7 @@ paths:
       - Shares
   /portal/shares/{id}:
     delete:
-      description: Revokes a share by its ID. Only the asset owner can revoke.
+      description: Revokes a share by its ID. Only the owner can revoke.
       parameters:
       - description: Share ID
         in: path

--- a/pkg/admin/system.go
+++ b/pkg/admin/system.go
@@ -303,9 +303,6 @@ func (h *Handler) listConnections(w http.ResponseWriter, _ *http.Request) {
 			// Multi-connection toolkits (apigateway, trino with multiple
 			// catalogs, etc.) must expand to one entry per real connection
 			// because that is what the persona filter authorizes against.
-			// Listing the single toolkit-level entry would make patterns
-			// like "blackbaud" unmatchable in the editor's live preview
-			// even though they work correctly at runtime.
 			if lister, ok := tk.(toolkit.ConnectionLister); ok {
 				for _, conn := range lister.ListConnections() {
 					conns = append(conns, connectionInfo{

--- a/pkg/admin/system_test.go
+++ b/pkg/admin/system_test.go
@@ -430,11 +430,8 @@ func TestListConnections(t *testing.T) {
 
 	// A multi-connection toolkit (apigateway with N upstream connections,
 	// trino with multiple catalogs) must expand to one entry per real
-	// connection. The persona filter authorizes against the connection
-	// name (apigateway resolves "blackbaud" at call time), so listing the
-	// single toolkit-level entry makes patterns like "blackbaud"
-	// unmatchable in the editor's live preview even when they work
-	// correctly at runtime.
+	// connection because the persona filter authorizes against the
+	// connection name resolved at call time.
 	t.Run("multi-connection toolkit expands to one entry per connection", func(t *testing.T) {
 		mt := mockMultiConnectionToolkit{
 			mockToolkit: mockToolkit{

--- a/pkg/portal/collection_handler.go
+++ b/pkg/portal/collection_handler.go
@@ -619,6 +619,7 @@ func (h *Handler) uploadCollectionThumbnail(w http.ResponseWriter, r *http.Reque
 // @Param        id  path  string  true  "Collection ID"
 // @Success      200  {file}  binary
 // @Failure      401  {object}  problemDetail
+// @Failure      403  {object}  problemDetail
 // @Failure      404  {object}  problemDetail
 // @Failure      503  {object}  problemDetail
 // @Security     ApiKeyAuth
@@ -636,6 +637,14 @@ func (h *Handler) getCollectionThumbnail(w http.ResponseWriter, r *http.Request)
 	if err != nil || coll.ThumbnailS3Key == "" {
 		writeError(w, http.StatusNotFound, "thumbnail not found")
 		return
+	}
+
+	if coll.OwnerID != user.UserID {
+		perm := h.collectionSharePermission(r, id, user)
+		if perm == "" {
+			writeError(w, http.StatusForbidden, errAccessDenied)
+			return
+		}
 	}
 
 	if h.deps.S3Client == nil {

--- a/pkg/portal/collection_handler_test.go
+++ b/pkg/portal/collection_handler_test.go
@@ -1360,3 +1360,91 @@ func TestListSharedCollections(t *testing.T) {
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
 	})
 }
+
+func TestGetCollectionThumbnail_SharedUser(t *testing.T) {
+	sharedUser := &User{UserID: "other-user", Email: "other@example.com"}
+
+	t.Run("shared_user_can_view", func(t *testing.T) {
+		coll := baseCollection()
+		coll.ThumbnailS3Key = "portal/collections/coll-1/thumbnail.png"
+		cs := &collHandlerMockCollStore{getColl: coll}
+		shares := &mockCollectionShareStore{collPermission: "viewer"}
+		s3 := &mockS3Client{getData: []byte("PNG"), getCT: "image/png"}
+		h := newTestHandlerWithCollections(&mockAssetStore{}, shares, cs, s3, sharedUser)
+
+		r := httptest.NewRequestWithContext(context.Background(), "GET", "/api/v1/portal/collections/coll-1/thumbnail", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
+	})
+
+	t.Run("non_shared_user_forbidden", func(t *testing.T) {
+		coll := baseCollection()
+		coll.ThumbnailS3Key = "portal/collections/coll-1/thumbnail.png"
+		cs := &collHandlerMockCollStore{getColl: coll}
+		shares := &mockCollectionShareStore{collPermission: "", collPermErr: fmt.Errorf("no permission")}
+		s3 := &mockS3Client{getData: []byte("PNG"), getCT: "image/png"}
+		h := newTestHandlerWithCollections(&mockAssetStore{}, shares, cs, s3, sharedUser)
+
+		r := httptest.NewRequestWithContext(context.Background(), "GET", "/api/v1/portal/collections/coll-1/thumbnail", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+}
+
+func TestRevokeCollectionShare(t *testing.T) {
+	t.Run("owner_can_revoke", func(t *testing.T) {
+		coll := baseCollection()
+		cs := &collHandlerMockCollStore{getColl: coll}
+		share := &Share{ID: "cs1", CollectionID: "coll-1"}
+		shares := &mockCollectionShareStore{
+			mockShareStore: mockShareStore{getByIDShare: share},
+		}
+		h := newTestHandlerWithCollections(&mockAssetStore{}, shares, cs, &mockS3Client{}, testUser)
+
+		r := httptest.NewRequestWithContext(context.Background(), "DELETE", "/api/v1/portal/shares/cs1", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp statusResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+		assert.Equal(t, "revoked", resp.Status)
+	})
+
+	t.Run("non_owner_forbidden", func(t *testing.T) {
+		coll := baseCollection()
+		coll.OwnerID = "someone-else"
+		cs := &collHandlerMockCollStore{getColl: coll}
+		share := &Share{ID: "cs1", CollectionID: "coll-1"}
+		shares := &mockCollectionShareStore{
+			mockShareStore: mockShareStore{getByIDShare: share},
+		}
+		h := newTestHandlerWithCollections(&mockAssetStore{}, shares, cs, &mockS3Client{}, testUser)
+
+		r := httptest.NewRequestWithContext(context.Background(), "DELETE", "/api/v1/portal/shares/cs1", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("collection_not_found", func(t *testing.T) {
+		cs := &collHandlerMockCollStore{getErr: fmt.Errorf("not found")}
+		share := &Share{ID: "cs1", CollectionID: "coll-1"}
+		shares := &mockCollectionShareStore{
+			mockShareStore: mockShareStore{getByIDShare: share},
+		}
+		h := newTestHandlerWithCollections(&mockAssetStore{}, shares, cs, &mockS3Client{}, testUser)
+
+		r := httptest.NewRequestWithContext(context.Background(), "DELETE", "/api/v1/portal/shares/cs1", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}

--- a/pkg/portal/handler.go
+++ b/pkg/portal/handler.go
@@ -1241,7 +1241,7 @@ func (h *Handler) listShares(w http.ResponseWriter, r *http.Request) {
 // revokeShare handles DELETE /api/v1/portal/shares/{id}.
 //
 // @Summary      Revoke share
-// @Description  Revokes a share by its ID. Only the asset owner can revoke.
+// @Description  Revokes a share by its ID. Only the owner can revoke.
 // @Tags         Shares
 // @Produce      json
 // @Param        id  path  string  true  "Share ID"
@@ -1267,15 +1267,21 @@ func (h *Handler) revokeShare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify ownership: check that the share's asset belongs to this user.
-	asset, err := h.deps.AssetStore.Get(r.Context(), share.AssetID)
-	if err != nil {
-		writeError(w, http.StatusNotFound, "associated asset not found")
-		return
-	}
-	if asset.OwnerID != user.UserID {
-		writeError(w, http.StatusForbidden, "only the owner can revoke this share")
-		return
+	if share.CollectionID != "" {
+		if err := h.verifyCollectionOwner(r.Context(), share.CollectionID, user); err != nil {
+			writeError(w, err.code, err.message)
+			return
+		}
+	} else {
+		asset, err := h.deps.AssetStore.Get(r.Context(), share.AssetID)
+		if err != nil {
+			writeError(w, http.StatusNotFound, "associated asset not found")
+			return
+		}
+		if asset.OwnerID != user.UserID {
+			writeError(w, http.StatusForbidden, "only the owner can revoke this share")
+			return
+		}
 	}
 
 	if err := h.deps.ShareStore.Revoke(r.Context(), shareID); err != nil {
@@ -1284,6 +1290,27 @@ func (h *Handler) revokeShare(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, statusResponse{Status: statusRevoked})
+}
+
+type ownerError struct {
+	code    int
+	message string
+}
+
+func (e *ownerError) Error() string { return e.message }
+
+func (h *Handler) verifyCollectionOwner(ctx context.Context, collectionID string, user *User) *ownerError {
+	if h.deps.CollectionStore == nil {
+		return &ownerError{http.StatusNotFound, "collections not available"}
+	}
+	coll, err := h.deps.CollectionStore.Get(ctx, collectionID)
+	if err != nil {
+		return &ownerError{http.StatusNotFound, "associated collection not found"}
+	}
+	if coll.OwnerID != user.UserID {
+		return &ownerError{http.StatusForbidden, "only the owner can revoke this share"}
+	}
+	return nil
 }
 
 // listSharedWithMe handles GET /api/v1/portal/shared-with-me.


### PR DESCRIPTION
## Summary

- Collection share DELETE returned 404 because `revokeShare` assumed every share had an `AssetID` and verified ownership via the asset. Collection shares have `CollectionID` instead, so the asset lookup failed.
- Shared collection thumbnails returned 403 because `getCollectionThumbnail` checked authentication but not share-based authorization.
- Tidied code comments in the admin package.

## What changed

### `pkg/portal/handler.go`

`revokeShare` now branches on `share.CollectionID`: if set, ownership is verified against the collection via `verifyCollectionOwner`; otherwise the existing asset-ownership path runs. The store's `Revoke` method was already generic (operates on share ID), so no store changes were needed.

### `pkg/portal/collection_handler.go`

`getCollectionThumbnail` now checks `coll.OwnerID != user.UserID` and falls back to `collectionSharePermission` before serving the image, matching the pattern used by `getCollection`.

### `pkg/admin/system.go`, `pkg/admin/system_test.go`

Removed vendor-specific names from code comments.

## Test plan

- [x] `TestRevokeCollectionShare/owner_can_revoke` - owner successfully revokes a collection share
- [x] `TestRevokeCollectionShare/non_owner_forbidden` - non-owner gets 403
- [x] `TestRevokeCollectionShare/collection_not_found` - missing collection gets 404
- [x] `TestGetCollectionThumbnail_SharedUser/shared_user_can_view` - user with share grant gets the thumbnail
- [x] `TestGetCollectionThumbnail_SharedUser/non_shared_user_forbidden` - user without share grant gets 403
- [x] All existing revoke and thumbnail tests pass unchanged
- [x] `make verify` core checks pass (fmt, test/race, lint, security, coverage, patch coverage 91.2%)