### PR TITLE
fix(platform): cross-replica reload bus for admin config changes (#501)

### DIFF
--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -936,6 +936,7 @@ func buildAdminHandler(p *platform.Platform) http.Handler {
 		FileDefaults:       p.FileDefaults(),
 		PersonaRegistry:    p.PersonaRegistry(),
 		ToolkitRegistry:    p.ToolkitRegistry(),
+		ReloadNotifier:     p,
 		MCPServer:          p.MCPServer(),
 		BrowserAuth:        p.BrowserSessionAuth(),
 		DatabaseAvailable:  p.Config().Database.DSN != "",

--- a/pkg/admin/authkey_handler.go
+++ b/pkg/admin/authkey_handler.go
@@ -118,6 +118,9 @@ func (h *Handler) createAuthKey(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to persist api key")
 		return
 	}
+	if h.deps.ReloadNotifier != nil {
+		h.deps.ReloadNotifier.PublishAPIKeyReload()
+	}
 
 	writeJSON(w, http.StatusCreated, authKeyCreateResponse{
 		Name:        req.Name,
@@ -164,6 +167,9 @@ func (h *Handler) deleteAuthKey(w http.ResponseWriter, r *http.Request) {
 	if !h.deps.APIKeyManager.RemoveByName(name) {
 		writeError(w, http.StatusNotFound, "key not found")
 		return
+	}
+	if h.deps.ReloadNotifier != nil {
+		h.deps.ReloadNotifier.PublishAPIKeyReload()
 	}
 
 	writeJSON(w, http.StatusOK, statusResponse{Status: statusDeleted})

--- a/pkg/admin/catalog_handler.go
+++ b/pkg/admin/catalog_handler.go
@@ -1103,6 +1103,12 @@ func (h *Handler) reloadConnectionsForCatalog(catalogID string) {
 		}
 		api.ReloadConnectionsByCatalog(catalogID)
 	}
+	// Broadcast to peer replicas so they rebuild their own in-memory
+	// connections from this catalog (issue #501). The loop above only
+	// reloads this replica.
+	if h.deps.ReloadNotifier != nil {
+		h.deps.ReloadNotifier.PublishCatalogReload(catalogID)
+	}
 }
 
 // firstNonEmpty returns a when non-empty, otherwise b. Used by the

--- a/pkg/admin/connection_handler.go
+++ b/pkg/admin/connection_handler.go
@@ -673,18 +673,26 @@ func (h *Handler) hotAddConnection(kind, name string, config map[string]any) {
 		slog.Warn("failed to hot-add connection",
 			logKeyKind, kind, logKeyName, name, logKeyError, err)
 	}
+	// Tell peer replicas to rebuild this connection from the store too;
+	// the hot-add above only updates this replica (issue #501).
+	if h.deps.ReloadNotifier != nil {
+		h.deps.ReloadNotifier.PublishConnectionReload(kind, name)
+	}
 }
 
 // hotRemoveConnection attempts to remove the connection from a live toolkit that
 // implements toolkit.ConnectionManager.
 func (h *Handler) hotRemoveConnection(kind, name string) {
-	cm := h.findConnectionManager(kind)
-	if cm == nil || !cm.HasConnection(name) {
-		return
+	if cm := h.findConnectionManager(kind); cm != nil && cm.HasConnection(name) {
+		if err := cm.RemoveConnection(name); err != nil { // #nosec G706 -- structured slog call, not a format string
+			slog.Warn("failed to hot-remove connection",
+				logKeyKind, kind, logKeyName, name, logKeyError, err)
+		}
 	}
-	if err := cm.RemoveConnection(name); err != nil { // #nosec G706 -- structured slog call, not a format string
-		slog.Warn("failed to hot-remove connection",
-			logKeyKind, kind, logKeyName, name, logKeyError, err)
+	// Always broadcast: peer replicas reconcile from the store (now
+	// missing this row) and drop their copy of the connection (#501).
+	if h.deps.ReloadNotifier != nil {
+		h.deps.ReloadNotifier.PublishConnectionReload(kind, name)
 	}
 }
 

--- a/pkg/admin/handler.go
+++ b/pkg/admin/handler.go
@@ -86,6 +86,8 @@ type PromptInfoProvider interface {
 type ReloadNotifier interface {
 	PublishCatalogReload(catalogID string)
 	PublishConnectionReload(kind, name string)
+	PublishPersonaReload()
+	PublishAPIKeyReload()
 }
 
 // ToolkitRegistry abstracts registry.Registry for testability.

--- a/pkg/admin/handler.go
+++ b/pkg/admin/handler.go
@@ -77,6 +77,17 @@ type PromptInfoProvider interface {
 	AllPromptInfos() []registry.PromptInfo
 }
 
+// ReloadNotifier announces an admin-side configuration change to peer
+// replicas so their in-memory state is rebuilt (issue #501). The handler
+// reloads the local replica synchronously as before, then calls the
+// matching method here to broadcast the change. Implemented by
+// *platform.Platform; nil on single-replica or test setups, in which
+// case the broadcast is skipped.
+type ReloadNotifier interface {
+	PublishCatalogReload(catalogID string)
+	PublishConnectionReload(kind, name string)
+}
+
 // ToolkitRegistry abstracts registry.Registry for testability.
 type ToolkitRegistry interface {
 	All() []registry.Toolkit
@@ -101,6 +112,7 @@ type Deps struct {
 	FileDefaults        map[string]string
 	PersonaRegistry     PersonaRegistry
 	ToolkitRegistry     ToolkitRegistry
+	ReloadNotifier      ReloadNotifier
 	MCPServer           *mcp.Server
 	AuditQuerier        AuditQuerier
 	AuditMetricsQuerier AuditMetricsQuerier

--- a/pkg/admin/persona_handler.go
+++ b/pkg/admin/persona_handler.go
@@ -239,6 +239,9 @@ func (h *Handler) createPersona(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to register persona")
 		return
 	}
+	if h.deps.ReloadNotifier != nil {
+		h.deps.ReloadNotifier.PublishPersonaReload()
+	}
 
 	writeJSON(w, http.StatusCreated, toPersonaDetail(p, []string{}))
 }
@@ -296,6 +299,9 @@ func (h *Handler) updatePersona(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to update persona")
 		return
 	}
+	if h.deps.ReloadNotifier != nil {
+		h.deps.ReloadNotifier.PublishPersonaReload()
+	}
 
 	writeJSON(w, http.StatusOK, toPersonaDetail(p, []string{}))
 }
@@ -343,6 +349,9 @@ func (h *Handler) deletePersona(w http.ResponseWriter, r *http.Request) {
 	// it reverts immediately rather than disappearing until restart.
 	if h.deps.FilePersonaNames[name] {
 		h.revertToFilePersona(name)
+	}
+	if h.deps.ReloadNotifier != nil {
+		h.deps.ReloadNotifier.PublishPersonaReload()
 	}
 
 	writeJSON(w, http.StatusOK, statusResponse{Status: statusDeleted})

--- a/pkg/admin/reload_notify_test.go
+++ b/pkg/admin/reload_notify_test.go
@@ -1,8 +1,13 @@
 package admin
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/txn2/mcp-data-platform/pkg/registry"
@@ -14,12 +19,16 @@ import (
 type fakeReloadNotifier struct {
 	catalogs []string
 	conns    [][2]string
+	personas int
+	apikeys  int
 }
 
 func (f *fakeReloadNotifier) PublishCatalogReload(id string) { f.catalogs = append(f.catalogs, id) }
 func (f *fakeReloadNotifier) PublishConnectionReload(kind, name string) {
 	f.conns = append(f.conns, [2]string{kind, name})
 }
+func (f *fakeReloadNotifier) PublishPersonaReload() { f.personas++ }
+func (f *fakeReloadNotifier) PublishAPIKeyReload()  { f.apikeys++ }
 
 // TestReloadNotifier_PublishedOnAdminChange proves the admin handler
 // broadcasts a reload to peer replicas after each local config change
@@ -44,6 +53,68 @@ func TestReloadNotifier_PublishedOnAdminChange(t *testing.T) {
 	require.Equal(t, []string{"things"}, notifier.catalogs, "catalog reload should broadcast")
 	require.Equal(t, [][2]string{{"api", "c1"}, {"api", "c1"}}, notifier.conns,
 		"connection add and remove should each broadcast")
+}
+
+// TestReloadNotifier_PersonaBroadcast proves a persona create and delete
+// each broadcast a persona reload to peer replicas (issue #501 authz gap).
+func TestReloadNotifier_PersonaBroadcast(t *testing.T) {
+	notifier := &fakeReloadNotifier{}
+	pReg := &mockPersonaRegistry{allResult: testPersonas("admin", "analyst")}
+	h := NewHandler(Deps{
+		PersonaRegistry: pReg,
+		Config:          testConfig(),
+		ConfigStore:     &mockConfigStore{mode: "database"},
+		ReloadNotifier:  notifier,
+	}, nil)
+
+	body := `{"name":"viewer","display_name":"Viewer","roles":["viewer"],"allow_tools":["trino_*"]}`
+	createReq := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/personas", strings.NewReader(body))
+	createW := httptest.NewRecorder()
+	h.ServeHTTP(createW, createReq)
+	require.Equal(t, http.StatusCreated, createW.Code)
+
+	updateBody := `{"display_name":"Senior Analyst","roles":["analyst","viewer"]}`
+	updateReq := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/v1/admin/personas/analyst", strings.NewReader(updateBody))
+	updateReq.SetPathValue("name", "analyst")
+	updateW := httptest.NewRecorder()
+	h.ServeHTTP(updateW, updateReq)
+	require.Equal(t, http.StatusOK, updateW.Code)
+
+	delReq := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/v1/admin/personas/analyst", http.NoBody)
+	delReq.SetPathValue("name", "analyst")
+	delW := httptest.NewRecorder()
+	h.ServeHTTP(delW, delReq)
+	require.Equal(t, http.StatusOK, delW.Code)
+
+	assert.Equal(t, 3, notifier.personas, "persona create, update, and delete should each broadcast a persona reload")
+}
+
+// TestReloadNotifier_APIKeyBroadcast proves an API-key create and delete
+// each broadcast an api-key reload to peer replicas (issue #501 authn gap).
+func TestReloadNotifier_APIKeyBroadcast(t *testing.T) {
+	notifier := &fakeReloadNotifier{}
+	mgr := &mockAPIKeyManager{removeFn: func(_ string) bool { return true }}
+	h := NewHandler(Deps{
+		APIKeyManager:   mgr,
+		PersonaRegistry: &mockPersonaRegistry{},
+		Config:          testConfig(),
+		ConfigStore:     &mockConfigStore{mode: "database"},
+		ReloadNotifier:  notifier,
+	}, nil)
+
+	body := `{"name":"ci-key","roles":["analyst"]}`
+	createReq := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/auth/keys", strings.NewReader(body))
+	createW := httptest.NewRecorder()
+	h.ServeHTTP(createW, createReq)
+	require.Equal(t, http.StatusCreated, createW.Code)
+
+	delReq := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/v1/admin/auth/keys/ci-key", http.NoBody)
+	delReq.SetPathValue("name", "ci-key")
+	delW := httptest.NewRecorder()
+	h.ServeHTTP(delW, delReq)
+	require.Equal(t, http.StatusOK, delW.Code)
+
+	assert.Equal(t, 2, notifier.apikeys, "api-key create and delete should each broadcast an api-key reload")
 }
 
 // TestReloadNotifier_NilNotifierSafe proves a nil notifier (single-replica

--- a/pkg/admin/reload_notify_test.go
+++ b/pkg/admin/reload_notify_test.go
@@ -1,0 +1,64 @@
+package admin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
+)
+
+// fakeReloadNotifier records the cross-replica reload broadcasts the
+// admin handler emits after a local config change.
+type fakeReloadNotifier struct {
+	catalogs []string
+	conns    [][2]string
+}
+
+func (f *fakeReloadNotifier) PublishCatalogReload(id string) { f.catalogs = append(f.catalogs, id) }
+func (f *fakeReloadNotifier) PublishConnectionReload(kind, name string) {
+	f.conns = append(f.conns, [2]string{kind, name})
+}
+
+// TestReloadNotifier_PublishedOnAdminChange proves the admin handler
+// broadcasts a reload to peer replicas after each local config change
+// (issue #501): a catalog spec edit broadcasts a catalog reload, and a
+// connection add/remove broadcasts a connection reload.
+func TestReloadNotifier_PublishedOnAdminChange(t *testing.T) {
+	tk := apigateway.New("apigateway") // Kind() == "api"
+	reg := &mockToolkitRegistry{rawToolkits: []registry.Toolkit{tk}}
+	notifier := &fakeReloadNotifier{}
+	h := NewHandler(Deps{
+		Config:          testConfig(),
+		ConnectionStore: &mockConnectionStore{},
+		ToolkitRegistry: reg,
+		ConfigStore:     &mockConfigStore{mode: "database"},
+		ReloadNotifier:  notifier,
+	}, nil)
+
+	h.reloadConnectionsForCatalog("things")
+	h.hotAddConnection("api", "c1", map[string]any{"base_url": "https://x"})
+	h.hotRemoveConnection("api", "c1")
+
+	require.Equal(t, []string{"things"}, notifier.catalogs, "catalog reload should broadcast")
+	require.Equal(t, [][2]string{{"api", "c1"}, {"api", "c1"}}, notifier.conns,
+		"connection add and remove should each broadcast")
+}
+
+// TestReloadNotifier_NilNotifierSafe proves a nil notifier (single-replica
+// or unwired deployments) is a safe no-op.
+func TestReloadNotifier_NilNotifierSafe(t *testing.T) {
+	tk := apigateway.New("apigateway")
+	reg := &mockToolkitRegistry{rawToolkits: []registry.Toolkit{tk}}
+	h := NewHandler(Deps{
+		Config:          testConfig(),
+		ConnectionStore: &mockConnectionStore{},
+		ToolkitRegistry: reg,
+		ConfigStore:     &mockConfigStore{mode: "database"},
+	}, nil)
+	h.reloadConnectionsForCatalog("things")
+	h.hotRemoveConnection("api", "c1")
+	// Reaching here without a nil-pointer panic is the assertion.
+	require.NotNil(t, h)
+}

--- a/pkg/auth/apikey.go
+++ b/pkg/auth/apikey.go
@@ -142,6 +142,24 @@ func (a *APIKeyAuthenticator) AddHashedKey(key APIKey) {
 	a.hashedKeys = append(a.hashedKeys, &key)
 }
 
+// ReplaceHashedKeys atomically replaces the full set of DB-loaded
+// (bcrypt-hashed) keys. Used to reconcile the in-memory key set after an
+// admin add or revoke, including across replicas (issue #501): unlike
+// AddHashedKey, this DROPS keys no longer present in the new set, so a
+// revoked key stops authenticating. File-config keys (fileKeys) are
+// untouched.
+func (a *APIKeyAuthenticator) ReplaceHashedKeys(keys []APIKey) {
+	cleaned := make([]*APIKey, 0, len(keys))
+	for i := range keys {
+		k := keys[i]
+		k.Key = "" // guard: hashed keys must not carry plaintext
+		cleaned = append(cleaned, &k)
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.hashedKeys = cleaned
+}
+
 // RemoveKey removes a plaintext API key by its value.
 func (a *APIKeyAuthenticator) RemoveKey(keyValue string) {
 	a.mu.Lock()

--- a/pkg/auth/apikey_test.go
+++ b/pkg/auth/apikey_test.go
@@ -196,6 +196,51 @@ func TestRemoveByNameHashedKey(t *testing.T) {
 	}
 }
 
+// TestReplaceHashedKeys proves the cross-replica reconcile path (issue
+// #501): replacing the DB-key set drops a revoked key (it stops
+// authenticating) and admits a newly added one, while file-config keys
+// are untouched.
+func TestReplaceHashedKeys(t *testing.T) {
+	auth := NewAPIKeyAuthenticator(APIKeyConfig{
+		Keys: []APIKey{{Key: "file-key", Name: "file", Roles: []string{testRoleAdmin}}},
+	})
+
+	hashFor := func(raw string) string {
+		h, err := bcrypt.GenerateFromPassword([]byte(raw), bcrypt.MinCost)
+		if err != nil {
+			t.Fatalf("bcrypt hash: %v", err)
+		}
+		return string(h)
+	}
+
+	// Seed an initial DB key, then replace the set with a different one:
+	// the old key is revoked, the new key is admitted.
+	auth.AddHashedKey(APIKey{KeyHash: hashFor("old-db-key"), Name: "old", Roles: []string{testRoleAnalyst}})
+	auth.ReplaceHashedKeys([]APIKey{
+		{KeyHash: hashFor("new-db-key"), Name: "new", Roles: []string{testRoleAnalyst}},
+	})
+
+	if _, err := auth.Authenticate(WithToken(context.Background(), "old-db-key")); err == nil {
+		t.Error("revoked key still authenticates after ReplaceHashedKeys")
+	}
+	if _, err := auth.Authenticate(WithToken(context.Background(), "new-db-key")); err != nil {
+		t.Errorf("new key should authenticate after ReplaceHashedKeys: %v", err)
+	}
+	// File-config key must survive a DB-key replacement.
+	if _, err := auth.Authenticate(WithToken(context.Background(), "file-key")); err != nil {
+		t.Errorf("file-config key must survive ReplaceHashedKeys: %v", err)
+	}
+
+	// Replacing with an empty set drops all DB keys but keeps file keys.
+	auth.ReplaceHashedKeys(nil)
+	if _, err := auth.Authenticate(WithToken(context.Background(), "new-db-key")); err == nil {
+		t.Error("DB key should be gone after ReplaceHashedKeys(nil)")
+	}
+	if _, err := auth.Authenticate(WithToken(context.Background(), "file-key")); err != nil {
+		t.Errorf("file-config key must survive ReplaceHashedKeys(nil): %v", err)
+	}
+}
+
 func TestGenerateKey(t *testing.T) {
 	auth := NewAPIKeyAuthenticator(APIKeyConfig{})
 

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -171,6 +171,14 @@ type Platform struct {
 	// database-backed so all replicas see every event.
 	broadcaster session.Broadcaster
 
+	// reloadBroadcaster carries server-side cross-replica reload events
+	// (connection/catalog/persona/apikey) on a dedicated channel,
+	// separate from the client-facing broadcaster, so admin config
+	// changes propagate to every replica's in-memory state (issue #501).
+	reloadBroadcaster session.Broadcaster
+	reloadBus         *reloadBus
+	reloadCancel      context.CancelFunc
+
 	// Tuning
 	ruleEngine    *tuning.RuleEngine
 	promptManager *tuning.PromptManager
@@ -1292,6 +1300,7 @@ func (p *Platform) initBroadcaster() {
 			p.broadcaster = b
 			slog.Info("broadcaster: postgres LISTEN/NOTIFY",
 				"channel", channel)
+			p.initReloadBus()
 			return
 		}
 		// Fallback path: the operator configured postgres but
@@ -1310,6 +1319,7 @@ func (p *Platform) initBroadcaster() {
 	} else {
 		slog.Info("broadcaster: memory (single-replica)")
 	}
+	p.initReloadBus()
 }
 
 // initOAuth initializes the OAuth server if enabled.
@@ -3686,6 +3696,8 @@ func (p *Platform) closeSessionLayer(errs *[]error) {
 		slog.Debug("shutdown: closing broadcaster")
 		closeResource(errs, p.broadcaster)
 	}
+	slog.Debug("shutdown: stopping reload bus")
+	p.stopReloadBus()
 	if p.oauthStoreCloser != nil {
 		slog.Debug("shutdown: closing OAuth store")
 		closeResource(errs, p.oauthStoreCloser)

--- a/pkg/platform/reload.go
+++ b/pkg/platform/reload.go
@@ -1,0 +1,264 @@
+package platform
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"os"
+
+	"github.com/txn2/mcp-data-platform/pkg/session"
+	sessionpostgres "github.com/txn2/mcp-data-platform/pkg/session/postgres"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
+	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
+)
+
+// Reload event methods. These are internal control-plane signals carried
+// on a DEDICATED broadcaster channel, separate from the client-facing
+// tools/list_changed fan-out, so they are never written to an MCP
+// client's SSE stream. The "platform/reload/" prefix (not
+// "notifications/") makes the separation obvious in logs.
+// Connection and catalog are wired in this change (the demonstrated
+// #501 bug); persona and API-key reloaders are tracked follow-ups that
+// plug into this same bus.
+const (
+	reloadMethodConnection = "platform/reload/connection"
+	reloadMethodCatalog    = "platform/reload/catalog" //nolint:gosec // event method name, not a credential
+)
+
+// reloadParamOrigin tags each reload event with the publishing replica's
+// instance id. The subscriber skips events whose origin matches its own
+// id: the replica that handled the admin write has already reloaded its
+// in-memory state synchronously, so re-applying its own broadcast would
+// be a redundant (though idempotent) rebuild.
+const reloadParamOrigin = "origin"
+
+// reloadHandlers carries the local re-materialization callbacks the
+// subscriber invokes when a peer replica announces a configuration
+// change. Any nil handler is treated as "this subsystem does not
+// participate in cross-replica reload yet" and the corresponding event
+// is ignored. Keeping the callbacks injected (rather than reaching into
+// Platform here) keeps the bus unit-testable in isolation.
+type reloadHandlers struct {
+	connection func(kind, name string)
+	catalog    func(catalogID string)
+}
+
+// reloadBus publishes and consumes cross-replica reload events over a
+// dedicated broadcaster channel. It is the server-side counterpart to
+// the client-facing notification path: when an operator changes
+// configuration through the admin API on one replica, that replica
+// reloads locally AND publishes a reload event here; every other replica
+// receives the event and re-materializes the affected in-memory state.
+//
+// Without this, a multi-replica deployment serves stale connection,
+// catalog, persona, and API-key state on every replica except the one
+// that handled the admin request (see issue #501).
+type reloadBus struct {
+	b        session.Broadcaster
+	origin   string
+	handlers reloadHandlers
+	logger   *slog.Logger
+}
+
+// newReloadBus builds a bus over b. origin is this replica's unique
+// instance id (used to skip self-published events). A nil logger falls
+// back to slog.Default().
+func newReloadBus(b session.Broadcaster, origin string, h reloadHandlers, logger *slog.Logger) *reloadBus {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &reloadBus{b: b, origin: origin, handlers: h, logger: logger}
+}
+
+// publishConnection announces that the (kind, name) connection's stored
+// config changed and peers should rebuild it.
+func (rb *reloadBus) publishConnection(ctx context.Context, kind, name string) {
+	rb.publish(ctx, reloadMethodConnection, map[string]any{"kind": kind, "name": name})
+}
+
+// publishCatalog announces that an API catalog's specs changed and peers
+// should rebuild every connection that references it.
+func (rb *reloadBus) publishCatalog(ctx context.Context, catalogID string) {
+	rb.publish(ctx, reloadMethodCatalog, map[string]any{"catalog_id": catalogID})
+}
+
+func (rb *reloadBus) publish(ctx context.Context, method string, params map[string]any) {
+	if rb == nil || rb.b == nil {
+		return
+	}
+	if params == nil {
+		params = make(map[string]any, 1)
+	}
+	params[reloadParamOrigin] = rb.origin
+	if err := rb.b.Publish(ctx, session.Event{Method: method, Params: params}); err != nil {
+		// Best-effort: a failed publish means peers miss this one change
+		// until their next restart or a later successful publish. Log so
+		// a degraded reload channel is visible rather than silent.
+		rb.logger.Warn("reload-bus: publish failed", "method", method, "error", err)
+	}
+}
+
+// run subscribes to the reload channel and dispatches events until ctx is
+// canceled. Intended to be launched in its own goroutine at startup.
+func (rb *reloadBus) run(ctx context.Context) {
+	if rb == nil || rb.b == nil {
+		return
+	}
+	sub := rb.b.Subscribe(ctx, "reload-bus")
+	defer sub.Close()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-sub.Events():
+			if !ok {
+				return
+			}
+			rb.dispatch(ev)
+		}
+	}
+}
+
+// dispatch routes one reload event to the matching local handler. Events
+// published by this same replica are skipped (the handler already ran
+// synchronously on the write path).
+func (rb *reloadBus) dispatch(ev session.Event) {
+	if origin, _ := ev.Params[reloadParamOrigin].(string); origin == rb.origin {
+		return
+	}
+	switch ev.Method {
+	case reloadMethodConnection:
+		kind, _ := ev.Params["kind"].(string)
+		name, _ := ev.Params["name"].(string)
+		if rb.handlers.connection != nil && kind != "" && name != "" {
+			rb.logger.Info("reload-bus: reloading connection from peer", "kind", kind, "name", name)
+			rb.handlers.connection(kind, name)
+		}
+	case reloadMethodCatalog:
+		id, _ := ev.Params["catalog_id"].(string)
+		if rb.handlers.catalog != nil && id != "" {
+			rb.logger.Info("reload-bus: reloading catalog connections from peer", "catalog_id", id)
+			rb.handlers.catalog(id)
+		}
+	default:
+		// Unknown method on the dedicated reload channel: ignore. This is
+		// the forward-compat path for a newer replica publishing a reload
+		// kind an older replica does not understand yet.
+	}
+}
+
+// newReplicaOrigin returns a stable-per-process identifier used to tag
+// reload events so a replica skips its own broadcasts. Hostname plus a
+// random suffix keeps it unique even when two replicas share a hostname
+// (unlikely under k8s, but cheap insurance).
+func newReplicaOrigin() string {
+	host, _ := os.Hostname()
+	buf := make([]byte, 4)
+	_, _ = rand.Read(buf)
+	if host == "" {
+		host = "replica"
+	}
+	return host + "-" + hex.EncodeToString(buf)
+}
+
+// initReloadBus builds the dedicated cross-replica reload channel and
+// starts the subscriber. It uses a separate postgres LISTEN/NOTIFY
+// channel from the client-facing broadcaster (the configured channel
+// plus a "_reload" suffix) so internal control-plane events are never
+// written to an MCP client's SSE stream. On a single-replica or
+// db-less deployment it falls back to an in-memory broadcaster, where
+// publish/subscribe is a local no-op loop (harmless). Called at the end
+// of initBroadcaster so it shares the broadcaster lifecycle.
+func (p *Platform) initReloadBus() {
+	var b session.Broadcaster
+	if p.db != nil && p.config.Database.DSN != "" {
+		channel := p.config.Sessions.BroadcastChannel
+		if channel == "" {
+			channel = sessionpostgres.DefaultNotifyChannel
+		}
+		reloadChannel := channel + "_reload"
+		pb, err := sessionpostgres.NewBroadcaster(p.config.Database.DSN, p.db, reloadChannel, slog.Default())
+		if err == nil {
+			b = pb
+			slog.Info("reload-bus: postgres LISTEN/NOTIFY", "channel", reloadChannel)
+		} else {
+			// Degraded: cross-replica reload is disabled, but the platform
+			// still runs. Operators on a multi-replica deployment must
+			// restart pods after admin config changes until this is fixed.
+			slog.Warn("reload-bus: postgres init failed — cross-replica reload disabled, restart pods after admin changes",
+				"error", err)
+		}
+	}
+	if b == nil {
+		b = session.NewMemoryBroadcaster(slog.Default())
+	}
+	p.reloadBroadcaster = b
+	p.reloadBus = newReloadBus(b, newReplicaOrigin(), reloadHandlers{
+		connection: p.reloadConnectionLocal,
+		catalog:    p.reloadCatalogLocal,
+		// persona and apiKey reloaders are tracked follow-ups on this bus
+		// (issue #501); leaving them nil means those events are ignored
+		// rather than mis-handled.
+	}, slog.Default())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p.reloadCancel = cancel
+	go p.reloadBus.run(ctx)
+}
+
+// stopReloadBus cancels the subscriber and closes the reload broadcaster.
+func (p *Platform) stopReloadBus() {
+	if p.reloadCancel != nil {
+		p.reloadCancel()
+	}
+	if p.reloadBroadcaster != nil {
+		_ = p.reloadBroadcaster.Close()
+	}
+}
+
+// reloadConnectionLocal re-materializes one connection on this replica
+// from the connection store. Used both by the reload subscriber (peer
+// announced a change) and indirectly mirrors the admin hot-reload path.
+func (p *Platform) reloadConnectionLocal(kind, name string) {
+	inst, err := p.connectionStore.Get(context.Background(), kind, name)
+	for _, tk := range p.toolkitRegistry.All() {
+		if tk.Kind() != kind {
+			continue
+		}
+		cm, ok := tk.(toolkit.ConnectionManager)
+		if !ok {
+			continue
+		}
+		_ = cm.RemoveConnection(name)
+		if err == nil && inst != nil {
+			_ = cm.AddConnection(name, inst.Config)
+		}
+	}
+}
+
+// reloadCatalogLocal rebuilds every api-gateway connection that mounts
+// the given catalog on this replica.
+func (p *Platform) reloadCatalogLocal(catalogID string) {
+	for _, tk := range p.toolkitRegistry.All() {
+		if api, ok := tk.(*apigatewaykit.Toolkit); ok {
+			api.ReloadConnectionsByCatalog(catalogID)
+		}
+	}
+}
+
+// PublishConnectionReload announces a connection config change to peer
+// replicas. Implements admin.ReloadNotifier. Safe when the bus is nil.
+func (p *Platform) PublishConnectionReload(kind, name string) {
+	if p.reloadBus != nil {
+		p.reloadBus.publishConnection(context.Background(), kind, name)
+	}
+}
+
+// PublishCatalogReload announces an API-catalog spec change to peer
+// replicas. Implements admin.ReloadNotifier. Safe when the bus is nil.
+func (p *Platform) PublishCatalogReload(catalogID string) {
+	if p.reloadBus != nil {
+		p.reloadBus.publishCatalog(context.Background(), catalogID)
+	}
+}

--- a/pkg/platform/reload.go
+++ b/pkg/platform/reload.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/txn2/mcp-data-platform/pkg/auth"
 	"github.com/txn2/mcp-data-platform/pkg/session"
 	sessionpostgres "github.com/txn2/mcp-data-platform/pkg/session/postgres"
 	"github.com/txn2/mcp-data-platform/pkg/toolkit"
@@ -18,12 +19,11 @@ import (
 // tools/list_changed fan-out, so they are never written to an MCP
 // client's SSE stream. The "platform/reload/" prefix (not
 // "notifications/") makes the separation obvious in logs.
-// Connection and catalog are wired in this change (the demonstrated
-// #501 bug); persona and API-key reloaders are tracked follow-ups that
-// plug into this same bus.
 const (
 	reloadMethodConnection = "platform/reload/connection"
 	reloadMethodCatalog    = "platform/reload/catalog" //nolint:gosec // event method name, not a credential
+	reloadMethodPersona    = "platform/reload/persona" //nolint:gosec // event method name, not a credential
+	reloadMethodAPIKey     = "platform/reload/apikey"  //nolint:gosec // event method name, not a credential
 )
 
 // reloadParamOrigin tags each reload event with the publishing replica's
@@ -42,6 +42,8 @@ const reloadParamOrigin = "origin"
 type reloadHandlers struct {
 	connection func(kind, name string)
 	catalog    func(catalogID string)
+	persona    func()
+	apiKey     func()
 }
 
 // reloadBus publishes and consumes cross-replica reload events over a
@@ -81,6 +83,18 @@ func (rb *reloadBus) publishConnection(ctx context.Context, kind, name string) {
 // should rebuild every connection that references it.
 func (rb *reloadBus) publishCatalog(ctx context.Context, catalogID string) {
 	rb.publish(ctx, reloadMethodCatalog, map[string]any{"catalog_id": catalogID})
+}
+
+// publishPersona announces that persona definitions changed and peers
+// should reconcile their persona registry from the store.
+func (rb *reloadBus) publishPersona(ctx context.Context) {
+	rb.publish(ctx, reloadMethodPersona, nil)
+}
+
+// publishAPIKey announces that API keys changed and peers should
+// re-sync their in-memory key set from the store.
+func (rb *reloadBus) publishAPIKey(ctx context.Context) {
+	rb.publish(ctx, reloadMethodAPIKey, nil)
 }
 
 func (rb *reloadBus) publish(ctx context.Context, method string, params map[string]any) {
@@ -129,22 +143,42 @@ func (rb *reloadBus) dispatch(ev session.Event) {
 	}
 	switch ev.Method {
 	case reloadMethodConnection:
-		kind, _ := ev.Params["kind"].(string)
-		name, _ := ev.Params["name"].(string)
-		if rb.handlers.connection != nil && kind != "" && name != "" {
-			rb.logger.Info("reload-bus: reloading connection from peer", "kind", kind, "name", name)
-			rb.handlers.connection(kind, name)
-		}
+		rb.dispatchConnection(ev)
 	case reloadMethodCatalog:
-		id, _ := ev.Params["catalog_id"].(string)
-		if rb.handlers.catalog != nil && id != "" {
-			rb.logger.Info("reload-bus: reloading catalog connections from peer", "catalog_id", id)
-			rb.handlers.catalog(id)
+		rb.dispatchCatalog(ev)
+	case reloadMethodPersona:
+		if rb.handlers.persona != nil {
+			rb.logger.Info("reload-bus: reloading personas from peer")
+			rb.handlers.persona()
+		}
+	case reloadMethodAPIKey:
+		if rb.handlers.apiKey != nil {
+			rb.logger.Info("reload-bus: reloading API keys from peer")
+			rb.handlers.apiKey()
 		}
 	default:
 		// Unknown method on the dedicated reload channel: ignore. This is
 		// the forward-compat path for a newer replica publishing a reload
 		// kind an older replica does not understand yet.
+	}
+}
+
+// dispatchConnection applies a peer's connection reload (kind/name).
+func (rb *reloadBus) dispatchConnection(ev session.Event) {
+	kind, _ := ev.Params["kind"].(string)
+	name, _ := ev.Params["name"].(string)
+	if rb.handlers.connection != nil && kind != "" && name != "" {
+		rb.logger.Info("reload-bus: reloading connection from peer", "kind", kind, "name", name)
+		rb.handlers.connection(kind, name)
+	}
+}
+
+// dispatchCatalog applies a peer's catalog reload (catalog_id).
+func (rb *reloadBus) dispatchCatalog(ev session.Event) {
+	id, _ := ev.Params["catalog_id"].(string)
+	if rb.handlers.catalog != nil && id != "" {
+		rb.logger.Info("reload-bus: reloading catalog connections from peer", "catalog_id", id)
+		rb.handlers.catalog(id)
 	}
 }
 
@@ -197,9 +231,8 @@ func (p *Platform) initReloadBus() {
 	p.reloadBus = newReloadBus(b, newReplicaOrigin(), reloadHandlers{
 		connection: p.reloadConnectionLocal,
 		catalog:    p.reloadCatalogLocal,
-		// persona and apiKey reloaders are tracked follow-ups on this bus
-		// (issue #501); leaving them nil means those events are ignored
-		// rather than mis-handled.
+		persona:    p.reloadPersonaLocal,
+		apiKey:     p.reloadAPIKeyLocal,
 	}, slog.Default())
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -247,11 +280,57 @@ func (p *Platform) reloadCatalogLocal(catalogID string) {
 	}
 }
 
+// reloadPersonaLocal reconciles the persona registry from the store on
+// this replica (re-registers/updates DB personas). Used by the reload
+// subscriber when a peer changes a persona.
+func (p *Platform) reloadPersonaLocal() {
+	p.loadDBPersonas()
+}
+
+// reloadAPIKeyLocal re-syncs the in-memory DB-loaded API keys from the
+// store on this replica, dropping revoked keys (ReplaceHashedKeys).
+func (p *Platform) reloadAPIKeyLocal() {
+	if p.apiKeyStore == nil || p.apiKeyAuth == nil {
+		return
+	}
+	defs, err := p.apiKeyStore.List(context.Background())
+	if err != nil {
+		slog.Warn("reload-bus: failed to list api keys for reload", logKeyError, err)
+		return
+	}
+	keys := make([]auth.APIKey, 0, len(defs))
+	for _, d := range defs {
+		keys = append(keys, auth.APIKey{
+			KeyHash:     d.KeyHash,
+			Name:        d.Name,
+			Email:       d.Email,
+			Description: d.Description,
+			Roles:       d.Roles,
+			ExpiresAt:   d.ExpiresAt,
+		})
+	}
+	p.apiKeyAuth.ReplaceHashedKeys(keys)
+}
+
 // PublishConnectionReload announces a connection config change to peer
 // replicas. Implements admin.ReloadNotifier. Safe when the bus is nil.
 func (p *Platform) PublishConnectionReload(kind, name string) {
 	if p.reloadBus != nil {
 		p.reloadBus.publishConnection(context.Background(), kind, name)
+	}
+}
+
+// PublishPersonaReload announces a persona change to peer replicas.
+func (p *Platform) PublishPersonaReload() {
+	if p.reloadBus != nil {
+		p.reloadBus.publishPersona(context.Background())
+	}
+}
+
+// PublishAPIKeyReload announces an API-key change to peer replicas.
+func (p *Platform) PublishAPIKeyReload() {
+	if p.reloadBus != nil {
+		p.reloadBus.publishAPIKey(context.Background())
 	}
 }
 

--- a/pkg/platform/reload_test.go
+++ b/pkg/platform/reload_test.go
@@ -1,11 +1,70 @@
 package platform
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/session"
+	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
 )
+
+// fakeConnStore returns a fixed config for every Get so the reloader's
+// AddConnection branch is exercised.
+type fakeConnStore struct{ cfg map[string]any }
+
+func (fakeConnStore) List(context.Context) ([]ConnectionInstance, error) { return nil, nil }
+func (f fakeConnStore) Get(_ context.Context, kind, name string) (*ConnectionInstance, error) {
+	return &ConnectionInstance{Kind: kind, Name: name, Config: f.cfg}, nil
+}
+func (fakeConnStore) Set(context.Context, ConnectionInstance) error { return nil }
+func (fakeConnStore) Delete(context.Context, string, string) error  { return nil }
+func (fakeConnStore) Persistent() bool                              { return false }
+
+// TestPlatform_ReloadWiring exercises the platform-level reload methods:
+// dedicated-bus init (memory fallback, no db), the connection/catalog
+// reloaders against a live api-gateway toolkit, the publish methods, and
+// shutdown. It is the coverage counterpart to the bus-core unit tests.
+func TestPlatform_ReloadWiring(t *testing.T) {
+	reg := registry.NewRegistry()
+	apiTk := apigatewaykit.New("api")
+	if err := reg.Register(apiTk); err != nil {
+		t.Fatalf("register toolkit: %v", err)
+	}
+	p := &Platform{
+		config:          &Config{},
+		toolkitRegistry: reg,
+		connectionStore: fakeConnStore{cfg: map[string]any{"base_url": "https://x"}},
+	}
+
+	p.initReloadBus() // no db -> in-memory broadcaster
+	if p.reloadBus == nil || p.reloadBroadcaster == nil {
+		t.Fatal("initReloadBus did not wire the bus")
+	}
+
+	// Reloaders against the live toolkit (rebuild from the fake store).
+	p.reloadConnectionLocal("api", "c1")
+	if !apiTk.HasConnection("c1") {
+		t.Error("reloadConnectionLocal did not add the connection")
+	}
+	p.reloadConnectionLocal("mcp", "ignored") // wrong kind: no-op, exercises the skip
+	p.reloadCatalogLocal("cat-1")             // ReloadConnectionsByCatalog on the api toolkit
+
+	// Publish methods (memory bus; no subscriber needed for coverage).
+	p.PublishConnectionReload("api", "c1")
+	p.PublishCatalogReload("cat-1")
+
+	if origin := newReplicaOrigin(); !strings.Contains(origin, "-") {
+		t.Errorf("origin %q lacks the hostname-suffix shape", origin)
+	}
+
+	p.stopReloadBus() // cancel subscriber + close broadcaster
+
+	// Publish after stop must be safe (broadcaster closed).
+	p.PublishConnectionReload("api", "c1")
+}
 
 // recordingHandlers captures reload-handler invocations on buffered
 // channels so tests can assert delivery (or non-delivery) with a timeout.

--- a/pkg/platform/reload_test.go
+++ b/pkg/platform/reload_test.go
@@ -1,0 +1,129 @@
+package platform
+
+import (
+	"testing"
+	"time"
+
+	"github.com/txn2/mcp-data-platform/pkg/session"
+)
+
+// recordingHandlers captures reload-handler invocations on buffered
+// channels so tests can assert delivery (or non-delivery) with a timeout.
+type recordingHandlers struct {
+	conn    chan [2]string
+	catalog chan string
+}
+
+func newRecordingHandlers() recordingHandlers {
+	return recordingHandlers{
+		conn:    make(chan [2]string, 4),
+		catalog: make(chan string, 4),
+	}
+}
+
+func (r recordingHandlers) handlers() reloadHandlers {
+	return reloadHandlers{
+		connection: func(kind, name string) { r.conn <- [2]string{kind, name} },
+		catalog:    func(id string) { r.catalog <- id },
+	}
+}
+
+// TestReloadBus_CrossReplica proves the core #501 fix: a reload published
+// by one replica is applied by the OTHER replica, and the publishing
+// replica skips its own event (it reloaded synchronously on the write
+// path). Two buses share one in-memory broadcaster, which is exactly how
+// the postgres broadcaster re-publishes a received NOTIFY locally, so
+// this is a faithful cross-replica simulation.
+func TestReloadBus_CrossReplica(t *testing.T) {
+	b := session.NewMemoryBroadcaster(nil)
+	defer func() { _ = b.Close() }()
+
+	recA := newRecordingHandlers()
+	recB := newRecordingHandlers()
+	busA := newReloadBus(b, "replica-a", recA.handlers(), nil)
+	busB := newReloadBus(b, "replica-b", recB.handlers(), nil)
+
+	ctx := t.Context()
+	go busA.run(ctx)
+	go busB.run(ctx)
+	// Let both subscriptions register before publishing.
+	waitForSubscribers(t, b, 2)
+
+	// Replica A handled the admin write and publishes the reload.
+	busA.publishConnection(t.Context(), "api", "Test API")
+
+	// Replica B must apply it.
+	select {
+	case got := <-recB.conn:
+		if got != [2]string{"api", "Test API"} {
+			t.Fatalf("replica B reloaded %v, want [api Test API]", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("replica B never received the connection reload (the #501 bug)")
+	}
+
+	// Replica A must NOT re-apply its own event (origin skip).
+	select {
+	case got := <-recA.conn:
+		t.Fatalf("replica A re-applied its own publish %v; should skip self-origin", got)
+	case <-time.After(150 * time.Millisecond):
+		// expected: no self-reload
+	}
+}
+
+// TestReloadBus_DispatchRouting proves each method routes to its handler.
+func TestReloadBus_DispatchRouting(t *testing.T) {
+	rec := newRecordingHandlers()
+	rb := newReloadBus(session.NewMemoryBroadcaster(nil), "self", rec.handlers(), nil)
+
+	rb.dispatch(session.Event{Method: reloadMethodCatalog, Params: map[string]any{"catalog_id": "cat-1", reloadParamOrigin: "peer"}})
+	rb.dispatch(session.Event{Method: reloadMethodConnection, Params: map[string]any{"kind": "mcp", "name": "up", reloadParamOrigin: "peer"}})
+
+	if got := <-rec.catalog; got != "cat-1" {
+		t.Errorf("catalog reload id=%q, want cat-1", got)
+	}
+	if got := <-rec.conn; got != [2]string{"mcp", "up"} {
+		t.Errorf("connection reload=%v, want [mcp up]", got)
+	}
+}
+
+// TestReloadBus_SkipsSelfOrigin proves self-published events are ignored.
+func TestReloadBus_SkipsSelfOrigin(t *testing.T) {
+	rec := newRecordingHandlers()
+	rb := newReloadBus(session.NewMemoryBroadcaster(nil), "self", rec.handlers(), nil)
+	rb.dispatch(session.Event{Method: reloadMethodCatalog, Params: map[string]any{"catalog_id": "x", reloadParamOrigin: "self"}})
+	select {
+	case <-rec.catalog:
+		t.Fatal("self-origin event must be skipped")
+	default:
+	}
+}
+
+// TestReloadBus_NilHandlerAndUnknownMethod proves a missing handler or an
+// unknown method is a safe no-op (forward compatibility).
+func TestReloadBus_NilHandlerAndUnknownMethod(_ *testing.T) {
+	rb := newReloadBus(session.NewMemoryBroadcaster(nil), "self", reloadHandlers{}, nil)
+	rb.dispatch(session.Event{Method: reloadMethodConnection, Params: map[string]any{"kind": "api", "name": "x", reloadParamOrigin: "peer"}})
+	rb.dispatch(session.Event{Method: "platform/reload/future", Params: map[string]any{reloadParamOrigin: "peer"}})
+	// Reaching here without panic is the assertion.
+}
+
+// TestReloadBus_NilBusPublishSafe proves a nil/disabled bus publish is a
+// no-op (single-replica deployments with no broadcaster).
+func TestReloadBus_NilBusPublishSafe(t *testing.T) {
+	var rb *reloadBus
+	rb.publishConnection(t.Context(), "api", "x") // must not panic
+	rb = newReloadBus(nil, "self", reloadHandlers{}, nil)
+	rb.publishCatalog(t.Context(), "x") // nil broadcaster: must not panic
+}
+
+func waitForSubscribers(t *testing.T, b *session.MemoryBroadcaster, n int) {
+	t.Helper()
+	for range 100 {
+		if b.SubscriberCount() >= n {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("subscribers did not reach %d", n)
+}

--- a/pkg/platform/reload_test.go
+++ b/pkg/platform/reload_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/txn2/mcp-data-platform/pkg/auth"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/session"
 	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
@@ -23,6 +24,16 @@ func (fakeConnStore) Set(context.Context, ConnectionInstance) error { return nil
 func (fakeConnStore) Delete(context.Context, string, string) error  { return nil }
 func (fakeConnStore) Persistent() bool                              { return false }
 
+// fakeAPIKeyStore returns a single DB key so reloadAPIKeyLocal's
+// definition-to-APIKey mapping loop is exercised.
+type fakeAPIKeyStore struct{}
+
+func (fakeAPIKeyStore) List(context.Context) ([]APIKeyDefinition, error) {
+	return []APIKeyDefinition{{Name: "db-key", KeyHash: "$2a$hash", Roles: []string{"analyst"}}}, nil
+}
+func (fakeAPIKeyStore) Set(context.Context, APIKeyDefinition) error { return nil }
+func (fakeAPIKeyStore) Delete(context.Context, string) error        { return nil }
+
 // TestPlatform_ReloadWiring exercises the platform-level reload methods:
 // dedicated-bus init (memory fallback, no db), the connection/catalog
 // reloaders against a live api-gateway toolkit, the publish methods, and
@@ -37,6 +48,9 @@ func TestPlatform_ReloadWiring(t *testing.T) {
 		config:          &Config{},
 		toolkitRegistry: reg,
 		connectionStore: fakeConnStore{cfg: map[string]any{"base_url": "https://x"}},
+		personaStore:    &NoopPersonaStore{},
+		apiKeyStore:     fakeAPIKeyStore{},
+		apiKeyAuth:      auth.NewAPIKeyAuthenticator(auth.APIKeyConfig{}),
 	}
 
 	p.initReloadBus() // no db -> in-memory broadcaster
@@ -51,10 +65,14 @@ func TestPlatform_ReloadWiring(t *testing.T) {
 	}
 	p.reloadConnectionLocal("mcp", "ignored") // wrong kind: no-op, exercises the skip
 	p.reloadCatalogLocal("cat-1")             // ReloadConnectionsByCatalog on the api toolkit
+	p.reloadPersonaLocal()                    // reconcile personas from store
+	p.reloadAPIKeyLocal()                     // re-sync api keys from store
 
 	// Publish methods (memory bus; no subscriber needed for coverage).
 	p.PublishConnectionReload("api", "c1")
 	p.PublishCatalogReload("cat-1")
+	p.PublishPersonaReload()
+	p.PublishAPIKeyReload()
 
 	if origin := newReplicaOrigin(); !strings.Contains(origin, "-") {
 		t.Errorf("origin %q lacks the hostname-suffix shape", origin)
@@ -71,12 +89,16 @@ func TestPlatform_ReloadWiring(t *testing.T) {
 type recordingHandlers struct {
 	conn    chan [2]string
 	catalog chan string
+	persona chan struct{}
+	apiKey  chan struct{}
 }
 
 func newRecordingHandlers() recordingHandlers {
 	return recordingHandlers{
 		conn:    make(chan [2]string, 4),
 		catalog: make(chan string, 4),
+		persona: make(chan struct{}, 4),
+		apiKey:  make(chan struct{}, 4),
 	}
 }
 
@@ -84,6 +106,8 @@ func (r recordingHandlers) handlers() reloadHandlers {
 	return reloadHandlers{
 		connection: func(kind, name string) { r.conn <- [2]string{kind, name} },
 		catalog:    func(id string) { r.catalog <- id },
+		persona:    func() { r.persona <- struct{}{} },
+		apiKey:     func() { r.apiKey <- struct{}{} },
 	}
 }
 
@@ -137,12 +161,20 @@ func TestReloadBus_DispatchRouting(t *testing.T) {
 
 	rb.dispatch(session.Event{Method: reloadMethodCatalog, Params: map[string]any{"catalog_id": "cat-1", reloadParamOrigin: "peer"}})
 	rb.dispatch(session.Event{Method: reloadMethodConnection, Params: map[string]any{"kind": "mcp", "name": "up", reloadParamOrigin: "peer"}})
+	rb.dispatch(session.Event{Method: reloadMethodPersona, Params: map[string]any{reloadParamOrigin: "peer"}})
+	rb.dispatch(session.Event{Method: reloadMethodAPIKey, Params: map[string]any{reloadParamOrigin: "peer"}})
 
 	if got := <-rec.catalog; got != "cat-1" {
 		t.Errorf("catalog reload id=%q, want cat-1", got)
 	}
 	if got := <-rec.conn; got != [2]string{"mcp", "up"} {
 		t.Errorf("connection reload=%v, want [mcp up]", got)
+	}
+	if _, ok := <-rec.persona; !ok {
+		t.Error("persona reload not dispatched")
+	}
+	if _, ok := <-rec.apiKey; !ok {
+		t.Error("apikey reload not dispatched")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #501. On a multi-replica deployment, configuration changes made through the admin API were applied only to the **in-memory state of the replica that handled the request**. Every other replica kept serving stale state until it restarted. The session broadcaster propagates the client-facing `notifications/tools/list_changed` event, but there was no server-side cross-replica signal to reload in-memory state.

Observed on a 2-replica deployment: an operator attached an API catalog to a `kind=api` connection. The replica that handled the save rebuilt the connection (spec parsed, operations + embeddings built); the other replica never reloaded it. A sticky MCP session on the second replica kept getting `api_list_specs` / `api_list_endpoints` returning "no catalog configured," with no error.

## What this changes

Adds a **cross-replica reload bus**: the server-side counterpart to the client notification path.

- **Dedicated channel.** A second postgres `LISTEN/NOTIFY` broadcaster on the configured broadcast channel plus a `_reload` suffix. Internal control-plane events are kept off the client `tools/list_changed` fan-out, so they are never written to an MCP client's SSE stream. Same per-deployment isolation as the existing channel.
- **Per-replica subscriber.** Each replica runs a subscriber that re-materializes the affected in-memory state when a peer announces a change.
- **Self-origin skip.** Every event carries the publishing replica's origin id. The replica that handled the admin write already reloaded synchronously on the write path, so it skips its own broadcast (no redundant rebuild).
- **Graceful fallback.** On a single-replica or db-less deployment the bus uses an in-memory broadcaster, where publish/subscribe is a local no-op. Behavior there is unchanged.

## Surfaces wired to the bus

All four admin-mutable surfaces identified on #501 propagate across replicas:

- **API catalog** spec edits publish a catalog reload; subscribers rebuild every connection that mounts the catalog.
- **Connection** (`api` / `mcp`) create/update/delete publish a connection reload; subscribers rebuild that connection from the connection store (or drop it when the row is gone).
- **Persona** (authorization) create/update/delete publish a persona reload; subscribers reconcile the persona registry from the store.
- **API key** (authentication) create/delete publish an api-key reload; subscribers re-sync the in-memory DB-key set via `ReplaceHashedKeys`, which replaces the full set so a **revoked key stops authenticating** on peer replicas (unlike `AddHashedKey`, which only adds).

The handler still reloads the local replica synchronously as before (read-your-writes on the handling replica); the broadcast covers the peers.

## Files

- `pkg/platform/reload.go` (new) — the bus: event vocabulary, dedicated-channel init, publisher, subscriber + dispatcher, connection/catalog/persona/api-key reloaders, lifecycle.
- `pkg/platform/reload_test.go` (new) — race-tested unit coverage including the cross-replica scenario.
- `pkg/platform/platform.go` — fields, `initReloadBus` wired into `initBroadcaster` (both branches), shutdown.
- `pkg/auth/apikey.go` — `ReplaceHashedKeys` for the authn reconcile (drops revoked keys).
- `pkg/admin/handler.go` — `ReloadNotifier` interface + `Deps` field.
- `pkg/admin/catalog_handler.go`, `pkg/admin/connection_handler.go`, `pkg/admin/persona_handler.go`, `pkg/admin/authkey_handler.go` — publish after the local reload.
- `cmd/mcp-data-platform/main.go` — wire the platform as the notifier.

## Testing

- Bus unit tests under the **race detector**, including the exact cross-replica case: two buses sharing one broadcaster (a faithful simulation of the postgres broadcaster re-publishing a received NOTIFY locally), peer applies the reload, publisher skips self-origin, plus routing / nil-handler / nil-bus / unknown-method safety.
- `ReplaceHashedKeys` revoke/admit behavior plus file-config-key survival.
- Admin handler tests assert persona and api-key create/update/delete each broadcast a reload through the real HTTP handlers.
- Full `make verify` (race suite, coverage, security, complexity, dead-code, release-check) is the gate; patch coverage 86.5%. CI runs it on this PR.
