### PR TITLE
fix(ui): preserve mermaid node labels in markdown assets (#521)

### DIFF
--- a/ui/src/components/renderers/MarkdownRenderer.test.tsx
+++ b/ui/src/components/renderers/MarkdownRenderer.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeMermaidSvg } from "./MarkdownRenderer";
+
+// Mermaid v11 emits node labels as HTML inside an SVG <foreignObject> (the
+// default `htmlLabels: true` path), while subgraph/cluster titles are plain
+// SVG <text>. Issue #521: a DOMPurify `svg`-only profile stripped the
+// foreignObject HTML, so node labels rendered invisible while titles survived.
+// These tests pin the sanitizer to a behavior that keeps both visible without
+// reintroducing an XSS hole.
+describe("sanitizeMermaidSvg", () => {
+  // A representative fragment of mermaid v11 flowchart output: one node whose
+  // label is an HTML span inside a foreignObject, and one cluster title as SVG
+  // text.
+  const mermaidSvg = `
+    <svg role="graphics-document document" viewBox="0 0 200 200" class="flowchart">
+      <g class="node default">
+        <foreignObject width="120" height="24">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display: table-cell;">
+            <span class="nodeLabel"><p>Node label that should be visible</p></span>
+          </div>
+        </foreignObject>
+      </g>
+      <g class="cluster">
+        <text class="cluster-label"><tspan>Subgraph title that IS visible</tspan></text>
+      </g>
+    </svg>`;
+
+  it("preserves HTML node labels rendered inside a foreignObject", () => {
+    const out = sanitizeMermaidSvg(mermaidSvg);
+    expect(out).toContain("Node label that should be visible");
+    expect(out.toLowerCase()).toContain("foreignobject");
+    expect(out).toContain("nodeLabel");
+  });
+
+  it("preserves SVG-text subgraph titles (no regression)", () => {
+    const out = sanitizeMermaidSvg(mermaidSvg);
+    expect(out).toContain("Subgraph title that IS visible");
+    expect(out).toContain("cluster-label");
+  });
+
+  it("still strips <script> elements", () => {
+    const malicious = `<svg><script>window.__pwned = true;</script><text>ok</text></svg>`;
+    const out = sanitizeMermaidSvg(malicious);
+    expect(out).not.toContain("__pwned");
+    expect(out.toLowerCase()).not.toContain("<script");
+    expect(out).toContain("ok");
+  });
+
+  it("still strips inline event-handler attributes", () => {
+    const malicious = `<svg><g class="node" onclick="alert(1)"><text>label</text></g></svg>`;
+    const out = sanitizeMermaidSvg(malicious);
+    expect(out.toLowerCase()).not.toContain("onclick");
+    expect(out).toContain("label");
+  });
+
+  it("strips event handlers on HTML smuggled inside a foreignObject", () => {
+    const malicious = `<svg><foreignObject><div xmlns="http://www.w3.org/1999/xhtml"><img src="x" onerror="alert(1)">payload</div></foreignObject></svg>`;
+    const out = sanitizeMermaidSvg(malicious);
+    expect(out.toLowerCase()).not.toContain("onerror");
+    // the benign text content survives; the handler does not
+    expect(out).toContain("payload");
+  });
+
+  // The fix deliberately keeps HTML alive inside foreignObject, so the most
+  // important guard is that genuinely dangerous elements smuggled there are
+  // still neutralized. This also fails loudly if MERMAID_FORBID_CONTENTS ever
+  // stops content-stripping these tags (e.g. a careless edit or a DOMPurify
+  // upgrade that changes the default forbid-contents list).
+  it("strips <script> smuggled inside a foreignObject", () => {
+    const malicious = `<svg><foreignObject><div xmlns="http://www.w3.org/1999/xhtml"><script>window.__pwned = true;</script>safe</div></foreignObject></svg>`;
+    const out = sanitizeMermaidSvg(malicious);
+    expect(out).not.toContain("__pwned");
+    expect(out.toLowerCase()).not.toContain("<script");
+    expect(out).toContain("safe");
+  });
+
+  it("strips <iframe> smuggled inside a foreignObject", () => {
+    const malicious = `<svg><foreignObject><div xmlns="http://www.w3.org/1999/xhtml"><iframe src="javascript:alert(1)"></iframe>safe</div></foreignObject></svg>`;
+    const out = sanitizeMermaidSvg(malicious);
+    expect(out.toLowerCase()).not.toContain("<iframe");
+    expect(out).toContain("safe");
+  });
+});

