### PR TITLE
docs(site): unify on a single rail header, nav, and hero cleanup

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -10,36 +10,9 @@
   <meta name="page-template" content="home">
 {% endblock %}
 
-{# Replace Material's header with the txn2 rail. #}
-{% block header %}
-<header class="rail" data-md-component="header">
-  <a class="skiplink" href="#main">skip to content</a>
-  <a href="./" class="rail__brand" aria-label="mcp-data-platform home">
-    <span class="rail__mark" aria-hidden="true">◐</span>
-    <span class="rail__name">mcp-data-platform</span>
-    <span class="rail__sep" aria-hidden="true">·</span>
-    <span class="rail__sub">composable mcp data platform</span>
-  </a>
-  <div class="rail__meta">
-    <span class="rail__rel">v1.x</span>
-    <span class="rail__dot" aria-hidden="true">●</span>
-    <span data-clock>·· UTC</span>
-    <span class="rail__dot" aria-hidden="true">●</span>
-    <a href="https://txn2.com" class="rail__org">part of <em class="serif">txn2</em>&nbsp;↗</a>
-  </div>
-  <nav class="rail__nav" aria-label="primary">
-    <a href="./" aria-current="page">home</a>
-    <a href="server/installation/">install</a>
-    <a href="server/overview/">server</a>
-    <a href="library/overview/">library</a>
-    <a href="reference/tools-api/">reference</a>
-    <a href="https://github.com/txn2/mcp-data-platform" class="rail__cta">github&nbsp;↗</a>
-  </nav>
-</header>
-{% endblock %}
-
-{# No nav tabs on the homepage. #}
-{% block tabs %}{% endblock %}
+{# The header (the txn2 rail) is shared across all pages via
+   docs/overrides/partials/header.html, so the homepage no longer defines its
+   own header block. #}
 
 {# No announce. #}
 {% block announce %}{% endblock %}
@@ -64,7 +37,7 @@
       <p class="hero__stamp__line">org / txn2</p>
       <p class="hero__stamp__line">est. 2025</p>
       <p class="hero__stamp__line"><a href="https://pkg.go.dev/github.com/txn2/mcp-data-platform">pkg.go.dev&nbsp;↗</a></p>
-      <p class="hero__stamp__line hero__stamp__line--ok">apache 2.0 · semantic first</p>
+      <p class="hero__stamp__line hero__stamp__line--ok">apache 2.0</p>
     </div>
 
     <div class="hero__main">

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -79,12 +79,9 @@
   <script src="{{ 'javascripts/mermaid-fullscreen.js' | url }}"></script>
 {% endblock %}
 
-{# Inner-page skip-to-content. The homepage template overrides block header
-   wholesale and includes its own skiplink targeting #main. #}
-{% block header %}
-<a class="skiplink" href="#main">skip to content</a>
-{{ super() }}
-{% endblock %}
+{# The header (the txn2 rail) is defined once in docs/overrides/partials/header.html
+   and rendered by Material's default `block header` include, so no per-template
+   header override is needed here. The rail carries its own skip-to-content link. #}
 
 {# Inner-page skip target. Material's <main data-md-component="main"> has no
    id, so we drop a focusable anchor at the top of the content area. The

--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -1,0 +1,55 @@
+{#-
+  Custom txn2 "rail" header. Overrides Material's stock partials/header.html so
+  EVERY page (home and inner docs pages) renders the same header. Top-level
+  navigation is the curated rail nav below; the full nav tree lives in the left
+  sidebar (navigation.tabs is intentionally disabled in mkdocs.yml).
+
+  Links use the `url` filter so they resolve correctly from any page depth.
+  Search and the mobile drawer toggle reuse Material's machinery: the
+  `#__search` / `#__drawer` checkbox inputs are rendered in base.html on every
+  page, so the labels here drive Material's standard behavior.
+-#}
+<header class="rail" data-md-component="header">
+  <a class="skiplink" href="#main">skip to content</a>
+
+  <a href="{{ '.' | url }}" class="rail__brand" aria-label="{{ config.site_name }} home">
+    <span class="rail__mark" aria-hidden="true">◐</span>
+    <span class="rail__name">mcp-data-platform</span>
+    <span class="rail__sep" aria-hidden="true">·</span>
+    <span class="rail__sub">composable mcp data platform</span>
+  </a>
+
+  <div class="rail__meta">
+    <span class="rail__rel">v1.x</span>
+    <span class="rail__dot" aria-hidden="true">●</span>
+    <span data-clock>·· UTC</span>
+    <span class="rail__dot" aria-hidden="true">●</span>
+    <a href="https://txn2.com" class="rail__org">part of <em class="serif">txn2</em>&nbsp;↗</a>
+  </div>
+
+  <nav class="rail__nav" aria-label="primary">
+    {%- if not page.is_homepage %}
+    <label class="rail__icon md-header__button md-icon" for="__drawer" title="menu" aria-label="menu">
+      {% include ".icons/material/menu.svg" %}
+    </label>
+    {%- endif %}
+
+    <a href="{{ '.' | url }}"{% if page.is_homepage %} aria-current="page"{% endif %}>home</a>
+    <a href="{{ 'server/installation/' | url }}">install</a>
+    <a href="{{ 'server/overview/' | url }}">server</a>
+    <a href="{{ 'library/overview/' | url }}">library</a>
+    <a href="{{ 'reference/tools-api/' | url }}">reference</a>
+
+    {%- if "material/search" in config.plugins %}
+      {%- set search = config.plugins["material/search"] | attr("config") %}
+      {%- if search.enabled %}
+    <label class="rail__icon md-header__button md-icon" for="__search" title="search" aria-label="{{ lang.t('search.title') }}">
+      {% include ".icons/material/magnify.svg" %}
+    </label>
+    {% include "partials/search.html" %}
+      {%- endif %}
+    {%- endif %}
+
+    <a href="{{ config.repo_url | default('https://github.com/txn2/mcp-data-platform', true) }}" class="rail__cta">github&nbsp;↗</a>
+  </nav>
+</header>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -371,6 +371,27 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   .rail__nav a:not(.rail__cta) { display: none; }
 }
 
+/* Rail search + drawer controls.
+   The labels reuse Material's .md-header__button so Material's responsive
+   show/hide (menu icon below the sidebar breakpoint, search box vs. magnify
+   icon by viewport) applies automatically; we only retint them for the rail. */
+.rail__nav .rail__icon.md-header__button {
+  color: var(--paper-dim);
+  margin: 0;
+  padding: 4px;
+  height: auto;
+  line-height: 0;
+}
+.rail__nav .rail__icon.md-header__button:hover { color: var(--signal); }
+.rail__nav .rail__icon.md-header__button svg {
+  width: 1.15rem;
+  height: 1.15rem;
+  fill: currentColor;
+}
+/* Keep the inline search box from stretching the rail's nav cell. */
+.rail__nav .md-search { display: flex; align-items: center; }
+.rail__nav .md-search__form { background: var(--ink); }
+
 /* ──────────────────────────────────────────────────────────────
    HERO
    All rules scoped under .page--home so component classes never
@@ -448,7 +469,10 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 
 .page--home .hero__display {
-  flex: 1 1 auto;
+  /* Hug the title to its own width (do not grow to fill the row) so the
+     right-pinned hero__stamp keeps a clear gutter instead of colliding with
+     the display type on wide screens. */
+  flex: 0 1 auto;
   min-width: 0;
   font-family: var(--serif);
   font-weight: 300;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,8 +22,9 @@ theme:
     - navigation.instant
     - navigation.instant.progress
     - navigation.tracking
-    - navigation.tabs
-    - navigation.tabs.sticky
+    # Top-level navigation lives in the custom rail header (docs/overrides/partials/header.html).
+    # navigation.tabs is intentionally OFF so the full nav tree renders in the left sidebar;
+    # with tabs on, removing the Material tab bar would make non-active sections unreachable.
     - navigation.sections
     - navigation.top
     - navigation.footer
@@ -102,12 +103,12 @@ nav:
     - Configuration: reference/configuration.md
     - Providers: reference/providers.md
     - Middleware: reference/middleware.md
-  - Support:
-    - Release Highlights: release-highlights.md
-    - Troubleshooting: support/troubleshooting.md
-    - Research:
-      - MCP Gateway Landscape Survey: research/mcp-gateway-landscape-2026.md
-      - MCP Gateway Live End-to-End Test: research/mcp-gateway-livetest-2026.md
+    - Support:
+      - Release Highlights: release-highlights.md
+      - Troubleshooting: support/troubleshooting.md
+      - Research:
+        - MCP Gateway Landscape Survey: research/mcp-gateway-landscape-2026.md
+        - MCP Gateway Live End-to-End Test: research/mcp-gateway-livetest-2026.md
 
 extra:
   social:


### PR DESCRIPTION
## Summary

Unifies the documentation site on a single header and cleans up the hero. Follow-up to #564 (the Release Highlights timeline, already merged); this PR is the header/nav/hero work that wasn't part of that merge.

Previously the home page used a bespoke "rail" header while every other page fell through to Material's stock header + tab bar — two unrelated headers with different navigation and styling.

## Changes

- **One shared header.** New `docs/overrides/partials/header.html` renders the txn2 rail on every page (overrides Material's `block header` include). Nav links resolve via the `url` filter; search and the mobile drawer toggle reuse Material's machinery (`#__search` / `#__drawer`).
- **Remove the per-template header overrides** from `home.html` and `main.html`.
- **Disable `navigation.tabs` / `navigation.tabs.sticky`** so the full nav tree renders in the left sidebar. With tabs on, removing the tab bar would make non-active top-level sections unreachable.
- **Fold the Support nav section under Reference.**
- **Hero fix.** The display title no longer stretches the full row (`flex: 0 1 auto`), so the right-pinned metadata stamp keeps a clear gutter instead of colliding with the title on wide screens.
- **Hero stamp:** drop "semantic first", leaving "apache 2.0".

## Verification

- `mkdocs build --strict` passes.
- Local visual checks of the home page and an inner page at desktop width: consistent rail header, search + sidebar working, Support nested under Reference, hero gutter restored.
- Mobile width not visually confirmed (browser screenshot tooling timed out); the drawer/search controls use Material's stock `md-header__button` classes, so they inherit standard responsive behavior.
