### PR TITLE
feat(audit): tag events with event_kind to split MCP from API gateway (#465)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -809,6 +809,7 @@ Every tool call produces one row in `audit_logs` with these fields:
 | `parameters` | JSONB | Tool call arguments with sensitive values redacted. |
 | `success` | BOOLEAN | `true` if tool handler succeeded. |
 | `error_message` | TEXT | Error description if `success` is `false`. |
+| `event_kind` | VARCHAR(64) | High-level category: `apigateway_invoke` for apigateway HTTP calls, `mcp_tool_call` for all other toolkits. See [Event kind](#event-kind-mcp-vs-api-gateway). |
 | `created_date` | DATE | Partition key derived from `timestamp`. |
 
 ## Parameter Sanitization
@@ -840,6 +841,17 @@ Tools on this platform are reachable through three entry points; the audit row's
 | `admin` | Admin REST API at `POST /api/v1/admin/tools/call`. Portal-driven tool runs. |
 
 Both REST entry points open an in-memory MCP session against the assembled server and tag the context (`middleware.WithSource`) before the call so the existing audit middleware records the originating class. Filter via `GET /api/v1/admin/audit/events?source=...` or the **All Sources** dropdown in the portal.
+
+## Event kind: MCP vs API gateway
+
+The `event_kind` field separates apigateway HTTP traffic from MCP tool calls. It is derived at write time from the toolkit kind — `apigateway_invoke` when the toolkit kind is `api`, `mcp_tool_call` otherwise — so it does not rely on tool-name matching. The split lets the MCP Activity view exclude high-volume gateway traffic by default while a dedicated gateway view includes it.
+
+| `event_kind` | Meaning |
+|--------------|---------|
+| `mcp_tool_call` | Tool routed through the trino, datahub, s3, or MCP gateway toolkits. |
+| `apigateway_invoke` | HTTP API call through the apigateway toolkit (`api_*` tools). |
+
+Accepted on the event list, stats, and all metrics endpoints (timeseries, breakdown, overview, performance, enrichment, discovery): `GET /api/v1/admin/audit/events?event_kind=apigateway_invoke`.
 
 ## Retention and partition rotation
 

--- a/docs/server/audit.md
+++ b/docs/server/audit.md
@@ -53,6 +53,7 @@ Every successful or failed tool call produces one row in `audit_logs`:
   "parameters": {"sql": "SELECT count(*) FROM orders"},
   "success": true,
   "error_message": "",
+  "event_kind": "mcp_tool_call",
   "created_date": "2026-02-04"
 }
 ```
@@ -86,6 +87,7 @@ Every successful or failed tool call produces one row in `audit_logs`:
 | `enrichment_tokens_full` | INTEGER | Estimated tokens for the full (non-dedup) enrichment content. Uses `chars / 4` approximation. |
 | `enrichment_tokens_dedup` | INTEGER | Estimated tokens for the dedup enrichment content. `0` when full enrichment was sent. |
 | `enrichment_mode` | VARCHAR(20) | Enrichment mode used: `full`, `summary`, `reference`, `none`, or empty (not enriched). |
+| `event_kind` | VARCHAR(64) | High-level event category: `apigateway_invoke` for HTTP API calls through the apigateway toolkit, `mcp_tool_call` for every other toolkit. Lets the Activity view split gateway traffic from MCP tool calls. See [Event kind](#event-kind-mcp-vs-api-gateway). |
 | `created_date` | DATE | Partition key derived from `timestamp`. Used for retention cleanup. |
 
 ## Caller class via source
@@ -109,6 +111,25 @@ GET /api/v1/admin/audit/events?source=admin   # portal-driven only
 ```
 
 Or in the portal UI, use the **All Sources** dropdown on the Audit Log page. The dropdown lists every source value seen in the current time window.
+
+## Event kind: MCP vs API gateway
+
+The `event_kind` field separates two classes of audited activity that otherwise share the same row shape:
+
+| `event_kind` | What it means |
+|--------------|---------------|
+| `mcp_tool_call` | A tool routed through one of the MCP toolkits (`trino`, `datahub`, `s3`, or the MCP gateway). |
+| `apigateway_invoke` | An HTTP API call proxied through the apigateway toolkit (`api_invoke_endpoint`, `api_export`, and the other `api_*` tools). |
+
+The kind is derived at write time from the toolkit kind, so it does not depend on tool-name string matching. A high-traffic API gateway can produce many rows per agent turn; the split lets the MCP Activity view exclude that traffic by default while a dedicated gateway view includes it.
+
+Filter by event kind in the admin API. The filter is accepted on the event list, stats, and every metrics endpoint (timeseries, breakdown, overview, performance, enrichment, discovery):
+
+```
+GET /api/v1/admin/audit/events?event_kind=mcp_tool_call        # MCP tool calls only
+GET /api/v1/admin/audit/events?event_kind=apigateway_invoke    # API gateway calls only
+GET /api/v1/admin/audit/metrics/timeseries?event_kind=mcp_tool_call
+```
 
 ## Parameter Sanitization
 

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -170,6 +170,12 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by MCP session ID",
                         "name": "session_id",
                         "in": "query"
@@ -373,6 +379,12 @@ const docTemplate = `{
                         "description": "End time (RFC 3339)",
                         "name": "end_time",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -430,6 +442,12 @@ const docTemplate = `{
                         "description": "End time (RFC 3339)",
                         "name": "end_time",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -477,6 +495,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "End time (RFC 3339)",
                         "name": "end_time",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
                         "in": "query"
                     }
                 ],
@@ -526,6 +550,12 @@ const docTemplate = `{
                         "description": "End time (RFC 3339)",
                         "name": "end_time",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -573,6 +603,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "End time (RFC 3339)",
                         "name": "end_time",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
                         "in": "query"
                     }
                 ],
@@ -627,6 +663,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "End time (RFC 3339)",
                         "name": "end_time",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
                         "in": "query"
                     }
                 ],
@@ -696,6 +738,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Filter by event source",
                         "name": "source",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
                         "in": "query"
                     },
                     {
@@ -6890,6 +6938,16 @@ const docTemplate = `{
         "admin.auditFiltersResponse": {
             "type": "object",
             "properties": {
+                "event_kinds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "mcp_tool_call",
+                        "apigateway_invoke"
+                    ]
+                },
                 "sources": {
                     "type": "array",
                     "items": {
@@ -8162,6 +8220,15 @@ const docTemplate = `{
                 "error_message": {
                     "type": "string"
                 },
+                "event_kind": {
+                    "description": "EventKind is the high-level category of the event. Set to\n\"mcp_tool_call\" for tools routed through the MCP toolkits (trino,\ndatahub, s3, mcp gateway) and \"apigateway_invoke\" for upstream\nHTTP API calls via the apigateway toolkit. Lets the portal split\nMCP activity from gateway noise without coupling to tool-name\npatterns. See EventType constants in event.go.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/audit.EventType"
+                        }
+                    ],
+                    "example": "mcp_tool_call"
+                },
                 "id": {
                     "type": "string",
                     "example": "evt_a1b2c3d4e5f6"
@@ -8227,6 +8294,23 @@ const docTemplate = `{
                     "example": "550e8400-e29b-41d4-a716-446655440000"
                 }
             }
+        },
+        "audit.EventType": {
+            "type": "string",
+            "enum": [
+                "tool_call",
+                "auth",
+                "admin",
+                "mcp_tool_call",
+                "apigateway_invoke"
+            ],
+            "x-enum-varnames": [
+                "EventTypeToolCall",
+                "EventTypeAuth",
+                "EventTypeAdmin",
+                "EventTypeMCPToolCall",
+                "EventTypeAPIGatewayInvoke"
+            ]
         },
         "audit.Overview": {
             "type": "object",

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -164,6 +164,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by MCP session ID",
                         "name": "session_id",
                         "in": "query"
@@ -367,6 +373,12 @@
                         "description": "End time (RFC 3339)",
                         "name": "end_time",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -424,6 +436,12 @@
                         "description": "End time (RFC 3339)",
                         "name": "end_time",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -471,6 +489,12 @@
                         "type": "string",
                         "description": "End time (RFC 3339)",
                         "name": "end_time",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
                         "in": "query"
                     }
                 ],
@@ -520,6 +544,12 @@
                         "description": "End time (RFC 3339)",
                         "name": "end_time",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -567,6 +597,12 @@
                         "type": "string",
                         "description": "End time (RFC 3339)",
                         "name": "end_time",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
                         "in": "query"
                     }
                 ],
@@ -621,6 +657,12 @@
                         "type": "string",
                         "description": "End time (RFC 3339)",
                         "name": "end_time",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
                         "in": "query"
                     }
                 ],
@@ -690,6 +732,12 @@
                         "type": "string",
                         "description": "Filter by event source",
                         "name": "source",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by event kind (mcp_tool_call, apigateway_invoke)",
