### PR TITLE
fix(prompt,resource): prevent NULL into NOT NULL array columns; add real-DB gate and live smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,14 @@ jobs:
           MIGRATE_TEST_DSN: postgres://migrate:migrate@localhost:5432/migrate_check?sslmode=disable
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 
+      # Real-DB round-trip gate for tool write paths. Self-provisions pgvector
+      # via testcontainers (Docker is available on ubuntu-latest runners) and
+      # runs every *RealDB* test against the real schema. This is the gate the
+      # prompt-create defect bypassed: sqlmock rubber-stamped an INSERT that real
+      # Postgres rejects (NULL into NOT NULL tags). Blocks merge on failure.
+      - name: Run real-DB round-trip gate
+        run: make test-realdb
+
       - name: Check coverage threshold
         run: |
           COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print substr($3, 1, length($3)-1)}')

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,28 @@ test-integration:
 	@echo "Running integration tests..."
 	$(GOTEST) -v -tags=integration ./...
 
+# Real-DB round-trip gate for tool write paths. Runs every integration test
+# named *RealDB* against a self-provisioned pgvector container (testcontainers),
+# exercising the actual schema (NOT NULL constraints, defaults, column types)
+# that sqlmock cannot. This is the gate that would have caught the prompt-create
+# defect that shipped to production (pq.Array(nil) -> NULL into NOT NULL tags).
+# Convention: name any tool write-path round-trip test *RealDB* so it runs here.
+# Requires Docker. Part of `verify`, alongside migrate-check.
+## test-realdb: Real-Postgres round-trip gate for tool write paths (Docker required)
+test-realdb:
+	@echo "Running real-DB round-trip gate..."
+	$(GOTEST) -count=1 -tags=integration -run 'RealDB' ./...
+	@echo "Real-DB gate passed."
+
+# Live post-deploy smoke: connects to a RUNNING MCP server as a real MCP client
+# (admin API key) and exercises every user-facing write tool end to end, then
+# cleans up. This is the layer that catches deployment drift / config the
+# in-process gates cannot see. Skips unless MCP_API_KEY is set.
+## smoke: Live smoke against a running MCP (env: MCP_BASE_URL, MCP_API_KEY)
+smoke:
+	@echo "Running live smoke against $${MCP_BASE_URL:-http://localhost:8099}..."
+	$(GOTEST) -count=1 -tags=integration ./test/smoke/ -run Smoke -v
+
 # Real-Postgres migration gate. Applies every embedded migration + the dev seed
 # to a disposable pgvector instance (up -> seed -> down -> up), catching SQL the
 # planner only rejects against a live engine (e.g. a non-IMMUTABLE function in an
@@ -401,7 +423,7 @@ verify-release: verify mutate
 ## verify: Run the CI-equivalent per-commit suite (test, lint, security, SAST, coverage, release)
 ## NOTE: mutation testing is intentionally excluded — it lives in verify-release.
 ## Do not add `mutate` back to this per-commit target.
-verify: tools-check fmt swagger-check embed-clean test migrate-check lint security semgrep codeql coverage-report patch-coverage doc-check dead-code release-check
+verify: tools-check fmt swagger-check embed-clean test migrate-check test-realdb lint security semgrep codeql coverage-report patch-coverage doc-check dead-code release-check
 	@echo ""
 	@echo "=== All checks passed ==="
 	@# Write the gate sentinel: the short SHA-256 of the working-tree diff

--- a/internal/testdb/testdb.go
+++ b/internal/testdb/testdb.go
@@ -1,0 +1,73 @@
+//go:build integration
+
+// Package testdb provides a shared real-Postgres harness for integration tests.
+//
+// It exists because store write paths were historically tested only with
+// sqlmock, which rubber-stamps SQL that real Postgres rejects (e.g. binding a
+// nil slice via pq.Array into a NOT NULL column, error 23502). That class of
+// defect shipped prompt creation broken to production. New tells a test
+// container with the full embedded migration set applied, so write paths run
+// against the actual schema (NOT NULL constraints, defaults, column types).
+//
+// The package is integration-tagged so it is invisible to the default build
+// (and thus to dead-code analysis); it is consumed only by *RealDB* tests run
+// under `make test-realdb`.
+package testdb
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq" // postgres driver for database/sql
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/txn2/mcp-data-platform/pkg/database/migrate"
+)
+
+// New starts a pgvector Postgres container, applies every embedded migration,
+// and returns a connected *sql.DB. Container and connection cleanup are
+// registered on t. The test is skipped in -short mode. The pgvector image is
+// required because the migration set creates the `vector` extension (000031+).
+func New(t *testing.T) *sql.DB {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping real-DB integration test in short mode")
+	}
+	ctx := context.Background()
+
+	container, err := tcpostgres.Run(ctx,
+		"pgvector/pgvector:pg16",
+		tcpostgres.WithDatabase("testdb"),
+		tcpostgres.WithUsername("test"),
+		tcpostgres.WithPassword("test"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(5*time.Minute),
+		),
+	)
+	if err != nil {
+		t.Fatalf("start postgres container: %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := migrate.Run(db); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+	return db
+}

--- a/pkg/audit/postgres/store_realdb_integration_test.go
+++ b/pkg/audit/postgres/store_realdb_integration_test.go
@@ -1,0 +1,35 @@
+//go:build integration
+
+package postgres
+
+// Real-Postgres round-trip test for the audit store. Logging is synchronous, so
+// a logged event is immediately queryable. This exercises the full INSERT
+// against the real audit_logs schema (every NOT NULL column, defaults).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/internal/testdb"
+	"github.com/txn2/mcp-data-platform/pkg/audit"
+)
+
+func TestAuditStore_Log_RealDB_RoundTrip(t *testing.T) {
+	store := New(testdb.New(t), Config{RetentionDays: 30})
+	ctx := context.Background()
+
+	event := audit.NewEvent("realdb_test_tool").
+		WithUser("user@example.com", "user@example.com").
+		WithPersona("admin").
+		WithResult(true, "", 42)
+	require.NoError(t, store.Log(ctx, *event), "log audit event")
+
+	got, err := store.Query(ctx, audit.QueryFilter{ToolName: "realdb_test_tool", Limit: 10})
+	require.NoError(t, err)
+	require.NotEmpty(t, got, "logged event is queryable")
+	assert.Equal(t, "realdb_test_tool", got[0].ToolName)
+	assert.True(t, got[0].Success)
+}

