### PR TITLE
feat(portal): markdown connection descriptions with collapsible reveal

### DIFF
--- a/ui/src/components/renderers/CollapsibleMarkdown.test.tsx
+++ b/ui/src/components/renderers/CollapsibleMarkdown.test.tsx
@@ -56,4 +56,25 @@ describe("CollapsibleMarkdown", () => {
     ).toBeInTheDocument();
     restore();
   });
+
+  it("uses a taller clamp when maxHeightPx is raised", () => {
+    // 150px overflows the default ~84px clamp but fits within a 200px clamp,
+    // so the toggle must not appear when the caller raises maxHeightPx.
+    const restore = setScrollHeight(150);
+    render(<CollapsibleMarkdown content="medium description" maxHeightPx={200} />);
+
+    expect(screen.getByText("medium description")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    restore();
+  });
+
+  it("still clamps content taller than the raised maxHeightPx", () => {
+    const restore = setScrollHeight(400);
+    render(<CollapsibleMarkdown content="long description" maxHeightPx={200} />);
+
+    expect(
+      screen.getByRole("button", { name: "Show more" }),
+    ).toBeInTheDocument();
+    restore();
+  });
 });

--- a/ui/src/components/renderers/CollapsibleMarkdown.tsx
+++ b/ui/src/components/renderers/CollapsibleMarkdown.tsx
@@ -17,6 +17,10 @@ interface CollapsibleMarkdownProps {
   // background so the fade at the clamp edge blends in (e.g. "from-card",
   // "from-muted"). Defaults to the card background.
   fadeFrom?: string;
+  // maxHeightPx overrides the collapsed clamp height for consumers that want
+  // a taller preview (e.g. connection descriptions clamp to ~200px). Defaults
+  // to COLLAPSED_MAX_PX so existing consumers (memory records) are unaffected.
+  maxHeightPx?: number;
 }
 
 // CollapsibleMarkdown renders markdown clamped to a few lines with a
@@ -25,6 +29,7 @@ interface CollapsibleMarkdownProps {
 export function CollapsibleMarkdown({
   content,
   fadeFrom = "from-card",
+  maxHeightPx = COLLAPSED_MAX_PX,
 }: CollapsibleMarkdownProps) {
   const ref = useRef<HTMLDivElement>(null);
   const [expanded, setExpanded] = useState(false);
@@ -41,9 +46,9 @@ export function CollapsibleMarkdown({
     if (!el) {
       return;
     }
-    setOverflowing(el.scrollHeight > COLLAPSED_MAX_PX + OVERFLOW_SLACK_PX);
+    setOverflowing(el.scrollHeight > maxHeightPx + OVERFLOW_SLACK_PX);
     setExpanded(false);
-  }, [content]);
+  }, [content, maxHeightPx]);
 
   const clamped = overflowing && !expanded;
 