+                        "name": "event_kind",
                         "in": "query"
                     },
                     {
@@ -6884,6 +6932,16 @@
         "admin.auditFiltersResponse": {
             "type": "object",
             "properties": {
+                "event_kinds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "mcp_tool_call",
+                        "apigateway_invoke"
+                    ]
+                },
                 "sources": {
                     "type": "array",
                     "items": {
@@ -8156,6 +8214,15 @@
                 "error_message": {
                     "type": "string"
                 },
+                "event_kind": {
+                    "description": "EventKind is the high-level category of the event. Set to\n\"mcp_tool_call\" for tools routed through the MCP toolkits (trino,\ndatahub, s3, mcp gateway) and \"apigateway_invoke\" for upstream\nHTTP API calls via the apigateway toolkit. Lets the portal split\nMCP activity from gateway noise without coupling to tool-name\npatterns. See EventType constants in event.go.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/audit.EventType"
+                        }
+                    ],
+                    "example": "mcp_tool_call"
+                },
                 "id": {
                     "type": "string",
                     "example": "evt_a1b2c3d4e5f6"
@@ -8221,6 +8288,23 @@
                     "example": "550e8400-e29b-41d4-a716-446655440000"
                 }
             }
+        },
+        "audit.EventType": {
+            "type": "string",
+            "enum": [
+                "tool_call",
+                "auth",
+                "admin",
+                "mcp_tool_call",
+                "apigateway_invoke"
+            ],
+            "x-enum-varnames": [
+                "EventTypeToolCall",
+                "EventTypeAuth",
+                "EventTypeAdmin",
+                "EventTypeMCPToolCall",
+                "EventTypeAPIGatewayInvoke"
+            ]
         },
         "audit.Overview": {
             "type": "object",

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -94,6 +94,13 @@ definitions:
     type: object
   admin.auditFiltersResponse:
     properties:
+      event_kinds:
+        example:
+        - mcp_tool_call
+        - apigateway_invoke
+        items:
+          type: string
+        type: array
       sources:
         example:
         - mcp
@@ -1004,6 +1011,17 @@ definitions:
         type: integer
       error_message:
         type: string
+      event_kind:
+        allOf:
+        - $ref: '#/definitions/audit.EventType'
+        description: |-
+          EventKind is the high-level category of the event. Set to
+          "mcp_tool_call" for tools routed through the MCP toolkits (trino,
+          datahub, s3, mcp gateway) and "apigateway_invoke" for upstream
+          HTTP API calls via the apigateway toolkit. Lets the portal split
+          MCP activity from gateway noise without coupling to tool-name
+          patterns. See EventType constants in event.go.
+        example: mcp_tool_call
       id:
         example: evt_a1b2c3d4e5f6
         type: string
@@ -1053,6 +1071,20 @@ definitions:
         example: 550e8400-e29b-41d4-a716-446655440000
         type: string
     type: object
+  audit.EventType:
+    enum:
+    - tool_call
+    - auth
+    - admin
+    - mcp_tool_call
+    - apigateway_invoke
+    type: string
+    x-enum-varnames:
+    - EventTypeToolCall
+    - EventTypeAuth
+    - EventTypeAdmin
+    - EventTypeMCPToolCall
+    - EventTypeAPIGatewayInvoke
   audit.Overview:
     properties:
       avg_duration_ms:
@@ -2569,6 +2601,10 @@ paths:
         in: query
         name: source
         type: string
+      - description: Filter by event kind (mcp_tool_call, apigateway_invoke)
+        in: query
+        name: event_kind
+        type: string
       - description: Filter by MCP session ID
         in: query
         name: session_id
@@ -2699,6 +2735,10 @@ paths:
         in: query
         name: end_time
         type: string
+      - description: Filter by event kind (mcp_tool_call, apigateway_invoke)
+        in: query
+        name: event_kind
+        type: string
       produces:
       - application/json
       responses:
@@ -2734,6 +2774,10 @@ paths:
         in: query
         name: end_time
         type: string
+      - description: Filter by event kind (mcp_tool_call, apigateway_invoke)
+        in: query
+        name: event_kind
+        type: string
       produces:
       - application/json
       responses:
@@ -2764,6 +2808,10 @@ paths:
         in: query
         name: end_time
         type: string
+      - description: Filter by event kind (mcp_tool_call, apigateway_invoke)
+        in: query
+        name: event_kind
+        type: string
       produces:
       - application/json
       responses:
@@ -2793,6 +2841,10 @@ paths:
         in: query
         name: end_time
         type: string
+      - description: Filter by event kind (mcp_tool_call, apigateway_invoke)
+        in: query
+        name: event_kind
+        type: string
       produces:
       - application/json
       responses:
@@ -2821,6 +2873,10 @@ paths:
       - description: End time (RFC 3339)
         in: query
         name: end_time
+        type: string
+      - description: Filter by event kind (mcp_tool_call, apigateway_invoke)
+        in: query
+        name: event_kind
         type: string
       produces:
       - application/json
@@ -2854,6 +2910,10 @@ paths:
       - description: End time (RFC 3339)
         in: query
         name: end_time
+        type: string
+      - description: Filter by event kind (mcp_tool_call, apigateway_invoke)
+        in: query
+        name: event_kind
         type: string
       produces:
       - application/json
@@ -2898,6 +2958,10 @@ paths:
       - description: Filter by event source
         in: query
         name: source
+        type: string
+      - description: Filter by event kind (mcp_tool_call, apigateway_invoke)
+        in: query
+        name: event_kind
         type: string
       - description: Events after this time (RFC 3339)
         in: query

--- a/pkg/admin/audit.go
+++ b/pkg/admin/audit.go
@@ -21,6 +21,7 @@ type auditFiltersResponse struct {
 	Tools        []string          `json:"tools" example:"trino_query,datahub_search,s3_list_objects"`
 	ToolkitKinds []string          `json:"toolkit_kinds" example:"api,datahub,trino,s3,memory"`
 	Sources      []string          `json:"sources" example:"mcp,rest,admin"`
+	EventKinds   []string          `json:"event_kinds" example:"mcp_tool_call,apigateway_invoke"`
 	UserLabels   map[string]string `json:"user_labels,omitempty"`
 }
 
@@ -37,6 +38,7 @@ const (
 	colToolName       = "tool_name"
 	colToolkitKind    = "toolkit_kind"
 	colSource         = "source"
+	colEventKind      = "event_kind"
 )
 
 // listAuditEvents handles GET /api/v1/admin/audit/events.
@@ -49,6 +51,7 @@ const (
 // @Param        tool_name     query  string  false  "Filter by tool name"
 // @Param        toolkit_kind  query  string  false  "Filter by toolkit kind (e.g. api, trino, datahub, s3, memory)"
 // @Param        source        query  string  false  "Filter by event source (e.g. mcp)"
+// @Param        event_kind    query  string  false  "Filter by event kind (mcp_tool_call, apigateway_invoke)"
 // @Param        session_id    query  string  false  "Filter by MCP session ID"
 // @Param        success       query  boolean false  "Filter by success/failure"
 // @Param        start_time    query  string  false  "Events after this time (RFC 3339)"
@@ -69,6 +72,7 @@ func (h *Handler) listAuditEvents(w http.ResponseWriter, r *http.Request) {
 		ToolName:    q.Get(colToolName),
 		ToolkitKind: q.Get(colToolkitKind),
 		Source:      q.Get(colSource),
+		EventKind:   q.Get(colEventKind),
 		SessionID:   q.Get("session_id"),
 		Search:      q.Get("search"),
 		SortBy:      q.Get("sort_by"),
@@ -164,6 +168,12 @@ func (h *Handler) listAuditEventFilters(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	eventKinds, err := h.deps.AuditQuerier.Distinct(r.Context(), colEventKind, startTime, endTime)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to query distinct event kinds")
+		return
+	}
+
 	if users == nil {
 		users = []string{}
 	}
@@ -175,6 +185,9 @@ func (h *Handler) listAuditEventFilters(w http.ResponseWriter, r *http.Request) 
 	}
 	if sources == nil {
 		sources = []string{}
+	}
+	if eventKinds == nil {
+		eventKinds = []string{}
 	}
 
 	// Fetch user_id → user_email mapping for display labels.
@@ -189,6 +202,7 @@ func (h *Handler) listAuditEventFilters(w http.ResponseWriter, r *http.Request) 
 		Tools:        tools,
 		ToolkitKinds: toolkitKinds,
 		Sources:      sources,
+		EventKinds:   eventKinds,
 		UserLabels:   userLabels,
 	})
 }
