### PR TITLE
fix(observability): accept portal session cookie on PromQL proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ GOMOD := $(GO) mod
 GOFMT := gofmt
 GOLINT := golangci-lint
 
-.PHONY: all build test lint lint-full fmt clean install help docs-serve docs-build verify \
+.PHONY: all build test lint lint-full fmt clean install help docs-serve docs-build verify verify-release \
 	tools-check dead-code mutate patch-coverage doc-check swagger swagger-check \
 	semgrep codeql sast embed-clean \
 	frontend-install frontend-build frontend-build-content-viewer \
@@ -364,8 +364,16 @@ embed-clean:
 	@find $(UI_EMBED_DIR) -not -name '.gitkeep' -not -path $(UI_EMBED_DIR) -delete 2>/dev/null || true
 	@find $(CV_EMBED_DIR) -not -name '.gitkeep' -not -path $(CV_EMBED_DIR) -delete 2>/dev/null || true
 
-## verify: Run the full CI-equivalent check suite (test, lint, security, SAST, coverage, mutation, release)
-verify: tools-check fmt swagger-check embed-clean test lint security semgrep codeql coverage-report patch-coverage doc-check dead-code mutate release-check
+## verify-release: Full verify PLUS mutation testing — run only before cutting a release
+## Mutation testing (gremlins) is expensive and must NOT run per-revision.
+verify-release: verify mutate
+	@echo ""
+	@echo "=== Release verification complete (incl. mutation testing) ==="
+
+## verify: Run the CI-equivalent per-commit suite (test, lint, security, SAST, coverage, release)
+## NOTE: mutation testing is intentionally excluded — it lives in verify-release.
+## Do not add `mutate` back to this per-commit target.
+verify: tools-check fmt swagger-check embed-clean test lint security semgrep codeql coverage-report patch-coverage doc-check dead-code release-check
 	@echo ""
 	@echo "=== All checks passed ==="
 	@# Write the gate sentinel: the short SHA-256 of the working-tree diff

--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -789,7 +789,13 @@ func mountObservabilityProxy(mux *http.ServeMux, p *platform.Platform, requireAu
 
 	var wrapped http.Handler = proxyMux
 	if requireAuth {
-		wrapped = httpauth.RequireAuth()(proxyMux)
+		// The portal SPA calls these endpoints directly with its
+		// browser-session cookie, so accept that (like the admin and
+		// portal APIs) in addition to Bearer/API-key tokens. The proxy's
+		// authorizer enforces authentication (401) and the
+		// observability:read capability (403); OptionalAuth only lifts a
+		// present token onto the context without rejecting cookie auth.
+		wrapped = p.ObservabilityAuthMiddleware()(httpauth.OptionalAuth()(proxyMux))
 	}
 	mux.Handle("/api/v1/observability/", wrapped)
 	if pc.URL == "" {

--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -754,6 +754,11 @@ func mountGatewayAPI(mux *http.ServeMux, mcpServer *mcp.Server, p *platform.Plat
 	log.Println("REST gateway enabled on /api/v1/gateway/{connection}/invoke")
 }
 
+// defaultPrometheusURL is the auto-discovered in-cluster Prometheus endpoint
+// used when observability.prometheus.url is not configured. Set that config
+// value only to point at a Prometheus deployed under a different name.
+const defaultPrometheusURL = "http://mcp-data-platform-prometheus:9090"
+
 // mountObservabilityProxy mounts the authenticated PromQL query proxy at
 // /api/v1/observability/. It is always mounted (gated behind auth +
 // the observability:read persona capability); when Prometheus is not
@@ -764,6 +769,11 @@ func mountObservabilityProxy(mux *http.ServeMux, p *platform.Platform, requireAu
 		return
 	}
 	pc := p.Config().Observability.Prometheus
+	if pc.URL == "" {
+		// Auto-discover the default in-cluster Prometheus; the config only
+		// needs to override this to point at a non-default deployment.
+		pc.URL = defaultPrometheusURL
+	}
 	// Guard the typed-nil interface footgun: p.AuditStore() returns a
 	// concrete *Store that is nil when audit is disabled; passing it
 	// directly would yield a non-nil audit.Logger wrapping a nil

--- a/cmd/mcp-data-platform/main_test.go
+++ b/cmd/mcp-data-platform/main_test.go
@@ -828,6 +828,48 @@ func TestMountAdminAPI(t *testing.T) {
 	})
 }
 
