### PR TITLE
Persona editor: stop listing non-gateable toolkits as connections; fix group quick-add patterns

### DIFF
--- a/pkg/admin/system.go
+++ b/pkg/admin/system.go
@@ -315,6 +315,13 @@ func (h *Handler) listConnections(w http.ResponseWriter, _ *http.Request) {
 				}
 				continue
 			}
+			// Built-in single-instance toolkits (knowledge, memory, portal,
+			// platform) report an empty Connection(), which the persona filter
+			// always allows as platform-level (IsConnectionAllowed): not a
+			// gateable connection, so it does not belong in this list.
+			if tk.Connection() == "" {
+				continue
+			}
 			conns = append(conns, connectionInfo{
 				Kind:        tk.Kind(),
 				Name:        tk.Name(),

--- a/pkg/admin/system_test.go
+++ b/pkg/admin/system_test.go
@@ -428,6 +428,35 @@ func TestListConnections(t *testing.T) {
 		assert.Equal(t, float64(0), body["total"])
 	})
 
+	// Built-in single-instance toolkits (knowledge, memory, portal) report an
+	// empty Connection(). The persona filter always allows an empty connection
+	// name, so they are not gateable connections and must not appear here —
+	// listing them produced phantom "denied" rows in the persona editor that
+	// no allow pattern could clear.
+	t.Run("excludes toolkits with an empty connection name", func(t *testing.T) {
+		reg := &mockToolkitRegistry{
+			allResult: []mockToolkit{
+				{kind: "trino", name: "prod", connection: "prod-trino", tools: []string{"trino_query"}},
+				{kind: "knowledge", name: "knowledge", connection: "", tools: []string{"capture_insight"}},
+				{kind: "memory", name: "memory", connection: "", tools: []string{"memory_recall"}},
+			},
+		}
+		h := NewHandler(Deps{ToolkitRegistry: reg}, nil)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/admin/connections", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var body connectionListResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+		require.Len(t, body.Connections, 1, "only the real (non-empty) connection should be listed")
+		assert.Equal(t, "prod-trino", body.Connections[0].Connection)
+		for _, c := range body.Connections {
+			assert.NotEmpty(t, c.Connection, "no empty-connection rows may be returned")
+		}
+	})
+
 	// A multi-connection toolkit (apigateway with N upstream connections,
 	// trino with multiple catalogs) must expand to one entry per real
 	// connection because the persona filter authorizes against the

--- a/ui/src/pages/settings/PersonaEditor.tsx
+++ b/ui/src/pages/settings/PersonaEditor.tsx
@@ -362,6 +362,32 @@ export function PersonaEditor({
     [scope, draft.denyTools, draft.denyConnections, onUpdate],
   );
 
+  // addMany adds every given pattern in a single update. Looping addAllow/
+  // addDeny would not work: each call reads the same pre-update draft, so only
+  // the last addition would survive. Used by the group "allow/deny all"
+  // buttons when a kind glob does not match every item (gateway tool names
+  // like "mcptest__echo" and connection names like "Test API" are not
+  // kind-prefixed, so a `${kind}_*` pattern matches none of them).
+  const addMany = useCallback(
+    (bucket: "allow" | "deny", patterns: string[]) => {
+      const clean = patterns.map((n) => n.trim()).filter(Boolean);
+      const key = (
+        scope === "tools"
+          ? bucket === "allow"
+            ? "allowTools"
+            : "denyTools"
+          : bucket === "allow"
+            ? "allowConnections"
+            : "denyConnections"
+      ) as keyof PersonaDraft;
+      const cur = draft[key] as string[];
+      const next = cur.slice();
+      for (const p of clean) if (!next.includes(p)) next.push(p);
+      if (next.length !== cur.length) onUpdate({ [key]: next });
+    },
+    [scope, draft, onUpdate],
+  );
+
   const removeAllow = useCallback(
     (pattern: string) => {
       if (scope === "tools")
@@ -858,6 +884,19 @@ export function PersonaEditor({
               const kindAllow = kindItems.filter(
                 (it) => resolved.get(it.key)?.decision === "allow",
               ).length;
+              // Prefer the concise `${kind}_*` glob ONLY when it actually
+              // matches every item in the group (native toolkits, whose tools
+              // are kind-prefixed) — it stays correct as future tools are
+              // added. Gateway tools ("mcptest__echo") and connection names
+              // ("Test API") are not kind-prefixed, so fall back to granting
+              // each item by exact name. Either way the action covers the whole
+              // kind group, independent of the search/status filter.
+              const kindGlob = `${kind}_*`;
+              const globCoversAll = kindItems.every((it) =>
+                matchPattern(kindGlob, it.primary),
+              );
+              const groupNames = kindItems.map((it) => it.primary);
+              const noun = scope === "tools" ? "tool" : "connection";
               return (
                 <div key={kind} className="mb-5 last:mb-0">
                   <div className="mb-1.5 flex items-baseline justify-between border-b pb-1">
@@ -871,18 +910,34 @@ export function PersonaEditor({
                     </div>
                     <div className="flex gap-1">
                       <button
-                        onClick={() => addAllow(`${kind}_*`)}
+                        onClick={() =>
+                          globCoversAll
+                            ? addAllow(kindGlob)
+                            : addMany("allow", groupNames)
+                        }
                         className="rounded px-1.5 py-0.5 font-mono text-[10px] text-emerald-700 hover:bg-emerald-50 dark:text-emerald-400 dark:hover:bg-emerald-950/40"
-                        title={`Add allow rule: ${kind}_*`}
+                        title={
+                          globCoversAll
+                            ? `Add allow rule: ${kindGlob}`
+                            : `Allow every ${kind} ${noun} by name`
+                        }
                       >
-                        + allow {kind}_*
+                        + allow {globCoversAll ? kindGlob : "all"}
                       </button>
                       <button
-                        onClick={() => addDeny(`${kind}_*`)}
+                        onClick={() =>
+                          globCoversAll
+                            ? addDeny(kindGlob)
+                            : addMany("deny", groupNames)
+                        }
                         className="rounded px-1.5 py-0.5 font-mono text-[10px] text-rose-700 hover:bg-rose-50 dark:text-rose-400 dark:hover:bg-rose-950/40"
-                        title={`Add deny rule: ${kind}_*`}
+                        title={
+                          globCoversAll
+                            ? `Add deny rule: ${kindGlob}`
+                            : `Deny every ${kind} ${noun} by name`
+                        }
                       >
-                        + deny {kind}_*
+                        + deny {globCoversAll ? kindGlob : "all"}
                       </button>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary

Two related fixes to the persona editor's connection permissions UI. After connection access became deny-by-default (#545), several long-standing rough edges in this screen turned from cosmetic into blocking. This PR addresses the worst of them.

## 1. Built-in toolkits no longer appear as "connections"

`GET /api/v1/admin/connections` (`pkg/admin/system.go` `listConnections`) iterated **every** registered toolkit with no filter, so built-in single-instance toolkits (`knowledge`, `memory`, `portal`, `platform`) showed up as connection rows. These toolkits report an empty `Connection()`, and the persona filter always treats an empty connection name as platform-level and **allows** it (`pkg/persona/filter.go` `IsConnectionAllowed`). They are not gateable connections.

The consequences in the editor were:

- **Phantom "denied" rows.** Under deny-by-default the preview ran `resolve("", ...)`, which has no allow match for an empty name, so these rows rendered as denied even though the server always allows them. Before deny-by-default the empty-allow-means-all default hid this; now it is visible and wrong.
- **Dead check/deny buttons.** The row quick-add adds the item's exact name as a pattern. For these rows the name is `""`, and the add helper no-ops on an empty pattern, so clicking the check or deny button did nothing.
- **A "1 denied" you could not clear.** The combination produced a stuck denial in the "What can X do?" summary that no per-row action could resolve, forcing operators to add a blanket `*`.

Fix: `listConnections` now skips toolkits whose `Connection()` is empty. Only real, authorizable connections (trino, s3, datahub, api, mcp) are listed. This is keyed on the same signal the persona filter authorizes against, rather than a hardcoded kind allowlist, so it cannot drift from authorization semantics.

## 2. Group quick-add patterns that match nothing

Each kind group offered a quick-add button hardcoded to `${kind}_*` (for example `+ allow mcp_*`). That glob is correct for native toolkits whose tools are kind-prefixed (`trino_query` matches `trino_*`), but:

- Gateway/MCP tools are named `<connection>__<tool>` (`mcptest__echo`), so `mcp_*` matches **none** of them. The MCP group showed "0/N allowed" with a suggestion that granted nothing.
- Connection names (`Test API`, `platform-admin`, `acme`) are not kind-prefixed either, so the connection-tab `${kind}_*` buttons also matched nothing.

Fix: the group button is now a hybrid.

- When `${kind}_*` actually matches every item in the group (native, kind-prefixed tools), it keeps the concise glob and shows `+ allow trino_*`. This preserves the affordance and continues to cover tools added in future releases.
- Otherwise it grants each item by exact name and shows `+ allow all` (and `+ deny all`).

The action operates on the whole kind group rather than the search/status-filtered subset, so "all" is accurate. The two near-identical `addMany*` helpers were consolidated into a single `addMany(bucket, names)` that applies all additions in one update (looping the single-add helper would read a stale draft and only keep the last addition).

## Testing

`make verify` passes end to end (race tests, coverage, lint, gosec, govulncheck, semgrep, CodeQL, doc-check, dead-code, mutation, GoReleaser dry-run). The change was run through the adversarial review pass before verification; the review caught an over-correction (the first cut dropped the valid `${kind}_*` glob for native toolkits too), which the hybrid above resolves.

- `pkg/admin/system_test.go` - new subtest asserts toolkits with an empty `Connection()` are excluded from the response and only the real connection is listed.
- `ui/src/pages/settings/PersonaEditor.tsx` - typecheck and build clean.

## Compatibility

No breaking changes. This is a bug fix on top of the v1.79.0 connection-access model and is patch-appropriate.
