### PR TITLE
feat(prompts): scope native MCP prompts/list and prompts/get to the caller

### DIFF
--- a/pkg/middleware/mcp_prompt_visibility.go
+++ b/pkg/middleware/mcp_prompt_visibility.go
@@ -1,0 +1,138 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// PromptVisibility reports whether a prompt is visible to a caller identified
+// by email, persona memberships, and admin status. Built-in (non-database)
+// prompts MUST return true. The platform supplies this; it consults the
+// per-prompt scope/owner recorded at registration time.
+type PromptVisibility func(email string, personas []string, isAdmin bool, promptName string) bool
+
+// PromptVisibilityConfig configures the prompts visibility filter.
+type PromptVisibilityConfig struct {
+	Authenticator    Authenticator
+	PersonasForRoles PersonasForRoles
+	AdminPersona     string
+	IsVisible        PromptVisibility
+}
+
+// MCPPromptVisibilityMiddleware scopes the native MCP prompt surface to the
+// caller. It filters prompts/list and denies prompts/get for prompts the
+// caller may not see: global and built-in prompts to everyone, persona-scoped
+// prompts to members of the prompt's personas, and personal prompts to their
+// owner. It mirrors the tools/list and resources visibility filters.
+//
+// This matters because every database prompt — including every user's personal
+// prompts — is registered on the single shared MCP server, so without this
+// filter the SDK returns all of them to every client (and serves any of them by
+// name). The REST API and the manage_prompt tool already scope by owner/persona;
+// this closes the same gap on the native MCP prompts surface.
+func MCPPromptVisibilityMiddleware(cfg PromptVisibilityConfig) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			switch method {
+			case methodPromptsList:
+				result, err := next(ctx, method, req)
+				if err != nil {
+					return result, err
+				}
+				return filterPromptVisibility(ctx, cfg, req, result), nil
+			case methodPromptsGet:
+				if err := denyHiddenPromptGet(ctx, cfg, req); err != nil {
+					return nil, err
+				}
+				return next(ctx, method, req)
+			default:
+				return next(ctx, method, req)
+			}
+		}
+	}
+}
+
+// resolvePromptCaller resolves the caller's email, persona memberships, and
+// admin status for a prompt visibility decision. A nil PlatformContext (auth
+// failed or absent) yields an empty identity, so only global and built-in
+// prompts survive — fail closed.
+func resolvePromptCaller(ctx context.Context, cfg PromptVisibilityConfig, req mcp.Request) (email string, personas []string, isAdmin bool) {
+	pc := getOrAuthenticatePC(ctx, req, cfg.Authenticator, cfg.PersonasForRoles, cfg.AdminPersona)
+	if pc == nil {
+		return "", nil, false
+	}
+	email = pc.UserEmail
+	isAdmin = pc.IsAdmin
+	if cfg.PersonasForRoles != nil {
+		personas = cfg.PersonasForRoles(pc.Roles)
+	} else if pc.PersonaName != "" {
+		personas = []string{pc.PersonaName}
+	}
+	return email, personas, isAdmin
+}
+
+// filterPromptVisibility removes prompts the caller may not see from a
+// prompts/list result.
+func filterPromptVisibility(ctx context.Context, cfg PromptVisibilityConfig, req mcp.Request, result mcp.Result) mcp.Result {
+	listResult, ok := result.(*mcp.ListPromptsResult)
+	if !ok || listResult == nil || cfg.IsVisible == nil {
+		return result
+	}
+
+	email, personas, isAdmin := resolvePromptCaller(ctx, cfg, req)
+
+	before := len(listResult.Prompts)
+	filtered := make([]*mcp.Prompt, 0, before)
+	for _, pr := range listResult.Prompts {
+		if cfg.IsVisible(email, personas, isAdmin, pr.Name) {
+			filtered = append(filtered, pr)
+		}
+	}
+	listResult.Prompts = filtered
+
+	if before != len(filtered) {
+		slog.Debug("prompts list: filtered",
+			"in", before,
+			"out", len(filtered),
+		)
+	}
+	return listResult
+}
+
+// denyHiddenPromptGet returns a not-found error when the caller requests a
+// prompt they are not entitled to see, so a known name cannot be used to fetch
+// another user's prompt content. It deliberately mirrors a not-found result
+// rather than a permission error so callers cannot probe for a prompt's
+// existence. Returns nil (allow) for visible prompts, built-in prompts, and
+// when the name cannot be determined (the SDK handles those).
+func denyHiddenPromptGet(ctx context.Context, cfg PromptVisibilityConfig, req mcp.Request) error {
+	if cfg.IsVisible == nil {
+		return nil
+	}
+	name := promptNameFromRequest(req)
+	if name == "" {
+		return nil
+	}
+	email, personas, isAdmin := resolvePromptCaller(ctx, cfg, req)
+	if cfg.IsVisible(email, personas, isAdmin, name) {
+		return nil
+	}
+	slog.Debug("prompts get: denied hidden prompt", "prompt", name)
+	return fmt.Errorf("prompt %q not found", name)
+}
+
+// promptNameFromRequest extracts the requested prompt name from a prompts/get
+// request, or "" when it cannot be determined.
+func promptNameFromRequest(req mcp.Request) string {
+	if req == nil {
+		return ""
+	}
+	params, ok := req.GetParams().(*mcp.GetPromptParams)
+	if !ok || params == nil {
+		return ""
+	}
+	return params.Name
+}

