### PR TITLE
fix(apigateway): strip query string before operation match so list traffic stops resolving to "unknown" (#519)

### DIFF
--- a/pkg/toolkits/apigateway/openapi.go
+++ b/pkg/toolkits/apigateway/openapi.go
@@ -115,6 +115,29 @@ var pathItemMethods = []struct {
 	{"HEAD", func(p *openapi3.PathItem) *openapi3.Operation { return p.Head }},
 }
 
+// synthesizedOperationID builds the operationId used for an operation
+// that declares none. method must already be upper-cased; rawPath is
+// spec-relative. Shared by appendItemOperations (which advertises the id
+// via api_list_endpoints) and the metric operation resolver so the
+// listed id and the metric label can never diverge.
+func synthesizedOperationID(method, rawPath string) string {
+	return method + " " + rawPath
+}
+
+// listableMethod reports whether m (upper-cased) is an HTTP method
+// api_list_endpoints advertises, i.e. one of pathItemMethods. The
+// resolver only synthesizes ids for these: the router also matches
+// OPTIONS/TRACE/CONNECT, which pathItemMethods omits, so synthesizing
+// for them would invent a metric label no catalog entry carries.
+func listableMethod(m string) bool {
+	for _, pm := range pathItemMethods {
+		if pm.method == m {
+			return true
+		}
+	}
+	return false
+}
+
 // itemOpsCtx bundles the per-path-item context appendItemOperations
 // needs. Kept as a struct so the function stays under revive's
 // argument-limit ceiling.
@@ -150,7 +173,7 @@ func appendItemOperations(ops []OperationSummary, embedTexts []string, item *ope
 		}
 		id := op.OperationID
 		if id == "" {
-			id = m.method + " " + c.rawPath
+			id = synthesizedOperationID(m.method, c.rawPath)
 		}
 		summary := OperationSummary{
 			OperationID: id,

--- a/pkg/toolkits/apigateway/operation_resolver.go
+++ b/pkg/toolkits/apigateway/operation_resolver.go
@@ -42,22 +42,65 @@ func (t *Toolkit) ResolveOperationID(_ context.Context, connection, method, path
 
 	req := &http.Request{
 		Method: strings.ToUpper(method),
-		URL:    &url.URL{Path: ensureLeadingSlash(path)},
+		URL:    &url.URL{Path: ensureLeadingSlash(stripQueryAndFragment(path))},
 	}
 	route, _, err := router.FindRoute(req)
 	if err != nil || route == nil || route.Operation == nil {
 		return ""
 	}
-	return route.Operation.OperationID
+	if id := route.Operation.OperationID; id != "" {
+		return id
+	}
+	// The matched operation declares no operationId. Synthesize the same
+	// id api_list_endpoints advertises for it (appendItemOperations) so
+	// the metric label agrees with the listed, invokable id instead of
+	// falling through to "unknown". Only methods the catalog lists qualify:
+	// the router also matches OPTIONS/TRACE/CONNECT, which pathItemMethods
+	// omits, so synthesizing for them would invent a label no catalog entry
+	// carries. rawPath is spec-relative, NOT route.Path (the
+	// effectiveBasePath-prefixed router key), because that is what the list
+	// side synthesizes from.
+	upper := strings.ToUpper(method)
+	if !listableMethod(upper) {
+		return ""
+	}
+	if raw := c.rawPathForRoute(route.Path); raw != "" {
+		return synthesizedOperationID(upper, raw)
+	}
+	return ""
+}
+
+// stripQueryAndFragment removes a "?query" and/or "#fragment" suffix
+// from a runtime path, leaving only the path component the router
+// matches on. A collection endpoint invoked with query parameters
+// (e.g. /v1/orders?limit=100) must still resolve to its operation;
+// leaving the query string in url.URL.Path makes the router try to
+// match it as part of the path and fall through to "" (#519).
+func stripQueryAndFragment(p string) string {
+	if i := strings.IndexAny(p, "?#"); i >= 0 {
+		return p[:i]
+	}
+	return p
 }
 
 // opRouter returns the connection's lazily-built path-matching router,
-// or nil when the connection has no usable spec paths.
+// or nil when the connection has no usable spec paths. The companion
+// rawByKey map (effectiveBasePath-prefixed router key -> spec-relative
+// raw path) is built in the same pass so operationId synthesis can
+// recover the raw path a matched route came from.
 func (c *conn) opRouter() routers.Router {
 	c.operationRouterOnce.Do(func() {
-		c.operationRouter = buildOperationRouter(c.specs)
+		c.operationRouter, c.operationRawPaths = buildOperationRouter(c.specs)
 	})
 	return c.operationRouter
+}
+
+// rawPathForRoute maps a matched route's effectiveBasePath-prefixed
+// Path back to the spec-relative raw path it was registered under, or
+// "" when unknown. Used to synthesize the operationId for operations
+// with no declared id, matching what api_list_endpoints advertises.
+func (c *conn) rawPathForRoute(routePath string) string {
+	return c.operationRawPaths[routePath]
 }
 
 // buildOperationRouter assembles a single gorillamux router covering
@@ -65,20 +108,28 @@ func (c *conn) opRouter() routers.Router {
 // paths are rebased to effectiveBasePath + rawPath (the runtime full
 // path) and the server is pinned to "/" so matching is path-only and
 // host-independent. Returns nil when no spec contributes any path.
-func buildOperationRouter(specs map[string]*specState) routers.Router {
+//
+// The second return value maps each router path key
+// (effectiveBasePath+rawPath) back to its spec-relative rawPath so the
+// resolver can synthesize "<METHOD> <rawPath>" ids for operations that
+// declare no operationId, mirroring api_list_endpoints.
+func buildOperationRouter(specs map[string]*specState) (router routers.Router, rawByKey map[string]string) {
 	paths := openapi3.NewPaths()
+	rawByKey = make(map[string]string)
 	count := 0
 	for _, st := range specs {
 		if st == nil || st.doc == nil || st.doc.Paths == nil {
 			continue
 		}
 		for rawPath, item := range st.doc.Paths.Map() {
-			paths.Set(st.effectiveBasePath+rawPath, item)
+			key := st.effectiveBasePath + rawPath
+			paths.Set(key, item)
+			rawByKey[key] = rawPath
 			count++
 		}
 	}
 	if count == 0 {
-		return nil
+		return nil, nil
 	}
 
 	doc := &openapi3.T{
@@ -89,9 +140,9 @@ func buildOperationRouter(specs map[string]*specState) routers.Router {
 	}
 	router, err := gorillamux.NewRouter(doc)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	return router
+	return router, rawByKey
 }
 
 // ensureLeadingSlash normalizes a runtime path so the router (which

--- a/pkg/toolkits/apigateway/operation_resolver_test.go
+++ b/pkg/toolkits/apigateway/operation_resolver_test.go
@@ -30,6 +30,13 @@ paths:
           schema: { type: string }
       responses:
         "200": { description: ok }
+  /widgets:
+    get:
+      responses:
+        "200": { description: ok }
+    options:
+      responses:
+        "204": { description: no content }
 `
 
 // newResolverTestToolkit builds a toolkit with one connection whose
@@ -69,6 +76,23 @@ func TestResolveOperationID(t *testing.T) {
 		{"missing base path returns empty", "GET", "/users/1", ""},
 		{"empty path returns empty", "GET", "", ""},
 		{"relative path normalized to leading slash", "GET", "v1/users/9", "getUser"},
+		// #519: a collection endpoint invoked with a query string must
+		// still resolve. Before the fix the "?..." stayed in the path
+		// component and the collection route ("^/v1/users$") missed,
+		// collapsing list/bulk traffic into "unknown".
+		{"collection with query string", "GET", "/v1/users?limit=100&offset=0", "listUsers"},
+		{"item with query string", "GET", "/v1/users/123?expand=lines", "getUser"},
+		{"collection with fragment", "GET", "/v1/users#frag", "listUsers"},
+		// #519: an operation with no declared operationId must resolve
+		// to the same synthesized "<METHOD> <rawPath>" id that
+		// api_list_endpoints advertises, not "unknown".
+		{"synthesized id for missing operationId", "GET", "/v1/widgets", "GET /widgets"},
+		{"synthesized id with query string", "GET", "/v1/widgets?page=2", "GET /widgets"},
+		{"synthesized id lowercase method normalized", "get", "/v1/widgets", "GET /widgets"},
+		// #519: the router matches OPTIONS (openapi3 PathItem.Operations
+		// includes it) but api_list_endpoints does not list it, so the
+		// resolver must NOT synthesize a metric label for it.
+		{"unlisted method not synthesized", "OPTIONS", "/v1/widgets", ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/toolkits/apigateway/toolkit.go
+++ b/pkg/toolkits/apigateway/toolkit.go
@@ -281,6 +281,12 @@ type conn struct {
 	// catalog edit, so no separate cache-invalidation path is needed.
 	operationRouterOnce sync.Once
 	operationRouter     routers.Router
+	// operationRawPaths maps each operationRouter path key
+	// (effectiveBasePath+rawPath) back to its spec-relative rawPath so
+	// ResolveOperationID can synthesize "<METHOD> <rawPath>" ids for
+	// operations with no declared operationId, matching the ids
+	// api_list_endpoints advertises. Built alongside operationRouter.
+	operationRawPaths map[string]string
 	// testDescs is a unit-test-only aid: lets ranking_test.go's
 	// buildTestConn / populateTestEmbeddings round-trip an
 	// operation's description through buildEmbedText without making


### PR DESCRIPTION
## Summary

Fixes #519. In the admin Traffic Flow view (the `connection → operation` sankey) and anywhere `apigateway_inbound_requests_total` is grouped by `operation_id`, a large share of inbound REST-shim traffic resolved to the literal operation `unknown` even though the requests targeted operations that exist in the connection's catalog and are returned by `api_list_endpoints`.

Root cause: the operation resolver matched the runtime path **without stripping the query string first**. `ResolveOperationID` built the match request from the raw runtime path, so a `?...` stayed in `url.URL.Path` and the gorillamux router tried to match it as part of the path. Collection/list endpoints invoked with query parameters (`/v1/orders?limit=100&offset=0`) failed to match their route and fell through to `unknown`, while item-by-id paths matched anyway because the `{id}` segment regex (`[^/]+`) greedily consumed the `?...`. Since paginated list/bulk calls are the dominant pattern for ETL/data-integration clients, the `unknown` flow could rival the largest named operation.

This is purely an observability/labeling defect: the upstream call itself was never affected, only the resolved metric label.

## What changed

`pkg/toolkits/apigateway/operation_resolver.go`
- **Strip the query string and fragment** from the runtime path before matching (`stripQueryAndFragment`), so a collection endpoint invoked with query parameters resolves to its operation. The query string is still preserved on `meta.path` for the actual upstream call; only the metric resolver matches on the path component.
- **Synthesize the catalog's id** when a matched operation declares no `operationId`, instead of falling through to `unknown`. The metric label now agrees with the listed, invokable id that `api_list_endpoints` advertises. The spec-relative raw path is recovered via a per-connection `effectiveBasePath+rawPath → rawPath` map (`operationRawPaths`) built once, lazily, alongside the router.

`pkg/toolkits/apigateway/openapi.go`
- Extracted two shared helpers so the catalog side and the resolver cannot drift:
  - `synthesizedOperationID(method, rawPath)` — the single source of truth for the `"<METHOD> <rawPath>"` id, used by both `appendItemOperations` (which advertises it via `api_list_endpoints`) and the resolver.
  - `listableMethod(method)` — whether a method is one `api_list_endpoints` lists (`pathItemMethods`). The router also matches `OPTIONS`/`TRACE`/`CONNECT`, which the catalog omits, so the resolver guards synthesis with this to avoid inventing a metric label no catalog entry carries.

`pkg/toolkits/apigateway/toolkit.go`
- Added the `conn.operationRawPaths` field (built alongside `operationRouter`, discarded on `ReloadConnection` like the router, so no separate cache-invalidation path is needed).

## Behavior

Resolving runtime paths against a representative spec (base path `/v1`):

| Method + path | Before | After |
|---|---|---|
| `GET /v1/orders/ord_123` | `GetOrder` | `GetOrder` |
| `GET /v1/orders` | `ListOrders` | `ListOrders` |
| `GET /v1/orders?limit=100&offset=0` | **`unknown`** | **`ListOrders`** |
| `GET /v1/orders/ord_123?expand=lines` | `GetOrder` | `GetOrder` |
| `GET /v1/widgets` (no `operationId`) | **`unknown`** | **`GET /widgets`** |
| `OPTIONS /v1/widgets` (not in catalog) | `unknown` | `unknown` (not synthesized) |

## Tests

Extended the table-driven `TestResolveOperationID` to cover item-by-id, clean collection, collection + query string, item + query string, fragment, missing-`operationId` (synthesized id), synthesized id + query string, lowercase-method normalization, and an unlisted (`OPTIONS`) method that must **not** be synthesized. New helpers `synthesizedOperationID` and `listableMethod` are at 100% coverage.

## Acceptance criteria (from #519)

- [x] A collection/list endpoint invoked with a query string resolves to its declared `operationId` in `apigateway_inbound_requests_total`, not `unknown`.
- [x] An operation that exists in `api_list_endpoints` (including synthesized ids) resolves to the same id in the metric.
- [x] The Traffic Flow sankey no longer shows a large `unknown` node for list-heavy connections whose operations are all in the catalog.

## Verification

`make verify` passes end to end (tests with `-race`, ≥80% total + patch coverage, golangci-lint patch-scoped, gosec, govulncheck, Semgrep, CodeQL, mutation testing, GoReleaser dry-run).

## Out of scope

The issue's secondary note 2 (decode-failure `/invoke` requests record an empty `meta.path` and land in the same `unknown` bucket) is a separate metric-label-semantics decision: the query-string defect and missing-`operationId` synthesis are what cause the dominant misattribution the issue is about. The empty-path-on-decode-failure case is left for a follow-up if a distinct `bad_request` label is wanted.