@@ -231,6 +245,7 @@ func (h *Handler) getAuditEvent(w http.ResponseWriter, r *http.Request) {
 // @Param        tool_name     query  string  false  "Filter by tool name"
 // @Param        toolkit_kind  query  string  false  "Filter by toolkit kind"
 // @Param        source        query  string  false  "Filter by event source"
+// @Param        event_kind    query  string  false  "Filter by event kind (mcp_tool_call, apigateway_invoke)"
 // @Param        start_time    query  string  false  "Events after this time (RFC 3339)"
 // @Param        end_time      query  string  false  "Events before this time (RFC 3339)"
 // @Success      200  {object}  auditStatsResponse
@@ -245,6 +260,7 @@ func (h *Handler) getAuditStats(w http.ResponseWriter, r *http.Request) {
 		ToolName:    q.Get(colToolName),
 		ToolkitKind: q.Get(colToolkitKind),
 		Source:      q.Get(colSource),
+		EventKind:   q.Get(colEventKind),
 		StartTime:   parseTimeParam(q, "start_time"),
 		EndTime:     parseTimeParam(q, "end_time"),
 	}

--- a/pkg/admin/audit_metrics.go
+++ b/pkg/admin/audit_metrics.go
@@ -10,6 +10,7 @@ import (
 const (
 	paramStartTime = "start_time"
 	paramEndTime   = "end_time"
+	paramEventKind = "event_kind"
 )
 
 // registerAuditMetricsRoutes registers audit metrics endpoints.
@@ -34,6 +35,7 @@ func (h *Handler) registerAuditMetricsRoutes() {
 // @Param        resolution  query  string  false  "Time bucket resolution: minute, hour, day (default: hour)"
 // @Param        start_time  query  string  false  "Start time (RFC 3339)"
 // @Param        end_time    query  string  false  "End time (RFC 3339)"
+// @Param        event_kind  query  string  false  "Filter by event kind (mcp_tool_call, apigateway_invoke)"
 // @Success      200  {array}   audit.TimeseriesBucket
 // @Failure      400  {object}  problemDetail
 // @Failure      500  {object}  problemDetail
@@ -56,6 +58,7 @@ func (h *Handler) getAuditTimeseries(w http.ResponseWriter, r *http.Request) {
 		Resolution: resolution,
 		StartTime:  parseTimeParam(q, paramStartTime),
 		EndTime:    parseTimeParam(q, paramEndTime),
+		EventKind:  q.Get(paramEventKind),
 	}
 
 	buckets, err := h.deps.AuditMetricsQuerier.Timeseries(r.Context(), filter)
@@ -77,6 +80,7 @@ func (h *Handler) getAuditTimeseries(w http.ResponseWriter, r *http.Request) {
 // @Param        limit       query  integer false  "Max entries (default: 10, max: 100)"
 // @Param        start_time  query  string  false  "Start time (RFC 3339)"
 // @Param        end_time    query  string  false  "End time (RFC 3339)"
+// @Param        event_kind  query  string  false  "Filter by event kind (mcp_tool_call, apigateway_invoke)"
 // @Success      200  {array}   audit.BreakdownEntry
 // @Failure      400  {object}  problemDetail
 // @Failure      500  {object}  problemDetail
@@ -105,6 +109,7 @@ func (h *Handler) getAuditBreakdown(w http.ResponseWriter, r *http.Request) {
 		Limit:     limit,
 		StartTime: parseTimeParam(q, paramStartTime),
 		EndTime:   parseTimeParam(q, paramEndTime),
+		EventKind: q.Get(paramEventKind),
 	}
 
 	entries, err := h.deps.AuditMetricsQuerier.Breakdown(r.Context(), filter)
@@ -124,6 +129,7 @@ func (h *Handler) getAuditBreakdown(w http.ResponseWriter, r *http.Request) {
 // @Produce      json
 // @Param        start_time  query  string  false  "Start time (RFC 3339)"
 // @Param        end_time    query  string  false  "End time (RFC 3339)"
+// @Param        event_kind  query  string  false  "Filter by event kind (mcp_tool_call, apigateway_invoke)"
 // @Success      200  {object}  audit.Overview
 // @Failure      500  {object}  problemDetail
 // @Security     ApiKeyAuth
@@ -137,6 +143,7 @@ func (h *Handler) getAuditOverview(w http.ResponseWriter, r *http.Request) {
 		audit.MetricsFilter{
 			StartTime: parseTimeParam(q, paramStartTime),
 			EndTime:   parseTimeParam(q, paramEndTime),
+			EventKind: q.Get(paramEventKind),
 		},
 	)
 	if err != nil {
@@ -155,6 +162,7 @@ func (h *Handler) getAuditOverview(w http.ResponseWriter, r *http.Request) {
 // @Produce      json
 // @Param        start_time  query  string  false  "Start time (RFC 3339)"
 // @Param        end_time    query  string  false  "End time (RFC 3339)"
+// @Param        event_kind  query  string  false  "Filter by event kind (mcp_tool_call, apigateway_invoke)"
 // @Success      200  {object}  audit.PerformanceStats
 // @Failure      500  {object}  problemDetail
 // @Security     ApiKeyAuth
@@ -168,6 +176,7 @@ func (h *Handler) getAuditPerformance(w http.ResponseWriter, r *http.Request) {
 		audit.MetricsFilter{
 			StartTime: parseTimeParam(q, paramStartTime),
 			EndTime:   parseTimeParam(q, paramEndTime),
+			EventKind: q.Get(paramEventKind),
 		},
 	)
 	if err != nil {
@@ -186,6 +195,7 @@ func (h *Handler) getAuditPerformance(w http.ResponseWriter, r *http.Request) {
 // @Produce      json
 // @Param        start_time  query  string  false  "Start time (RFC 3339)"
 // @Param        end_time    query  string  false  "End time (RFC 3339)"
+// @Param        event_kind  query  string  false  "Filter by event kind (mcp_tool_call, apigateway_invoke)"
 // @Success      200  {object}  audit.EnrichmentStats
 // @Failure      500  {object}  problemDetail
 // @Security     ApiKeyAuth
@@ -196,8 +206,11 @@ func (h *Handler) getAuditEnrichment(w http.ResponseWriter, r *http.Request) {
 
 	stats, err := h.deps.AuditMetricsQuerier.Enrichment(
 		r.Context(),
-		parseTimeParam(q, paramStartTime),
-		parseTimeParam(q, paramEndTime),
+		audit.MetricsFilter{
+			StartTime: parseTimeParam(q, paramStartTime),
+			EndTime:   parseTimeParam(q, paramEndTime),
+			EventKind: q.Get(paramEventKind),
+		},
 	)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to query enrichment metrics")
@@ -215,6 +228,7 @@ func (h *Handler) getAuditEnrichment(w http.ResponseWriter, r *http.Request) {
 // @Produce      json
 // @Param        start_time  query  string  false  "Start time (RFC 3339)"
 // @Param        end_time    query  string  false  "End time (RFC 3339)"
+// @Param        event_kind  query  string  false  "Filter by event kind (mcp_tool_call, apigateway_invoke)"
 // @Success      200  {object}  audit.DiscoveryStats
 // @Failure      500  {object}  problemDetail
 // @Security     ApiKeyAuth
@@ -225,8 +239,11 @@ func (h *Handler) getAuditDiscovery(w http.ResponseWriter, r *http.Request) {
 
 	stats, err := h.deps.AuditMetricsQuerier.Discovery(
 		r.Context(),
-		parseTimeParam(q, paramStartTime),
-		parseTimeParam(q, paramEndTime),
+		audit.MetricsFilter{
+			StartTime: parseTimeParam(q, paramStartTime),
+			EndTime:   parseTimeParam(q, paramEndTime),
+			EventKind: q.Get(paramEventKind),
+		},
 	)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to query discovery metrics")

--- a/pkg/admin/audit_metrics_test.go
+++ b/pkg/admin/audit_metrics_test.go
@@ -48,11 +48,11 @@ func (m *mockAuditMetricsQuerier) Performance(_ context.Context, _ audit.Metrics
 	return m.performanceResult, m.performanceErr
 }
 
-func (m *mockAuditMetricsQuerier) Enrichment(_ context.Context, _, _ *time.Time) (*audit.EnrichmentStats, error) {
+func (m *mockAuditMetricsQuerier) Enrichment(_ context.Context, _ audit.MetricsFilter) (*audit.EnrichmentStats, error) {
 	return m.enrichmentResult, m.enrichmentErr
 }
 
-func (m *mockAuditMetricsQuerier) Discovery(_ context.Context, _, _ *time.Time) (*audit.DiscoveryStats, error) {
+func (m *mockAuditMetricsQuerier) Discovery(_ context.Context, _ audit.MetricsFilter) (*audit.DiscoveryStats, error) {
 	return m.discoveryResult, m.discoveryErr
 }
 

--- a/pkg/admin/audit_test.go
+++ b/pkg/admin/audit_test.go
@@ -50,6 +50,18 @@ func TestListAuditEvents(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
 
+	t.Run("passes event_kind into filter", func(t *testing.T) {
+		aq := &mockAuditQuerier{queryResult: events[:1], countResult: 1}
+		h := NewHandler(Deps{AuditQuerier: aq}, nil)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/admin/audit/events?event_kind=apigateway_invoke", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "apigateway_invoke", aq.lastQueryFilter.EventKind)
+	})
+
 	t.Run("returns empty list on no results", func(t *testing.T) {
 		aq := &mockAuditQuerier{queryResult: nil, countResult: 0}
 		h := NewHandler(Deps{AuditQuerier: aq}, nil)
@@ -175,6 +187,7 @@ func TestListAuditEventFilters(t *testing.T) {
 		require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
 		assert.Equal(t, []string{"alice@acme.com", "bob@acme.com"}, body.Users)
 		assert.Equal(t, []string{"alice@acme.com", "bob@acme.com"}, body.Tools)
+		assert.Equal(t, []string{"alice@acme.com", "bob@acme.com"}, body.EventKinds)
 	})
 
 	t.Run("returns empty arrays when no events", func(t *testing.T) {

--- a/pkg/admin/handler.go
+++ b/pkg/admin/handler.go
@@ -44,8 +44,8 @@ type AuditMetricsQuerier interface {
 	Breakdown(ctx context.Context, filter audit.BreakdownFilter) ([]audit.BreakdownEntry, error)
 	Overview(ctx context.Context, filter audit.MetricsFilter) (*audit.Overview, error)
 	Performance(ctx context.Context, filter audit.MetricsFilter) (*audit.PerformanceStats, error)
-	Enrichment(ctx context.Context, startTime, endTime *time.Time) (*audit.EnrichmentStats, error)
-	Discovery(ctx context.Context, startTime, endTime *time.Time) (*audit.DiscoveryStats, error)
+	Enrichment(ctx context.Context, filter audit.MetricsFilter) (*audit.EnrichmentStats, error)
+	Discovery(ctx context.Context, filter audit.MetricsFilter) (*audit.DiscoveryStats, error)
 }
 
 // PersonaRegistry abstracts persona.Registry for testability.

--- a/pkg/admin/testhelpers_test.go
+++ b/pkg/admin/testhelpers_test.go
@@ -207,9 +207,13 @@ type mockAuditQuerier struct {
 	distinctErr         error
 	distinctPairsResult map[string]string
 	distinctPairsErr    error
+	// lastQueryFilter records the filter passed to the most recent
+	// Query call so handler tests can assert query-param extraction.
+	lastQueryFilter audit.QueryFilter
 }
 
-func (m *mockAuditQuerier) Query(_ context.Context, _ audit.QueryFilter) ([]audit.Event, error) {
+func (m *mockAuditQuerier) Query(_ context.Context, filter audit.QueryFilter) ([]audit.Event, error) {
+	m.lastQueryFilter = filter
 	return m.queryResult, m.queryErr
 }
 

--- a/pkg/audit/event.go
+++ b/pkg/audit/event.go
@@ -18,7 +18,36 @@ const (
 
 	// EventTypeAdmin is an administrative event.
 	EventTypeAdmin EventType = "admin"
+
+	// EventTypeMCPToolCall categorizes an MCP tool invocation routed
+	// through a non-apigateway toolkit (trino, datahub, s3, mcp gateway).
+	// Stamped into Event.EventKind at write time so the portal Activity
+	// view can exclude apigateway HTTP noise by default.
+	EventTypeMCPToolCall EventType = "mcp_tool_call"
+
+	// EventTypeAPIGatewayInvoke categorizes an HTTP API invocation
+	// through the apigateway toolkit. Stamped into Event.EventKind at
+	// write time so the portal Activity view can split these out from
+	// the MCP-only view.
+	EventTypeAPIGatewayInvoke EventType = "apigateway_invoke"
 )
+
+// toolkitKindAPIGateway is the toolkit-kind discriminator for the
+// apigateway toolkit (mirrors apigateway.Kind). Kept as a literal here
+// rather than importing the toolkit package so the low-level audit
+// package stays decoupled from toolkit implementations.
+const toolkitKindAPIGateway = "api"
+
+// EventKindForToolkit maps a toolkit kind to its high-level event
+// category. The apigateway toolkit ("api") produces HTTP invocations;
+// every other toolkit kind produces MCP tool calls. Used at audit
+// write time so the portal can split gateway noise from MCP activity.
+func EventKindForToolkit(toolkitKind string) EventType {
+	if toolkitKind == toolkitKindAPIGateway {
+		return EventTypeAPIGatewayInvoke
+	}
+	return EventTypeMCPToolCall
+}
 
 // NewEvent creates a new audit event.
 func NewEvent(toolName string) *Event {
@@ -110,6 +139,13 @@ func (e *Event) WithEnrichment(applied bool) *Event {
 // WithAuthorized records the authorization decision.
 func (e *Event) WithAuthorized(authorized bool) *Event {
 	e.Authorized = authorized
+	return e
+}
+
+// WithEventKind records the high-level category of the event
+// (e.g. mcp_tool_call, apigateway_invoke). See Event.EventKind.
+func (e *Event) WithEventKind(kind EventType) *Event {
+	e.EventKind = kind
 	return e
 }
 

--- a/pkg/audit/event_test.go
+++ b/pkg/audit/event_test.go
@@ -39,10 +39,35 @@ func TestEvent_Builders(t *testing.T) {
 		WithEnrichment(true).
 		WithAuthorized(true).
 		WithEnrichmentTokens(500, 45).
-		WithEnrichmentMode("full")
+		WithEnrichmentMode("full").
+		WithEventKind(EventTypeMCPToolCall)
 
 	assertEventCoreFields(t, event)
 	assertEventNewFields(t, event)
+	if event.EventKind != EventTypeMCPToolCall {
+		t.Errorf("EventKind = %q, want %q", event.EventKind, EventTypeMCPToolCall)
+	}
+}
+
+func TestEventKindForToolkit(t *testing.T) {
+	tests := []struct {
+		toolkitKind string
+		want        EventType
+	}{
+		{"api", EventTypeAPIGatewayInvoke},
+		{"trino", EventTypeMCPToolCall},
+		{"datahub", EventTypeMCPToolCall},
+		{"s3", EventTypeMCPToolCall},
+		{"mcp", EventTypeMCPToolCall},
+		{"", EventTypeMCPToolCall},
+	}
+	for _, tc := range tests {
+		t.Run(tc.toolkitKind, func(t *testing.T) {
+			if got := EventKindForToolkit(tc.toolkitKind); got != tc.want {
+				t.Errorf("EventKindForToolkit(%q) = %q, want %q", tc.toolkitKind, got, tc.want)
+			}
+		})
+	}
 }
 
 func assertEventCoreFields(t *testing.T, event *Event) {

--- a/pkg/audit/logger.go
+++ b/pkg/audit/logger.go
@@ -53,6 +53,13 @@ type Event struct {
 	// suggestions (issue #444).
 	EnrichmentMatchKind string `json:"enrichment_match_kind,omitempty" example:"urn"`
 	Authorized          bool   `json:"authorized" example:"true"`
+	// EventKind is the high-level category of the event. Set to
+	// "mcp_tool_call" for tools routed through the MCP toolkits (trino,
+	// datahub, s3, mcp gateway) and "apigateway_invoke" for upstream
+	// HTTP API calls via the apigateway toolkit. Lets the portal split
+	// MCP activity from gateway noise without coupling to tool-name
+	// patterns. See EventType constants in event.go.
+	EventKind EventType `json:"event_kind,omitempty" example:"mcp_tool_call"`
 }
 
 // SortOrder defines sort direction.
@@ -90,6 +97,7 @@ type QueryFilter struct {
 	ToolName    string
 	ToolkitKind string
 	Source      string
+	EventKind   string
 	Search      string
 	Success     *bool
 	SortBy      string

--- a/pkg/audit/metrics.go
+++ b/pkg/audit/metrics.go
@@ -29,6 +29,7 @@ type TimeseriesFilter struct {
 	StartTime  *time.Time
 	EndTime    *time.Time
 	UserID     string
+	EventKind  string
 }
 
 // TimeseriesBucket holds counts for a single time bucket.
@@ -83,6 +84,10 @@ type BreakdownFilter struct {
 	// breakdown and appear as "no calls recorded" even when they have
 	// activity (#343 bug 2).
 	ToolName string
+	// EventKind scopes the aggregation to a specific event category.
+	// Lets the portal MCP view exclude apigateway noise without
+	// modifying the breakdown call sites.
+	EventKind string
 }
 
 // MetricsFilter provides common filtering for aggregate metric queries.
@@ -90,6 +95,7 @@ type MetricsFilter struct {
 	StartTime *time.Time
 	EndTime   *time.Time
 	UserID    string
+	EventKind string
 }
 
 // BreakdownEntry holds aggregated stats for a single dimension value.

--- a/pkg/audit/postgres/metrics.go
+++ b/pkg/audit/postgres/metrics.go
@@ -45,6 +45,9 @@ func (s *Store) Timeseries(ctx context.Context, filter audit.TimeseriesFilter) (
 	if filter.UserID != "" {
 		qb = qb.Where(sq.Eq{colUserID: filter.UserID})
 	}
+	if filter.EventKind != "" {
+		qb = qb.Where(sq.Eq{colEventKind: filter.EventKind})
+	}
 
 	qb = qb.GroupBy("bucket").
 		OrderBy("bucket ASC")
@@ -136,6 +139,9 @@ func buildBreakdownQuery(filter audit.BreakdownFilter) (query string, args []any
 		// rendered them as "no calls recorded" in the UI.
 		qb = qb.Where(sq.Eq{colToolName: filter.ToolName})
 	}
+	if filter.EventKind != "" {
+		qb = qb.Where(sq.Eq{colEventKind: filter.EventKind})
+	}
 
 	qb = qb.GroupBy("dimension").
 		OrderBy("count DESC").
@@ -207,6 +213,9 @@ func (s *Store) Overview(ctx context.Context, filter audit.MetricsFilter) (*audi
 	if filter.UserID != "" {
 		qb = qb.Where(sq.Eq{colUserID: filter.UserID})
 	}
+	if filter.EventKind != "" {
+		qb = qb.Where(sq.Eq{colEventKind: filter.EventKind})
+	}
 
 	query, args, err := qb.ToSql()
 	if err != nil {
@@ -248,6 +257,9 @@ func (s *Store) Performance(ctx context.Context, filter audit.MetricsFilter) (*a
 	if filter.UserID != "" {
 		qb = qb.Where(sq.Eq{colUserID: filter.UserID})
 	}
+	if filter.EventKind != "" {
+		qb = qb.Where(sq.Eq{colEventKind: filter.EventKind})
+	}
 
 	query, args, err := qb.ToSql()
 	if err != nil {
@@ -274,9 +286,9 @@ func (s *Store) Performance(ctx context.Context, filter audit.MetricsFilter) (*a
 	return &p, nil
 }
 
-// Enrichment returns aggregate enrichment statistics for the given time range.
-func (s *Store) Enrichment(ctx context.Context, startTime, endTime *time.Time) (*audit.EnrichmentStats, error) {
-	start, end := defaultTimeRange(startTime, endTime)
+// Enrichment returns aggregate enrichment statistics for the given filter.
+func (s *Store) Enrichment(ctx context.Context, filter audit.MetricsFilter) (*audit.EnrichmentStats, error) {
+	start, end := defaultTimeRange(filter.StartTime, filter.EndTime)
 
 	qb := psq.Select(
 		"COUNT(*) AS total_calls",
@@ -295,6 +307,13 @@ func (s *Store) Enrichment(ctx context.Context, startTime, endTime *time.Time) (
 	).From("audit_logs").
 		Where(sq.GtOrEq{colTimestamp: start}).
 		Where(sq.LtOrEq{colTimestamp: end})
+
+	if filter.UserID != "" {
+		qb = qb.Where(sq.Eq{colUserID: filter.UserID})
+	}
+	if filter.EventKind != "" {
+		qb = qb.Where(sq.Eq{colEventKind: filter.EventKind})
+	}
 
 	query, args, err := qb.ToSql()
 	if err != nil {
@@ -323,17 +342,18 @@ func (s *Store) Enrichment(ctx context.Context, startTime, endTime *time.Time) (
 	return &stats, nil
 }
 
-// Discovery returns discovery-before-query pattern statistics for the given time range.
-func (s *Store) Discovery(ctx context.Context, startTime, endTime *time.Time) (*audit.DiscoveryStats, error) {
-	start, end := defaultTimeRange(startTime, endTime)
-
-	patternQuery := `
+// discoveryPatternQuery counts discovery-before-query session patterns.
+// The $3 event_kind predicate is a no-op when the bound value is empty
+// (caller always passes a value, "" meaning "all kinds"), which keeps
+// the SQL static — no string concatenation, no gosec G202.
+const discoveryPatternQuery = `
 WITH session_tools AS (
     SELECT session_id, toolkit_kind, tool_name,
            MIN(timestamp) AS first_call
     FROM audit_logs
     WHERE timestamp >= $1 AND timestamp <= $2
       AND session_id != ''
+      AND ($3 = '' OR event_kind = $3)
     GROUP BY session_id, toolkit_kind, tool_name
 ),
 session_patterns AS (
@@ -354,8 +374,27 @@ SELECT
     COUNT(*) FILTER (WHERE has_query AND NOT has_discovery) AS query_without_discovery
 FROM session_patterns`
 
+// discoveryTopToolsQuery ranks datahub discovery tools. Same static-$3
+// event_kind predicate as discoveryPatternQuery.
+const discoveryTopToolsQuery = `
+SELECT tool_name AS dimension,
+       COUNT(*) AS count,
+       CASE WHEN COUNT(*) > 0 THEN CAST(COUNT(*) FILTER (WHERE success = true) AS FLOAT) / COUNT(*) ELSE 0 END AS success_rate,
+       COALESCE(AVG(duration_ms), 0) AS avg_duration_ms
+FROM audit_logs
+WHERE timestamp >= $1 AND timestamp <= $2
+  AND toolkit_kind = 'datahub'
+  AND ($3 = '' OR event_kind = $3)
+GROUP BY tool_name
+ORDER BY count DESC
+LIMIT 10`
+
+// Discovery returns discovery-before-query pattern statistics for the given filter.
+func (s *Store) Discovery(ctx context.Context, filter audit.MetricsFilter) (*audit.DiscoveryStats, error) {
+	start, end := defaultTimeRange(filter.StartTime, filter.EndTime)
+
 	var stats audit.DiscoveryStats
-	err := s.db.QueryRowContext(ctx, patternQuery, start, end).Scan(
+	err := s.db.QueryRowContext(ctx, discoveryPatternQuery, start, end, filter.EventKind).Scan(
 		&stats.TotalSessions,
 		&stats.DiscoverySessions,
 		&stats.QuerySessions,
@@ -367,20 +406,7 @@ FROM session_patterns`
 		return nil, fmt.Errorf("querying discovery patterns: %w", err)
 	}
 
-	// Get top discovery tools
-	topToolsQuery := `
-SELECT tool_name AS dimension,
-       COUNT(*) AS count,
-       CASE WHEN COUNT(*) > 0 THEN CAST(COUNT(*) FILTER (WHERE success = true) AS FLOAT) / COUNT(*) ELSE 0 END AS success_rate,
-       COALESCE(AVG(duration_ms), 0) AS avg_duration_ms
-FROM audit_logs
-WHERE timestamp >= $1 AND timestamp <= $2
-  AND toolkit_kind = 'datahub'
-GROUP BY tool_name
-ORDER BY count DESC
-LIMIT 10`
-
-	rows, err := s.db.QueryContext(ctx, topToolsQuery, start, end)
+	rows, err := s.db.QueryContext(ctx, discoveryTopToolsQuery, start, end, filter.EventKind)
 	if err != nil {
 		return nil, fmt.Errorf("querying top discovery tools: %w", err)
 	}

--- a/pkg/audit/postgres/metrics_test.go
+++ b/pkg/audit/postgres/metrics_test.go
@@ -357,6 +357,119 @@ func TestOverview_Success(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestMetrics_EventKindFilter(t *testing.T) {
+	now := time.Now()
+	start := now.Add(-24 * time.Hour)
+
+	t.Run("timeseries", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+
+		rows := sqlmock.NewRows([]string{"bucket", "count", "success_count", "error_count", "avg_duration_ms"})
+		mock.ExpectQuery("SELECT").
+			WithArgs(start, now, "apigateway_invoke").
+			WillReturnRows(rows)
+
+		_, err = New(db, Config{}).Timeseries(context.Background(), audit.TimeseriesFilter{
+			Resolution: audit.ResolutionHour,
+			StartTime:  &start,
+			EndTime:    &now,
+			EventKind:  "apigateway_invoke",
+		})
+		require.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("breakdown", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+
+		rows := sqlmock.NewRows([]string{"dimension", "count", "success_rate", "avg_duration_ms"})
+		mock.ExpectQuery("SELECT").
+			WithArgs(start, now, "apigateway_invoke").
+			WillReturnRows(rows)
+
+		_, err = New(db, Config{}).Breakdown(context.Background(), audit.BreakdownFilter{
+			GroupBy:   audit.BreakdownByToolName,
+			StartTime: &start,
+			EndTime:   &now,
+			EventKind: "apigateway_invoke",
+		})
+		require.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("overview", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+
+		rows := sqlmock.NewRows([]string{
+			"total_calls", "success_rate", "avg_duration_ms",
+			"unique_users", "unique_tools", "enrichment_rate", "error_count",
+		}).AddRow(0, 0, 0, 0, 0, 0, 0)
+		mock.ExpectQuery("SELECT").
+			WithArgs(start, now, "apigateway_invoke").
+			WillReturnRows(rows)
+
+		_, err = New(db, Config{}).Overview(context.Background(), audit.MetricsFilter{
+			StartTime: &start,
+			EndTime:   &now,
+			EventKind: "apigateway_invoke",
+		})
+		require.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("performance", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+
+		rows := sqlmock.NewRows([]string{
+			"p50_ms", "p95_ms", "p99_ms", "avg_ms", "max_ms",
+			"avg_response_chars", "avg_request_chars",
+		}).AddRow(0, 0, 0, 0, 0, 0, 0)
+		mock.ExpectQuery("SELECT").
+			WithArgs(start, now, "apigateway_invoke").
+			WillReturnRows(rows)
+
+		_, err = New(db, Config{}).Performance(context.Background(), audit.MetricsFilter{
+			StartTime: &start,
+			EndTime:   &now,
+			EventKind: "apigateway_invoke",
+		})
+		require.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("enrichment", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+
+		rows := sqlmock.NewRows([]string{
+			"total_calls", "enriched_calls", "enrichment_rate",
+			"full_count", "summary_count", "reference_count", "none_count",
+			"total_tokens_full", "total_tokens_dedup", "tokens_saved",
+			"avg_tokens_full", "avg_tokens_dedup", "unique_sessions",
+		}).AddRow(0, 0, 0, 0, 0, 0, 0, int64(0), int64(0), int64(0), 0, 0, 0)
+		mock.ExpectQuery("SELECT").
+			WithArgs(start, now, "apigateway_invoke").
+			WillReturnRows(rows)
+
+		_, err = New(db, Config{}).Enrichment(context.Background(), audit.MetricsFilter{
+			StartTime: &start,
+			EndTime:   &now,
+			EventKind: "apigateway_invoke",
+		})
+		require.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
 func TestOverview_DefaultTimeRange(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
@@ -736,7 +849,7 @@ func TestEnrichment_Success(t *testing.T) {
 		WithArgs(start, now).
 		WillReturnRows(rows)
 
-	result, err := store.Enrichment(context.Background(), &start, &now)
+	result, err := store.Enrichment(context.Background(), audit.MetricsFilter{StartTime: &start, EndTime: &now})
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -771,7 +884,7 @@ func TestEnrichment_DefaultTimeRange(t *testing.T) {
 
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 
-	result, err := store.Enrichment(context.Background(), nil, nil)
+	result, err := store.Enrichment(context.Background(), audit.MetricsFilter{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, 0, result.TotalCalls)
@@ -785,7 +898,7 @@ func TestEnrichment_QueryError(t *testing.T) {
 	store := New(db, Config{})
 	mock.ExpectQuery("SELECT").WillReturnError(fmt.Errorf("db error"))
 
-	_, err = store.Enrichment(context.Background(), nil, nil)
+	_, err = store.Enrichment(context.Background(), audit.MetricsFilter{})
 	assert.ErrorContains(t, err, "querying enrichment")
 }
 
@@ -807,7 +920,7 @@ func TestDiscovery_Success(t *testing.T) {
 	}).AddRow(100, 60, 80, 50, 0.60, 20)
 
 	mock.ExpectQuery("WITH session_tools").
-		WithArgs(start, now).
+		WithArgs(start, now, "").
 		WillReturnRows(patternRows)
 
 	// Top tools query result
@@ -816,10 +929,10 @@ func TestDiscovery_Success(t *testing.T) {
 		AddRow("datahub_get_entity", 80, 1.0, 25.0)
 
 	mock.ExpectQuery("SELECT tool_name").
-		WithArgs(start, now).
+		WithArgs(start, now, "").
 		WillReturnRows(toolRows)
 
-	result, err := store.Discovery(context.Background(), &start, &now)
+	result, err := store.Discovery(context.Background(), audit.MetricsFilter{StartTime: &start, EndTime: &now})
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -832,6 +945,37 @@ func TestDiscovery_Success(t *testing.T) {
 	require.Len(t, result.TopDiscoveryTools, 2)
 	assert.Equal(t, "datahub_search", result.TopDiscoveryTools[0].Dimension)
 	assert.Equal(t, 120, result.TopDiscoveryTools[0].Count)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDiscovery_EventKindFilter(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := New(db, Config{})
+	now := time.Now()
+	start := now.Add(-24 * time.Hour)
+
+	patternRows := sqlmock.NewRows([]string{
+		"total_sessions", "discovery_sessions", "query_sessions",
+		"discovery_before_query", "discovery_rate", "query_without_discovery",
+	}).AddRow(0, 0, 0, 0, 0, 0)
+	mock.ExpectQuery("WITH session_tools").
+		WithArgs(start, now, "apigateway_invoke").
+		WillReturnRows(patternRows)
+
+	toolRows := sqlmock.NewRows([]string{"dimension", "count", "success_rate", "avg_duration_ms"})
+	mock.ExpectQuery("SELECT tool_name").
+		WithArgs(start, now, "apigateway_invoke").
+		WillReturnRows(toolRows)
+
+	_, err = store.Discovery(context.Background(), audit.MetricsFilter{
+		StartTime: &start,
+		EndTime:   &now,
+		EventKind: "apigateway_invoke",
+	})
+	require.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -851,7 +995,7 @@ func TestDiscovery_DefaultTimeRange(t *testing.T) {
 	toolRows := sqlmock.NewRows([]string{"dimension", "count", "success_rate", "avg_duration_ms"})
 	mock.ExpectQuery("SELECT tool_name").WillReturnRows(toolRows)
 
-	result, err := store.Discovery(context.Background(), nil, nil)
+	result, err := store.Discovery(context.Background(), audit.MetricsFilter{})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, 0, result.TotalSessions)
@@ -866,7 +1010,7 @@ func TestDiscovery_PatternQueryError(t *testing.T) {
 	store := New(db, Config{})
 	mock.ExpectQuery("WITH session_tools").WillReturnError(fmt.Errorf("db error"))
 
-	_, err = store.Discovery(context.Background(), nil, nil)
+	_, err = store.Discovery(context.Background(), audit.MetricsFilter{})
 	assert.ErrorContains(t, err, "querying discovery patterns")
 }
 
@@ -885,7 +1029,7 @@ func TestDiscovery_TopToolsQueryError(t *testing.T) {
 
 	mock.ExpectQuery("SELECT tool_name").WillReturnError(fmt.Errorf("tool query error"))
 
-	_, err = store.Discovery(context.Background(), nil, nil)
+	_, err = store.Discovery(context.Background(), audit.MetricsFilter{})
 	assert.ErrorContains(t, err, "querying top discovery tools")
 }
 
@@ -906,7 +1050,7 @@ func TestDiscovery_TopToolsScanError(t *testing.T) {
 		AddRow("tool", "bad", "bad", "bad")
 	mock.ExpectQuery("SELECT tool_name").WillReturnRows(toolRows)
 
-	_, err = store.Discovery(context.Background(), nil, nil)
+	_, err = store.Discovery(context.Background(), audit.MetricsFilter{})
 	assert.Error(t, err)
 }
 
@@ -928,7 +1072,7 @@ func TestDiscovery_TopToolsRowsErr(t *testing.T) {
 		RowError(0, fmt.Errorf("row iteration error"))
 	mock.ExpectQuery("SELECT tool_name").WillReturnRows(toolRows)
 
-	_, err = store.Discovery(context.Background(), nil, nil)
+	_, err = store.Discovery(context.Background(), audit.MetricsFilter{})
 	assert.Error(t, err)
 }
 
@@ -948,7 +1092,7 @@ func TestDiscovery_EmptyTopTools(t *testing.T) {
 	toolRows := sqlmock.NewRows([]string{"dimension", "count", "success_rate", "avg_duration_ms"})
 	mock.ExpectQuery("SELECT tool_name").WillReturnRows(toolRows)
 
-	result, err := store.Discovery(context.Background(), nil, nil)
+	result, err := store.Discovery(context.Background(), audit.MetricsFilter{})
 	require.NoError(t, err)
 	assert.NotNil(t, result.TopDiscoveryTools) // empty slice, not nil
 	assert.Empty(t, result.TopDiscoveryTools)

--- a/pkg/audit/postgres/store.go
+++ b/pkg/audit/postgres/store.go
@@ -50,6 +50,7 @@ const (
 	colUserEmail    = "user_email"
 	colSuccess      = "success"
 	colSource       = "source"
+	colEventKind    = "event_kind"
 )
 
 // psq is the PostgreSQL statement builder with dollar placeholders.
@@ -64,6 +65,7 @@ var auditColumns = []string{
 	"transport", "source", "enrichment_applied",
 	"enrichment_tokens_full", "enrichment_tokens_dedup",
 	"enrichment_mode", "enrichment_match_kind", "authorized",
+	colEventKind,
 }
 
 // Store implements audit.Logger using PostgreSQL.
@@ -99,8 +101,8 @@ func (s *Store) Log(ctx context.Context, event audit.Event) error {
 
 	query := `
 		INSERT INTO audit_logs
-		(id, timestamp, duration_ms, request_id, session_id, user_id, user_email, persona, tool_name, toolkit_kind, toolkit_name, connection, parameters, success, error_message, created_date, response_chars, request_chars, content_blocks, transport, source, enrichment_applied, enrichment_tokens_full, enrichment_tokens_dedup, enrichment_mode, enrichment_match_kind, authorized)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27)
+		(id, timestamp, duration_ms, request_id, session_id, user_id, user_email, persona, tool_name, toolkit_kind, toolkit_name, connection, parameters, success, error_message, created_date, response_chars, request_chars, content_blocks, transport, source, enrichment_applied, enrichment_tokens_full, enrichment_tokens_dedup, enrichment_mode, enrichment_match_kind, authorized, event_kind)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)
 	`
 
 	_, err = s.db.ExecContext(ctx, query,
@@ -131,6 +133,7 @@ func (s *Store) Log(ctx context.Context, event audit.Event) error {
 		event.EnrichmentMode,
 		event.EnrichmentMatchKind,
 		event.Authorized,
+		string(event.EventKind),
 	)
 	if err != nil {
 		return fmt.Errorf("inserting audit log: %w", err)
@@ -148,6 +151,7 @@ func applyAuditFilter(qb sq.SelectBuilder, filter audit.QueryFilter) sq.SelectBu
 		{colToolName, filter.ToolName},
 		{colToolkitKind, filter.ToolkitKind},
 		{colSource, filter.Source},
+		{colEventKind, filter.EventKind},
 	} {
 		if eq.val != "" {
 			qb = qb.Where(sq.Eq{eq.col: eq.val})
@@ -227,6 +231,7 @@ func (s *Store) Distinct(ctx context.Context, column string, startTime, endTime 
 		colToolName:    true,
 		colToolkitKind: true,
 		colSource:      true,
+		colEventKind:   true,
 	}
 	if !allowed[column] {
 		return nil, fmt.Errorf("distinct not supported for column %q", column)
@@ -339,6 +344,7 @@ func (s *Store) executeQuery(ctx context.Context, query string, args []any, limi
 func (*Store) scanEvent(rows *sql.Rows) (audit.Event, error) {
 	var event audit.Event
 	var params []byte
+	var eventKind sql.NullString
 
 	err := rows.Scan(
 		&event.ID,
@@ -367,6 +373,7 @@ func (*Store) scanEvent(rows *sql.Rows) (audit.Event, error) {
 		&event.EnrichmentMode,
 		&event.EnrichmentMatchKind,
 		&event.Authorized,
+		&eventKind,
 	)
 	if err != nil {
 		return event, fmt.Errorf("scanning audit log row: %w", err)
@@ -374,6 +381,9 @@ func (*Store) scanEvent(rows *sql.Rows) (audit.Event, error) {
 
 	if len(params) > 0 {
 		_ = json.Unmarshal(params, &event.Parameters)
+	}
+	if eventKind.Valid {
+		event.EventKind = audit.EventType(eventKind.String)
 	}
 
 	return event, nil

--- a/pkg/audit/postgres/store_test.go
+++ b/pkg/audit/postgres/store_test.go
@@ -28,7 +28,7 @@ const (
 	testCountFiltered = 7
 )
 
-// selectColumns lists the 26 SELECT column names in scan order.
+// selectColumns lists the SELECT column names in scan order.
 var selectColumns = []string{
 	"id", "timestamp", "duration_ms", "request_id", "session_id",
 	"user_id", "user_email", "persona", "tool_name", "toolkit_kind",
@@ -37,6 +37,7 @@ var selectColumns = []string{
 	"transport", "source", "enrichment_applied",
 	"enrichment_tokens_full", "enrichment_tokens_dedup",
 	"enrichment_mode", "enrichment_match_kind", "authorized",
+	"event_kind",
 }
 
 const (
@@ -71,6 +72,7 @@ func newTestEvent() audit.Event {
 		EnrichmentTokensDedup: testEnrichTokensDedup,
 		EnrichmentMode:        "full",
 		Authorized:            true,
+		EventKind:             audit.EventTypeMCPToolCall,
 	}
 }
 
@@ -130,6 +132,7 @@ func TestLog_Success(t *testing.T) {
 		event.EnrichmentMode,
 		event.EnrichmentMatchKind,
 		event.Authorized,
+		string(event.EventKind),
 	).WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err = store.Log(context.Background(), event)
@@ -159,6 +162,7 @@ func TestLog_NilParameters(t *testing.T) {
 		event.Transport, event.Source, event.EnrichmentApplied,
 		event.EnrichmentTokensFull, event.EnrichmentTokensDedup,
 		event.EnrichmentMode, event.EnrichmentMatchKind, event.Authorized,
+		string(event.EventKind),
 	).WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err = store.Log(context.Background(), event)
@@ -200,6 +204,7 @@ func testEventRows(mock sqlmock.Sqlmock, events ...audit.Event) {
 			event.Transport, event.Source, event.EnrichmentApplied,
 			event.EnrichmentTokensFull, event.EnrichmentTokensDedup,
 			event.EnrichmentMode, event.EnrichmentMatchKind, event.Authorized,
+			string(event.EventKind),
 		)
 	}
 	mock.ExpectQuery("SELECT .+ FROM audit_logs").WillReturnRows(rows)
@@ -239,6 +244,7 @@ func TestQuery_AllFilters(t *testing.T) {
 		SessionID:   "sess-789",
 		ToolName:    "trino_query",
 		ToolkitKind: "trino",
+		EventKind:   "mcp_tool_call",
 		Success:     &success,
 		Limit:       testFilterLimit,
 		Offset:      testFilterOffset,
@@ -258,6 +264,7 @@ func TestQuery_AllFilters(t *testing.T) {
 		event.Transport, event.Source, event.EnrichmentApplied,
 		event.EnrichmentTokensFull, event.EnrichmentTokensDedup,
 		event.EnrichmentMode, event.EnrichmentMatchKind, event.Authorized,
+		string(event.EventKind),
 	)
 
 	mock.ExpectQuery("SELECT .+ FROM audit_logs").WithArgs(
@@ -265,6 +272,7 @@ func TestQuery_AllFilters(t *testing.T) {
 		"sess-789",
 		"trino_query",
 		"trino",
+		"mcp_tool_call",
 		startTime,
 		endTime,
 		true,
@@ -295,6 +303,29 @@ func TestQuery_SessionIDFilter(t *testing.T) {
 	results, err := store.Query(context.Background(), filter)
 	assert.NoError(t, err)
 	assert.Empty(t, results)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestQuery_EventKindFilter(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := New(db, Config{RetentionDays: 90})
+
+	apiEvent := newTestEvent()
+	apiEvent.ID = "evt-api"
+	apiEvent.ToolName = "api_invoke_endpoint"
+	apiEvent.ToolkitKind = "api"
+	apiEvent.EventKind = audit.EventTypeAPIGatewayInvoke
+	testEventRows(mock, apiEvent)
+
+	results, err := store.Query(context.Background(), audit.QueryFilter{
+		EventKind: "apigateway_invoke",
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, audit.EventTypeAPIGatewayInvoke, results[0].EventKind)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -393,6 +424,7 @@ func TestScanEvent_AllFields(t *testing.T) {
 		event.EnrichmentMode,
 		event.EnrichmentMatchKind,
 		event.Authorized,
+		string(event.EventKind),
 	)
 	mock.ExpectQuery("SELECT .+ FROM audit_logs").WillReturnRows(rows)
 
@@ -711,6 +743,7 @@ func TestQuery_MultipleRows(t *testing.T) {
 			ev.Transport, ev.Source, ev.EnrichmentApplied,
 			ev.EnrichmentTokensFull, ev.EnrichmentTokensDedup,
 			ev.EnrichmentMode, ev.EnrichmentMatchKind, ev.Authorized,
+			string(ev.EventKind),
 		)
 	}
 	mock.ExpectQuery("SELECT .+ FROM audit_logs").WillReturnRows(rows)
@@ -744,6 +777,7 @@ func TestQuery_EmptyParameters(t *testing.T) {
 		event.Transport, event.Source, event.EnrichmentApplied,
 		event.EnrichmentTokensFull, event.EnrichmentTokensDedup,
 		event.EnrichmentMode, event.EnrichmentMatchKind, event.Authorized,
+		string(event.EventKind),
 	)
 	mock.ExpectQuery("SELECT .+ FROM audit_logs").WillReturnRows(rows)
 
@@ -832,6 +866,7 @@ func TestQuery_IDFilter(t *testing.T) {
 		event.Transport, event.Source, event.EnrichmentApplied,
 		event.EnrichmentTokensFull, event.EnrichmentTokensDedup,
 		event.EnrichmentMode, event.EnrichmentMatchKind, event.Authorized,
+		string(event.EventKind),
 	)
 	mock.ExpectQuery("SELECT .+ FROM audit_logs").WithArgs("evt-specific").WillReturnRows(rows)
 
@@ -1295,4 +1330,5 @@ func assertEventEqual(t *testing.T, expected, got audit.Event) {
 	assert.Equal(t, expected.EnrichmentTokensDedup, got.EnrichmentTokensDedup)
 	assert.Equal(t, expected.EnrichmentMode, got.EnrichmentMode)
 	assert.Equal(t, expected.Authorized, got.Authorized)
+	assert.Equal(t, expected.EventKind, got.EventKind)
 }

--- a/pkg/database/migrate/migrate_unit_test.go
+++ b/pkg/database/migrate/migrate_unit_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	migrateTestFileCount    = 94
+	migrateTestFileCount    = 96
 	migrateTestSuccess      = "success"
 	migrateTestFactoryError = "factory error"
 )

--- a/pkg/database/migrate/migrations/000048_audit_event_kind.down.sql
+++ b/pkg/database/migrate/migrations/000048_audit_event_kind.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE audit_logs DROP COLUMN IF EXISTS event_kind;

--- a/pkg/database/migrate/migrations/000048_audit_event_kind.up.sql
+++ b/pkg/database/migrate/migrations/000048_audit_event_kind.up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS event_kind VARCHAR(64);
+
+UPDATE audit_logs SET event_kind = 'apigateway_invoke'
+WHERE event_kind IS NULL AND tool_name LIKE 'api\_%' ESCAPE '\';
+
+UPDATE audit_logs SET event_kind = 'mcp_tool_call'
+WHERE event_kind IS NULL;

--- a/pkg/middleware/audit.go
+++ b/pkg/middleware/audit.go
@@ -43,6 +43,9 @@ type AuditEvent struct {
 	// operator-facing description.
 	EnrichmentMatchKind string `json:"enrichment_match_kind,omitempty"`
 	Authorized          bool   `json:"authorized"`
+	// EventKind is the high-level event category ("mcp_tool_call" or
+	// "apigateway_invoke"), derived from the toolkit kind at build time.
+	EventKind string `json:"event_kind,omitempty"`
 }
 
 // NoopAuditLogger discards all audit events.

--- a/pkg/middleware/audit_adapter.go
+++ b/pkg/middleware/audit_adapter.go
@@ -43,7 +43,8 @@ func (a *auditStoreAdapter) Log(ctx context.Context, event AuditEvent) error {
 		WithEnrichmentTokens(event.EnrichmentTokensFull, event.EnrichmentTokensDedup).
 		WithEnrichmentMode(event.EnrichmentMode).
 		WithEnrichmentMatchKind(event.EnrichmentMatchKind).
-		WithAuthorized(event.Authorized)
+		WithAuthorized(event.Authorized).
+		WithEventKind(audit.EventType(event.EventKind))
 
 	// Override timestamp from the event
 	auditEvent.Timestamp = event.Timestamp

--- a/pkg/middleware/mcp_audit.go
+++ b/pkg/middleware/mcp_audit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/txn2/mcp-data-platform/pkg/audit"
 	"github.com/txn2/mcp-data-platform/pkg/observability"
 )
 
@@ -154,6 +155,7 @@ func buildMCPAuditEvent(pc *PlatformContext, info auditCallInfo) AuditEvent {
 		EnrichmentMode:        pc.EnrichmentMode,
 		EnrichmentMatchKind:   pc.EnrichmentMatchKind,
 		Authorized:            pc.Authorized,
+		EventKind:             string(audit.EventKindForToolkit(pc.ToolkitKind)),
 	}
 }
 

--- a/pkg/middleware/mcp_audit_test.go
+++ b/pkg/middleware/mcp_audit_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/txn2/mcp-data-platform/pkg/audit"
 	"github.com/txn2/mcp-data-platform/pkg/observability"
 )
 
@@ -446,6 +447,93 @@ func TestMCPAuditMiddleware_ResponseSizeLogged(t *testing.T) {
 	require.Len(t, events, 1)
 	assert.Equal(t, testAuditCharsResult, events[0].ResponseChars) // "result data here" = 16 chars.
 	assert.Equal(t, 1, events[0].ContentBlocks)
+}
+
+// recordingAuditStore captures the final audit.Event values that reach
+// the storage sink. It implements the auditStore interface the real
+// auditStoreAdapter depends on, so a test can wire the real adapter
+// over it and assert the end-to-end conversion result.
+type recordingAuditStore struct {
+	mu     sync.Mutex
+	events []audit.Event
+}
+
+func (r *recordingAuditStore) Log(_ context.Context, event audit.Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, event)
+	return nil
+}
+
+func (r *recordingAuditStore) Events() []audit.Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]audit.Event, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+// TestMCPAuditMiddleware_EventKindEndToEnd proves the full audit path:
+// MCPAuditMiddleware derives the event kind from the toolkit kind in
+// PlatformContext, the real auditStoreAdapter maps it through its
+// builder chain, and the resulting audit.Event carries the correct
+// EventKind at the storage sink. Issue #465.
+func TestMCPAuditMiddleware_EventKindEndToEnd(t *testing.T) {
+	tests := []struct {
+		name        string
+		toolName    string
+		toolkitKind string
+		want        audit.EventType
+	}{
+		{
+			name:        "apigateway invoke",
+			toolName:    "api_invoke_endpoint",
+			toolkitKind: "api",
+			want:        audit.EventTypeAPIGatewayInvoke,
+		},
+		{
+			name:        "mcp tool call",
+			toolName:    testAuditToolName,
+			toolkitKind: testAuditToolkit,
+			want:        audit.EventTypeMCPToolCall,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &recordingAuditStore{}
+			// Real adapter over the recording sink — exercises the
+			// production builder chain, not a hand-built event.
+			logger := &auditStoreAdapter{store: rec}
+			mw := MCPAuditMiddleware(logger)
+
+			handler := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{&mcp.TextContent{Text: "ok"}},
+				}, nil
+			}
+			wrapped := mw(handler)
+
+			pc := NewPlatformContext("req-ek")
+			pc.UserID = testAuditEmail
+			pc.ToolName = tc.toolName
+			pc.ToolkitKind = tc.toolkitKind
+			ctx := WithPlatformContext(context.Background(), pc)
+
+			req := createAuditTestRequest(t, tc.toolName, nil)
+			_, err := wrapped(ctx, testAuditMethodCall, req)
+			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				return len(rec.Events()) == 1
+			}, time.Second, 10*time.Millisecond, "audit event should be logged")
+
+			got := rec.Events()[0]
+			assert.Equal(t, tc.want, got.EventKind)
+			assert.Equal(t, tc.toolName, got.ToolName)
+			assert.Equal(t, tc.toolkitKind, got.ToolkitKind)
+		})
+	}
 }
 
 // capturingAuditLogger captures audit events for testing.

--- a/scripts/codeql-baseline.txt
+++ b/scripts/codeql-baseline.txt
@@ -16,5 +16,5 @@
 # Triaging them out of scope; track separately if any becomes a real
 # concern.
 
-go/sql-injection pkg/audit/postgres/store.go:191
+go/sql-injection pkg/audit/postgres/store.go:195
 go/log-injection cmd/dev-mcp-mock/main.go:178


### PR DESCRIPTION
## Summary

Closes #465. Part of the observability epic #459.

API gateway HTTP invocations and MCP tool calls landed in `audit_logs` with an identical row shape and no reliable distinguisher. The portal's Activity view (and the planned MCP/API split in #464) could not exclude gateway noise. This adds an `event_kind` column, populated at write time, that categorizes every audited tool call as either `mcp_tool_call` or `apigateway_invoke`.

The kind is derived from the toolkit kind (`api` → `apigateway_invoke`, everything else → `mcp_tool_call`), not from tool-name string matching, so it is stable against tool renames.

## Changes

### Schema + event model
- **Migration `000048_audit_event_kind`** adds a nullable `event_kind VARCHAR(64)` column and backfills existing rows (`tool_name LIKE 'api\_%'` → `apigateway_invoke`, remainder → `mcp_tool_call`). The down migration drops the column.
- New `EventType` constants `EventTypeMCPToolCall` / `EventTypeAPIGatewayInvoke`, an `EventKindForToolkit(toolkitKind)` mapper, a `WithEventKind` builder, and the `EventKind` field on `audit.Event`.
- The PostgreSQL store INSERTs and scans the new column (nullable, read via `sql.NullString`).

### Write path
- `MCPAuditMiddleware` derives the kind from `PlatformContext.ToolkitKind` when building the audit event; the real `auditStoreAdapter` maps it through its builder chain to the store.

### Filtering
- `event_kind` filter added to `QueryFilter` and the metrics filter structs, wired through **every** admin endpoint that powers dashboard data: event list, stats, the filter dropdown (`Distinct`), and all six metrics endpoints (timeseries, breakdown, overview, performance, enrichment, discovery).
- `Enrichment` and `Discovery` previously took `(startTime, endTime)`; both now take `audit.MetricsFilter` so the filter reaches them uniformly. The Discovery queries use a static `($3 = '' OR event_kind = $3)` predicate (parameterized, no string concatenation) so an empty value is a no-op.

### Docs
- `docs/server/audit.md`, `docs/llms-full.txt`, and regenerated Swagger (`internal/apidocs/`) document the field, its values, and the filter on every endpoint.

## Notes
- The portal's default exclusion of `apigateway_*` from the MCP Activity view is the UI half and lands in #464; this PR is the backend foundation.
- `scripts/codeql-baseline.txt` line number updated (191→195): a pre-existing, allowlist-sanitized ORDER BY false positive shifted by the added lines. Same finding, relocated — not a new alert.

## Test plan
- [x] `make verify` green (race tests, lint, gosec, CodeQL, semgrep, ≥80% coverage, patch coverage, mutation ≥60%, GoReleaser dry-run)
- [x] Unit: `EventKindForToolkit` mapping per kind; `WithEventKind` builder; store `QueryFilter.EventKind` filter; `event_kind` filter on all squirrel metrics + Discovery (empty no-op and set value)
- [x] Handler: `event_kind` query param flows into the filter; filters endpoint returns `event_kinds`
- [x] **Integration**: `TestMCPAuditMiddleware_EventKindEndToEnd` drives the real middleware → adapter → store path and asserts `apigateway_invoke` for an `api_invoke_endpoint` call and `mcp_tool_call` for a trino call
- [ ] Manual (post-deploy): issue an `api_invoke_endpoint` and a `trino_query`, then `GET /api/v1/admin/audit/events?event_kind=apigateway_invoke` returns only the api call; `SELECT event_kind, COUNT(*) FROM audit_logs GROUP BY event_kind` shows both values