### PR TITLE
fix(apigateway): resolve api_get_endpoint_schema for synthesized operation ids under a base path

### DIFF
--- a/pkg/toolkits/apigateway/schema_lookup.go
+++ b/pkg/toolkits/apigateway/schema_lookup.go
@@ -145,7 +145,8 @@ func (t *Toolkit) handleGetEndpointSchema(_ context.Context, _ *mcp.CallToolRequ
 type operationMatch struct {
 	specName string
 	method   string
-	path     string
+	path     string // full runtime path: effectiveBasePath + spec rawPath
+	rawPath  string // spec-relative path, used to synthesize the operationId
 	op       *openapi3.Operation
 }
 
@@ -184,17 +185,25 @@ func collectOperationMatches(c *conn, operationID, specFilter string) ([]*operat
 			fullPath := basePath + path
 			id := op.OperationID
 			if id == "" {
-				// Synthesized id must match what buildOperationIndex
-				// emits or the operationID returned by
-				// api_list_endpoints will not resolve here. Both
-				// sites use METHOD + " " + full upstream path.
-				id = method + " " + fullPath
+				// Synthesize from the spec-relative path, NOT the
+				// basePath-prefixed fullPath. api_list_endpoints
+				// (appendItemOperations) advertises the id built from
+				// the spec-relative rawPath so the id stays a property
+				// of the spec content alone. Matching here on fullPath
+				// instead severed every synthesized-id lookup on any
+				// connection with a non-empty effectiveBasePath — the
+				// built-in platform-admin spec (base path /api/v1) hit
+				// this squarely: api_list_endpoints advertised
+				// "GET /admin/personas" while this resolver looked up
+				// "GET /api/v1/admin/personas" and returned not-found.
+				// Use the one shared helper so the two sites cannot drift.
+				id = synthesizedOperationID(method, path)
 			}
 			if id != operationID {
 				return
 			}
 			matches = append(matches, &operationMatch{
-				specName: specName, method: method, path: fullPath, op: op,
+				specName: specName, method: method, path: fullPath, rawPath: path, op: op,
 			})
 			candidates = append(candidates, schemaCandidate{
 				Spec: specName, Method: method, Path: fullPath,
@@ -244,7 +253,10 @@ func walkOperations(doc *openapi3.T, fn func(method, path string, op *openapi3.O
 // m.path is already the full upstream path (the spec's base path
 // prepended at collectOperationMatches time) so the output's Path
 // field agrees with the path reported by api_list_endpoints for
-// the same operation. Same for the synthesized OperationID.
+// the same operation. The synthesized OperationID, by contrast, is
+// built from the spec-relative rawPath via the shared helper so it
+// agrees with the id api_list_endpoints advertises (which is
+// base-path-independent), not with m.path.
 func buildEndpointSchemaOutput(m *operationMatch) EndpointSchemaOutput {
 	out := EndpointSchemaOutput{
 		Spec:        m.specName,
@@ -255,7 +267,7 @@ func buildEndpointSchemaOutput(m *operationMatch) EndpointSchemaOutput {
 		Description: m.op.Description,
 	}
 	if out.OperationID == "" {
-		out.OperationID = m.method + " " + m.path
+		out.OperationID = synthesizedOperationID(m.method, m.rawPath)
 	}
 	out.Parameters = flattenParameters(m.op.Parameters)
 	out.RequestBody = flattenRequestBody(m.op.RequestBody)

--- a/pkg/toolkits/apigateway/schema_lookup_test.go
+++ b/pkg/toolkits/apigateway/schema_lookup_test.go
@@ -786,3 +786,146 @@ func TestGetEndpointSchema_ConstAndEnumPreserved(t *testing.T) {
 		t.Errorf("status.enum not preserved (got %v): %+v", status["enum"], status)
 	}
 }
+
+// basePathNoOpIDSpec mirrors the built-in platform-admin spec: a
+// non-empty server base path (/api/v1) and operations that declare no
+// operationId. This is the exact shape that exposed the synthesized-id
+// divergence between api_list_endpoints and api_get_endpoint_schema:
+// the list side synthesizes "<METHOD> <spec-relative path>" while the
+// schema lookup formerly synthesized "<METHOD> <basePath+path>", so
+// every listed id returned not-found at the schema lookup. Includes a
+// collection path and a templated path to cover both.
+const basePathNoOpIDSpec = `
+openapi: 3.0.3
+info:
+  title: Platform Admin
+  version: "1.0"
+servers:
+  - url: https://admin.example.com/api/v1
+paths:
+  /admin/personas:
+    get:
+      summary: List personas
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+  /admin/personas/{name}:
+    get:
+      summary: Get persona
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+`
+
+func setupBasePathNoOpIDTk(t *testing.T) *Toolkit {
+	t.Helper()
+	tk := New("api")
+	setupCatalogWithSpec(t, tk, "platform-admin", "admin", basePathNoOpIDSpec)
+	if err := tk.AddConnection("c", map[string]any{
+		// base_url is the host root, so effectiveBasePath resolves to the
+		// spec's /api/v1 (non-empty) — the platform-admin scenario.
+		"base_url":   "https://admin.example.com",
+		"catalog_id": "platform-admin",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	return tk
+}
+
+// listOperation pulls a single operation out of a handleListEndpoints
+// result by its full runtime path, failing the test if absent.
+func listOperation(t *testing.T, tk *Toolkit, connection, path string) OperationSummary {
+	t.Helper()
+	_, raw, err := tk.handleListEndpoints(context.Background(), nil, ListEndpointsInput{
+		Connection: connection,
+	})
+	if err != nil {
+		t.Fatalf("handleListEndpoints: %v", err)
+	}
+	out, ok := raw.(ListEndpointsOutput)
+	if !ok {
+		t.Fatalf("list output type %T", raw)
+	}
+	for _, op := range out.Operations {
+		if op.Path == path {
+			return op
+		}
+	}
+	t.Fatalf("operation with path %q not in list: %+v", path, out.Operations)
+	return OperationSummary{}
+}
+
+// TestGetEndpointSchema_SynthesizedIDRoundTripsWithBasePath is the
+// regression guard for the platform-admin bug: an operation_id taken
+// verbatim from api_list_endpoints must resolve through
+// api_get_endpoint_schema even when the connection has a non-empty
+// effectiveBasePath and the operation declares no operationId.
+func TestGetEndpointSchema_SynthesizedIDRoundTripsWithBasePath(t *testing.T) {
+	tk := setupBasePathNoOpIDTk(t)
+
+	// The list side reports the full runtime path but a base-path-free
+	// synthesized id. Lock both down so a regression on either side trips
+	// this test.
+	listed := listOperation(t, tk, "c", "/api/v1/admin/personas")
+	if listed.OperationID != "GET /admin/personas" {
+		t.Fatalf("list operation_id = %q, want base-path-free %q", listed.OperationID, "GET /admin/personas")
+	}
+
+	// Feed the listed id straight into the schema lookup — the broken
+	// discover->schema flow.
+	r, _, err := tk.handleGetEndpointSchema(context.Background(), nil, GetEndpointSchemaInput{
+		Connection: "c", OperationID: listed.OperationID,
+	})
+	if err != nil || r.IsError {
+		t.Fatalf("schema lookup for %q: err=%v isError=%v body=%s",
+			listed.OperationID, err, r.IsError, textContent(r))
+	}
+	out := parseSchemaResult(t, r)
+	if out.OperationID != listed.OperationID {
+		t.Errorf("schema operation_id = %q, want round-trip %q", out.OperationID, listed.OperationID)
+	}
+	if out.Method != "GET" || out.Path != listed.Path {
+		t.Errorf("schema op mismatch: got method=%q path=%q, want GET %q", out.Method, out.Path, listed.Path)
+	}
+}
+
+// TestGetEndpointSchema_SynthesizedIDTemplatedPathWithBasePath covers
+// the templated-path variant (/admin/personas/{name}) so the round-trip
+// holds for path-parameter operations too.
+func TestGetEndpointSchema_SynthesizedIDTemplatedPathWithBasePath(t *testing.T) {
+	tk := setupBasePathNoOpIDTk(t)
+
+	listed := listOperation(t, tk, "c", "/api/v1/admin/personas/{name}")
+	if listed.OperationID != "GET /admin/personas/{name}" {
+		t.Fatalf("list operation_id = %q, want %q", listed.OperationID, "GET /admin/personas/{name}")
+	}
+
+	r, _, err := tk.handleGetEndpointSchema(context.Background(), nil, GetEndpointSchemaInput{
+		Connection: "c", OperationID: listed.OperationID,
+	})
+	if err != nil || r.IsError {
+		t.Fatalf("schema lookup for %q: err=%v isError=%v body=%s",
+			listed.OperationID, err, r.IsError, textContent(r))
+	}
+	out := parseSchemaResult(t, r)
+	if out.OperationID != listed.OperationID || out.Path != listed.Path {
+		t.Errorf("templated round-trip mismatch: got id=%q path=%q, want id=%q path=%q",
+			out.OperationID, out.Path, listed.OperationID, listed.Path)
+	}
+	if len(out.Parameters) != 1 || out.Parameters[0].In != "path" || out.Parameters[0].Name != "name" {
+		t.Errorf("expected one path param 'name': %+v", out.Parameters)
+	}
+}


### PR DESCRIPTION
## Summary

`api_get_endpoint_schema` returned `operation_id not found` for every operation advertised by `api_list_endpoints` on any API connection whose OpenAPI spec omits `operationId`s and resolves a non-empty base path. The two tools synthesized the fallback operation id differently, so the id you discover via the list tool could not be resolved by the schema tool. This routes both through the one shared helper so they agree for any base-path configuration, and adds regression tests.

## Root cause

Operations that declare no explicit `operationId` get a synthesized id. The two sites disagreed:

- `api_list_endpoints` (`appendItemOperations` in `pkg/toolkits/apigateway/openapi.go`) builds the id from the spec-relative path via the shared `synthesizedOperationID(method, rawPath)` helper. This is deliberate: the id is meant to be a property of the spec content alone, independent of the connection's base path.
- `api_get_endpoint_schema` (`collectOperationMatches` and `buildEndpointSchemaOutput` in `pkg/toolkits/apigateway/schema_lookup.go`) built the id from the base-path-prefixed full path (`method + " " + fullPath`).

Whenever a spec resolved a non-empty `effectiveBasePath`, the two ids diverged, so no id returned by the list tool could be resolved by the schema tool. A comment at the schema-lookup site asserted the two sites matched, which masked the divergence.

The built-in `platform-admin` connection is one case that hits this: its embedded spec sits under base path `/api/v1` and declares no `operationId`s, so `api_list_endpoints` advertised `GET /admin/personas` while the schema lookup searched for `GET /api/v1/admin/personas` and returned not-found.

## Fix

In `pkg/toolkits/apigateway/schema_lookup.go`:

- Add a `rawPath` (spec-relative) field to `operationMatch` alongside the existing full runtime `path`.
- Match using `synthesizedOperationID(method, path)` with the spec-relative path.
- Build the output id using `synthesizedOperationID(m.method, m.rawPath)`.

All operation-id synthesis now flows through the single shared helper already used by `api_list_endpoints` and the metrics resolver (`ResolveOperationID` in `pkg/toolkits/apigateway/operation_resolver.go`), so the sites cannot drift again. This is a general fix across all API connections, not a special-case for `platform-admin`.

## Scope and impact

- Affected: the discover-then-schema flow (`api_list_endpoints` then `api_get_endpoint_schema`) for any connection with a non-empty base path whose operations lack `operationId`s.
- Not affected: `api_invoke_endpoint` and `api_export` take method and path directly, never the synthesized id, so invocation was always functional. Connections that ship explicit `operationId`s, and connections with an empty base path, were already correct.

## Behavioral note

For a connection whose catalog bundles two specs that share a spec-relative path but differ only by base path, the synthesized ids now collide and `api_get_endpoint_schema` returns its existing ambiguity response (asking for the `spec` parameter) instead of resolving one arbitrarily. This matches what `api_list_endpoints` already advertises for that case and is covered by the existing `TestGetEndpointSchema_AmbiguousAcrossSpecs`.

## Testing

- New regression tests in `pkg/toolkits/apigateway/schema_lookup_test.go` drive the real flow: take the id straight from `api_list_endpoints` output and feed it to `api_get_endpoint_schema`, on a spec with a non-empty base path (`/api/v1`) and no `operationId`s. Covers a collection path and a templated path (`{name}`). Confirmed to fail before the fix (`operation_id "GET /admin/personas" not found`) and pass after.
- `make verify` green on this diff: patch coverage 100% (15/15 changed lines), total coverage 88.2%, race tests, golangci-lint, gosec, govulncheck (no vulnerabilities), Semgrep, CodeQL, and GoReleaser dry-run.

## Follow-up

Running instances pick up the fix only after a release and redeploy.