@@ -52,7 +57,7 @@ export function CollapsibleMarkdown({
       <div
         ref={ref}
         className="relative overflow-hidden"
-        style={clamped ? { maxHeight: COLLAPSED_MAX_PX } : undefined}
+        style={clamped ? { maxHeight: maxHeightPx } : undefined}
       >
         <MarkdownRenderer content={content} bare />
         {clamped && (

--- a/ui/src/pages/settings/ConnectionsPanel.tsx
+++ b/ui/src/pages/settings/ConnectionsPanel.tsx
@@ -24,6 +24,8 @@ import {
 import { GatewayActionBar, GatewayRulesDrawer } from "./GatewayActions";
 import { ConnectionOAuthStatusCard } from "./ConnectionOAuthStatusCard";
 import { HelpDialog } from "@/components/HelpDialog";
+import { MarkdownEditor } from "@/components/MarkdownEditor";
+import { CollapsibleMarkdown } from "@/components/renderers/CollapsibleMarkdown";
 import { ApiGatewayAuthHelp, ApiGatewayTLSHelp } from "./ApiGatewayHelpContent";
 
 // ConnectionOAuthHealthBadge renders the per-row health indicator
@@ -583,7 +585,9 @@ function ConnectionViewer({
             </span>
           </div>
           {connection.description && (
-            <p className="mt-1 text-sm text-muted-foreground">{connection.description}</p>
+            <div className="mt-1">
+              <CollapsibleMarkdown content={connection.description} maxHeightPx={200} fadeFrom="from-muted" />
+            </div>
           )}
           {connection.source === "both" && (
             <p className="mt-1 text-xs text-muted-foreground">
@@ -976,12 +980,11 @@ function ConnectionEditor({ connection, onSave, onCancel, onDirtyChange }: Edito
         {/* Description */}
         <div>
           <label className="mb-1 block text-xs font-medium">Description</label>
-          <input
-            type="text"
+          <MarkdownEditor
             value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="What this connection is for..."
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none ring-ring focus:ring-2"
+            onChange={setDescription}
+            minHeight="160px"
+            placeholder="What this connection is for... (usage notes, datasets/schemas, gotchas, owner/contact)"
           />
         </div>
 


### PR DESCRIPTION
## Summary

Brings connection descriptions in the Connections settings panel in line with how personas already handle rich text. Two changes (closes #541):

1. The connection editor now uses the `MarkdownEditor` component for the description field instead of a single-line `<input>`, so descriptions can hold formatted, multi-line content.
2. The connection view page renders the description as markdown inside a `CollapsibleMarkdown`, clamped so longer descriptions do not blow out the panel height.

## Changes

### 1. Markdown editor for the description field
`ui/src/pages/settings/ConnectionsPanel.tsx` (`ConnectionEditor`)

Replaced the single-line description `<input>` with the same `MarkdownEditor` component personas use (`ui/src/components/MarkdownEditor.tsx`), giving the write / split / preview toolbar (bold, italic, code, H1/H2, lists, quote, link, rule). The `description`/`setDescription` state is unchanged, so the save path (`description || undefined`) and dirty tracking behave exactly as before; `MarkdownEditor.onChange` passes the raw string, matching the previous `setDescription(e.target.value)`.

`minHeight="160px"` matches the persona context description fields (`PersonaEditor.tsx:720`) rather than the editor's 400px default.

### 2. Collapsible rendered description on the view page
`ui/src/pages/settings/ConnectionsPanel.tsx` (`ConnectionViewer`)

Replaced the plain `<p>{connection.description}</p>` with `CollapsibleMarkdown`, which renders markdown and clamps to a max height with a fade and Show more / Show less toggle, resetting to collapsed when the selected connection changes (the behavior added for #515). This keeps clicking between connections in the sidebar smooth.

`fadeFrom="from-muted"` matches the actual background the description sits on: the panel renders directly into `AppShell`'s `<main className="... bg-muted/40 ...">` with no card wrapper.

### 3. Optional `maxHeightPx` prop on `CollapsibleMarkdown`
`ui/src/components/renderers/CollapsibleMarkdown.tsx`

Per the issue's preferred approach, added an optional `maxHeightPx?: number` prop (default `COLLAPSED_MAX_PX = 84`) and pass `200` from the connections panel, instead of raising the shared constant. The existing consumers (memory records in `KnowledgePage.tsx` / `MyKnowledgePage.tsx`) do not pass the prop and so keep the original 84px clamp. The prop is included in the `useLayoutEffect` dependency list so overflow is re-measured if it changes.

## Acceptance criteria

- [x] Editing a connection presents a markdown editor (write/preview) for the description, matching the persona editor.
- [x] A short description renders fully with no toggle; a long one clamps to ~200px with a fade and a Show more toggle, expanding in place.
- [x] All connections render at a consistent collapsed height (CollapsibleMarkdown resets to collapsed on content change), so clicking between them does not cause vertical jumpiness.
- [x] The clamp change does not alter existing `CollapsibleMarkdown` consumers: `maxHeightPx` defaults to the original `COLLAPSED_MAX_PX`, and memory-record call sites do not pass it.

## Out of scope (unchanged)

- `description` remains a plain text field persisted via the admin API and YAML config; storing markdown source in the same string requires no backend schema change.
- `list_connections` emits the description to the LLM as raw text; markdown source there is harmless. No change.
- Indexing connection descriptions into unified semantic search is tracked separately.

## Testing

- `ui/src/components/renderers/CollapsibleMarkdown.test.tsx`: added two tests covering the new prop (taller clamp suppresses the toggle when content fits within `maxHeightPx`; content taller than `maxHeightPx` still clamps and shows the toggle).
- Full UI test suite: 143 passed.
- `tsc --noEmit` clean; `npm run build` succeeds.
- `make verify` passed end to end (includes the GoReleaser dry-run that rebuilds and embeds the UI).

No Go, config, migration, or CLI changes.