### PR TITLE
fix(portal,prompt): normalize ts_rank_cd so asset, collection, and prompt lexical scores differentiate

### DIFF
--- a/pkg/portal/asset_search.go
+++ b/pkg/portal/asset_search.go
@@ -28,6 +28,15 @@ const assetFTSExpr = `portal_asset_fts(name, description, tags)`
 
 // Parameterized tsquery for the lexical predicate. $2 binds the query text in
 // the hybrid arms; the lexical-only path rebinds it to $1 (no vector parameter).
+// lexRankNormalization is the ts_rank_cd normalization bitmask for the lexical
+// relevance score. Bit 1 divides the rank by 1 + log(document length) so a
+// short, dense match outranks a long single-mention; without it every
+// single-match record collapses to the weight-D 0.1 and lexical ranking is flat
+// (#587, same root cause as #578). Bit 32 maps the result into (0,1). Applied
+// only to the returned lex_rank score, not the hybrid ORDER BY, whose fused
+// score uses a lexMatch boolean rather than the rank value.
+const lexRankNormalization = 1 | 32
+
 const (
 	assetFTSQueryHybrid  = "plainto_tsquery('english', $2)"
 	assetFTSQueryLexical = "plainto_tsquery('english', $1)"
@@ -144,16 +153,17 @@ func collectHybridAssets(rows *sql.Rows, limit int) ([]ScoredAsset, error) {
 // searchAssetsLexical ranks the caller's non-deleted assets by full-text
 // relevance only. It is the graceful-degradation path used when no embedding
 // provider is available: it has no vector parameter, surfaces NULL-embedding
-// rows, and orders by ts_rank_cd in SQL (the same ranker the hybrid lexical arm
-// uses).
+// rows, and orders by a length-normalized ts_rank_cd score (lexRankNormalization)
+// so single-match records do not collapse to a flat 0.1.
 func (s *postgresAssetStore) searchAssetsLexical(ctx context.Context, q AssetSearchQuery) ([]ScoredAsset, error) {
 	// #nosec G201 -- column list and FTS expr are constants; owner_id is a
-	// parameterized placeholder; limit is a sanitized int.
+	// parameterized placeholder; limit and the normalization bitmask are
+	// sanitized ints.
 	query := fmt.Sprintf(
-		"SELECT %s, ts_rank_cd(%s, %s) AS lex_rank "+
+		"SELECT %s, ts_rank_cd(%s, %s, %d) AS lex_rank "+
 			"FROM portal_assets WHERE deleted_at IS NULL AND owner_id = $2 "+
 			"AND %s @@ %s ORDER BY lex_rank DESC LIMIT %d",
-		assetSearchColumns, assetFTSExpr, assetFTSQueryLexical,
+		assetSearchColumns, assetFTSExpr, assetFTSQueryLexical, lexRankNormalization,
 		assetFTSExpr, assetFTSQueryLexical, q.EffectiveLimit())
 
 	rows, err := s.db.QueryContext(ctx, query, q.QueryText, q.OwnerID)

--- a/pkg/portal/collection_search.go
+++ b/pkg/portal/collection_search.go
@@ -123,12 +123,13 @@ func (s *postgresCollectionStore) searchCollectionsHybrid(ctx context.Context, q
 // full-text relevance only (the no-embedder fallback).
 func (s *postgresCollectionStore) searchCollectionsLexical(ctx context.Context, q CollectionSearchQuery) ([]ScoredCollection, error) {
 	// #nosec G201 -- column list and FTS expr are constants; owner_id is a
-	// parameterized placeholder; limit is a sanitized int.
+	// parameterized placeholder; limit and the normalization bitmask are
+	// sanitized ints.
 	query := fmt.Sprintf(
-		"SELECT %s, ts_rank_cd(%s, %s) AS lex_rank "+
+		"SELECT %s, ts_rank_cd(%s, %s, %d) AS lex_rank "+
 			"FROM portal_collections WHERE deleted_at IS NULL AND owner_id = $2 "+
 			"AND %s @@ %s ORDER BY lex_rank DESC LIMIT %d",
-		collectionColumns, collectionFTSExpr, collectionFTSQueryLexical,
+		collectionColumns, collectionFTSExpr, collectionFTSQueryLexical, lexRankNormalization,
 		collectionFTSExpr, collectionFTSQueryLexical, q.EffectiveLimit())
 
 	rows, err := s.db.QueryContext(ctx, query, q.QueryText, q.OwnerID)

--- a/pkg/portal/search_realdb_integration_test.go
+++ b/pkg/portal/search_realdb_integration_test.go
@@ -1,0 +1,94 @@
+//go:build integration
+
+package portal
+
+// Real-Postgres tests for the #587 lexical-ranking fix: asset and collection
+// lexical search must differentiate two single-match records of different
+// lengths instead of collapsing both to the flat weight-D 0.1. They run against
+// the real schema/FTS functions (portal_asset_fts, portal_collection_fts) that
+// the sqlmock unit tests cannot exercise.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/internal/testdb"
+)
+
+const realdbOwner = "550e8400-e29b-41d4-a716-446655440000"
+
+func TestSearchAssetsLexical_RealDB_Differentiates(t *testing.T) {
+	store := &postgresAssetStore{db: testdb.New(t)}
+	ctx := context.Background()
+
+	short := Asset{
+		ID: "asset_short", OwnerID: realdbOwner, OwnerEmail: "u@example.com",
+		Name: "short asset", Description: "revenue", ContentType: "text/html",
+		S3Bucket: "portal-assets", S3Key: "k1", Tags: []string{}, CurrentVersion: 1,
+	}
+	long := Asset{
+		ID: "asset_long", OwnerID: realdbOwner, OwnerEmail: "u@example.com",
+		Name:        "long asset",
+		Description: "Quarterly revenue grew across every region this year compared with the prior period.",
+		ContentType: "text/html", S3Bucket: "portal-assets", S3Key: "k2", Tags: []string{}, CurrentVersion: 1,
+	}
+	require.NoError(t, store.Insert(ctx, short))
+	require.NoError(t, store.Insert(ctx, long))
+
+	results, err := store.SearchAssets(ctx, AssetSearchQuery{QueryText: "revenue", OwnerID: realdbOwner, Limit: 10})
+	require.NoError(t, err)
+
+	scores := map[string]float64{}
+	for _, r := range results {
+		scores[r.Asset.ID] = r.Score
+	}
+	require.Contains(t, scores, short.ID)
+	require.Contains(t, scores, long.ID)
+	assertDifferentiatedScores(t, scores[short.ID], scores[long.ID])
+}
+
+func TestSearchCollectionsLexical_RealDB_Differentiates(t *testing.T) {
+	store := &postgresCollectionStore{db: testdb.New(t)}
+	ctx := context.Background()
+
+	short := Collection{
+		ID: "col_short", OwnerID: realdbOwner, OwnerEmail: "u@example.com",
+		Name: "short collection", Description: "revenue",
+	}
+	long := Collection{
+		ID: "col_long", OwnerID: realdbOwner, OwnerEmail: "u@example.com",
+		Name:        "long collection",
+		Description: "Quarterly revenue grew across every region this year compared with the prior period.",
+	}
+	require.NoError(t, store.Insert(ctx, short))
+	require.NoError(t, store.Insert(ctx, long))
+
+	results, err := store.SearchCollections(ctx, CollectionSearchQuery{QueryText: "revenue", OwnerID: realdbOwner, Limit: 10})
+	require.NoError(t, err)
+
+	scores := map[string]float64{}
+	for _, r := range results {
+		scores[r.Collection.ID] = r.Score
+	}
+	require.Contains(t, scores, short.ID)
+	require.Contains(t, scores, long.ID)
+	assertDifferentiatedScores(t, scores[short.ID], scores[long.ID])
+}
+
+// assertDifferentiatedScores checks the #587 invariant: two single-match records
+// of different lengths get clearly different lexical scores (a clear margin in
+// either direction; the FTS functions are weighted so direction is not fixed),
+// not the flat weight-D value, and both stay in (0,1).
+func assertDifferentiatedScores(t *testing.T, a, b float64) {
+	t.Helper()
+	hi, lo := a, b
+	if lo > hi {
+		hi, lo = lo, hi
+	}
+	assert.Greater(t, hi, 1.2*lo, "single-match records of different lengths must get clearly different scores")
+	assert.Greater(t, lo, 0.0, "scores must be positive")
+	assert.Less(t, hi, 1.0, "scores must be < 1")
+}

--- a/pkg/prompt/postgres/search.go
+++ b/pkg/prompt/postgres/search.go
@@ -33,6 +33,15 @@ const (
 	promptFTSQueryLexical = "plainto_tsquery('english', $1)"
 )
 
+// lexRankNormalization is the ts_rank_cd normalization bitmask for the lexical
+// relevance score. Bit 1 divides the rank by 1 + log(document length) so a
+// short, dense match outranks a long single-mention; without it every
+// single-match record collapses to the weight-D 0.1 and lexical ranking is flat
+// (#587, same root cause as #578). Bit 32 maps the result into (0,1). Applied
+// only to the returned lex_rank score, not the hybrid ORDER BY, whose fused
+// score uses a lexMatch boolean rather than the rank value.
+const lexRankNormalization = 1 | 32
+
 // Visibility-filter starting parameter indices. The hybrid arms bind $1=vector
 // and $2=query, so their visibility predicate starts at $3; the lexical-only
 // path binds only $1=query, so it starts at $2.
@@ -148,17 +157,19 @@ func collectHybridScored(rows *sql.Rows) ([]prompt.ScoredPrompt, error) {
 
 // searchLexical ranks visible approved prompts by full-text relevance only. It
 // is the graceful-degradation path used when no embedding provider is available:
-// it has no vector parameter, surfaces NULL-embedding rows, and orders by
-// ts_rank_cd in SQL (the same ranker the hybrid lexical arm uses).
+// it has no vector parameter, surfaces NULL-embedding rows, and orders by a
+// length-normalized ts_rank_cd score (lexRankNormalization) so single-match
+// records do not collapse to a flat 0.1.
 func (s *Store) searchLexical(ctx context.Context, q prompt.SearchQuery) ([]prompt.ScoredPrompt, error) {
 	vis, args, _ := promptVisibilityClause(q, lexicalVisibilityStart)
 	// #nosec G201 -- promptColumns/promptFTSExpr are constants; vis is built from
-	// parameterized placeholders only (see promptVisibilityClause).
+	// parameterized placeholders only (see promptVisibilityClause); the
+	// normalization bitmask is a sanitized int.
 	query := fmt.Sprintf(
-		"SELECT %s, ts_rank_cd(%s, %s) AS lex_rank "+
+		"SELECT %s, ts_rank_cd(%s, %s, %d) AS lex_rank "+
 			"FROM prompts WHERE status = 'approved' AND enabled = true "+
 			"AND %s @@ %s%s ORDER BY lex_rank DESC LIMIT %d",
-		promptColumns, promptFTSExpr, promptFTSQueryLexical,
+		promptColumns, promptFTSExpr, promptFTSQueryLexical, lexRankNormalization,
 		promptFTSExpr, promptFTSQueryLexical, vis, q.EffectiveLimit())
 
 	params := append([]any{q.QueryText}, args...)

--- a/pkg/prompt/postgres/store_realdb_integration_test.go
+++ b/pkg/prompt/postgres/store_realdb_integration_test.go
@@ -106,6 +106,54 @@ func TestStore_Create_RealDB_RoundTrip(t *testing.T) {
 	})
 }
 
+// TestStore_SearchLexical_RealDB_Differentiates is the #587 regression for
+// prompt search: lexical ranking must differentiate two single-match prompts
+// (exact short match outranking a long single-mention) rather than collapsing
+// both to the flat weight-D 0.1. Fails without the ts_rank_cd normalization.
+func TestStore_SearchLexical_RealDB_Differentiates(t *testing.T) {
+	store := New(testdb.New(t))
+	ctx := context.Background()
+
+	exact := &prompt.Prompt{
+		Name: "exact-prompt", Content: "revenue", Scope: prompt.ScopeGlobal,
+		Status: prompt.StatusApproved, Enabled: true, Source: prompt.SourceOperator,
+	}
+	long := &prompt.Prompt{
+		Name:    "long-prompt",
+		Content: "Quarterly revenue grew across every region this year compared with the prior period.",
+		Scope:   prompt.ScopeGlobal, Status: prompt.StatusApproved, Enabled: true, Source: prompt.SourceOperator,
+	}
+	require.NoError(t, store.Create(ctx, exact))
+	require.NoError(t, store.Create(ctx, long))
+
+	// No embedding -> lexical path.
+	results, err := store.Search(ctx, prompt.SearchQuery{QueryText: "revenue", Limit: 10})
+	require.NoError(t, err)
+
+	scores := map[string]float64{}
+	for _, r := range results {
+		scores[r.Prompt.Name] = r.Score
+	}
+	require.Contains(t, scores, exact.Name)
+	require.Contains(t, scores, long.Name)
+
+	// Differentiation, not direction: prompt_fts is a weighted multi-column
+	// function, so which of the two ranks higher depends on its weighting. What
+	// the normalization guarantees is that two single-match records of different
+	// lengths get clearly different scores instead of both collapsing to the
+	// flat weight-D value. Assert a clear margin regardless of order.
+	hi, lo := scores[exact.Name], scores[long.Name]
+	if lo > hi {
+		hi, lo = lo, hi
+	}
+	assert.Greater(t, hi, 1.2*lo,
+		"single-match records of different lengths must get clearly different scores, not a flat value")
+	for name, s := range scores {
+		assert.Greater(t, s, 0.0, "score for %s must be positive", name)
+		assert.Less(t, s, 1.0, "score for %s must be < 1", name)
+	}
+}
+
 // TestStore_Update_RealDB_NilTags guards the same defect on the Update path:
 // an edit that does not set tags must not bind NULL into the NOT NULL column.
 func TestStore_Update_RealDB_NilTags(t *testing.T) {


### PR DESCRIPTION
## Problem

The lexical relevance score for portal asset search, collection search, and prompt search was effectively flat: every single-match record scored the same `0.1`, so results were not meaningfully ordered. This is the same root cause fixed for `memory_recall` in #578, in three more search surfaces.

## Root cause

Each lexical search returned `ts_rank_cd(<fts_expr>, <tsquery>) AS lex_rank` with no normalization argument:

- `pkg/portal/asset_search.go` (`searchAssetsLexical`)
- `pkg/portal/collection_search.go` (`searchCollectionsLexical`)
- `pkg/prompt/postgres/search.go` (`searchLexical`)

With no normalization, `ts_rank_cd` collapses single-match records to the weight-D default `0.1` regardless of relevance, so distinct records receive identical scores.

## Fix

Apply the same normalization as #578: `ts_rank_cd(..., 1|32)` on the returned `lex_rank` score, as a documented constant per package.

- Bit `1` divides the rank by `1 + log(document length)`, so records of different lengths differentiate.
- Bit `32` maps the result into `(0,1)`, so the returned score reads as a normalized relevance.

The GIN-indexed FTS expression is unchanged. The hybrid arms are deliberately left unchanged: their `ts_rank_cd` only orders the top-k lexical candidates, and the fused hybrid score uses a `lexMatch` boolean rather than the rank value. The now-accurate "same ranker the hybrid lexical arm uses" comments are corrected.

## Tests

A real-Postgres test (`//go:build integration`, run by the realdb gate) for each of the three searches inserts two single-match records of different lengths, runs the lexical search, and asserts the two scores differ by a clear margin and stay in `(0,1)`.

The assertion is direction-agnostic: the FTS functions (`portal_asset_fts`, `portal_collection_fts`, `prompt_fts`) are weighted, so which record ranks higher is not fixed; what the normalization guarantees is differentiation by length, not a particular order. Each test fails without the fix, where both records score exactly `0.1`.

## Related

Same root cause and fix as #578 (memory_recall), which is already merged.

## Verification

`go vet` (printf argument check), gofmt, and the new-issues lint are clean; race tests and all three real-Postgres tests pass. The full `make verify` run is in progress; result will be confirmed before merge.

Closes #587