--- a/ui/src/components/renderers/MarkdownRenderer.tsx
+++ b/ui/src/components/renderers/MarkdownRenderer.tsx
@@ -5,6 +5,42 @@ import type { Components } from "react-markdown";
 import mermaid from "mermaid";
 import DOMPurify from "dompurify";
 
+// DOMPurify's default FORBID_CONTENTS strips the children of `foreignObject`
+// (among others). We reuse that default list but drop `foreignobject` so the
+// HTML label markup mermaid places inside it survives. Everything else in the
+// list (script, style, iframe, ...) is still content-stripped.
+const MERMAID_FORBID_CONTENTS = [
+  "annotation-xml", "audio", "colgroup", "desc", "head", "iframe", "math", "mi",
+  "mn", "mo", "ms", "mtext", "noembed", "noframes", "noscript", "plaintext",
+  "script", "style", "svg", "template", "thead", "title", "video", "xmp",
+];
+
+/**
+ * Sanitize a mermaid-rendered SVG before injecting it into the DOM.
+ *
+ * Mermaid v11 renders node labels with `htmlLabels: true` (the default): the
+ * label text is an HTML `<span>`/`<div>` living inside an SVG `<foreignObject>`.
+ * DOMPurify's `svg`-only profile dropped that HTML, so node labels rendered
+ * invisible while subgraph/cluster titles (emitted as SVG `<text>`) survived
+ * (issue #521). Three settings are required to keep the labels while staying
+ * safe:
+ *   - `USE_PROFILES.html` so the `<div>`/`<span>`/`<p>` label tags are allowed.
+ *   - `ADD_TAGS: ['foreignObject']` because the svg profile disallows it.
+ *   - `HTML_INTEGRATION_POINTS: { foreignobject: true }` so DOMPurify's
+ *     namespace check treats foreignObject as an HTML integration point and
+ *     keeps its xhtml children (it only allows `annotation-xml` by default).
+ * Plus `MERMAID_FORBID_CONTENTS` so foreignObject contents are not stripped.
+ * Scripts and inline event handlers (onclick/onerror/...) are still removed.
+ */
+export function sanitizeMermaidSvg(svg: string): string {
+  return DOMPurify.sanitize(svg, {
+    USE_PROFILES: { svg: true, svgFilters: true, html: true },
+    ADD_TAGS: ["foreignObject"],
+    FORBID_CONTENTS: MERMAID_FORBID_CONTENTS,
+    HTML_INTEGRATION_POINTS: { foreignobject: true, "annotation-xml": true },
+  });
+}
+
 /** Detect whether the document is currently in dark mode. */
 function isDark(): boolean {
   return document.documentElement.classList.contains("dark");
@@ -73,7 +109,7 @@ function MermaidBlock({ content }: { content: string }) {
       .render(id, content)
       .then(({ svg }) => {
         if (!cancelled && ref.current) {
-          ref.current.innerHTML = DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true } });
+          ref.current.innerHTML = sanitizeMermaidSvg(svg);
           setError(null);
         }
       })
@@ -95,7 +131,7 @@ function MermaidBlock({ content }: { content: string }) {
       mermaid
         .render(id + "t", content)
         .then(({ svg }) => {
-          if (ref.current) ref.current.innerHTML = DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true } });
+          if (ref.current) ref.current.innerHTML = sanitizeMermaidSvg(svg);
         })
         .catch(() => {});
     });
