### PR TITLE
fix(knowledge): real changeset rollback + list_changesets actions (#492)

### DIFF
--- a/docs/knowledge/admin-api.md
+++ b/docs/knowledge/admin-api.md
@@ -372,7 +372,7 @@ curl -s "https://mcp.example.com/api/v1/admin/knowledge/changesets/cs_x1y2z3a4b5
 POST /api/v1/admin/knowledge/changesets/{id}/rollback
 ```
 
-Reverts a changeset by restoring the `previous_value` metadata to the DataHub entity.
+Reverts the DataHub aspects the changeset mutated back to their before-image, transitions the changeset's source insights to `rolled_back`, and marks the changeset rolled back. Uses the same revert engine as the `apply_knowledge` MCP `rollback` action; see [Governance: Rollback](governance.md#rollback) for the full semantics.
 
 **Example:**
 
@@ -386,12 +386,22 @@ curl -X POST "https://mcp.example.com/api/v1/admin/knowledge/changesets/cs_x1y2z
 ```json
 {
   "changeset_id": "cs_x1y2z3a4b5c6",
-  "rolled_back": true,
-  "message": "Changeset rolled back. Previous metadata restored."
+  "target_urn": "urn:li:dataset:(urn:li:dataPlatform:trino,hive.sales.orders,PROD)",
+  "reverted_changes": ["removed glossary term urn:li:glossaryTerm:gross-margin"],
+  "skipped_changes": [],
+  "insights_rolled_back": ["a1b2c3d4e5f6"],
+  "rolled_back_by": "admin@example.com"
 }
 ```
 
-A changeset can only be rolled back once. Attempting to roll back an already-rolled-back changeset returns an error.
+**Status codes:**
+
+| Status | Condition |
+|--------|-----------|
+| `200` | Reverted and recorded. |
+| `404` | Changeset not found. |
+| `409` | Already rolled back, or a newer changeset has since modified the same aspect. |
+| `422` | Changeset contains change types whose prior state was not captured (column descriptions, structured properties, incidents, curated queries, context documents, prompts). |
 
 ## Error Responses
 

--- a/docs/knowledge/governance.md
+++ b/docs/knowledge/governance.md
@@ -207,11 +207,19 @@ Tag names and glossary term names are automatically normalized to full DataHub U
   "entity_urn": "urn:li:dataset:(urn:li:dataPlatform:trino,hive.sales.orders,PROD)",
   "changes_applied": 2,
   "insights_marked_applied": 1,
-  "message": "Changes applied to DataHub. Changeset cs_x1y2z3a4b5c6 recorded for rollback."
+  "resulting_state": {
+    "description": "Order records with gross margin amounts (before returns)",
+    "tags": ["urn:li:tag:gross-margin"],
+    "glossary_terms": [],
+    "owners": []
+  },
+  "message": "Changes applied to DataHub. Roll back with action=rollback changeset_id=cs_x1y2z3a4b5c6. changes_applied counts requested changes; verify against resulting_state below."
 }
 ```
 
 Source insights move to `applied` status with a reference to the changeset.
+
+`changes_applied` counts the changes that were dispatched without error; a duplicate add (for example a tag that was already present) is a no-op upstream and still counts. The `resulting_state` field is a fresh read-back of the entity's description, tags, glossary terms, and owners after the apply, so callers can confirm what actually persisted without a follow-up call. Writes are not transactional: if a change in the middle of the list fails, earlier changes have already persisted and are reported in the error message rather than silently rolled back.
 
 ## Changeset Tracking
 
@@ -230,11 +238,25 @@ Every `apply` action creates a changeset record in the `knowledge_changesets` ta
 | `rolled_back_by` | Who reverted the changes |
 | `rolled_back_at` | When the changes were reverted |
 
-The `previous_value` field captures the entity's metadata at the time of application, which is used for rollback.
+The `previous_value` field captures the entity's metadata (description, tags, glossary terms, owners) at the time of application. This before-image is what bounds rollback: a change can be reverted only when its prior state is recoverable from this snapshot.
+
+## Discovering Changesets
+
+Use the `list_changesets` action to find an entity's changesets without already holding their ids (for example, before a rollback):
+
+```json
+{ "action": "list_changesets", "entity_urn": "urn:li:dataset:(urn:li:dataPlatform:trino,hive.sales.orders,PROD)" }
+```
+
+Each entry returns `changeset_id`, `created_at`, `applied_by`, `change_type`, `source_insight_ids`, and the current `rolled_back` status.
 
 ## Rollback
 
-Changesets can be rolled back through the [Admin REST API](admin-api.md):
+A changeset can be rolled back through either the `apply_knowledge` MCP tool or the [Admin REST API](admin-api.md). Both paths use the same revert engine.
+
+```json
+{ "action": "rollback", "changeset_id": "cs_x1y2z3a4b5c6", "confirm": true }
+```
 
 ```bash
 curl -X POST \
@@ -242,12 +264,21 @@ curl -X POST \
   -H "Authorization: Bearer $ADMIN_TOKEN"
 ```
 
-Rollback restores the `previous_value` metadata to the DataHub entity. The changeset is marked as rolled back with the user and timestamp.
+Rollback reverts each change the apply made, back to its before-image:
 
-**Limitations:**
+- A tag, glossary term, or documentation link the apply **added** is removed, **unless** it was already present in the before-image (in which case the add was a no-op and the pre-existing value is kept). This is what preserves an entity's canonical glossary term when an apply added another term alongside it.
+- A tag the apply **removed** is restored.
+- A description the apply changed is reset to the prior description.
 
-- Rollback restores the metadata snapshot from the time of application. If the entity's metadata was modified by other means after the apply, the rollback overwrites those changes too.
-- A changeset can only be rolled back once.
+The rollback also transitions the changeset's source insights from `applied` to `rolled_back` and records the rollback as its own auditable tool call referencing the original `changeset_id`.
+
+**When rollback is refused (rather than silently applied):**
+
+- The changeset has already been rolled back.
+- A newer, not-yet-rolled-back changeset has since modified the same aspect on the same entity. Reverting would clobber that newer change, so the rollback is blocked and names the conflicting changeset; roll the newer one back first, or restore the desired state with a fresh apply.
+- The changeset contains change types whose prior state was not captured in the before-image and therefore cannot be reverted automatically: column-level descriptions, structured properties, incidents, curated queries, context documents, and prompts. For these, restore the desired state with a new apply.
+
+When the changeset contains a mix of revertible and unrevertible change types, the rollback is refused as a whole so it never leaves the entity in a partially reverted state.
 
 ## Complete Workflow Example
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1387,12 +1387,15 @@ Review, synthesize, and apply captured insights to the data catalog. Admin-only.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `action` | string | Yes | bulk_review, review, synthesize, apply, approve, reject |
-| `entity_urn` | string | Conditional | Required for review, synthesize, apply |
+| `action` | string | Yes | bulk_review, review, synthesize, apply, approve, reject, rollback, list_changesets |
+| `entity_urn` | string | Conditional | Required for review, synthesize, apply, list_changesets |
 | `insight_ids` | array | Conditional | Required for approve, reject; optional for synthesize, apply |
 | `changes` | array | Conditional | Required for apply |
-| `confirm` | bool | No | Required when `require_confirmation` is true |
+| `changeset_id` | string | Conditional | Required for rollback |
+| `confirm` | bool | No | Required when `require_confirmation` is true (apply and rollback) |
 | `review_notes` | string | No | Notes for approve/reject actions |
+
+The `rollback` action reverts a changeset's changes to their before-image (removing added tags/glossary terms/documentation links, restoring a changed description), transitions the source insights to `rolled_back`, and marks the changeset rolled back. It is refused if the changeset is already rolled back, if a newer changeset has since modified the same aspect, or if the changeset touched change types whose prior state was not captured (column descriptions, structured properties, incidents, curated queries, context documents, prompts). The `list_changesets` action lists an entity's changesets for discovering rollback targets.
 
 ## Memory Tools
 
@@ -1578,7 +1581,7 @@ Every organization has tribal knowledge about its data that lives in the heads o
 The system has two MCP tools and an Admin REST API:
 
 - `capture_insight`: Records domain knowledge during sessions. Available to all personas when enabled. Creates insights with status `pending`.
-- `apply_knowledge`: Admin-only tool for reviewing, approving, synthesizing, and applying insights to DataHub. Actions: `bulk_review`, `review`, `synthesize`, `apply`, `approve`, `reject`.
+- `apply_knowledge`: Admin-only tool for reviewing, approving, synthesizing, applying, and rolling back insights to DataHub. Actions: `bulk_review`, `review`, `synthesize`, `apply`, `approve`, `reject`, `rollback`, `list_changesets`.
 - Admin REST API: HTTP endpoints for managing insights and changesets outside the MCP protocol.
 
 ## Configuration

--- a/docs/reference/tools-api.md
+++ b/docs/reference/tools-api.md
@@ -991,11 +991,12 @@ Review, synthesize, and apply captured insights to the data catalog. Admin-only.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `action` | string | Yes | One of: `bulk_review`, `review`, `synthesize`, `apply`, `approve`, `reject` |
-| `entity_urn` | string | Conditional | Required for `review`, `synthesize`, `apply` |
+| `action` | string | Yes | One of: `bulk_review`, `review`, `synthesize`, `apply`, `approve`, `reject`, `rollback`, `list_changesets` |
+| `entity_urn` | string | Conditional | Required for `review`, `synthesize`, `apply`, `list_changesets`; optional for `rollback` (validates the changeset belongs to this entity) |
 | `insight_ids` | array | Conditional | Required for `approve`, `reject`; optional for `synthesize`, `apply` |
 | `changes` | array | Conditional | Required for `apply` |
-| `confirm` | bool | No | Required when `require_confirmation` is enabled |
+| `changeset_id` | string | Conditional | Required for `rollback` |
+| `confirm` | bool | No | Required when `require_confirmation` is enabled (for `apply` and `rollback`) |
 | `review_notes` | string | No | Notes for `approve`/`reject` actions |
 
 **Change Schema (for `apply` action):**
@@ -1036,6 +1037,10 @@ Review, synthesize, and apply captured insights to the data catalog. Admin-only.
 | `reject` | Transition insights to rejected status | `insight_ids` |
 | `synthesize` | Structured change proposals from approved insights | `entity_urn` |
 | `apply` | Write changes to DataHub with changeset tracking | `entity_urn`, `changes` |
+| `list_changesets` | List an entity's changesets (id, timestamp, actor, change type, rollback status) | `entity_urn` |
+| `rollback` | Revert a changeset's changes to their before-image | `changeset_id`, `confirm` |
+
+`rollback` reverts the changes an `apply` made: it removes added tags/glossary terms/documentation links (keeping any that pre-existed in the before-image), restores a changed description, transitions the source insights to `rolled_back`, and marks the changeset rolled back. It is refused if the changeset is already rolled back, if a newer changeset has since modified the same aspect, or if the changeset touched change types whose prior state was not captured (column descriptions, structured properties, incidents, curated queries, context documents, prompts).
 
 **Response Schema (apply):**
 
@@ -1045,7 +1050,13 @@ Review, synthesize, and apply captured insights to the data catalog. Admin-only.
   "entity_urn": "urn:li:dataset:(urn:li:dataPlatform:trino,hive.sales.orders,PROD)",
   "changes_applied": 2,
   "insights_marked_applied": 1,
-  "message": "Changes applied to DataHub. Changeset cs_x1y2z3a4b5c6d7e8f9a0b1c2d3e4f5a6 recorded for rollback."
+  "resulting_state": {
+    "description": "Order records with gross margin amounts (before returns)",
+    "tags": ["urn:li:tag:gross-margin"],
+    "glossary_terms": [],
+    "owners": []
+  },
+  "message": "Changes applied to DataHub. Roll back with action=rollback changeset_id=cs_x1y2z3a4b5c6d7e8f9a0b1c2d3e4f5a6. changes_applied counts requested changes; verify against resulting_state below."
 }
 ```
 

--- a/docs/server/tools.md
+++ b/docs/server/tools.md
@@ -586,11 +586,12 @@ Review, synthesize, and apply captured insights to the data catalog. Admin-only.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `action` | string | Yes | bulk_review, review, synthesize, apply, approve, reject |
-| `entity_urn` | string | Conditional | Required for review, synthesize, apply |
+| `action` | string | Yes | bulk_review, review, synthesize, apply, approve, reject, rollback, list_changesets |
+| `entity_urn` | string | Conditional | Required for review, synthesize, apply, list_changesets |
 | `insight_ids` | array | Conditional | Required for approve, reject |
 | `changes` | array | Conditional | Required for apply |
-| `confirm` | bool | No | Required when `require_confirmation` is true |
+| `changeset_id` | string | Conditional | Required for rollback |
+| `confirm` | bool | No | Required when `require_confirmation` is true (apply and rollback) |
 | `review_notes` | string | No | Notes for approve/reject actions |
 
 **Actions:**
@@ -600,6 +601,8 @@ Review, synthesize, and apply captured insights to the data catalog. Admin-only.
 - **approve/reject**: Transition insight status with optional notes
 - **synthesize**: Structured change proposals from approved insights
 - **apply**: Write changes to DataHub with changeset tracking
+- **list_changesets**: List an entity's changesets (id, timestamp, actor, change type, rollback status)
+- **rollback**: Revert a changeset's changes to their before-image and transition its source insights to `rolled_back` (requires `changeset_id` and `confirm`)
 
 **Supported change types for `apply` action:**
 

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -2269,7 +2269,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Rolls back a changeset, restoring previous values to DataHub.",
+                "description": "Reverts the DataHub aspects a changeset mutated back to their pre-change\nstate, transitions the source insights to rolled_back, and marks the\nchangeset rolled back. Refused (409) when already rolled back or when a\nnewer changeset has since touched the same aspect, and (422) when the\nchangeset contains change types whose prior state was not captured.",
                 "produces": [
                     "application/json"
                 ],
@@ -2290,7 +2290,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/admin.statusResponse"
+                            "$ref": "#/definitions/knowledge.RollbackResult"
                         }
                     },
                     "404": {
@@ -2301,6 +2301,12 @@ const docTemplate = `{
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
                         "schema": {
                             "$ref": "#/definitions/admin.problemDetail"
                         }
@@ -9034,6 +9040,38 @@ const docTemplate = `{
                 "urn": {
                     "type": "string",
                     "example": "urn:li:dataset:(urn:li:dataPlatform:trino,hive.sales.orders,PROD)"
+                }
+            }
+        },
+        "knowledge.RollbackResult": {
+            "type": "object",
+            "properties": {
+                "changeset_id": {
+                    "type": "string"
+                },
+                "insights_rolled_back": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "reverted_changes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "rolled_back_by": {
+                    "type": "string"
+                },
+                "skipped_changes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "target_urn": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -2263,7 +2263,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Rolls back a changeset, restoring previous values to DataHub.",
+                "description": "Reverts the DataHub aspects a changeset mutated back to their pre-change\nstate, transitions the source insights to rolled_back, and marks the\nchangeset rolled back. Refused (409) when already rolled back or when a\nnewer changeset has since touched the same aspect, and (422) when the\nchangeset contains change types whose prior state was not captured.",
                 "produces": [
                     "application/json"
                 ],
@@ -2284,7 +2284,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/admin.statusResponse"
+                            "$ref": "#/definitions/knowledge.RollbackResult"
                         }
                     },
                     "404": {
@@ -2295,6 +2295,12 @@
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
                         "schema": {
                             "$ref": "#/definitions/admin.problemDetail"
                         }
@@ -9028,6 +9034,38 @@
                 "urn": {
                     "type": "string",
                     "example": "urn:li:dataset:(urn:li:dataPlatform:trino,hive.sales.orders,PROD)"
+                }
+            }
+        },
+        "knowledge.RollbackResult": {
+            "type": "object",
+            "properties": {
+                "changeset_id": {
+                    "type": "string"
+                },
+                "insights_rolled_back": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "reverted_changes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "rolled_back_by": {
+                    "type": "string"
+                },
+                "skipped_changes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "target_urn": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -1664,6 +1664,27 @@ definitions:
         example: urn:li:dataset:(urn:li:dataPlatform:trino,hive.sales.orders,PROD)
         type: string
     type: object
+  knowledge.RollbackResult:
+    properties:
+      changeset_id:
+        type: string
+      insights_rolled_back:
+        items:
+          type: string
+        type: array
+      reverted_changes:
+        items:
+          type: string
+        type: array
+      rolled_back_by:
+        type: string
+      skipped_changes:
+        items:
+          type: string
+        type: array
+      target_urn:
+        type: string
+    type: object
   knowledge.SuggestedAction:
     properties:
       action_type:
@@ -3934,7 +3955,12 @@ paths:
       - Knowledge
   /admin/knowledge/changesets/{id}/rollback:
     post:
-      description: Rolls back a changeset, restoring previous values to DataHub.
+      description: |-
+        Reverts the DataHub aspects a changeset mutated back to their pre-change
+        state, transitions the source insights to rolled_back, and marks the
+        changeset rolled back. Refused (409) when already rolled back or when a
+        newer changeset has since touched the same aspect, and (422) when the
+        changeset contains change types whose prior state was not captured.
       parameters:
       - description: Changeset ID
         in: path
@@ -3947,13 +3973,17 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/admin.statusResponse'
+            $ref: '#/definitions/knowledge.RollbackResult'
         "404":
           description: Not Found
           schema:
             $ref: '#/definitions/admin.problemDetail'
         "409":
           description: Conflict
+          schema:
+            $ref: '#/definitions/admin.problemDetail'
+        "422":
+          description: Unprocessable Entity
           schema:
             $ref: '#/definitions/admin.problemDetail'
         "500":

--- a/pkg/admin/knowledge.go
+++ b/pkg/admin/knowledge.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -321,13 +322,18 @@ func (h *KnowledgeHandler) GetChangeset(w http.ResponseWriter, r *http.Request) 
 // RollbackChangeset handles POST /api/v1/admin/knowledge/changesets/{id}/rollback.
 //
 // @Summary      Rollback changeset
-// @Description  Rolls back a changeset, restoring previous values to DataHub.
+// @Description  Reverts the DataHub aspects a changeset mutated back to their pre-change
+// @Description  state, transitions the source insights to rolled_back, and marks the
+// @Description  changeset rolled back. Refused (409) when already rolled back or when a
+// @Description  newer changeset has since touched the same aspect, and (422) when the
+// @Description  changeset contains change types whose prior state was not captured.
 // @Tags         Knowledge
 // @Produce      json
 // @Param        id  path  string  true  "Changeset ID"
-// @Success      200  {object}  statusResponse
+// @Success      200  {object}  knowledge.RollbackResult
 // @Failure      404  {object}  problemDetail
 // @Failure      409  {object}  problemDetail
+// @Failure      422  {object}  problemDetail
 // @Failure      500  {object}  problemDetail
 // @Security     ApiKeyAuth
 // @Security     BearerAuth
@@ -335,25 +341,10 @@ func (h *KnowledgeHandler) GetChangeset(w http.ResponseWriter, r *http.Request) 
 func (h *KnowledgeHandler) RollbackChangeset(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue(pathParamID)
 
-	// Get changeset to check state and get previous values
 	cs, err := h.changesetStore.GetChangeset(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "changeset not found")
 		return
-	}
-	if cs.RolledBack {
-		writeError(w, http.StatusConflict, "changeset already rolled back")
-		return
-	}
-
-	// Write previous values back to DataHub
-	if h.datahubWriter != nil {
-		if desc, ok := cs.PreviousValue["description"].(string); ok && desc != "" {
-			if err := h.datahubWriter.UpdateDescription(r.Context(), cs.TargetURN, desc); err != nil {
-				writeError(w, http.StatusInternalServerError, "rollback failed: "+err.Error())
-				return
-			}
-		}
 	}
 
 	rolledBackBy := ""
@@ -361,12 +352,30 @@ func (h *KnowledgeHandler) RollbackChangeset(w http.ResponseWriter, r *http.Requ
 		rolledBackBy = user.UserID
 	}
 
-	if err := h.changesetStore.RollbackChangeset(r.Context(), id, rolledBackBy); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+	deps := knowledge.RollbackDeps{Writer: h.datahubWriter, Changesets: h.changesetStore, Insights: h.insightStore}
+	result, err := knowledge.RevertChangeset(r.Context(), deps, cs, rolledBackBy)
+	if err != nil {
+		writeRollbackError(w, err)
 		return
 	}
 
-	writeJSON(w, http.StatusOK, statusResponse{Status: "rolled_back"})
+	writeJSON(w, http.StatusOK, result)
+}
+
+// writeRollbackError maps a RevertChangeset failure onto the appropriate HTTP status.
+func writeRollbackError(w http.ResponseWriter, err error) {
+	var unrevertible *knowledge.UnrevertibleError
+	var conflict *knowledge.RollbackConflictError
+	switch {
+	case errors.Is(err, knowledge.ErrChangesetAlreadyRolledBack):
+		writeError(w, http.StatusConflict, "changeset already rolled back")
+	case errors.As(err, &conflict):
+		writeError(w, http.StatusConflict, conflict.Error())
+	case errors.As(err, &unrevertible):
+		writeError(w, http.StatusUnprocessableEntity, unrevertible.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "rollback failed: "+err.Error())
+	}
 }
 
 // parseTimeParam parses an RFC3339 time from a query parameter.

--- a/pkg/admin/knowledge_test.go
+++ b/pkg/admin/knowledge_test.go
@@ -66,6 +66,10 @@ type mockInsightStore struct {
 	markAppliedErr error
 	supersedeCount int
 	supersedeErr   error
+
+	// MarkRolledBack — used by the rollback handler
+	markRolledBackErr error
+	rolledBackIDs     []string
 }
 
 func (m *mockInsightStore) Insert(_ context.Context, _ knowledge.Insight) error {
@@ -111,6 +115,11 @@ func (m *mockInsightStore) Stats(_ context.Context, _ knowledge.InsightFilter) (
 
 func (m *mockInsightStore) MarkApplied(_ context.Context, _, _, _ string) error {
 	return m.markAppliedErr
+}
+
+func (m *mockInsightStore) MarkRolledBack(_ context.Context, id, _ string) error {
+	m.rolledBackIDs = append(m.rolledBackIDs, id)
+	return m.markRolledBackErr
 }
 
 func (m *mockInsightStore) Supersede(_ context.Context, _, _ string) (int, error) {
@@ -183,6 +192,10 @@ type mockDataHubWriter struct {
 	updateDescCalled int
 	lastDescURN      string
 	lastDescValue    string
+
+	removeTagCalls  []string
+	removeTermCalls []string
+	removeLinkCalls []string
 }
 
 func (*mockDataHubWriter) GetCurrentMetadata(_ context.Context, _ string) (*knowledge.EntityMetadata, error) {
@@ -196,10 +209,23 @@ func (m *mockDataHubWriter) UpdateDescription(_ context.Context, urn, desc strin
 	return m.updateDescErr
 }
 
-func (*mockDataHubWriter) AddTag(_ context.Context, _, _ string) error          { return nil }
-func (*mockDataHubWriter) RemoveTag(_ context.Context, _, _ string) error       { return nil }
+func (*mockDataHubWriter) AddTag(_ context.Context, _, _ string) error { return nil }
+func (m *mockDataHubWriter) RemoveTag(_ context.Context, _, tag string) error {
+	m.removeTagCalls = append(m.removeTagCalls, tag)
+	return nil
+}
 func (*mockDataHubWriter) AddGlossaryTerm(_ context.Context, _, _ string) error { return nil }
+func (m *mockDataHubWriter) RemoveGlossaryTerm(_ context.Context, _, termURN string) error {
+	m.removeTermCalls = append(m.removeTermCalls, termURN)
+	return nil
+}
+
 func (*mockDataHubWriter) AddDocumentationLink(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func (m *mockDataHubWriter) RemoveDocumentationLink(_ context.Context, _, url string) error {
+	m.removeLinkCalls = append(m.removeLinkCalls, url)
 	return nil
 }
 
@@ -766,56 +792,81 @@ func TestGetChangeset(t *testing.T) {
 
 // --- RollbackChangeset tests ---
 
+// addTermChangeset builds a changeset whose recorded change added a glossary term
+// that was not present in the before-image, so rollback should remove it.
+func addTermChangeset(id, termURN string) *knowledge.Changeset {
+	return &knowledge.Changeset{
+		ID:            id,
+		TargetURN:     "urn:li:dataset:test",
+		ChangeType:    "add_glossary_term",
+		CreatedAt:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		PreviousValue: map[string]any{"glossary_terms": []any{"urn:li:glossaryTerm:canonical"}},
+		NewValue: map[string]any{
+			"change_0": map[string]any{"change_type": "add_glossary_term", "target": "", "detail": termURN},
+		},
+	}
+}
+
 func TestRollbackChangeset(t *testing.T) {
-	t.Run("successful rollback", func(t *testing.T) {
-		cs := &knowledge.Changeset{
-			ID:            "cs-roll",
-			TargetURN:     "urn:li:dataset:test",
-			PreviousValue: map[string]any{"description": "original desc"},
-			RolledBack:    false,
-		}
+	t.Run("successful rollback removes the added term and records the rollback", func(t *testing.T) {
+		cs := addTermChangeset("cs-roll", "urn:li:glossaryTerm:added")
+		cs.SourceInsightIDs = []string{"ins-1"}
 		writer := &mockDataHubWriter{}
 		csStore := &mockChangesetStore{getResult: cs}
-		kh := NewKnowledgeHandler(nil, csStore, writer)
+		insightStore := &mockInsightStore{}
+		kh := NewKnowledgeHandler(insightStore, csStore, writer)
 
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/knowledge/changesets/cs-roll/rollback", http.NoBody)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/changesets/cs-roll/rollback", http.NoBody)
 		req.SetPathValue("id", "cs-roll")
 		w := httptest.NewRecorder()
 		kh.RollbackChangeset(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		var resp map[string]string
+		var resp knowledge.RollbackResult
 		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
-		assert.Equal(t, "rolled_back", resp["status"])
-		assert.Equal(t, 1, writer.updateDescCalled)
-		assert.Equal(t, "urn:li:dataset:test", writer.lastDescURN)
-		assert.Equal(t, "original desc", writer.lastDescValue)
+		assert.Equal(t, "cs-roll", resp.ChangesetID)
+		assert.Equal(t, []string{"urn:li:glossaryTerm:added"}, writer.removeTermCalls)
+		assert.Equal(t, 1, csStore.rollbackCalled)
+		assert.Equal(t, []string{"ins-1"}, insightStore.rolledBackIDs)
+	})
+
+	t.Run("keeps a pre-existing term rather than removing it", func(t *testing.T) {
+		// The before-image already contained the term, so the add was a no-op and
+		// rollback must not remove the canonical term.
+		cs := addTermChangeset("cs-keep", "urn:li:glossaryTerm:canonical")
+		writer := &mockDataHubWriter{}
+		csStore := &mockChangesetStore{getResult: cs}
+		kh := NewKnowledgeHandler(&mockInsightStore{}, csStore, writer)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/changesets/cs-keep/rollback", http.NoBody)
+		req.SetPathValue("id", "cs-keep")
+		w := httptest.NewRecorder()
+		kh.RollbackChangeset(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Empty(t, writer.removeTermCalls, "must not remove a pre-existing term")
 		assert.Equal(t, 1, csStore.rollbackCalled)
 	})
 
 	t.Run("already rolled back returns 409", func(t *testing.T) {
-		cs := &knowledge.Changeset{
-			ID:         "cs-already",
-			RolledBack: true,
-		}
+		cs := &knowledge.Changeset{ID: "cs-already", RolledBack: true}
 		csStore := &mockChangesetStore{getResult: cs}
-		kh := NewKnowledgeHandler(nil, csStore, nil)
+		kh := NewKnowledgeHandler(&mockInsightStore{}, csStore, &mockDataHubWriter{})
 
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/knowledge/changesets/cs-already/rollback", http.NoBody)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/changesets/cs-already/rollback", http.NoBody)
 		req.SetPathValue("id", "cs-already")
 		w := httptest.NewRecorder()
 		kh.RollbackChangeset(w, req)
 
 		assert.Equal(t, http.StatusConflict, w.Code)
-		pd := decodeProblem(w.Body.Bytes())
-		assert.Equal(t, "changeset already rolled back", pd.Detail)
+		assert.Equal(t, "changeset already rolled back", decodeProblem(w.Body.Bytes()).Detail)
 	})
 
 	t.Run("changeset not found returns 404", func(t *testing.T) {
 		csStore := &mockChangesetStore{getErr: fmt.Errorf("not found")}
-		kh := NewKnowledgeHandler(nil, csStore, nil)
+		kh := NewKnowledgeHandler(&mockInsightStore{}, csStore, &mockDataHubWriter{})
 
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/knowledge/changesets/missing/rollback", http.NoBody)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/changesets/missing/rollback", http.NoBody)
 		req.SetPathValue("id", "missing")
 		w := httptest.NewRecorder()
 		kh.RollbackChangeset(w, req)
@@ -823,122 +874,116 @@ func TestRollbackChangeset(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, w.Code)
 	})
 
+	t.Run("unrevertible change type returns 422", func(t *testing.T) {
+		cs := &knowledge.Changeset{
+			ID:        "cs-unrev",
+			TargetURN: "urn:li:dataset:test",
+			NewValue: map[string]any{
+				"change_0": map[string]any{"change_type": "set_structured_property", "target": "urn:li:structuredProperty:x", "detail": "v"},
+			},
+		}
+		csStore := &mockChangesetStore{getResult: cs}
+		kh := NewKnowledgeHandler(&mockInsightStore{}, csStore, &mockDataHubWriter{})
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/changesets/cs-unrev/rollback", http.NoBody)
+		req.SetPathValue("id", "cs-unrev")
+		w := httptest.NewRecorder()
+		kh.RollbackChangeset(w, req)
+
+		assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+		assert.Contains(t, decodeProblem(w.Body.Bytes()).Detail, "set_structured_property")
+		assert.Equal(t, 0, csStore.rollbackCalled, "must not record a rollback it did not perform")
+	})
+
+	t.Run("conflict with a newer changeset returns 409", func(t *testing.T) {
+		cs := addTermChangeset("cs-old", "urn:li:glossaryTerm:added")
+		newer := &knowledge.Changeset{
+			ID:        "cs-newer",
+			TargetURN: "urn:li:dataset:test",
+			CreatedAt: time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC),
+			NewValue: map[string]any{
+				"change_0": map[string]any{"change_type": "add_glossary_term", "target": "", "detail": "urn:li:glossaryTerm:other"},
+			},
+		}
+		csStore := &mockChangesetStore{
+			getResult:  cs,
+			listResult: []mockChangesetListResult{{changesets: []knowledge.Changeset{*newer}, total: 1}},
+		}
+		kh := NewKnowledgeHandler(&mockInsightStore{}, csStore, &mockDataHubWriter{})
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/changesets/cs-old/rollback", http.NoBody)
+		req.SetPathValue("id", "cs-old")
+		w := httptest.NewRecorder()
+		kh.RollbackChangeset(w, req)
+
+		assert.Equal(t, http.StatusConflict, w.Code)
+		assert.Contains(t, decodeProblem(w.Body.Bytes()).Detail, "cs-newer")
+		assert.Equal(t, 0, csStore.rollbackCalled)
+	})
+
 	t.Run("datahub writer error returns 500", func(t *testing.T) {
 		cs := &knowledge.Changeset{
 			ID:            "cs-fail",
 			TargetURN:     "urn:li:dataset:test",
+			CreatedAt:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
 			PreviousValue: map[string]any{"description": "old desc"},
-			RolledBack:    false,
+			NewValue: map[string]any{
+				"change_0": map[string]any{"change_type": "update_description", "target": "", "detail": "new desc"},
+			},
 		}
 		writer := &mockDataHubWriter{updateDescErr: fmt.Errorf("datahub down")}
 		csStore := &mockChangesetStore{getResult: cs}
-		kh := NewKnowledgeHandler(nil, csStore, writer)
+		kh := NewKnowledgeHandler(&mockInsightStore{}, csStore, writer)
 
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/knowledge/changesets/cs-fail/rollback", http.NoBody)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/changesets/cs-fail/rollback", http.NoBody)
 		req.SetPathValue("id", "cs-fail")
 		w := httptest.NewRecorder()
 		kh.RollbackChangeset(w, req)
 
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
-		pd := decodeProblem(w.Body.Bytes())
-		assert.Contains(t, pd.Detail, "rollback failed")
+		assert.Contains(t, decodeProblem(w.Body.Bytes()).Detail, "rollback failed")
+		assert.Equal(t, 0, csStore.rollbackCalled, "must not record a rollback when the DataHub write failed")
 	})
 
-	t.Run("rollback without datahub writer skips write-back", func(t *testing.T) {
+	t.Run("restores prior description and records admin as rolled_back_by", func(t *testing.T) {
 		cs := &knowledge.Changeset{
-			ID:            "cs-nowriter",
+			ID:            "cs-desc",
 			TargetURN:     "urn:li:dataset:test",
-			PreviousValue: map[string]any{"description": "old desc"},
-			RolledBack:    false,
-		}
-		csStore := &mockChangesetStore{getResult: cs}
-		kh := NewKnowledgeHandler(nil, csStore, nil)
-
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/knowledge/changesets/cs-nowriter/rollback", http.NoBody)
-		req.SetPathValue("id", "cs-nowriter")
-		w := httptest.NewRecorder()
-		kh.RollbackChangeset(w, req)
-
-		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, 1, csStore.rollbackCalled)
-	})
-
-	t.Run("rollback with empty previous description skips write-back", func(t *testing.T) {
-		cs := &knowledge.Changeset{
-			ID:            "cs-empty",
-			TargetURN:     "urn:li:dataset:test",
-			PreviousValue: map[string]any{"description": ""},
-			RolledBack:    false,
+			CreatedAt:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			PreviousValue: map[string]any{"description": "original desc"},
+			NewValue: map[string]any{
+				"change_0": map[string]any{"change_type": "update_description", "target": "", "detail": "new desc"},
+			},
 		}
 		writer := &mockDataHubWriter{}
 		csStore := &mockChangesetStore{getResult: cs}
-		kh := NewKnowledgeHandler(nil, csStore, writer)
+		kh := NewKnowledgeHandler(&mockInsightStore{}, csStore, writer)
 
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/knowledge/changesets/cs-empty/rollback", http.NoBody)
-		req.SetPathValue("id", "cs-empty")
+		ctx := context.WithValue(context.Background(), adminUserKey, &User{UserID: "admin-1", Roles: []string{"admin"}})
+		req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/changesets/cs-desc/rollback", http.NoBody)
+		req.SetPathValue("id", "cs-desc")
 		w := httptest.NewRecorder()
 		kh.RollbackChangeset(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, 0, writer.updateDescCalled,
-			"should not call UpdateDescription for empty previous description")
-		assert.Equal(t, 1, csStore.rollbackCalled)
-	})
-
-	t.Run("rollback with no description key in previous_value skips write-back", func(t *testing.T) {
-		cs := &knowledge.Changeset{
-			ID:            "cs-nokey",
-			TargetURN:     "urn:li:dataset:test",
-			PreviousValue: map[string]any{"tags": []string{"tag1"}},
-			RolledBack:    false,
-		}
-		writer := &mockDataHubWriter{}
-		csStore := &mockChangesetStore{getResult: cs}
-		kh := NewKnowledgeHandler(nil, csStore, writer)
-
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/knowledge/changesets/cs-nokey/rollback", http.NoBody)
-		req.SetPathValue("id", "cs-nokey")
-		w := httptest.NewRecorder()
-		kh.RollbackChangeset(w, req)
-
-		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, 0, writer.updateDescCalled)
+		assert.Equal(t, 1, writer.updateDescCalled)
+		assert.Equal(t, "original desc", writer.lastDescValue)
+		var resp knowledge.RollbackResult
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+		assert.Equal(t, "admin-1", resp.RolledBackBy)
 	})
 
 	t.Run("store rollback error returns 500", func(t *testing.T) {
-		cs := &knowledge.Changeset{
-			ID:            "cs-storeerr",
-			PreviousValue: map[string]any{},
-			RolledBack:    false,
-		}
+		cs := addTermChangeset("cs-storeerr", "urn:li:glossaryTerm:added")
 		csStore := &mockChangesetStore{getResult: cs, rollbackErr: fmt.Errorf("rollback db error")}
-		kh := NewKnowledgeHandler(nil, csStore, nil)
+		kh := NewKnowledgeHandler(&mockInsightStore{}, csStore, &mockDataHubWriter{})
 
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/knowledge/changesets/cs-storeerr/rollback", http.NoBody)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/changesets/cs-storeerr/rollback", http.NoBody)
 		req.SetPathValue("id", "cs-storeerr")
 		w := httptest.NewRecorder()
 		kh.RollbackChangeset(w, req)
 
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
-	})
-
-	t.Run("includes admin user as rolled_back_by", func(t *testing.T) {
-		cs := &knowledge.Changeset{
-			ID:            "cs-admin",
-			PreviousValue: map[string]any{},
-			RolledBack:    false,
-		}
-		csStore := &mockChangesetStore{getResult: cs}
-		kh := NewKnowledgeHandler(nil, csStore, nil)
-
-		ctx := context.WithValue(context.Background(), adminUserKey, &User{UserID: "admin-1", Roles: []string{"admin"}})
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/knowledge/changesets/cs-admin/rollback", http.NoBody)
-		req = req.WithContext(ctx)
-		req.SetPathValue("id", "cs-admin")
-		w := httptest.NewRecorder()
-		kh.RollbackChangeset(w, req)
-
-		assert.Equal(t, http.StatusOK, w.Code)
 	})
 }
 

--- a/pkg/toolkits/knowledge/datahub_client_writer.go
+++ b/pkg/toolkits/knowledge/datahub_client_writer.go
@@ -299,10 +299,26 @@ func (w *DataHubClientWriter) AddGlossaryTerm(ctx context.Context, urn, termURN 
 	return nil
 }
 
+// RemoveGlossaryTerm removes a glossary term association from an entity.
+func (w *DataHubClientWriter) RemoveGlossaryTerm(ctx context.Context, urn, termURN string) error {
+	if err := w.client.RemoveGlossaryTerm(ctx, urn, termURN); err != nil {
+		return fmt.Errorf("removing glossary term %s from %s: %w", termURN, urn, err)
+	}
+	return nil
+}
+
 // AddDocumentationLink adds a documentation link to an entity.
 func (w *DataHubClientWriter) AddDocumentationLink(ctx context.Context, urn, linkURL, description string) error {
 	if err := w.client.AddLink(ctx, urn, linkURL, description); err != nil {
 		return fmt.Errorf("adding link to %s: %w", urn, err)
+	}
+	return nil
+}
+
+// RemoveDocumentationLink removes a documentation link from an entity by URL.
+func (w *DataHubClientWriter) RemoveDocumentationLink(ctx context.Context, urn, linkURL string) error {
+	if err := w.client.RemoveLink(ctx, urn, linkURL); err != nil {
+		return fmt.Errorf("removing link from %s: %w", urn, err)
 	}
 	return nil
 }

--- a/pkg/toolkits/knowledge/datahub_writer.go
+++ b/pkg/toolkits/knowledge/datahub_writer.go
@@ -18,7 +18,11 @@ type DataHubWriter interface {
 	AddTag(ctx context.Context, urn string, tag string) error
 	RemoveTag(ctx context.Context, urn string, tag string) error
 	AddGlossaryTerm(ctx context.Context, urn string, termURN string) error
+	// RemoveGlossaryTerm removes a glossary term association. Used to revert add_glossary_term.
+	RemoveGlossaryTerm(ctx context.Context, urn string, termURN string) error
 	AddDocumentationLink(ctx context.Context, urn string, url string, description string) error
+	// RemoveDocumentationLink removes a documentation link by URL. Used to revert add_documentation.
+	RemoveDocumentationLink(ctx context.Context, urn string, url string) error
 	CreateCuratedQuery(ctx context.Context, entityURN, name, sql, description string) (string, error)
 
 	// Structured properties (DataHub 1.4.x)
@@ -68,8 +72,14 @@ func (*NoopDataHubWriter) RemoveTag(_ context.Context, _, _ string) error { retu
 // AddGlossaryTerm is a no-op.
 func (*NoopDataHubWriter) AddGlossaryTerm(_ context.Context, _, _ string) error { return nil }
 
+// RemoveGlossaryTerm is a no-op.
+func (*NoopDataHubWriter) RemoveGlossaryTerm(_ context.Context, _, _ string) error { return nil }
+
 // AddDocumentationLink is a no-op.
 func (*NoopDataHubWriter) AddDocumentationLink(_ context.Context, _, _, _ string) error { return nil }
+
+// RemoveDocumentationLink is a no-op.
+func (*NoopDataHubWriter) RemoveDocumentationLink(_ context.Context, _, _ string) error { return nil }
 
 // CreateCuratedQuery is a no-op.
 func (*NoopDataHubWriter) CreateCuratedQuery(_ context.Context, _, _, _, _ string) (string, error) {

--- a/pkg/toolkits/knowledge/memory_adapter.go
+++ b/pkg/toolkits/knowledge/memory_adapter.go
@@ -151,6 +151,20 @@ func (a *memoryInsightAdapter) MarkApplied(ctx context.Context, id, appliedBy, c
 	return nil
 }
 
+// MarkRolledBack transitions an applied insight to rolled_back in the memory store.
+func (a *memoryInsightAdapter) MarkRolledBack(ctx context.Context, id, rolledBackBy string) error {
+	meta := map[string]any{
+		metaKeyReviewedBy:    rolledBackBy,
+		metaKeyInsightStatus: StatusRolledBack,
+	}
+	if err := a.store.Update(ctx, id, memory.RecordUpdate{
+		Metadata: meta,
+	}); err != nil {
+		return fmt.Errorf("marking insight rolled back: %w", err)
+	}
+	return nil
+}
+
 // Supersede marks older insights for an entity as superseded by a newer one.
 func (a *memoryInsightAdapter) Supersede(ctx context.Context, entityURN, excludeID string) (int, error) {
 	// List active records for this entity.

--- a/pkg/toolkits/knowledge/memory_adapter_test.go
+++ b/pkg/toolkits/knowledge/memory_adapter_test.go
@@ -403,6 +403,27 @@ func TestMemoryInsightAdapter_MarkApplied_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "marking insight applied")
 }
 
+func TestMemoryInsightAdapter_MarkRolledBack(t *testing.T) {
+	store := &mockMemoryStore{}
+	adapter := NewMemoryInsightAdapter(store)
+
+	err := adapter.MarkRolledBack(context.Background(), "ins-001", "admin@example.com")
+	require.NoError(t, err)
+	assert.True(t, store.updateCalled)
+	assert.Equal(t, "ins-001", store.updateID)
+	assert.Equal(t, StatusRolledBack, store.updateData.Metadata[metaKeyInsightStatus])
+	assert.Equal(t, "admin@example.com", store.updateData.Metadata[metaKeyReviewedBy])
+}
+
+func TestMemoryInsightAdapter_MarkRolledBack_Error(t *testing.T) {
+	store := &mockMemoryStore{updateErr: fmt.Errorf("update failed")}
+	adapter := NewMemoryInsightAdapter(store)
+
+	err := adapter.MarkRolledBack(context.Background(), "ins-001", "admin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "marking insight rolled back")
+}
+
 func TestMemoryInsightAdapter_Supersede(t *testing.T) {
 	store := &mockMemoryStore{
 		listRecords: []memory.Record{

--- a/pkg/toolkits/knowledge/rollback.go
+++ b/pkg/toolkits/knowledge/rollback.go
@@ -1,0 +1,315 @@
+package knowledge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrChangesetAlreadyRolledBack is returned when a rollback targets a changeset
+// that has already been rolled back.
+var ErrChangesetAlreadyRolledBack = errors.New("changeset already rolled back")
+
+// UnrevertibleError is returned when a changeset contains change types whose
+// pre-change state is not captured in the changeset's before-image, so they
+// cannot be reverted automatically. The recovery path for these is a manual
+// re-apply of the desired state.
+type UnrevertibleError struct {
+	ChangeTypes []string
+}
+
+// Error implements the error interface.
+func (e *UnrevertibleError) Error() string {
+	return fmt.Sprintf("changeset cannot be rolled back automatically: change types %s "+
+		"do not record enough prior state to revert; restore the desired state with a new apply",
+		strings.Join(e.ChangeTypes, ", "))
+}
+
+// RollbackConflictError is returned when a newer, not-yet-rolled-back changeset
+// has since mutated the same metadata aspect. Reverting would silently clobber
+// that newer change, so the rollback is refused.
+type RollbackConflictError struct {
+	ConflictingIDs []string
+	Aspects        []string
+}
+
+// Error implements the error interface.
+func (e *RollbackConflictError) Error() string {
+	return fmt.Sprintf("rollback blocked: newer changeset(s) %s modified the same aspect(s) %s; "+
+		"roll those back first or restore the desired state with a new apply",
+		strings.Join(e.ConflictingIDs, ", "), strings.Join(e.Aspects, ", "))
+}
+
+// RollbackResult summarizes the outcome of a successful changeset rollback.
+type RollbackResult struct {
+	ChangesetID        string   `json:"changeset_id"`
+	TargetURN          string   `json:"target_urn"`
+	RevertedChanges    []string `json:"reverted_changes"`
+	SkippedChanges     []string `json:"skipped_changes,omitempty"`
+	InsightsRolledBack []string `json:"insights_rolled_back"`
+	RolledBackBy       string   `json:"rolled_back_by,omitempty"`
+}
+
+// recordedChange is a single change reconstructed from a changeset's new_value.
+type recordedChange struct {
+	ChangeType string
+	Target     string
+	Detail     string
+}
+
+// priorState holds the subset of an entity's before-image that rollback can use.
+type priorState struct {
+	Description   string
+	Tags          map[string]bool
+	GlossaryTerms map[string]bool
+}
+
+// RollbackDeps bundles the stores and writer a rollback operates on. It is the
+// shared dependency set for both the apply_knowledge MCP tool and the admin REST
+// endpoint.
+type RollbackDeps struct {
+	Writer     DataHubWriter
+	Changesets ChangesetStore
+	Insights   InsightStore
+}
+
+// RevertChangeset reverts the DataHub aspects mutated by a changeset back to
+// their pre-change state, transitions the source insights to rolled_back, and
+// marks the changeset as rolled back. It is the single rollback implementation
+// shared by the apply_knowledge MCP tool and the admin REST endpoint.
+//
+// It refuses (rather than silently no-ops) when the changeset is already rolled
+// back, when it contains change types whose prior state was not captured, or
+// when a newer changeset has since touched the same aspect.
+func RevertChangeset(ctx context.Context, deps RollbackDeps, cs *Changeset, rolledBackBy string) (*RollbackResult, error) {
+	if cs.RolledBack {
+		return nil, ErrChangesetAlreadyRolledBack
+	}
+
+	changes := parseRecordedChanges(cs.NewValue)
+	if unsupported := unrevertibleChangeTypes(changes); len(unsupported) > 0 {
+		return nil, &UnrevertibleError{ChangeTypes: unsupported}
+	}
+	if err := checkRollbackConflicts(ctx, deps.Changesets, cs, changes); err != nil {
+		return nil, err
+	}
+
+	prior := parsePriorState(cs.PreviousValue)
+	reverted, skipped, err := applyInverseChanges(ctx, deps.Writer, cs.TargetURN, changes, prior)
+	if err != nil {
+		return nil, fmt.Errorf("rollback aborted after reverting %d change(s): %w", len(reverted), err)
+	}
+
+	rolledBackInsights := rollbackInsights(ctx, deps.Insights, cs.SourceInsightIDs, rolledBackBy)
+
+	if err := deps.Changesets.RollbackChangeset(ctx, cs.ID, rolledBackBy); err != nil {
+		return nil, fmt.Errorf("reverted DataHub but recording the rollback failed: %w", err)
+	}
+
+	return &RollbackResult{
+		ChangesetID:        cs.ID,
+		TargetURN:          cs.TargetURN,
+		RevertedChanges:    reverted,
+		SkippedChanges:     skipped,
+		InsightsRolledBack: rolledBackInsights,
+		RolledBackBy:       rolledBackBy,
+	}, nil
+}
+
+// revertibleChangeTypes is the set of change types whose inverse operation can be
+// derived from the changeset's recorded before-image. Change types absent here
+// (column descriptions, structured properties, incidents, curated queries,
+// context documents, prompts) do not capture enough prior state to revert.
+var revertibleChangeTypes = map[string]bool{
+	string(actionUpdateDescription): true,
+	string(actionAddTag):            true,
+	string(actionRemoveTag):         true,
+	string(actionFlagQualityIssue):  true,
+	string(actionAddGlossaryTerm):   true,
+	string(actionAddDocumentation):  true,
+}
+
+// unrevertibleChangeTypes returns the distinct change types in the changeset that
+// cannot be reverted from the recorded before-image. Column-level description
+// changes are unrevertible even though update_description itself is revertible,
+// because the before-image only captures the entity-level description.
+func unrevertibleChangeTypes(changes []recordedChange) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, c := range changes {
+		if !isRevertible(c) && !seen[c.ChangeType] {
+			seen[c.ChangeType] = true
+			out = append(out, c.ChangeType)
+		}
+	}
+	return out
+}
+
+// isRevertible reports whether a single recorded change has a derivable inverse.
+func isRevertible(c recordedChange) bool {
+	if c.ChangeType == string(actionUpdateDescription) {
+		_, isColumn := parseColumnTarget(c.Target)
+		return !isColumn
+	}
+	return revertibleChangeTypes[c.ChangeType]
+}
+
+// applyInverseChanges performs the inverse of each recorded change against
+// DataHub. It returns human-readable descriptions of the reverted and skipped
+// (pre-existing, so left untouched) changes. On the first write error it stops
+// and returns what was reverted so far alongside the error.
+func applyInverseChanges(
+	ctx context.Context,
+	writer DataHubWriter,
+	urn string,
+	changes []recordedChange,
+	prior priorState,
+) (reverted, skipped []string, err error) {
+	for _, c := range changes {
+		desc, didRevert, applyErr := applyInverse(ctx, writer, urn, c, prior)
+		if applyErr != nil {
+			return reverted, skipped, applyErr
+		}
+		if didRevert {
+			reverted = append(reverted, desc)
+		} else {
+			skipped = append(skipped, desc)
+		}
+	}
+	return reverted, skipped, nil
+}
+
+// applyInverse reverts a single change. didRevert is false when the change was a
+// no-op at apply time (the value already existed in the before-image), so the
+// rollback intentionally leaves the pre-existing value in place.
+func applyInverse(ctx context.Context, writer DataHubWriter, urn string, c recordedChange, prior priorState) (desc string, didRevert bool, err error) {
+	switch c.ChangeType {
+	case string(actionUpdateDescription):
+		return revertDescription(ctx, writer, urn, prior)
+	case string(actionAddTag):
+		return revertAddedTag(ctx, writer, urn, normalizeTagURN(c.Detail), prior)
+	case string(actionFlagQualityIssue):
+		return revertAddedTag(ctx, writer, urn, qualityIssueTagURN, prior)
+	case string(actionRemoveTag):
+		return revertRemovedTag(ctx, writer, urn, normalizeTagURN(c.Detail), prior)
+	case string(actionAddGlossaryTerm):
+		return revertAddedTerm(ctx, writer, urn, normalizeGlossaryTermURN(c.Detail), prior)
+	case string(actionAddDocumentation):
+		return revertAddedDocumentation(ctx, writer, urn, c.Target)
+	default:
+		return "", false, fmt.Errorf("no inverse defined for change type %q", c.ChangeType)
+	}
+}
+
+func revertDescription(ctx context.Context, writer DataHubWriter, urn string, prior priorState) (desc string, reverted bool, err error) {
+	if err := writer.UpdateDescription(ctx, urn, prior.Description); err != nil {
+		return "", false, fmt.Errorf("restoring description: %w", err)
+	}
+	return "restored description", true, nil
+}
+
+func revertAddedTag(ctx context.Context, writer DataHubWriter, urn, tagURN string, prior priorState) (desc string, reverted bool, err error) {
+	if prior.Tags[tagURN] {
+		return fmt.Sprintf("kept pre-existing tag %s", tagURN), false, nil
+	}
+	if err := writer.RemoveTag(ctx, urn, tagURN); err != nil {
+		return "", false, fmt.Errorf("removing tag %s: %w", tagURN, err)
+	}
+	return fmt.Sprintf("removed tag %s", tagURN), true, nil
+}
+
+func revertRemovedTag(ctx context.Context, writer DataHubWriter, urn, tagURN string, prior priorState) (desc string, reverted bool, err error) {
+	if !prior.Tags[tagURN] {
+		return fmt.Sprintf("tag %s was not present before; nothing to restore", tagURN), false, nil
+	}
+	if err := writer.AddTag(ctx, urn, tagURN); err != nil {
+		return "", false, fmt.Errorf("restoring tag %s: %w", tagURN, err)
+	}
+	return fmt.Sprintf("restored tag %s", tagURN), true, nil
+}
+
+func revertAddedTerm(ctx context.Context, writer DataHubWriter, urn, termURN string, prior priorState) (desc string, reverted bool, err error) {
+	if prior.GlossaryTerms[termURN] {
+		return fmt.Sprintf("kept pre-existing glossary term %s", termURN), false, nil
+	}
+	if err := writer.RemoveGlossaryTerm(ctx, urn, termURN); err != nil {
+		return "", false, fmt.Errorf("removing glossary term %s: %w", termURN, err)
+	}
+	return fmt.Sprintf("removed glossary term %s", termURN), true, nil
+}
+
+func revertAddedDocumentation(ctx context.Context, writer DataHubWriter, urn, linkURL string) (desc string, reverted bool, err error) {
+	if err := writer.RemoveDocumentationLink(ctx, urn, linkURL); err != nil {
+		return "", false, fmt.Errorf("removing documentation link %s: %w", linkURL, err)
+	}
+	return fmt.Sprintf("removed documentation link %s", linkURL), true, nil
+}
+
+// rollbackInsights transitions each source insight to rolled_back. A failure on
+// one insight is logged via the returned slice (the insight is simply omitted)
+// rather than aborting the rollback, which has already mutated DataHub.
+func rollbackInsights(ctx context.Context, store InsightStore, insightIDs []string, rolledBackBy string) []string {
+	var done []string
+	for _, id := range insightIDs {
+		if err := store.MarkRolledBack(ctx, id, rolledBackBy); err == nil {
+			done = append(done, id)
+		}
+	}
+	return done
+}
+
+// parseRecordedChanges reconstructs the ordered changes from a changeset's
+// new_value map, which uses change_0, change_1, ... keys (see changesToMap).
+func parseRecordedChanges(newValue map[string]any) []recordedChange {
+	var changes []recordedChange
+	for i := 0; ; i++ {
+		entry, ok := newValue[fmt.Sprintf("change_%d", i)].(map[string]any)
+		if !ok {
+			break
+		}
+		changes = append(changes, recordedChange{
+			ChangeType: stringField(entry, "change_type"),
+			Target:     stringField(entry, fieldTarget),
+			Detail:     stringField(entry, fieldDetail),
+		})
+	}
+	return changes
+}
+
+// parsePriorState extracts the revert-relevant subset of a changeset's
+// previous_value before-image (see metadataToMap).
+func parsePriorState(prev map[string]any) priorState {
+	return priorState{
+		Description:   stringField(prev, fieldDescription),
+		Tags:          stringSetField(prev, "tags"),
+		GlossaryTerms: stringSetField(prev, "glossary_terms"),
+	}
+}
+
+// stringField reads a string value from a decoded JSON map, tolerating absence.
+func stringField(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// stringSetField reads a JSON array of strings into a set, tolerating absence
+// and the []any shape produced by encoding/json.
+func stringSetField(m map[string]any, key string) map[string]bool {
+	out := map[string]bool{}
+	switch v := m[key].(type) {
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out[s] = true
+			}
+		}
+	case []string:
+		for _, s := range v {
+			out[s] = true
+		}
+	}
+	return out
+}

--- a/pkg/toolkits/knowledge/rollback_conflict.go
+++ b/pkg/toolkits/knowledge/rollback_conflict.go
@@ -1,0 +1,91 @@
+package knowledge
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+// aspectFamily maps a change type to the DataHub aspect it mutates. Two
+// changesets conflict for rollback purposes when they touch the same family.
+func aspectFamily(c recordedChange) string {
+	switch c.ChangeType {
+	case string(actionUpdateDescription):
+		if field, isColumn := parseColumnTarget(c.Target); isColumn {
+			return "column_description:" + field
+		}
+		return "description"
+	case string(actionAddTag), string(actionRemoveTag), string(actionFlagQualityIssue):
+		return "tags"
+	case string(actionAddGlossaryTerm):
+		return "glossary_terms"
+	case string(actionAddDocumentation):
+		return "documentation"
+	default:
+		return c.ChangeType
+	}
+}
+
+// aspectFamilies returns the distinct aspect families a set of changes touches.
+func aspectFamilies(changes []recordedChange) map[string]bool {
+	out := map[string]bool{}
+	for _, c := range changes {
+		out[aspectFamily(c)] = true
+	}
+	return out
+}
+
+// checkRollbackConflicts refuses the rollback when a newer, not-yet-rolled-back
+// changeset on the same entity has mutated an aspect this changeset also touched.
+// Reverting in that case would silently clobber the newer write, so the caller
+// must roll the newer changeset back first (or re-apply the desired state).
+func checkRollbackConflicts(ctx context.Context, csStore ChangesetStore, cs *Changeset, changes []recordedChange) error {
+	families := aspectFamilies(changes)
+
+	notRolledBack := false
+	since := cs.CreatedAt
+	later, _, err := csStore.ListChangesets(ctx, ChangesetFilter{
+		EntityURN:  cs.TargetURN,
+		Since:      &since,
+		RolledBack: &notRolledBack,
+		Limit:      MaxLimit,
+	})
+	if err != nil {
+		return fmt.Errorf("checking for conflicting changesets: %w", err)
+	}
+
+	conflictIDs := map[string]bool{}
+	conflictAspects := map[string]bool{}
+	for i := range later {
+		other := &later[i]
+		// Defensive: do not rely solely on the store's RolledBack filter, and never
+		// treat the changeset itself or an older/equal one as a conflict.
+		if other.ID == cs.ID || other.RolledBack || !other.CreatedAt.After(cs.CreatedAt) {
+			continue
+		}
+		for fam := range aspectFamilies(parseRecordedChanges(other.NewValue)) {
+			if families[fam] {
+				conflictIDs[other.ID] = true
+				conflictAspects[fam] = true
+			}
+		}
+	}
+
+	if len(conflictIDs) == 0 {
+		return nil
+	}
+	return &RollbackConflictError{
+		ConflictingIDs: sortedKeys(conflictIDs),
+		Aspects:        sortedKeys(conflictAspects),
+	}
+}
+
+// sortedKeys returns the keys of a set in deterministic order.
+func sortedKeys(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/toolkits/knowledge/rollback_handlers.go
+++ b/pkg/toolkits/knowledge/rollback_handlers.go
@@ -1,0 +1,112 @@
+package knowledge
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// changesetSummary is the discovery-surface view of a changeset, omitting the
+// verbose before/after value maps. Returned by the list_changesets action.
+type changesetSummary struct {
+	ChangesetID      string     `json:"changeset_id"`
+	CreatedAt        time.Time  `json:"created_at"`
+	TargetURN        string     `json:"target_urn"`
+	ChangeType       string     `json:"change_type"`
+	AppliedBy        string     `json:"applied_by,omitempty"`
+	SourceInsightIDs []string   `json:"source_insight_ids,omitempty"`
+	RolledBack       bool       `json:"rolled_back"`
+	RolledBackBy     string     `json:"rolled_back_by,omitempty"`
+	RolledBackAt     *time.Time `json:"rolled_back_at,omitempty"`
+}
+
+// handleRollback reverts a previously applied changeset, restoring the mutated
+// aspects to their pre-change state.
+func (t *Toolkit) handleRollback(ctx context.Context, input applyKnowledgeInput) (*mcp.CallToolResult, any, error) {
+	if input.ChangesetID == "" {
+		return errorResult("changeset_id is required for rollback action"), nil, nil
+	}
+	if t.requireConfirmation && !input.Confirm {
+		return jsonResult(map[string]any{
+			"confirmation_required": true,
+			"changeset_id":          input.ChangesetID,
+			fieldMessage:            "Set confirm: true to roll back this changeset.",
+		})
+	}
+
+	cs, err := t.changesetStore.GetChangeset(ctx, input.ChangesetID)
+	if err != nil {
+		return errorResult("changeset not found: " + input.ChangesetID), nil, nil //nolint:nilerr // MCP protocol
+	}
+	if input.EntityURN != "" && cs.TargetURN != input.EntityURN {
+		return errorResult("changeset " + input.ChangesetID + " does not belong to entity " + input.EntityURN), nil, nil
+	}
+
+	deps := RollbackDeps{Writer: t.datahubWriter, Changesets: t.changesetStore, Insights: t.store}
+	result, err := RevertChangeset(ctx, deps, cs, userIDFromContext(ctx))
+	if err != nil {
+		return rollbackErrorResult(err), nil, nil
+	}
+	return jsonResult(result)
+}
+
+// rollbackErrorResult maps rollback failures to user-facing tool errors with the
+// most actionable message for each failure mode.
+func rollbackErrorResult(err error) *mcp.CallToolResult {
+	var unrevertible *UnrevertibleError
+	var conflict *RollbackConflictError
+	switch {
+	case errors.Is(err, ErrChangesetAlreadyRolledBack):
+		return errorResult("changeset has already been rolled back")
+	case errors.As(err, &unrevertible):
+		return errorResult(unrevertible.Error())
+	case errors.As(err, &conflict):
+		return errorResult(conflict.Error())
+	default:
+		return errorResult("rollback failed: " + err.Error())
+	}
+}
+
+// handleListChangesets returns the changesets for an entity so an agent can
+// discover rollback targets without already holding their ids.
+func (t *Toolkit) handleListChangesets(ctx context.Context, input applyKnowledgeInput) (*mcp.CallToolResult, any, error) {
+	if input.EntityURN == "" {
+		return errorResult("entity_urn is required for list_changesets action"), nil, nil
+	}
+
+	changesets, total, err := t.changesetStore.ListChangesets(ctx, ChangesetFilter{
+		EntityURN: input.EntityURN,
+		Limit:     MaxLimit,
+	})
+	if err != nil {
+		return errorResult("failed to list changesets: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	summaries := make([]changesetSummary, 0, len(changesets))
+	for i := range changesets {
+		summaries = append(summaries, toChangesetSummary(&changesets[i]))
+	}
+
+	return jsonResult(map[string]any{
+		fieldEntityURN: input.EntityURN,
+		"total":        total,
+		"changesets":   summaries,
+	})
+}
+
+// toChangesetSummary projects a changeset onto the discovery view.
+func toChangesetSummary(cs *Changeset) changesetSummary {
+	return changesetSummary{
+		ChangesetID:      cs.ID,
+		CreatedAt:        cs.CreatedAt,
+		TargetURN:        cs.TargetURN,
+		ChangeType:       cs.ChangeType,
+		AppliedBy:        cs.AppliedBy,
+		SourceInsightIDs: cs.SourceInsightIDs,
+		RolledBack:       cs.RolledBack,
+		RolledBackBy:     cs.RolledBackBy,
+		RolledBackAt:     cs.RolledBackAt,
+	}
+}

--- a/pkg/toolkits/knowledge/rollback_handlers_test.go
+++ b/pkg/toolkits/knowledge/rollback_handlers_test.go
@@ -1,0 +1,264 @@
+package knowledge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func termApplyChangeset(id, termURN string) Changeset {
+	return Changeset{
+		ID:            id,
+		TargetURN:     testEntityURN,
+		ChangeType:    "add_glossary_term",
+		CreatedAt:     time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC),
+		PreviousValue: map[string]any{"glossary_terms": []any{}},
+		NewValue:      map[string]any{"change_0": changeEntry("add_glossary_term", "", termURN)},
+	}
+}
+
+func TestHandleRollback_MissingChangesetID(t *testing.T) {
+	tk := newApplyToolkit(t, &fullSpyStore{}, &spyChangesetStore{}, &spyWriter{})
+	result, _, err := tk.handleApplyKnowledge(context.Background(), nil, applyKnowledgeInput{Action: "rollback"})
+	require.Nil(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestHandleRollback_ConfirmationRequired(t *testing.T) {
+	tk, err := New(testName, &fullSpyStore{})
+	require.NoError(t, err)
+	tk.SetApplyConfig(ApplyConfig{Enabled: true, RequireConfirmation: true}, &spyChangesetStore{}, &spyWriter{})
+
+	result, _, callErr := tk.handleApplyKnowledge(context.Background(), nil,
+		applyKnowledgeInput{Action: "rollback", ChangesetID: "cs1"})
+	require.Nil(t, callErr)
+	require.False(t, result.IsError)
+	m := parseJSONResult(t, result)
+	assert.Equal(t, true, m["confirmation_required"])
+}
+
+func TestHandleRollback_NotFound(t *testing.T) {
+	tk := newApplyToolkit(t, &fullSpyStore{}, &spyChangesetStore{}, &spyWriter{})
+	result, _, err := tk.handleApplyKnowledge(context.Background(), nil,
+		applyKnowledgeInput{Action: "rollback", ChangesetID: "missing"})
+	require.Nil(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestHandleRollback_EntityMismatch(t *testing.T) {
+	cs := termApplyChangeset("cs1", "urn:li:glossaryTerm:x")
+	tk := newApplyToolkit(t, &fullSpyStore{}, &spyChangesetStore{Changesets: []Changeset{cs}}, &spyWriter{})
+	result, _, err := tk.handleApplyKnowledge(context.Background(), nil,
+		applyKnowledgeInput{Action: "rollback", ChangesetID: "cs1", EntityURN: "urn:li:dataset:other"})
+	require.Nil(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestHandleRollback_Success(t *testing.T) {
+	cs := termApplyChangeset("cs1", "urn:li:glossaryTerm:x")
+	cs.SourceInsightIDs = []string{"ins-1"}
+	store := &fullSpyStore{Insights: []Insight{{ID: "ins-1", Status: StatusApplied}}}
+	csStore := &spyChangesetStore{Changesets: []Changeset{cs}}
+	writer := &spyWriter{}
+	tk := newApplyToolkit(t, store, csStore, writer)
+
+	result, _, err := tk.handleApplyKnowledge(ctxWithUser("admin-1", "s", "admin"), nil,
+		applyKnowledgeInput{Action: "rollback", ChangesetID: "cs1", Confirm: true})
+	require.Nil(t, err)
+	require.False(t, result.IsError)
+	m := parseJSONResult(t, result)
+	assert.Equal(t, "cs1", m["changeset_id"])
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "RemoveGlossaryTerm", writer.WriteCalls[0].Method)
+	assert.True(t, csStore.Changesets[0].RolledBack)
+	assert.Equal(t, StatusRolledBack, store.Insights[0].Status)
+}
+
+func TestHandleRollback_AlreadyRolledBack(t *testing.T) {
+	cs := termApplyChangeset("cs1", "urn:li:glossaryTerm:x")
+	cs.RolledBack = true
+	tk := newApplyToolkit(t, &fullSpyStore{}, &spyChangesetStore{Changesets: []Changeset{cs}}, &spyWriter{})
+	result, _, err := tk.handleApplyKnowledge(context.Background(), nil,
+		applyKnowledgeInput{Action: "rollback", ChangesetID: "cs1", Confirm: true})
+	require.Nil(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestHandleRollback_Unrevertible(t *testing.T) {
+	cs := Changeset{
+		ID:        "cs1",
+		TargetURN: testEntityURN,
+		NewValue:  map[string]any{"change_0": changeEntry("raise_incident", "title", "desc")},
+	}
+	tk := newApplyToolkit(t, &fullSpyStore{}, &spyChangesetStore{Changesets: []Changeset{cs}}, &spyWriter{})
+	result, _, err := tk.handleApplyKnowledge(context.Background(), nil,
+		applyKnowledgeInput{Action: "rollback", ChangesetID: "cs1", Confirm: true})
+	require.Nil(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestHandleRollback_Conflict(t *testing.T) {
+	cs := termApplyChangeset("cs-old", "urn:li:glossaryTerm:a")
+	newer := termApplyChangeset("cs-new", "urn:li:glossaryTerm:b")
+	newer.CreatedAt = cs.CreatedAt.Add(time.Hour)
+	tk := newApplyToolkit(t, &fullSpyStore{}, &spyChangesetStore{Changesets: []Changeset{cs, newer}}, &spyWriter{})
+
+	result, _, err := tk.handleApplyKnowledge(context.Background(), nil,
+		applyKnowledgeInput{Action: "rollback", ChangesetID: "cs-old", Confirm: true})
+	require.Nil(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestHandleRollback_GenericError(t *testing.T) {
+	// Reverting succeeds but recording the rollback fails -> generic error branch.
+	cs := termApplyChangeset("cs1", "urn:li:glossaryTerm:x")
+	tk := newApplyToolkit(t, &fullSpyStore{},
+		&spyChangesetStore{Changesets: []Changeset{cs}, RollbackErr: errStub}, &spyWriter{})
+
+	result, _, err := tk.handleApplyKnowledge(context.Background(), nil,
+		applyKnowledgeInput{Action: "rollback", ChangesetID: "cs1", Confirm: true})
+	require.Nil(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestRevertChangeset_WriterErrors(t *testing.T) {
+	cases := []struct {
+		name   string
+		change map[string]any
+		prev   map[string]any
+	}{
+		{"description", changeEntry("update_description", "", "new"), map[string]any{"description": "old"}},
+		{"tag", changeEntry("add_tag", "", "pii"), map[string]any{"tags": []any{}}},
+		{"documentation", changeEntry("add_documentation", "https://x", "d"), map[string]any{}},
+		{"restore_removed_tag", changeEntry("remove_tag", "", "pii"), map[string]any{"tags": []any{normalizeTagURN("pii")}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := baseChangeset("cs1", map[string]any{"change_0": tc.change}, tc.prev)
+			_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: &spyWriter{FailAtCall: 1}, Changesets: seededStore(cs), Insights: &fullSpyStore{}}, cs, "admin")
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestHandleListChangesets_MissingEntityURN(t *testing.T) {
+	tk := newApplyToolkit(t, &fullSpyStore{}, &spyChangesetStore{}, &spyWriter{})
+	result, _, err := tk.handleApplyKnowledge(context.Background(), nil,
+		applyKnowledgeInput{Action: "list_changesets"})
+	require.Nil(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestHandleListChangesets_Success(t *testing.T) {
+	cs := termApplyChangeset("cs1", "urn:li:glossaryTerm:x")
+	tk := newApplyToolkit(t, &fullSpyStore{}, &spyChangesetStore{Changesets: []Changeset{cs}}, &spyWriter{})
+	result, _, err := tk.handleApplyKnowledge(context.Background(), nil,
+		applyKnowledgeInput{Action: "list_changesets", EntityURN: testEntityURN})
+	require.Nil(t, err)
+	require.False(t, result.IsError)
+	m := parseJSONResult(t, result)
+	assert.EqualValues(t, 1, m["total"])
+	list, ok := m["changesets"].([]any)
+	require.True(t, ok)
+	require.Len(t, list, 1)
+	entry, ok := list[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "cs1", entry["changeset_id"])
+	assert.Equal(t, false, entry["rolled_back"])
+}
+
+func TestHandleListChangesets_StoreError(t *testing.T) {
+	tk := newApplyToolkit(t, &fullSpyStore{}, &spyChangesetStore{ListErr: errStub}, &spyWriter{})
+	result, _, err := tk.handleApplyKnowledge(context.Background(), nil,
+		applyKnowledgeInput{Action: "list_changesets", EntityURN: testEntityURN})
+	require.Nil(t, err)
+	assert.True(t, result.IsError)
+}
+
+func TestValidateAction_RollbackAndList(t *testing.T) {
+	assert.NoError(t, ValidateAction("rollback"))
+	assert.NoError(t, ValidateAction("list_changesets"))
+}
+
+var errStub = errors.New("stub store failure")
+
+// TestApplyRollbackEndToEnd exercises apply -> list_changesets -> rollback through
+// a real mcp.Server and in-memory client session, proving the new actions are
+// registered and that an apply's changeset is discoverable and revertible end to
+// end (not just that the handler functions work in isolation).
+func TestApplyRollbackEndToEnd(t *testing.T) {
+	store := &fullSpyStore{Insights: []Insight{{ID: "ins-1", Status: StatusPending, EntityURNs: []string{testEntityURN}}}}
+	csStore := &spyChangesetStore{}
+	writer := &spyWriter{Metadata: &EntityMetadata{GlossaryTerms: []string{}, Tags: []string{}, Owners: []string{}}}
+	tk := newApplyToolkit(t, store, csStore, writer)
+
+	s := mcp.NewServer(&mcp.Implementation{Name: testName, Version: testVersion}, nil)
+	tk.RegisterTools(s)
+
+	ctx := context.Background()
+	t1, t2 := mcp.NewInMemoryTransports()
+	serverSess, err := s.Connect(ctx, t1, nil)
+	require.NoError(t, err)
+	defer func() { _ = serverSess.Close() }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0"}, nil)
+	clientSess, err := client.Connect(ctx, t2, nil)
+	require.NoError(t, err)
+	defer func() { _ = clientSess.Close() }()
+
+	// 1. apply add_glossary_term
+	applyResp := callTool(ctx, t, clientSess, map[string]any{
+		"action":     "apply",
+		"entity_urn": testEntityURN,
+		"changes": []map[string]any{
+			{"change_type": "add_glossary_term", "target": "", "detail": "urn:li:glossaryTerm:e2e"},
+		},
+	})
+	changesetID, ok := applyResp["changeset_id"].(string)
+	require.True(t, ok, "apply response must carry changeset_id")
+	require.NotEmpty(t, changesetID)
+
+	// 2. list_changesets surfaces it
+	listResp := callTool(ctx, t, clientSess, map[string]any{
+		"action": "list_changesets", "entity_urn": testEntityURN,
+	})
+	list, ok := listResp["changesets"].([]any)
+	require.True(t, ok)
+	require.Len(t, list, 1)
+	first, ok := list[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, changesetID, first["changeset_id"])
+
+	// 3. rollback reverts the add and records it
+	rbResp := callTool(ctx, t, clientSess, map[string]any{
+		"action": "rollback", "changeset_id": changesetID, "confirm": true,
+	})
+	assert.Equal(t, changesetID, rbResp["changeset_id"])
+
+	require.Len(t, writer.WriteCalls, 2, "one AddGlossaryTerm on apply, one RemoveGlossaryTerm on rollback")
+	assert.Equal(t, "AddGlossaryTerm", writer.WriteCalls[0].Method)
+	assert.Equal(t, "RemoveGlossaryTerm", writer.WriteCalls[1].Method)
+	require.Len(t, csStore.Changesets, 1)
+	assert.True(t, csStore.Changesets[0].RolledBack)
+}
+
+// callTool invokes apply_knowledge through the client session and returns the
+// decoded JSON result, failing the test on a tool error.
+func callTool(ctx context.Context, t *testing.T, sess *mcp.ClientSession, args map[string]any) map[string]any {
+	t.Helper()
+	res, err := sess.CallTool(ctx, &mcp.CallToolParams{Name: applyToolName, Arguments: args})
+	require.NoError(t, err)
+	require.False(t, res.IsError, "tool returned error: %v", res.Content)
+	require.NotEmpty(t, res.Content)
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &m))
+	return m
+}

--- a/pkg/toolkits/knowledge/rollback_test.go
+++ b/pkg/toolkits/knowledge/rollback_test.go
@@ -1,0 +1,342 @@
+package knowledge
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const rbURN = "urn:li:dataset:rb"
+
+// seededStore returns a changeset store pre-populated with cs so RollbackChangeset
+// (which looks the changeset up by id) succeeds.
+func seededStore(cs *Changeset) *spyChangesetStore {
+	return &spyChangesetStore{Changesets: []Changeset{*cs}}
+}
+
+// changeEntry builds a single recorded-change map as stored in new_value.
+func changeEntry(changeType, target, detail string) map[string]any {
+	return map[string]any{"change_type": changeType, "target": target, "detail": detail}
+}
+
+func baseChangeset(id string, newValue, prevValue map[string]any) *Changeset {
+	return &Changeset{
+		ID:            id,
+		TargetURN:     rbURN,
+		CreatedAt:     time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC),
+		PreviousValue: prevValue,
+		NewValue:      newValue,
+	}
+}
+
+func TestRevertChangeset_RemovesAddedTerm(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{"change_0": changeEntry("add_glossary_term", "", "urn:li:glossaryTerm:new")},
+		map[string]any{"glossary_terms": []any{"urn:li:glossaryTerm:canonical"}},
+	)
+	cs.SourceInsightIDs = []string{"ins-1"}
+	store := seededStore(cs)
+	writer := &spyWriter{}
+	insights := &fullSpyStore{Insights: []Insight{{ID: "ins-1", Status: StatusApplied}}}
+
+	res, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: insights}, cs, "admin")
+	require.NoError(t, err)
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "RemoveGlossaryTerm", writer.WriteCalls[0].Method)
+	assert.Equal(t, "urn:li:glossaryTerm:new", writer.WriteCalls[0].Arg1)
+	assert.True(t, store.Changesets[0].RolledBack)
+	assert.Equal(t, []string{"ins-1"}, res.InsightsRolledBack)
+	assert.Equal(t, StatusRolledBack, insights.Insights[0].Status)
+	assert.Len(t, res.RevertedChanges, 1)
+}
+
+func TestRevertChangeset_KeepsPreExistingTerm(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{"change_0": changeEntry("add_glossary_term", "", "urn:li:glossaryTerm:canonical")},
+		map[string]any{"glossary_terms": []any{"urn:li:glossaryTerm:canonical"}},
+	)
+	store := seededStore(cs)
+	writer := &spyWriter{}
+
+	res, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	require.NoError(t, err)
+	assert.Empty(t, writer.WriteCalls, "pre-existing term must not be removed")
+	assert.Len(t, res.SkippedChanges, 1)
+	assert.True(t, store.Changesets[0].RolledBack)
+}
+
+func TestRevertChangeset_RemovesAddedTag(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{"change_0": changeEntry("add_tag", "", "pii")},
+		map[string]any{"tags": []any{}},
+	)
+	store := seededStore(cs)
+	writer := &spyWriter{}
+
+	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	require.NoError(t, err)
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "RemoveTag", writer.WriteCalls[0].Method)
+	assert.Equal(t, normalizeTagURN("pii"), writer.WriteCalls[0].Arg1)
+}
+
+func TestRevertChangeset_ReAddsRemovedTag(t *testing.T) {
+	tagURN := normalizeTagURN("pii")
+	cs := baseChangeset("cs1",
+		map[string]any{"change_0": changeEntry("remove_tag", "", "pii")},
+		map[string]any{"tags": []any{tagURN}},
+	)
+	store := seededStore(cs)
+	writer := &spyWriter{}
+
+	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	require.NoError(t, err)
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "AddTag", writer.WriteCalls[0].Method)
+	assert.Equal(t, tagURN, writer.WriteCalls[0].Arg1)
+}
+
+func TestRevertChangeset_RemovedTagNotPreviouslyPresentIsNoop(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{"change_0": changeEntry("remove_tag", "", "pii")},
+		map[string]any{"tags": []any{}},
+	)
+	store := seededStore(cs)
+	writer := &spyWriter{}
+
+	res, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	require.NoError(t, err)
+	assert.Empty(t, writer.WriteCalls)
+	assert.Len(t, res.SkippedChanges, 1)
+}
+
+func TestRevertChangeset_FlagQualityIssueRemovesTag(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{"change_0": changeEntry("flag_quality_issue", "", "stale data")},
+		map[string]any{"tags": []any{}},
+	)
+	store := seededStore(cs)
+	writer := &spyWriter{}
+
+	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	require.NoError(t, err)
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "RemoveTag", writer.WriteCalls[0].Method)
+	assert.Equal(t, qualityIssueTagURN, writer.WriteCalls[0].Arg1)
+}
+
+func TestRevertChangeset_RestoresDescription(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{"change_0": changeEntry("update_description", "", "new desc")},
+		map[string]any{"description": "old desc"},
+	)
+	store := seededStore(cs)
+	writer := &spyWriter{}
+
+	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	require.NoError(t, err)
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "UpdateDescription", writer.WriteCalls[0].Method)
+	assert.Equal(t, "old desc", writer.WriteCalls[0].Arg1)
+}
+
+func TestRevertChangeset_RemovesDocumentationLink(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{"change_0": changeEntry("add_documentation", "https://docs/x", "the docs")},
+		map[string]any{},
+	)
+	store := seededStore(cs)
+	writer := &spyWriter{}
+
+	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	require.NoError(t, err)
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "RemoveDocumentationLink", writer.WriteCalls[0].Method)
+	assert.Equal(t, "https://docs/x", writer.WriteCalls[0].Arg1)
+}
+
+func TestRevertChangeset_AlreadyRolledBack(t *testing.T) {
+	cs := baseChangeset("cs1", map[string]any{}, map[string]any{})
+	cs.RolledBack = true
+
+	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: &spyWriter{}, Changesets: seededStore(cs), Insights: &fullSpyStore{}}, cs, "admin")
+	assert.ErrorIs(t, err, ErrChangesetAlreadyRolledBack)
+}
+
+func TestRevertChangeset_UnrevertibleChangeType(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{"change_0": changeEntry("set_structured_property", "urn:li:structuredProperty:x", "v")},
+		map[string]any{},
+	)
+	store := seededStore(cs)
+	writer := &spyWriter{}
+
+	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	var unrev *UnrevertibleError
+	require.ErrorAs(t, err, &unrev)
+	assert.Equal(t, []string{"set_structured_property"}, unrev.ChangeTypes)
+	assert.Empty(t, writer.WriteCalls, "must not mutate DataHub for an unrevertible changeset")
+	assert.False(t, store.Changesets[0].RolledBack)
+}
+
+func TestRevertChangeset_ColumnDescriptionIsUnrevertible(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{"change_0": changeEntry("update_description", "column:amount", "new col desc")},
+		map[string]any{"description": "entity desc"},
+	)
+	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: &spyWriter{}, Changesets: seededStore(cs), Insights: &fullSpyStore{}}, cs, "admin")
+	var unrev *UnrevertibleError
+	require.ErrorAs(t, err, &unrev)
+	assert.Equal(t, []string{"update_description"}, unrev.ChangeTypes)
+}
+
+func TestRevertChangeset_ConflictWithNewerChangeset(t *testing.T) {
+	cs := baseChangeset("cs-old",
+		map[string]any{"change_0": changeEntry("add_glossary_term", "", "urn:li:glossaryTerm:a")},
+		map[string]any{"glossary_terms": []any{}},
+	)
+	newer := baseChangeset("cs-new",
+		map[string]any{"change_0": changeEntry("add_glossary_term", "", "urn:li:glossaryTerm:b")},
+		map[string]any{},
+	)
+	newer.CreatedAt = cs.CreatedAt.Add(time.Hour)
+	store := &spyChangesetStore{Changesets: []Changeset{*cs, *newer}}
+	writer := &spyWriter{}
+
+	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	var conflict *RollbackConflictError
+	require.ErrorAs(t, err, &conflict)
+	assert.Equal(t, []string{"cs-new"}, conflict.ConflictingIDs)
+	assert.Equal(t, []string{"glossary_terms"}, conflict.Aspects)
+	assert.Empty(t, writer.WriteCalls)
+}
+
+func TestRevertChangeset_RolledBackNewerChangesetIsNotConflict(t *testing.T) {
+	cs := baseChangeset("cs-old",
+		map[string]any{"change_0": changeEntry("add_glossary_term", "", "urn:li:glossaryTerm:a")},
+		map[string]any{"glossary_terms": []any{}},
+	)
+	newer := baseChangeset("cs-new",
+		map[string]any{"change_0": changeEntry("add_glossary_term", "", "urn:li:glossaryTerm:b")},
+		map[string]any{},
+	)
+	newer.CreatedAt = cs.CreatedAt.Add(time.Hour)
+	newer.RolledBack = true
+	store := &spyChangesetStore{Changesets: []Changeset{*cs, *newer}}
+
+	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: &spyWriter{}, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	assert.NoError(t, err, "a rolled-back newer changeset is not a conflict")
+}
+
+func TestRevertChangeset_WriterErrorAbortsBeforeRecording(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{"change_0": changeEntry("add_glossary_term", "", "urn:li:glossaryTerm:new")},
+		map[string]any{"glossary_terms": []any{}},
+	)
+	store := seededStore(cs)
+	writer := &spyWriter{FailAtCall: 1}
+
+	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	require.Error(t, err)
+	assert.False(t, store.Changesets[0].RolledBack, "must not record a rollback that failed mid-write")
+}
+
+func TestRevertChangeset_ConflictListError(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{"change_0": changeEntry("add_tag", "", "pii")},
+		map[string]any{"tags": []any{}},
+	)
+	store := &spyChangesetStore{Changesets: []Changeset{*cs}, ListErr: errors.New("db down")}
+
+	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: &spyWriter{}, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicting changesets")
+}
+
+// --- Parse helpers ---
+
+func TestParseRecordedChanges(t *testing.T) {
+	nv := map[string]any{
+		"change_0": changeEntry("add_tag", "", "pii"),
+		"change_1": changeEntry("add_glossary_term", "", "urn:li:glossaryTerm:x"),
+	}
+	got := parseRecordedChanges(nv)
+	require.Len(t, got, 2)
+	assert.Equal(t, "add_tag", got[0].ChangeType)
+	assert.Equal(t, "urn:li:glossaryTerm:x", got[1].Detail)
+}
+
+func TestParsePriorState(t *testing.T) {
+	prev := map[string]any{
+		"description":    "d",
+		"tags":           []any{"urn:li:tag:a"},
+		"glossary_terms": []string{"urn:li:glossaryTerm:b"},
+	}
+	ps := parsePriorState(prev)
+	assert.Equal(t, "d", ps.Description)
+	assert.True(t, ps.Tags["urn:li:tag:a"])
+	assert.True(t, ps.GlossaryTerms["urn:li:glossaryTerm:b"])
+}
+
+func TestStringSetField_AbsentOrWrongType(t *testing.T) {
+	assert.Empty(t, stringSetField(map[string]any{}, "tags"))
+	assert.Empty(t, stringSetField(map[string]any{"tags": 42}, "tags"))
+}
+
+func TestAspectFamily(t *testing.T) {
+	cases := map[string]struct {
+		change recordedChange
+		want   string
+	}{
+		"entity description": {recordedChange{ChangeType: "update_description", Target: ""}, "description"},
+		"column description": {recordedChange{ChangeType: "update_description", Target: "column:amount"}, "column_description:amount"},
+		"add tag":            {recordedChange{ChangeType: "add_tag"}, "tags"},
+		"remove tag":         {recordedChange{ChangeType: "remove_tag"}, "tags"},
+		"quality flag":       {recordedChange{ChangeType: "flag_quality_issue"}, "tags"},
+		"glossary":           {recordedChange{ChangeType: "add_glossary_term"}, "glossary_terms"},
+		"documentation":      {recordedChange{ChangeType: "add_documentation"}, "documentation"},
+		"other":              {recordedChange{ChangeType: "raise_incident"}, "raise_incident"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, aspectFamily(tc.change))
+		})
+	}
+}
+
+// --- MarkRolledBack store impls ---
+
+func TestPostgresStore_MarkRolledBack(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	store := NewPostgresStore(db)
+	mock.ExpectExec("UPDATE knowledge_insights").
+		WithArgs(StatusRolledBack, "admin", sqlmock.AnyArg(), "ins-1", StatusApplied).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	assert.NoError(t, store.MarkRolledBack(context.Background(), "ins-1", "admin"))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPostgresStore_MarkRolledBack_DBError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	store := NewPostgresStore(db)
+	mock.ExpectExec("UPDATE knowledge_insights").
+		WillReturnError(errors.New("boom"))
+
+	assert.Error(t, store.MarkRolledBack(context.Background(), "ins-1", "admin"))
+}
+
+func TestNoopStore_MarkRolledBack(t *testing.T) {
+	assert.NoError(t, NewNoopStore().MarkRolledBack(context.Background(), "x", "admin"))
+}

--- a/pkg/toolkits/knowledge/schemas.go
+++ b/pkg/toolkits/knowledge/schemas.go
@@ -94,11 +94,15 @@ var applyKnowledgeSchema = json.RawMessage(`{
   "properties": {
     "action": {
       "type": "string",
-      "description": "The action to perform. Valid values: bulk_review, review, synthesize, apply, approve, reject"
+      "description": "The action to perform. Valid values: bulk_review, review, synthesize, apply, approve, reject, rollback, list_changesets"
     },
     "entity_urn": {
       "type": "string",
-      "description": "Target entity URN (required for review, synthesize, apply)"
+      "description": "Target entity URN (required for review, synthesize, apply, list_changesets; optional for rollback to validate the changeset belongs to this entity)"
+    },
+    "changeset_id": {
+      "type": "string",
+      "description": "Changeset to revert (required for rollback action). Obtain it from a prior apply response or the list_changesets action."
     },
     "insight_ids": {
       "type": "array",
@@ -139,7 +143,7 @@ var applyKnowledgeSchema = json.RawMessage(`{
     },
     "confirm": {
       "type": "boolean",
-      "description": "Set to true to confirm apply action when confirmation is required"
+      "description": "Set to true to confirm the apply or rollback action when confirmation is required"
     },
     "review_notes": {
       "type": "string",

--- a/pkg/toolkits/knowledge/store.go
+++ b/pkg/toolkits/knowledge/store.go
@@ -31,6 +31,10 @@ type InsightStore interface {
 	Update(ctx context.Context, id string, updates InsightUpdate) error
 	Stats(ctx context.Context, filter InsightFilter) (*InsightStats, error)
 	MarkApplied(ctx context.Context, id, appliedBy, changesetRef string) error
+	// MarkRolledBack transitions an applied insight to rolled_back. It is a no-op
+	// for insights not currently in the applied state, so re-running a rollback
+	// does not error or double-transition.
+	MarkRolledBack(ctx context.Context, id, rolledBackBy string) error
 	Supersede(ctx context.Context, entityURN string, excludeID string) (int, error)
 }
 
@@ -410,6 +414,23 @@ func (s *postgresStore) MarkApplied(ctx context.Context, id, appliedBy, changese
 	return nil
 }
 
+// MarkRolledBack transitions an applied insight to rolled_back. The WHERE clause
+// gates on the current status being applied so the call is idempotent: rolling
+// back the same changeset twice (or an insight whose status has since changed)
+// is a no-op rather than an error.
+func (s *postgresStore) MarkRolledBack(ctx context.Context, id, rolledBackBy string) error {
+	query := `
+		UPDATE knowledge_insights
+		SET status = $1, reviewed_by = $2, reviewed_at = $3
+		WHERE id = $4 AND status = $5
+	`
+
+	if _, err := s.db.ExecContext(ctx, query, StatusRolledBack, rolledBackBy, time.Now(), id, StatusApplied); err != nil {
+		return fmt.Errorf("marking insight as rolled back: %w", err)
+	}
+	return nil
+}
+
 // Supersede marks pending insights for an entity as superseded, except excludeID.
 func (s *postgresStore) Supersede(ctx context.Context, entityURN, excludeID string) (int, error) {
 	query := `
@@ -464,6 +485,7 @@ func (*noopStore) Stats(_ context.Context, _ InsightFilter) (*InsightStats, erro
 }
 
 func (*noopStore) MarkApplied(_ context.Context, _, _, _ string) error   { return nil }    //nolint:revive // interface impl
+func (*noopStore) MarkRolledBack(_ context.Context, _, _ string) error   { return nil }    //nolint:revive // interface impl
 func (*noopStore) Supersede(_ context.Context, _, _ string) (int, error) { return 0, nil } //nolint:revive // interface impl
 
 // Verify interface compliance.

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -72,6 +72,8 @@ type applyKnowledgeInput struct {
 	Confirm    bool          `json:"confirm,omitempty"`
 	// For approve/reject actions
 	ReviewNotes string `json:"review_notes,omitempty"`
+	// ChangesetID is the target changeset for the rollback action.
+	ChangesetID string `json:"changeset_id,omitempty"`
 }
 
 // ApplyConfig configures the apply_knowledge tool.
@@ -178,8 +180,13 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 		mcp.AddTool(s, &mcp.Tool{
 			Name:  applyToolName,
 			Title: "Apply Knowledge",
-			Description: "Reviews, synthesizes, and applies captured insights to the data catalog. Admin-only. " +
-				"Actions: bulk_review, review, synthesize, apply, approve, reject. " +
+			Description: "Reviews, synthesizes, applies, and rolls back captured insights to the data catalog. Admin-only. " +
+				"Actions: bulk_review, review, synthesize, apply, approve, reject, rollback, list_changesets. " +
+				"rollback (changeset_id required, confirm required) reverts the aspects a prior apply changed, back to their before-image: " +
+				"it removes tags/glossary terms/documentation links the apply added (leaving any that pre-existed) and restores the prior description. " +
+				"Rollback is refused if the changeset is already rolled back, if a newer changeset has since changed the same aspect, " +
+				"or if the changeset touched change types whose prior state was not captured (column descriptions, structured properties, incidents, curated queries, context documents, prompts). " +
+				"list_changesets (entity_urn required) lists an entity's changesets with their ids, timestamps, actors, and rollback status. " +
 				"Change types: update_description, add_tag, remove_tag, add_glossary_term, flag_quality_issue, add_documentation, add_curated_query, " +
 				"set_structured_property, remove_structured_property, raise_incident, resolve_incident, " +
 				"add_context_document, update_context_document, remove_context_document. " +
@@ -281,7 +288,11 @@ func (t *Toolkit) handleApplyKnowledge(ctx context.Context, _ *mcp.CallToolReque
 	if err := ValidateAction(input.Action); err != nil {
 		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol
 	}
+	return t.dispatchApplyAction(ctx, input)
+}
 
+// dispatchApplyAction routes a validated apply_knowledge action to its handler.
+func (t *Toolkit) dispatchApplyAction(ctx context.Context, input applyKnowledgeInput) (*mcp.CallToolResult, any, error) {
 	switch input.Action {
 	case actionBulkReview:
 		return t.handleBulkReview(ctx)
@@ -295,6 +306,10 @@ func (t *Toolkit) handleApplyKnowledge(ctx context.Context, _ *mcp.CallToolReque
 		return t.handleApproveReject(ctx, input, StatusApproved)
 	case actionReject:
 		return t.handleApproveReject(ctx, input, StatusRejected)
+	case actionRollback:
+		return t.handleRollback(ctx, input)
+	case actionListChangesets:
+		return t.handleListChangesets(ctx, input)
 	default:
 		return errorResult("unknown action: " + input.Action), nil, nil
 	}
@@ -528,7 +543,15 @@ func (t *Toolkit) recordChangesetAndMarkApplied(ctx context.Context, input apply
 		fieldEntityURN:            input.EntityURN,
 		"changes_applied":         len(input.Changes),
 		"insights_marked_applied": len(input.InsightIDs),
-		fieldMessage:              fmt.Sprintf("Changes applied to DataHub. Changeset %s recorded for rollback.", csID),
+		fieldMessage: fmt.Sprintf("Changes applied to DataHub. Roll back with action=rollback changeset_id=%s. "+
+			"changes_applied counts requested changes; verify against resulting_state below.", csID),
+	}
+
+	// Re-read the entity so the caller can verify what actually persisted without
+	// a follow-up call. This closes the gap where changes_applied counted requested
+	// changes (a duplicate add is a no-op upstream) rather than verified writes.
+	if meta, err := t.datahubWriter.GetCurrentMetadata(ctx, input.EntityURN); err == nil {
+		result["resulting_state"] = metadataToMap(meta)
 	}
 
 	if len(createdURNs) > 0 {
@@ -602,7 +625,13 @@ func (t *Toolkit) dispatchNonColumnChanges(ctx context.Context, urn string, chan
 	for i, c := range changes {
 		queryURN, err := t.dispatchChange(ctx, urn, c)
 		if err != nil {
-			return nil, fmt.Errorf("datahub write failed for change %d of %d: %w, no changes were applied", i+1, len(changes), err)
+			// Writes are not transactional: changes 1..i already persisted and are
+			// NOT automatically undone. Report this honestly so the caller can use
+			// rollback (or re-apply) rather than assuming a clean failure.
+			if i == 0 {
+				return nil, fmt.Errorf("datahub write failed for change 1 of %d: %w (no changes were applied)", len(changes), err)
+			}
+			return nil, fmt.Errorf("datahub write failed for change %d of %d: %w (changes 1-%d were already applied and were NOT rolled back)", i+1, len(changes), err, i)
 		}
 		if queryURN != "" {
 			createdURNs = append(createdURNs, queryURN)

--- a/pkg/toolkits/knowledge/toolkit_test.go
+++ b/pkg/toolkits/knowledge/toolkit_test.go
@@ -51,9 +51,10 @@ type fullSpyStore struct {
 	SupersedeErr   error
 
 	// Track calls
-	StatusCalls      []statusCall
-	MarkAppliedCalls []markAppliedCall
-	SupersedeCalls   []supersedeCall
+	StatusCalls       []statusCall
+	MarkAppliedCalls  []markAppliedCall
+	MarkRolledBackIDs []string
+	SupersedeCalls    []supersedeCall
 
 	// Configurable returns for Stats
 	StatsResult *InsightStats
@@ -168,6 +169,16 @@ func (s *fullSpyStore) MarkApplied(_ context.Context, id, appliedBy, changesetRe
 			s.Insights[i].AppliedBy = appliedBy
 			s.Insights[i].ChangesetRef = changesetRef
 			return nil
+		}
+	}
+	return nil
+}
+
+func (s *fullSpyStore) MarkRolledBack(_ context.Context, id, _ string) error {
+	s.MarkRolledBackIDs = append(s.MarkRolledBackIDs, id)
+	for i := range s.Insights {
+		if s.Insights[i].ID == id && s.Insights[i].Status == StatusApplied {
+			s.Insights[i].Status = StatusRolledBack
 		}
 	}
 	return nil
@@ -308,8 +319,16 @@ func (w *spyWriter) AddGlossaryTerm(_ context.Context, urn, termURN string) erro
 	return w.recordAndCheck("AddGlossaryTerm", urn, termURN, "")
 }
 
+func (w *spyWriter) RemoveGlossaryTerm(_ context.Context, urn, termURN string) error {
+	return w.recordAndCheck("RemoveGlossaryTerm", urn, termURN, "")
+}
+
 func (w *spyWriter) AddDocumentationLink(_ context.Context, urn, url, desc string) error {
 	return w.recordAndCheck("AddDocumentationLink", urn, url, desc)
+}
+
+func (w *spyWriter) RemoveDocumentationLink(_ context.Context, urn, url string) error {
+	return w.recordAndCheck("RemoveDocumentationLink", urn, url, "")
 }
 
 func (w *spyWriter) CreateCuratedQuery(_ context.Context, urn, name, sqlText, _ string) (string, error) {

--- a/pkg/toolkits/knowledge/types.go
+++ b/pkg/toolkits/knowledge/types.go
@@ -277,12 +277,14 @@ const (
 
 // Apply-knowledge action names exposed by the apply_knowledge MCP tool.
 const (
-	actionBulkReview = "bulk_review"
-	actionReview     = "review"
-	actionSynthesize = "synthesize"
-	actionApply      = "apply"
-	actionApprove    = "approve"
-	actionReject     = "reject"
+	actionBulkReview     = "bulk_review"
+	actionReview         = "review"
+	actionSynthesize     = "synthesize"
+	actionApply          = "apply"
+	actionApprove        = "approve"
+	actionReject         = "reject"
+	actionRollback       = "rollback"
+	actionListChangesets = "list_changesets"
 )
 
 // validTransitions defines allowed status transitions.
@@ -497,21 +499,26 @@ type ProposedChange struct {
 	SourceInsightIDs []string `json:"source_insight_ids"`
 }
 
+// actionList is the human-readable list of valid apply_knowledge actions.
+const actionList = "bulk_review, review, synthesize, apply, approve, reject, rollback, list_changesets"
+
 // ValidateAction checks whether an action value is valid.
 func ValidateAction(action string) error {
 	validActions := map[string]bool{
-		actionBulkReview: true,
-		actionReview:     true,
-		actionSynthesize: true,
-		actionApply:      true,
-		actionApprove:    true,
-		actionReject:     true,
+		actionBulkReview:     true,
+		actionReview:         true,
+		actionSynthesize:     true,
+		actionApply:          true,
+		actionApprove:        true,
+		actionReject:         true,
+		actionRollback:       true,
+		actionListChangesets: true,
 	}
 	if action == "" {
-		return fmt.Errorf("action is required and must be one of: bulk_review, review, synthesize, apply, approve, reject")
+		return fmt.Errorf("action is required and must be one of: %s", actionList)
 	}
 	if !validActions[action] {
-		return fmt.Errorf("invalid action %q: must be one of: bulk_review, review, synthesize, apply, approve, reject", action)
+		return fmt.Errorf("invalid action %q: must be one of: %s", action, actionList)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #492.

## Problem

`apply_knowledge` recorded a `changeset_id` on every `apply` and the response said the changeset was "recorded for rollback," but no action on the tool surface could perform a rollback. The action enum was `bulk_review, review, synthesize, apply, approve, reject`. An agent that made a catalog change it needed to undo had no in-band way to do it.

There was also a rollback path on the admin REST API (`POST /api/v1/admin/knowledge/changesets/{id}/rollback`), but its handler restored **only the entity description** while its own doc comment claimed it was "restoring previous values to DataHub." Tags, glossary terms, and documentation links a changeset added were left in place, and the changeset was still marked `rolled_back`. The flag said reverted; the catalog was not.

## What this changes

### A single shared revert engine

`pkg/toolkits/knowledge/rollback.go` (`RevertChangeset`) is the one rollback implementation, used by both the new MCP tool actions and the admin REST endpoint. No per-surface fork.

It reverts each recorded change back to the changeset's before-image:

- A tag, glossary term, or documentation link the apply **added** is removed, unless it was already present in the before-image (in which case the add was a no-op upstream and the pre-existing value is kept). This is what preserves an entity's canonical glossary term when an apply added another term alongside it.
- A tag the apply **removed** is restored.
- A description the apply changed is reset to the prior description.

It transitions the changeset's source insights `applied -> rolled_back` (the lifecycle docs already referenced `rolled_back`; this wires the state to a real transition) and marks the changeset rolled back.

### New `apply_knowledge` actions

- `rollback` (`changeset_id` required, `confirm` required when `require_confirmation` is set): reverts a changeset as above.
- `list_changesets` (`entity_urn` required): lists an entity's changesets with id, timestamp, actor, change type, and rollback status, so an agent can discover a rollback target without already holding its id.

### Refusal instead of silent or partial reverts

Rollback is refused, with an actionable message, when:

- The changeset is already rolled back (`409` on REST).
- A newer, not-yet-rolled-back changeset has since modified the same aspect on the same entity; reverting would clobber that newer write, so the conflict is surfaced and names the offending changeset (`409`). See `pkg/toolkits/knowledge/rollback_conflict.go`.
- The changeset contains change types whose prior state is not captured in the before-image and therefore cannot be reverted: column descriptions, structured properties, incidents, curated queries, context documents, prompts (`422`). A changeset mixing revertible and unrevertible types is refused as a whole so it never lands in a partially reverted state.

The before-image (`metadataToMap`) captures description, tags, glossary terms, and owners, so rollback is scoped to exactly the change types that snapshot can restore. This matches the issue's own framing ("using the before-image the changeset already captures").

### Admin REST handler unified

`pkg/admin/knowledge.go` `RollbackChangeset` now calls the shared engine instead of its description-only logic, returns the full restored state, and maps failures to `404` / `409` / `422`.

### Apply response hardening

The `apply` response now includes `resulting_state`, a fresh read-back of the entity's description, tags, glossary terms, and owners, so callers can verify what actually persisted without a follow-up read. The mid-sequence failure message no longer claims "no changes were applied" when earlier changes already persisted (writes are not transactional); it now reports which changes landed.

Note on the issue's "set vs add" concern: against the pinned `mcp-datahub@v1.8.1`, `AddGlossaryTerm` already performs an additive read-modify-write with de-duplication, so it does not clobber existing terms. No change was needed there.

## Acceptance criteria

- [x] `apply_knowledge action=rollback changeset_id=... confirm=true` reverts the changeset and returns the restored state.
- [x] Rolling back an already-rolled-back changeset is rejected with a clear message.
- [x] Rollback that would overwrite a newer change to the same aspect is blocked, not applied silently.
- [x] Insights tied to a rolled-back changeset transition to `rolled_back`.
- [x] The rollback is audit-logged (the action runs as an `apply_knowledge` tool call carrying `changeset_id`, captured by the existing MCP audit middleware).
- [x] Changesets for an entity are discoverable without prior knowledge of their ids (`list_changesets`).

## Testing

- Unit tests for the revert engine: each revertible change type, pre-existing-value retention, already-rolled-back, unrevertible refusal, conflict block, insight transition, partial-write abort. New `MarkRolledBack` covered on the postgres, memory-adapter, and noop stores.
- An end-to-end test wires a real `mcp.Server` and in-memory client session and exercises `apply -> list_changesets -> rollback`, asserting the writer received `AddGlossaryTerm` on apply and `RemoveGlossaryTerm` on rollback and that the changeset is recorded rolled back.
- `make verify` passes (tests with race, lint, gosec, govulncheck, semgrep, CodeQL, coverage, swagger). Patch coverage on changed lines is 100%. Mutation testing on `pkg/toolkits/knowledge` reports 0 surviving mutants.

## Docs

`docs/knowledge/governance.md`, `docs/knowledge/admin-api.md`, `docs/server/tools.md`, `docs/reference/tools-api.md`, and `docs/llms-full.txt` updated for the new actions and the rollback semantics; swagger regenerated.