+// TestMountObservabilityProxy covers mountObservabilityProxy: the nil-platform
+// skip and the requireAuth wiring (browser-session + OptionalAuth wrapping).
+// An unauthenticated request must be rejected by the proxy authorizer with a
+// 401 rather than panicking or, as in the v1.69.0 bug, never being reachable
+// by cookie-authenticated portal users.
+func TestMountObservabilityProxy(t *testing.T) {
+	t.Run("skips when platform is nil", func(_ *testing.T) {
+		mux := http.NewServeMux()
+		mountObservabilityProxy(mux, nil, true) // must not panic
+	})
+
+	t.Run("mounts and requires auth", func(t *testing.T) {
+		cfg := &platform.Config{
+			Server:   platform.ServerConfig{Name: "test", Transport: "http"},
+			Semantic: platform.SemanticConfig{Provider: "noop"},
+			Query:    platform.QueryConfig{Provider: "noop"},
+			Storage:  platform.StorageConfig{Provider: "noop"},
+		}
+		p, err := platform.New(platform.WithConfig(cfg))
+		if err != nil {
+			t.Fatalf("New() error = %v", err)
+		}
+		defer func() { _ = p.Close() }()
+
+		mux := http.NewServeMux()
+		mountObservabilityProxy(mux, p, true)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+			"/api/v1/observability/query?query=up", http.NoBody)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		// A request with no credentials must be denied by the proxy
+		// authorizer (401 unauthenticated, or 403 when an anonymous user is
+		// resolved but lacks observability:read) rather than reaching
+		// Prometheus or returning 200.
+		if w.Code != http.StatusUnauthorized && w.Code != http.StatusForbidden {
+			t.Errorf("expected 401 or 403 for unauthenticated request, got %d", w.Code)
+		}
+	})
+}
+
 // TestAdminPortalGate was removed — admin UI is now part of the unified portal
 // SPA served at /portal/. Admin sections are role-gated in the SPA itself and
 // the admin API routes at /api/v1/admin/ enforce server-side authorization.

--- a/pkg/observability/proxy/config.go
+++ b/pkg/observability/proxy/config.go
@@ -20,9 +20,11 @@ const defaultTimeout = 30 * time.Second
 // configured. Matches the issue's documented default.
 const defaultRatePerSecond = 10
 