--- a/pkg/middleware/mcp_prompt_visibility_test.go
+++ b/pkg/middleware/mcp_prompt_visibility_test.go
@@ -1,0 +1,279 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+var errTest = errors.New("upstream failure")
+
+func promptListResult(names ...string) *mcp.ListPromptsResult {
+	prompts := make([]*mcp.Prompt, len(names))
+	for i, n := range names {
+		prompts[i] = &mcp.Prompt{Name: n}
+	}
+	return &mcp.ListPromptsResult{Prompts: prompts}
+}
+
+func promptResultNames(r *mcp.ListPromptsResult) []string {
+	out := make([]string, len(r.Prompts))
+	for i, p := range r.Prompts {
+		out[i] = p.Name
+	}
+	return out
+}
+
+func TestMCPPromptVisibilityMiddleware_FiltersList(t *testing.T) {
+	base := func(_ context.Context, method string, _ mcp.Request) (mcp.Result, error) {
+		if method == methodPromptsList {
+			return promptListResult("global", "secret", "mine"), nil
+		}
+		return &mcp.CallToolResult{}, nil
+	}
+	cfg := PromptVisibilityConfig{
+		IsVisible: func(_ string, _ []string, _ bool, name string) bool {
+			return name != "secret"
+		},
+	}
+	handler := MCPPromptVisibilityMiddleware(cfg)(base)
+
+	got, err := handler(context.Background(), methodPromptsList, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lr, ok := got.(*mcp.ListPromptsResult)
+	if !ok {
+		t.Fatalf("want *mcp.ListPromptsResult, got %T", got)
+	}
+	names := promptResultNames(lr)
+	if len(names) != 2 || names[0] != "global" || names[1] != "mine" {
+		t.Errorf("expected [global mine], got %v", names)
+	}
+}
+
+func TestMCPPromptVisibilityMiddleware_PassThroughNonList(t *testing.T) {
+	base := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return &mcp.CallToolResult{}, nil
+	}
+	called := false
+	cfg := PromptVisibilityConfig{IsVisible: func(_ string, _ []string, _ bool, _ string) bool {
+		called = true
+		return true
+	}}
+	handler := MCPPromptVisibilityMiddleware(cfg)(base)
+	if _, err := handler(context.Background(), "tools/call", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("IsVisible must not be consulted for non-prompts/list methods")
+	}
+}
+
+func TestMCPPromptVisibilityMiddleware_NilIsVisibleNoOp(t *testing.T) {
+	base := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return promptListResult("a", "b"), nil
+	}
+	handler := MCPPromptVisibilityMiddleware(PromptVisibilityConfig{})(base)
+	got, _ := handler(context.Background(), methodPromptsList, nil)
+	lr, ok := got.(*mcp.ListPromptsResult)
+	if !ok {
+		t.Fatalf("want *mcp.ListPromptsResult, got %T", got)
+	}
+	if len(lr.Prompts) != 2 {
+		t.Errorf("nil IsVisible must not filter; got %d", len(lr.Prompts))
+	}
+}
+
+func TestMCPPromptVisibilityMiddleware_ResolvesCallerIdentity(t *testing.T) {
+	base := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return promptListResult("mine"), nil
+	}
+	var gotEmail string
+	var gotPersonas []string
+	cfg := PromptVisibilityConfig{
+		Authenticator: &mockAuthenticator{
+			authenticateFunc: func(_ context.Context) (*UserInfo, error) {
+				return &UserInfo{UserID: "u", Email: "sarah@example.com", Roles: []string{"r-analyst"}}, nil
+			},
+		},
+		PersonasForRoles: func(roles []string) []string {
+			if len(roles) > 0 && roles[0] == "r-analyst" {
+				return []string{"analyst"}
+			}
+			return nil
+		},
+		IsVisible: func(email string, personas []string, _ bool, _ string) bool {
+			gotEmail = email
+			gotPersonas = personas
+			return true
+		},
+	}
+	handler := MCPPromptVisibilityMiddleware(cfg)(base)
+	if _, err := handler(context.Background(), methodPromptsList, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotEmail != "sarah@example.com" {
+		t.Errorf("email = %q; want sarah@example.com", gotEmail)
+	}
+	if len(gotPersonas) != 1 || gotPersonas[0] != "analyst" {
+		t.Errorf("personas = %v; want [analyst]", gotPersonas)
+	}
+}
+
+func TestMCPPromptVisibilityMiddleware_AllowsVisibleGet(t *testing.T) {
+	nextCalled := false
+	base := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		nextCalled = true
+		return &mcp.GetPromptResult{}, nil
+	}
+	cfg := PromptVisibilityConfig{
+		IsVisible: func(_ string, _ []string, _ bool, name string) bool { return name == "ok" },
+	}
+	handler := MCPPromptVisibilityMiddleware(cfg)(base)
+	req := &mcp.ServerRequest[*mcp.GetPromptParams]{Params: &mcp.GetPromptParams{Name: "ok"}}
+
+	_, err := handler(context.Background(), methodPromptsGet, req)
+	if err != nil {
+		t.Fatalf("visible prompt get should not error: %v", err)
+	}
+	if !nextCalled {
+		t.Error("next handler must run for a visible prompt")
+	}
+}
+
+func TestMCPPromptVisibilityMiddleware_DeniesHiddenGet(t *testing.T) {
+	nextCalled := false
+	base := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		nextCalled = true
+		return &mcp.GetPromptResult{}, nil
+	}
+	cfg := PromptVisibilityConfig{
+		IsVisible: func(_ string, _ []string, _ bool, name string) bool { return name != "secret" },
+	}
+	handler := MCPPromptVisibilityMiddleware(cfg)(base)
+	req := &mcp.ServerRequest[*mcp.GetPromptParams]{Params: &mcp.GetPromptParams{Name: "secret"}}
+
+	_, err := handler(context.Background(), methodPromptsGet, req)
+	if err == nil {
+		t.Fatal("hidden prompt get must be denied")
+	}
+	if nextCalled {
+		t.Error("next handler must NOT run for a hidden prompt (no content fetched)")
+	}
+}
+
+func TestMCPPromptVisibilityMiddleware_GetEdgeCasesAllow(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  PromptVisibilityConfig
+		req  mcp.Request
+	}{
+		{
+			name: "nil IsVisible is a no-op",
+			cfg:  PromptVisibilityConfig{},
+			req:  &mcp.ServerRequest[*mcp.GetPromptParams]{Params: &mcp.GetPromptParams{Name: "x"}},
+		},
+		{
+			name: "missing name defers to the SDK",
+			cfg:  PromptVisibilityConfig{IsVisible: func(_ string, _ []string, _ bool, _ string) bool { return false }},
+			req:  &mcp.ServerRequest[*mcp.GetPromptParams]{Params: &mcp.GetPromptParams{Name: ""}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			nextCalled := false
+			base := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+				nextCalled = true
+				return &mcp.GetPromptResult{}, nil
+			}
+			handler := MCPPromptVisibilityMiddleware(tc.cfg)(base)
+			if _, err := handler(context.Background(), methodPromptsGet, tc.req); err != nil {
+				t.Fatalf("expected allow, got error: %v", err)
+			}
+			if !nextCalled {
+				t.Error("next must run when the get is allowed")
+			}
+		})
+	}
+}
+
+func TestMCPPromptVisibilityMiddleware_GetNilRequestAllows(t *testing.T) {
+	nextCalled := false
+	base := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		nextCalled = true
+		return &mcp.GetPromptResult{}, nil
+	}
+	cfg := PromptVisibilityConfig{IsVisible: func(_ string, _ []string, _ bool, _ string) bool { return false }}
+	handler := MCPPromptVisibilityMiddleware(cfg)(base)
+	if _, err := handler(context.Background(), methodPromptsGet, nil); err != nil {
+		t.Fatalf("nil request should defer to the SDK, got error: %v", err)
+	}
+	if !nextCalled {
+		t.Error("next must run when the name cannot be determined")
+	}
+}
+
+func TestMCPPromptVisibilityMiddleware_ListErrorPropagates(t *testing.T) {
+	wantErr := errTest
+	base := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return nil, wantErr
+	}
+	cfg := PromptVisibilityConfig{IsVisible: func(_ string, _ []string, _ bool, _ string) bool { return true }}
+	handler := MCPPromptVisibilityMiddleware(cfg)(base)
+	if _, err := handler(context.Background(), methodPromptsList, nil); !errors.Is(err, wantErr) {
+		t.Errorf("expected the upstream error to propagate, got %v", err)
+	}
+}
+
+func TestResolvePromptCaller_PersonaNameFallback(t *testing.T) {
+	// When PersonasForRoles is nil, a single PersonaName from an existing
+	// PlatformContext is used as the caller's persona set.
+	base := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return promptListResult("p"), nil
+	}
+	var gotPersonas []string
+	cfg := PromptVisibilityConfig{
+		IsVisible: func(_ string, personas []string, _ bool, _ string) bool {
+			gotPersonas = personas
+			return true
+		},
+	}
+	ctx := WithPlatformContext(context.Background(), &PlatformContext{UserEmail: "x@example.com", PersonaName: "analyst"})
+	handler := MCPPromptVisibilityMiddleware(cfg)(base)
+	if _, err := handler(ctx, methodPromptsList, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(gotPersonas) != 1 || gotPersonas[0] != "analyst" {
+		t.Errorf("personas = %v; want [analyst]", gotPersonas)
+	}
+}
+
+func TestMCPPromptVisibilityMiddleware_NoAuthYieldsEmptyIdentity(t *testing.T) {
+	// No authenticator → nil PlatformContext → empty identity, so an
+	// IsVisible that hides non-global-on-empty-email drops the personal prompt.
+	base := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return promptListResult("mine"), nil
+	}
+	gotEmail := "unset"
+	cfg := PromptVisibilityConfig{
+		IsVisible: func(email string, _ []string, _ bool, _ string) bool {
+			gotEmail = email
+			return email != ""
+		},
+	}
+	handler := MCPPromptVisibilityMiddleware(cfg)(base)
+	got, _ := handler(context.Background(), methodPromptsList, nil)
+	lr, ok := got.(*mcp.ListPromptsResult)
+	if !ok {
+		t.Fatalf("want *mcp.ListPromptsResult, got %T", got)
+	}
+	if gotEmail != "" {
+		t.Errorf("expected empty identity with no authenticator, got %q", gotEmail)
+	}
+	if len(lr.Prompts) != 0 {
+		t.Errorf("anonymous caller should see no personal prompts; got %d", len(lr.Prompts))
+	}
+}

