### PR TITLE
fix(portal): collection share thumbnails, idempotent revoke, confirm UI

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,6 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/getkin/kin-openapi v0.138.0 h1:ebfE0JAmF6AqHrNBy1KO3Fs68K9tPs48HalvLPo7Rv4=
-github.com/getkin/kin-openapi v0.138.0/go.mod h1:vUYWaKyMqj7PfTybelXtLuLN9tReS12vxnzMRK+z2GY=
 github.com/getkin/kin-openapi v0.139.0 h1:pBFXcZJFwz9J1X64jzxlOoNgFm+TF7kNrs9+HJVN6Ic=
 github.com/getkin/kin-openapi v0.139.0/go.mod h1:NGxPfE4PwS/TRXEbyx2RrxDFPZvxcWw31Tw8XXjPZLs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -217,8 +215,6 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/modelcontextprotocol/go-sdk v1.6.0 h1:PPLS3kn7WtOEnR+Af4X5H96SG0qSab8R/ZQT/HkhPkY=
-github.com/modelcontextprotocol/go-sdk v1.6.0/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
 github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
@@ -228,12 +224,8 @@ github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7P
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/oasdiff/yaml v0.0.9 h1:zQOvd2UKoozsSsAknnWoDJlSK4lC0mpmjfDsfqNwX48=
-github.com/oasdiff/yaml v0.0.9/go.mod h1:8lvhgJG4xiKPj3HN5lDow4jZHPlx1i7dIwzkdAo6oAM=
 github.com/oasdiff/yaml v0.1.0 h1:0bqZjfKc/8S9urj4JuwepX41WX9EoA6ifhU3SV06cXg=
 github.com/oasdiff/yaml v0.1.0/go.mod h1:kOlRmMdL2X3vucLCEQO5u61SU22RysnfXvcttrZA1O0=
-github.com/oasdiff/yaml3 v0.0.12 h1:75urAtPeDg2/iDEWwzNrLOWxI9N/dCh81nTTJtokt2M=
-github.com/oasdiff/yaml3 v0.0.12/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/oasdiff/yaml3 v0.0.13 h1:06svmvOHOVBqF81+sY2EUScvUI/iS/vl2VIeUUxZQwg=
 github.com/oasdiff/yaml3 v0.0.13/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/pkg/admin/assets_test.go
+++ b/pkg/admin/assets_test.go
@@ -104,6 +104,10 @@ func (*mockAdminShareStore) ListActiveCollectionShareSummaries(_ context.Context
 	return map[string]portal.ShareSummary{}, nil
 }
 
