### PR TITLE
fix(connections): validate config before save, skip bad instances on startup (#467, #481)

### DIFF
--- a/pkg/admin/connection_handler.go
+++ b/pkg/admin/connection_handler.go
@@ -193,6 +193,11 @@ func (h *Handler) setConnectionInstance(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	if err := registry.ValidateConnectionConfig(kind, req.Config); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid connection config: "+err.Error())
+		return
+	}
+
 	inst := platform.ConnectionInstance{
 		Kind:        kind,
 		Name:        name,

--- a/pkg/admin/connection_handler_test.go
+++ b/pkg/admin/connection_handler_test.go
@@ -291,7 +291,7 @@ func TestSetConnectionInstance(t *testing.T) {
 		h := connTestHandler(store, true)
 
 		body := `{"description":"No config"}`
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/v1/admin/connection-instances/trino/prod", strings.NewReader(body))
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/v1/admin/connection-instances/s3/bucket1", strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, req)
@@ -302,6 +302,51 @@ func TestSetConnectionInstance(t *testing.T) {
 		require.NoError(t, json.NewDecoder(w.Body).Decode(&result))
 		assert.NotNil(t, result.Config)
 		assert.Empty(t, result.Config)
+	})
+
+	t.Run("invalid trino config returns 400", func(t *testing.T) {
+		store := &mockConnectionStore{}
+		h := connTestHandler(store, true)
+
+		body := `{"config":{},"description":"Missing host"}`
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/v1/admin/connection-instances/trino/prod", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		pd := decodeProblem(w.Body.Bytes())
+		assert.Contains(t, pd.Detail, "host is required")
+	})
+
+	t.Run("invalid api config returns 400", func(t *testing.T) {
+		store := &mockConnectionStore{}
+		h := connTestHandler(store, true)
+
+		body := `{"config":{},"description":"Missing base_url"}`
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/v1/admin/connection-instances/api/test", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		pd := decodeProblem(w.Body.Bytes())
+		assert.Contains(t, pd.Detail, "base_url is required")
+	})
+
+	t.Run("invalid mcp config returns 400", func(t *testing.T) {
+		store := &mockConnectionStore{}
+		h := connTestHandler(store, true)
+
+		body := `{"config":{},"description":"Missing endpoint"}`
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/v1/admin/connection-instances/mcp/test", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		pd := decodeProblem(w.Body.Bytes())
+		assert.Contains(t, pd.Detail, "endpoint is required")
 	})
 
 	t.Run("read-only mode returns 404 for PUT", func(t *testing.T) {
@@ -824,8 +869,8 @@ func TestSetConnectionInstance_StripsMTLSCertNotAfterFromIncomingBody(t *testing
 		"description": "test"
 	}`)
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut,
-		"/api/v1/admin/connection-instances/trino/test", body)
-	req.SetPathValue("kind", "trino")
+		"/api/v1/admin/connection-instances/api/test", body)
+	req.SetPathValue("kind", "api")
 	req.SetPathValue("name", "test")
 	rr := httptest.NewRecorder()
 	h.setConnectionInstance(rr, req)

--- a/pkg/registry/factories.go
+++ b/pkg/registry/factories.go
@@ -75,9 +75,10 @@ func S3Factory(name string, cfg map[string]any) (Toolkit, error) {
 }
 
 // GatewayAggregateFactory creates a multi-connection gateway toolkit from
-// all configured instances. Per-instance config parse errors fail the
-// factory; upstream connectivity failures are absorbed and logged so an
-// unreachable upstream cannot block platform startup.
+// all configured instances. Per-instance config parse errors are logged
+// and skipped by ParseMultiConfig; upstream connectivity failures are
+// absorbed and logged so a misconfigured or unreachable upstream cannot
+// block platform startup.
 func GatewayAggregateFactory(defaultName string, instances map[string]map[string]any) (Toolkit, error) {
 	cfg, err := gatewaykit.ParseMultiConfig(defaultName, instances)
 	if err != nil {
@@ -88,15 +89,40 @@ func GatewayAggregateFactory(defaultName string, instances map[string]map[string
 
 // APIGatewayAggregateFactory creates a multi-connection api-gateway
 // toolkit from all configured instances. Per-instance config parse
-// errors fail the factory; per-connection materialization failures
-// (auth-builder errors) are logged and skipped so a single bad
-// connection cannot block platform startup. Outbound HTTP failures
-// happen at invocation time and are surfaced through the tool's
-// response envelope, not at startup.
+// errors are logged and skipped by ParseMultiConfig; per-connection
+// materialization failures (auth-builder errors) are also logged and
+// skipped so a single bad connection cannot block platform startup.
+// Outbound HTTP failures happen at invocation time and are surfaced
+// through the tool's response envelope, not at startup.
 func APIGatewayAggregateFactory(defaultName string, instances map[string]map[string]any) (Toolkit, error) {
 	cfg, err := apigatewaykit.ParseMultiConfig(defaultName, instances)
 	if err != nil {
 		return nil, fmt.Errorf("parsing apigateway multi config: %w", err)
 	}
 	return apigatewaykit.NewMulti(cfg), nil
+}
+
+// ValidateConnectionConfig validates a connection config map against
+// the per-kind parser. Returns nil when the config is valid or the
+// kind has no registered validator.
+func ValidateConnectionConfig(kind string, cfg map[string]any) error {
+	var err error
+	switch kind {
+	case "trino":
+		_, err = trinokit.ParseConfig(cfg)
+	case "datahub":
+		_, err = datahubkit.ParseConfig(cfg)
+	case "s3":
+		_, err = s3kit.ParseConfig(cfg)
+	case gatewaykit.Kind:
+		_, err = gatewaykit.ParseConfig(cfg)
+	case apigatewaykit.Kind:
+		_, err = apigatewaykit.ParseConfig(cfg)
+	default:
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("validating %s config: %w", kind, err)
+	}
+	return nil
 }

--- a/pkg/registry/factories_test.go
+++ b/pkg/registry/factories_test.go
@@ -1,0 +1,85 @@
+package registry
+
+import (
+	"testing"
+)
+
+func TestValidateConnectionConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		kind    string
+		cfg     map[string]any
+		wantErr bool
+	}{
+		{
+			name:    "trino valid",
+			kind:    "trino",
+			cfg:     map[string]any{"host": "trino.example.com"},
+			wantErr: false,
+		},
+		{
+			name:    "trino missing host",
+			kind:    "trino",
+			cfg:     map[string]any{},
+			wantErr: true,
+		},
+		{
+			name:    "s3 empty config valid",
+			kind:    "s3",
+			cfg:     map[string]any{},
+			wantErr: false,
+		},
+		{
+			name:    "datahub missing url",
+			kind:    "datahub",
+			cfg:     map[string]any{},
+			wantErr: true,
+		},
+		{
+			name:    "datahub valid",
+			kind:    "datahub",
+			cfg:     map[string]any{"url": "http://datahub.example.com"},
+			wantErr: false,
+		},
+		{
+			name:    "mcp gateway missing endpoint",
+			kind:    "mcp",
+			cfg:     map[string]any{},
+			wantErr: true,
+		},
+		{
+			name:    "mcp gateway valid",
+			kind:    "mcp",
+			cfg:     map[string]any{"endpoint": "http://upstream.example.com/mcp"},
+			wantErr: false,
+		},
+		{
+			name:    "api gateway missing base_url",
+			kind:    "api",
+			cfg:     map[string]any{},
+			wantErr: true,
+		},
+		{
+			name:    "api gateway valid",
+			kind:    "api",
+			cfg:     map[string]any{"base_url": "http://api.example.com"},
+			wantErr: false,
+		},
+		{
+			name:    "unknown kind passes",
+			kind:    "custom",
+			cfg:     map[string]any{},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateConnectionConfig(tc.kind, tc.cfg)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ValidateConnectionConfig(%q) error = %v, wantErr %v",
+					tc.kind, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/registry/loader.go
+++ b/pkg/registry/loader.go
@@ -1,7 +1,7 @@
 package registry
 
 import (
-	"fmt"
+	"log/slog"
 	"maps"
 )
 
@@ -57,7 +57,9 @@ func (l *Loader) Load(cfg LoaderConfig) error {
 			}
 
 			if err := l.registry.CreateAndRegister(toolkitCfg); err != nil {
-				return fmt.Errorf("loading toolkit %s/%s: %w", kind, name, err)
+				slog.Warn("skipping bad toolkit instance",
+					"kind", kind, "name", name, "error", err)
+				continue
 			}
 		}
 	}
@@ -110,7 +112,9 @@ func (l *Loader) loadKindFromMap(kind string, kindMap map[string]any) error {
 		}
 
 		if err := l.registry.CreateAndRegister(toolkitCfg); err != nil {
-			return fmt.Errorf("loading toolkit %s/%s: %w", kind, name, err)
+			slog.Warn("skipping bad toolkit instance",
+				"kind", kind, "name", name, "error", err)
+			continue
 		}
 	}
 	return nil
@@ -137,7 +141,9 @@ func (l *Loader) loadAggregate(
 ) error {
 	toolkit, err := factory(defaultName, instances)
 	if err != nil {
-		return fmt.Errorf("loading aggregate toolkit %s: %w", kind, err)
+		slog.Warn("skipping aggregate toolkit",
+			"kind", kind, "error", err)
+		return nil
 	}
 	return l.registry.Register(toolkit)
 }

--- a/pkg/registry/loader_test.go
+++ b/pkg/registry/loader_test.go
@@ -93,9 +93,9 @@ func TestLoader_Load(t *testing.T) {
 		}
 	})
 
-	t.Run("missing factory", func(t *testing.T) {
-		registry := NewRegistry()
-		loader := NewLoader(registry)
+	t.Run("missing factory skipped", func(t *testing.T) {
+		reg := NewRegistry()
+		loader := NewLoader(reg)
 
 		cfg := LoaderConfig{
 			Toolkits: map[string]ToolkitKindConfig{
@@ -109,8 +109,11 @@ func TestLoader_Load(t *testing.T) {
 		}
 
 		err := loader.Load(cfg)
-		if err == nil {
-			t.Error("expected error for missing factory")
+		if err != nil {
+			t.Errorf("expected error to be skipped, got: %v", err)
+		}
+		if len(reg.All()) != 0 {
+			t.Errorf("expected 0 toolkits, got %d", len(reg.All()))
 		}
 	})
 
@@ -173,7 +176,7 @@ func TestLoader_Load(t *testing.T) {
 		}
 	})
 
-	t.Run("aggregate factory error propagated", func(t *testing.T) {
+	t.Run("aggregate factory error skipped", func(t *testing.T) {
 		reg := NewRegistry()
 		reg.RegisterAggregateFactory("failing", func(_ string, _ map[string]map[string]any) (Toolkit, error) {
 			return nil, fmt.Errorf("aggregate creation failed")
@@ -190,8 +193,11 @@ func TestLoader_Load(t *testing.T) {
 		}
 
 		err := loader.Load(cfg)
-		if err == nil {
-			t.Error("expected error from aggregate factory")
+		if err != nil {
+			t.Errorf("expected error to be skipped, got: %v", err)
+		}
+		if len(reg.All()) != 0 {
+			t.Errorf("expected 0 toolkits, got %d", len(reg.All()))
 		}
 	})
 }
@@ -281,9 +287,9 @@ func TestLoader_LoadFromMap(t *testing.T) {
 		}
 	})
 
-	t.Run("missing factory", func(t *testing.T) {
-		registry := NewRegistry()
-		loader := NewLoader(registry)
+	t.Run("missing factory skipped", func(t *testing.T) {
+		reg := NewRegistry()
+		loader := NewLoader(reg)
 
 		toolkits := map[string]any{
 			"unknown": map[string]any{
@@ -295,8 +301,11 @@ func TestLoader_LoadFromMap(t *testing.T) {
 		}
 
 		err := loader.LoadFromMap(toolkits)
-		if err == nil {
-			t.Error("expected error for missing factory")
+		if err != nil {
+			t.Errorf("expected error to be skipped, got: %v", err)
+		}
+		if len(reg.All()) != 0 {
+			t.Errorf("expected 0 toolkits, got %d", len(reg.All()))
 		}
 	})
 
@@ -349,7 +358,7 @@ func TestLoader_LoadFromMap(t *testing.T) {
 		}
 	})
 
-	t.Run("aggregate factory error from map", func(t *testing.T) {
+	t.Run("aggregate factory error from map skipped", func(t *testing.T) {
 		reg := NewRegistry()
 		reg.RegisterAggregateFactory("fail-map", func(_ string, _ map[string]map[string]any) (Toolkit, error) {
 			return nil, fmt.Errorf("map aggregate failed")
@@ -364,8 +373,11 @@ func TestLoader_LoadFromMap(t *testing.T) {
 		}
 
 		err := loader.LoadFromMap(toolkits)
-		if err == nil {
-			t.Error("expected error from aggregate factory")
+		if err != nil {
+			t.Errorf("expected error to be skipped, got: %v", err)
+		}
+		if len(reg.All()) != 0 {
+			t.Errorf("expected 0 toolkits, got %d", len(reg.All()))
 		}
 	})
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -385,12 +385,15 @@ func TestGatewayAggregateFactory_NoInstancesReturnsEmptyToolkit(t *testing.T) {
 	_ = tk.Close()
 }
 
-func TestGatewayAggregateFactory_BadInstanceConfigReturnsError(t *testing.T) {
-	_, err := GatewayAggregateFactory(regTestTest, map[string]map[string]any{
-		"broken": {}, // missing endpoint
+func TestGatewayAggregateFactory_BadInstanceSkipped(t *testing.T) {
+	tk, err := GatewayAggregateFactory(regTestTest, map[string]map[string]any{
+		"broken": {}, // missing endpoint, skipped
 	})
-	if err == nil {
-		t.Fatal("expected parse error for missing endpoint")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tk.Kind() != "mcp" {
+		t.Errorf("Kind: got %q, want %q", tk.Kind(), "mcp")
 	}
 }
 
@@ -411,12 +414,15 @@ func TestAPIGatewayAggregateFactory_NoInstancesReturnsEmptyToolkit(t *testing.T)
 	_ = tk.Close()
 }
 
-func TestAPIGatewayAggregateFactory_BadInstanceConfigReturnsError(t *testing.T) {
-	_, err := APIGatewayAggregateFactory(regTestTest, map[string]map[string]any{
-		"broken": {}, // missing base_url
+func TestAPIGatewayAggregateFactory_BadInstanceSkipped(t *testing.T) {
+	tk, err := APIGatewayAggregateFactory(regTestTest, map[string]map[string]any{
+		"broken": {}, // missing base_url, skipped
 	})
-	if err == nil {
-		t.Fatal("expected parse error for missing base_url")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tk.Kind() != "api" {
+		t.Errorf("Kind: got %q, want %q", tk.Kind(), "api")
 	}
 }
 

--- a/pkg/toolkits/apigateway/config.go
+++ b/pkg/toolkits/apigateway/config.go
@@ -13,6 +13,7 @@ package apigateway
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"strings"
 	"time"
@@ -319,14 +320,17 @@ type MultiConfig struct {
 }
 
 // ParseMultiConfig validates and returns the parsed config for every
-// instance. Per-instance parse errors fail the platform startup; HTTP
+// instance. Per-instance parse errors are logged and the bad instance is
+// skipped so one misconfigured connection cannot block startup. HTTP
 // connectivity failures are handled at invocation time, not here.
 func ParseMultiConfig(defaultName string, raw map[string]map[string]any) (MultiConfig, error) {
 	parsed := make(map[string]Config, len(raw))
 	for name, r := range raw {
 		c, err := ParseConfig(r)
 		if err != nil {
-			return MultiConfig{}, fmt.Errorf("apigateway/%s: %w", name, err)
+			slog.Warn("skipping invalid connection instance",
+				"kind", Kind, "instance", name, "error", err)
+			continue
 		}
 		if c.ConnectionName == "" {
 			c.ConnectionName = name

--- a/pkg/toolkits/apigateway/config_test.go
+++ b/pkg/toolkits/apigateway/config_test.go
@@ -466,15 +466,22 @@ func TestParseMultiConfig_SetsConnectionName(t *testing.T) {
 	}
 }
 
-func TestParseMultiConfig_PropagatesPerInstanceError(t *testing.T) {
-	_, err := ParseMultiConfig("", map[string]map[string]any{
-		"bad": {"auth_mode": AuthModeBearer}, // missing base_url + credential
+func TestParseMultiConfig_SkipsBadInstance(t *testing.T) {
+	mc, err := ParseMultiConfig("good", map[string]map[string]any{
+		"good": {"base_url": "http://good.example.com"},
+		"bad":  {"auth_mode": AuthModeBearer}, // missing base_url + credential
 	})
-	if err == nil {
-		t.Fatal("ParseMultiConfig: want error, got nil")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "apigateway/bad") {
-		t.Errorf("error = %q; want instance-prefixed error", err.Error())
+	if len(mc.Instances) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(mc.Instances))
+	}
+	if _, ok := mc.Instances["good"]; !ok {
+		t.Error("expected good instance to be present")
+	}
+	if _, ok := mc.Instances["bad"]; ok {
+		t.Error("expected bad instance to be excluded")
 	}
 }
 

--- a/pkg/toolkits/gateway/config.go
+++ b/pkg/toolkits/gateway/config.go
@@ -5,6 +5,7 @@ package gateway
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 )
 
@@ -152,15 +153,17 @@ type MultiConfig struct {
 }
 
 // ParseMultiConfig validates and returns the parsed config for every
-// instance. Per-instance parse errors are surfaced as fatal (operator must
-// fix the config); dial/connectivity errors are handled at load time in
-// NewMulti, not here.
+// instance. Per-instance parse errors are logged and the bad instance is
+// skipped so one misconfigured connection cannot block startup.
+// Dial/connectivity errors are handled at load time in NewMulti, not here.
 func ParseMultiConfig(defaultName string, raw map[string]map[string]any) (MultiConfig, error) {
 	parsed := make(map[string]Config, len(raw))
 	for name, r := range raw {
 		c, err := ParseConfig(r)
 		if err != nil {
-			return MultiConfig{}, fmt.Errorf("gateway/%s: %w", name, err)
+			slog.Warn("skipping invalid connection instance",
+				"kind", Kind, "instance", name, "error", err)
+			continue
 		}
 		if c.ConnectionName == "" {
 			c.ConnectionName = name

--- a/pkg/toolkits/gateway/toolkit_test.go
+++ b/pkg/toolkits/gateway/toolkit_test.go
@@ -290,15 +290,22 @@ func TestNewMulti_LoadsHealthyInstances(t *testing.T) {
 	}
 }
 
-func TestParseMultiConfig_SurfacesBadInstance(t *testing.T) {
-	_, err := ParseMultiConfig("primary", map[string]map[string]any{
+func TestParseMultiConfig_SkipsBadInstance(t *testing.T) {
+	mc, err := ParseMultiConfig("primary", map[string]map[string]any{
+		"good":  {"endpoint": "http://good.example.com/mcp"},
 		connCRM: {}, // no endpoint
 	})
-	if err == nil {
-		t.Fatal("expected parse error")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "gateway/crm") {
-		t.Errorf("error should name the instance, got: %v", err)
+	if len(mc.Instances) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(mc.Instances))
+	}
+	if _, ok := mc.Instances["good"]; !ok {
+		t.Error("expected good instance to be present")
+	}
+	if _, ok := mc.Instances[connCRM]; ok {
+		t.Error("expected bad instance to be excluded")
 	}
 }
 

--- a/pkg/toolkits/trino/config.go
+++ b/pkg/toolkits/trino/config.go
@@ -2,6 +2,7 @@ package trino
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 )
 
@@ -23,7 +24,9 @@ func ParseMultiConfig(defaultName string, instances map[string]map[string]any) (
 	for name, raw := range instances {
 		cfg, err := ParseConfig(raw)
 		if err != nil {
-			return mc, fmt.Errorf("instance %s: %w", name, err)
+			slog.Warn("skipping invalid connection instance",
+				"kind", "trino", "instance", name, "error", err)
+			continue
 		}
 		if cfg.ConnectionName == "" {
 			cfg.ConnectionName = name

--- a/pkg/toolkits/trino/config_test.go
+++ b/pkg/toolkits/trino/config_test.go
@@ -524,26 +524,38 @@ func TestParseMultiConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("error in instance config", func(t *testing.T) {
+	t.Run("bad instance skipped good instance kept", func(t *testing.T) {
 		instances := map[string]map[string]any{
 			"good": {"host": "good.example.com"},
 			"bad":  {"timeout": "not-a-duration"},
 		}
 
-		_, err := ParseMultiConfig("good", instances)
-		if err == nil {
-			t.Error("expected error for invalid instance config")
+		mc, err := ParseMultiConfig("good", instances)
+		if err != nil {
+			t.Fatalf(trinoCfgTestUnexpectedErr, err)
+		}
+		if len(mc.Instances) != 1 {
+			t.Fatalf("expected 1 instance, got %d", len(mc.Instances))
+		}
+		if _, ok := mc.Instances["good"]; !ok {
+			t.Error("expected good instance to be present")
+		}
+		if _, ok := mc.Instances["bad"]; ok {
+			t.Error("expected bad instance to be excluded")
 		}
 	})
 
-	t.Run("missing host returns error", func(t *testing.T) {
+	t.Run("missing host skips instance", func(t *testing.T) {
 		instances := map[string]map[string]any{
 			"missing-host": {"user": "testuser"},
 		}
 
-		_, err := ParseMultiConfig("missing-host", instances)
-		if err == nil {
-			t.Error("expected error for missing host")
+		mc, err := ParseMultiConfig("missing-host", instances)
+		if err != nil {
+			t.Fatalf(trinoCfgTestUnexpectedErr, err)
+		}
+		if len(mc.Instances) != 0 {
+			t.Errorf("expected 0 instances, got %d", len(mc.Instances))
 		}
 	})
 }

--- a/ui/src/pages/settings/ConnectionsPanel.tsx
+++ b/ui/src/pages/settings/ConnectionsPanel.tsx
@@ -468,6 +468,85 @@ export function ConnectionsPanel() {
 // Connection Viewer (read-only)
 // ---------------------------------------------------------------------------
 
+const CONFIG_LABELS: Record<string, Record<string, string>> = {
+  trino: {
+    host: "Host",
+    port: "Port",
+    user: "Username",
+    password: "Password",
+    catalog: "Default Catalog",
+    schema: "Default Schema",
+    ssl: "SSL / TLS",
+    ssl_verify: "SSL Verify",
+    read_only: "Read Only",
+    default_limit: "Default Limit",
+    max_limit: "Max Limit",
+    timeout: "Timeout",
+    connection_name: "Connection Name",
+    description: "Description",
+  },
+  s3: {
+    endpoint: "Endpoint",
+    region: "Region",
+    access_key_id: "Access Key ID",
+    secret_access_key: "Secret Access Key",
+    session_token: "Session Token",
+    profile: "Profile",
+    bucket_prefix: "Bucket Prefix",
+    use_path_style: "Force Path Style",
+    disable_ssl: "Disable SSL",
+    read_only: "Read Only",
+    timeout: "Timeout",
+    max_get_size: "Max GET Size",
+    max_put_size: "Max PUT Size",
+    connection_name: "Connection Name",
+  },
+  mcp: {
+    endpoint: "Endpoint",
+    auth_mode: "Auth Mode",
+    credential: "Credential",
+    connect_timeout: "Connect Timeout",
+    call_timeout: "Call Timeout",
+    trust_level: "Trust Level",
+    connection_name: "Connection Name",
+    oauth_grant: "OAuth Grant Type",
+    oauth_token_url: "OAuth Token URL",
+    oauth_authorization_url: "OAuth Authorization URL",
+    oauth_client_id: "OAuth Client ID",
+    oauth_client_secret: "OAuth Client Secret",
+    oauth_scope: "OAuth Scope",
+    oauth_prompt: "OAuth Prompt",
+  },
+  api: {
+    base_url: "Base URL",
+    auth_mode: "Auth Mode",
+    credential: "Credential",
+    api_key_header: "API Key Header",
+    api_key_param: "API Key Parameter",
+    api_key_placement: "API Key Placement",
+    username: "Username",
+    password: "Password",
+    connect_timeout: "Connect Timeout",
+    call_timeout: "Call Timeout",
+    trust_level: "Trust Level",
+    max_response_bytes: "Max Response Bytes",
+    catalog_id: "OpenAPI Catalog",
+    connection_name: "Connection Name",
+    oauth2_token_url: "OAuth2 Token URL",
+    oauth2_authorization_url: "OAuth2 Authorization URL",
+    oauth2_client_id: "OAuth2 Client ID",
+    oauth2_client_secret: "OAuth2 Client Secret",
+    oauth2_scopes: "OAuth2 Scopes",
+    oauth2_endpoint_auth_style: "OAuth2 Auth Style",
+    oauth2_prompt: "OAuth2 Prompt",
+    mtls_client_cert_pem: "mTLS Client Certificate",
+    mtls_client_key_pem: "mTLS Client Key",
+    mtls_cert_not_after: "mTLS Cert Expiry",
+    tls_ca_bundle_pem: "TLS CA Bundle",
+    static_headers: "Static Headers",
+  },
+};
+
 function ConnectionViewer({
   connection,
   isReadOnly,
@@ -584,10 +663,15 @@ function ConnectionViewer({
               const displayValue = typeof value === "object" && value !== null
                 ? JSON.stringify(value)
                 : String(value);
+              const labelMap = CONFIG_LABELS[connection.kind] ?? {};
+              const displayLabel = labelMap[key];
               return (
                 <div key={key} className="flex items-center gap-4 px-4 py-2">
-                  <span className="text-xs font-mono text-muted-foreground w-48 shrink-0 truncate">
-                    {key}
+                  <span className="text-xs text-muted-foreground w-48 shrink-0 truncate" title={key}>
+                    {displayLabel ?? key}
+                    {displayLabel && (
+                      <span className="ml-1 font-mono text-[10px] opacity-50">{key}</span>
+                    )}
                   </span>
                   <span className="text-xs font-mono flex-1 truncate">
                     {displayValue}
@@ -714,6 +798,14 @@ function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: Edito
     setConfigObj(next);
   }, []);
   const configJson = JSON.stringify(configObj); // for dirty tracking
+  const isConfigValid = useMemo(() => {
+    switch (kind) {
+      case "trino": return Boolean(configObj.host);
+      case "mcp": return Boolean(configObj.endpoint);
+      case "api": return Boolean(configObj.base_url);
+      default: return true;
+    }
+  }, [kind, configObj]);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
@@ -787,7 +879,7 @@ function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: Edito
           <button
             type="button"
             onClick={handleSave}
-            disabled={isPending || (isCreate && (!name.trim() || !nameValid))}
+            disabled={isPending || !isConfigValid || (isCreate && (!name.trim() || !nameValid))}
             className={cn(
               "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-all disabled:opacity-50",
               saveSuccess
@@ -954,6 +1046,7 @@ function ConfigField({
   placeholder,
   mono,
   sensitive,
+  required,
 }: {
   label: string;
   help?: string;
@@ -963,10 +1056,14 @@ function ConfigField({
   placeholder?: string;
   mono?: boolean;
   sensitive?: boolean;
+  required?: boolean;
 }) {
   return (
     <div>
-      <label className="mb-1 block text-xs font-medium">{label}</label>
+      <label className="mb-1 block text-xs font-medium">
+        {label}
+        {required && <span className="text-destructive ml-0.5">*</span>}
+      </label>
       <input
         type={sensitive ? "password" : type}
         value={value}
@@ -1040,6 +1137,7 @@ function TrinoConfigForm({ config, onChange }: ConfigFormProps) {
           onChange={(v) => onChange(update(config, "host", v))}
           placeholder="trino.example.com"
           mono
+          required
           help="Trino coordinator hostname or IP address"
         />
         <ConfigField
@@ -1431,6 +1529,7 @@ function GatewayConfigForm({ config, onChange }: ConfigFormProps) {
         onChange={(v) => onChange(update(config, "endpoint", v))}
         placeholder="https://vendor.example.com/mcp"
         mono
+        required
       />
       <div>
         <label className="mb-1 block text-xs font-medium">Auth mode</label>
@@ -1762,6 +1861,7 @@ function ApiGatewayConfigForm({
         onChange={(v) => onChange(update(config, "base_url", v))}
         placeholder="https://api.vendor.example.com"
         mono
+        required
       />
       <div>
         <div className="mb-1 flex items-center justify-between">


### PR DESCRIPTION
## Summary

Closes #467, closes #481.

A malformed `connection_instances` row crash-loops the server on startup. The aggregate toolkit loader aborts the entire toolkit kind on the first parse failure, so one bad row brings down all connections of that kind. The root cause is that the admin save endpoint persists rows without calling per-kind config validation, so invalid configs enter the database silently in the first place.

These two issues are two halves of the same problem. This PR addresses both: prevent bad rows at write time, survive them at read time, and surface required fields in the portal so operators see the constraint before they save.

## Changes

### Write-time validation (#481)
- `pkg/registry/factories.go`: New `ValidateConnectionConfig(kind, cfg)` dispatches to the per-kind `ParseConfig`. Returns a wrapped error keyed by kind.
- `pkg/admin/connection_handler.go`: `setConnectionInstance` calls the validator between the existing catalog check and `ConnectionStore.Set`. Returns 400 on invalid config. Placement is after the redacted-field merge so secrets are not seen by validation as `[REDACTED]` strings.

### Read-time resilience (#467)
- `pkg/toolkits/{trino,gateway,apigateway}/config.go`: `ParseMultiConfig` now logs a warning and skips bad instances instead of returning an error. If all instances are bad, the toolkit loads with zero connections (safe, just no tools exposed).
- `pkg/registry/loader.go`: `Load`, `LoadFromMap`, and `loadAggregate` skip-and-warn instead of returning errors, so any per-instance or aggregate failure does not block startup.

### Portal UI
- `ui/src/pages/settings/ConnectionsPanel.tsx`:
  - `ConfigField` gains a `required` prop that renders a red asterisk.
  - Trino Host, MCP gateway Endpoint, API gateway Base URL marked as required.
  - Save button disabled until required fields are filled (`isConfigValid` memo).
  - New `CONFIG_LABELS` map renders human-readable field labels in the read-only detail view, with the raw snake_case key shown as small secondary text for operators who need it.

## Why both halves

Fixing only write-time validation leaves any pre-existing bad row in production untouched. Fixing only read-time resilience silently degrades the system on every load. Both are needed: prevention plus tolerance.

## Test plan

- [x] `make verify` passes locally (fmt, test, lint, security, semgrep, codeql, coverage ≥80%, patch coverage ≥80%, doc-check, dead-code, mutation ≥60%, release dry-run)
- [x] `golangci-lint --new-from-rev=origin/main` clean
- [x] Unit tests: `pkg/registry/factories_test.go` covers `ValidateConnectionConfig` per kind (valid, missing required, unknown kind passes)
- [x] Admin handler tests: invalid trino/api/mcp configs return 400 with the per-kind required-field message
- [x] `ParseMultiConfig` tests updated in trino/gateway/apigateway to assert skip-and-warn (bad instance excluded, good instance retained, no error)
- [x] Loader tests assert aggregate factory failures and unknown kinds are skipped without blocking startup
- [x] UI: TypeScript compiles, required-field asterisks render, Save button disabled when required field empty
- [ ] Manual: insert a malformed `connection_instances` row, restart server, verify it starts with a warning log and the bad connection is excluded from `list_connections`
- [ ] Manual: PUT a connection with empty config via admin API for each kind, verify 400 with the kind-specific required-field error