### PR TITLE
fix(portal): correct per-tool connection count in persona editor

### DIFF
--- a/ui/src/pages/settings/PersonaEditor.tsx
+++ b/ui/src/pages/settings/PersonaEditor.tsx
@@ -251,6 +251,16 @@ export function PersonaEditor({
     [connsData],
   );
 
+  const toolConnectionCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const conn of connections) {
+      for (const toolName of conn.tools ?? []) {
+        counts.set(toolName, (counts.get(toolName) ?? 0) + 1);
+      }
+    }
+    return counts;
+  }, [connections]);
+
   interface Item {
     key: string;
     primary: string;
@@ -261,16 +271,19 @@ export function PersonaEditor({
 
   const items = useMemo<Item[]>(() => {
     if (scope === "tools") {
-      return uniqueTools.map((t) => ({
-        key: t.name,
-        primary: t.name,
-        secondary: t.kinds.join(" · "),
-        tertiary:
-          t.connections.length === 1
-            ? "1 connection"
-            : `${t.connections.length} connections`,
-        kind: t.primaryKind,
-      }));
+      return uniqueTools.map((t) => {
+        const connCount = toolConnectionCounts.get(t.name) ?? t.connections.length;
+        return {
+          key: t.name,
+          primary: t.name,
+          secondary: t.kinds.join(" · "),
+          tertiary:
+            connCount === 1
+              ? "1 connection"
+              : `${connCount} connections`,
+          kind: t.primaryKind,
+        };
+      });
     }
     return connections.map((c) => {
       // The backend authorizes against toolkit.Connection() (see
@@ -288,7 +301,7 @@ export function PersonaEditor({
         kind: c.kind,
       };
     });
-  }, [scope, uniqueTools, connections]);
+  }, [scope, uniqueTools, connections, toolConnectionCounts]);
 
   const allowList = scope === "tools" ? draft.allowTools : draft.allowConnections;
   const denyList = scope === "tools" ? draft.denyTools : draft.denyConnections;


### PR DESCRIPTION
## Summary

- The persona editor's Tools tab showed "1 connection" for every tool, regardless of how many connections actually provide that tool. Multi-connection toolkits (e.g., API gateway with 10 upstream connections) expose the same tools (`api_export`, `api_invoke_endpoint`, etc.) across all upstreams, but the `/tools` API returns one entry per unique tool name with a single connection, so `aggregateTools` always counted 1.
- Added a `toolConnectionCounts` memo that cross-references the `/connections` response (which correctly expands multi-connection toolkits to one entry per real connection, each listing its tools) to derive the true count. Falls back to the existing `aggregateTools` count for tools not found in any connection (defensive).

## Root cause

Two admin API endpoints return overlapping but structurally different data:

| Endpoint | Granularity | Multi-connection toolkits |
|---|---|---|
| `GET /admin/tools` | One entry per unique tool name | Single `connection` field (first resolved) |
| `GET /admin/connections` | One entry per real connection | Full `tools[]` array per connection |

The old code derived connection counts solely from the tools response. The fix cross-references connections, which is the authoritative source for the tool-to-connection mapping.

## Test plan

- [ ] Open persona editor for a persona with `*` allow pattern
- [ ] Verify API tools show the correct connection count (e.g., "10 connections" matching the Connections tab)
- [ ] Verify non-multi-connection toolkits (Trino, DataHub, S3) still show "1 connection" correctly
- [ ] Switch to Connections tab and verify tool counts per connection are unchanged
- [ ] `make verify` passes (confirmed locally)