### PR TITLE
fix(knowledge): persist mapped memory status on insight reject/rollback so recall excludes them

### DIFF
--- a/pkg/memory/postgres.go
+++ b/pkg/memory/postgres.go
@@ -181,6 +181,10 @@ func buildUpdateColumns(updates RecordUpdate) (sq.UpdateBuilder, bool, error) {
 		qb = qb.Set(colDimension, updates.Dimension)
 		hasUpdates = true
 	}
+	if updates.Status != "" {
+		qb = qb.Set(colStatus, updates.Status)
+		hasUpdates = true
+	}
 	if updates.Metadata != nil {
 		meta, err := json.Marshal(updates.Metadata)
 		if err != nil {

--- a/pkg/memory/postgres_test.go
+++ b/pkg/memory/postgres_test.go
@@ -600,6 +600,11 @@ func TestBuildUpdateColumns(t *testing.T) {
 			hasUpdates: true,
 		},
 		{
+			name:       "status only",
+			updates:    RecordUpdate{Status: StatusArchived},
+			hasUpdates: true,
+		},
+		{
 			name: "all fields",
 			updates: RecordUpdate{
 				Content:    "updated",
@@ -623,6 +628,16 @@ func TestBuildUpdateColumns(t *testing.T) {
 			assert.Equal(t, tt.hasUpdates, hasUpdates)
 		})
 	}
+}
+
+func TestBuildUpdateColumns_SetsStatusColumn(t *testing.T) {
+	qb, hasUpdates, err := buildUpdateColumns(RecordUpdate{Status: StatusArchived})
+	require.NoError(t, err)
+	require.True(t, hasUpdates)
+	query, args, err := qb.ToSql()
+	require.NoError(t, err)
+	assert.Contains(t, query, colStatus+" =", "update must set the status column")
+	assert.Contains(t, args, StatusArchived)
 }
 
 // --- applyPagination tests ---

--- a/pkg/memory/store_realdb_integration_test.go
+++ b/pkg/memory/store_realdb_integration_test.go
@@ -39,3 +39,56 @@ func TestMemoryStore_Insert_RealDB_RoundTrip(t *testing.T) {
 	assert.Equal(t, rec.Content, got.Content)
 	assert.Equal(t, "knowledge", got.Dimension)
 }
+
+// TestMemoryStore_StatusUpdate_RealDB_ArchivedExcludedFromActive is the #579
+// regression at the store level: archiving a record via Update (the path a
+// rejected insight takes) must move the status COLUMN, so a status-filtered
+// read (what memory_recall uses) excludes it, while an archived-status read
+// still finds it (archived, not deleted).
+func TestMemoryStore_StatusUpdate_RealDB_ArchivedExcludedFromActive(t *testing.T) {
+	store := NewPostgresStore(testdb.New(t))
+	ctx := context.Background()
+
+	rec := Record{
+		ID:        "mem_realdb_reject",
+		Content:   "Insight that will be rejected.",
+		Dimension: "knowledge",
+		Category:  "business_context",
+		Source:    "user",
+		Status:    StatusActive,
+	}
+	require.NoError(t, store.Insert(ctx, rec))
+
+	containsID := func(records []Record, id string) bool {
+		for _, r := range records {
+			if r.ID == id {
+				return true
+			}
+		}
+		return false
+	}
+	activeList := func() []Record {
+		recs, _, err := store.List(ctx, Filter{Dimension: "knowledge", Status: StatusActive, Limit: 50})
+		require.NoError(t, err)
+		return recs
+	}
+
+	// Before reject: the active-status list (what recall uses) contains it.
+	require.True(t, containsID(activeList(), rec.ID), "record must be in the active list before reject")
+
+	// Reject maps to archived; Update threads Status through to the column.
+	require.NoError(t, store.Update(ctx, rec.ID, RecordUpdate{Status: StatusArchived}))
+
+	got, err := store.Get(ctx, rec.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, StatusArchived, got.Status, "update must move the status column to archived")
+
+	// After reject: the active-status list excludes it (recall no longer sees it).
+	assert.False(t, containsID(activeList(), rec.ID), "archived insight must not appear in an active-status list")
+
+	// An archived-status list still finds it (archived, not deleted).
+	archived, _, err := store.List(ctx, Filter{Dimension: "knowledge", Status: StatusArchived, Limit: 50})
+	require.NoError(t, err)
+	assert.True(t, containsID(archived, rec.ID), "archived insight must remain visible under an archived-status list")
+}

--- a/pkg/memory/types.go
+++ b/pkg/memory/types.go
@@ -178,8 +178,13 @@ type RecordUpdate struct {
 	Category   string
 	Confidence string
 	Dimension  string
-	Metadata   map[string]any
-	Embedding  []float32
+	// Status transitions the record's lifecycle column (active, archived,
+	// superseded). Empty leaves it unchanged. Required so a status change made
+	// via Update (e.g. an insight rejection that maps to archived) moves the
+	// status column, not just metadata, so status-filtered reads honor it.
+	Status    string
+	Metadata  map[string]any
+	Embedding []float32
 	// EmbeddingModel and EmbeddingTextHash travel with Embedding: when an
 	// update re-embeds changed content, the write path stamps the model
 	// and content hash alongside the new vector so the row's breadcrumbs

--- a/pkg/toolkits/knowledge/memory_adapter.go
+++ b/pkg/toolkits/knowledge/memory_adapter.go
@@ -177,6 +177,11 @@ func (a *memoryInsightAdapter) UpdateStatus(ctx context.Context, id, status, rev
 		metaKeyInsightStatus: status,
 	}
 	if err := a.store.Update(ctx, id, memory.RecordUpdate{
+		// Persist the mapped memory status to the column, not just the metadata:
+		// a rejected insight maps to archived, and recall filters on the status
+		// column, so without this a rejected insight stays active and keeps
+		// surfacing in memory_recall.
+		Status:   mapInsightStatusToMemory(status),
 		Metadata: meta,
 	}); err != nil {
 		return fmt.Errorf("updating insight status: %w", err)
@@ -251,6 +256,11 @@ func (a *memoryInsightAdapter) MarkApplied(ctx context.Context, id, appliedBy, c
 		// applied count at zero (mirrors MarkRolledBack / UpdateStatus).
 		metaKeyInsightStatus: StatusApplied,
 	}
+	// Deliberately metadata-only: applied maps to active, and a legitimately
+	// applied insight (approved -> applied) is already active, so the column
+	// needs no change. Force-writing active here would resurrect a previously
+	// archived insight (e.g. apply called on a rejected id, which the apply path
+	// does not transition-validate) back into recall, re-opening #579.
 	if err := a.store.Update(ctx, id, memory.RecordUpdate{
 		Metadata: meta,
 	}); err != nil {
@@ -266,6 +276,9 @@ func (a *memoryInsightAdapter) MarkRolledBack(ctx context.Context, id, rolledBac
 		metaKeyInsightStatus: StatusRolledBack,
 	}
 	if err := a.store.Update(ctx, id, memory.RecordUpdate{
+		// Rolled-back insights map to archived; persist it to the status column
+		// so they stop surfacing in memory_recall (same fix as UpdateStatus).
+		Status:   mapInsightStatusToMemory(StatusRolledBack),
 		Metadata: meta,
 	}); err != nil {
 		return fmt.Errorf("marking insight rolled back: %w", err)

--- a/pkg/toolkits/knowledge/memory_adapter_test.go
+++ b/pkg/toolkits/knowledge/memory_adapter_test.go
@@ -420,6 +420,24 @@ func TestMemoryInsightAdapter_UpdateStatus(t *testing.T) {
 	assert.Equal(t, "reviewer@example.com", store.updateData.Metadata["reviewed_by"])
 	assert.Equal(t, "LGTM", store.updateData.Metadata["review_notes"])
 	assert.Equal(t, StatusApproved, store.updateData.Metadata["insight_status"])
+	// Approved maps to the active memory status column.
+	assert.Equal(t, memory.StatusActive, store.updateData.Status)
+}
+
+// TestMemoryInsightAdapter_UpdateStatus_RejectArchives is the #579 regression:
+// rejecting an insight must move the memory status COLUMN to archived (not just
+// metadata), because memory_recall filters on the column. Without this a
+// rejected insight stays active and keeps surfacing in recall.
+func TestMemoryInsightAdapter_UpdateStatus_RejectArchives(t *testing.T) {
+	store := &mockMemoryStore{}
+	adapter := NewMemoryInsightAdapter(store)
+
+	err := adapter.UpdateStatus(context.Background(), "ins-001", StatusRejected, "rev@example.com", "not useful")
+	require.NoError(t, err)
+	require.True(t, store.updateCalled)
+	assert.Equal(t, StatusRejected, store.updateData.Metadata["insight_status"])
+	assert.Equal(t, memory.StatusArchived, store.updateData.Status,
+		"rejected insight must archive the status column so recall excludes it")
 }
 
 func TestMemoryInsightAdapter_UpdateStatus_Error(t *testing.T) {
@@ -599,6 +617,8 @@ func TestMemoryInsightAdapter_MarkRolledBack(t *testing.T) {
 	assert.Equal(t, "ins-001", store.updateID)
 	assert.Equal(t, StatusRolledBack, store.updateData.Metadata[metaKeyInsightStatus])
 	assert.Equal(t, "admin@example.com", store.updateData.Metadata[metaKeyReviewedBy])
+	// Rolled-back maps to archived; the column must move too (same bug as reject).
+	assert.Equal(t, memory.StatusArchived, store.updateData.Status)
 }
 
 func TestMemoryInsightAdapter_MarkRolledBack_Error(t *testing.T) {


### PR DESCRIPTION
## Problem

Rejected insights kept appearing in `memory_recall`. Insight status transitions wrote only the metadata `insight_status`, never the memory `status` column. `memory_recall` filters on the status column, so a rejected insight stayed `status=active` and kept surfacing. The intended `rejected -> archived` mapping existed but was applied only at insert, never on the transition.

## Root cause

`memoryInsightAdapter.UpdateStatus` (and `MarkRolledBack`) called `store.Update` with `RecordUpdate{Metadata: ...}` only. `memory.RecordUpdate` had no `Status` field and `buildUpdateColumns` never set the `status` column, so the record's lifecycle column never moved. Recall's search path applies `archivedExclusion` on the column, which therefore never excluded a rejected insight.

## Fix

- Add a `Status` field to `memory.RecordUpdate` and set the `status` column in `buildUpdateColumns` when it is non-empty (`pkg/memory`).
- Persist `mapInsightStatusToMemory(status)` to the column on the reject/approve transition (`UpdateStatus`) and on `MarkRolledBack` (`pkg/toolkits/knowledge`). `MarkRolledBack` had the identical bug: rolled-back insights also map to archived but stayed active.
- `MarkApplied` is deliberately left metadata-only. Applied maps to active, and an approved-then-applied insight is already active, so the column needs no change. Force-writing active there would resurrect a previously archived insight (the apply path does not transition-validate its input ids) back into recall, re-opening this bug. This was caught in review and reverted.

## Behavior preserved

The admin review path is unaffected. `memoryInsightAdapter.List` filters by explicit status and maps it to the memory status (then post-filters on the metadata `insight_status`), so `List(status=rejected)` still finds rejected insights. Only the recall/search surface, which is what this issue is about, now excludes them.

Note: there is a pre-existing `List` (no archived-exclusion) vs `Search` (archived-excluded) asymmetry. With rejected insights now archived, they show in the admin browse-all list but not in search-all unless the explicit Rejected filter is chosen. That is a separate, pre-existing design choice and is not data loss (records remain retrievable by explicit status); worth a small follow-up if consistency is desired.

## Tests

- Adapter unit tests: reject -> archived column, rollback -> archived, approve -> active.
- `buildUpdateColumns` sets the `status` column in the generated SQL.
- Real-Postgres test (`//go:build integration`, run by the realdb gate): a record is present in the active-status list before reject, archived via `Update`, then absent from the active-status list and still present in the archived-status list. Proven to fail without the store fix (`no fields to update`).

## Verification

`make verify` green (fmt, race tests, lint, security, semgrep, codeql, coverage, patch coverage, realdb, dead-code, mutation, release-check).

Closes #579