--- a/pkg/middleware/mcp_resources.go
+++ b/pkg/middleware/mcp_resources.go
@@ -161,7 +161,7 @@ func containsManagedResources(resources []*mcp.Resource, prefix string) bool {
 // authorized the filter so callers can include user/persona attribution in
 // their log lines. Returns (nil, nil) when auth fails.
 func resolveVisibleManagedURIsWithPC(ctx context.Context, req mcp.Request, cfg ManagedResourceConfig) (pc *PlatformContext, visible map[string]bool) {
-	pc = getOrAuthenticatePC(ctx, req, cfg)
+	pc = getOrAuthenticatePC(ctx, req, cfg.Authenticator, cfg.PersonasForRoles, cfg.AdminPersona)
 	if pc == nil {
 		return nil, nil
 	}
@@ -223,7 +223,7 @@ func handleManagedRead(ctx context.Context, next mcp.MethodHandler, method strin
 	}
 	slog.Debug("managed resources read: found in store", logKeyURI, uri, "scope", res.Scope, "id", res.ID)
 
-	pc := getOrAuthenticatePC(ctx, req, cfg)
+	pc := getOrAuthenticatePC(ctx, req, cfg.Authenticator, cfg.PersonasForRoles, cfg.AdminPersona)
 	if pc == nil {
 		slog.Warn("managed resources read: auth failed, falling through to SDK", logKeyURI, uri)
 		return next(ctx, method, req)
@@ -307,12 +307,12 @@ func claimsFromPC(pc *PlatformContext, cfg ManagedResourceConfig) resource.Claim
 // (set by MCPToolCallMiddleware for tools/call), or authenticates the user
 // directly for resources/list and resources/read methods. Returns nil if
 // authentication fails or no authenticator is configured.
-func getOrAuthenticatePC(ctx context.Context, req mcp.Request, cfg ManagedResourceConfig) *PlatformContext {
+func getOrAuthenticatePC(ctx context.Context, req mcp.Request, auth Authenticator, personasForRoles PersonasForRoles, adminPersona string) *PlatformContext {
 	if pc := GetPlatformContext(ctx); pc != nil {
 		slog.Debug("getOrAuthenticatePC: using existing PlatformContext", logKeyUserID, pc.UserID)
 		return pc
 	}
-	if cfg.Authenticator == nil {
+	if auth == nil {
 		slog.Debug("getOrAuthenticatePC: no authenticator configured")
 		return nil
 	}
@@ -322,7 +322,7 @@ func getOrAuthenticatePC(ctx context.Context, req mcp.Request, cfg ManagedResour
 	}
 	tokenPresent := GetToken(ctx) != ""
 	slog.Debug("getOrAuthenticatePC: attempting direct auth", "token_present", tokenPresent)
-	userInfo, err := cfg.Authenticator.Authenticate(ctx)
+	userInfo, err := auth.Authenticate(ctx)
 	if err != nil || userInfo == nil {
 		slog.Debug("getOrAuthenticatePC: auth failed", logKeyError, err, "user_nil", userInfo == nil)
 		return nil
@@ -334,12 +334,12 @@ func getOrAuthenticatePC(ctx context.Context, req mcp.Request, cfg ManagedResour
 		Roles:     userInfo.Roles,
 	}
 	// Resolve persona for admin status.
-	if cfg.PersonasForRoles != nil {
-		personas := cfg.PersonasForRoles(userInfo.Roles)
+	if personasForRoles != nil {
+		personas := personasForRoles(userInfo.Roles)
 		if len(personas) > 0 {
 			pc.PersonaName = personas[0]
 		}
-		pc.IsAdmin = cfg.AdminPersona != "" && slices.Contains(personas, cfg.AdminPersona)
+		pc.IsAdmin = adminPersona != "" && slices.Contains(personas, adminPersona)
 	}
 	return pc
 }

--- a/pkg/middleware/mcp_resources_test.go
+++ b/pkg/middleware/mcp_resources_test.go
@@ -193,7 +193,7 @@ func TestGetOrAuthenticatePC(t *testing.T) {
 	t.Run("returns existing PlatformContext", func(t *testing.T) {
 		existing := &PlatformContext{UserID: "existing"}
 		ctx := context.WithValue(context.Background(), platformContextKey, existing)
-		got := getOrAuthenticatePC(ctx, nil, ManagedResourceConfig{})
+		got := getOrAuthenticatePC(ctx, nil, nil, nil, "")
 		if got != existing {
 			t.Error("should return existing PlatformContext")
 		}
@@ -212,7 +212,7 @@ func TestGetOrAuthenticatePC(t *testing.T) {
 		req := &mcp.ServerRequest[*mcp.ReadResourceParams]{
 			Params: &mcp.ReadResourceParams{URI: "mcp://global/test/file.txt"},
 		}
-		got := getOrAuthenticatePC(context.Background(), req, cfg)
+		got := getOrAuthenticatePC(context.Background(), req, cfg.Authenticator, cfg.PersonasForRoles, cfg.AdminPersona)
 		if got == nil {
 			t.Fatal("expected non-nil PlatformContext")
 		}
@@ -227,14 +227,14 @@ func TestGetOrAuthenticatePC(t *testing.T) {
 	t.Run("returns nil when auth fails", func(t *testing.T) {
 		auth := &mockManagedAuth{err: fmt.Errorf("unauthorized")}
 		cfg := ManagedResourceConfig{Authenticator: auth}
-		got := getOrAuthenticatePC(context.Background(), nil, cfg)
+		got := getOrAuthenticatePC(context.Background(), nil, cfg.Authenticator, cfg.PersonasForRoles, cfg.AdminPersona)
 		if got != nil {
 			t.Error("expected nil when auth fails")
 		}
 	})
 
 	t.Run("returns nil when no authenticator", func(t *testing.T) {
-		got := getOrAuthenticatePC(context.Background(), nil, ManagedResourceConfig{})
+		got := getOrAuthenticatePC(context.Background(), nil, nil, nil, "")
 		if got != nil {
 			t.Error("expected nil when no authenticator configured")
 		}
@@ -249,7 +249,7 @@ func TestGetOrAuthenticatePC(t *testing.T) {
 			AdminPersona:     "admin",
 			PersonasForRoles: func(_ []string) []string { return []string{"analyst"} },
 		}
-		got := getOrAuthenticatePC(context.Background(), nil, cfg)
+		got := getOrAuthenticatePC(context.Background(), nil, cfg.Authenticator, cfg.PersonasForRoles, cfg.AdminPersona)
 		if got == nil {
 			t.Fatal("expected non-nil PlatformContext")
 		}

--- a/pkg/middleware/mcp_visibility.go
+++ b/pkg/middleware/mcp_visibility.go
@@ -13,6 +13,7 @@ const (
 	methodToolsList              = "tools/list"
 	methodResourcesTemplatesList = "resources/templates/list"
 	methodPromptsList            = "prompts/list"
+	methodPromptsGet             = "prompts/get"
 )
 
 // ToolVisibilityConfig configures tool visibility filtering for tools/list responses.

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -239,6 +239,14 @@ type Platform struct {
 	promptInfosMu sync.RWMutex
 	promptInfos   []registry.PromptInfo
 
+	// promptScopes records the scope/owner/personas of each database-backed
+	// prompt by name, so the prompts/list visibility middleware can hide
+	// prompts the caller is not entitled to see. Built-in prompts are absent
+	// from this map and are always visible. Maintained in registerDatabasePrompt
+	// and UnregisterRuntimePrompt.
+	promptScopesMu sync.RWMutex
+	promptScopes   map[string]promptScope
+
 	// MCP Apps
 	mcpAppsRegistry *mcpapps.Registry
 
@@ -2409,6 +2417,7 @@ func (p *Platform) finalizeSetup() {
 
 	// 8. Tool visibility - reduces tools/list for token savings
 	p.addToolVisibilityMiddleware()
+	p.addPromptVisibilityMiddleware()
 
 	// 8.5 Description overrides - replaces tool descriptions with workflow guidance
 	p.addDescriptionOverrideMiddleware()
@@ -2509,6 +2518,25 @@ func (p *Platform) addToolVisibilityMiddleware() {
 
 	p.mcpServer.AddReceivingMiddleware(
 		middleware.MCPToolVisibilityMiddleware(cfg),
+	)
+}
+
+// addPromptVisibilityMiddleware registers prompts/list visibility filtering so
+// a caller only sees prompts they are entitled to (global + built-in to all,
+// persona prompts to persona members, personal prompts to their owner). Without
+// it the shared MCP server returns every database prompt — including other
+// users' personal prompts — to every client.
+func (p *Platform) addPromptVisibilityMiddleware() {
+	cfg := middleware.PromptVisibilityConfig{
+		Authenticator: p.authenticator,
+		AdminPersona:  p.config.Admin.Persona,
+		IsVisible:     p.isPromptVisible,
+	}
+	if p.personaRegistry != nil {
+		cfg.PersonasForRoles = personasForRolesFunc(p.personaRegistry)
+	}
+	p.mcpServer.AddReceivingMiddleware(
+		middleware.MCPPromptVisibilityMiddleware(cfg),
 	)
 }
 

--- a/pkg/platform/prompt_visibility_test.go
+++ b/pkg/platform/prompt_visibility_test.go
@@ -1,0 +1,152 @@
+package platform
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/prompt"
+)
+
+// fakePromptAuth is a minimal Authenticator returning a fixed caller identity.
+type fakePromptAuth struct {
+	email string
+	roles []string
+}
+
+func (f *fakePromptAuth) Authenticate(_ context.Context) (*middleware.UserInfo, error) {
+	return &middleware.UserInfo{UserID: f.email, Email: f.email, Roles: f.roles}, nil
+}
+
+// TestPromptVisibility_EndToEnd wires the real prompts/list middleware to the
+// real isPromptVisible rule and the per-prompt scope map populated at
+// registration, proving another user's personal prompt is dropped from the
+// list a caller receives. This is the assembled-system check for the fix: the
+// SDK hands every registered prompt to every client, and the middleware must
+// remove the ones the caller is not entitled to see.
+func TestPromptVisibility_EndToEnd(t *testing.T) {
+	p := &Platform{}
+	// Stands in for registerDatabasePrompt populating promptScopes at boot/runtime.
+	p.setPromptScope(&prompt.Prompt{Name: "global-help", Scope: prompt.ScopeGlobal})
+	p.setPromptScope(&prompt.Prompt{Name: "personal-sarah", Scope: prompt.ScopePersonal, OwnerEmail: "sarah@example.com"})
+	p.setPromptScope(&prompt.Prompt{Name: "personal-bob", Scope: prompt.ScopePersonal, OwnerEmail: "bob@example.com"})
+	p.setPromptScope(&prompt.Prompt{Name: "analyst-report", Scope: prompt.ScopePersona, Personas: []string{"analyst"}})
+	p.setPromptScope(&prompt.Prompt{Name: "engineer-report", Scope: prompt.ScopePersona, Personas: []string{"engineer"}})
+
+	// Wire exactly as addPromptVisibilityMiddleware does, with Sarah (an
+	// analyst) as the authenticated caller.
+	cfg := middleware.PromptVisibilityConfig{
+		Authenticator: &fakePromptAuth{email: "sarah@example.com", roles: []string{"r-analyst"}},
+		PersonasForRoles: func(roles []string) []string {
+			if slices.Contains(roles, "r-analyst") {
+				return []string{"analyst"}
+			}
+			return nil
+		},
+		IsVisible: p.isPromptVisible,
+	}
+
+	// The SDK returns ALL registered prompts (plus a built-in) to every client.
+	base := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return &mcp.ListPromptsResult{Prompts: []*mcp.Prompt{
+			{Name: "builtin-overview"},
+			{Name: "global-help"},
+			{Name: "personal-sarah"},
+			{Name: "personal-bob"},
+			{Name: "analyst-report"},
+			{Name: "engineer-report"},
+		}}, nil
+	}
+
+	handler := middleware.MCPPromptVisibilityMiddleware(cfg)(base)
+	got, err := handler(context.Background(), "prompts/list", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lr, ok := got.(*mcp.ListPromptsResult)
+	if !ok {
+		t.Fatalf("want *mcp.ListPromptsResult, got %T", got)
+	}
+
+	visible := make(map[string]bool, len(lr.Prompts))
+	for _, pr := range lr.Prompts {
+		visible[pr.Name] = true
+	}
+
+	// Sarah may see: the built-in, the global prompt, her own personal prompt,
+	// and the analyst persona prompt.
+	for _, name := range []string{"builtin-overview", "global-help", "personal-sarah", "analyst-report"} {
+		if !visible[name] {
+			t.Errorf("expected %q visible to Sarah", name)
+		}
+	}
+	// She must NOT see Bob's personal prompt or the engineer persona prompt.
+	for _, name := range []string{"personal-bob", "engineer-report"} {
+		if visible[name] {
+			t.Errorf("%q must NOT be visible to Sarah", name)
+		}
+	}
+}
+
+func TestIsPromptVisible(t *testing.T) {
+	p := &Platform{}
+	p.setPromptScope(&prompt.Prompt{Name: "g", Scope: prompt.ScopeGlobal})
+	p.setPromptScope(&prompt.Prompt{Name: "mine", Scope: prompt.ScopePersonal, OwnerEmail: "sarah@example.com"})
+	p.setPromptScope(&prompt.Prompt{Name: "team", Scope: prompt.ScopePersona, Personas: []string{"analyst", "lead"}})
+	p.setPromptScope(&prompt.Prompt{Name: "weird", Scope: "bogus"})
+
+	cases := []struct {
+		name     string
+		email    string
+		personas []string
+		isAdmin  bool
+		prompt   string
+		want     bool
+	}{
+		{"built-in always visible", "", nil, false, "not-registered", true},
+		{"global to anonymous", "", nil, false, "g", true},
+		{"personal to owner", "sarah@example.com", nil, false, "mine", true},
+		{"personal hidden from other user", "bob@example.com", nil, false, "mine", false},
+		{"personal hidden from anonymous", "", nil, false, "mine", false},
+		{"persona to member", "x", []string{"analyst"}, false, "team", true},
+		{"persona to member (second persona)", "x", []string{"lead"}, false, "team", true},
+		{"persona hidden from non-member", "x", []string{"engineer"}, false, "team", false},
+		{"persona hidden when no personas", "x", nil, false, "team", false},
+		{"admin sees another user's personal", "bob@example.com", nil, true, "mine", true},
+		{"admin sees non-member persona", "x", []string{"engineer"}, true, "team", true},
+		{"unknown scope hidden (fail closed)", "sarah@example.com", nil, false, "weird", false},
+		{"admin sees unknown scope", "sarah@example.com", nil, true, "weird", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := p.isPromptVisible(c.email, c.personas, c.isAdmin, c.prompt); got != c.want {
+				t.Errorf("isPromptVisible(%q, %v, admin=%v, %q) = %v; want %v",
+					c.email, c.personas, c.isAdmin, c.prompt, got, c.want)
+			}
+		})
+	}
+}
+
+func TestPromptScopeLifecycle(t *testing.T) {
+	p := &Platform{}
+	p.setPromptScope(&prompt.Prompt{Name: "mine", Scope: prompt.ScopePersonal, OwnerEmail: "sarah@example.com"})
+	if p.isPromptVisible("bob@example.com", nil, false, "mine") {
+		t.Fatal("personal prompt must be hidden from a non-owner")
+	}
+
+	// Unregister: the name is no longer a database prompt, so it falls back to
+	// the built-in default (visible). Guards against a stale hide after delete.
+	p.deletePromptScope("mine")
+	if !p.isPromptVisible("bob@example.com", nil, false, "mine") {
+		t.Error("after deletePromptScope the name should be treated as built-in (visible)")
+	}
+
+	// Re-register with a new scope (the update path) overwrites the entry.
+	p.setPromptScope(&prompt.Prompt{Name: "mine", Scope: prompt.ScopeGlobal})
+	if !p.isPromptVisible("bob@example.com", nil, false, "mine") {
+		t.Error("re-registered global prompt should be visible to everyone")
+	}
+}

--- a/pkg/platform/prompts.go
+++ b/pkg/platform/prompts.go
@@ -4,6 +4,7 @@ package platform
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"sort"
 	"strings"
 
@@ -12,6 +13,68 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/prompt"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 )
+
+// promptScope records the visibility attributes of a database-backed prompt,
+// used by the prompts/list filter to decide whether a caller may see it.
+type promptScope struct {
+	scope      string
+	ownerEmail string
+	personas   []string
+}
+
+// setPromptScope records (or replaces) a database prompt's visibility entry.
+func (p *Platform) setPromptScope(pr *prompt.Prompt) {
+	p.promptScopesMu.Lock()
+	defer p.promptScopesMu.Unlock()
+	if p.promptScopes == nil {
+		p.promptScopes = make(map[string]promptScope)
+	}
+	p.promptScopes[pr.Name] = promptScope{
+		scope:      pr.Scope,
+		ownerEmail: pr.OwnerEmail,
+		personas:   pr.Personas,
+	}
+}
+
+// deletePromptScope drops a database prompt's visibility entry.
+func (p *Platform) deletePromptScope(name string) {
+	p.promptScopesMu.Lock()
+	defer p.promptScopesMu.Unlock()
+	delete(p.promptScopes, name)
+}
+
+// isPromptVisible reports whether a prompt should appear in prompts/list for a
+// caller with the given identity. Built-in prompts (absent from promptScopes)
+// are always visible. Database prompts are gated by scope: global to everyone,
+// personal only to the owning email, persona only when the caller belongs to
+// one of the prompt's personas. An empty/anonymous caller therefore sees only
+// global and built-in prompts (fail closed). Admins see everything.
+func (p *Platform) isPromptVisible(email string, personas []string, isAdmin bool, name string) bool {
+	p.promptScopesMu.RLock()
+	ps, ok := p.promptScopes[name]
+	p.promptScopesMu.RUnlock()
+	if !ok {
+		return true // built-in / non-database prompt
+	}
+	if isAdmin {
+		return true
+	}
+	switch ps.scope {
+	case prompt.ScopeGlobal:
+		return true
+	case prompt.ScopePersonal:
+		return email != "" && email == ps.ownerEmail
+	case prompt.ScopePersona:
+		for _, pn := range personas {
+			if slices.Contains(ps.personas, pn) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false // unknown scope: fail closed
+	}
+}
 
 // Prompt and toolkit kind constants.
 const (
@@ -394,6 +457,13 @@ func (p *Platform) registerDatabasePrompts() {
 func (p *Platform) registerDatabasePrompt(pr *prompt.Prompt) {
 	promptContent := pr.Content
 
+	// Record scope/owner BEFORE AddPrompt makes the prompt servable, so a
+	// concurrent prompts/list or prompts/get during a runtime registration
+	// never sees the new prompt as an unrecorded (and therefore visible)
+	// built-in. Without this ordering a freshly created personal prompt would
+	// be briefly visible to every caller.
+	p.setPromptScope(pr)
+
 	mcpArgs := make([]*mcp.PromptArgument, 0, len(pr.Arguments))
 	for _, arg := range pr.Arguments {
 		mcpArgs = append(mcpArgs, &mcp.PromptArgument{
@@ -440,6 +510,7 @@ func (p *Platform) RegisterRuntimePrompt(pr *prompt.Prompt) {
 // Called after delete operations on the prompt store.
 func (p *Platform) UnregisterRuntimePrompt(name string) {
 	p.mcpServer.RemovePrompts(name)
+	p.deletePromptScope(name)
 	p.promptInfosMu.Lock()
 	for i, info := range p.promptInfos {
 		if info.Name == name {


### PR DESCRIPTION
## Summary

Scopes the native MCP prompt surface (`prompts/list` and `prompts/get`) to the calling user, bringing it in line with the access model the REST API and the `manage_prompt` tool already enforce.

## Background

Database-backed prompts are all registered on the single shared MCP server (`registerDatabasePrompt` → `mcpServer.AddPrompt`). The REST API and `manage_prompt` scope prompt access by owner and persona, but the native MCP `prompts/list` and `prompts/get` were never wired to that model: the SDK returned every registered prompt to every client, and served any of them by name. Personal and persona-scoped prompts were therefore visible across users on the MCP surface even though the same data is correctly scoped everywhere else.

## What changed

### Visibility middleware (`pkg/middleware/mcp_prompt_visibility.go`)
A new `MCPPromptVisibilityMiddleware`, mirroring the existing tools/list and managed-resource filters:
- **`prompts/list`** is filtered to what the caller may see.
- **`prompts/get`** returns a not-found error for prompts the caller may not see, so a known name cannot fetch another user's content and existence is not revealed.

The rule (`isPromptVisible`):
- **global** and **built-in** prompts → everyone
- **persona** prompts → callers who belong to one of the prompt's personas (resolved from roles via `PersonasForRoles`, matching the resource filter's multi-persona handling)
- **personal** prompts → the owner (by email)
- an **unauthenticated** caller sees only global + built-in (fail closed); **admins** see all; an unknown scope is hidden (fail closed)

### Scope tracking (`pkg/platform/prompts.go`)
Each database prompt's `scope` / `ownerEmail` / `personas` is recorded in an in-memory map, keyed by name, so the filter is O(1) and built-in prompts (absent from the map) stay visible. The entry is recorded **before** the prompt is made servable (`AddPrompt`) and cleared on unregister, and is refreshed by the update path (which unregisters + re-registers), so it never holds stale visibility.

### Shared caller resolution (`pkg/middleware/mcp_resources.go`)
`getOrAuthenticatePC` now takes the auth primitives directly (`Authenticator`, `PersonasForRoles`, `AdminPersona`) instead of the resource config, so the prompt and resource filters share one caller-resolution path rather than forking it.

## Review note

An adversarial review of this change caught an ordering issue that this PR fixes: `setPromptScope` originally ran *after* `AddPrompt`, leaving a brief window on the runtime create path where a newly created prompt was servable but not yet recorded (and so treated as a visible built-in). Recording the scope before `AddPrompt` closes that window.

## Testing

- Unit tests for the visibility rule across every scope plus admin, fail-closed, and unknown-scope cases; the list filter, get allow/deny, identity resolution, no-auth empty identity, and method pass-through; and the registration map lifecycle (create / update-scope / delete).
- An **end-to-end test** wiring the real middleware to the real rule and the registration map, asserting that one user's personal prompt and a non-member persona prompt are absent from another user's `prompts/list`.
- New functions are at or above the project's 80% threshold (most at 100%). `go test ./pkg/... ./internal/...` passes; **0 new lint** issues vs `main`. The full `make verify` gate was run as the final check.

## Recommended verification before/after merge

The definitive confirmation is a live two-user check: connect a second user's client and confirm the first user's personal prompts no longer appear in its `prompts/list` and cannot be fetched via `prompts/get`.

## Out of scope (follow-up)

Surfaced by the review, intentionally not bundled into this change:
- Email and persona-name matching is case-sensitive (fails closed, consistent with the existing create/update checks); a platform-wide email-normalization pass is the right home for it.
- `manage_prompt list` resolves only the caller's primary persona, where this filter (correctly, matching resources) uses the full set; aligning `mergeExtraScopes` is a separate change.
- The scope-visibility predicate now exists in three places (resources, this filter, `manage_prompt`); extracting one shared predicate is a worthwhile refactor.
