### PR TITLE
fix(gateway): reconnect dropped MCP upstream sessions and surface per-connection health

### DIFF
--- a/pkg/platform/connections_tool.go
+++ b/pkg/platform/connections_tool.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -19,14 +20,24 @@ import (
 // rather than only via a downstream tool failing with "no catalog
 // configured".
 type connectionEntry struct {
-	Kind              string `json:"kind"`
-	Name              string `json:"name"`
-	Connection        string `json:"connection"`
-	Description       string `json:"description,omitempty"`
-	IsDefault         bool   `json:"is_default,omitempty"`
-	DataHubSourceName string `json:"datahub_source_name,omitempty"`
-	CatalogID         string `json:"catalog_id,omitempty"`
-	OperationCount    int    `json:"operation_count,omitempty"`
+	Kind              string            `json:"kind"`
+	Name              string            `json:"name"`
+	Connection        string            `json:"connection"`
+	Description       string            `json:"description,omitempty"`
+	IsDefault         bool              `json:"is_default,omitempty"`
+	DataHubSourceName string            `json:"datahub_source_name,omitempty"`
+	CatalogID         string            `json:"catalog_id,omitempty"`
+	OperationCount    int               `json:"operation_count,omitempty"`
+	Health            *connectionHealth `json:"health,omitempty"`
+}
+
+// connectionHealth is the runtime reachability of a connection, surfaced for
+// gateway kinds that hold a live upstream session so an evicted or dead
+// upstream is visible from list_connections.
+type connectionHealth struct {
+	Reachable   bool   `json:"reachable"`
+	LastSuccess string `json:"last_success,omitempty"`
+	LastError   string `json:"last_error,omitempty"`
 }
 
 // listConnectionsOutput is the JSON response for the list_connections tool.
@@ -99,6 +110,16 @@ func (p *Platform) entriesFromLister(entries []connectionEntry, tk registry.Tool
 		}
 		if src := p.connectionSources.ForConnection(tk.Kind(), conn.Name); src != nil {
 			entry.DataHubSourceName = src.DataHubSourceName
+		}
+		if conn.Health != nil {
+			h := &connectionHealth{
+				Reachable: conn.Health.Reachable,
+				LastError: conn.Health.LastError,
+			}
+			if conn.Health.LastSuccessUnix > 0 {
+				h.LastSuccess = time.Unix(conn.Health.LastSuccessUnix, 0).UTC().Format(time.RFC3339)
+			}
+			entry.Health = h
 		}
 		entries = append(entries, entry)
 	}

--- a/pkg/platform/connections_tool_test.go
+++ b/pkg/platform/connections_tool_test.go
@@ -153,6 +153,48 @@ func TestHandleListConnections(t *testing.T) {
 	})
 }
 
