### PR TITLE
fix(portal): manage_artifact content-only update no longer reports failure on a committed write

### DIFF
--- a/pkg/toolkits/portal/toolkit.go
+++ b/pkg/toolkits/portal/toolkit.go
@@ -492,14 +492,29 @@ func (t *Toolkit) handleUpdate(ctx context.Context, input manageArtifactInput) (
 		updates.Description = &input.Description
 	}
 
-	if input.Content != "" {
+	hasContent := input.Content != ""
+	// Content is versioned separately via uploadContentUpdate, which updates the
+	// asset's current-version pointer. A metadata update is only present when one
+	// of the indexable fields was supplied. The metadata Update must not run for a
+	// content-only edit: the store's applyUpdateFields rejects an empty update
+	// with "no fields to update", which would report failure even though the
+	// content write already committed.
+	hasMetadata := updates.Name != nil || updates.Description != nil || updates.Tags != nil
+
+	if !hasContent && !hasMetadata {
+		return errorResult("no fields to update: provide content, name, description, or tags"), nil, nil
+	}
+
+	if hasContent {
 		if contentErr := t.uploadContentUpdate(ctx, asset, input); contentErr != nil {
 			return errorResult("failed to upload new content: " + contentErr.Error()), nil, nil //nolint:nilerr // MCP protocol
 		}
 	}
 
-	if err := t.assetStore.Update(ctx, input.AssetID, updates); err != nil {
-		return errorResult("failed to update asset: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	if hasMetadata {
+		if err := t.assetStore.Update(ctx, input.AssetID, updates); err != nil {
+			return errorResult("failed to update asset: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		}
 	}
 
 	return jsonResult(map[string]any{

--- a/pkg/toolkits/portal/toolkit_test.go
+++ b/pkg/toolkits/portal/toolkit_test.go
@@ -239,19 +239,81 @@ func TestManageArtifact_UpdateWithContent(t *testing.T) {
 		Tags: []string{}, Provenance: portal.Provenance{},
 	})
 
+	versions := newInMemoryVersionStore()
 	s3 := &mockS3Client{}
 	tk := New(Config{
-		Name: "test", AssetStore: store, S3Client: s3,
+		Name: "test", AssetStore: store, VersionStore: versions, S3Client: s3,
+		S3Bucket: "bucket", S3Prefix: "assets/",
+	})
+
+	ctx := middleware.WithPlatformContext(context.Background(), &middleware.PlatformContext{UserID: "user1"})
+
+	// Content-only update: no metadata fields. The content write commits a new
+	// version; the handler must not then run the empty metadata Update, which the
+	// store rejects with "no fields to update", reporting failure on a write that
+	// actually committed (#573).
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "update", AssetID: "a1", Content: "<div>Updated</div>",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError, "content-only update must succeed")
+
+	vv, _, _ := versions.ListByAsset(context.Background(), "a1", 0, 0)
+	assert.Len(t, vv, 1, "content update must create exactly one version")
+}
+
+func TestManageArtifact_UpdateNoFields(t *testing.T) {
+	store := newInMemoryAssetStore()
+	_ = store.Insert(context.Background(), portal.Asset{
+		ID: "a1", OwnerID: "user1", Name: "Old", Tags: []string{},
+		Provenance: portal.Provenance{},
+	})
+
+	versions := newInMemoryVersionStore()
+	tk := New(Config{
+		Name: "test", AssetStore: store, VersionStore: versions, S3Bucket: "bucket",
+	})
+
+	ctx := middleware.WithPlatformContext(context.Background(), &middleware.PlatformContext{UserID: "user1"})
+
+	// Neither content nor metadata: a genuine no-op must report an error and
+	// create no version.
+	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
+		Action: "update", AssetID: "a1",
+	})
+	require.NoError(t, err)
+	assert.True(t, result.IsError, "empty update must report an error")
+
+	vv, _, _ := versions.ListByAsset(context.Background(), "a1", 0, 0)
+	assert.Empty(t, vv, "empty update must not create a version")
+}
+
+func TestManageArtifact_UpdateContentAndMetadata(t *testing.T) {
+	store := newInMemoryAssetStore()
+	_ = store.Insert(context.Background(), portal.Asset{
+		ID: "a1", OwnerID: "user1", Name: "Old", ContentType: "text/html",
+		Tags: []string{}, Provenance: portal.Provenance{},
+	})
+
+	versions := newInMemoryVersionStore()
+	s3 := &mockS3Client{}
+	tk := New(Config{
+		Name: "test", AssetStore: store, VersionStore: versions, S3Client: s3,
 		S3Bucket: "bucket", S3Prefix: "assets/",
 	})
 
 	ctx := middleware.WithPlatformContext(context.Background(), &middleware.PlatformContext{UserID: "user1"})
 
 	result, _, err := tk.handleManageArtifact(ctx, nil, manageArtifactInput{
-		Action: "update", AssetID: "a1", Content: "<div>Updated</div>",
+		Action: "update", AssetID: "a1", Content: "<div>v2</div>", Name: "New Name",
 	})
 	require.NoError(t, err)
 	assert.False(t, result.IsError)
+
+	asset, _ := store.Get(context.Background(), "a1")
+	assert.Equal(t, "New Name", asset.Name, "metadata must be applied alongside content")
+	vv, _, _ := versions.ListByAsset(context.Background(), "a1", 0, 0)
+	assert.Len(t, vv, 1, "content+metadata update must create one version")
 }
 
 func TestManageArtifact_UpdateWrongOwner(t *testing.T) {
@@ -400,6 +462,14 @@ func (s *inMemoryAssetStore) Update(_ context.Context, id string, updates portal
 	a, ok := s.assets[id]
 	if !ok || a.DeletedAt != nil {
 		return notFoundError{}
+	}
+	// Mirror the real store's applyUpdateFields guard: an update with no fields
+	// set is rejected. Without this the mock rubber-stamps an empty update that
+	// real Postgres rejects, hiding the content-only update bug (#573).
+	if updates.Name == nil && updates.Description == nil && updates.Tags == nil &&
+		updates.ContentType == "" && updates.S3Key == "" && !updates.HasContent &&
+		updates.ThumbnailS3Key == nil {
+		return fmt.Errorf("no fields to update")
 	}
 	if updates.Name != nil {
 		a.Name = *updates.Name


### PR DESCRIPTION
## Problem

`manage_artifact` update with `content` (and no metadata fields) returned `failed to update asset: no fields to update`, even though the new content version was actually written. The reported outcome contradicted the side effect: a caller that trusts the error retries (creating duplicate versions) or concludes the artifact is unchanged. For an agent that plans its next step from the tool result, a result that disagrees with the committed state is the worst failure mode.

## Root cause

`handleUpdate` (`pkg/toolkits/portal/toolkit.go`) uploads content via `uploadContentUpdate`, which creates the new version and, in the Postgres store, repoints the asset row (`current_version`, `s3_key`, `content_type`, `size_bytes`) in the same transaction. It then **unconditionally** called `assetStore.Update` with an `AssetUpdate` that only ever carries Name/Description/Tags. On a content-only edit that update is empty, and the store's `applyUpdateFields` (`pkg/portal/store.go`) rejects an empty update with "no fields to update". The handler surfaced that as failure, despite the content write having already committed.

## Fix

Gate the metadata `Update` on whether metadata fields are actually present:

- compute `hasContent` / `hasMetadata`
- return a clear no-op error only when neither is supplied
- upload content when present
- call `assetStore.Update` only when there are metadata fields

Content versioning is unchanged; the redundant empty metadata update is simply no longer issued on a content-only edit.

## Why this was not caught before (test integrity)

`TestManageArtifact_UpdateWithContent` was passing only because the in-memory test store's `Update` rubber-stamped empty updates that real Postgres rejects, the same mock-versus-reality gap behind earlier write-path defects. This PR makes the in-memory store mirror the real store's empty-update guard, so the test now exercises the real path. With the faithful mock, the test fails against the unfixed handler and passes with the fix (verified by temporarily reverting the handler change).

## Tests

- content-only update: succeeds and creates exactly one version
- no-op (no content, no metadata): returns an error and creates no version
- content + metadata: both applied, one version created
- the REST admin handler was checked and does not share the bug (content and metadata are separate endpoints there, so it never issues an empty metadata update after a content write)

## Verification

- Full `pkg/toolkits/portal` package green; `gofmt` and `go vet` clean
- `make verify` green (full CI-equivalent suite: fmt, race tests, lint, security, coverage, mutation testing, release-check)

Closes #573