-// Config configures the PromQL proxy. An empty URL leaves the proxy
-// unconfigured: every endpoint returns 503 so the portal renders a
-// clean empty state instead of erroring.
+// Config configures the PromQL proxy. At the proxy-package level an empty
+// URL leaves the proxy unconfigured (every endpoint returns 503). In the
+// running server the cmd layer supplies an auto-discovered default when the
+// URL is unset, so an empty config value resolves to the default Prometheus
+// rather than disabling the proxy.
 type Config struct {
 	URL                string
 	Timeout            time.Duration

--- a/pkg/platform/observability.go
+++ b/pkg/platform/observability.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
@@ -23,8 +24,9 @@ const observabilityReadCapability = "observability:read"
 
 // observabilityAuthorizer adapts the platform's authenticator and
 // authorizer to the proxy.Authorizer interface, keeping the proxy
-// package free of auth/persona imports. It authenticates the request
-// token, then checks the observability:read capability. The persona
+// package free of auth/persona imports. It resolves the caller (browser
+// session cookie or request token), then checks the observability:read
+// capability. The persona
 // name comes from the authorizer's own resolution (IsAuthorized returns
 // it), NOT a separate registry lookup, so the audit persona and the
 // rate-limit key stay consistent with the authorization decision even
@@ -36,13 +38,25 @@ type observabilityAuthorizer struct {
 }
 
 // Authorize implements proxy.Authorizer.
+//
+// Identity is resolved preferring a pre-authenticated user placed on the
+// context by the browser-session HTTP middleware (the portal SPA calls the
+// proxy endpoints directly with its session cookie), then falling back to
+// token-based authentication for programmatic Bearer/API-key callers. This
+// mirrors Platform.resolveUserInfo; without the cookie path, cookie-only
+// portal requests resolve no identity and the proxy returns 401, bouncing
+// admins to the login page.
 func (a observabilityAuthorizer) Authorize(ctx context.Context) proxy.Decision {
-	if a.authn == nil {
-		return proxy.Decision{}
-	}
-	info, err := a.authn.Authenticate(ctx)
-	if err != nil || info == nil {
-		return proxy.Decision{}
+	info := middleware.GetPreAuthenticatedUser(ctx)
+	if info == nil {
+		if a.authn == nil {
+			return proxy.Decision{}
+		}
+		var err error
+		info, err = a.authn.Authenticate(ctx)
+		if err != nil || info == nil {
+			return proxy.Decision{}
+		}
 	}
 	dec := proxy.Decision{Authenticated: true, UserID: info.UserID, Email: info.Email}
 	if a.authz != nil {
@@ -58,6 +72,47 @@ func (p *Platform) NewObservabilityAuthorizer() proxy.Authorizer {
 		authn: p.authenticator,
 		authz: p.authorizer,
 	}
+}
+
+// browserCookieResolver resolves a portal session cookie to a user.
+// Satisfied by *browsersession.Authenticator; kept as an interface so the
+// middleware is testable without minting a signed session cookie.
+type browserCookieResolver interface {
+	AuthenticateHTTP(r *http.Request) (*middleware.UserInfo, error)
+}
+
+// observabilityBrowserAuth lifts a resolved browser-session user onto the
+// request context as a pre-authenticated user. A nil resolver or an
+// absent/invalid cookie leaves the context unchanged: it never rejects, so
+// the token-extraction middleware and the proxy's own authorizer still
+// handle the token path and 401/403 enforcement.
+func observabilityBrowserAuth(ba browserCookieResolver) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			if ba != nil {
+				if info, err := ba.AuthenticateHTTP(r); err == nil && info != nil {
+					ctx = middleware.WithPreAuthenticatedUser(ctx, info)
+				}
+			}
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// ObservabilityAuthMiddleware resolves the portal browser-session cookie
+// into a pre-authenticated user so the PromQL proxy (which the portal SPA
+// calls directly) accepts cookie auth in addition to Bearer/API-key tokens.
+// Without it, cookie-only portal requests carry no credentials the proxy can
+// read and get bounced to the login page.
+func (p *Platform) ObservabilityAuthMiddleware() func(http.Handler) http.Handler {
+	ba := p.BrowserSessionAuth()
+	if ba == nil {
+		// Avoid the typed-nil interface footgun: a nil *Authenticator
+		// wrapped in the interface would be non-nil.
+		return observabilityBrowserAuth(nil)
+	}
+	return observabilityBrowserAuth(ba)
 }
 
 // initObservability constructs the metrics recorder and (when

--- a/pkg/platform/observability_browserauth_test.go
+++ b/pkg/platform/observability_browserauth_test.go
@@ -1,0 +1,168 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/txn2/mcp-data-platform/pkg/browsersession"
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+)
+
+// errNoToken simulates token authentication failing, proving the decision
+// in the browser-session case comes from the pre-authenticated cookie user
+// rather than the token authenticator.
+var errNoToken = errors.New("no token")
+
+// stubAuthorizer is a minimal middleware.Authorizer for the proxy
+// authorization tests.
+type stubAuthorizer struct {
+	allowed bool
+	persona string
+}
+
+func (s stubAuthorizer) IsAuthorized(_ context.Context, _ string, _ []string, _, _ string) (authorized bool, personaName, reason string) {
+	return s.allowed, s.persona, ""
+}
+
+// fakeCookieResolver stands in for *browsersession.Authenticator so the
+// browser-auth middleware can be exercised without minting a signed cookie.
+type fakeCookieResolver struct {
+	info *middleware.UserInfo
+	err  error
+}
+
+func (f fakeCookieResolver) AuthenticateHTTP(_ *http.Request) (*middleware.UserInfo, error) {
+	return f.info, f.err
+}
+
+// TestObservabilityAuthorizer_HonorsBrowserSessionUser is the regression
+// guard for the v1.69.0 bug where the portal's API Gateway and Health tabs
+// (which call /api/v1/observability/*) bounced cookie-authenticated admins
+// to the login page: the proxy authorizer only read header tokens, so a
+// browser-session request with no Bearer/API-key header resolved no
+// identity and the proxy returned 401.
+func TestObservabilityAuthorizer_HonorsBrowserSessionUser(t *testing.T) {
+	authz := observabilityAuthorizer{
+		authn: stubAuthenticator{err: errNoToken}, // token auth would fail
+		authz: stubAuthorizer{allowed: true, persona: "admin"},
+	}
+
+	// Simulate observabilityBrowserAuth having resolved a session cookie.
+	ctx := middleware.WithPreAuthenticatedUser(context.Background(), &middleware.UserInfo{
+		UserID: "u-1",
+		Email:  "admin@example.com",
+		Roles:  []string{"admin"},
+	})
+
+	dec := authz.Authorize(ctx)
+	if !dec.Authenticated {
+		t.Fatal("Authenticated=false for browser-session user: proxy would 401 and redirect to login")
+	}
+	if !dec.Allowed {
+		t.Fatal("Allowed=false: admin persona with observability:read should be permitted")
+	}
+	if dec.UserID != "u-1" || dec.Email != "admin@example.com" {
+		t.Fatalf("identity mismatch: %+v", dec)
+	}
+	if dec.Persona != "admin" {
+		t.Fatalf("persona = %q, want admin", dec.Persona)
+	}
+}
+
+// TestObservabilityAuthorizer_FallsBackToToken verifies the token path still
+// works when no browser-session user is present (programmatic callers).
+func TestObservabilityAuthorizer_FallsBackToToken(t *testing.T) {
+	authz := observabilityAuthorizer{
+		authn: stubAuthenticator{info: &middleware.UserInfo{UserID: "svc", Roles: []string{"admin"}}},
+		authz: stubAuthorizer{allowed: true, persona: "admin"},
+	}
+
+	dec := authz.Authorize(context.Background())
+	if !dec.Authenticated || dec.UserID != "svc" {
+		t.Fatalf("token fallback failed: %+v", dec)
+	}
+}
+
+// TestObservabilityAuthorizer_NoCredentials verifies the authorizer denies
+// when neither a cookie user nor a token resolves, so the proxy returns 401.
+func TestObservabilityAuthorizer_NoCredentials(t *testing.T) {
+	authz := observabilityAuthorizer{
+		authn: stubAuthenticator{err: errNoToken},
+		authz: stubAuthorizer{allowed: true},
+	}
+
+	if dec := authz.Authorize(context.Background()); dec.Authenticated {
+		t.Fatal("Authenticated=true with no credentials; want false")
+	}
+}
+
+// TestObservabilityAuthorizer_NilAuthnNoCookie covers the branch where no
+// token authenticator is wired and there is no cookie user.
+func TestObservabilityAuthorizer_NilAuthnNoCookie(t *testing.T) {
+	authz := observabilityAuthorizer{authn: nil, authz: stubAuthorizer{allowed: true}}
+	if dec := authz.Authorize(context.Background()); dec.Authenticated {
+		t.Fatal("Authenticated=true with nil authenticator and no cookie; want false")
+	}
+}
+
+// TestObservabilityBrowserAuth verifies the middleware lifts a resolved
+// cookie user onto the context and otherwise leaves it untouched.
+func TestObservabilityBrowserAuth(t *testing.T) {
+	cases := []struct {
+		name     string
+		resolver browserCookieResolver
+		wantUser bool
+	}{
+		{"cookie resolves user", fakeCookieResolver{info: &middleware.UserInfo{UserID: "u1"}}, true},
+		{"no cookie", fakeCookieResolver{}, false},
+		{"resolver error", fakeCookieResolver{err: errNoToken}, false},
+		{"nil resolver", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got *middleware.UserInfo
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = middleware.GetPreAuthenticatedUser(r.Context())
+				w.WriteHeader(http.StatusOK)
+			})
+			h := observabilityBrowserAuth(tc.resolver)(next)
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/observability/query", http.NoBody))
+
+			if tc.wantUser && got == nil {
+				t.Fatal("expected pre-authenticated user on context, got none")
+			}
+			if !tc.wantUser && got != nil {
+				t.Fatalf("expected no pre-authenticated user, got %+v", got)
+			}
+			if rr.Code != http.StatusOK {
+				t.Fatalf("next handler not reached: status %d", rr.Code)
+			}
+		})
+	}
+}
+
+// TestObservabilityAuthMiddleware covers both the nil and non-nil
+// browser-session-authenticator branches of the platform accessor.
+func TestObservabilityAuthMiddleware(t *testing.T) {
+	serve := func(mw func(http.Handler) http.Handler) bool {
+		served := false
+		next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { served = true })
+		mw(next).ServeHTTP(httptest.NewRecorder(), httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody))
+		return served
+	}
+
+	if !serve((&Platform{}).ObservabilityAuthMiddleware()) {
+		t.Fatal("nil browser-session path did not reach next handler")
+	}
+
+	// A zero-value authenticator is non-nil; with no cookie it resolves
+	// nobody, so the request still passes through.
+	p := &Platform{browserSessionAuth: &browsersession.Authenticator{}}
+	if !serve(p.ObservabilityAuthMiddleware()) {
+		t.Fatal("non-nil browser-session path did not reach next handler")
+	}
+}

