### PR TITLE
fix(gatewayhttp): map auth/authz denials to 403/401 instead of 500 (#533)

### DIFF
--- a/pkg/gatewayhttp/handler.go
+++ b/pkg/gatewayhttp/handler.go
@@ -276,9 +276,9 @@ func firstTextContent(content []mcp.Content) (string, bool) {
 	return "", false
 }
 
-// classifyToolError inspects an MCP tool error envelope and picks an
-// HTTP status that best represents the failure. The matched patterns
-// are stable strings emitted by the apigateway toolkit and the MCP
+// classifyToolError inspects an MCP tool error and picks an HTTP
+// status that best represents the failure. The matched patterns are
+// stable strings emitted by the apigateway toolkit and the MCP
 // auth/authz middleware. Categories, in order of evaluation:
 //
 //   - "authentication failed" → 401 (caller's token bad)
@@ -295,12 +295,31 @@ func firstTextContent(content []mcp.Content) (string, bool) {
 // surface as auth failures, but BEFORE the "not found" pattern
 // because a transport error reading "no such host" must not be
 // mistaken for a connection-name lookup miss.
+//
+// Two producers feed this classifier with DIFFERENT payload shapes
+// (issue #533): the apigateway toolkit wraps its message in a
+// {"error":"..."} JSON envelope, while the auth/authz middleware
+// (PlatformError, see pkg/middleware) emits a bare string such as
+// "not authorized: ...". The envelope is only a serialization detail
+// and must not change the HTTP status, so the message is normalized
+// first (unwrap the envelope when present, otherwise use the raw
+// payload) and the SAME switch classifies both. Previously a
+// non-envelope payload short-circuited to 500, turning a permanent
+// 403/401 denial into a retryable 5xx that made upstream HTTP clients
+// retry-loop on a request that could never succeed.
+//
+// An unrecognized message defaults to 400, not 500: every genuine
+// transient or server-side condition (timeout → 504, transport → 502)
+// is matched explicitly above, so an unmatched message is by
+// elimination not known-retryable, and defaulting unknowns to a
+// retryable 5xx is the very retry-storm failure mode this classifier
+// exists to prevent.
 func classifyToolError(payload string) (status int, message string) {
+	msg := payload
 	var env errorEnvelope
-	if err := json.Unmarshal([]byte(payload), &env); err != nil {
-		return http.StatusInternalServerError, payload
+	if err := json.Unmarshal([]byte(payload), &env); err == nil && env.Error != "" {
+		msg = env.Error
 	}
-	msg := env.Error
 	lower := strings.ToLower(msg)
 	switch {
 	case strings.Contains(lower, "authentication failed"):

--- a/pkg/gatewayhttp/handler_test.go
+++ b/pkg/gatewayhttp/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -244,11 +245,33 @@ func TestClassifyToolError(t *testing.T) {
 			payload:    `{"error":"dial tcp: lookup api.example.com: no such host"}`,
 			wantStatus: http.StatusBadGateway,
 		},
+		// Issue #533: the auth/authz middleware emits a bare-string
+		// payload (PlatformError), NOT a JSON envelope. These cases lock
+		// in that a plain string is classified on its message, not
+		// short-circuited to 500.
 		{
-			name:       "non-JSON payload → 500 with raw text",
+			name:       "plain-string authorization denial → 403",
+			payload:    `not authorized: connection not allowed for persona: example-persona`,
+			wantStatus: http.StatusForbidden,
+			wantMsg:    "not authorized: connection not allowed for persona: example-persona",
+		},
+		{
+			name:       "plain-string authentication failure → 401",
+			payload:    `authentication failed: invalid token`,
+			wantStatus: http.StatusUnauthorized,
+			wantMsg:    "authentication failed: invalid token",
+		},
+		{
+			name:       "unrecognized non-JSON payload → 400 (non-retryable, not 500)",
 			payload:    `garbage`,
-			wantStatus: http.StatusInternalServerError,
+			wantStatus: http.StatusBadRequest,
 			wantMsg:    "garbage",
+		},
+		{
+			name:       "JSON object without an error field → 400 with raw payload",
+			payload:    `{"unexpected":"shape"}`,
+			wantStatus: http.StatusBadRequest,
+			wantMsg:    `{"unexpected":"shape"}`,
 		},
 	}
 	for _, tc := range tests {
@@ -680,6 +703,123 @@ func TestIntegration_HeadersAndQueryForwarded(t *testing.T) {
 	}`
 	status, _ := postJSON(t, gateway.URL+"/api/v1/gateway/acme/invoke", body)
 	require.Equal(t, http.StatusOK, status)
+}
+
+// denyingAuthorizer always denies, mimicking a persona that does not
+// permit the requested connection. It returns the exact (false,
+// persona, reason) shape the real persona authorizer returns.
+type denyingAuthorizer struct {
+	persona string
+	reason  string
+}
+
+func (d denyingAuthorizer) IsAuthorized(_ context.Context, _ string, _ []string, _, _ string) (authorized bool, personaName, reason string) {
+	return false, d.persona, d.reason
+}
+
+// failingAuthenticator always fails authentication, mimicking a
+// rejected credential.
+type failingAuthenticator struct {
+	err string
+}
+
+func (f failingAuthenticator) Authenticate(_ context.Context) (*middleware.UserInfo, error) {
+	return nil, errors.New(f.err)
+}
+
+// newGatewayHTTPServerWithAuth wires the gateway over a real MCP server
+// that has the apigateway toolkit AND the real MCPToolCallMiddleware
+// attached. Auth/authz denials therefore travel the exact production
+// path: middleware -> PlatformError (a BARE STRING, not a JSON
+// envelope) -> in-memory MCP session -> REST classifier. This is what
+// proves issue #533 end to end. A unit test on classifyToolError alone
+// cannot, because it cannot demonstrate that the middleware's actual
+// output reaches the classifier in the bare-string shape the
+// classifier must handle — the original bug was precisely that the two
+// were never tested together.
+func newGatewayHTTPServerWithAuth(t *testing.T, upstreamURL, connName string, authn middleware.Authenticator, authz middleware.Authorizer) *httptest.Server {
+	t.Helper()
+
+	tk := apigatewaykit.New("apigateway")
+	if upstreamURL != "" {
+		require.NoError(t, tk.AddConnection(connName, map[string]any{
+			"base_url":        upstreamURL,
+			"auth_mode":       apigatewaykit.AuthModeNone,
+			"call_timeout":    "5s",
+			"connect_timeout": "2s",
+		}))
+	}
+
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "v1"}, nil)
+	tk.RegisterTools(mcpServer)
+	mcpServer.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(
+		authn, authz, nil, middleware.ToolCallConfig{Transport: "http"}))
+
+	handler, err := NewHandler(Deps{MCPServer: mcpServer})
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(func() {
+		time.Sleep(10 * time.Millisecond)
+	})
+	return srv
+}
+
+// TestIntegration_AuthorizationDeniedIsForbidden is the regression test
+// for issue #533: a persona denial originates in the auth/authz
+// middleware as a bare-string PlatformError, flows through the
+// in-memory MCP session, and must surface to the REST caller as HTTP
+// 403 — NOT a retryable 500. Before the fix the gateway returned 500,
+// causing upstream HTTP clients to retry-loop on a permanent denial.
+func TestIntegration_AuthorizationDeniedIsForbidden(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	authz := denyingAuthorizer{
+		persona: "example-persona",
+		reason:  "connection not allowed for persona: example-persona",
+	}
+	gateway := newGatewayHTTPServerWithAuth(t, upstream.URL, "acme",
+		&middleware.NoopAuthenticator{DefaultUserID: "u1", DefaultRoles: []string{"analyst"}},
+		authz)
+	defer gateway.Close()
+
+	status, respBody := postJSON(t, gateway.URL+"/api/v1/gateway/acme/invoke",
+		`{"method":"GET","path":"/v1/x"}`)
+
+	require.Equal(t, http.StatusForbidden, status,
+		"a persona denial must surface as 403, not a retryable 5xx (issue #533)")
+	assert.Equal(t, 0, upstreamHits,
+		"the denial must occur before any upstream call is made")
+	var env errorEnvelope
+	require.NoError(t, json.Unmarshal(respBody, &env))
+	assert.Contains(t, env.Error, "not authorized",
+		"the 403 body must carry the denial reason for the caller")
+}
+
+// TestIntegration_AuthenticationFailedIsUnauthorized is the companion
+// regression test for issue #533 covering the 401 path: a rejected
+// credential produces a bare-string "authentication failed" error from
+// the middleware that must surface as HTTP 401, not 500.
+func TestIntegration_AuthenticationFailedIsUnauthorized(t *testing.T) {
+	gateway := newGatewayHTTPServerWithAuth(t, "", "acme",
+		failingAuthenticator{err: "invalid token"},
+		&middleware.NoopAuthorizer{})
+	defer gateway.Close()
+
+	status, respBody := postJSON(t, gateway.URL+"/api/v1/gateway/acme/invoke",
+		`{"method":"GET","path":"/v1/x"}`)
+
+	require.Equal(t, http.StatusUnauthorized, status,
+		"a rejected credential must surface as 401, not a retryable 5xx (issue #533)")
+	var env errorEnvelope
+	require.NoError(t, json.Unmarshal(respBody, &env))
+	assert.Contains(t, env.Error, "authentication failed",
+		"the 401 body must indicate the authentication failure")
 }
 
 // TestIntegration_SourceTaggedRest proves the central goal of issue #x:


### PR DESCRIPTION
## Summary

The REST gateway shim (`pkg/gatewayhttp/handler.go`) returned **HTTP 500** for authorization and authentication denials that should be **403** and **401**. Because 5xx is retryable under standard HTTP client semantics and 4xx is not, upstream automation clients retry-looped on a permission denial that can never succeed, inflating latency and upstream call volume until they gave up.

Observed in production: a persona-denied `POST /api/v1/gateway/{connection}/invoke` returned `status: 500` with body `{"error":"not authorized: connection not allowed for persona: <persona>"}`. The body text was correct; the status code was wrong.

Closes #533.

## Root cause

Two distinct error producers feed `classifyToolError`, emitting **different content shapes**:

1. **apigateway toolkit errors** — `errorResult()` (`pkg/toolkits/apigateway/toolkit.go:1152`) wraps the message in a JSON envelope: `{"error":"..."}`.
2. **auth/authz middleware errors** — `createCategorizedErrorResult()` -> `PlatformError.Error()` (`pkg/middleware/mcp.go:402`, `:76`) returns a **bare string**, e.g. `not authorized: <reason>`.

`classifyToolError` (`pkg/gatewayhttp/handler.go`) assumed shape #1 unconditionally:

```go
var env errorEnvelope
if err := json.Unmarshal([]byte(payload), &env); err != nil {
    return http.StatusInternalServerError, payload   // every bare-string middleware error landed here
}
```

A bare-string payload fails `json.Unmarshal`, so the function returned `500` immediately. The classification `switch` below it (which maps `"not authorized"` -> 403 and `"authentication failed"` -> 401) was never reached. `writeError` then re-wrapped the raw text into `{"error":"..."}`, producing exactly the observed response.

### Impact surface

Every middleware-injected error reaching the REST gateway was miscoded:

| Real condition | Middleware text (`pkg/middleware/mcp.go`) | Correct status | Pre-fix status |
|---|---|---|---|
| Authorization denied | `not authorized: ...` (line 276) | 403 | **500** |
| Authentication failed | `authentication failed: ...` (line 250) | 401 | **500** |

Toolkit-originated errors (timeout -> 504, transport -> 502, not-found -> 404, validation -> 400) were unaffected because they already emit the JSON envelope.

The admin REST shim (`pkg/admin/tools.go`) is **not** affected: by design it always returns HTTP 200 and carries `is_error` in the JSON body (so the admin console renders tool errors inline, like an MCP client would). It never maps tool errors to HTTP status, so the bug was isolated to the gateway shim — the only shim that promises HTTP status semantics to non-MCP clients.

## The fix

`classifyToolError` now normalizes the message before classifying: unwrap the `{"error":...}` envelope when present, otherwise use the raw payload, then run **both** producer shapes through the same `switch`. The envelope is only a serialization detail and must not change the HTTP status.

Unknown messages default to **400, not 500**: every genuine transient or server-side condition (timeout -> 504, transport -> 502) is matched explicitly, so an unmatched message is by elimination not known-retryable. Defaulting unknowns to a retryable 5xx is the exact retry-storm failure mode this classifier exists to prevent. Note that 500 was never a documented gateway status (`NewHandler` docs list 200/400/401/403/404/502/504); genuine platform-fault 500s (MCP connect failure, transport error, malformed SDK result) remain in `invoke()`/`writeToolResult()` and are untouched.

## Why this wasn't caught before

`TestClassifyToolError` only ever fed the classifier the **toolkit's** JSON envelope (`{"error":"not authorized: ..."}`) and asserted 403 — green. But the authorization middleware never emits that envelope in production; it emits a bare string. The test exercised a payload shape the real authz path does not produce, and no test wired a real authz denial through the in-memory MCP session to the REST status code. The divergence between the two payload shapes was invisible to the suite. This is the "manually constructs the correct input" anti-pattern called out in `CLAUDE.md` section 5.

## Tests

**Unit (`TestClassifyToolError`)**
- Added plain-string `not authorized: ...` -> 403 and `authentication failed: ...` -> 401 cases (the real middleware shape).
- Corrected the case that **encoded the bug**: `garbage` -> 500 is now `garbage` -> 400.
- Added a JSON-object-without-error-field -> 400 case.

**Integration (new)**
- `TestIntegration_AuthorizationDeniedIsForbidden` and `TestIntegration_AuthenticationFailedIsUnauthorized` wire the **real** `MCPToolCallMiddleware` into the gateway server, so a genuine persona/auth denial travels the exact production path: middleware -> bare-string `PlatformError` -> in-memory MCP session -> REST classifier. They assert 403/401 end-to-end, and the 403 test also asserts the upstream was never called (denial happens before proxying).

**Proof the tests are not tautological:** reverting only the `handler.go` fix makes both integration tests fail with the precise production symptom (403->500, 401->500); they pass against the fix.

## Verification

`make verify` is fully green: race tests, total + patch coverage (>=80%), `golangci-lint` (incl. `--new-from-rev`), `gosec` + `govulncheck`, semgrep, CodeQL, dead-code, mutation (>=60% efficacy), and GoReleaser dry-run.

## Acceptance criteria (from #533)

- [x] `classifyToolError` maps a plain-string `not authorized: ...` payload to 403.
- [x] `classifyToolError` maps a plain-string `authentication failed: ...` payload to 401.
- [x] Existing JSON-envelope cases (504/502/404/400) continue to pass unchanged.
- [x] Integration test wires the real assembled server and asserts a genuine persona denial -> 403 end-to-end.
- [x] An authentication failure through the same real path -> 401 end-to-end.
