### PR TITLE
fix(memory): normalize ts_rank_cd so lexical recall scores differentiate

### DIFF
--- a/pkg/memory/postgres.go
+++ b/pkg/memory/postgres.go
@@ -344,6 +344,21 @@ const rawRecordCols = "id, created_at, updated_at, created_by, persona, dimensio
 // 000054) or the planner will not use the index.
 const ftsExpr = "to_tsvector('english', content)"
 
+// ftsRankNormalization is the ts_rank_cd normalization bitmask for the
+// LexicalSearch score. Bit 1 divides the rank by 1 + log(document length) so a
+// short, dense match outranks a long document that mentions the term once;
+// without it every single-match record collapses to the same weight-D 0.1 and
+// lexical ranking is effectively flat (#578). Bit 32 maps the result into (0,1)
+// so the returned score reads as a normalized relevance. Verified against real
+// Postgres: with no normalization two single-match records both score 0.1; with
+// 1|32 the exact match scores ~0.126 versus ~0.046 for a long single-mention.
+//
+// Deliberately NOT applied to the HybridSearch lexArm: its ts_rank_cd only
+// orders the top-k lexical candidates, and the fused hybrid score uses a
+// lexMatch boolean, not the rank value, so normalizing it would change which
+// candidates survive without improving the score.
+const ftsRankNormalization = 1 | 32
+
 // ftsQuery is the parameterized tsquery the lexical predicate compares
 // against. $2 is the user's query text in HybridSearch; LexicalSearch
 // rebinds it to $1 (it has no vector parameter).
@@ -468,10 +483,10 @@ func (s *postgresStore) LexicalSearch(ctx context.Context, query LexicalQuery) (
 	// #nosec G201 -- tableName/cols/exprs are constants; query text,
 	// persona, status are parameterized; limit is a sanitized int.
 	sqlStr := fmt.Sprintf(
-		"SELECT %s, ts_rank_cd(%s, %s) AS score "+
+		"SELECT %s, ts_rank_cd(%s, %s, %d) AS score "+
 			"FROM %s WHERE %s @@ %s%s%s "+
 			"ORDER BY score DESC LIMIT %d",
-		rawRecordCols, ftsExpr, lexQuery, tableName, ftsExpr, lexQuery, archivedExclusion(query.Status), filterClause, limit)
+		rawRecordCols, ftsExpr, lexQuery, ftsRankNormalization, tableName, ftsExpr, lexQuery, archivedExclusion(query.Status), filterClause, limit)
 
 	rows, err := s.db.QueryContext(ctx, sqlStr, args...)
 	if err != nil {

--- a/pkg/memory/store_realdb_integration_test.go
+++ b/pkg/memory/store_realdb_integration_test.go
@@ -92,3 +92,41 @@ func TestMemoryStore_StatusUpdate_RealDB_ArchivedExcludedFromActive(t *testing.T
 	require.NoError(t, err)
 	assert.True(t, containsID(archived, rec.ID), "archived insight must remain visible under an archived-status list")
 }
+
+// TestMemoryStore_LexicalSearch_RealDB_Differentiates is the #578 regression:
+// lexical ranking must differentiate two single-match records (an exact short
+// match outranking a long single-mention) rather than collapsing both to the
+// flat weight-D 0.1, and scores must stay within (0,1].
+func TestMemoryStore_LexicalSearch_RealDB_Differentiates(t *testing.T) {
+	store := NewPostgresStore(testdb.New(t))
+	ctx := context.Background()
+
+	exact := Record{ID: "lex_exact", Dimension: "knowledge", Status: StatusActive, Content: "revenue"}
+	long := Record{
+		ID: "lex_long", Dimension: "knowledge", Status: StatusActive,
+		Content: "Quarterly revenue grew across every region this year compared with the prior period.",
+	}
+	require.NoError(t, store.Insert(ctx, exact))
+	require.NoError(t, store.Insert(ctx, long))
+
+	results, err := store.LexicalSearch(ctx, LexicalQuery{QueryText: "revenue", Dimension: "knowledge", Limit: 10})
+	require.NoError(t, err)
+
+	scores := map[string]float64{}
+	for _, r := range results {
+		scores[r.Record.ID] = r.Score
+	}
+	require.Contains(t, scores, exact.ID)
+	require.Contains(t, scores, long.ID)
+
+	// Substantially differentiated: the exact short match must outrank the long
+	// single-mention by a clear margin. The flat-0.1 bug made these equal; a
+	// too-weak normalization would make them nearly equal.
+	assert.Greater(t, scores[exact.ID], 2*scores[long.ID],
+		"exact match must rank well above a long single-mention, not collapse to a flat score")
+	// Scores are bounded into (0,1) by the 32 normalization bit.
+	for id, s := range scores {
+		assert.Greater(t, s, 0.0, "score for %s must be positive", id)
+		assert.Less(t, s, 1.0, "score for %s must be < 1", id)
+	}
+}


### PR DESCRIPTION
## Problem

`memory_recall` with the lexical strategy returned an effectively flat relevance score: every single-match short record scored the same `0.1`, so an exact match and a long document mentioning the term once were indistinguishable. An agent ranking by this score sees no meaningful ordering.

## Root cause

`LexicalSearch` selected `ts_rank_cd(to_tsvector('english', content), tsquery) AS score` with no normalization argument. With unweighted content, `ts_rank_cd` assigns the weight-D default; for a single-match short record the cover-density rank collapses to `0.1` regardless of relevance, so distinct records receive identical scores.

## Fix

Add a documented normalization bitmask to the `LexicalSearch` score: `ts_rank_cd(..., 1|32)`.

- Bit `1` divides the rank by `1 + log(document length)`, so a short, dense match outranks a long document that mentions the term once.
- Bit `32` maps the result into `(0,1)`, so the returned score reads as a normalized relevance.

The GIN index expression (`to_tsvector('english', content)`) is unchanged, so the index is still used; only the ranking argument changed.

The flag was chosen empirically against real Postgres, not assumed: a probe showed that flag `32` alone does NOT fix the flat case (two single-match records both stay at `0.0909`), while the log-length bit differentiates them (exact `~0.126` vs long single-mention `~0.046`).

`HybridSearch` is deliberately left unchanged. Its `ts_rank_cd` is only used in `ORDER BY` to select the top-k lexical candidates, and the fused hybrid score uses a `lexMatch` boolean rather than the rank value, so normalizing it would change which candidates survive without improving the score.

## Tests

- A real-Postgres test (`//go:build integration`, run by the realdb gate) inserts an exact short record and a long single-mention record, runs `LexicalSearch`, and asserts the exact match outranks the long one by a clear margin and both scores fall in `(0,1)`. It fails without the fix (both score `0.1`).
- Existing sqlmock tests for `LexicalSearch`/`HybridSearch` execute the changed line, so patch coverage is satisfied.

## Related

The same flat-score pattern exists in portal asset search, collection search, and prompt search (each uses an unnormalized `ts_rank_cd ... AS lex_rank`). That is tracked separately in #587, since those are distinct search features needing their own change and tests.

## Verification

`make verify` green (fmt, race tests, lint, security, semgrep, codeql, coverage, patch coverage, realdb, dead-code, mutation, release-check).

Closes #578