+func (*mockAdminShareStore) GetUserAssetPermissionViaCollection(_ context.Context, _, _, _ string) (portal.SharePermission, error) {
+	return "", fmt.Errorf("no collection share")
+}
+
 type mockAdminS3Client struct {
 	getData   []byte
 	getCT     string

--- a/pkg/portal/handler.go
+++ b/pkg/portal/handler.go
@@ -1817,11 +1817,15 @@ func (h *Handler) canViewAsset(w http.ResponseWriter, r *http.Request, assetID s
 		writeError(w, http.StatusInternalServerError, "failed to check share access")
 		return false
 	}
-	if perm == "" {
-		writeError(w, http.StatusForbidden, errAccessDenied)
-		return false
+	if perm != "" {
+		return true
 	}
-	return true
+	collPerm, _ := h.deps.ShareStore.GetUserAssetPermissionViaCollection(r.Context(), assetID, user.UserID, user.Email)
+	if collPerm != "" {
+		return true
+	}
+	writeError(w, http.StatusForbidden, errAccessDenied)
+	return false
 }
 
 // canEditAsset checks owner or editor share access, writing an HTTP error on failure.
@@ -1834,11 +1838,15 @@ func (h *Handler) canEditAsset(w http.ResponseWriter, r *http.Request, assetID s
 		writeError(w, http.StatusInternalServerError, "failed to check share access")
 		return false
 	}
-	if perm != PermissionEditor {
-		writeError(w, http.StatusForbidden, "only the owner or an editor can update this asset")
-		return false
+	if perm == PermissionEditor {
+		return true
 	}
-	return true
+	collPerm, _ := h.deps.ShareStore.GetUserAssetPermissionViaCollection(r.Context(), assetID, user.UserID, user.Email)
+	if collPerm == PermissionEditor {
+		return true
+	}
+	writeError(w, http.StatusForbidden, "only the owner or an editor can update this asset")
+	return false
 }
 
 // resolveSharePermission validates and resolves the permission for a new share.

--- a/pkg/portal/handler_test.go
+++ b/pkg/portal/handler_test.go
@@ -62,20 +62,22 @@ func (m *mockAssetStore) Update(_ context.Context, _ string, _ AssetUpdate) erro
 func (m *mockAssetStore) SoftDelete(_ context.Context, _ string) error { return m.deleteErr }
 
 type mockShareStore struct {
-	insertErr     error
-	getByIDShare  *Share
-	getByIDErr    error
-	getByTokenRes *Share
-	getByTokenErr error
-	listByAsset   []Share
-	listByAssetE  error
-	sharedWithRes []SharedAsset
-	sharedWithTot int
-	sharedWithErr error
-	revokeErr     error
-	incrementErr  error
-	summaries     map[string]ShareSummary
-	summariesErr  error
+	insertErr      error
+	getByIDShare   *Share
+	getByIDErr     error
+	getByTokenRes  *Share
+	getByTokenErr  error
+	listByAsset    []Share
+	listByAssetE   error
+	sharedWithRes  []SharedAsset
+	sharedWithTot  int
+	sharedWithErr  error
+	revokeErr      error
+	incrementErr   error
+	summaries      map[string]ShareSummary
+	summariesErr   error
+	collAssetPerm  SharePermission
+	collAssetPermE error
 }
 
 func (m *mockShareStore) Insert(_ context.Context, _ Share) error { return m.insertErr }
@@ -110,6 +112,16 @@ func (*mockShareStore) GetUserCollectionPermission(_ context.Context, _, _, _ st
 
 func (*mockShareStore) ListSharedCollectionsWithUser(_ context.Context, _, _ string, _, _ int) ([]SharedCollection, int, error) {
 	return nil, 0, nil
+}
+
+func (m *mockShareStore) GetUserAssetPermissionViaCollection(_ context.Context, _, _, _ string) (SharePermission, error) {
+	if m.collAssetPerm != "" {
+		return m.collAssetPerm, nil
+	}
+	if m.collAssetPermE != nil {
+		return "", m.collAssetPermE
+	}
+	return "", fmt.Errorf("no collection share")
 }
 
 func (*mockShareStore) ListActiveCollectionShareSummaries(_ context.Context, _ []string) (map[string]ShareSummary, error) {
@@ -217,6 +229,10 @@ func (c *captureShareStore) ListSharedCollectionsWithUser(ctx context.Context, u
 
 func (c *captureShareStore) ListActiveCollectionShareSummaries(ctx context.Context, ids []string) (map[string]ShareSummary, error) {
 	return c.inner.ListActiveCollectionShareSummaries(ctx, ids)
+}
+
+func (c *captureShareStore) GetUserAssetPermissionViaCollection(ctx context.Context, assetID, userID, email string) (SharePermission, error) {
+	return c.inner.GetUserAssetPermissionViaCollection(ctx, assetID, userID, email)
 }
 
 // authMiddleware injects a User into the context for testing.
@@ -1773,6 +1789,19 @@ func TestCanEditAssetDBError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
+func TestCanEditAssetViaCollectionShare(t *testing.T) {
+	asset := &Asset{ID: "a1", OwnerID: "owner1"}
+	h := newTestHandler(
+		&mockAssetStore{},
+		&mockShareStore{listByAsset: []Share{}, collAssetPerm: "editor"},
+		&mockS3Client{}, nil,
+	)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/test", http.NoBody)
+	assert.True(t, h.canEditAsset(w, req, "a1", asset, &User{UserID: "u1", Email: "u1@example.com"}))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
 func TestResolveSharePermission(t *testing.T) {
 	perm, err := resolveSharePermission(createShareRequest{}, "user@example.com")
 	assert.NoError(t, err)
@@ -2603,6 +2632,46 @@ func TestGetThumbnailDeletedAsset(t *testing.T) {
 	h.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusGone, w.Code)
+}
+
+func TestGetThumbnailViaCollectionShare(t *testing.T) {
+	now := time.Now()
+	asset := &Asset{
+		ID: "a1", OwnerID: "other-user", S3Bucket: "b", ThumbnailS3Key: "portal/other/a1/thumbnail.png",
+		Tags: []string{}, Provenance: Provenance{}, CreatedAt: now, UpdatedAt: now,
+	}
+	sharedUser := &User{UserID: "dan-uuid", Email: "dan@example.com"}
+
+	t.Run("granted via collection share", func(t *testing.T) {
+		s3 := &mockS3Client{getData: []byte("PNG"), getCT: "image/png"}
+		h := newTestHandler(
+			&mockAssetStore{getAsset: asset},
+			&mockShareStore{listByAsset: []Share{}, collAssetPerm: "viewer"},
+			s3, sharedUser,
+		)
+
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/api/v1/portal/assets/a1/thumbnail", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
+		assert.Equal(t, "PNG", w.Body.String())
+	})
+
+	t.Run("denied without any share", func(t *testing.T) {
+		h := newTestHandler(
+			&mockAssetStore{getAsset: asset},
+			&mockShareStore{listByAsset: []Share{}},
+			&mockS3Client{getData: []byte("PNG"), getCT: "image/png"}, sharedUser,
+		)
+
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/api/v1/portal/assets/a1/thumbnail", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
 }
 
 // --- Permission tests ---

--- a/pkg/portal/store.go
+++ b/pkg/portal/store.go
@@ -85,6 +85,7 @@ type ShareStore interface {
 	ListSharedCollectionsWithUser(ctx context.Context, userID, email string, limit, offset int) ([]SharedCollection, int, error)
 	ListActiveShareSummaries(ctx context.Context, assetIDs []string) (map[string]ShareSummary, error)
 	ListActiveCollectionShareSummaries(ctx context.Context, collectionIDs []string) (map[string]ShareSummary, error)
+	GetUserAssetPermissionViaCollection(ctx context.Context, assetID, userID, email string) (SharePermission, error)
 	Revoke(ctx context.Context, id string) error
 	IncrementAccess(ctx context.Context, id string) error
 }
@@ -819,21 +820,33 @@ func (s *postgresShareStore) ListActiveCollectionShareSummaries(ctx context.Cont
 	return result, nil
 }
 
+func (s *postgresShareStore) GetUserAssetPermissionViaCollection(ctx context.Context, assetID, userID, email string) (SharePermission, error) { //nolint:revive // interface impl
+	query := `
+		SELECT ps.permission FROM portal_shares ps
+		JOIN portal_collection_sections cs ON cs.collection_id = ps.collection_id
+		JOIN portal_collection_items ci ON ci.section_id = cs.id
+		WHERE ci.asset_id = $1
+		  AND ps.collection_id IS NOT NULL
+		  AND ps.revoked = FALSE
+		  AND (ps.expires_at IS NULL OR ps.expires_at > NOW())
+		  AND (ps.shared_with_user_id = $2 OR ($3 != '' AND LOWER(ps.shared_with_email) = LOWER($3)))
+		ORDER BY CASE ps.permission WHEN 'editor' THEN 0 ELSE 1 END
+		LIMIT 1
+	`
+	var perm string
+	err := s.db.QueryRowContext(ctx, query, assetID, userID, email).Scan(&perm)
+	if err != nil {
+		return "", fmt.Errorf("querying asset permission via collection: %w", err)
+	}
+	return SharePermission(perm), nil
+}
+
 func (s *postgresShareStore) Revoke(ctx context.Context, id string) error { //nolint:revive // interface impl
-	query := `UPDATE portal_shares SET revoked = TRUE WHERE id = $1 AND revoked = FALSE`
-	result, err := s.db.ExecContext(ctx, query, id)
+	query := `UPDATE portal_shares SET revoked = TRUE WHERE id = $1`
+	_, err := s.db.ExecContext(ctx, query, id)
 	if err != nil {
 		return fmt.Errorf("revoking share: %w", err)
 	}
-
-	affected, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("checking rows affected: %w", err)
-	}
-	if affected == 0 {
-		return fmt.Errorf("share not found or already revoked: %s", id)
-	}
-
 	return nil
 }
 
@@ -960,6 +973,10 @@ func (*noopShareStore) ListActiveShareSummaries(_ context.Context, _ []string) (
 
 func (*noopShareStore) ListActiveCollectionShareSummaries(_ context.Context, _ []string) (map[string]ShareSummary, error) { //nolint:revive // interface impl
 	return map[string]ShareSummary{}, nil
+}
+
+func (*noopShareStore) GetUserAssetPermissionViaCollection(_ context.Context, _, _, _ string) (SharePermission, error) { //nolint:revive // interface impl
+	return "", nil
 }
 
 func (*noopShareStore) Revoke(_ context.Context, _ string) error          { return nil } //nolint:revive // interface impl

--- a/pkg/portal/store_test.go
+++ b/pkg/portal/store_test.go
@@ -2,6 +2,7 @@ package portal
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -549,7 +550,43 @@ func TestPostgresShareStoreRevoke(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestPostgresShareStoreRevokeNotFound(t *testing.T) {
+func TestPostgresShareStoreGetUserAssetPermissionViaCollection(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close() //nolint:errcheck // test cleanup
+
+		store := NewPostgresShareStore(db)
+
+		mock.ExpectQuery("SELECT ps.permission FROM portal_shares").
+			WithArgs("asset-1", "user-1", "user@example.com").
+			WillReturnRows(sqlmock.NewRows([]string{"permission"}).AddRow("editor"))
+
+		perm, err := store.GetUserAssetPermissionViaCollection(context.Background(), "asset-1", "user-1", "user@example.com")
+		assert.NoError(t, err)
+		assert.Equal(t, SharePermission("editor"), perm)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("not_found", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close() //nolint:errcheck // test cleanup
+
+		store := NewPostgresShareStore(db)
+
+		mock.ExpectQuery("SELECT ps.permission FROM portal_shares").
+			WithArgs("asset-1", "user-1", "user@example.com").
+			WillReturnError(sql.ErrNoRows)
+
+		perm, err := store.GetUserAssetPermissionViaCollection(context.Background(), "asset-1", "user-1", "user@example.com")
+		assert.Error(t, err)
+		assert.Equal(t, SharePermission(""), perm)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestPostgresShareStoreRevokeIdempotent(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer db.Close() //nolint:errcheck // test cleanup
@@ -561,8 +598,7 @@ func TestPostgresShareStoreRevokeNotFound(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
 	err = store.Revoke(context.Background(), "missing")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not found or already revoked")
+	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/ui/src/api/portal/hooks.ts
+++ b/ui/src/api/portal/hooks.ts
@@ -228,6 +228,7 @@ export function useRevokeShare() {
       apiFetch(`/shares/${shareId}`, { method: "DELETE" }),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ["shares"] });
+      void qc.invalidateQueries({ queryKey: ["collection-shares"] });
     },
   });
 }

--- a/ui/src/components/ShareDialog.tsx
+++ b/ui/src/components/ShareDialog.tsx
@@ -45,6 +45,7 @@ export function ShareDialog({ assetId, target, open, onOpenChange }: Props) {
   const [ttl, setTtl] = useState("24h");
   const [email, setEmail] = useState("");
   const [copied, setCopied] = useState<string | null>(null);
+  const [confirmRevoke, setConfirmRevoke] = useState<string | null>(null);
   const [permission, setPermission] = useState<SharePermission>("viewer");
   const [showOptions, setShowOptions] = useState(false);
   const [showExpiration, setShowExpiration] = useState(true);
@@ -97,7 +98,7 @@ export function ShareDialog({ assetId, target, open, onOpenChange }: Props) {
   const activeShares = shares.filter((s) => !s.revoked);
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+    <Dialog.Root open={open} onOpenChange={(v) => { if (!v) setConfirmRevoke(null); onOpenChange(v); }}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/40 z-40" />
         <Dialog.Content className="fixed top-1/2 left-1/2 z-50 -translate-x-1/2 -translate-y-1/2 w-full max-w-lg rounded-lg border bg-card p-6 shadow-lg">
@@ -259,14 +260,36 @@ export function ShareDialog({ assetId, target, open, onOpenChange }: Props) {
                           )}
                         </button>
                       )}
-                      <button
-                        type="button"
-                        onClick={() => revokeShare.mutate(share.id)}
-                        className="rounded p-1 hover:bg-destructive/10 text-destructive"
-                        title="Revoke"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
+                      {confirmRevoke === share.id ? (
+                        <div className="flex items-center gap-1">
+                          <button
+                            type="button"
+                            onClick={() => {
+                              revokeShare.mutate(share.id);
+                              setConfirmRevoke(null);
+                            }}
+                            className="rounded px-2 py-0.5 text-xs font-medium bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                          >
+                            Remove
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setConfirmRevoke(null)}
+                            className="rounded px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => setConfirmRevoke(share.id)}
+                          className="rounded p-1 hover:bg-destructive/10 text-destructive"
+                          title="Revoke"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </button>
+                      )}
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
## Summary

- Asset thumbnails inside shared collections returned 403 for recipients because `canViewAsset` only checked asset-level shares, not collection membership.
- Share revoke returned 500 on repeat clicks because `Revoke` errored on already-revoked shares and `useRevokeShare` did not invalidate collection share queries.
- The trash icon on shares fired the revoke mutation immediately with no confirmation step.

## What changed

### `pkg/portal/store.go`

`GetUserAssetPermissionViaCollection` joins `portal_shares` through `portal_collection_sections` and `portal_collection_items` to find whether a user has access to an asset via a shared collection. Returns the highest permission found.

`Revoke` is now idempotent: `UPDATE ... SET revoked = TRUE WHERE id = $1` without the `AND revoked = FALSE` guard, so revoking an already-revoked share succeeds silently.

### `pkg/portal/handler.go`

`canViewAsset` and `canEditAsset` fall back to `GetUserAssetPermissionViaCollection` when no direct asset share exists.

### `ui/src/api/portal/hooks.ts`

`useRevokeShare.onSuccess` now also invalidates `["collection-shares"]` queries so the share list refreshes after revoking a collection share.

### `ui/src/components/ShareDialog.tsx`

The trash icon now shows inline "Remove" / "Cancel" buttons instead of firing the mutation on click.

## Verified

- Ran `GetUserAssetPermissionViaCollection` SQL against production DB with a real shared user's email and an asset inside the shared collection. Returned `editor`.
- `TestGetThumbnailViaCollectionShare/granted_via_collection_share`: non-owner with no direct asset share but a collection-level share gets 200 and the thumbnail.
- `TestGetThumbnailViaCollectionShare/denied_without_any_share`: same user without any share gets 403.
- `TestGetThumbnailNotOwnerNotShared`: existing test unchanged, still 403.
- `TestRevokeCollectionShare` and `TestPostgresShareStoreRevokeIdempotent` pass.
- Full `go test -race ./pkg/portal/...` passes. `npx tsc --noEmit` clean.

## Test plan

- [x] `TestGetThumbnailViaCollectionShare/granted_via_collection_share` - 200
- [x] `TestGetThumbnailViaCollectionShare/denied_without_any_share` - 403
- [x] `TestGetThumbnailNotOwnerNotShared` - 403 (no regression)
- [x] `TestRevokeCollectionShare/owner_can_revoke` - 200
- [x] `TestPostgresShareStoreRevokeIdempotent` - no error on already-revoked
- [x] `go test -race ./pkg/portal/...` - all pass
- [x] `npx tsc --noEmit` - clean
- [ ] Deploy, open a shared collection as a recipient, verify asset thumbnails load
- [ ] Open share dialog, click trash, verify Remove/Cancel buttons appear before mutation fires