### PR TITLE
fix(ui): guard asset search filters against undefined description

### DIFF
--- a/ui/src/api/portal/types.ts
+++ b/ui/src/api/portal/types.ts
@@ -8,7 +8,9 @@ export interface Asset {
   owner_id: string;
   owner_email: string;
   name: string;
-  description: string;
+  // Optional: the API serializes description with `omitempty`, so an asset
+  // with no description omits the field entirely (arrives as undefined).
+  description?: string;
   content_type: string;
   s3_bucket: string;
   s3_key: string;

--- a/ui/src/components/AssetViewer.tsx
+++ b/ui/src/components/AssetViewer.tsx
@@ -192,7 +192,7 @@ export function AssetViewer({
   function startEdit() {
     if (!asset) return;
     setEditName(asset.name);
-    setEditDesc(asset.description);
+    setEditDesc(asset.description ?? "");
     setEditTags(asset.tags.join(", "));
     setEditing(true);
   }

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -1065,7 +1065,7 @@ export const handlers = [
       filtered = filtered.filter(
         (a) =>
           a.name.toLowerCase().includes(search) ||
-          a.description.toLowerCase().includes(search) ||
+          (a.description ?? "").toLowerCase().includes(search) ||
           a.owner_email.toLowerCase().includes(search) ||
           a.owner_id.toLowerCase().includes(search) ||
           a.tags.some((t: string) => t.toLowerCase().includes(search)),

--- a/ui/src/pages/assets/MyAssetsPage.test.tsx
+++ b/ui/src/pages/assets/MyAssetsPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MyAssetsPage } from "./MyAssetsPage";
 
@@ -102,6 +102,39 @@ describe("MyAssetsPage: share icons overlay on card thumbnail", () => {
 
     expect(screen.queryByTitle("Shared with users")).not.toBeInTheDocument();
     expect(screen.getByTitle("Has public link")).toBeInTheDocument();
+  });
+
+  it("searching does not crash when an asset has no description", () => {
+    // Regression: the API serializes description with `omitempty`, so an
+    // asset with no description arrives as undefined. The client-side search
+    // filter called `description.toLowerCase()` unguarded and crashed the
+    // page the moment the user typed anything.
+    mockUseAssets.mockReturnValue({
+      data: {
+        // The search term below must NOT match the name, so the filter
+        // falls through to the (undefined) description term that crashed.
+        data: [makeAsset({ name: "Annual Summary", description: undefined })],
+        total: 1,
+        limit: 50,
+        offset: 0,
+        share_summaries: {},
+      },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useAssets>);
+
+    render(<MyAssetsPage onNavigate={vi.fn()} />, { wrapper });
+    expect(screen.getByText("Annual Summary")).toBeInTheDocument();
+
+    // Typing a query that matches neither the name nor the absent description
+    // forces evaluation of the description branch of the filter.
+    expect(() =>
+      fireEvent.change(screen.getByPlaceholderText("Search assets..."), {
+        target: { value: "revenue" },
+      }),
+    ).not.toThrow();
+
+    // The descriptionless, non-matching asset is filtered out without crashing.
+    expect(screen.queryByText("Annual Summary")).not.toBeInTheDocument();
   });
 
   it("no share icons when share_summaries is empty", () => {

--- a/ui/src/pages/assets/MyAssetsPage.tsx
+++ b/ui/src/pages/assets/MyAssetsPage.tsx
@@ -65,8 +65,8 @@ export function MyAssetsPage({ onNavigate }: Props) {
   const assets = (data?.data ?? []).filter(
     (a) =>
       !search ||
-      a.name.toLowerCase().includes(search.toLowerCase()) ||
-      a.description.toLowerCase().includes(search.toLowerCase()),
+      (a.name ?? "").toLowerCase().includes(search.toLowerCase()) ||
+      (a.description ?? "").toLowerCase().includes(search.toLowerCase()),
   );
 
   return (

--- a/ui/src/pages/collections/CollectionEditorPage.tsx
+++ b/ui/src/pages/collections/CollectionEditorPage.tsx
@@ -134,9 +134,9 @@ function AssetBrowserModal({
       const q = search.toLowerCase();
       list = list.filter(
         (a) =>
-          a.name.toLowerCase().includes(q) ||
-          a.description.toLowerCase().includes(q) ||
-          a.tags.some((t) => t.toLowerCase().includes(q)),
+          (a.name ?? "").toLowerCase().includes(q) ||
+          (a.description ?? "").toLowerCase().includes(q) ||
+          (a.tags ?? []).some((t) => t.toLowerCase().includes(q)),
       );
     }
     list = [...list].sort((a, b) => {

--- a/ui/src/pages/prompts/MyPromptsPage.tsx
+++ b/ui/src/pages/prompts/MyPromptsPage.tsx
@@ -120,9 +120,9 @@ export function MyPromptsPage({ onNavigate }: Props) {
       const q = debouncedSearch.toLowerCase();
       list = list.filter(
         (p) =>
-          p.name.toLowerCase().includes(q) ||
-          p.display_name.toLowerCase().includes(q) ||
-          p.description.toLowerCase().includes(q),
+          (p.name ?? "").toLowerCase().includes(q) ||
+          (p.display_name ?? "").toLowerCase().includes(q) ||
+          (p.description ?? "").toLowerCase().includes(q),
       );
     }
     list.sort((a, b) => {

--- a/ui/src/pages/shared/SharedWithMePage.tsx
+++ b/ui/src/pages/shared/SharedWithMePage.tsx
@@ -56,8 +56,8 @@ export function SharedWithMePage({ onNavigate }: Props) {
   const items = (data?.data ?? []).filter(
     (item) =>
       !search ||
-      item.asset.name.toLowerCase().includes(search.toLowerCase()) ||
-      item.asset.description.toLowerCase().includes(search.toLowerCase()),
+      (item.asset.name ?? "").toLowerCase().includes(search.toLowerCase()) ||
+      (item.asset.description ?? "").toLowerCase().includes(search.toLowerCase()),
   );
 
   const filteredItems = items.filter(


### PR DESCRIPTION
## Summary

Searching the portal asset library could crash the entire frontend. Typing in the search box threw `Uncaught TypeError: Cannot read properties of undefined (reading 'toLowerCase')` and took down the page.

## Root cause

The portal API serializes an asset's description with `json:"description,omitempty"` (`pkg/portal/types.go:29`). An asset with no description omits the key entirely, so in the browser `asset.description` is `undefined`. The client-side asset-library search filters called `description.toLowerCase()` unguarded, so the moment a user typed a query the filter dereferenced `undefined`.

The TS `Asset` type declared `description: string`, which hid the problem: every *render* site already guarded with `{asset.description && ...}`, but the *filter* expressions assumed the field was always present.

## Changes

- Guard the `name` / `description` / `tags` terms with `?? ""` (`?? []` for tags) in the search filters that operate on assets and the same pattern on prompts:
  - `MyAssetsPage.tsx` (the reported crash)
  - `SharedWithMePage.tsx` (shared assets, same `Asset` object)
  - `CollectionEditorPage.tsx` (asset picker)
  - `MyPromptsPage.tsx` (identical pattern on prompt fields)
  - `mocks/handlers.ts` (MSW mock asset search, for type/test parity)
- Make the type honest: `Asset.description` is now optional (`description?: string`). This surfaced the remaining unguarded use at compile time and will catch future ones. The only consumer needing a touch was `AssetViewer.tsx` (`setEditDesc(asset.description ?? "")`).
- Add a regression test in `MyAssetsPage.test.tsx`: it renders a descriptionless asset and searches a term that does not match the name, forcing evaluation of the description branch.

## Testing

- `tsc --noEmit`: clean.
- Full UI suite: 148 tests pass across 16 files.
- Verified the new regression test **fails without the guard** and **passes with it** (not a tautology).

## Note

This is a source fix. The crash lives in the deployed JS bundle, so it requires a UI rebuild and redeploy to reach users.