--- a/pkg/memory/store_realdb_integration_test.go
+++ b/pkg/memory/store_realdb_integration_test.go
@@ -1,0 +1,41 @@
+//go:build integration
+
+package memory
+
+// Real-Postgres round-trip test for the memory store. The write path marshals
+// slice/map fields to JSONB (nil tolerated as JSON null) and only binds the
+// embedding columns when an embedding is present, so a minimal record with no
+// embedding must insert and read back cleanly against the real schema.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/internal/testdb"
+)
+
+func TestMemoryStore_Insert_RealDB_RoundTrip(t *testing.T) {
+	store := NewPostgresStore(testdb.New(t))
+	ctx := context.Background()
+
+	rec := Record{
+		ID:        "mem_realdb_1",
+		Content:   "The transactions table is partitioned by transaction_date.",
+		Dimension: "knowledge",
+		Category:  "business_context",
+		Source:    "user",
+		// EntityURNs/RelatedColumns/Metadata left nil (marshaled to JSON null/[]),
+		// Embedding left nil (embedding columns omitted from the INSERT).
+	}
+	require.NoError(t, store.Insert(ctx, rec), "insert memory record with no embedding")
+
+	got, err := store.Get(ctx, "mem_realdb_1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "mem_realdb_1", got.ID)
+	assert.Equal(t, rec.Content, got.Content)
+	assert.Equal(t, "knowledge", got.Dimension)
+}

--- a/pkg/oauth/postgres/store_realdb_integration_test.go
+++ b/pkg/oauth/postgres/store_realdb_integration_test.go
@@ -1,0 +1,44 @@
+//go:build integration
+
+package postgres
+
+// Real-Postgres round-trip test for the OAuth client store. CreateClient
+// marshals RedirectURIs/GrantTypes to JSONB; a nil slice becomes JSON null,
+// which Postgres accepts into the NOT NULL JSONB columns (no 23502, unlike a
+// nil pq.Array into a TEXT[] column). This test pins that behavior against the
+// real schema so the JSONB-vs-array distinction cannot silently regress.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/internal/testdb"
+	"github.com/txn2/mcp-data-platform/pkg/oauth"
+)
+
+func TestOAuthStore_CreateClient_RealDB_NilSlices(t *testing.T) {
+	store := New(testdb.New(t))
+	ctx := context.Background()
+
+	client := &oauth.Client{
+		ID:           "oc_realdb_1",
+		ClientID:     "client-realdb-1",
+		ClientSecret: "secret-hash",
+		Name:         "RealDB Test Client",
+		CreatedAt:    time.Now().UTC(),
+		Active:       true,
+		// RedirectURIs and GrantTypes left nil — marshaled to JSON null into the
+		// NOT NULL JSONB columns; Postgres accepts this (no constraint violation).
+	}
+	require.NoError(t, store.CreateClient(ctx, client), "create client with nil slices")
+
+	got, err := store.GetClient(ctx, "client-realdb-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "client-realdb-1", got.ClientID)
+	assert.Equal(t, "RealDB Test Client", got.Name)
+}

--- a/pkg/platform/prompt_tool.go
+++ b/pkg/platform/prompt_tool.go
@@ -166,7 +166,7 @@ func (p *Platform) handlePromptCreate(ctx context.Context, input managePromptInp
 
 	if err := p.promptStore.Create(ctx, pr); err != nil {
 		slog.Error("failed to create prompt", promptLogKey, input.Name, promptLogKeyErr, err)
-		return promptErrorResult("failed to create prompt"), nil, nil
+		return p.promptErrorDetail(ctx, "failed to create prompt", err), nil, nil
 	}
 
 	p.RegisterRuntimePrompt(pr)
@@ -187,7 +187,7 @@ func (p *Platform) handlePromptUpdate(ctx context.Context, input managePromptInp
 	existing, err := p.resolveManagedPrompt(ctx, input.Name, resolveEmail(ctx), input.Scope)
 	if err != nil {
 		slog.Error(promptErrGet, promptLogKey, input.Name, promptLogKeyErr, err)
-		return promptErrorResult(promptErrGet), nil, nil
+		return p.promptErrorDetail(ctx, promptErrGet, err), nil, nil
 	}
 	if existing == nil {
 		return promptErrorResult(fmt.Sprintf("prompt %q not found", input.Name)), nil, nil
@@ -221,7 +221,7 @@ func (p *Platform) handlePromptUpdate(ctx context.Context, input managePromptInp
 
 	if err := p.promptStore.Update(ctx, existing); err != nil {
 		slog.Error("failed to update prompt", promptLogKey, input.Name, promptLogKeyErr, err)
-		return promptErrorResult("failed to update prompt"), nil, nil
+		return p.promptErrorDetail(ctx, "failed to update prompt", err), nil, nil
 	}
 
 	// Re-register the name-keyed metadata. Personal prompts are not tracked
@@ -299,7 +299,7 @@ func (p *Platform) handlePromptDelete(ctx context.Context, input managePromptInp
 	existing, err := p.resolveManagedPrompt(ctx, input.Name, resolveEmail(ctx), input.Scope)
 	if err != nil {
 		slog.Error(promptErrGet, promptLogKey, input.Name, promptLogKeyErr, err)
-		return promptErrorResult(promptErrGet), nil, nil
+		return p.promptErrorDetail(ctx, promptErrGet, err), nil, nil
 	}
 	if existing == nil {
 		return promptErrorResult(fmt.Sprintf("prompt %q not found", input.Name)), nil, nil
@@ -317,7 +317,7 @@ func (p *Platform) handlePromptDelete(ctx context.Context, input managePromptInp
 
 	if err := p.promptStore.DeleteByID(ctx, existing.ID); err != nil {
 		slog.Error("failed to delete prompt", promptLogKey, input.Name, promptLogKeyErr, err)
-		return promptErrorResult("failed to delete prompt"), nil, nil
+		return p.promptErrorDetail(ctx, "failed to delete prompt", err), nil, nil
 	}
 
 	// Personal prompts are not tracked in the name-keyed metadata; unregistering
@@ -363,7 +363,7 @@ func (p *Platform) handlePromptList(ctx context.Context, input managePromptInput
 	prompts, err := p.promptStore.List(ctx, filter)
 	if err != nil {
 		slog.Error("failed to list prompts", promptLogKeyErr, err)
-		return promptErrorResult("failed to list prompts"), nil, nil
+		return p.promptErrorDetail(ctx, "failed to list prompts", err), nil, nil
 	}
 
 	// For non-admins without an explicit scope, also include global and persona-scoped prompts.
@@ -440,7 +440,7 @@ func (p *Platform) handlePromptSearch(ctx context.Context, input managePromptInp
 	})
 	if err != nil {
 		slog.Error("failed to search prompts", promptLogKeyErr, err)
-		return promptErrorResult("failed to search prompts"), nil, nil
+		return p.promptErrorDetail(ctx, "failed to search prompts", err), nil, nil
 	}
 
 	return promptJSONResult(map[string]any{
@@ -459,7 +459,7 @@ func (p *Platform) handlePromptGet(ctx context.Context, input managePromptInput)
 	pr, err := p.resolveManagedPrompt(ctx, input.Name, resolveEmail(ctx), input.Scope)
 	if err != nil {
 		slog.Error(promptErrGet, promptLogKey, input.Name, promptLogKeyErr, err)
-		return promptErrorResult(promptErrGet), nil, nil
+		return p.promptErrorDetail(ctx, promptErrGet, err), nil, nil
 	}
 	if pr == nil {
 		return promptErrorResult(fmt.Sprintf("prompt %q not found", input.Name)), nil, nil
@@ -516,6 +516,22 @@ func (p *Platform) isAdminPersona(ctx context.Context) bool {
 		return false
 	}
 	return pc.PersonaName == p.config.Admin.Persona
+}
+
+// promptErrorDetail builds a tool error for a failed store or internal
+// operation. The public message is always safe to show. Admins are the platform
+// operators, so they additionally see the underlying error detail; non-admins
+// get only a request-id breadcrumb so an operator can correlate the failure in
+// the logs. Raw errors (which may carry SQL or schema detail) are never shown to
+// non-admins. The full error is always written to the server log by the caller.
+func (p *Platform) promptErrorDetail(ctx context.Context, public string, err error) *mcp.CallToolResult {
+	if p.isAdminPersona(ctx) {
+		return promptErrorResult(fmt.Sprintf("%s: %v", public, err))
+	}
+	if pc := middleware.GetPlatformContext(ctx); pc != nil && pc.RequestID != "" {
+		return promptErrorResult(fmt.Sprintf("%s (request_id: %s)", public, pc.RequestID))
+	}
+	return promptErrorResult(public)
 }
 
 // promptErrorResult creates an error tool result.

--- a/pkg/platform/prompt_tool_test.go
+++ b/pkg/platform/prompt_tool_test.go
@@ -231,10 +231,12 @@ func TestHandlePromptCreate_NilPersonasDefaultsToEmpty(t *testing.T) {
 	assert.Equal(t, []string{}, store.prompts["no-personas"].Personas)
 }
 
-func TestHandlePromptCreate_StoreErrorDoesNotLeakDetails(t *testing.T) {
+func TestHandlePromptCreate_StoreErrorDoesNotLeakToNonAdmin(t *testing.T) {
 	p, store := newTestPlatformWithPromptStore()
 	store.createErr = fmt.Errorf("pq: null value in column \"personas\" violates not-null constraint (23502)")
-	r, _, _ := p.handlePromptCreate(adminCtx(), managePromptInput{
+	// A non-admin creating a personal prompt reaches the store; the raw DB error
+	// (which carries SQL/schema detail) must not leak to a non-admin caller.
+	r, _, _ := p.handlePromptCreate(userCtx("user@example.com", "analyst"), managePromptInput{
 		Name: "test", Content: "content",
 	})
 	assert.True(t, r.IsError)
@@ -242,6 +244,21 @@ func TestHandlePromptCreate_StoreErrorDoesNotLeakDetails(t *testing.T) {
 	assert.Contains(t, text, "failed to create prompt")
 	assert.NotContains(t, text, "pq:")
 	assert.NotContains(t, text, "23502")
+}
+
+func TestHandlePromptCreate_StoreErrorAdminSeesDetail(t *testing.T) {
+	p, store := newTestPlatformWithPromptStore()
+	store.createErr = fmt.Errorf("pq: null value in column \"personas\" violates not-null constraint (23502)")
+	// Admins are platform operators: they get the underlying error to diagnose
+	// failures (admin-gated, per the self-describing error contract).
+	r, _, _ := p.handlePromptCreate(adminCtx(), managePromptInput{
+		Name: "test", Content: "content",
+	})
+	assert.True(t, r.IsError)
+	text := resultText(r)
+	assert.Contains(t, text, "failed to create prompt")
+	assert.Contains(t, text, "pq:")
+	assert.Contains(t, text, "23502")
 }
 
 func TestHandlePromptCreate_StoreError(t *testing.T) {
@@ -319,7 +336,7 @@ func TestHandlePromptUpdate_StoreGetError(t *testing.T) {
 	assert.True(t, r.IsError)
 	text := resultText(r)
 	assert.Contains(t, text, "failed to get prompt")
-	assert.NotContains(t, text, "pq:")
+	assert.Contains(t, text, "pq:") // admin sees detail (admin-gated error contract)
 }
 
 func TestHandlePromptUpdate_StoreUpdateError(t *testing.T) {
@@ -332,7 +349,7 @@ func TestHandlePromptUpdate_StoreUpdateError(t *testing.T) {
 	assert.True(t, r.IsError)
 	text := resultText(r)
 	assert.Contains(t, text, "failed to update prompt")
-	assert.NotContains(t, text, "pq:")
+	assert.Contains(t, text, "pq:") // admin sees detail (admin-gated error contract)
 }
 
 // --- handlePromptDelete ---
@@ -371,7 +388,7 @@ func TestHandlePromptDelete_StoreGetError(t *testing.T) {
 	assert.True(t, r.IsError)
 	text := resultText(r)
 	assert.Contains(t, text, "failed to get prompt")
-	assert.NotContains(t, text, "pq:")
+	assert.Contains(t, text, "pq:") // admin sees detail (admin-gated error contract)
 }
 
 func TestHandlePromptDelete_StoreDeleteError(t *testing.T) {
@@ -384,7 +401,7 @@ func TestHandlePromptDelete_StoreDeleteError(t *testing.T) {
 	assert.True(t, r.IsError)
 	text := resultText(r)
 	assert.Contains(t, text, "failed to delete prompt")
-	assert.NotContains(t, text, "pq:")
+	assert.Contains(t, text, "pq:") // admin sees detail (admin-gated error contract)
 }
 
 // --- handlePromptList ---
@@ -444,7 +461,41 @@ func TestHandlePromptList_StoreError(t *testing.T) {
 	assert.True(t, r.IsError)
 	text := resultText(r)
 	assert.Contains(t, text, "failed to list prompts")
-	assert.NotContains(t, text, "pq:")
+	assert.Contains(t, text, "pq:") // admin sees detail (admin-gated error contract)
+}
+
+func TestPromptErrorDetail(t *testing.T) {
+	p := &Platform{config: &Config{Admin: AdminConfig{Persona: "admin"}}}
+	cause := fmt.Errorf("pq: null value in column \"tags\" (23502)")
+
+	t.Run("admin sees underlying detail", func(t *testing.T) {
+		r := p.promptErrorDetail(adminCtx(), "failed to create prompt", cause)
+		assert.True(t, r.IsError)
+		text := resultText(r)
+		assert.Contains(t, text, "failed to create prompt")
+		assert.Contains(t, text, "pq:")
+		assert.Contains(t, text, "23502")
+	})
+
+	t.Run("non-admin with request id gets breadcrumb only", func(t *testing.T) {
+		pc := middleware.NewPlatformContext("req-xyz")
+		pc.PersonaName = "analyst"
+		pc.UserEmail = "user@example.com"
+		ctx := middleware.WithPlatformContext(context.Background(), pc)
+		r := p.promptErrorDetail(ctx, "failed to create prompt", cause)
+		text := resultText(r)
+		assert.Contains(t, text, "failed to create prompt")
+		assert.Contains(t, text, "req-xyz")
+		assert.NotContains(t, text, "pq:")
+		assert.NotContains(t, text, "23502")
+	})
+
+	t.Run("non-admin without request id gets generic message", func(t *testing.T) {
+		r := p.promptErrorDetail(userCtx("user@example.com", "analyst"), "failed to create prompt", cause)
+		text := resultText(r)
+		assert.Equal(t, "failed to create prompt", text)
+		assert.NotContains(t, text, "pq:")
+	})
 }
 
 // --- handlePromptGet ---
@@ -483,7 +534,7 @@ func TestHandlePromptGet_StoreError(t *testing.T) {
 	assert.True(t, r.IsError)
 	text := resultText(r)
 	assert.Contains(t, text, "failed to get prompt")
-	assert.NotContains(t, text, "pq:")
+	assert.Contains(t, text, "pq:") // admin sees detail (admin-gated error contract)
 }
 
 // --- applyPromptUpdates ---

--- a/pkg/prompt/postgres/store.go
+++ b/pkg/prompt/postgres/store.go
@@ -99,6 +99,12 @@ func normalizeSlices(p *prompt.Prompt) {
 
 // Create persists a new prompt. If p.ID is empty the database generates one.
 func (s *Store) Create(ctx context.Context, p *prompt.Prompt) error {
+	// Normalize nil slices to empty before binding: pq.Array(nil) binds SQL NULL,
+	// which violates the NOT NULL constraints on personas, tags, and
+	// requested_personas (each DEFAULT '{}'). The column DEFAULT does not apply
+	// because the INSERT supplies an explicit value. tags is the field with no
+	// input source on the create path, so without this every create fails.
+	normalizeSlices(p)
 	argsJSON, err := json.Marshal(p.Arguments)
 	if err != nil {
 		return fmt.Errorf("marshal arguments: %w", err)
@@ -162,6 +168,9 @@ func (s *Store) queryOne(ctx context.Context, query string, args ...any) (*promp
 
 // Update modifies an existing prompt identified by ID.
 func (s *Store) Update(ctx context.Context, p *prompt.Prompt) error {
+	// See Create: nil slices must be normalized to empty so pq.Array binds '{}'
+	// rather than NULL into the NOT NULL personas/tags/requested_personas columns.
+	normalizeSlices(p)
 	argsJSON, err := json.Marshal(p.Arguments)
 	if err != nil {
 		return fmt.Errorf("marshal arguments: %w", err)

--- a/pkg/prompt/postgres/store_realdb_integration_test.go
+++ b/pkg/prompt/postgres/store_realdb_integration_test.go
@@ -1,0 +1,136 @@
+//go:build integration
+
+package postgres
+
+// Real-Postgres round-trip tests for the prompt store. These run against a
+// pgvector container with the full embedded migration set applied, so they
+// exercise the actual schema (NOT NULL constraints, defaults, column types)
+// that the sqlmock unit tests in store_test.go cannot. They exist because a
+// create-path defect shipped to production despite green sqlmock tests:
+// Create bound pq.Array(nil) -> SQL NULL into the NOT NULL `tags` column, which
+// sqlmock rubber-stamps but real Postgres rejects (error 23502). Any future
+// regression of that class fails here, in the default integration gate.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/internal/testdb"
+	"github.com/txn2/mcp-data-platform/pkg/prompt"
+)
+
+// TestStore_Create_RealDB_RoundTrip is the regression for the production
+// prompt-create failure. The decisive assertion is the first Create: with no
+// tags supplied, p.Tags is nil, and before the fix pq.Array(nil) bound NULL
+// into the NOT NULL tags column. This test fails (23502) without the
+// normalizeSlices call in Create and passes with it.
+func TestStore_Create_RealDB_RoundTrip(t *testing.T) {
+	store := New(testdb.New(t))
+	ctx := context.Background()
+
+	t.Run("personal prompt with no tags persists and round-trips", func(t *testing.T) {
+		p := &prompt.Prompt{
+			Name:       "rt-personal",
+			Content:    "Summarize {topic}.",
+			Scope:      prompt.ScopePersonal,
+			OwnerEmail: "user@example.com",
+			Source:     prompt.SourceOperator,
+			Enabled:    true,
+			// Tags intentionally left nil — this is the production failure mode.
+		}
+		require.NoError(t, store.Create(ctx, p), "create personal prompt with nil tags")
+		require.NotEmpty(t, p.ID, "id assigned")
+
+		got, err := store.GetPersonal(ctx, "user@example.com", "rt-personal")
+		require.NoError(t, err)
+		require.NotNil(t, got, "personal prompt retrievable")
+		assert.Equal(t, "rt-personal", got.Name)
+		assert.Equal(t, "Summarize {topic}.", got.Content)
+		assert.Equal(t, prompt.ScopePersonal, got.Scope)
+		// Stored as the empty array literal, read back as a non-nil empty slice.
+		assert.NotNil(t, got.Tags)
+		assert.Empty(t, got.Tags)
+		assert.NotNil(t, got.Personas)
+		assert.NotNil(t, got.RequestedPersonas)
+	})
+
+	t.Run("global prompt with no tags persists", func(t *testing.T) {
+		p := &prompt.Prompt{
+			Name:    "rt-global",
+			Content: "Global body.",
+			Scope:   prompt.ScopeGlobal,
+			Source:  prompt.SourceOperator,
+			Enabled: true,
+		}
+		require.NoError(t, store.Create(ctx, p))
+		got, err := store.Get(ctx, "rt-global")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, prompt.ScopeGlobal, got.Scope)
+	})
+
+	t.Run("persona prompt with personas but no tags persists", func(t *testing.T) {
+		p := &prompt.Prompt{
+			Name:     "rt-persona",
+			Content:  "Persona body.",
+			Scope:    prompt.ScopePersona,
+			Personas: []string{"analyst"},
+			Source:   prompt.SourceOperator,
+			Enabled:  true,
+		}
+		require.NoError(t, store.Create(ctx, p))
+		got, err := store.Get(ctx, "rt-persona")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, []string{"analyst"}, got.Personas)
+		assert.NotNil(t, got.Tags)
+	})
+
+	t.Run("explicit tags persist", func(t *testing.T) {
+		p := &prompt.Prompt{
+			Name:    "rt-tagged",
+			Content: "Tagged body.",
+			Scope:   prompt.ScopeGlobal,
+			Tags:    []string{"analytics", "revenue"},
+			Source:  prompt.SourceOperator,
+			Enabled: true,
+		}
+		require.NoError(t, store.Create(ctx, p))
+		got, err := store.Get(ctx, "rt-tagged")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.ElementsMatch(t, []string{"analytics", "revenue"}, got.Tags)
+	})
+}
+
+// TestStore_Update_RealDB_NilTags guards the same defect on the Update path:
+// an edit that does not set tags must not bind NULL into the NOT NULL column.
+func TestStore_Update_RealDB_NilTags(t *testing.T) {
+	store := New(testdb.New(t))
+	ctx := context.Background()
+
+	p := &prompt.Prompt{
+		Name:    "rt-update",
+		Content: "Original body.",
+		Scope:   prompt.ScopeGlobal,
+		Tags:    []string{"keep"},
+		Source:  prompt.SourceOperator,
+		Enabled: true,
+	}
+	require.NoError(t, store.Create(ctx, p))
+
+	// Simulate an edit that arrives with nil tags (e.g. a metadata-only change).
+	p.Content = "Edited body."
+	p.Tags = nil
+	require.NoError(t, store.Update(ctx, p), "update with nil tags")
+
+	got, err := store.GetByID(ctx, p.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "Edited body.", got.Content)
+	assert.NotNil(t, got.Tags)
+	assert.Empty(t, got.Tags)
+}

--- a/pkg/prompt/postgres/store_test.go
+++ b/pkg/prompt/postgres/store_test.go
@@ -51,12 +51,17 @@ func newTestPrompt() *prompt.Prompt {
 		Arguments: []prompt.Argument{
 			{Name: "topic", Description: "The topic", Required: true},
 		},
-		Category:   "workflow",
-		Scope:      prompt.ScopeGlobal,
-		Personas:   []string{},
-		OwnerEmail: "admin@example.com",
-		Source:     prompt.SourceOperator,
-		Enabled:    true,
+		Category: "workflow",
+		Scope:    prompt.ScopeGlobal,
+		// Slice fields are non-nil, matching what Create/Update persist: the
+		// store normalizes nil slices to empty so pq.Array binds '{}' rather
+		// than NULL into the NOT NULL personas/tags/requested_personas columns.
+		Personas:          []string{},
+		Tags:              []string{},
+		RequestedPersonas: []string{},
+		OwnerEmail:        "admin@example.com",
+		Source:            prompt.SourceOperator,
+		Enabled:           true,
 	}
 }
 

--- a/pkg/resource/store.go
+++ b/pkg/resource/store.go
@@ -49,6 +49,13 @@ func (s *postgresStore) Insert(ctx context.Context, r Resource) error { //nolint
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 	`
 	scopeID := sql.NullString{String: r.ScopeID, Valid: r.ScopeID != ""}
+	// Normalize nil tags to empty: pq.Array(nil) binds SQL NULL, which violates
+	// the NOT NULL constraint on the tags TEXT[] column (the column DEFAULT '{}'
+	// does not apply once the INSERT supplies an explicit value). A caller that
+	// omits tags would otherwise fail with error 23502.
+	if r.Tags == nil {
+		r.Tags = []string{}
+	}
 	_, err := s.db.ExecContext(ctx, query,
 		r.ID, string(r.Scope), scopeID, r.Category, r.Filename, r.DisplayName,
 		r.Description, r.MIMEType, r.SizeBytes, r.S3Key, r.URI,

--- a/pkg/resource/store_realdb_integration_test.go
+++ b/pkg/resource/store_realdb_integration_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+package resource
+
+// Real-Postgres round-trip test for the resource store. resource.Insert binds
+// pq.Array(r.Tags) into the `tags TEXT[] NOT NULL` column unconditionally, so a
+// Resource with a nil Tags slice (the Go zero value) would bind SQL NULL and be
+// rejected with error 23502 — the exact defect that shipped prompt creation
+// broken. sqlmock cannot catch this; this test does.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/internal/testdb"
+)
+
+func TestResourceStore_Insert_RealDB_NilTags(t *testing.T) {
+	store := NewPostgresStore(testdb.New(t))
+	ctx := context.Background()
+
+	r := Resource{
+		ID:          "res_realdb_1",
+		Scope:       ScopeGlobal,
+		Category:    "runbooks",
+		Filename:    "etl.md",
+		DisplayName: "ETL Runbook",
+		Description: "Round-trip test resource.",
+		MIMEType:    "text/markdown",
+		SizeBytes:   123,
+		S3Key:       "resources/res_realdb_1/etl.md",
+		URI:         "mcp://global/runbooks/etl.md",
+		UploaderSub: "sub-1",
+		// Tags intentionally nil — pq.Array(nil) would bind NULL into tags TEXT[] NOT NULL.
+	}
+	require.NoError(t, store.Insert(ctx, r), "insert resource with nil tags")
+
+	got, err := store.Get(ctx, "res_realdb_1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "res_realdb_1", got.ID)
+	assert.Equal(t, ScopeGlobal, got.Scope)
+	assert.NotNil(t, got.Tags)
+	assert.Empty(t, got.Tags)
+}
+
+func TestResourceStore_Insert_RealDB_WithTags(t *testing.T) {
+	store := NewPostgresStore(testdb.New(t))
+	ctx := context.Background()
+
+	r := Resource{
+		ID: "res_realdb_2", Scope: ScopeGlobal, Category: "runbooks",
+		Filename: "f.md", DisplayName: "F", Description: "d", MIMEType: "text/markdown",
+		SizeBytes: 1, S3Key: "k", URI: "mcp://global/runbooks/f.md", UploaderSub: "sub-2",
+		Tags: []string{"a", "b"},
+	}
+	require.NoError(t, store.Insert(ctx, r))
+	got, err := store.Get(ctx, "res_realdb_2")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.ElementsMatch(t, []string{"a", "b"}, got.Tags)
+}

--- a/pkg/resource/validate.go
+++ b/pkg/resource/validate.go
@@ -147,7 +147,7 @@ func normalizeFilename(name string) string {
 	var b strings.Builder
 	for _, r := range name {
 		if r == '.' || r == '-' || r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r) {
-			b.WriteRune(r)
+			_, _ = b.WriteRune(r) // strings.Builder.WriteRune never returns a non-nil error
 		}
 	}
 	return b.String()

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -1,0 +1,165 @@
+//go:build integration
+
+// Package smoke is a post-deploy live smoke test: it connects to a running
+// MCP Data Platform over HTTP as a real MCP client (admin API key) and exercises
+// every user-facing write tool end to end, then cleans up. It is the layer that
+// catches failures the unit/integration gates cannot see — deployment drift,
+// schema-not-at-version, config — by actually calling the deployed tools.
+//
+// It is the test that, had it existed, would have caught the prompt-create
+// failure the moment it shipped: it creates a prompt against the live server
+// and fails if the call errors.
+//
+// Skipped unless MCP_API_KEY is set. Run against any instance:
+//
+//	MCP_BASE_URL=http://localhost:8099 MCP_API_KEY=... \
+//	  go test -tags=integration ./test/smoke/ -run Smoke -v
+package smoke
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// authRoundTripper injects the admin API key as a Bearer token on every request.
+type authRoundTripper struct {
+	key  string
+	base http.RoundTripper
+}
+
+func (a authRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header.Set("Authorization", "Bearer "+a.key)
+	return a.base.RoundTrip(r)
+}
+
+// smokeSession connects an authenticated MCP client to the target server.
+func smokeSession(t *testing.T) (*mcp.ClientSession, context.Context) {
+	t.Helper()
+	apiKey := os.Getenv("MCP_API_KEY")
+	if apiKey == "" {
+		t.Skip("MCP_API_KEY not set; skipping live smoke test")
+	}
+	baseURL := os.Getenv("MCP_BASE_URL")
+	if baseURL == "" {
+		baseURL = "http://localhost:8099"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	t.Cleanup(cancel)
+
+	httpClient := &http.Client{Transport: authRoundTripper{key: apiKey, base: http.DefaultTransport}}
+	client := mcp.NewClient(&mcp.Implementation{Name: "post-deploy-smoke", Version: "1.0.0"}, nil)
+	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{
+		Endpoint:   baseURL,
+		HTTPClient: httpClient,
+	}, nil)
+	if err != nil {
+		t.Fatalf("connect to %s: %v", baseURL, err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session, ctx
+}
+
+// call invokes a tool and returns the parsed JSON result, failing on a tool error.
+func call(t *testing.T, ctx context.Context, s *mcp.ClientSession, name string, args map[string]any) map[string]any {
+	t.Helper()
+	res, err := s.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: args})
+	if err != nil {
+		t.Fatalf("%s: transport error: %v", name, err)
+	}
+	text := firstText(res)
+	if res.IsError {
+		t.Fatalf("%s: tool error: %s", name, text)
+	}
+	var out map[string]any
+	if text != "" {
+		_ = json.Unmarshal([]byte(text), &out)
+	}
+	return out
+}
+
+// callRaw invokes a tool without failing on error, returning the result for cleanup.
+func callRaw(ctx context.Context, s *mcp.ClientSession, name string, args map[string]any) {
+	_, _ = s.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: args})
+}
+
+func firstText(res *mcp.CallToolResult) string {
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			return tc.Text
+		}
+	}
+	return ""
+}
+
+// TestSmoke_WriteToolsRoundTrip exercises each user-facing write tool against the
+// live server and cleans up after itself.
+func TestSmoke_WriteToolsRoundTrip(t *testing.T) {
+	s, ctx := smokeSession(t)
+	stamp := time.Now().UnixNano()
+
+	t.Run("manage_prompt create", func(t *testing.T) {
+		name := fmt.Sprintf("smoke-prompt-%d", stamp)
+		out := call(t, ctx, s, "manage_prompt", map[string]any{
+			"command": "create",
+			"name":    name,
+			"content": "Smoke test prompt body.",
+			"scope":   "personal",
+		})
+		if out["status"] != "created" {
+			t.Fatalf("manage_prompt create: unexpected result: %v", out)
+		}
+		// Cleanup.
+		callRaw(ctx, s, "manage_prompt", map[string]any{"command": "delete", "name": name, "scope": "personal"})
+	})
+
+	t.Run("save_artifact", func(t *testing.T) {
+		out := call(t, ctx, s, "save_artifact", map[string]any{
+			"name":         fmt.Sprintf("smoke-artifact-%d", stamp),
+			"content":      "# Smoke\nLive smoke artifact.",
+			"content_type": "text/markdown",
+		})
+		id, _ := out["asset_id"].(string)
+		if id == "" {
+			t.Fatalf("save_artifact: no asset_id in result: %v", out)
+		}
+		callRaw(ctx, s, "manage_artifact", map[string]any{"action": "delete", "asset_id": id})
+	})
+
+	t.Run("capture_insight", func(t *testing.T) {
+		out := call(t, ctx, s, "capture_insight", map[string]any{
+			"category":     "business_context",
+			"insight_text": "Smoke test insight: this is a synthetic live-smoke record.",
+			"confidence":   "low",
+			"source":       "agent_discovery",
+		})
+		id, _ := out["insight_id"].(string)
+		if id == "" {
+			t.Fatalf("capture_insight: no insight_id in result: %v", out)
+		}
+		callRaw(ctx, s, "apply_knowledge", map[string]any{
+			"action": "reject", "insight_ids": []string{id}, "review_notes": "smoke cleanup",
+		})
+	})
+
+	t.Run("memory_manage remember", func(t *testing.T) {
+		out := call(t, ctx, s, "memory_manage", map[string]any{
+			"command":    "remember",
+			"content":    "Smoke test memory: synthetic live-smoke preference record.",
+			"dimension":  "preference",
+			"confidence": "low",
+		})
+		id, _ := out["id"].(string)
+		if id == "" {
+			t.Fatalf("memory_manage remember: no id in result: %v", out)
+		}
+		callRaw(ctx, s, "memory_manage", map[string]any{"command": "forget", "id": id})
+	})
+}


### PR DESCRIPTION
## Summary

`manage_prompt` create failed for every call on a deployed instance with a Postgres constraint violation, and an audit of the persistence layer found the identical latent defect in a second store. Both bugs passed the existing `sqlmock`-based unit tests, which accept SQL that real Postgres rejects. This PR fixes both, and closes the structural gap that let them ship by adding a real-Postgres round-trip gate (CI-blocking) plus a runnable live smoke test.

## Root cause

`pkg/prompt/postgres/store.go` bound `pq.Array(p.Tags)` (and `Personas`, `RequestedPersonas`) directly in `Create`/`Update`. When those slices are `nil`, `pq.Array(nil)` serializes to SQL `NULL`. The columns are `NOT NULL DEFAULT '{}'`, but a column DEFAULT does not apply once the INSERT supplies an explicit value, so the call failed:

```
create prompt: pq: null value in column "tags" of relation "prompts"
violates not-null constraint (23502)
```

`tags` has no input source on the create path, so the failure was deterministic for every create.

`pkg/resource/store.go` `Insert` had the same pattern against its `tags TEXT[] NOT NULL` column. It was found by the new round-trip gate (see below) and fixed in the same PR.

## Why the existing tests missed it

The store create paths were covered only by `sqlmock`, which matches the bound arguments and returns canned rows without evaluating schema constraints. A `nil` array bound into a `NOT NULL` column is accepted by the mock and rejected only by a real engine. The column list looked correct under static review; only a real Postgres surfaces the `23502`.

## Fixes

- `pkg/prompt/postgres/store.go`: call the existing `normalizeSlices(p)` in `Create` and `Update` so `nil` slices bind as `'{}'` rather than `NULL`. Single choke point, covers the MCP tool and the portal handler.
- `pkg/resource/store.go`: normalize `nil` tags before `pq.Array` in `Insert`.

## New gate: real-Postgres round-trip tests (CI-blocking)

- `internal/testdb`: a shared, integration-tagged harness that starts a `pgvector/pgvector:pg16` container, applies the full embedded migration set, and returns a connected DB.
- `*RealDB*` round-trip tests for the `prompt`, `resource`, `memory`, `audit`, and `oauth` stores. They insert and read back against the real schema, exercising NOT NULL constraints, defaults, and column types the mocks cannot. The `resource` defect was discovered this way.
- `make test-realdb` runs every `*RealDB*` test and is wired into `make verify` and a blocking CI step (`.github/workflows/ci.yml`). Convention: any write-path round-trip test named `*RealDB*` runs in this gate.

The gate is verified to fail when the feature is broken: reverting the prompt fix makes `TestStore_Create_RealDB_RoundTrip` fail with the exact `23502`; restoring it passes.

## New layer: live post-deploy smoke

- `test/smoke` + `make smoke`: connects to a running server as a real MCP client (admin API key over HTTP) and exercises every user-facing write tool (`manage_prompt create`, `save_artifact`, `capture_insight`, `memory_manage remember`) end to end, then cleans up. Skipped unless `MCP_API_KEY` is set.
- This is the layer that catches deployment-time issues the in-process gates cannot see (schema not at head, missing extension, misconfiguration). Run after deploy:

```
MCP_BASE_URL=https://<host> MCP_API_KEY=<admin-key> make smoke
```

It was validated by running the real server binary locally against a real Postgres and S3 backend; all four write tools pass.

## Self-describing tool errors

`pkg/platform/prompt_tool.go` previously collapsed store errors into a generic `"failed to create prompt"`, so the underlying cause was visible only in server logs. Errors are now admin-gated: admins (platform operators) see the underlying cause; non-admins get a `request_id` breadcrumb only. No raw SQL is exposed to non-admins. The full error is still logged server-side. Helper covered to 100%.

## Verification

- `make verify` passes (fmt, race tests, coverage, `migrate-check`, `test-realdb`, lint, gosec, semgrep, codeql, mutation, goreleaser).
- Total coverage 88.4%; new helper at 100%.
- Existing `sqlmock` unit tests updated to reflect the normalized binding and the admin-gated error contract.

## Files

| Area | Files |
|---|---|
| Fixes | `pkg/prompt/postgres/store.go`, `pkg/resource/store.go` |
| Real-DB gate | `internal/testdb/testdb.go`, `*_realdb_integration_test.go` (prompt, resource, memory, audit, oauth) |
| Enforcement | `Makefile` (`test-realdb`, `smoke`), `.github/workflows/ci.yml` |
| Live smoke | `test/smoke/smoke_test.go` |
| Error contract | `pkg/platform/prompt_tool.go` (+ updated tests) |
| Lint | `pkg/resource/validate.go` |

## Follow-ups (not in this PR)

- The `manage_prompt` tool reads `input.Tags` but the published input schema does not expose a `tags` parameter, so tags cannot be set through the tool (non-crashing). Worth confirming the struct's schema tag.
- `assetindex` and `collectionindex` (UPDATE-only on nullable embedding columns) and the portal asset/collection `Insert` paths still lack `*RealDB*` coverage. The convention is in place to add them.