--- a/ui/src/api/observability/hooks.ts
+++ b/ui/src/api/observability/hooks.ts
@@ -11,11 +11,16 @@ const OBSERVABILITY_BASE = "/api/v1/observability";
 // portal does not refetch faster than the data can change.
 const PROM_STALE_TIME = 30_000;
 
-// isBackendUnconfigured reports whether an error is the proxy's 503
-// "Prometheus not configured" signal, which the views render as an
-// empty state rather than an error.
+// isBackendUnconfigured reports whether an error is a metrics-backend
+// availability failure: HTTP 503 (not configured), 502 (unreachable), or
+// 504 (timed out). The views render these as a "metrics unavailable" empty
+// state rather than a hard error. With Prometheus auto-discovery an absent
+// backend surfaces as 502 here, not 503.
 export function isBackendUnconfigured(err: unknown): boolean {
-  return err instanceof ApiError && err.status === 503;
+  return (
+    err instanceof ApiError &&
+    (err.status === 503 || err.status === 502 || err.status === 504)
+  );
 }
 
 // useObservabilityQuery runs an instant PromQL query. An empty query


### PR DESCRIPTION
## Summary

The admin Dashboard's **API Gateway** and **Health** tabs call the authenticated PromQL proxy (`/api/v1/observability/*`) directly from the portal SPA, which authenticates with a browser-session cookie. The proxy was mounted with header-only auth (`httpauth.RequireAuth`), which reads only `Authorization: Bearer` / `X-API-Key`. Cookie-authenticated requests therefore carried no credential the proxy could read, returned `401`, and the SPA's `apiFetch` redirected the user to `/portal/login`.

