### PR TITLE
feat(portal): semantic + lexical search for Knowledge & Memory (#516)

### DIFF
--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -890,6 +890,9 @@ func wirePortalOptionalDeps(deps *portal.Deps, p *platform.Platform) {
 	if p.MemoryStore() != nil {
 		deps.MemoryStore = p.MemoryStore()
 	}
+	if ep := p.EmbeddingProvider(); ep != nil {
+		deps.EmbeddingProvider = ep
+	}
 	if pr := p.PersonaRegistry(); pr != nil {
 		tr := p.ToolkitRegistry()
 		deps.PersonaResolver = buildPersonaResolver(pr, tr)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1917,7 +1917,7 @@ Human-uploaded reference materials (SQL templates, runbooks, checklists) accessi
 Assets and collections shared by other users. Two tabs: Assets (grid/table with content type, tags, sharer, permission badge, size, date) and Collections (table with name, sharer, access level, date).
 
 ## Knowledge & Memory
-Personal view of captured insights and memories. Knowledge tab: summary cards, status filters, insight cards with category/status badges, entity URNs. Memory tab: summary cards, status/dimension filters, memory cards with markdown content.
+Personal view of captured insights and memories. Knowledge tab: summary cards, status filters, insight cards with category/status badges, entity URNs. Memory tab: summary cards, status/dimension filters, memory cards with markdown content. Both tabs have a relevance search box (hybrid semantic + lexical when an embedding provider is configured, lexical fallback otherwise) that respects the active filters and is always scoped to the requesting user. Backed by `GET /api/v1/portal/memory/records/search?q=` and `GET /api/v1/portal/knowledge/insights/search?q=`.
 
 ## Prompts
 Personal and available prompt templates. Two tabs: Personal (create/edit/delete own prompts) and Available (global/persona prompts). Search, sortable columns, expandable rows with full content and copy button. Scope badges: Personal, Global, Persona, System.

--- a/docs/server/portal-user.md
+++ b/docs/server/portal-user.md
@@ -154,17 +154,21 @@ Two tabs:
 ### Knowledge
 
 - **Summary cards** — Total insights, pending, approved, and applied counts
+- **Search** — Free-text search ranks your insights by relevance to the query. With an embedding provider configured it uses hybrid (semantic + lexical) ranking; without one it falls back to lexical search. Results respect the active status filter, and search is always scoped to your own insights
 - **Status filters** — All, Pending, Approved, Applied, Rejected
 - **Insight cards** — Category badge, status badge, creation date, insight text (rendered as markdown), linked entity URNs, and review notes
-- **Pagination** — 20 items per page
+- **Pagination** — 20 items per page (browse mode; search returns a ranked top-K)
 
 ### Memory
 
 - **Summary cards** — Total memories, active, stale, and dimension count
+- **Search** — Free-text search ranks your memory records by relevance, using hybrid (semantic + lexical) ranking when an embedding provider is configured and lexical search otherwise. Results respect the active status and dimension filters, and search is always scoped to your own records
 - **Filters** — Status (All, Active, Stale, Archived) and dimension dropdown
 - **Memory cards** — Dimension, category, status, content (rendered as markdown), entity URN links, and stale reason if applicable
 
 See [Knowledge Capture](../knowledge/overview.md) and [Memory Layer](../memory/overview.md) for how these are created during sessions.
+
+The search box mirrors the `memory_recall` tool: it ranks semantically when an embedding provider is configured and degrades to lexical search otherwise, so search always returns results even without embeddings.
 
 ## Prompts
 

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -8210,6 +8210,73 @@ const docTemplate = `{
                 }
             }
         },
+        "/portal/knowledge/insights/search": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Ranks the current user's knowledge insights by relevance to q. Uses hybrid (semantic + lexical) ranking when an embedding provider is configured, falling back to lexical-only otherwise. Always scoped server-side to the requesting user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Search my knowledge insights",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by insight status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max results (default: 20)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.paginatedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/knowledge/insights/stats": {
             "get": {
                 "security": [
@@ -8345,6 +8412,79 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/portal.paginatedResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/memory/records/search": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Ranks the current user's memory records by relevance to q. Uses hybrid (semantic + lexical) ranking when an embedding provider is configured, falling back to lexical-only otherwise. Always scoped server-side to the requesting user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memory"
+                ],
+                "summary": "Search my memory records",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by dimension",
+                        "name": "dimension",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max results (default: 20)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.paginatedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
                         }
                     },
                     "401": {

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -8204,6 +8204,73 @@
                 }
             }
         },
+        "/portal/knowledge/insights/search": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Ranks the current user's knowledge insights by relevance to q. Uses hybrid (semantic + lexical) ranking when an embedding provider is configured, falling back to lexical-only otherwise. Always scoped server-side to the requesting user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Search my knowledge insights",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by insight status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max results (default: 20)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.paginatedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/knowledge/insights/stats": {
             "get": {
                 "security": [
@@ -8339,6 +8406,79 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/portal.paginatedResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/memory/records/search": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Ranks the current user's memory records by relevance to q. Uses hybrid (semantic + lexical) ranking when an embedding provider is configured, falling back to lexical-only otherwise. Always scoped server-side to the requesting user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Memory"
+                ],
+                "summary": "Search my memory records",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by dimension",
+                        "name": "dimension",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max results (default: 20)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.paginatedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
                         }
                     },
                     "401": {

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -8295,6 +8295,51 @@ paths:
       summary: List my insights
       tags:
       - Knowledge
+  /portal/knowledge/insights/search:
+    get:
+      description: Ranks the current user's knowledge insights by relevance to q.
+        Uses hybrid (semantic + lexical) ranking when an embedding provider is configured,
+        falling back to lexical-only otherwise. Always scoped server-side to the requesting
+        user.
+      parameters:
+      - description: Search query
+        in: query
+        name: q
+        required: true
+        type: string
+      - description: Filter by insight status
+        in: query
+        name: status
+        type: string
+      - description: 'Max results (default: 20)'
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/portal.paginatedResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Search my knowledge insights
+      tags:
+      - Knowledge
   /portal/knowledge/insights/stats:
     get:
       description: Returns aggregate statistics for the current user's insights.
@@ -8388,6 +8433,55 @@ paths:
       - ApiKeyAuth: []
       - BearerAuth: []
       summary: List my memory records
+      tags:
+      - Memory
+  /portal/memory/records/search:
+    get:
+      description: Ranks the current user's memory records by relevance to q. Uses
+        hybrid (semantic + lexical) ranking when an embedding provider is configured,
+        falling back to lexical-only otherwise. Always scoped server-side to the requesting
+        user.
+      parameters:
+      - description: Search query
+        in: query
+        name: q
+        required: true
+        type: string
+      - description: Filter by dimension
+        in: query
+        name: dimension
+        type: string
+      - description: Filter by status
+        in: query
+        name: status
+        type: string
+      - description: 'Max results (default: 20)'
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/portal.paginatedResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Search my memory records
       tags:
       - Memory
   /portal/memory/records/stats:

--- a/pkg/embedding/kind_test.go
+++ b/pkg/embedding/kind_test.go
@@ -30,6 +30,24 @@ func TestIsConfigured(t *testing.T) {
 	}
 }
 
+// TestIsZeroVector covers the shared hybrid-vs-lexical fallback signal:
+// an all-zero vector (the noop provider's output) is "zero"; any non-zero
+// component, including a single one in any position, is not.
+func TestIsZeroVector(t *testing.T) {
+	if !IsZeroVector(nil) {
+		t.Errorf("IsZeroVector(nil) = false; want true")
+	}
+	if !IsZeroVector([]float32{0, 0, 0}) {
+		t.Errorf("IsZeroVector(all-zero) = false; want true")
+	}
+	if IsZeroVector([]float32{0, 0, 0.0001}) {
+		t.Errorf("IsZeroVector(trailing non-zero) = true; want false")
+	}
+	if IsZeroVector([]float32{-1, 0, 0}) {
+		t.Errorf("IsZeroVector(leading non-zero) = true; want false")
+	}
+}
+
 // TestModelName returns the provider's model when exposed, else "". The
 // memory write path and the indexjobs memory Sink both read the model
 // this way, so they must agree.

--- a/pkg/embedding/provider.go
+++ b/pkg/embedding/provider.go
@@ -51,6 +51,21 @@ func IsConfigured(p Provider) bool {
 	return p.Kind() != KindNoop
 }
 
+// IsZeroVector reports whether every component of v is zero, the signature
+// of the noop provider's output (an unconfigured embedder). Cosine
+// similarity against a zero vector is meaningless, so request-path callers
+// (memory_recall, the portal knowledge/memory search) use this to degrade
+// to lexical ranking. Shared so every surface makes the same hybrid-vs-
+// lexical decision and they cannot drift.
+func IsZeroVector(v []float32) bool {
+	for _, x := range v {
+		if x != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // modelNamed is the optional interface a concrete provider implements
 // to expose its underlying model identifier (e.g. "nomic-embed-text").
 // It is kept off the Provider interface because not every provider has

--- a/pkg/memory/hybrid_search_test.go
+++ b/pkg/memory/hybrid_search_test.go
@@ -159,6 +159,36 @@ func TestHybridSearch_PersonaAndStatusFilters(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestHybridSearch_CreatedByAndDimensionFilters verifies the per-user and
+// per-dimension scope predicates (the portal's "my knowledge" search
+// boundary) are bound in order after the vector and query: created_by=$3,
+// dimension=$4, persona=$5, status=$6.
+func TestHybridSearch_CreatedByAndDimensionFilters(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	store := NewPostgresStore(db)
+
+	mock.ExpectQuery("UNION ALL").
+		WithArgs(sqlmock.AnyArg(), "orders", "user@example.com", DimensionKnowledge, "analyst", StatusActive).
+		WillReturnRows(sqlmock.NewRows(hybridColumns))
+
+	_, err = store.HybridSearch(context.Background(), HybridQuery{
+		Embedding: []float32{0.1},
+		QueryText: "orders",
+		CreatedBy: "user@example.com",
+		Dimension: DimensionKnowledge,
+		Persona:   "analyst",
+		Status:    StatusActive,
+		Limit:     10,
+	})
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestHybridSearch_QueryError(t *testing.T) {
 	t.Parallel()
 
@@ -281,6 +311,35 @@ func TestLexicalSearch_SurfacesNullEmbeddingRows(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestLexicalSearch_CreatedByAndDimensionFilters verifies the lexical arm
+// binds the same scope predicates after its single $1=query parameter:
+// created_by=$2, dimension=$3, persona=$4, status=$5. This is the
+// embedder-unavailable path of the portal's per-user knowledge search.
+func TestLexicalSearch_CreatedByAndDimensionFilters(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	store := NewPostgresStore(db)
+
+	mock.ExpectQuery("ts_rank_cd").
+		WithArgs("orders_fact", "user@example.com", DimensionKnowledge, "analyst", StatusActive).
+		WillReturnRows(sqlmock.NewRows(lexicalColumns))
+
+	_, err = store.LexicalSearch(context.Background(), LexicalQuery{
+		QueryText: "orders_fact",
+		CreatedBy: "user@example.com",
+		Dimension: DimensionKnowledge,
+		Persona:   "analyst",
+		Status:    StatusActive,
+		Limit:     10,
+	})
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestLexicalSearch_QueryError(t *testing.T) {
 	t.Parallel()
 
@@ -294,6 +353,58 @@ func TestLexicalSearch_QueryError(t *testing.T) {
 	_, err = store.LexicalSearch(context.Background(), LexicalQuery{QueryText: "q", Limit: 10})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "lexical search")
+}
+
+// --- VectorSearch ---
+
+// TestVectorSearch_CreatedByAndDimensionFilters covers the cosine arm now
+// that it shares scopeFilters: with only $1=vector fixed, the scope
+// predicates start at $2 (created_by=$2, dimension=$3, status=$4). It also
+// asserts the returned row is scored and MinScore filtering is applied.
+func TestVectorSearch_CreatedByAndDimensionFilters(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	store := NewPostgresStore(db)
+
+	rows := sqlmock.NewRows(lexicalColumns) // record cols + score, same shape
+	addLexicalRow(rows, "above", true, 0.80)
+	addLexicalRow(rows, "below", true, 0.10) // dropped by MinScore
+	mock.ExpectQuery("ORDER BY embedding").
+		WithArgs(sqlmock.AnyArg(), "user@example.com", DimensionKnowledge, StatusActive).
+		WillReturnRows(rows)
+
+	got, err := store.VectorSearch(context.Background(), VectorQuery{
+		Embedding: []float32{0.1, 0.2},
+		CreatedBy: "user@example.com",
+		Dimension: DimensionKnowledge,
+		Status:    StatusActive,
+		MinScore:  0.5,
+		Limit:     10,
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1, "MinScore must drop the below-threshold row")
+	assert.Equal(t, "above", got[0].Record.ID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestArchivedExclusion pins the rule that resolves the archived-status
+// search contradiction: the default `status <> 'archived'` predicate is
+// emitted only when no explicit status is requested. An explicit status
+// (including "archived") is enforced separately by scopeFilters, so it
+// must NOT also get the exclusion, or `status <> 'archived' AND status =
+// 'archived'` would match nothing.
+func TestArchivedExclusion(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, " AND status <> 'archived'", archivedExclusion(""),
+		"no explicit status must default to excluding archived (recall semantics)")
+	assert.Equal(t, "", archivedExclusion("archived"),
+		"an explicit archived filter must not also exclude archived")
+	assert.Equal(t, "", archivedExclusion(StatusActive),
+		"any explicit status governs fully; no default exclusion")
 }
 
 func TestClampStoreLimit(t *testing.T) {

--- a/pkg/memory/postgres.go
+++ b/pkg/memory/postgres.go
@@ -304,19 +304,11 @@ func (s *postgresStore) VectorSearch(ctx context.Context, query VectorQuery) ([]
 
 	// Build SQL manually to avoid squirrel placeholder collision with the
 	// vector parameter ($1) used in the ORDER BY and SELECT expressions.
-	args := []any{pgvector.NewVector(query.Embedding)}
-	paramIdx := 2
+	// Optional scope predicates start at $2 (only $1=vector is fixed).
+	filterClause, filterArgs := scopeFilters(query.CreatedBy, query.Dimension, query.Persona, query.Status, 2)
+	args := append([]any{pgvector.NewVector(query.Embedding)}, filterArgs...)
 
-	where := "WHERE embedding IS NOT NULL AND status <> 'archived'"
-	if query.Persona != "" {
-		where += fmt.Sprintf(" AND persona = $%d", paramIdx)
-		args = append(args, query.Persona)
-		paramIdx++
-	}
-	if query.Status != "" {
-		where += fmt.Sprintf(" AND status = $%d", paramIdx)
-		args = append(args, query.Status)
-	}
+	where := "WHERE embedding IS NOT NULL" + archivedExclusion(query.Status) + filterClause
 
 	sqlStr := fmt.Sprintf( // #nosec G201 -- tableName is a constant, cols are hardcoded, where uses parameterized placeholders, limit is a sanitized int
 		"SELECT %s, 1 - (embedding <=> $1) AS score FROM %s %s ORDER BY embedding <=> $1 LIMIT %d",
@@ -354,27 +346,53 @@ const ftsExpr = "to_tsvector('english', content)"
 const ftsQuery = "plainto_tsquery('english', $2)"
 
 // Scope-filter starting parameter indices. HybridSearch binds $1=vector
-// and $2=query, so its optional persona/status predicates start at $3;
-// LexicalSearch binds only $1=query, so its filters start at $2.
+// and $2=query, so its optional created_by/dimension/persona/status
+// predicates start at $3; LexicalSearch binds only $1=query, so its
+// filters start at $2. VectorSearch binds only $1=vector and passes 2.
 const (
 	hybridFilterStartParam  = 3
 	lexicalFilterStartParam = 2
 )
 
-// scopeFilters builds the optional persona/status predicates shared by
-// the search arms, parameterized from startIdx. Returns the clause
-// (prefixed with " AND " when non-empty) and the matching args so the
-// caller can append them after the fixed query/vector parameters.
-func scopeFilters(persona, status string, startIdx int) (clause string, args []any) {
-	idx := startIdx
-	if persona != "" {
-		clause += fmt.Sprintf(" AND persona = $%d", idx)
-		args = append(args, persona)
-		idx++
+// archivedExclusion returns the default predicate that hides archived
+// rows. It applies only when the caller requested no explicit status: an
+// explicit status (including "archived") is enforced by scopeFilters and
+// governs fully, so a portal search can surface archived rows when the
+// user asks for them, while recall and the default (status-unset) search
+// still exclude archived. Without this, a hardcoded `status <> 'archived'`
+// base ANDed with an explicit `status = 'archived'` is unsatisfiable and
+// silently returns zero rows.
+func archivedExclusion(status string) string {
+	if status == "" {
+		return " AND status <> 'archived'"
 	}
-	if status != "" {
-		clause += fmt.Sprintf(" AND status = $%d", idx)
-		args = append(args, status)
+	return ""
+}
+
+// scopeFilters builds the optional created_by/dimension/persona/status
+// predicates shared by the search arms, parameterized from startIdx.
+// Returns the clause (prefixed with " AND " when non-empty) and the
+// matching args so the caller can append them after the fixed
+// query/vector parameters. created_by comes first because per-user
+// scoping is the portal's security boundary (a user must not be able to
+// search another user's records); the args slice is appended in the same
+// order the placeholders are emitted.
+func scopeFilters(createdBy, dimension, persona, status string, startIdx int) (clause string, args []any) {
+	idx := startIdx
+	for _, f := range []struct {
+		col, val string
+	}{
+		{colCreatedBy, createdBy},
+		{colDimension, dimension},
+		{colPersona, persona},
+		{colStatus, status},
+	} {
+		if f.val == "" {
+			continue
+		}
+		clause += fmt.Sprintf(" AND %s = $%d", f.col, idx)
+		args = append(args, f.val)
+		idx++
 	}
 	return clause, args
 }
@@ -390,7 +408,8 @@ func scopeFilters(persona, status string, startIdx int) (clause string, args []a
 // union is deduped by id (keeping the higher fused score) and sorted.
 func (s *postgresStore) HybridSearch(ctx context.Context, query HybridQuery) ([]ScoredRecord, error) {
 	limit := clampStoreLimit(query.Limit)
-	filterClause, filterArgs := scopeFilters(query.Persona, query.Status, hybridFilterStartParam)
+	filterClause, filterArgs := scopeFilters(query.CreatedBy, query.Dimension, query.Persona, query.Status, hybridFilterStartParam)
+	archived := archivedExclusion(query.Status)
 	args := make([]any, 0, 2+len(filterArgs))
 	args = append(args, pgvector.NewVector(query.Embedding), query.QueryText)
 	args = append(args, filterArgs...)
@@ -400,14 +419,14 @@ func (s *postgresStore) HybridSearch(ctx context.Context, query HybridQuery) ([]
 	// sanitized int.
 	vecArm := fmt.Sprintf(
 		"SELECT %s, 1 - (embedding <=> $1) AS vec_score, (%s @@ %s) AS lex_match "+
-			"FROM %s WHERE embedding IS NOT NULL AND status <> 'archived'%s "+
+			"FROM %s WHERE embedding IS NOT NULL%s%s "+
 			"ORDER BY embedding <=> $1 LIMIT %d",
-		rawRecordCols, ftsExpr, ftsQuery, tableName, filterClause, limit)
+		rawRecordCols, ftsExpr, ftsQuery, tableName, archived, filterClause, limit)
 	lexArm := fmt.Sprintf(
 		"SELECT %s, CASE WHEN embedding IS NOT NULL THEN 1 - (embedding <=> $1) ELSE 0 END AS vec_score, TRUE AS lex_match "+
-			"FROM %s WHERE %s @@ %s AND status <> 'archived'%s "+
+			"FROM %s WHERE %s @@ %s%s%s "+
 			"ORDER BY ts_rank_cd(%s, %s) DESC LIMIT %d",
-		rawRecordCols, tableName, ftsExpr, ftsQuery, filterClause, ftsExpr, ftsQuery, limit)
+		rawRecordCols, tableName, ftsExpr, ftsQuery, archived, filterClause, ftsExpr, ftsQuery, limit)
 	// #nosec G202 -- vecArm and lexArm are assembled from constant column
 	// and expression strings with parameterized placeholders; no user
 	// input is concatenated into the SQL.
@@ -434,7 +453,7 @@ func (s *postgresStore) HybridSearch(ctx context.Context, query HybridQuery) ([]
 // as the other arms.
 func (s *postgresStore) LexicalSearch(ctx context.Context, query LexicalQuery) ([]ScoredRecord, error) {
 	limit := clampStoreLimit(query.Limit)
-	filterClause, filterArgs := scopeFilters(query.Persona, query.Status, lexicalFilterStartParam)
+	filterClause, filterArgs := scopeFilters(query.CreatedBy, query.Dimension, query.Persona, query.Status, lexicalFilterStartParam)
 	args := make([]any, 0, 1+len(filterArgs))
 	args = append(args, query.QueryText)
 	args = append(args, filterArgs...)
@@ -446,9 +465,9 @@ func (s *postgresStore) LexicalSearch(ctx context.Context, query LexicalQuery) (
 	// persona, status are parameterized; limit is a sanitized int.
 	sqlStr := fmt.Sprintf(
 		"SELECT %s, ts_rank_cd(%s, %s) AS score "+
-			"FROM %s WHERE %s @@ %s AND status <> 'archived'%s "+
+			"FROM %s WHERE %s @@ %s%s%s "+
 			"ORDER BY score DESC LIMIT %d",
-		rawRecordCols, ftsExpr, lexQuery, tableName, ftsExpr, lexQuery, filterClause, limit)
+		rawRecordCols, ftsExpr, lexQuery, tableName, ftsExpr, lexQuery, archivedExclusion(query.Status), filterClause, limit)
 
 	rows, err := s.db.QueryContext(ctx, sqlStr, args...)
 	if err != nil {

--- a/pkg/memory/search_types.go
+++ b/pkg/memory/search_types.go
@@ -1,10 +1,19 @@
 package memory
 
 // VectorQuery defines parameters for vector similarity search.
+//
+// CreatedBy and Dimension are optional scope filters. CreatedBy restricts
+// results to a single owner (the portal's per-user "my knowledge" search
+// scopes by the caller's email so a user cannot search another user's
+// records); Dimension restricts to one LOCOMO dimension (the Knowledge
+// tab scopes to DimensionKnowledge, since insights are knowledge-dimension
+// memory records). Persona and Status mirror the other scope filters.
 type VectorQuery struct {
 	Embedding []float32
 	Limit     int
 	MinScore  float64
+	CreatedBy string
+	Dimension string
 	Persona   string
 	Status    string
 }
@@ -12,12 +21,14 @@ type VectorQuery struct {
 // HybridQuery defines parameters for hybrid (vector + lexical) recall.
 // Embedding drives the cosine arm; QueryText drives the lexical arm
 // (Postgres full-text). A row matching either arm is a candidate; the
-// two signals are fused per row by fuseHybridScore. Persona and Status
-// are optional scope filters mirroring VectorQuery.
+// two signals are fused per row by fuseHybridScore. CreatedBy, Dimension,
+// Persona, and Status are optional scope filters mirroring VectorQuery.
 type HybridQuery struct {
 	Embedding []float32
 	QueryText string
 	Limit     int
+	CreatedBy string
+	Dimension string
 	Persona   string
 	Status    string
 }
@@ -26,10 +37,13 @@ type HybridQuery struct {
 // graceful-degradation path when no embedding provider is available.
 // Unlike the vector arm, lexical search does not filter on a non-null
 // embedding, so it also surfaces rows whose embedding was never
-// computed (saved during an embedder outage).
+// computed (saved during an embedder outage). CreatedBy, Dimension,
+// Persona, and Status are optional scope filters mirroring VectorQuery.
 type LexicalQuery struct {
 	QueryText string
 	Limit     int
+	CreatedBy string
+	Dimension string
 	Persona   string
 	Status    string
 }

--- a/pkg/portal/handler.go
+++ b/pkg/portal/handler.go
@@ -20,21 +20,26 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/txn2/mcp-data-platform/pkg/audit"
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
 	"github.com/txn2/mcp-data-platform/pkg/memory"
 	"github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
 )
 
 // Common error messages, path value keys, and query parameter names.
 const (
-	errAuthRequired    = "authentication required"
-	errAssetNotFound   = "asset not found"
-	errAssetDeleted    = "asset has been deleted"
-	errStorageNotReady = "content storage not configured"
-	errAccessDenied    = "access denied"
-	pathKeyID          = "id"
-	paramLimit         = "limit"
-	paramOffset        = "offset"
-	headerContentType  = "Content-Type"
+	errAuthRequired        = "authentication required"
+	errSearchScopeRequired = "a user identity (email) is required to scope search results"
+	errAssetNotFound       = "asset not found"
+	errAssetDeleted        = "asset has been deleted"
+	errStorageNotReady     = "content storage not configured"
+	errAccessDenied        = "access denied"
+	// logKeyError is the structured-logging key for an error value.
+	logKeyError       = "error"
+	pathKeyID         = "id"
+	paramLimit        = "limit"
+	paramOffset       = "offset"
+	paramQuery        = "q"
+	headerContentType = "Content-Type"
 )
 
 // defaultNoticeText is the notice shown on public shares when no custom text is provided.
@@ -53,9 +58,24 @@ type InsightReader interface {
 	Stats(ctx context.Context, filter knowledge.InsightFilter) (*knowledge.InsightStats, error)
 }
 
-// MemoryReader provides read-only access to user memory records.
+// MemoryReader provides read-only access to user memory records. The
+// search methods back the portal's per-user "my knowledge" search: both
+// queries are scoped to the caller via CreatedBy server-side, so a user
+// can never search another user's records.
 type MemoryReader interface {
 	List(ctx context.Context, filter memory.Filter) ([]memory.Record, int, error)
+	HybridSearch(ctx context.Context, q memory.HybridQuery) ([]memory.ScoredRecord, error)
+	LexicalSearch(ctx context.Context, q memory.LexicalQuery) ([]memory.ScoredRecord, error)
+}
+
+// InsightSearcher is the optional relevance-search capability of the
+// insight store. Only the memory-backed adapter implements it (insights
+// are knowledge-dimension memory records there); the legacy separate-table
+// store, used only when the memory layer is disabled, has no embeddings
+// and does not implement it. The knowledge-search route is registered only
+// when the wired InsightStore satisfies this interface.
+type InsightSearcher interface {
+	Search(ctx context.Context, q knowledge.InsightSearchQuery) ([]knowledge.ScoredInsight, error)
 }
 
 // PersonaInfo holds resolved persona details for the current user.
@@ -85,6 +105,7 @@ type Deps struct {
 	AuditMetrics       AuditMetrics
 	InsightStore       InsightReader
 	MemoryStore        MemoryReader
+	EmbeddingProvider  embedding.Provider
 	PersonaResolver    PersonaResolver
 	// Platform brand (far right of public viewer header)
 	BrandName    string // display name (default: "MCP Data Platform")
@@ -186,12 +207,18 @@ func (h *Handler) registerRoutes() {
 	if h.deps.InsightStore != nil {
 		h.mux.HandleFunc("GET /api/v1/portal/knowledge/insights", h.listMyInsights)
 		h.mux.HandleFunc("GET /api/v1/portal/knowledge/insights/stats", h.getMyInsightStats)
+		// Relevance search is registered only when the wired insight store
+		// supports it (memory-backed deployments); see InsightSearcher.
+		if _, ok := h.deps.InsightStore.(InsightSearcher); ok {
+			h.mux.HandleFunc("GET /api/v1/portal/knowledge/insights/search", h.searchMyInsights)
+		}
 	}
 
 	// Memory routes (user-scoped memory records)
 	if h.deps.MemoryStore != nil {
 		h.mux.HandleFunc("GET /api/v1/portal/memory/records", h.listMyMemories)
 		h.mux.HandleFunc("GET /api/v1/portal/memory/records/stats", h.getMyMemoryStats)
+		h.mux.HandleFunc("GET /api/v1/portal/memory/records/search", h.searchMyMemories)
 	}
 
 	// Public routes (rate limited)
@@ -822,7 +849,7 @@ func (h *Handler) cleanupOrphanedS3(ctx context.Context, bucket, key string) {
 	}
 	if err := h.deps.S3Client.DeleteObject(ctx, bucket, key); err != nil {
 		slog.Warn("failed to clean up orphaned S3 object", // #nosec G706 -- structured log, not user-facing
-			"bucket", bucket, "key", key, "error", err)
+			"bucket", bucket, "key", key, logKeyError, err)
 	}
 }
 
@@ -1702,6 +1729,182 @@ func (h *Handler) getMyMemoryStats(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, stats)
 }
 
+// scoredMemoryRecord is a memory record plus its search relevance score.
+// The embedded record preserves the same JSON shape as the list endpoint,
+// so the only addition the client sees is the "score" field.
+type scoredMemoryRecord struct {
+	memory.Record
+	Score float64 `json:"score"`
+}
+
+// scoredInsightRecord is an insight plus its search relevance score,
+// embedding the insight to preserve the list endpoint's JSON shape.
+type scoredInsightRecord struct {
+	knowledge.Insight
+	Score float64 `json:"score"`
+}
+
+// searchMyMemories handles GET /api/v1/portal/memory/records/search.
+//
+// @Summary      Search my memory records
+// @Description  Ranks the current user's memory records by relevance to q. Uses hybrid (semantic + lexical) ranking when an embedding provider is configured, falling back to lexical-only otherwise. Always scoped server-side to the requesting user.
+// @Tags         Memory
+// @Produce      json
+// @Param        q          query  string   true   "Search query"
+// @Param        dimension  query  string   false  "Filter by dimension"
+// @Param        status     query  string   false  "Filter by status"
+// @Param        limit      query  integer  false  "Max results (default: 20)"
+// @Success      200  {object}  paginatedResponse
+// @Failure      400  {object}  problemDetail
+// @Failure      401  {object}  problemDetail
+// @Failure      500  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/memory/records/search [get]
+func (h *Handler) searchMyMemories(w http.ResponseWriter, r *http.Request) {
+	user := GetUser(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, errAuthRequired)
+		return
+	}
+	// Email is the sole server-side scoping key. An empty email would make
+	// scopeFilters omit the created_by predicate and return every user's
+	// records, so fail closed rather than run an unscoped search (#516).
+	if user.Email == "" {
+		writeError(w, http.StatusForbidden, errSearchScopeRequired)
+		return
+	}
+
+	query := strings.TrimSpace(r.URL.Query().Get(paramQuery))
+	if query == "" {
+		writeError(w, http.StatusBadRequest, "query parameter 'q' is required")
+		return
+	}
+
+	limit := intParam(r, paramLimit, memory.DefaultLimit)
+	emb := h.embedSearchQuery(r.Context(), query)
+
+	var (
+		scored []memory.ScoredRecord
+		err    error
+	)
+	if len(emb) > 0 {
+		scored, err = h.deps.MemoryStore.HybridSearch(r.Context(), memory.HybridQuery{
+			Embedding: emb,
+			QueryText: query,
+			CreatedBy: user.Email,
+			Dimension: r.URL.Query().Get("dimension"),
+			Status:    r.URL.Query().Get("status"),
+			Limit:     limit,
+		})
+	} else {
+		scored, err = h.deps.MemoryStore.LexicalSearch(r.Context(), memory.LexicalQuery{
+			QueryText: query,
+			CreatedBy: user.Email,
+			Dimension: r.URL.Query().Get("dimension"),
+			Status:    r.URL.Query().Get("status"),
+			Limit:     limit,
+		})
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to search memory records")
+		return
+	}
+
+	results := make([]scoredMemoryRecord, 0, len(scored))
+	for i := range scored {
+		results = append(results, scoredMemoryRecord{Record: scored[i].Record, Score: scored[i].Score})
+	}
+	writeJSON(w, http.StatusOK, paginatedResponse{
+		Data: results, Total: len(results), Limit: limit, Offset: 0,
+	})
+}
+
+// searchMyInsights handles GET /api/v1/portal/knowledge/insights/search.
+//
+// @Summary      Search my knowledge insights
+// @Description  Ranks the current user's knowledge insights by relevance to q. Uses hybrid (semantic + lexical) ranking when an embedding provider is configured, falling back to lexical-only otherwise. Always scoped server-side to the requesting user.
+// @Tags         Knowledge
+// @Produce      json
+// @Param        q       query  string   true   "Search query"
+// @Param        status  query  string   false  "Filter by insight status"
+// @Param        limit   query  integer  false  "Max results (default: 20)"
+// @Success      200  {object}  paginatedResponse
+// @Failure      400  {object}  problemDetail
+// @Failure      401  {object}  problemDetail
+// @Failure      500  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/knowledge/insights/search [get]
+func (h *Handler) searchMyInsights(w http.ResponseWriter, r *http.Request) {
+	user := GetUser(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, errAuthRequired)
+		return
+	}
+
+	// The route is only registered when the store implements InsightSearcher,
+	// so this assertion holds; guard defensively regardless.
+	if user.Email == "" {
+		writeError(w, http.StatusForbidden, errSearchScopeRequired)
+		return
+	}
+
+	searcher, ok := h.deps.InsightStore.(InsightSearcher)
+	if !ok {
+		writeError(w, http.StatusNotFound, "knowledge search not available")
+		return
+	}
+
+	query := strings.TrimSpace(r.URL.Query().Get(paramQuery))
+	if query == "" {
+		writeError(w, http.StatusBadRequest, "query parameter 'q' is required")
+		return
+	}
+
+	limit := intParam(r, paramLimit, knowledge.DefaultLimit)
+	scored, err := searcher.Search(r.Context(), knowledge.InsightSearchQuery{
+		QueryText:  query,
+		Embedding:  h.embedSearchQuery(r.Context(), query),
+		CapturedBy: user.Email,
+		Status:     r.URL.Query().Get("status"),
+		Limit:      limit,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to search insights")
+		return
+	}
+
+	results := make([]scoredInsightRecord, 0, len(scored))
+	for i := range scored {
+		results = append(results, scoredInsightRecord{Insight: scored[i].Insight, Score: scored[i].Score})
+	}
+	writeJSON(w, http.StatusOK, paginatedResponse{
+		Data: results, Total: len(results), Limit: limit, Offset: 0,
+	})
+}
+
+// embedSearchQuery returns the query embedding when an embedding provider
+// is configured and reachable, or nil to signal the lexical-only fallback.
+// A nil/noop provider, an embed error, or a zero vector (the noop
+// provider's output) all degrade to lexical search, mirroring the
+// memory_recall tool's behavior so the portal and the agent surface rank
+// the same way.
+func (h *Handler) embedSearchQuery(ctx context.Context, query string) []float32 {
+	if !embedding.IsConfigured(h.deps.EmbeddingProvider) {
+		return nil
+	}
+	emb, err := h.deps.EmbeddingProvider.Embed(ctx, query)
+	if err != nil {
+		slog.Warn("portal search embedding failed; falling back to lexical", logKeyError, err)
+		return nil
+	}
+	if embedding.IsZeroVector(emb) {
+		return nil
+	}
+	return emb
+}
+
 // --- Helpers ---
 
 // statusResponse is a generic status response.
@@ -1972,7 +2175,7 @@ func (h *Handler) performAssetCopy(ctx context.Context, asset *Asset, user *User
 		}
 		if _, err := h.deps.VersionStore.CreateVersion(ctx, v1); err != nil {
 			slog.Warn("failed to create initial version for copied asset", // #nosec G706 -- structured log, not user-facing
-				"asset_id", newID, "error", err)
+				"asset_id", newID, logKeyError, err)
 		}
 	}
 
@@ -2120,7 +2323,7 @@ func (h *Handler) createAsset(w http.ResponseWriter, r *http.Request) {
 	}
 	if _, err := h.deps.VersionStore.CreateVersion(ctx, v1); err != nil {
 		slog.Warn("failed to create initial version for new asset", // #nosec G706 -- structured log, not user-facing
-			"asset_id", newID, "error", err)
+			"asset_id", newID, logKeyError, err)
 	}
 
 	writeJSON(w, http.StatusCreated, newAsset)

--- a/pkg/portal/handler_test.go
+++ b/pkg/portal/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/txn2/mcp-data-platform/pkg/audit"
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
 	"github.com/txn2/mcp-data-platform/pkg/memory"
 	"github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
 )
@@ -2169,6 +2170,149 @@ func (m *mockInsightStore) Stats(_ context.Context, f knowledge.InsightFilter) (
 
 var _ InsightReader = (*mockInsightStore)(nil)
 
+// mockSearchableInsightStore implements both InsightReader and
+// InsightSearcher, modeling the memory-backed adapter that powers
+// knowledge search in real deployments.
+type mockSearchableInsightStore struct {
+	mockInsightStore
+	searchResult []knowledge.ScoredInsight
+	searchErr    error
+	lastQuery    knowledge.InsightSearchQuery
+}
+
+func (m *mockSearchableInsightStore) Search(_ context.Context, q knowledge.InsightSearchQuery) ([]knowledge.ScoredInsight, error) {
+	m.lastQuery = q
+	return m.searchResult, m.searchErr
+}
+
+var (
+	_ InsightReader   = (*mockSearchableInsightStore)(nil)
+	_ InsightSearcher = (*mockSearchableInsightStore)(nil)
+)
+
+func newKnowledgeSearchHandler(store InsightReader, emb embedding.Provider, user *User) *Handler {
+	return NewHandler(Deps{
+		AssetStore:        &mockAssetStore{},
+		ShareStore:        &mockShareStore{},
+		InsightStore:      store,
+		EmbeddingProvider: emb,
+	}, testAuthMiddleware(user))
+}
+
+func TestSearchMyInsights_Success(t *testing.T) {
+	store := &mockSearchableInsightStore{
+		searchResult: []knowledge.ScoredInsight{
+			{Insight: knowledge.Insight{ID: "ins-1", CapturedBy: "user-1@example.com", Status: "approved"}, Score: 0.93},
+		},
+	}
+	user := &User{UserID: "user-1", Email: "user-1@example.com"}
+	h := newKnowledgeSearchHandler(store, &fakeEmbedder{vec: []float32{0.1, 0.2, 0.3}}, user)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/knowledge/insights/search?q=churn&status=approved&limit=7", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "user-1@example.com", store.lastQuery.CapturedBy, "search must be scoped to the caller")
+	assert.Equal(t, "churn", store.lastQuery.QueryText)
+	assert.Equal(t, "approved", store.lastQuery.Status)
+	assert.Equal(t, 7, store.lastQuery.Limit)
+	assert.NotEmpty(t, store.lastQuery.Embedding, "configured embedder must supply a query vector")
+
+	var resp struct {
+		Total int `json:"total"`
+		Data  []struct {
+			ID    string  `json:"id"`
+			Score float64 `json:"score"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Equal(t, 1, resp.Total)
+	require.Len(t, resp.Data, 1)
+	assert.InDelta(t, 0.93, resp.Data[0].Score, 1e-6)
+	assert.Equal(t, "ins-1", resp.Data[0].ID)
+}
+
+func TestSearchMyInsights_LexicalWhenNoEmbedder(t *testing.T) {
+	store := &mockSearchableInsightStore{}
+	user := &User{UserID: "user-1", Email: "user-1@example.com"}
+	h := newKnowledgeSearchHandler(store, nil, user)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/knowledge/insights/search?q=churn", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, store.lastQuery.Embedding, "no embedder means a lexical (no-vector) query")
+}
+
+// TestSearchMyInsights_RouteNotRegisteredWithoutSearcher proves the route
+// is gated on the InsightSearcher capability: a plain InsightReader (the
+// legacy separate-table store) does not get a search route, so the path
+// 404s rather than 500-ing or silently misbehaving.
+func TestSearchMyInsights_RouteNotRegisteredWithoutSearcher(t *testing.T) {
+	store := &mockInsightStore{} // InsightReader only, no Search
+	user := &User{UserID: "user-1", Email: "user-1@example.com"}
+	h := newKnowledgeTestHandler(store, user)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/knowledge/insights/search?q=churn", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestSearchMyInsights_MissingQuery(t *testing.T) {
+	store := &mockSearchableInsightStore{}
+	user := &User{UserID: "user-1", Email: "user-1@example.com"}
+	h := newKnowledgeSearchHandler(store, nil, user)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/knowledge/insights/search?q=", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSearchMyInsights_Unauthenticated(t *testing.T) {
+	h := newKnowledgeSearchHandler(&mockSearchableInsightStore{}, nil, nil)
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/knowledge/insights/search?q=x", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestSearchMyInsights_EmptyEmailFailsClosed(t *testing.T) {
+	store := &mockSearchableInsightStore{}
+	user := &User{UserID: "u1", Email: ""}
+	h := newKnowledgeSearchHandler(store, nil, user)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/knowledge/insights/search?q=churn", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, knowledge.InsightSearchQuery{}, store.lastQuery,
+		"no search may run without a scoping email")
+}
+
+func TestSearchMyInsights_Error(t *testing.T) {
+	store := &mockSearchableInsightStore{searchErr: fmt.Errorf("db error")}
+	user := &User{UserID: "user-1", Email: "user-1@example.com"}
+	h := newKnowledgeSearchHandler(store, nil, user)
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/knowledge/insights/search?q=x", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
 func newKnowledgeTestHandler(store *mockInsightStore, user *User) *Handler {
 	return NewHandler(Deps{
 		AssetStore:   &mockAssetStore{},
@@ -3773,15 +3917,29 @@ func TestVersionedExtension(t *testing.T) {
 // --- Memory mock and tests ---
 
 type mockMemoryStore struct {
-	listResult []memory.Record
-	listTotal  int
-	listErr    error
-	lastFilter memory.Filter
+	listResult   []memory.Record
+	listTotal    int
+	listErr      error
+	lastFilter   memory.Filter
+	searchResult []memory.ScoredRecord
+	searchErr    error
+	lastHybridQ  *memory.HybridQuery
+	lastLexicalQ *memory.LexicalQuery
 }
 
 func (m *mockMemoryStore) List(_ context.Context, f memory.Filter) ([]memory.Record, int, error) {
 	m.lastFilter = f
 	return m.listResult, m.listTotal, m.listErr
+}
+
+func (m *mockMemoryStore) HybridSearch(_ context.Context, q memory.HybridQuery) ([]memory.ScoredRecord, error) {
+	m.lastHybridQ = &q
+	return m.searchResult, m.searchErr
+}
+
+func (m *mockMemoryStore) LexicalSearch(_ context.Context, q memory.LexicalQuery) ([]memory.ScoredRecord, error) {
+	m.lastLexicalQ = &q
+	return m.searchResult, m.searchErr
 }
 
 var _ MemoryReader = (*mockMemoryStore)(nil)
@@ -3792,6 +3950,194 @@ func newMemoryTestHandler(store *mockMemoryStore, user *User) *Handler {
 		ShareStore:  &mockShareStore{},
 		MemoryStore: store,
 	}, testAuthMiddleware(user))
+}
+
+// fakeEmbedder is a configured (non-noop) embedding provider for tests.
+// It returns a fixed non-zero vector so the search handlers take the
+// hybrid path; set embedErr to exercise the lexical fallback on error.
+type fakeEmbedder struct {
+	vec      []float32
+	embedErr error
+}
+
+func (f *fakeEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	if f.embedErr != nil {
+		return nil, f.embedErr
+	}
+	return f.vec, nil
+}
+
+func (f *fakeEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = f.vec
+	}
+	return out, nil
+}
+func (*fakeEmbedder) Dimension() int { return 3 }
+func (*fakeEmbedder) Kind() string   { return embedding.KindOllama }
+
+func newMemorySearchHandler(store *mockMemoryStore, emb embedding.Provider, user *User) *Handler {
+	return NewHandler(Deps{
+		AssetStore:        &mockAssetStore{},
+		ShareStore:        &mockShareStore{},
+		MemoryStore:       store,
+		EmbeddingProvider: emb,
+	}, testAuthMiddleware(user))
+}
+
+func TestSearchMyMemories_HybridWhenEmbedderConfigured(t *testing.T) {
+	store := &mockMemoryStore{
+		searchResult: []memory.ScoredRecord{
+			{Record: memory.Record{ID: "mem-1", CreatedBy: "alice@example.com", Content: "churn"}, Score: 0.87},
+		},
+	}
+	user := &User{UserID: "u1", Email: "alice@example.com"}
+	h := newMemorySearchHandler(store, &fakeEmbedder{vec: []float32{0.1, 0.2, 0.3}}, user)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/memory/records/search?q=churn&dimension=event&status=active&limit=5", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, store.lastHybridQ, "configured embedder must select hybrid search")
+	assert.Nil(t, store.lastLexicalQ)
+	assert.Equal(t, "alice@example.com", store.lastHybridQ.CreatedBy, "search must be scoped to the caller")
+	assert.Equal(t, "event", store.lastHybridQ.Dimension)
+	assert.Equal(t, "active", store.lastHybridQ.Status)
+	assert.Equal(t, "churn", store.lastHybridQ.QueryText)
+	assert.Equal(t, 5, store.lastHybridQ.Limit)
+
+	var resp struct {
+		Total int `json:"total"`
+		Data  []struct {
+			ID    string  `json:"id"`
+			Score float64 `json:"score"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, 1, resp.Total)
+	require.Len(t, resp.Data, 1)
+	// The score field rides along with the record fields.
+	assert.InDelta(t, 0.87, resp.Data[0].Score, 1e-6)
+	assert.Equal(t, "mem-1", resp.Data[0].ID)
+}
+
+func TestSearchMyMemories_LexicalFallbackWithoutEmbedder(t *testing.T) {
+	store := &mockMemoryStore{}
+	user := &User{UserID: "u1", Email: "alice@example.com"}
+	// No embedding provider: the handler must use lexical search.
+	h := newMemorySearchHandler(store, nil, user)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/memory/records/search?q=churn", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, store.lastLexicalQ, "missing embedder must select lexical search")
+	assert.Nil(t, store.lastHybridQ)
+	assert.Equal(t, "alice@example.com", store.lastLexicalQ.CreatedBy)
+}
+
+func TestSearchMyMemories_NoopEmbedderFallsBackToLexical(t *testing.T) {
+	store := &mockMemoryStore{}
+	user := &User{UserID: "u1", Email: "alice@example.com"}
+	// A noop provider reports Kind()==noop, so IsConfigured is false.
+	h := newMemorySearchHandler(store, embedding.NewNoopProvider(3), user)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/memory/records/search?q=churn", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, store.lastLexicalQ, "noop embedder must degrade to lexical")
+	assert.Nil(t, store.lastHybridQ)
+}
+
+func TestSearchMyMemories_ZeroVectorFallsBackToLexical(t *testing.T) {
+	store := &mockMemoryStore{}
+	user := &User{UserID: "u1", Email: "alice@example.com"}
+	// A configured (non-noop) provider that nonetheless returns a zero
+	// vector: cosine is meaningless, so the handler must degrade to lexical.
+	h := newMemorySearchHandler(store, &fakeEmbedder{vec: []float32{0, 0, 0}}, user)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/memory/records/search?q=churn", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, store.lastLexicalQ, "a zero query vector must degrade to lexical search")
+	assert.Nil(t, store.lastHybridQ)
+}
+
+func TestSearchMyMemories_EmbedErrorFallsBackToLexical(t *testing.T) {
+	store := &mockMemoryStore{}
+	user := &User{UserID: "u1", Email: "alice@example.com"}
+	h := newMemorySearchHandler(store, &fakeEmbedder{embedErr: fmt.Errorf("ollama down")}, user)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/memory/records/search?q=churn", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, store.lastLexicalQ, "embed error must degrade to lexical, not fail the request")
+}
+
+func TestSearchMyMemories_MissingQuery(t *testing.T) {
+	store := &mockMemoryStore{}
+	user := &User{UserID: "u1", Email: "alice@example.com"}
+	h := newMemorySearchHandler(store, nil, user)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/memory/records/search?q=%20%20", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "blank query must be rejected")
+}
+
+func TestSearchMyMemories_Unauthenticated(t *testing.T) {
+	h := newMemorySearchHandler(&mockMemoryStore{}, nil, nil)
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/memory/records/search?q=x", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestSearchMyMemories_EmptyEmailFailsClosed proves the per-user scope
+// boundary: an authenticated user with no email must be rejected, not
+// allowed to run a search that would omit the created_by predicate and
+// return every user's records (#516).
+func TestSearchMyMemories_EmptyEmailFailsClosed(t *testing.T) {
+	store := &mockMemoryStore{}
+	user := &User{UserID: "u1", Email: ""} // authenticated but no email
+	h := newMemorySearchHandler(store, nil, user)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/memory/records/search?q=churn", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Nil(t, store.lastHybridQ, "no search may run without a scoping email")
+	assert.Nil(t, store.lastLexicalQ, "no search may run without a scoping email")
+}
+
+func TestSearchMyMemories_Error(t *testing.T) {
+	store := &mockMemoryStore{searchErr: fmt.Errorf("db error")}
+	user := &User{UserID: "u1", Email: "alice@example.com"}
+	h := newMemorySearchHandler(store, nil, user)
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/memory/records/search?q=x", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 func TestListMyMemories_Success(t *testing.T) {

--- a/pkg/portal/search_integration_test.go
+++ b/pkg/portal/search_integration_test.go
@@ -1,0 +1,99 @@
+package portal
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/memory"
+)
+
+// hybridSearchColumns is the column order HybridSearch scans: the 17 raw
+// record columns followed by the per-arm vec_score and lex_match signals.
+// sqlmock scans positionally, so only the count/order matter.
+var hybridSearchColumns = []string{
+	"id", "created_at", "updated_at", "created_by", "persona", "dimension",
+	"content", "category", "confidence", "source",
+	"entity_urns", "related_columns", "metadata",
+	"status", "stale_reason", "stale_at", "last_verified",
+	"vec_score", "lex_match",
+}
+
+func addHybridSearchRow(rows *sqlmock.Rows, id, createdBy string, vecScore float64) {
+	now := time.Now()
+	rows.AddRow(
+		id, now, now, createdBy, "analyst", memory.DimensionKnowledge,
+		"content for "+id, "business_context", "high", "user",
+		[]byte("[]"), []byte("[]"), []byte("{}"),
+		"active", nil, nil, nil,
+		vecScore, true,
+	)
+}
+
+// TestIntegration_SearchMyMemories_RealStoreEnforcesOwnerScope wires the
+// real portal Handler to a real memory.PostgresStore (sqlmock at the DB
+// boundary) and a configured embedder, then sends a real HTTP request
+// through the real mux + auth middleware. It proves the end-to-end claim
+// that matters for #516: the authenticated caller's email actually arrives
+// as the created_by SQL predicate (the per-user search boundary), and the
+// relevance score travels back to the JSON response. A unit test with a
+// mocked store cannot prove the store is invoked with the right scope
+// through the real wiring; this does.
+func TestIntegration_SearchMyMemories_RealStoreEnforcesOwnerScope(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	store := memory.NewPostgresStore(db)
+
+	const callerEmail = "alice@example.com"
+
+	// HybridSearch binds $1=vector, $2=query, then the scope predicates.
+	// With only created_by set (the request sends no dimension/status), the
+	// owner scope must land at $3 = the caller's email. If the handler
+	// failed to scope by the caller, this expectation would not be met.
+	rows := sqlmock.NewRows(hybridSearchColumns)
+	addHybridSearchRow(rows, "mem-1", callerEmail, 0.88)
+	mock.ExpectQuery("UNION ALL").
+		WithArgs(sqlmock.AnyArg(), "churn analysis", callerEmail).
+		WillReturnRows(rows)
+
+	h := NewHandler(Deps{
+		AssetStore:        &mockAssetStore{},
+		ShareStore:        &mockShareStore{},
+		MemoryStore:       store,
+		EmbeddingProvider: &fakeEmbedder{vec: []float32{0.1, 0.2, 0.3}},
+	}, testAuthMiddleware(&User{UserID: "u1", Email: callerEmail}))
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/api/v1/portal/memory/records/search?q=churn+analysis", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet(),
+		"the real store must be queried with the caller's email as the created_by scope")
+
+	var resp struct {
+		Total int `json:"total"`
+		Data  []struct {
+			ID    string  `json:"id"`
+			Score float64 `json:"score"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Equal(t, 1, resp.Total)
+	require.Len(t, resp.Data, 1)
+	assert.Equal(t, "mem-1", resp.Data[0].ID)
+	// HybridSearch returns the fused vec+lexical score (the fusion formula
+	// itself is unit-tested in pkg/memory); here we only assert a real
+	// non-zero ranking score survived the round trip to JSON.
+	assert.Positive(t, resp.Data[0].Score, "a real relevance score must reach the JSON response")
+}

--- a/pkg/toolkits/knowledge/memory_adapter.go
+++ b/pkg/toolkits/knowledge/memory_adapter.go
@@ -92,6 +92,73 @@ func (a *memoryInsightAdapter) List(ctx context.Context, filter InsightFilter) (
 	return insights, total, nil
 }
 
+// InsightSearchQuery parameterizes a relevance-ranked insight search. It
+// is owner-scoped (CapturedBy) and, like List, restricted to the knowledge
+// dimension by the adapter. Embedding drives semantic (hybrid) ranking
+// when non-empty; a nil/empty Embedding selects the lexical-only path used
+// when no embedding provider is configured. The caller (the portal search
+// handler) owns the embedder and precomputes Embedding so the adapter does
+// not depend on an embedding provider.
+type InsightSearchQuery struct {
+	QueryText  string
+	Embedding  []float32
+	CapturedBy string
+	Status     string
+	Limit      int
+}
+
+// ScoredInsight pairs an insight with its search relevance score.
+type ScoredInsight struct {
+	Insight Insight
+	Score   float64
+}
+
+// Search returns the caller's knowledge-dimension insights ranked by
+// relevance to the query. It delegates to the shared memory search
+// primitives (HybridSearch when an embedding is supplied, LexicalSearch
+// otherwise), enforcing the same owner + knowledge-dimension scope as
+// List, then maps the scored records back to insights. As in List, the
+// exact insight status is recovered per record and post-filtered, because
+// the memory status enum is coarser than the insight status.
+func (a *memoryInsightAdapter) Search(ctx context.Context, q InsightSearchQuery) ([]ScoredInsight, error) {
+	var (
+		scored []memory.ScoredRecord
+		err    error
+	)
+	memStatus := mapInsightStatusToMemory(q.Status)
+	if len(q.Embedding) > 0 {
+		scored, err = a.store.HybridSearch(ctx, memory.HybridQuery{
+			Embedding: q.Embedding,
+			QueryText: q.QueryText,
+			CreatedBy: q.CapturedBy,
+			Dimension: a.dimension,
+			Status:    memStatus,
+			Limit:     q.Limit,
+		})
+	} else {
+		scored, err = a.store.LexicalSearch(ctx, memory.LexicalQuery{
+			QueryText: q.QueryText,
+			CreatedBy: q.CapturedBy,
+			Dimension: a.dimension,
+			Status:    memStatus,
+			Limit:     q.Limit,
+		})
+	}
+	if err != nil {
+		return nil, fmt.Errorf("searching insight records: %w", err)
+	}
+
+	results := make([]ScoredInsight, 0, len(scored))
+	for i := range scored {
+		insight := recordToInsight(scored[i].Record)
+		if q.Status != "" && insight.Status != q.Status {
+			continue
+		}
+		results = append(results, ScoredInsight{Insight: insight, Score: scored[i].Score})
+	}
+	return results, nil
+}
+
 // UpdateStatus changes the review status of an insight.
 func (a *memoryInsightAdapter) UpdateStatus(ctx context.Context, id, status, reviewedBy, reviewNotes string) error {
 	meta := map[string]any{

--- a/pkg/toolkits/knowledge/memory_adapter_test.go
+++ b/pkg/toolkits/knowledge/memory_adapter_test.go
@@ -2,6 +2,7 @@ package knowledge
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -35,6 +36,10 @@ type mockMemoryStore struct {
 	supersedeNewID  string
 	supersedeErr    error
 	supersedeCalls  []struct{ OldID, NewID string }
+	searchResult    []memory.ScoredRecord
+	searchErr       error
+	lastHybridQ     *memory.HybridQuery
+	lastLexicalQ    *memory.LexicalQuery
 }
 
 func (m *mockMemoryStore) Insert(_ context.Context, record memory.Record) error {
@@ -71,12 +76,14 @@ func (*mockMemoryStore) VectorSearch(_ context.Context, _ memory.VectorQuery) ([
 	return nil, nil //nolint:nilnil // mock returns nil for both
 }
 
-func (*mockMemoryStore) HybridSearch(_ context.Context, _ memory.HybridQuery) ([]memory.ScoredRecord, error) {
-	return nil, nil //nolint:nilnil // mock returns nil for both
+func (m *mockMemoryStore) HybridSearch(_ context.Context, q memory.HybridQuery) ([]memory.ScoredRecord, error) {
+	m.lastHybridQ = &q
+	return m.searchResult, m.searchErr
 }
 
-func (*mockMemoryStore) LexicalSearch(_ context.Context, _ memory.LexicalQuery) ([]memory.ScoredRecord, error) {
-	return nil, nil //nolint:nilnil // mock returns nil for both
+func (m *mockMemoryStore) LexicalSearch(_ context.Context, q memory.LexicalQuery) ([]memory.ScoredRecord, error) {
+	m.lastLexicalQ = &q
+	return m.searchResult, m.searchErr
 }
 
 func (*mockMemoryStore) EntityLookup(_ context.Context, _, _ string) ([]memory.Record, error) {
@@ -96,6 +103,73 @@ func (m *mockMemoryStore) Supersede(_ context.Context, oldID, newID string) erro
 }
 
 var _ memory.Store = (*mockMemoryStore)(nil)
+
+func TestMemoryInsightAdapter_Search_HybridScopesToOwnerAndDimension(t *testing.T) {
+	store := &mockMemoryStore{
+		searchResult: []memory.ScoredRecord{
+			{Record: memory.Record{ID: "i1", CreatedBy: "user@example.com", Content: "churn analysis"}, Score: 0.91},
+		},
+	}
+	adapter := &memoryInsightAdapter{store: store, dimension: memory.DimensionKnowledge}
+
+	got, err := adapter.Search(context.Background(), InsightSearchQuery{
+		QueryText:  "churn",
+		Embedding:  []float32{0.1, 0.2},
+		CapturedBy: "user@example.com",
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "i1", got[0].Insight.ID)
+	assert.InDelta(t, 0.91, got[0].Score, 1e-9)
+
+	require.NotNil(t, store.lastHybridQ, "embedding present must select the hybrid arm")
+	assert.Nil(t, store.lastLexicalQ)
+	assert.Equal(t, "user@example.com", store.lastHybridQ.CreatedBy, "must scope to the owner")
+	assert.Equal(t, memory.DimensionKnowledge, store.lastHybridQ.Dimension, "must scope to the knowledge dimension")
+}
+
+func TestMemoryInsightAdapter_Search_LexicalFallbackWhenNoEmbedding(t *testing.T) {
+	store := &mockMemoryStore{}
+	adapter := &memoryInsightAdapter{store: store, dimension: memory.DimensionKnowledge}
+
+	_, err := adapter.Search(context.Background(), InsightSearchQuery{
+		QueryText:  "churn",
+		CapturedBy: "user@example.com",
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, store.lastLexicalQ, "no embedding must select the lexical arm")
+	assert.Nil(t, store.lastHybridQ)
+	assert.Equal(t, "user@example.com", store.lastLexicalQ.CreatedBy)
+	assert.Equal(t, memory.DimensionKnowledge, store.lastLexicalQ.Dimension)
+}
+
+func TestMemoryInsightAdapter_Search_PostFiltersByStatus(t *testing.T) {
+	store := &mockMemoryStore{
+		searchResult: []memory.ScoredRecord{
+			{Record: memory.Record{ID: "approved", CreatedBy: "u", Metadata: map[string]any{metaKeyInsightStatus: "approved"}}, Score: 0.8},
+			{Record: memory.Record{ID: "pending", CreatedBy: "u", Metadata: map[string]any{metaKeyInsightStatus: "pending"}}, Score: 0.7},
+		},
+	}
+	adapter := &memoryInsightAdapter{store: store, dimension: memory.DimensionKnowledge}
+
+	got, err := adapter.Search(context.Background(), InsightSearchQuery{
+		QueryText: "x", Embedding: []float32{0.1}, CapturedBy: "u", Status: "approved", Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1, "only the approved insight survives the exact-status post-filter")
+	assert.Equal(t, "approved", got[0].Insight.ID)
+}
+
+func TestMemoryInsightAdapter_Search_Error(t *testing.T) {
+	store := &mockMemoryStore{searchErr: errors.New("boom")}
+	adapter := &memoryInsightAdapter{store: store, dimension: memory.DimensionKnowledge}
+
+	_, err := adapter.Search(context.Background(), InsightSearchQuery{QueryText: "x", CapturedBy: "u"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "searching insight records")
+}
 
 func TestMemoryInsightAdapter_Insert(t *testing.T) {
 	store := &mockMemoryStore{}

--- a/pkg/toolkits/memory/recall.go
+++ b/pkg/toolkits/memory/recall.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
 	memstore "github.com/txn2/mcp-data-platform/pkg/memory"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
@@ -146,7 +147,7 @@ func (t *Toolkit) recallBySemantic(ctx context.Context, query, persona string, i
 	status := statusFilter(includeStale)
 
 	emb, err := t.embedder.Embed(ctx, query)
-	if err != nil || isZeroVector(emb) {
+	if err != nil || embedding.IsZeroVector(emb) {
 		if err != nil {
 			slog.Debug("embedding query failed; falling back to lexical recall", "error", err)
 		}
@@ -206,19 +207,6 @@ func (t *Toolkit) lexicalOutcome(ctx context.Context, query, persona, status str
 		out.note = degradedNote
 	}
 	return out, nil
-}
-
-// isZeroVector reports whether every element is zero, the signature of
-// the noop embedding provider (real embeddings are never all-zero). A
-// zero query vector yields meaningless cosine similarity, so it forces
-// the lexical fallback.
-func isZeroVector(v []float32) bool {
-	for _, x := range v {
-		if x != 0 {
-			return false
-		}
-	}
-	return true
 }
 
 // recallByGraph walks DataHub lineage to find memories on related entities.

--- a/ui/src/api/portal/hooks.ts
+++ b/ui/src/api/portal/hooks.ts
@@ -16,6 +16,8 @@ import type {
   InsightStats,
   MemoryRecord,
   MemoryStats,
+  ScoredMemoryRecord,
+  ScoredInsight,
   Collection,
   CollectionConfig,
   CollectionResponse,
@@ -403,6 +405,28 @@ export function useMyInsightStats() {
   });
 }
 
+// useSearchMyInsights ranks the caller's insights by relevance to query.
+// Disabled (no request) until query is non-empty, so the list endpoint
+// remains the default browse experience.
+export function useSearchMyInsights(
+  query: string,
+  params?: { status?: string; limit?: number },
+) {
+  const q = query.trim();
+  const sp = new URLSearchParams({ q });
+  if (params?.status) sp.set("status", params.status);
+  if (params?.limit) sp.set("limit", String(params.limit));
+
+  return useQuery({
+    queryKey: ["search-my-insights", q, params],
+    enabled: q.length > 0,
+    queryFn: () =>
+      apiFetch<PaginatedResponse<ScoredInsight>>(
+        `/knowledge/insights/search?${sp.toString()}`,
+      ),
+  });
+}
+
 // --- Collections ---
 
 export function useCollections(params?: { search?: string; limit?: number; offset?: number }) {
@@ -669,5 +693,28 @@ export function useMyMemoryStats() {
   return useQuery({
     queryKey: ["my-memory-stats"],
     queryFn: () => apiFetch<MemoryStats>("/memory/records/stats"),
+  });
+}
+
+// useSearchMyMemories ranks the caller's memory records by relevance to
+// query. Disabled (no request) until query is non-empty, so the list
+// endpoint remains the default browse experience.
+export function useSearchMyMemories(
+  query: string,
+  params?: { dimension?: string; status?: string; limit?: number },
+) {
+  const q = query.trim();
+  const sp = new URLSearchParams({ q });
+  if (params?.dimension) sp.set("dimension", params.dimension);
+  if (params?.status) sp.set("status", params.status);
+  if (params?.limit) sp.set("limit", String(params.limit));
+
+  return useQuery({
+    queryKey: ["search-my-memories", q, params],
+    enabled: q.length > 0,
+    queryFn: () =>
+      apiFetch<PaginatedResponse<ScoredMemoryRecord>>(
+        `/memory/records/search?${sp.toString()}`,
+      ),
   });
 }

--- a/ui/src/api/portal/types.ts
+++ b/ui/src/api/portal/types.ts
@@ -261,3 +261,7 @@ export interface MemoryStats {
   by_category: Record<string, number>;
   by_status: Record<string, number>;
 }
+
+// Search results carry a relevance score alongside the record fields.
+export type ScoredMemoryRecord = MemoryRecord & { score: number };
+export type ScoredInsight = Insight & { score: number };

--- a/ui/src/pages/knowledge/MyKnowledgePage.tsx
+++ b/ui/src/pages/knowledge/MyKnowledgePage.tsx
@@ -1,12 +1,14 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   useMyInsights,
   useMyInsightStats,
   useMyMemories,
   useMyMemoryStats,
+  useSearchMyInsights,
+  useSearchMyMemories,
 } from "@/api/portal/hooks";
 import { StatCard } from "@/components/cards/StatCard";
-import { Lightbulb, ChevronLeft, ChevronRight } from "lucide-react";
+import { Lightbulb, ChevronLeft, ChevronRight, Search } from "lucide-react";
 import type { Insight, MemoryRecord } from "@/api/portal/types";
 import { MarkdownRenderer } from "@/components/renderers/MarkdownRenderer";
 import { CollapsibleMarkdown } from "@/components/renderers/CollapsibleMarkdown";
@@ -68,6 +70,43 @@ const DIMENSION_LABELS: Record<string, string> = {
 const PAGE_SIZE = 20;
 
 type Tab = "knowledge" | "memory";
+
+// useDebounced returns value after it has stopped changing for delayMs,
+// so typing in a search box issues one request after the user pauses
+// rather than one per keystroke.
+function useDebounced<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(t);
+  }, [value, delayMs]);
+  return debounced;
+}
+
+// SearchBox is a controlled text input with a leading search icon, shared
+// by the Knowledge and Memory tabs.
+function SearchBox({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+}) {
+  return (
+    <div className="relative min-w-[220px] flex-1">
+      <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full rounded-md border bg-background pl-9 pr-3 py-2 text-sm outline-none ring-ring focus:ring-2"
+      />
+    </div>
+  );
+}
 
 function BadgeLabel({ status }: { status: string }) {
   const badge = STATUS_BADGES[status] ?? {
@@ -214,6 +253,9 @@ export function MyKnowledgePage() {
 function MyKnowledgeSection() {
   const [statusFilter, setStatusFilter] = useState("");
   const [offset, setOffset] = useState(0);
+  const [searchInput, setSearchInput] = useState("");
+  const search = useDebounced(searchInput, 300);
+  const searching = search.trim().length > 0;
 
   const stats = useMyInsightStats();
   const insights = useMyInsights({
@@ -221,10 +263,18 @@ function MyKnowledgeSection() {
     limit: PAGE_SIZE,
     offset,
   });
+  // Search refines by the active status filter and ranks by relevance.
+  const searchResults = useSearchMyInsights(search, {
+    status: statusFilter || undefined,
+    limit: PAGE_SIZE,
+  });
 
   const s = stats.data;
   const totalItems = insights.data?.total ?? 0;
-  const items = insights.data?.data ?? [];
+  const items = searching
+    ? (searchResults.data?.data ?? [])
+    : (insights.data?.data ?? []);
+  const listLoading = searching ? searchResults.isLoading : insights.isLoading;
   const hasNext = offset + PAGE_SIZE < totalItems;
   const hasPrev = offset > 0;
 
@@ -250,29 +300,42 @@ function MyKnowledgeSection() {
         <StatCard label="Applied" value={s?.by_status?.applied ?? 0} />
       </div>
 
-      {/* Filters */}
-      <div className="flex items-center gap-1">
-        {statusFilters.map((f) => (
-          <button
-            key={f.value}
-            onClick={() => {
-              setStatusFilter(f.value);
-              setOffset(0);
-            }}
-            className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-              statusFilter === f.value
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground hover:bg-muted"
-            }`}
-          >
-            {f.label}
-          </button>
-        ))}
+      {/* Search + Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <SearchBox
+          value={searchInput}
+          onChange={setSearchInput}
+          placeholder="Search insights..."
+        />
+        <div className="flex items-center gap-1">
+          {statusFilters.map((f) => (
+            <button
+              key={f.value}
+              onClick={() => {
+                setStatusFilter(f.value);
+                setOffset(0);
+              }}
+              className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                statusFilter === f.value
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-muted"
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Insights List */}
-      {insights.isLoading ? (
-        <p className="text-sm text-muted-foreground">Loading...</p>
+      {listLoading ? (
+        <p className="text-sm text-muted-foreground">
+          {searching ? "Searching..." : "Loading..."}
+        </p>
+      ) : searching && items.length === 0 ? (
+        <p className="py-12 text-center text-sm text-muted-foreground">
+          No insights match &quot;{search.trim()}&quot;.
+        </p>
       ) : items.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
           <Lightbulb className="h-12 w-12 mb-2 opacity-30" />
@@ -301,8 +364,8 @@ function MyKnowledgeSection() {
         </div>
       )}
 
-      {/* Pagination */}
-      {totalItems > PAGE_SIZE && (
+      {/* Pagination (browse mode only; search returns a ranked top-K) */}
+      {!searching && totalItems > PAGE_SIZE && (
         <div className="flex items-center justify-between text-xs text-muted-foreground">
           <span>
             {offset + 1}-{Math.min(offset + PAGE_SIZE, totalItems)} of{" "}
@@ -338,6 +401,9 @@ function MyMemorySection() {
   const [statusFilter, setStatusFilter] = useState("");
   const [dimensionFilter, setDimensionFilter] = useState("");
   const [offset, setOffset] = useState(0);
+  const [searchInput, setSearchInput] = useState("");
+  const search = useDebounced(searchInput, 300);
+  const searching = search.trim().length > 0;
 
   const stats = useMyMemoryStats();
   const memories = useMyMemories({
@@ -346,9 +412,18 @@ function MyMemorySection() {
     limit: PAGE_SIZE,
     offset,
   });
+  // Search refines by the active status and dimension filters.
+  const searchResults = useSearchMyMemories(search, {
+    status: statusFilter || undefined,
+    dimension: dimensionFilter || undefined,
+    limit: PAGE_SIZE,
+  });
   const s = stats.data;
   const totalItems = memories.data?.total ?? 0;
-  const items = memories.data?.data ?? [];
+  const items = searching
+    ? (searchResults.data?.data ?? [])
+    : (memories.data?.data ?? []);
+  const listLoading = searching ? searchResults.isLoading : memories.isLoading;
   const hasNext = offset + PAGE_SIZE < totalItems;
   const hasPrev = offset > 0;
 
@@ -381,8 +456,13 @@ function MyMemorySection() {
         />
       </div>
 
-      {/* Filters */}
+      {/* Search + Filters */}
       <div className="flex flex-wrap items-center gap-3">
+        <SearchBox
+          value={searchInput}
+          onChange={setSearchInput}
+          placeholder="Search memories..."
+        />
         <div className="flex items-center gap-1">
           {statusFilters.map((f) => (
             <button
@@ -418,8 +498,14 @@ function MyMemorySection() {
       </div>
 
       {/* Memory List */}
-      {memories.isLoading ? (
-        <p className="text-sm text-muted-foreground">Loading...</p>
+      {listLoading ? (
+        <p className="text-sm text-muted-foreground">
+          {searching ? "Searching..." : "Loading..."}
+        </p>
+      ) : searching && items.length === 0 ? (
+        <p className="py-12 text-center text-sm text-muted-foreground">
+          No memories match &quot;{search.trim()}&quot;.
+        </p>
       ) : items.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
           <p className="text-sm font-medium">No memories yet</p>
@@ -437,8 +523,8 @@ function MyMemorySection() {
         </div>
       )}
 
-      {/* Pagination */}
-      {totalItems > PAGE_SIZE && (
+      {/* Pagination (browse mode only; search returns a ranked top-K) */}
+      {!searching && totalItems > PAGE_SIZE && (
         <div className="flex items-center justify-between text-xs text-muted-foreground">
           <span>
             {offset + 1}-{Math.min(offset + PAGE_SIZE, totalItems)} of{" "}


### PR DESCRIPTION
## Summary

Adds user-scoped relevance search to the portal's **Knowledge & Memory** page. A user can type a free-text query on either tab and get results ranked by relevance, always scoped server-side to their own records. Closes #516.

Previously the page offered only status/dimension filter buttons. The MCP already supported semantic + lexical recall via the `memory_recall` tool; this brings the equivalent experience to the portal UI.

## Background

Knowledge insights are stored as **knowledge-dimension memory records** (`memoryInsightAdapter`, `pkg/toolkits/knowledge/memory_adapter.go`). They share the `memory_records` table and the same embeddings as memories. So a single search over the memory store serves both tabs:

- **Memory tab** searches across dimensions.
- **Knowledge tab** scopes to `dimension = knowledge`.

There is no separate insight index; both tabs rank through the same primitives.

## What changed

### Search primitives (`pkg/memory`)
- Added `CreatedBy` and `Dimension` scope to `VectorQuery` / `HybridQuery` / `LexicalQuery`, enforced in SQL via a shared `scopeFilters` helper.
- The default exclude-archived predicate now applies only when no explicit status is requested. An explicit status (including `archived`) is honored rather than producing a contradictory `status <> 'archived' AND status = 'archived'` that matches nothing. Recall semantics are unchanged: `memory_recall` passes no explicit status, so archived stays excluded there.

### Portal endpoints (`pkg/portal`)
- `GET /api/v1/portal/memory/records/search?q=...`
- `GET /api/v1/portal/knowledge/insights/search?q=...`
- Both scoped server-side by the caller's email (`created_by`). The handlers fail closed (`403`) when the authenticated identity carries no email, so a search never runs without a scoping key.
- Hybrid ranking (vector + lexical) when an embedding provider is configured; lexical-only fallback when it is not, when the embedder errors, or when it returns a zero vector. This mirrors `memory_recall` so the portal and the agent surface rank the same way.

### Knowledge adapter (`pkg/toolkits/knowledge`)
- Added an `InsightSearcher` capability to the memory-backed adapter. It delegates to the shared memory search with the same owner + `knowledge`-dimension scope and the same status post-filter as the list path, then maps scored records back to insights.
- The knowledge-search route registers only when the wired store implements `InsightSearcher`, so the legacy separate-table store (used only when the memory layer is disabled) does not get a non-functional route.

### Shared helper (`pkg/embedding`)
- Extracted `IsZeroVector` so the portal search and `memory_recall` share one hybrid-vs-lexical decision and cannot drift.

### Frontend (`ui`)
- Debounced search box on both the Knowledge and Memory tabs.
- Search refines by the active status/dimension filters and ranks by relevance. Pagination is hidden in search mode, which returns a ranked top-K.
- Without an embedding provider, lexical results still appear.

### Docs
- Updated `docs/server/portal-user.md` and `docs/llms-full.txt`; regenerated swagger.

## API

Two new authenticated endpoints, behind the same auth middleware as the existing portal list routes. The response uses the standard paginated shape with a `score` field added per row.

| Method | Path | Params |
| --- | --- | --- |
| GET | `/api/v1/portal/memory/records/search` | `q` (required), `dimension`, `status`, `limit` |
| GET | `/api/v1/portal/knowledge/insights/search` | `q` (required), `status`, `limit` |

## Testing

- Unit tests for the new scope filters across the vector, hybrid, and lexical arms; the archived-status rule; the embed/lexical fallback paths (no embedder, noop, embed error, zero vector); the empty-email fail-closed guard; and the route-gating on the `InsightSearcher` capability.
- Integration test wiring the real handler to a real `memory.PostgresStore` (sqlmock at the DB boundary): a real HTTP request proves the caller's email reaches the store's `created_by` predicate and the relevance score reaches the JSON response.
- New functions are covered at or above the project's 80% threshold.
- `make verify` passes end to end (fmt, swagger, race tests, lint, gosec, govulncheck, semgrep, CodeQL, coverage, patch coverage, dead code, mutation, release dry-run).

## Out of scope

- The `recall_insight` MCP tool (#442) is a separate surface and is not part of this change.