@@ -132,7 +168,7 @@ export function MarkdownRenderer({ content, bare }: { content: string | null | u
     code: useCallback(
       // react-markdown passes `node` (hast AST) — destructure it out so it
       // doesn't leak into the DOM as an invalid attribute.
-      ({ className, children, node: _node, ...rest }: // eslint-disable-line @typescript-eslint/no-unused-vars
+      ({ className, children, node: _node, ...rest }:
         React.ComponentProps<"code"> & { node?: unknown }) => {
         const match = /language-(\w+)/.exec(className || "");
         const lang = match?.[1];
@@ -152,7 +188,7 @@ export function MarkdownRenderer({ content, bare }: { content: string | null | u
     ),
     // Strip the `node` prop from <pre> as well to prevent DOM warnings.
     pre: useCallback(
-      ({ node: _node, ...rest }: React.ComponentProps<"pre"> & { node?: unknown }) => ( // eslint-disable-line @typescript-eslint/no-unused-vars
+      ({ node: _node, ...rest }: React.ComponentProps<"pre"> & { node?: unknown }) => (
         <pre {...rest} />
       ),
       [],


### PR DESCRIPTION
Closes #521.

## Problem

Mermaid diagrams in `text/markdown` portal assets rendered with **invisible node labels**: boxes, edges, arrowheads, and subgraph/cluster titles all drew correctly, but the text inside nodes did not appear, on both light and dark themes. The reported tell was the asymmetry: subgraph titles were always visible, node labels never were.

## Root cause

The defect was in the sanitizer pass over mermaid's output, not in CSS or the diagram source.

`MarkdownRenderer.tsx` sanitized the rendered SVG with `DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true } })`. Mermaid v11 renders node labels with `htmlLabels: true` (its default), so the label text is an HTML `<span>`/`<div>`/`<p>` living inside an SVG `<foreignObject>`. The SVG-only DOMPurify profile removed that HTML, so node labels disappeared, while subgraph/cluster titles (emitted as plain SVG `<text>`) passed through untouched. That matches the observed symptom exactly.

The mermaid block is already wrapped in `not-prose`, so Tailwind typography was not the cause.

Verified against the bundled DOMPurify 3.4.0 source, three separate defaults each had to be addressed for foreignObject HTML to survive:

- `foreignobject` is in the `svg` profile's disallowed set, so the element itself is dropped.
- `foreignobject` is in `DEFAULT_FORBID_CONTENTS`, so even when the element is kept, its children are stripped.
- `HTML_INTEGRATION_POINTS` defaults to only `annotation-xml`, so DOMPurify's namespace check treats the xhtml children of foreignObject as invalid and removes them.

## Fix

Add a single exported `sanitizeMermaidSvg()` and route both sanitize call sites through it. It uses the minimal config that keeps the labels while still sanitizing:

- `USE_PROFILES: { svg: true, svgFilters: true, html: true }` so the label tags (`div`/`span`/`p`) are allowed.
- `ADD_TAGS: ["foreignObject"]` since the svg profile disallows it.
- `FORBID_CONTENTS` set to DOMPurify's default list minus `foreignobject`, so foreignObject contents are no longer force-stripped while `script`, `style`, `iframe`, and the rest of the default list still are.
- `HTML_INTEGRATION_POINTS: { foreignobject: true, "annotation-xml": true }` so the namespace check keeps foreignObject's xhtml children (the `annotation-xml` default is preserved, not dropped).

Sanitization is unchanged for everything else: `<script>`, `<iframe>`, and inline event-handler attributes (`onclick`, `onerror`, ...) are still removed, including when smuggled inside a `<foreignObject>`.

## Acceptance criteria (from the issue)

- The minimal repro diagram renders node labels legibly with no `%%{init}%%`, no `themeVariables`, and no `classDef` color in the source. Verified by `preserves HTML node labels rendered inside a foreignObject`.
- Subgraph titles continue to render. Verified by `preserves SVG-text subgraph titles (no regression)`.

## Tests

New `MarkdownRenderer.test.tsx` exercises the exported sanitizer directly (7 cases):

- node labels inside foreignObject are preserved
- subgraph titles still render (no regression)
- `<script>` elements and inline event-handler attributes are stripped
- `<script>`, `<iframe>`, and event handlers smuggled **inside** a foreignObject are stripped (the dangerous vector this change keeps HTML alive for)

The label-preservation tests fail against the old `{ svg: true }` config and pass against the new one, so they pin the regression rather than testing DOMPurify's baseline.

## Verification

- `npx vitest run` (full UI suite): passes
- `npx tsc --noEmit`: clean
- `npx eslint`: 0 problems (also removed two now-unnecessary `eslint-disable` directives in the same file)
- `npm run build`: succeeds

`tsc --noEmit` and `npm run build` are the UI gates CI runs (`.github/workflows/ci.yml`).

## Not included (tracked separately)

`ThumbnailGenerator.tsx` renders mermaid SVG via `innerHTML` without a DOMPurify pass, so the invisible-label bug does not reproduce there. That path is untouched here to keep this change focused on the asset viewer. The two mermaid renderers could be unified on `sanitizeMermaidSvg` in a follow-up.
