### PR TITLE
fix(ui): validate prompt name and use the markdown editor in prompt forms

### DIFF
--- a/ui/src/pages/prompts/AdminPromptsPage.tsx
+++ b/ui/src/pages/prompts/AdminPromptsPage.tsx
@@ -26,6 +26,9 @@ import {
 } from "@/api/admin/hooks";
 import type { Prompt } from "@/api/admin/types";
 import { cn } from "@/lib/utils";
+import { MarkdownEditor } from "@/components/MarkdownEditor";
+import { PromptNameField } from "./PromptNameField";
+import { validatePromptName, isPromptNameConflict } from "./promptName";
 
 interface Props {
   onNavigate: (path: string) => void;
@@ -40,7 +43,6 @@ const scopeStyles: Record<string, ScopeStyle> = {
   system: { label: "System", icon: MessageSquare, color: "bg-amber-500/10 text-amber-400 border-amber-500/20" },
 };
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- literal key, always present
 const defaultScopeStyle: ScopeStyle = scopeStyles["personal"]!;
 
 function getScopeStyle(scope: string): ScopeStyle {
@@ -117,6 +119,7 @@ export function AdminPromptsPage({ onNavigate: _onNavigate }: Props) {
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);
+  const [nameConflict, setNameConflict] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<SortKey>("name");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
@@ -185,12 +188,18 @@ export function AdminPromptsPage({ onNavigate: _onNavigate }: Props) {
 
   function handleSubmit() {
     setMutationError(null);
+    setNameConflict(null);
     const personas = form.personas
       .split(",")
       .map((s) => s.trim())
       .filter(Boolean);
     const onError = (err: unknown) => {
-      setMutationError(err instanceof Error ? err.message : "Operation failed");
+      const msg = err instanceof Error ? err.message : "Operation failed";
+      if (isPromptNameConflict(msg)) {
+        setNameConflict("That name is already taken.");
+      } else {
+        setMutationError(msg);
+      }
     };
 
     if (formMode === "create") {
@@ -309,10 +318,11 @@ export function AdminPromptsPage({ onNavigate: _onNavigate }: Props) {
             </button>
           </div>
           <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="text-xs text-muted-foreground">Name</label>
-              <input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} className="w-full rounded-md border bg-background px-3 py-1.5 text-sm outline-none" placeholder="my-prompt" />
-            </div>
+            <PromptNameField
+              value={form.name}
+              onChange={(v) => { setForm({ ...form, name: v }); setNameConflict(null); }}
+              serverError={nameConflict}
+            />
             <div>
               <label className="text-xs text-muted-foreground">Display Name</label>
               <input value={form.display_name} onChange={(e) => setForm({ ...form, display_name: e.target.value })} className="w-full rounded-md border bg-background px-3 py-1.5 text-sm outline-none" placeholder="My Prompt" />
@@ -323,7 +333,12 @@ export function AdminPromptsPage({ onNavigate: _onNavigate }: Props) {
             </div>
             <div className="col-span-2">
               <label className="text-xs text-muted-foreground">Content</label>
-              <textarea value={form.content} onChange={(e) => setForm({ ...form, content: e.target.value })} rows={4} className="w-full rounded-md border bg-background px-3 py-1.5 text-sm outline-none font-mono" placeholder="Prompt content with {arg} placeholders..." />
+              <MarkdownEditor
+                value={form.content}
+                onChange={(v) => setForm({ ...form, content: v })}
+                minHeight="10rem"
+                placeholder="Prompt content with {arg} placeholders..."
+              />
             </div>
             <div>
               <label className="text-xs text-muted-foreground">Scope</label>
@@ -359,7 +374,7 @@ export function AdminPromptsPage({ onNavigate: _onNavigate }: Props) {
           )}
           <div className="flex justify-end gap-2 pt-2">
             <button onClick={() => setFormMode("closed")} className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted">Cancel</button>
-            <button onClick={handleSubmit} disabled={!form.name || !form.content || isMutating} className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
+            <button onClick={handleSubmit} disabled={!form.content || isMutating || validatePromptName(form.name) !== null} className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
               <Save className="h-3.5 w-3.5" />
               {isMutating ? "Saving..." : formMode === "create" ? "Create" : "Save"}
             </button>

--- a/ui/src/pages/prompts/MyPromptsPage.tsx
+++ b/ui/src/pages/prompts/MyPromptsPage.tsx
@@ -16,6 +16,9 @@ import { useMyPrompts, useCreateMyPrompt } from "@/api/portal/hooks";
 import type { Prompt } from "@/api/admin/types";
 import { cn } from "@/lib/utils";
 import { extractPromptArguments } from "./promptArguments";
+import { MarkdownEditor } from "@/components/MarkdownEditor";
+import { PromptNameField } from "./PromptNameField";
+import { validatePromptName, isPromptNameConflict } from "./promptName";
 
 interface Props {
   onNavigate: (path: string) => void;
@@ -87,6 +90,7 @@ export function MyPromptsPage({ onNavigate }: Props) {
   const [creating, setCreating] = useState(false);
   const [form, setForm] = useState<FormData>(emptyForm);
   const [mutationError, setMutationError] = useState<string | null>(null);
+  const [nameConflict, setNameConflict] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<SortKey>("name");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
@@ -156,6 +160,7 @@ export function MyPromptsPage({ onNavigate }: Props) {
 
   function handleCreate() {
     setMutationError(null);
+    setNameConflict(null);
     createMutation.mutate(form, {
       onSuccess: (p) => {
         setCreating(false);
@@ -163,7 +168,12 @@ export function MyPromptsPage({ onNavigate }: Props) {
         if (p?.id) onNavigate(`/prompts/${p.id}`);
       },
       onError: (err) => {
-        setMutationError(err instanceof Error ? err.message : "Operation failed");
+        const msg = err instanceof Error ? err.message : "Operation failed";
+        if (isPromptNameConflict(msg)) {
+          setNameConflict("That name is already taken.");
+        } else {
+          setMutationError(msg);
+        }
       },
     });
   }
@@ -240,10 +250,11 @@ export function MyPromptsPage({ onNavigate }: Props) {
             <button onClick={() => setCreating(false)} className="text-muted-foreground hover:text-foreground"><X className="h-4 w-4" /></button>
           </div>
           <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="text-xs text-muted-foreground">Name</label>
-              <input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} className="w-full rounded-md border bg-background px-3 py-1.5 text-sm outline-none" placeholder="my-prompt" />
-            </div>
+            <PromptNameField
+              value={form.name}
+              onChange={(v) => { setForm({ ...form, name: v }); setNameConflict(null); }}
+              serverError={nameConflict}
+            />
             <div>
               <label className="text-xs text-muted-foreground">Display Name</label>
               <input value={form.display_name} onChange={(e) => setForm({ ...form, display_name: e.target.value })} className="w-full rounded-md border bg-background px-3 py-1.5 text-sm outline-none" placeholder="My Prompt" />
@@ -260,7 +271,12 @@ export function MyPromptsPage({ onNavigate }: Props) {
             </div>
             <div className="col-span-2">
               <label className="text-xs text-muted-foreground">Content (Markdown)</label>
-              <textarea value={form.content} onChange={(e) => handleContentChange(e.target.value)} rows={6} className="w-full rounded-md border bg-background px-3 py-1.5 text-sm outline-none font-mono" placeholder="Prompt content with {{arg}} placeholders..." />
+              <MarkdownEditor
+                value={form.content}
+                onChange={handleContentChange}
+                minHeight="12rem"
+                placeholder="Prompt content with {{arg}} placeholders..."
+              />
               <p className="text-[11px] text-muted-foreground mt-1">
                 Use <code className="font-mono">{"{{name}}"}</code> (preferred) or <code className="font-mono">{"{name}"}</code> to declare an argument. Rows auto-appear below as you type.
               </p>
@@ -318,7 +334,7 @@ export function MyPromptsPage({ onNavigate }: Props) {
           )}
           <div className="flex justify-end gap-2 pt-2">
             <button onClick={() => setCreating(false)} className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted">Cancel</button>
-            <button onClick={handleCreate} disabled={!form.name || !form.content || createMutation.isPending} className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
+            <button onClick={handleCreate} disabled={!form.content || createMutation.isPending || validatePromptName(form.name) !== null} className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50">
               <Save className="h-3.5 w-3.5" /> {createMutation.isPending ? "Saving..." : "Create"}
             </button>
           </div>

--- a/ui/src/pages/prompts/PromptNameField.tsx
+++ b/ui/src/pages/prompts/PromptNameField.tsx
@@ -1,0 +1,40 @@
+import { cn } from "@/lib/utils";
+import { validatePromptName, PROMPT_NAME_MAX_LENGTH } from "./promptName";
+
+interface PromptNameFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  // serverError is a name-specific error from a failed save (e.g. a duplicate
+  // name). Shown only when the typed value is otherwise locally valid, since a
+  // local format error is the more immediate thing to fix.
+  serverError?: string | null;
+}
+
+const NAME_HELP = "Lowercase letters, digits, hyphens, and underscores; must start with a letter or digit.";
+
+// PromptNameField renders the prompt name input with inline validation that
+// mirrors the server rule, plus helper text. Shared by the create and edit
+// forms so they enforce the name format identically.
+export function PromptNameField({ value, onChange, serverError }: PromptNameFieldProps) {
+  const formatError = value ? validatePromptName(value) : null;
+  const error = formatError ?? serverError ?? null;
+  return (
+    <div>
+      <label className="text-xs text-muted-foreground">Name</label>
+      <input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        maxLength={PROMPT_NAME_MAX_LENGTH}
+        placeholder="my-prompt"
+        aria-invalid={error ? true : undefined}
+        className={cn(
+          "w-full rounded-md border bg-background px-3 py-1.5 text-sm outline-none",
+          error && "border-red-500/60",
+        )}
+      />
+      <p className={cn("text-[11px] mt-1", error ? "text-red-400" : "text-muted-foreground")}>
+        {error ?? NAME_HELP}
+      </p>
+    </div>
+  );
+}

--- a/ui/src/pages/prompts/PromptViewerPage.tsx
+++ b/ui/src/pages/prompts/PromptViewerPage.tsx
@@ -21,7 +21,10 @@ import {
 import { useMyPrompts, useUpdateMyPrompt, useDeleteMyPrompt, useCreateAsset } from "@/api/portal/hooks";
 import { ShareDialog } from "@/components/ShareDialog";
 import { MarkdownRenderer } from "@/components/renderers/MarkdownRenderer";
+import { MarkdownEditor } from "@/components/MarkdownEditor";
 import { LoadingIndicator } from "@/components/LoadingIndicator";
+import { PromptNameField } from "./PromptNameField";
+import { validatePromptName, isPromptNameConflict } from "./promptName";
 import type { Prompt } from "@/api/admin/types";
 import { cn } from "@/lib/utils";
 import { extractPromptArguments } from "./promptArguments";
@@ -132,6 +135,7 @@ export function PromptViewerPage({ promptId, onNavigate, onBack }: Props) {
   const [editing, setEditing] = useState(false);
   const [form, setForm] = useState<EditForm>({ name: "", display_name: "", description: "", content: "", category: "", arguments: [] });
   const [error, setError] = useState<string | null>(null);
+  const [nameConflict, setNameConflict] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [shareAssetId, setShareAssetId] = useState<string | null>(null);
@@ -177,6 +181,7 @@ export function PromptViewerPage({ promptId, onNavigate, onBack }: Props) {
   const handleSave = useCallback(() => {
     if (!prompt) return;
     setError(null);
+    setNameConflict(null);
     updateMutation.mutate(
       { id: prompt.id, ...form },
       {
@@ -184,7 +189,12 @@ export function PromptViewerPage({ promptId, onNavigate, onBack }: Props) {
           setEditing(false);
         },
         onError: (err) => {
-          setError(err instanceof Error ? err.message : "Save failed");
+          const msg = err instanceof Error ? err.message : "Save failed";
+          if (isPromptNameConflict(msg)) {
+            setNameConflict("That name is already taken.");
+          } else {
+            setError(msg);
+          }
         },
       },
     );
@@ -353,7 +363,7 @@ export function PromptViewerPage({ promptId, onNavigate, onBack }: Props) {
           <>
             <button
               onClick={handleSave}
-              disabled={!dirty || updateMutation.isPending}
+              disabled={!dirty || updateMutation.isPending || validatePromptName(form.name) !== null}
               className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
             >
               <Save className="h-3.5 w-3.5" /> {updateMutation.isPending ? "Saving..." : "Save"}
@@ -411,10 +421,11 @@ export function PromptViewerPage({ promptId, onNavigate, onBack }: Props) {
       {editing && (
         <div className="rounded-lg border bg-card p-4 space-y-3">
           <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="text-xs text-muted-foreground">Name</label>
-              <input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} className="w-full rounded-md border bg-background px-3 py-1.5 text-sm outline-none" />
-            </div>
+            <PromptNameField
+              value={form.name}
+              onChange={(v) => { setForm({ ...form, name: v }); setNameConflict(null); }}
+              serverError={nameConflict}
+            />
             <div>
               <label className="text-xs text-muted-foreground">Display Name</label>
               <input value={form.display_name} onChange={(e) => setForm({ ...form, display_name: e.target.value })} className="w-full rounded-md border bg-background px-3 py-1.5 text-sm outline-none" />
@@ -435,11 +446,11 @@ export function PromptViewerPage({ promptId, onNavigate, onBack }: Props) {
           </div>
           <div>
             <label className="text-xs text-muted-foreground">Content (Markdown)</label>
-            <textarea
+            <MarkdownEditor
               value={form.content}
-              onChange={(e) => handleContentChange(e.target.value)}
-              rows={16}
-              className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none font-mono"
+              onChange={handleContentChange}
+              minHeight="20rem"
+              placeholder="Prompt content with {{arg}} placeholders..."
             />
             <p className="text-[11px] text-muted-foreground mt-1">
               Use <code className="font-mono">{"{{name}}"}</code> (preferred) or <code className="font-mono">{"{name}"}</code> to declare an argument. Rows auto-appear below as you type.

--- a/ui/src/pages/prompts/promptName.test.ts
+++ b/ui/src/pages/prompts/promptName.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { validatePromptName, isPromptNameConflict, PROMPT_NAME_MAX_LENGTH } from "./promptName";
+
+describe("validatePromptName", () => {
+  it("accepts lowercase, digits, hyphens, and underscores", () => {
+    for (const name of ["daily-sales-report", "daily_sales_report", "report1", "a", "0name"]) {
+      expect(validatePromptName(name)).toBeNull();
+    }
+  });
+
+  it("rejects empty, uppercase, spaces, and a leading non-alphanumeric", () => {
+    expect(validatePromptName("")).toMatch(/required/i);
+    expect(validatePromptName("Daily Report")).toMatch(/lowercase/i);
+    expect(validatePromptName("daily report")).toMatch(/lowercase/i);
+    expect(validatePromptName("CamelCase")).toMatch(/lowercase/i);
+    // Must start with a letter or digit, not a hyphen/underscore.
+    expect(validatePromptName("-leading")).toMatch(/lowercase/i);
+    expect(validatePromptName("_leading")).toMatch(/lowercase/i);
+  });
+
+  it("rejects names over the max length", () => {
+    expect(validatePromptName("a".repeat(PROMPT_NAME_MAX_LENGTH))).toBeNull();
+    expect(validatePromptName("a".repeat(PROMPT_NAME_MAX_LENGTH + 1))).toMatch(/at most/i);
+  });
+
+  it("mirrors the backend pattern exactly", () => {
+    // Same regex as pkg/prompt/prompt.go validNamePattern.
+    expect(validatePromptName("ok-1_2")).toBeNull();
+    expect(validatePromptName("bad!")).toMatch(/lowercase/i);
+  });
+});
+
+describe("isPromptNameConflict", () => {
+  it("detects the server's duplicate-name message", () => {
+    expect(isPromptNameConflict("prompt name already exists")).toBe(true);
+    expect(isPromptNameConflict("Prompt name already exists")).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isPromptNameConflict("internal server error")).toBe(false);
+    expect(isPromptNameConflict("")).toBe(false);
+  });
+});

--- a/ui/src/pages/prompts/promptName.ts
+++ b/ui/src/pages/prompts/promptName.ts
@@ -1,0 +1,26 @@
+// Prompt name rules mirrored from the backend (pkg/prompt/prompt.go,
+// ValidateName / maxNameLength / validNamePattern). Keep these in sync with
+// that file so the form rejects exactly what the server rejects, before a
+// round-trip.
+export const PROMPT_NAME_MAX_LENGTH = 128;
+export const PROMPT_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
+
+// validatePromptName returns a human-readable error when the name is invalid,
+// or null when it is acceptable.
+export function validatePromptName(name: string): string | null {
+  if (!name) return "Name is required.";
+  if (name.length > PROMPT_NAME_MAX_LENGTH) {
+    return `Name must be at most ${PROMPT_NAME_MAX_LENGTH} characters.`;
+  }
+  if (!PROMPT_NAME_PATTERN.test(name)) {
+    return "Use lowercase letters, digits, hyphens, and underscores; must start with a letter or digit.";
+  }
+  return null;
+}
+
+// isPromptNameConflict reports whether a save error is the server's
+// duplicate-name (409) response, so callers can surface it on the name field
+// rather than as a generic banner.
+export function isPromptNameConflict(message: string): boolean {
+  return /already exists/i.test(message);
+}


### PR DESCRIPTION
## Summary

Polishes the portal prompt editor so it stops accepting input the backend will reject, and brings the markdown editing experience in line with the rest of the portal. Three small, independent UX gaps, fixed across all three prompt forms (view/edit, user create, admin).

## Problems

All verified in the current code:

1. **The name field accepted invalid input.** The backend enforces `^[a-z0-9][a-z0-9_-]*$` and a 128-char max (`pkg/prompt/prompt.go`, `ValidateName`), but the portal forms were bare `<input>`s with no `pattern`, `maxLength`, or `required`. A user could type `My Prompt`, hit Save, and only then learn it was rejected, as a generic error banner.
2. **Duplicate names surfaced as a generic banner.** Names are globally unique (`name TEXT NOT NULL UNIQUE`, migration `000030`); the API returns `409 "prompt name already exists"`, but the UI showed it as an undifferentiated red banner rather than on the name field.
3. **Content used a bare `<textarea>`.** Prompt `content` is markdown, but it was edited in a plain textarea, while the agent-instructions field already uses the richer `MarkdownEditor` (CodeMirror, formatting toolbar, live preview).

## Changes

- **Shared `promptName.ts`** — `validatePromptName` mirrors the backend rule exactly (same pattern, same 128 max, matching messages), plus `isPromptNameConflict` to detect the 409. Single source of truth, with a comment to keep it in sync with `pkg/prompt/prompt.go`.
- **Shared `PromptNameField`** — name input with inline format validation, `maxLength`, helper text, and a red inline error. Used by all three forms so they enforce the name identically.
- **All three forms** (`PromptViewerPage`, `MyPromptsPage`, `AdminPromptsPage`): name input -> `PromptNameField`; **Save/Create disabled while the name is invalid** (format errors no longer need a server round-trip); content `<textarea>` -> `MarkdownEditor`; duplicate-name 409 surfaced inline on the name field as **"That name is already taken."**
- Removed a now-unused `eslint-disable` directive the change surfaced.

## A note on the helper text

The first cut said "Must be unique," which is unactionable: prompt names are globally unique across all users (including personal prompts a user cannot see), so a user can't know what is taken. The helper text now states only the format rule, and uniqueness is communicated **reactively** via the inline "already taken" message when a real collision occurs.

This also surfaced two deeper design questions that are **out of scope here** and belong to the prompt-library epic (#525): whether global name uniqueness should be relaxed to per-`(owner, scope)`, and the fact that a user has no self-service path to promote a personal prompt to persona/global today (the "Share" button currently exports a markdown asset rather than sharing the prompt). Those are documented on #525; this PR only fixes the editor UX.

## Testing

- Unit tests for `validatePromptName` (accepts valid forms; rejects empty, uppercase, spaces, leading non-alphanumeric, over-length) and `isPromptNameConflict`.
- `tsc --noEmit` clean; `eslint` clean on changed files; full UI suite passes (154 tests); production `vite build` succeeds.

## Scope

UI only; no API or schema change. The backend already validated names and enforced uniqueness; this aligns the forms with that behavior and upgrades the content editor.
