### PR TITLE
fix(knowledge): scope portal knowledge/memory correctly, collapse long memory, unify owner on email (#515)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1397,6 +1397,8 @@ Record domain knowledge shared during a session.
 | `related_columns` | array | No | [] | Related columns (max 20) |
 | `suggested_actions` | array | No | [] | Proposed catalog changes (max 5) |
 
+Captured insights are owned by the user's email (`memory_records.created_by`), the same key `memory_manage` and the portal use, so a person's insights and memories appear together under their **My Knowledge** view. Insights captured before this was unified (keyed on the OIDC subject) are migrated to email by `000056_knowledge_owner_email_backfill`.
+
 ### apply_knowledge
 
 Review, synthesize, and apply captured insights to the data catalog. Admin-only. Requires `knowledge.apply.enabled: true`.

--- a/docs/memory/overview.md
+++ b/docs/memory/overview.md
@@ -117,6 +117,8 @@ The write path stamps `embedding_model` and `embedding_text_hash` (SHA-256 of th
 
 Now writes to `memory_records` instead of the legacy `knowledge_insights` table. Creates memory records with insight-specific metadata (suggested_actions, related_columns). Generates embeddings via Ollama when available.
 
+Ownership is keyed on the user's **email** (`created_by`), the same key `memory_manage` uses and the one the portal scopes by, so a person's insights and memories share an owner and both appear under their **My Knowledge** view. Insights captured before this was unified were keyed on the OIDC subject; the `000056_knowledge_owner_email_backfill` migration rewrites those rows to the email last seen for that subject in `audit_logs` (stashing the original in `metadata.legacy_created_by` so it is reversible). Rows with no audit mapping are left unchanged.
+
 ### apply_knowledge (existing, refactored)
 
 Reads from `memory_records` via an adapter. Promotes curated memories into durable DataHub knowledge (context documents, glossary terms, tags, structured properties).

--- a/pkg/database/migrate/migrate_unit_test.go
+++ b/pkg/database/migrate/migrate_unit_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	migrateTestFileCount    = 110
+	migrateTestFileCount    = 112
 	migrateTestSuccess      = "success"
 	migrateTestFactoryError = "factory error"
 )

--- a/pkg/database/migrate/migrations/000056_knowledge_owner_email_backfill.down.sql
+++ b/pkg/database/migrate/migrations/000056_knowledge_owner_email_backfill.down.sql
@@ -1,0 +1,7 @@
+-- Restore the pre-backfill created_by from the stashed legacy value and
+-- remove the stash. Only rows the up migration touched carry
+-- metadata.legacy_created_by, so this reverses exactly that set.
+UPDATE memory_records
+SET created_by = metadata->>'legacy_created_by',
+    metadata = metadata - 'legacy_created_by'
+WHERE metadata ? 'legacy_created_by';

--- a/pkg/database/migrate/migrations/000056_knowledge_owner_email_backfill.up.sql
+++ b/pkg/database/migrate/migrations/000056_knowledge_owner_email_backfill.up.sql
@@ -1,0 +1,28 @@
+-- Issue #515: unify knowledge-insight ownership on user email.
+--
+-- capture_insight historically stored the OIDC subject (or "apikey:<name>")
+-- in knowledge_insights.captured_by, which the 000031 migration carried into
+-- memory_records.created_by. memory_manage and the portal both scope by email
+-- (memory_records.created_by is documented as "user email"), so insight rows
+-- keyed by subject never matched their owner in the portal: the owner saw an
+-- empty knowledge list.
+--
+-- Going forward capture_insight writes the email. This backfills existing
+-- knowledge-dimension rows whose created_by is a non-email identifier (no "@")
+-- to the email last seen for that subject in audit_logs. The original value is
+-- stashed in metadata.legacy_created_by so the change is reversible. Rows with
+-- no audit mapping are left unchanged (no worse than before); rows already
+-- keyed by email are skipped by the NOT LIKE '%@%' guard.
+UPDATE memory_records m
+SET created_by = sub.user_email,
+    metadata = jsonb_set(m.metadata, '{legacy_created_by}', to_jsonb(m.created_by), true)
+FROM (
+    SELECT DISTINCT ON (user_id) user_id, user_email
+    FROM audit_logs
+    WHERE user_id IS NOT NULL AND user_id <> ''
+      AND user_email IS NOT NULL AND user_email <> ''
+    ORDER BY user_id, timestamp DESC
+) sub
+WHERE m.dimension = 'knowledge'
+  AND m.created_by = sub.user_id
+  AND m.created_by NOT LIKE '%@%';

--- a/pkg/portal/handler.go
+++ b/pkg/portal/handler.go
@@ -1532,7 +1532,9 @@ func (h *Handler) listMyInsights(w http.ResponseWriter, r *http.Request) {
 
 	q := r.URL.Query()
 	filter := knowledge.InsightFilter{
-		CapturedBy: user.UserID,
+		// Insights are owned by email (see capture_insight and the 000031
+		// migration), matching how memories are scoped below.
+		CapturedBy: user.Email,
 		Status:     q.Get("status"),
 		Category:   q.Get("category"),
 		Limit:      intParam(r, paramLimit, knowledge.DefaultLimit),
@@ -1574,7 +1576,8 @@ func (h *Handler) getMyInsightStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	stats, err := h.deps.InsightStore.Stats(r.Context(), knowledge.InsightFilter{
-		CapturedBy: user.UserID,
+		// Owned by email, consistent with listMyInsights and capture_insight.
+		CapturedBy: user.Email,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to query insight stats")

--- a/pkg/portal/handler_test.go
+++ b/pkg/portal/handler_test.go
@@ -2176,7 +2176,7 @@ func TestListMyInsights_Success(t *testing.T) {
 		listResult: []knowledge.Insight{{ID: "ins-1", CapturedBy: "user-1", Status: "pending"}},
 		listTotal:  1,
 	}
-	user := &User{UserID: "user-1"}
+	user := &User{UserID: "user-1", Email: "user-1@example.com"}
 	h := newKnowledgeTestHandler(store, user)
 
 	req := httptest.NewRequestWithContext(context.Background(), "GET", "/api/v1/portal/knowledge/insights?status=pending&limit=10", http.NoBody)
@@ -2184,7 +2184,8 @@ func TestListMyInsights_Success(t *testing.T) {
 	h.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "user-1", store.lastFilter.CapturedBy)
+	// Insights are scoped by email, not the OIDC subject (issue #515).
+	assert.Equal(t, "user-1@example.com", store.lastFilter.CapturedBy)
 	assert.Equal(t, "pending", store.lastFilter.Status)
 	assert.Equal(t, 10, store.lastFilter.Limit)
 }
@@ -2236,7 +2237,7 @@ func TestGetMyInsightStats_Success(t *testing.T) {
 			ByConfidence: map[string]int{"high": 1},
 		},
 	}
-	user := &User{UserID: "user-1"}
+	user := &User{UserID: "user-1", Email: "user-1@example.com"}
 	h := newKnowledgeTestHandler(store, user)
 
 	req := httptest.NewRequestWithContext(context.Background(), "GET", "/api/v1/portal/knowledge/insights/stats", http.NoBody)
@@ -2244,7 +2245,8 @@ func TestGetMyInsightStats_Success(t *testing.T) {
 	h.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "user-1", store.lastFilter.CapturedBy)
+	// Stats are scoped by email, consistent with the list (issue #515).
+	assert.Equal(t, "user-1@example.com", store.lastFilter.CapturedBy)
 }
 
 func TestGetMyInsightStats_Unauthenticated(t *testing.T) {

--- a/pkg/toolkits/knowledge/memory_adapter.go
+++ b/pkg/toolkits/knowledge/memory_adapter.go
@@ -17,13 +17,17 @@ const (
 )
 
 // memoryInsightAdapter implements InsightStore by delegating to a memory.Store.
+// It is a knowledge-dimension view of the shared memory store: every query it
+// issues is scoped to dimension via the dimension field, so callers can never
+// see (or supersede) memory records from other dimensions.
 type memoryInsightAdapter struct {
-	store memory.Store
+	store     memory.Store
+	dimension string
 }
 
 // NewMemoryInsightAdapter creates an InsightStore backed by a memory.Store.
 func NewMemoryInsightAdapter(store memory.Store) InsightStore {
-	return &memoryInsightAdapter{store: store}
+	return &memoryInsightAdapter{store: store, dimension: memory.DimensionKnowledge}
 }
 
 // Insert creates a new insight record in the memory store.
@@ -48,6 +52,7 @@ func (a *memoryInsightAdapter) Get(ctx context.Context, id string) (*Insight, er
 // List returns insights matching the given filter.
 func (a *memoryInsightAdapter) List(ctx context.Context, filter InsightFilter) ([]Insight, int, error) {
 	mf := memory.Filter{
+		Dimension: a.dimension,
 		Category:  filter.Category,
 		EntityURN: filter.EntityURN,
 		CreatedBy: filter.CapturedBy,
@@ -58,10 +63,11 @@ func (a *memoryInsightAdapter) List(ctx context.Context, filter InsightFilter) (
 		Offset:    filter.Offset,
 	}
 
-	// Map insight statuses to memory statuses.
+	// Map the insight status onto its memory status. This mapping is lossy:
+	// pending, approved and applied all collapse to memory StatusActive, so
+	// the store fetch alone cannot distinguish them. The exact insight status
+	// is recovered per record below and post-filtered.
 	mf.Status = mapInsightStatusToMemory(filter.Status)
-
-	// Confidence filtering is done post-fetch since memory.Filter doesn't have it.
 
 	records, total, err := a.store.List(ctx, mf)
 	if err != nil {
@@ -71,7 +77,13 @@ func (a *memoryInsightAdapter) List(ctx context.Context, filter InsightFilter) (
 	insights := make([]Insight, 0, len(records))
 	for _, r := range records {
 		insight := recordToInsight(r)
+		// Confidence and the exact insight status are filtered post-fetch:
+		// memory.Filter has no confidence field, and its status enum is
+		// coarser than the insight status (see the lossy mapping above).
 		if filter.Confidence != "" && insight.Confidence != filter.Confidence {
+			continue
+		}
+		if filter.Status != "" && insight.Status != filter.Status {
 			continue
 		}
 		insights = append(insights, insight)
@@ -107,17 +119,18 @@ func (a *memoryInsightAdapter) Update(ctx context.Context, id string, updates In
 	return nil
 }
 
-// Stats returns aggregate counts of insights by category, confidence, and status.
+// Stats returns aggregate counts of insights by category, confidence, and
+// status. The memory.Store has no Stats method, so we page through the
+// matching records and tally them. The filter must be scoped the same way
+// List scopes (owner + knowledge dimension); otherwise the totals would
+// count other users' records and non-knowledge memory dimensions, leaving
+// the stat card and the list disagreeing.
 func (a *memoryInsightAdapter) Stats(ctx context.Context, filter InsightFilter) (*InsightStats, error) {
-	// Use List to build stats since memory.Store doesn't have a Stats method.
 	mf := memory.Filter{
-		Status: mapInsightStatusToMemory(filter.Status),
-		Limit:  memory.MaxLimit,
-	}
-
-	records, total, err := a.store.List(ctx, mf)
-	if err != nil {
-		return nil, fmt.Errorf("listing records for insight stats: %w", err)
+		Dimension: a.dimension,
+		CreatedBy: filter.CapturedBy,
+		Status:    mapInsightStatusToMemory(filter.Status),
+		Limit:     memory.MaxLimit,
 	}
 
 	stats := &InsightStats{
@@ -126,12 +139,25 @@ func (a *memoryInsightAdapter) Stats(ctx context.Context, filter InsightFilter) 
 		ByStatus:     make(map[string]int),
 	}
 
-	for _, r := range records {
-		stats.ByCategory[r.Category]++
-		stats.ByConfidence[r.Confidence]++
-		stats.ByStatus[r.Status]++
+	for {
+		records, _, err := a.store.List(ctx, mf)
+		if err != nil {
+			return nil, fmt.Errorf("listing records for insight stats: %w", err)
+		}
+		for i := range records {
+			// Report the insight status (pending/approved/applied/...),
+			// not the raw memory status, so the keys match what callers
+			// and the postgres store produce.
+			stats.ByStatus[resolveInsightStatus(records[i])]++
+			stats.ByCategory[records[i].Category]++
+			stats.ByConfidence[records[i].Confidence]++
+		}
+		if len(records) < memory.MaxLimit {
+			break
+		}
+		mf.Offset += memory.MaxLimit
 	}
-	stats.TotalPending = total
+	stats.TotalPending = stats.ByStatus[StatusPending]
 
 	return stats, nil
 }
@@ -141,8 +167,13 @@ func (a *memoryInsightAdapter) MarkApplied(ctx context.Context, id, appliedBy, c
 	meta := map[string]any{
 		colAppliedBy:        appliedBy,
 		metaKeyChangesetRef: changesetRef,
+		// Persist the applied status explicitly. The memory status of an
+		// applied insight stays StatusActive (see mapInsightStatusToMemory),
+		// so without this override resolveInsightStatus would report applied
+		// insights as pending, inflating the pending count and leaving the
+		// applied count at zero (mirrors MarkRolledBack / UpdateStatus).
+		metaKeyInsightStatus: StatusApplied,
 	}
-	// Mark as archived in memory (promoted/applied).
 	if err := a.store.Update(ctx, id, memory.RecordUpdate{
 		Metadata: meta,
 	}); err != nil {
@@ -167,8 +198,11 @@ func (a *memoryInsightAdapter) MarkRolledBack(ctx context.Context, id, rolledBac
 
 // Supersede marks older insights for an entity as superseded by a newer one.
 func (a *memoryInsightAdapter) Supersede(ctx context.Context, entityURN, excludeID string) (int, error) {
-	// List active records for this entity.
+	// List active records for this entity. Scoped to the knowledge dimension
+	// so we never supersede a non-knowledge memory record that happens to
+	// reference the same entity URN.
 	records, _, err := a.store.List(ctx, memory.Filter{
+		Dimension: a.dimension,
 		EntityURN: entityURN,
 		Status:    memory.StatusActive,
 		Limit:     memory.MaxLimit,

--- a/pkg/toolkits/knowledge/memory_adapter_test.go
+++ b/pkg/toolkits/knowledge/memory_adapter_test.go
@@ -269,6 +269,7 @@ func TestMemoryInsightAdapter_List_FilterMapping(t *testing.T) {
 
 	// Verify filter mapping
 	mf := store.listFilter
+	assert.Equal(t, memory.DimensionKnowledge, mf.Dimension)
 	assert.Equal(t, "correction", mf.Category)
 	assert.Equal(t, "urn:li:dataset:abc", mf.EntityURN)
 	assert.Equal(t, "user@example.com", mf.CreatedBy)
@@ -298,6 +299,31 @@ func TestMemoryInsightAdapter_List_ConfidencePostFiltering(t *testing.T) {
 	for _, ins := range insights {
 		assert.Equal(t, "high", ins.Confidence)
 	}
+}
+
+func TestMemoryInsightAdapter_List_StatusPostFilter(t *testing.T) {
+	// Both records are StatusActive in memory (pending/approved/applied all
+	// map to active), so the store cannot distinguish them. The adapter must
+	// post-filter by the resolved insight status. Without the post-filter,
+	// the "pending" tab would also list applied insights.
+	store := &mockMemoryStore{
+		listRecords: []memory.Record{
+			{ID: "r1", Status: memory.StatusActive}, // resolves to pending
+			{
+				ID:       "r2",
+				Status:   memory.StatusActive,
+				Metadata: map[string]any{metaKeyInsightStatus: StatusApplied},
+			},
+		},
+		listTotal: 2,
+	}
+	adapter := NewMemoryInsightAdapter(store)
+
+	insights, _, err := adapter.List(context.Background(), InsightFilter{Status: StatusPending})
+	require.NoError(t, err)
+	require.Len(t, insights, 1)
+	assert.Equal(t, "r1", insights[0].ID)
+	assert.Equal(t, StatusPending, insights[0].Status)
 }
 
 func TestMemoryInsightAdapter_List_Error(t *testing.T) {
@@ -368,17 +394,67 @@ func TestMemoryInsightAdapter_Stats(t *testing.T) {
 	}
 	adapter := NewMemoryInsightAdapter(store)
 
-	stats, err := adapter.Stats(context.Background(), InsightFilter{})
+	stats, err := adapter.Stats(context.Background(), InsightFilter{CapturedBy: "user@example.com"})
 	require.NoError(t, err)
 	require.NotNil(t, stats)
 
-	assert.Equal(t, 3, stats.TotalPending)
+	// Stats must be scoped exactly like List: owner + knowledge dimension.
+	// Otherwise the stat card counts other users' records and non-knowledge
+	// memory dimensions, disagreeing with the list (issue #515).
+	assert.Equal(t, "user@example.com", store.listFilter.CreatedBy)
+	assert.Equal(t, memory.DimensionKnowledge, store.listFilter.Dimension)
+
+	// ByStatus is keyed by insight status, not raw memory status:
+	// active -> pending, archived -> rejected.
+	assert.Equal(t, 2, stats.ByStatus[StatusPending])
+	assert.Equal(t, 1, stats.ByStatus[StatusRejected])
+	assert.Equal(t, 0, stats.ByStatus[memory.StatusActive])
+	// TotalPending counts the pending bucket, not the grand total.
+	assert.Equal(t, 2, stats.TotalPending)
 	assert.Equal(t, 2, stats.ByCategory["correction"])
 	assert.Equal(t, 1, stats.ByCategory["data_quality"])
 	assert.Equal(t, 2, stats.ByConfidence["high"])
 	assert.Equal(t, 1, stats.ByConfidence["low"])
-	assert.Equal(t, 2, stats.ByStatus[memory.StatusActive])
-	assert.Equal(t, 1, stats.ByStatus[memory.StatusArchived])
+}
+
+// paginatingMemoryStore returns records in MaxLimit-sized pages so the
+// Stats pagination loop can be exercised end to end. Without this, the
+// single-page mock would never drive the offset increment, and a broken
+// loop condition (e.g. dropping the break) would not be caught.
+type paginatingMemoryStore struct {
+	mockMemoryStore
+	all []memory.Record
+}
+
+func (p *paginatingMemoryStore) List(_ context.Context, filter memory.Filter) ([]memory.Record, int, error) {
+	start := filter.Offset
+	if start >= len(p.all) {
+		return nil, len(p.all), nil
+	}
+	end := min(start+filter.Limit, len(p.all))
+	return p.all[start:end], len(p.all), nil
+}
+
+func TestMemoryInsightAdapter_Stats_Paginates(t *testing.T) {
+	// One full page plus one extra forces a second List call.
+	total := memory.MaxLimit + 1
+	all := make([]memory.Record, total)
+	for i := range all {
+		all[i] = memory.Record{
+			ID:         fmt.Sprintf("r%d", i),
+			Category:   "correction",
+			Confidence: "high",
+			Status:     memory.StatusActive,
+		}
+	}
+	store := &paginatingMemoryStore{all: all}
+	adapter := NewMemoryInsightAdapter(store)
+
+	stats, err := adapter.Stats(context.Background(), InsightFilter{CapturedBy: "user@example.com"})
+	require.NoError(t, err)
+	assert.Equal(t, total, stats.ByCategory["correction"])
+	assert.Equal(t, total, stats.ByStatus[StatusPending])
+	assert.Equal(t, total, stats.TotalPending)
 }
 
 func TestMemoryInsightAdapter_Stats_Error(t *testing.T) {
@@ -400,6 +476,34 @@ func TestMemoryInsightAdapter_MarkApplied(t *testing.T) {
 	assert.Equal(t, "ins-001", store.updateID)
 	assert.Equal(t, "admin@example.com", store.updateData.Metadata["applied_by"])
 	assert.Equal(t, "cs-789", store.updateData.Metadata["changeset_ref"])
+	// Applied status must be persisted so resolveInsightStatus reports it as
+	// applied, not pending (an applied record stays StatusActive in memory).
+	assert.Equal(t, StatusApplied, store.updateData.Metadata[metaKeyInsightStatus])
+}
+
+// TestMemoryInsightAdapter_AppliedNotCountedAsPending proves the end-to-end
+// effect of MarkApplied persisting insight_status: an applied insight lands in
+// the applied bucket, not pending. Without the fix, Stats counted it as
+// pending and the applied StatCard read zero.
+func TestMemoryInsightAdapter_AppliedNotCountedAsPending(t *testing.T) {
+	store := &mockMemoryStore{
+		listRecords: []memory.Record{
+			{ID: "r1", Status: memory.StatusActive}, // genuinely pending
+			{
+				ID:       "r2",
+				Status:   memory.StatusActive, // applied stays active in memory
+				Metadata: map[string]any{metaKeyInsightStatus: StatusApplied},
+			},
+		},
+		listTotal: 2,
+	}
+	adapter := NewMemoryInsightAdapter(store)
+
+	stats, err := adapter.Stats(context.Background(), InsightFilter{CapturedBy: "u@example.com"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.ByStatus[StatusPending])
+	assert.Equal(t, 1, stats.ByStatus[StatusApplied])
+	assert.Equal(t, 1, stats.TotalPending)
 }
 
 func TestMemoryInsightAdapter_MarkApplied_Error(t *testing.T) {
@@ -452,6 +556,9 @@ func TestMemoryInsightAdapter_Supersede(t *testing.T) {
 	assert.Equal(t, "urn:li:dataset:abc", store.listFilter.EntityURN)
 	assert.Equal(t, memory.StatusActive, store.listFilter.Status)
 	assert.Equal(t, memory.MaxLimit, store.listFilter.Limit)
+	// Scoped to the knowledge dimension so it cannot supersede a
+	// non-knowledge memory record that shares the entity URN.
+	assert.Equal(t, memory.DimensionKnowledge, store.listFilter.Dimension)
 
 	// Verify supersede was called for old-1 and old-2 but not new-1
 	assert.Len(t, store.supersedeCalls, 2)

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -1001,10 +1001,14 @@ func buildInsight(id string, pc *middleware.PlatformContext, input captureInsigh
 		insight.SuggestedActions = []SuggestedAction{}
 	}
 
-	// Inject context from PlatformContext
+	// Inject context from PlatformContext. Ownership is keyed on the user's
+	// email, the canonical identity for memory_records.created_by (see the
+	// 000031 migration). memory_manage writes the same key, so insights and
+	// memories for one person share an owner and the portal can scope both
+	// with a single identity.
 	if pc != nil {
 		insight.SessionID = pc.SessionID
-		insight.CapturedBy = pc.UserID
+		insight.CapturedBy = pc.UserEmail
 		insight.Persona = pc.PersonaName
 	}
 

--- a/pkg/toolkits/knowledge/toolkit_test.go
+++ b/pkg/toolkits/knowledge/toolkit_test.go
@@ -398,10 +398,13 @@ func parseJSONResult(t *testing.T, result *mcp.CallToolResult) map[string]any {
 }
 
 // ctxWithUser creates a context with a PlatformContext carrying the given user.
+// UserEmail is set to the same value as userID so capture_insight (which keys
+// ownership on email, issue #515) records the identifier these tests assert on.
 func ctxWithUser(userID, sessionID, persona string) context.Context {
 	pc := &middleware.PlatformContext{
 		SessionID:   sessionID,
 		UserID:      userID,
+		UserEmail:   userID,
 		PersonaName: persona,
 	}
 	return middleware.WithPlatformContext(context.Background(), pc)
@@ -1064,6 +1067,7 @@ func TestBuildInsight(t *testing.T) {
 	pc := &middleware.PlatformContext{
 		SessionID:   "s1",
 		UserID:      "u1",
+		UserEmail:   "u1@example.com",
 		PersonaName: testPersona,
 	}
 
@@ -1076,7 +1080,8 @@ func TestBuildInsight(t *testing.T) {
 	insight := buildInsight("id-1", pc, input)
 	assert.Equal(t, "id-1", insight.ID)
 	assert.Equal(t, "s1", insight.SessionID)
-	assert.Equal(t, "u1", insight.CapturedBy)
+	// Ownership is keyed on email, not the OIDC subject (issue #515).
+	assert.Equal(t, "u1@example.com", insight.CapturedBy)
 	assert.Equal(t, testPersona, insight.Persona)
 	assert.Equal(t, "user", insight.Source)             // Default when empty
 	assert.Equal(t, testConfidence, insight.Confidence) // Default

--- a/ui/src/components/renderers/CollapsibleMarkdown.test.tsx
+++ b/ui/src/components/renderers/CollapsibleMarkdown.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { CollapsibleMarkdown } from "./CollapsibleMarkdown";
+
+// MarkdownRenderer pulls in mermaid, which is irrelevant to the collapse
+// behavior under test and noisy in jsdom. Stub it to a plain passthrough.
+vi.mock("./MarkdownRenderer", () => ({
+  MarkdownRenderer: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+// jsdom reports scrollHeight as 0, so overflow can never be detected
+// without a stub. Force a value to drive the two branches.
+function setScrollHeight(px: number): () => void {
+  const desc = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "scrollHeight",
+  );
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    get: () => px,
+  });
+  return () => {
+    if (desc) {
+      Object.defineProperty(HTMLElement.prototype, "scrollHeight", desc);
+    }
+  };
+}
+
+afterEach(cleanup);
+
+describe("CollapsibleMarkdown", () => {
+  it("renders short content with no toggle", () => {
+    const restore = setScrollHeight(20);
+    render(<CollapsibleMarkdown content="short note" />);
+
+    expect(screen.getByText("short note")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    restore();
+  });
+
+  it("clamps long content and toggles reveal", () => {
+    const restore = setScrollHeight(900);
+    render(<CollapsibleMarkdown content="a very long memory record" />);
+
+    const toggle = screen.getByRole("button", { name: "Show more" });
+    expect(toggle).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(
+      screen.getByRole("button", { name: "Show less" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show less" }));
+    expect(
+      screen.getByRole("button", { name: "Show more" }),
+    ).toBeInTheDocument();
+    restore();
+  });
+});

--- a/ui/src/components/renderers/CollapsibleMarkdown.tsx
+++ b/ui/src/components/renderers/CollapsibleMarkdown.tsx
@@ -1,0 +1,75 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import { MarkdownRenderer } from "./MarkdownRenderer";
+
+// COLLAPSED_MAX_PX is the clamped height when content overflows, roughly
+// three to four lines of body text. Long memory records (which can run to
+// hundreds of lines) collapse to this and reveal on demand instead of
+// dominating the page (issue #515).
+const COLLAPSED_MAX_PX = 84;
+
+// OVERFLOW_SLACK_PX avoids showing a "Show more" toggle for content that
+// only barely exceeds the clamp, where expanding reveals almost nothing.
+const OVERFLOW_SLACK_PX = 8;
+
+interface CollapsibleMarkdownProps {
+  content: string;
+  // fadeFrom is the Tailwind gradient color matching the container
+  // background so the fade at the clamp edge blends in (e.g. "from-card",
+  // "from-muted"). Defaults to the card background.
+  fadeFrom?: string;
+}
+
+// CollapsibleMarkdown renders markdown clamped to a few lines with a
+// Show more / Show less toggle. Content that fits within the clamp renders
+// in full with no toggle.
+export function CollapsibleMarkdown({
+  content,
+  fadeFrom = "from-card",
+}: CollapsibleMarkdownProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [overflowing, setOverflowing] = useState(false);
+
+  // Measure in a layout effect so the clamp is applied before the browser
+  // paints. With a plain effect a long record flashes in full for one frame
+  // before collapsing. Reset to collapsed when the content changes so an
+  // instance reused for a different record (e.g. a detail panel the user
+  // clicks through) starts collapsed rather than inheriting the prior
+  // record's expanded state.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+    setOverflowing(el.scrollHeight > COLLAPSED_MAX_PX + OVERFLOW_SLACK_PX);
+    setExpanded(false);
+  }, [content]);
+
+  const clamped = overflowing && !expanded;
+
+  return (
+    <div>
+      <div
+        ref={ref}
+        className="relative overflow-hidden"
+        style={clamped ? { maxHeight: COLLAPSED_MAX_PX } : undefined}
+      >
+        <MarkdownRenderer content={content} bare />
+        {clamped && (
+          <div
+            className={`pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t ${fadeFrom} to-transparent`}
+          />
+        )}
+      </div>
+      {overflowing && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="mt-1 text-xs font-medium text-primary hover:underline"
+        >
+          {expanded ? "Show less" : "Show more"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/knowledge/KnowledgePage.tsx
+++ b/ui/src/pages/knowledge/KnowledgePage.tsx
@@ -15,6 +15,7 @@ import { StatusBadge } from "@/components/cards/StatusBadge";
 import type { Insight, Changeset, MemoryRecord } from "@/api/admin/types";
 import { formatUser } from "@/lib/formatUser";
 import { MarkdownRenderer } from "@/components/renderers/MarkdownRenderer";
+import { CollapsibleMarkdown } from "@/components/renderers/CollapsibleMarkdown";
 import {
   PieChart,
   Pie,
@@ -1377,7 +1378,7 @@ function MemoryDrawer({
           <div>
             <p className="mb-1 text-xs text-muted-foreground">Content</p>
             <div className="rounded bg-muted p-3">
-              <MarkdownRenderer content={record.content} bare />
+              <CollapsibleMarkdown content={record.content} fadeFrom="from-muted" />
             </div>
           </div>
 

--- a/ui/src/pages/knowledge/MyKnowledgePage.tsx
+++ b/ui/src/pages/knowledge/MyKnowledgePage.tsx
@@ -5,11 +5,11 @@ import {
   useMyMemories,
   useMyMemoryStats,
 } from "@/api/portal/hooks";
-import { useEmbeddingProviderStatus } from "@/api/admin/hooks";
 import { StatCard } from "@/components/cards/StatCard";
 import { Lightbulb, ChevronLeft, ChevronRight } from "lucide-react";
 import type { Insight, MemoryRecord } from "@/api/portal/types";
 import { MarkdownRenderer } from "@/components/renderers/MarkdownRenderer";
+import { CollapsibleMarkdown } from "@/components/renderers/CollapsibleMarkdown";
 import { formatEntityUrn } from "@/lib/formatEntityUrn";
 
 const STATUS_BADGES: Record<string, { label: string; cls: string }> = {
@@ -143,7 +143,7 @@ function MemoryCard({ record }: { record: MemoryRecord }) {
           {new Date(record.created_at).toLocaleDateString()}
         </span>
       </div>
-      <MarkdownRenderer content={record.content} bare />
+      <CollapsibleMarkdown content={record.content} />
       {record.entity_urns && record.entity_urns.length > 0 && (
         <div className="flex flex-wrap gap-1">
           {record.entity_urns.map((urn) => (
@@ -346,9 +346,6 @@ function MyMemorySection() {
     limit: PAGE_SIZE,
     offset,
   });
-  const { data: embedStatus } = useEmbeddingProviderStatus();
-  const embedderUnconfigured = embedStatus?.status === "unconfigured";
-
   const s = stats.data;
   const totalItems = memories.data?.total ?? 0;
   const items = memories.data?.data ?? [];
@@ -373,22 +370,6 @@ function MyMemorySection() {
 
   return (
     <>
-      {embedderUnconfigured && (
-        <div
-          role="status"
-          className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
-        >
-          <strong>Embedding provider not configured.</strong> New memories are
-          persisted without vectors and semantic recall is unavailable; keyword
-          and entity-URN lookup still work. Set{" "}
-          <code className="rounded bg-amber-100 px-1 py-0.5 font-mono text-xs dark:bg-amber-900/40">
-            memory.embedding.provider
-          </code>{" "}
-          (e.g., to <code className="font-mono">ollama</code>) and restart to
-          enable semantic features.
-        </div>
-      )}
-
       {/* Summary Cards */}
       <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
         <StatCard label="Total Memories" value={s?.total ?? 0} />


### PR DESCRIPTION
## Summary

Fixes four independent defects in the Knowledge & Memory portal page, found together but unrelated. Each fix is below with its root cause linked to source lines. A new database migration unifies insight ownership; it was validated up and down against a real Postgres before commit.

Closes #515. User-facing knowledge/memory search remains a separate feature in #516 and is not part of this PR.

## Bug 1: "Total Insights" counted every user's records while the list was empty

When the memory store is active the portal uses `memoryInsightAdapter`, not the postgres insight store (`pkg/platform/platform.go:1510-1511`). Its `Stats` built a filter with only `Status` and `Limit`, so it counted every memory record for every user across all dimensions, while `List` correctly scoped to the owner. The per-status cards also read raw memory-status keys (`active`/`archived`) instead of insight-status keys (`pending`/`approved`/`applied`), so they always showed zero.

`Stats` now scopes by owner and knowledge dimension, pages through all matching rows, and counts by resolved insight status. `TotalPending` is taken from the pending bucket instead of the grand total.

## Bug 2: opening the Memory tab redirected non-admins to login

The user memory section called `useEmbeddingProviderStatus()` (`ui/src/pages/knowledge/MyKnowledgePage.tsx:349`), which fetches the admin-only `/api/v1/admin/embedding/status` (`pkg/admin/middleware.go:63-74`). A 401 from that admin endpoint routes through the admin client's `handleUnauthorized()`, which does `window.location.replace(login)` (`ui/src/api/admin/client.ts:32-34`).

Removed the admin call and the embedder banner from the user view. The banner remains on the admin CatalogsPanel where it belongs.

## Bug 3: knowledge was empty for users who had knowledge (identity-split scoping)

`capture_insight` stored the OIDC subject as the owner (`pkg/toolkits/knowledge/toolkit.go:1007`), but `memory_manage` (`pkg/toolkits/memory/manage.go:122`) and the portal scope by email. `memory_records.created_by` is documented as "user email" (`pkg/database/migrate/migrations/000031_memory_records.up.sql:14`), so the subject-keyed insight rows never matched their owner in the portal, and the list was permanently empty.

Owner identity is now unified on email:
- `capture_insight` writes `created_by = email`, matching `memory_manage` and the documented contract.
- Portal list and stats scope by email.
- Migration `000056_knowledge_owner_email_backfill` rewrites existing knowledge-dimension rows whose `created_by` is a non-email identifier to the email last seen for that subject in `audit_logs`. The original value is stashed in `metadata.legacy_created_by`, so the migration is reversible. Rows with no audit mapping or already keyed by email are left unchanged.

## Bug 4: memory content rendered in full with no collapse

Memory content was rendered without any clamp in both the admin detail panel (`KnowledgePage.tsx`) and the user card (`MyKnowledgePage.tsx`). New `CollapsibleMarkdown` clamps long records to a few lines with a Show more / Show less reveal, measures in a layout effect to avoid a flash of full content, and resets to collapsed when the content changes (so a reused instance does not inherit the prior record's expanded state). Short records render fully with no toggle.

## Additional fixes found during review

These were surfaced by an adversarial review of the diff:

- **Applied insights were counted as pending.** `MarkApplied` never persisted the applied status, and an applied insight stays `StatusActive` in memory, so `resolveInsightStatus` returned `pending`. This would have silently undermined the Bug 1 fix (Applied card showing zero, Pending inflated). `MarkApplied` now sets `insight_status = applied`, mirroring `MarkRolledBack` and `UpdateStatus`.
- **`Supersede` had no dimension filter** and could supersede a non-knowledge memory record sharing an entity URN. Rather than repeat the dimension literal per method (the exact omission that caused this), the knowledge dimension is now a construction-time field applied across `List`, `Stats`, and `Supersede`.
- **List status filter over-returned.** The memory status enum is coarser than the insight status (`pending`, `approved`, `applied` all map to `active`), so filtering by one returned all three. `List` now post-filters by resolved insight status, mirroring the existing confidence post-filter.

## Testing

- `make verify` green (fmt, race tests, lint, security, semgrep, codeql, coverage, patch coverage, doc-check, dead-code, mutation, release dry-run).
- Adapter `List`, `Stats`, `MarkApplied`, and `Supersede` are at 100% statement coverage.
- New unit tests cover the owner scoping, status-key resolution, applied-not-pending behavior, status post-filter, Supersede dimension scoping, and Stats pagination.
- `CollapsibleMarkdown` has a unit test for the clamp/reveal toggle and the no-toggle short-content case; the full UI suite (132 tests) and `tsc`/`build` pass.
- **Migration validated against a real Postgres** (partitioned `audit_logs`, `DISTINCT ON` picking the most recent email per subject, dimension and email guards): only the intended row was rewritten, and the down migration restored it exactly.
- Docs updated for the migration (`docs/memory/overview.md`, `docs/llms-full.txt`).

## Not covered

No live-deployment verification yet. Before release it is worth confirming on a running instance that the Memory tab no longer redirects a non-admin, the stat cards match the user's actual list, and the `000056` backfill maps existing rows correctly against real `audit_logs` data.