+func TestHandleListConnections_SurfacesHealth(t *testing.T) {
+	reg := registry.NewRegistry()
+	require.NoError(t, reg.Register(&mockConnectionListerToolkit{
+		mockToolkit: mockToolkit{kind: "mcp", name: "gw", tools: []string{"gw__echo"}},
+		connections: []toolkit.ConnectionDetail{
+			{Name: "up", Health: &toolkit.ConnectionHealth{Reachable: true, LastSuccessUnix: 1700000000}},
+			{Name: "down", Health: &toolkit.ConnectionHealth{Reachable: false, LastError: "dial failed"}},
+			{Name: "no-health"},
+		},
+	}))
+
+	p := &Platform{toolkitRegistry: reg}
+	result, _, err := p.handleListConnections(context.Background(), &mcp.CallToolRequest{})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var out listConnectionsOutput
+	tc, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &out))
+
+	byName := make(map[string]connectionEntry, len(out.Connections))
+	for _, c := range out.Connections {
+		byName[c.Name] = c
+	}
+
+	up := byName["up"]
+	require.NotNil(t, up.Health)
+	assert.True(t, up.Health.Reachable)
+	assert.NotEmpty(t, up.Health.LastSuccess, "last_success rendered from unix time")
+	assert.Empty(t, up.Health.LastError)
+
+	down := byName["down"]
+	require.NotNil(t, down.Health)
+	assert.False(t, down.Health.Reachable)
+	assert.Equal(t, "dial failed", down.Health.LastError)
+	assert.Empty(t, down.Health.LastSuccess, "zero unix time omitted")
+
+	// A connection without health tracking carries no health block.
+	assert.Nil(t, byName["no-health"].Health)
+}
+
 func TestHandleListConnections_WithConnectionLister(t *testing.T) {
 	t.Run("expands multi-connection toolkit", func(t *testing.T) {
 		reg := registry.NewRegistry()

--- a/pkg/toolkit/connection.go
+++ b/pkg/toolkit/connection.go
@@ -19,6 +19,23 @@ type ConnectionDetail struct {
 	IsDefault      bool
 	CatalogID      string
 	OperationCount int
+	// Health is optional per-connection reachability, populated by gateway
+	// kinds that hold a live upstream session (so an evicted or dead upstream
+	// is observable from list_connections instead of only when a downstream
+	// tool call fails). Nil for toolkits that do not track reachability.
+	Health *ConnectionHealth
+}
+
+// ConnectionHealth is the runtime reachability of a gateway upstream.
+type ConnectionHealth struct {
+	// Reachable is true when the connection has a live session and its most
+	// recent interaction did not end in an unrecovered error.
+	Reachable bool
+	// LastSuccessUnix is the unix-seconds time of the last successful
+	// forwarded call (or the initial connect). Zero when none has succeeded.
+	LastSuccessUnix int64
+	// LastError is the most recent call or connect failure, empty when healthy.
+	LastError string
 }
 
 // ConnectionLister is an optional interface for toolkits that manage multiple

--- a/pkg/toolkits/gateway/toolkit.go
+++ b/pkg/toolkits/gateway/toolkit.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -358,6 +359,8 @@ func (t *Toolkit) installLiveConnection(name string, cfg Config, res *discoverRe
 		desc:       "Gateway to " + cfg.Endpoint,
 		ccProvider: res.ccProvider,
 	}
+	// A successful dial + discover means the upstream is reachable now.
+	u.recordSuccess()
 	t.connections[name] = u
 	if t.server != nil {
 		t.addToolsToServerLocked(u)
@@ -500,12 +503,23 @@ func (t *Toolkit) notifyToolListChanged() {
 
 // upstream tracks a single live connection to a remote MCP server.
 type upstream struct {
-	name      string
-	config    Config
-	client    *upstreamClient
-	tools     []*mcp.Tool // cached definitions from discovery
-	toolNames []string
-	desc      string
+	name   string
+	config Config
+	client *upstreamClient
+	// reconnectMu single-flights re-dials when the upstream session is
+	// dropped (evicted or restarted). Concurrent forwarders that all hit the
+	// dead session serialize here; the first re-dials, the rest observe the
+	// already-swapped client and skip dialing again.
+	reconnectMu sync.Mutex
+	// lastSuccessUnix and lastCallErr track per-connection reachability for the
+	// list_connections health surface. Updated off the request path by the
+	// forwarder, so they use atomics rather than the toolkit lock; lastCallErr
+	// always holds a string ("" when healthy).
+	lastSuccessUnix atomic.Int64
+	lastCallErr     atomic.Value // string
+	tools           []*mcp.Tool  // cached definitions from discovery
+	toolNames       []string
+	desc            string
 	// ccProvider is the live in-memory client_credentials token
 	// provider for this connection. Non-nil ONLY for live oauth
 	// client_credentials upstreams; nil for authorization_code (which
@@ -794,6 +808,8 @@ func (t *Toolkit) installDialResult(r dialResult) error {
 		desc:       "Gateway to " + cfg.Endpoint,
 		ccProvider: r.ccProvider,
 	}
+	// A successful dial + discover means the upstream is reachable now.
+	u.recordSuccess()
 	t.connections[name] = u
 	if t.server != nil {
 		t.addToolsToServerLocked(u)
@@ -828,6 +844,10 @@ func (t *Toolkit) RemoveConnection(name string) error {
 	}
 	delete(t.connections, name)
 	client := u.client
+	// Clear the pointer so a concurrent in-flight forwarder reading currentClient
+	// sees the connection as gone (returns "upstream unavailable") rather than
+	// attempting to reconnect a removed connection.
+	u.client = nil
 	connectionName := u.config.ConnectionName
 	t.mu.Unlock()
 	if notify {
@@ -1133,6 +1153,7 @@ func (t *Toolkit) ListConnections() []toolkit.ConnectionDetail {
 			Name:        name,
 			Description: u.desc,
 			IsDefault:   name == t.defaultName,
+			Health:      u.health(),
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
@@ -1216,24 +1237,153 @@ func (t *Toolkit) addToolsToServerLocked(u *upstream) {
 func (t *Toolkit) makeForwarder(u *upstream, remoteName, localName string) mcp.ToolHandler {
 	connection := u.config.ConnectionName
 	callTimeout := u.config.CallTimeout
-	client := u.client
 	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		// Read the live client each call rather than capturing it: a re-dial
+		// (below) swaps u.client in place, and the forwarder must pick up the
+		// fresh session on subsequent calls.
+		client := t.currentClient(u)
 		if client == nil {
 			return upstreamErr(connection, "upstream unavailable"), nil
 		}
-		callCtx, cancel := context.WithTimeout(ctx, callTimeout)
-		defer cancel()
 
 		args := argumentsFromRequest(req)
-		res, err := client.callTool(callCtx, remoteName, args)
+		res, err := callTool(ctx, client, callTimeout, remoteName, args)
+		if err != nil && isSessionDropped(err) {
+			// The upstream evicted or restarted the session. Re-dial once and
+			// retry so a transient session loss is transparent to the caller,
+			// instead of failing every call until the toolkit is recreated.
+			fresh, rerr := t.reconnectUpstream(u, client)
+			if rerr != nil {
+				msg := "reconnect after dropped session failed: " + rerr.Error()
+				u.recordError(msg)
+				return upstreamErr(connection, msg), nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError, not as Go errors
+			}
+			res, err = callTool(ctx, fresh, callTimeout, remoteName, args)
+		}
 		if err != nil {
+			u.recordError(err.Error())
 			return upstreamErr(connection, err.Error()), nil
 		}
+		// The transport call succeeded; the connection is reachable even when the
+		// upstream tool itself returned res.IsError.
+		u.recordSuccess()
 		if !res.IsError {
 			t.applyEnrichment(ctx, connection, localName, req, res)
 		}
 		return res, nil
 	}
+}
+
+// recordSuccess marks the upstream reachable as of now and clears any prior
+// error. Called off the request path by the forwarder.
+func (u *upstream) recordSuccess() {
+	u.lastSuccessUnix.Store(time.Now().Unix())
+	u.lastCallErr.Store("")
+}
+
+// recordError records the most recent call or connect failure for the health
+// surface.
+func (u *upstream) recordError(msg string) {
+	u.lastCallErr.Store(msg)
+}
+
+// health snapshots the upstream's reachability for list_connections. The caller
+// must hold t.mu (read) because it reads u.client.
+func (u *upstream) health() *toolkit.ConnectionHealth {
+	lastErr := ""
+	if v := u.lastCallErr.Load(); v != nil {
+		lastErr, _ = v.(string)
+	}
+	// Placeholders (client == nil) never make a forwarded call, so their failure
+	// reason lives in u.lastError (the dial/discover error) instead. Surface it
+	// so an unreachable connection reports why.
+	if lastErr == "" {
+		lastErr = u.lastError
+	}
+	return &toolkit.ConnectionHealth{
+		Reachable:       u.client != nil && lastErr == "",
+		LastSuccessUnix: u.lastSuccessUnix.Load(),
+		LastError:       lastErr,
+	}
+}
+
+// callTool forwards a single call to the given client under a per-call timeout.
+func callTool(ctx context.Context, client *upstreamClient, timeout time.Duration,
+	remoteName string, args any,
+) (*mcp.CallToolResult, error) {
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return client.callTool(callCtx, remoteName, args)
+}
+
+// currentClient returns the connection's live upstream client under the read
+// lock. Returns nil when the connection is a placeholder (not yet dialed) or
+// has been removed.
+func (t *Toolkit) currentClient(u *upstream) *upstreamClient {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return u.client
+}
+
+// isSessionDropped reports whether err indicates the upstream MCP session was
+// evicted, restarted, or closed, as opposed to a normal tool error or a
+// transport timeout. These are the signals a re-dial can recover from. The
+// go-sdk surfaces them as wrapped text, so matching is by substring.
+func isSessionDropped(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "session not found") ||
+		strings.Contains(msg, "client is closing") ||
+		strings.Contains(msg, "server is closing") ||
+		strings.Contains(msg, "connection closed")
+}
+
+// reconnectUpstream re-dials the connection after its session was dropped and
+// swaps u.client to the fresh session. Single-flighted via u.reconnectMu: when
+// several concurrent forwarders hit the same dead session, the first re-dials
+// and the rest observe the already-swapped client (cur != dead) and reuse it.
+// dead is the session the caller just failed against; it is closed once a fresh
+// session is installed.
+func (t *Toolkit) reconnectUpstream(u *upstream, dead *upstreamClient) (*upstreamClient, error) {
+	u.reconnectMu.Lock()
+	defer u.reconnectMu.Unlock()
+
+	// Another in-flight call may have already reconnected.
+	if cur := t.currentClient(u); cur != nil && cur != dead {
+		return cur, nil
+	}
+
+	dialCtx, cancel := dialContext(u.config)
+	defer cancel()
+	provider, ccProvider := t.tokenProviderFor(u.name, u.config.OAuth)
+	fresh, err := dial(dialCtx, u.config, dialDeps{TokenProvider: provider})
+	if err != nil {
+		return nil, err
+	}
+
+	t.mu.Lock()
+	// If the connection was removed or replaced while we dialed, do not install
+	// the fresh session: it would never be tracked in t.connections and so never
+	// closed (a leak), and it would silently resurrect a removed connection.
+	if t.connections[u.name] != u {
+		t.mu.Unlock()
+		_ = fresh.close()
+		return nil, errors.New("connection removed during reconnect")
+	}
+	u.client = fresh
+	// For client_credentials, route Status / ReacquireOAuthToken through the
+	// provider the fresh session actually uses.
+	if ccProvider != nil {
+		u.ccProvider = ccProvider
+	}
+	t.mu.Unlock()
+
+	if dead != nil {
+		_ = dead.close()
+	}
+	return fresh, nil
 }
 
 // applyEnrichment runs the configured engine against the upstream response.

--- a/pkg/toolkits/gateway/toolkit_test.go
+++ b/pkg/toolkits/gateway/toolkit_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/connoauth"
 	"github.com/txn2/mcp-data-platform/pkg/session"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 	"github.com/txn2/mcp-data-platform/pkg/toolkits/gateway/enrichment"
 )
 
@@ -704,15 +705,30 @@ func TestEndToEnd_UpstreamErrorResultForwarded(t *testing.T) {
 }
 
 func TestEndToEnd_TransportFailureAttribution(t *testing.T) {
+	// Stand up an upstream we can take down entirely. A merely-dropped session
+	// is now recovered by the forwarder's reconnect (see #572), so to exercise
+	// attribution of a genuine, unrecoverable transport failure the whole
+	// upstream must be unreachable (the re-dial fails too).
+	srv := mcp.NewServer(&mcp.Implementation{Name: "upstream", Version: "0.0.1"}, nil)
+	type echoArgs struct {
+		Message string `json:"message"`
+	}
+	mcp.AddTool(srv, &mcp.Tool{Name: toolEcho, Description: "echo"},
+		func(_ context.Context, _ *mcp.CallToolRequest, a echoArgs) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "echo:" + a.Message}}}, nil, nil
+		})
+	ts := httptest.NewServer(mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return srv }, nil))
+
 	tk := New("primary")
 	t.Cleanup(func() { _ = tk.Close() })
-	_ = tk.AddConnection(connCRM, connectionConfig(upstreamServer(t), connCRM))
+	if err := tk.AddConnection(connCRM, connectionConfig(ts.URL, connCRM)); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
 
-	// Kill the upstream session so next call fails at transport.
-	tk.mu.RLock()
-	u := tk.connections[connCRM]
-	tk.mu.RUnlock()
-	_ = u.client.close()
+	// Take the upstream down: the existing session is dead and a re-dial cannot
+	// succeed, so the failure surfaces instead of being recovered.
+	ts.CloseClientConnections()
+	ts.Close()
 
 	client := platformWithToolkit(t, tk)
 	t.Cleanup(func() { _ = client.Close() })
@@ -1103,6 +1119,190 @@ func TestMakeForwarder_NilClientReturnsUnavailable(t *testing.T) {
 	if !strings.Contains(tc.Text, "upstream:nilc") || !strings.Contains(tc.Text, "upstream unavailable") {
 		t.Errorf("unexpected error text: %q", tc.Text)
 	}
+}
+
+// swappableUpstreamServer stands up an MCP upstream whose backing handler can
+// be replaced mid-test. Calling the returned kill func swaps in a fresh
+// StreamableHTTPHandler that has no record of the gateway's existing session
+// id, so the gateway's next request returns "session not found", simulating an
+// upstream restart or session eviction.
+func swappableUpstreamServer(t *testing.T) (url string, kill func()) {
+	t.Helper()
+	newHandler := func() http.Handler {
+		srv := mcp.NewServer(&mcp.Implementation{Name: "upstream", Version: "0.0.1"}, nil)
+		type echoArgs struct {
+			Message string `json:"message"`
+		}
+		mcp.AddTool(srv, &mcp.Tool{Name: toolEcho, Description: "echo"},
+			func(_ context.Context, _ *mcp.CallToolRequest, a echoArgs) (*mcp.CallToolResult, any, error) {
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{&mcp.TextContent{Text: "echo:" + a.Message}},
+				}, nil, nil
+			})
+		return mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return srv }, nil)
+	}
+
+	var mu sync.Mutex
+	current := newHandler()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		h := current
+		mu.Unlock()
+		h.ServeHTTP(w, r)
+	}))
+	t.Cleanup(func() {
+		ts.CloseClientConnections()
+		ts.Close()
+	})
+	kill = func() {
+		mu.Lock()
+		current = newHandler()
+		mu.Unlock()
+	}
+	return ts.URL, kill
+}
+
+// TestForwarder_ReconnectsAfterDroppedSession is the #572 regression: when the
+// upstream session is evicted or restarted, the gateway must re-dial and retry
+// transparently instead of returning "session not found" on every call until
+// the toolkit is recreated.
+func TestForwarder_ReconnectsAfterDroppedSession(t *testing.T) {
+	url, kill := swappableUpstreamServer(t)
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+
+	if err := tk.AddConnection(connCRM, connectionConfig(url, connCRM)); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+
+	tk.mu.RLock()
+	u := tk.connections[connCRM]
+	tk.mu.RUnlock()
+	require.NotNil(t, u)
+	require.NotNil(t, u.client)
+	firstClient := u.client
+
+	handler := tk.makeForwarder(u, toolEcho, localCRMEcho)
+	call := func(msg string) *mcp.CallToolResult {
+		req := &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{
+			Name:      toolEcho,
+			Arguments: json.RawMessage(`{"message":"` + msg + `"}`),
+		}}
+		res, err := handler(context.Background(), req)
+		require.NoError(t, err)
+		return res
+	}
+
+	// Baseline against the live session.
+	res := call("one")
+	require.False(t, res.IsError, "baseline call should succeed")
+	assert.Contains(t, firstText(t, res).Text, "echo:one")
+
+	// Evict the session.
+	kill()
+
+	// The next call hits a dead session; the forwarder must reconnect and retry.
+	res = call("two")
+	assert.False(t, res.IsError, "call after dropped session should reconnect and succeed: %+v", res)
+	assert.Contains(t, firstText(t, res).Text, "echo:two")
+
+	// The client was swapped to a fresh session.
+	tk.mu.RLock()
+	newClient := u.client
+	tk.mu.RUnlock()
+	assert.NotSame(t, firstClient, newClient, "expected a fresh upstream client after reconnect")
+}
+
+// healthFor returns the health snapshot for the named connection, or nil.
+func healthFor(details []toolkit.ConnectionDetail, name string) *toolkit.ConnectionHealth {
+	for _, d := range details {
+		if d.Name == name {
+			return d.Health
+		}
+	}
+	return nil
+}
+
+// TestListConnections_SurfacesHealth covers the #572 health surface: a live
+// connection reports reachable, and once the upstream is unreachable and a call
+// fails, list_connections reflects it instead of looking healthy.
+func TestListConnections_SurfacesHealth(t *testing.T) {
+	srv := mcp.NewServer(&mcp.Implementation{Name: "upstream", Version: "0.0.1"}, nil)
+	type echoArgs struct {
+		Message string `json:"message"`
+	}
+	mcp.AddTool(srv, &mcp.Tool{Name: toolEcho, Description: "echo"},
+		func(_ context.Context, _ *mcp.CallToolRequest, a echoArgs) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "echo:" + a.Message}}}, nil, nil
+		})
+	ts := httptest.NewServer(mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return srv }, nil))
+
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+	if err := tk.AddConnection(connCRM, connectionConfig(ts.URL, connCRM)); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+
+	// Healthy right after a successful connect.
+	h := healthFor(tk.ListConnections(), connCRM)
+	require.NotNil(t, h)
+	assert.True(t, h.Reachable, "reachable after connect")
+	assert.Positive(t, h.LastSuccessUnix, "last success recorded at connect")
+	assert.Empty(t, h.LastError)
+
+	// Take the upstream down and forward a call: it fails unrecoverably.
+	ts.CloseClientConnections()
+	ts.Close()
+	tk.mu.RLock()
+	u := tk.connections[connCRM]
+	tk.mu.RUnlock()
+	handler := tk.makeForwarder(u, toolEcho, localCRMEcho)
+	res, err := handler(context.Background(), &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{
+		Name:      toolEcho,
+		Arguments: json.RawMessage(`{"message":"x"}`),
+	}})
+	require.NoError(t, err)
+	require.True(t, res.IsError)
+
+	// list_connections now reports the connection as unreachable with the error.
+	h = healthFor(tk.ListConnections(), connCRM)
+	require.NotNil(t, h)
+	assert.False(t, h.Reachable, "unreachable after an unrecoverable failure")
+	assert.NotEmpty(t, h.LastError)
+}
+
+// TestForwarder_RemovedConnectionDoesNotReconnect guards the reconnect leak:
+// once a connection is removed, an in-flight forwarder must report the upstream
+// as unavailable rather than re-dialing and resurrecting a session that Close
+// would never reach.
+func TestForwarder_RemovedConnectionDoesNotReconnect(t *testing.T) {
+	url := upstreamServer(t)
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+	if err := tk.AddConnection(connCRM, connectionConfig(url, connCRM)); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+
+	tk.mu.RLock()
+	u := tk.connections[connCRM]
+	tk.mu.RUnlock()
+	handler := tk.makeForwarder(u, toolEcho, localCRMEcho)
+
+	if err := tk.RemoveConnection(connCRM); err != nil {
+		t.Fatalf("RemoveConnection: %v", err)
+	}
+
+	res, err := handler(context.Background(), &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{
+		Name:      toolEcho,
+		Arguments: json.RawMessage(`{"message":"x"}`),
+	}})
+	require.NoError(t, err)
+	require.True(t, res.IsError)
+	assert.Contains(t, firstText(t, res).Text, "upstream unavailable")
+
+	// The removed connection was not resurrected.
+	assert.False(t, tk.HasConnection(connCRM), "removed connection must not reappear")
+	assert.Nil(t, u.client, "client must be cleared on removal")
 }
 
 func TestConcurrentAddConnection_Safe(t *testing.T) {


### PR DESCRIPTION
## Problem

The MCP gateway held a single upstream session for the toolkit's lifetime. When the upstream evicted or restarted the session, the forwarder kept using the dead client and returned `session not found` on every call until the toolkit (process) was recreated. An entire `kind: mcp` toolkit could go dark with no signal: `list_connections` still listed the connection as present, and nothing surfaced that it was unreachable.

## Changes

### Reconnect on a dropped session (`pkg/toolkits/gateway`)

- The forwarder now reads the live client per call instead of capturing it once.
- On a dropped-session error (`isSessionDropped`: `session not found`, `client is closing`, `server is closing`, `connection closed`), it re-dials once and retries, so a transient session loss is transparent to the caller.
- The re-dial is single-flighted per connection (`reconnectMu`): concurrent calls hitting the same dead session serialize, the first re-dials, the rest reuse the fresh client.

### Per-connection health in `list_connections`

- `toolkit.ConnectionDetail` gains an optional `Health` (reachable, last success, last error).
- The gateway records last-success / last-error per upstream off the request path (atomics) and surfaces it through `list_connections`, so a dead or evicted upstream is observable there rather than only when a tool call fails. Placeholder connections report their dial error.

### Hardening from review

The change was put through an adversarial review before commit; it surfaced four real issues that are fixed here:

- **No resurrection of a removed connection.** `RemoveConnection` deletes the map entry and closes the client; it now also clears the client pointer, and `reconnectUpstream` verifies the connection is still the live map entry before installing the fresh session. Without this, an in-flight call could re-dial and install a session on an `*upstream` no longer tracked by `Close`, leaking it and silently undoing the removal.
- **`server is closing` is now treated as a dropped session,** so a sibling call racing a reconnect's close of the shared dead session recovers instead of failing.
- **`client_credentials` reconnects refresh the connection's token provider,** so `Status` / `ReacquireOAuthToken` operate on the provider the live session actually uses.
- **Health surfaces the placeholder dial error,** so an unreachable connection reports a reason instead of an empty error.

## Tests

- A swappable upstream handler reproduces session eviction: the forwarder fails with the exact production error (`failed to connect (session ID: ...): session not found`) without the fix and recovers with it.
- Removed-connection: a call after removal reports the upstream as unavailable and does not resurrect the connection.
- Health: reachable after connect; unreachable with a reason after an unrecoverable failure; `list_connections` renders the health block.
- `TestEndToEnd_TransportFailureAttribution` was updated to take the whole upstream down (a merely-dropped session now recovers), preserving its real intent of asserting error attribution.

## Scope

This closes the reconnect and health-surface parts of #572. The third item originally listed there, a per-toolkit liveness assertion in the smoke gate, was moved to #582 (test-gate work). Surfacing the new health field in the admin connections UI, and reconciling `Status().Healthy` with `Health.Reachable`, is tracked in #584.

## Verification

`make verify` green (fmt, race tests, lint, security, semgrep, codeql, coverage, patch coverage, dead-code, mutation, release-check). Patch coverage 83.8%.

Closes #572