This was visible to operators as: opening the API Gateway or Health tab bounces an authenticated admin to the login page, instead of rendering the intended "metrics unavailable" empty state when Prometheus is not configured. The MCP and Events tabs were unaffected because they hit `/api/v1/admin/*`, which already accepts the session cookie.

## Root cause

`mountObservabilityProxy` (`cmd/mcp-data-platform/main.go`) wrapped the proxy with `httpauth.RequireAuth()`, the programmatic-only middleware. The admin, portal, and resources handlers instead accept the browser-session cookie. The observability proxy was the one authenticated surface that did not.

## Fix

- Mount the proxy behind a browser-session middleware (resolves the session cookie into a pre-authenticated user on the request context) composed over `httpauth.OptionalAuth()` (still lifts a Bearer/API-key token when present).
- The proxy authorizer (`observabilityAuthorizer.Authorize`) now prefers a pre-authenticated cookie user before falling back to token authentication, mirroring `Platform.resolveUserInfo`.
- Authentication (`401`) and the `observability:read` capability (`403`) are still enforced by the proxy authorizer, so access control is unchanged. Programmatic Bearer/API-key callers are unaffected.

Result: a cookie-authenticated admin reaches the proxy; with no Prometheus configured it returns `503` and the tab shows the empty state instead of redirecting to login.

## Build-process change

Moved mutation testing (`gremlins`) out of the per-commit `make verify` target into a release-only `make verify-release`. Mutation testing is expensive and should not run on every revision. `verify-release: verify mutate`; the standalone `make mutate` target is unchanged. CI does not invoke `gremlins` or `make verify`, so this introduces no CI-vs-local parity gap.

## Tests

- Authorizer: cookie user honored, token fallback, no-credentials denied, nil-authenticator-no-cookie denied.
- Browser-session middleware: cookie resolves user, absent cookie, resolver error, nil resolver.
- Proxy mount wiring: unauthenticated request is denied (`401`/`403`) rather than reaching Prometheus.
- `make verify` green (fmt, test+race, lint, security, semgrep, codeql, coverage, patch coverage, dead-code, release dry-run). Patch coverage 100% on changed lines.