### PR TITLE
feat(apigateway): add WebDAV method support (PROPFIND, MKCOL, MOVE, COPY)

### DIFF
--- a/pkg/toolkits/apigateway/invoke.go
+++ b/pkg/toolkits/apigateway/invoke.go
@@ -32,6 +32,10 @@ var supportedMethods = map[string]bool{
 	http.MethodDelete: true,
 	http.MethodPatch:  true,
 	http.MethodHead:   true,
+	"PROPFIND":        true,
+	"MKCOL":           true,
+	"MOVE":            true,
+	"COPY":            true,
 }
 
 // maxTimeoutSeconds caps the per-call timeout the model can request.
@@ -58,6 +62,9 @@ var methodsAllowingBody = map[string]bool{
 	http.MethodPut:    true,
 	http.MethodDelete: true,
 	http.MethodPatch:  true,
+	"PROPFIND":        true,
+	"MOVE":            true,
+	"COPY":            true,
 }
 
 // InvokeInput is the parsed argument shape for api_invoke_endpoint.
@@ -181,7 +188,7 @@ func invoke(ctx context.Context, inv invocation, in InvokeInput) (InvokeOutput, 
 func validateMethod(method string) (string, error) {
 	m := strings.ToUpper(strings.TrimSpace(method))
 	if !supportedMethods[m] {
-		return "", fmt.Errorf("apigateway: method %q not supported (want GET, POST, PUT, DELETE, PATCH, or HEAD)", method)
+		return "", fmt.Errorf("apigateway: method %q not supported (want GET, POST, PUT, DELETE, PATCH, HEAD, PROPFIND, MKCOL, MOVE, or COPY)", method)
 	}
 	return m, nil
 }

--- a/pkg/toolkits/apigateway/invoke_test.go
+++ b/pkg/toolkits/apigateway/invoke_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestValidateMethod_AcceptsKnownAndRejectsOthers(t *testing.T) {
-	known := []string{"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"}
+	known := []string{"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "PROPFIND", "MKCOL", "MOVE", "COPY"}
 	for _, m := range known {
 		if got, err := validateMethod(m); err != nil || got != m {
 			t.Errorf("validateMethod(%q) = (%q, %v); want (%q, nil)", m, got, err, m)
@@ -23,7 +23,7 @@ func TestValidateMethod_AcceptsKnownAndRejectsOthers(t *testing.T) {
 	if got, err := validateMethod("get"); err != nil || got != "GET" {
 		t.Errorf("validateMethod(lowercase) = (%q, %v); want uppercase", got, err)
 	}
-	for _, m := range []string{"OPTIONS", "TRACE", "CONNECT", "BANANA"} {
+	for _, m := range []string{"OPTIONS", "TRACE", "CONNECT", "BANANA", "LOCK", "UNLOCK"} {
 		if _, err := validateMethod(m); err == nil {
 			t.Errorf("validateMethod(%q) want error", m)
 		}
@@ -579,6 +579,122 @@ func TestInvoke_EndToEnd_PostBodySent(t *testing.T) {
 	}
 	if !bytes.Contains(seenBody, []byte(`"name":"alice"`)) {
 		t.Errorf("body sent = %s", string(seenBody))
+	}
+}
+
+func TestInvoke_EndToEnd_PropfindSendsBody(t *testing.T) {
+	var seenMethod string
+	var seenBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenMethod = r.Method
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusMultiStatus)
+		_, _ = io.WriteString(w, `<multistatus/>`)
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		BaseURL: srv.URL, AuthMode: AuthModeNone,
+		ConnectTimeout: time.Second, CallTimeout: 5 * time.Second,
+		MaxResponseBytes: DefaultMaxResponseBytes,
+	}
+	auth, _ := NewAuthenticator(cfg)
+	xmlBody := `<?xml version="1.0"?><d:propfind xmlns:d="DAV:"><d:allprop/></d:propfind>`
+	out, err := invoke(context.Background(), invocation{cfg: cfg, auth: auth, client: newHTTPClient(cfg)}, InvokeInput{
+		Connection: "x", Method: "PROPFIND", Path: "/dav/files/user/",
+		Body:    xmlBody,
+		Headers: map[string]string{"Depth": "1", "Content-Type": "application/xml"},
+	})
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+	if seenMethod != "PROPFIND" {
+		t.Errorf("upstream method = %q; want PROPFIND", seenMethod)
+	}
+	if string(seenBody) != xmlBody {
+		t.Errorf("upstream body = %q; want XML propfind", string(seenBody))
+	}
+	if out.Status != http.StatusMultiStatus {
+		t.Errorf("status = %d; want 207", out.Status)
+	}
+}
+
+func TestInvoke_EndToEnd_WebDAVMethodsWithoutBody(t *testing.T) {
+	for _, method := range []string{"MKCOL", "MOVE", "COPY"} {
+		t.Run(method, func(t *testing.T) {
+			var seenMethod string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seenMethod = r.Method
+				w.WriteHeader(http.StatusCreated)
+			}))
+			defer srv.Close()
+
+			cfg := Config{
+				BaseURL: srv.URL, AuthMode: AuthModeNone,
+				ConnectTimeout: time.Second, CallTimeout: 5 * time.Second,
+				MaxResponseBytes: DefaultMaxResponseBytes,
+			}
+			auth, _ := NewAuthenticator(cfg)
+			out, err := invoke(context.Background(), invocation{cfg: cfg, auth: auth, client: newHTTPClient(cfg)}, InvokeInput{
+				Connection: "x", Method: method, Path: "/dav/files/user/folder",
+			})
+			if err != nil {
+				t.Fatalf("invoke: %v", err)
+			}
+			if seenMethod != method {
+				t.Errorf("upstream method = %q; want %q", seenMethod, method)
+			}
+			if out.Status != http.StatusCreated {
+				t.Errorf("status = %d; want 201", out.Status)
+			}
+		})
+	}
+}
+
+func TestEncodeBody_SkipsBodyForMKCOL(t *testing.T) {
+	body, ct, err := encodeBody("MKCOL", "should be dropped", nil, nil)
+	if err != nil {
+		t.Fatalf("encodeBody: %v", err)
+	}
+	if body != nil || ct != "" {
+		t.Errorf("body/ct = %v/%q; want nil/empty for MKCOL", body, ct)
+	}
+}
+
+func TestEncodeBody_AllowsBodyForMOVE(t *testing.T) {
+	xmlBody := `<?xml version="1.0"?><d:propertybehavior xmlns:d="DAV:"><d:keepalive>*</d:keepalive></d:propertybehavior>`
+	body, _, err := encodeBody("MOVE", xmlBody, nil, nil)
+	if err != nil {
+		t.Fatalf("encodeBody: %v", err)
+	}
+	if string(body) != xmlBody {
+		t.Errorf("body = %q; want XML propertybehavior", string(body))
+	}
+}
+
+func TestEncodeBody_AllowsBodyForCOPY(t *testing.T) {
+	xmlBody := `<?xml version="1.0"?><d:propertybehavior xmlns:d="DAV:"><d:keepalive>*</d:keepalive></d:propertybehavior>`
+	body, _, err := encodeBody("COPY", xmlBody, nil, nil)
+	if err != nil {
+		t.Fatalf("encodeBody: %v", err)
+	}
+	if string(body) != xmlBody {
+		t.Errorf("body = %q; want XML propertybehavior", string(body))
+	}
+}
+
+func TestEncodeBody_AllowsBodyForPROPFIND(t *testing.T) {
+	xmlBody := `<?xml version="1.0"?><d:propfind xmlns:d="DAV:"><d:allprop/></d:propfind>`
+	body, ct, err := encodeBody("PROPFIND", xmlBody, nil, nil)
+	if err != nil {
+		t.Fatalf("encodeBody: %v", err)
+	}
+	if string(body) != xmlBody {
+		t.Errorf("body = %q; want XML", string(body))
+	}
+	if !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("content-type = %q; want text/plain* (string body default)", ct)
 	}
 }
 

--- a/pkg/toolkits/apigateway/schemas.go
+++ b/pkg/toolkits/apigateway/schemas.go
@@ -75,7 +75,7 @@ var apiExportInputSchema = json.RawMessage(`{
     },
     "method": {
       "type": "string",
-      "enum": ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"],
+      "enum": ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "PROPFIND", "MKCOL", "MOVE", "COPY"],
       "description": "HTTP method. Required."
     },
     "path": {
@@ -138,7 +138,7 @@ var invokeEndpointSchema = json.RawMessage(`{
     },
     "method": {
       "type": "string",
-      "enum": ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"],
+      "enum": ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "PROPFIND", "MKCOL", "MOVE", "COPY"],
       "description": "HTTP method. Required."
     },
     "path": {
@@ -156,7 +156,7 @@ var invokeEndpointSchema = json.RawMessage(`{
       "additionalProperties": {"type": "string"}
     },
     "body": {
-      "description": "Optional request body. When the connection's OpenAPI catalog declares application/json on the resolved operation, objects/arrays are JSON-encoded and strings that parse as JSON pass through verbatim, both with Content-Type: application/json. Strings that do not parse as JSON, and bodies on operations the catalog does not declare, fall back to: objects/arrays as application/json, strings as text/plain. An explicit Content-Type in headers always wins. Ignored for GET and HEAD."
+      "description": "Optional request body. When the connection's OpenAPI catalog declares application/json on the resolved operation, objects/arrays are JSON-encoded and strings that parse as JSON pass through verbatim, both with Content-Type: application/json. Strings that do not parse as JSON, and bodies on operations the catalog does not declare, fall back to: objects/arrays as application/json, strings as text/plain. An explicit Content-Type in headers always wins. Ignored for GET, HEAD, and MKCOL."
     },
     "timeout_seconds": {
       "type": "integer",

--- a/pkg/toolkits/apigateway/toolkit.go
+++ b/pkg/toolkits/apigateway/toolkit.go
@@ -364,7 +364,8 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 		Description: "Make an authenticated HTTP request against a registered API connection. " +
 			"The connection's auth (none/bearer/api_key) is applied automatically; the model " +
 			"never handles credentials. Returns status, selected response headers, and the parsed " +
-			"or text response body. Method is restricted to GET, POST, PUT, DELETE, PATCH, HEAD; " +
+			"or text response body. Method is restricted to GET, POST, PUT, DELETE, PATCH, HEAD, " +
+			"PROPFIND, MKCOL, MOVE, COPY; " +
 			"path is joined to the connection's base_url; response bodies above the connection's " +
 			"max_response_bytes are truncated and flagged. Use list_connections to discover " +
 			"available kind=api connections.",


### PR DESCRIPTION
## Summary

- Adds PROPFIND, MKCOL, MOVE, and COPY to the API gateway's supported HTTP methods, enabling WebDAV-based connections (Nextcloud, SharePoint, ownCloud)
- PROPFIND, MOVE, and COPY allow request body forwarding per RFC 4918; MKCOL does not
- Updates tool description, JSON schema enums, and error messages to reflect the expanded method set

## Test plan

- [ ] `make verify` passes (all checks green)
- [ ] `TestValidateMethod_AcceptsKnownAndRejectsOthers` covers all 10 accepted methods and rejects LOCK/UNLOCK/OPTIONS/TRACE/CONNECT
- [ ] `TestInvoke_EndToEnd_PropfindSendsBody` proves PROPFIND forwards XML body and receives 207 Multi-Status
- [ ] `TestInvoke_EndToEnd_WebDAVMethodsWithoutBody` proves MKCOL/MOVE/COPY reach the upstream with the correct method
- [ ] `TestEncodeBody_SkipsBodyForMKCOL` confirms body is dropped for MKCOL
- [ ] `TestEncodeBody_AllowsBodyForMOVE` and `TestEncodeBody_AllowsBodyForCOPY` confirm body forwarding per RFC 4918
- [ ] `TestEncodeBody_AllowsBodyForPROPFIND` confirms body forwarding for PROPFIND

Closes #488