### PR TITLE
fix(resources): actionable error and self-healing prune for orphaned managed resources

### DIFF
--- a/pkg/middleware/mcp_resources.go
+++ b/pkg/middleware/mcp_resources.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -11,6 +12,18 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/resource"
 )
+
+// errResourceBlobMissing marks a read failure where the resource row exists but
+// its backing object is gone (an orphaned resource). handleManagedRead checks
+// for it to self-heal by pruning the dead row.
+var errResourceBlobMissing = errors.New("backing object missing")
+
+// resourcePruner is the optional capability to delete a resource row. The
+// configured Store (resource.Store) implements it; ResourceListProvider does
+// not require it, so the read path type-asserts and prunes only when available.
+type resourcePruner interface {
+	Delete(ctx context.Context, id string) error
+}
 
 const (
 	methodListResources = "resources/list"
@@ -237,7 +250,49 @@ func handleManagedRead(ctx context.Context, next mcp.MethodHandler, method strin
 	}
 
 	slog.Debug("managed resources read: serving content", logKeyURI, uri, "mime_type", res.MIMEType, "s3_key", res.S3Key)
-	return fetchResourceContent(ctx, cfg, res)
+	result, err := fetchResourceContent(ctx, cfg, res)
+	if err != nil && errors.Is(err, errResourceBlobMissing) {
+		// Self-heal: the backing object is confirmed gone, so the row is a
+		// permanent orphan that would keep appearing in resources/list and
+		// failing every read. Best-effort prune it so the list/read divergence
+		// closes the moment an orphan is actually accessed.
+		pruneOrphanedResource(ctx, cfg, res)
+	}
+	return result, err
+}
+
+// pruneOrphanedResource best-effort deletes a resource row whose backing object
+// is missing, so it stops appearing in resources/list. It only runs on a
+// confirmed not-found (errResourceBlobMissing), never on a transient failure,
+// and a delete error is logged but not surfaced (the read already returned the
+// actionable error to the caller).
+func pruneOrphanedResource(ctx context.Context, cfg ManagedResourceConfig, res *resource.Resource) {
+	pruner, ok := cfg.Store.(resourcePruner)
+	if !ok || res.ID == "" {
+		return
+	}
+	if delErr := pruner.Delete(ctx, res.ID); delErr != nil {
+		slog.Warn("managed resource: failed to prune orphaned row", logKeyURI, res.URI, "id", res.ID, logKeyError, delErr)
+		return
+	}
+	slog.Info("managed resource: pruned orphaned row (backing object missing)", logKeyURI, res.URI, "id", res.ID)
+}
+
+// isObjectNotFound reports whether a blob-store GetObject error indicates the
+// object does not exist (an orphaned resource), as opposed to a transient or
+// permission failure that a retry might resolve. The mcp-s3 client wraps the
+// underlying AWS/SeaweedFS error without a typed not-found, so detection is by
+// the standard S3 not-found signatures present in the wrapped message.
+func isObjectNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "nosuchkey") ||
+		strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "notfound") ||
+		strings.Contains(msg, "status code: 404") ||
+		strings.Contains(msg, "404 not found")
 }
 
 // fetchResourceContent fetches resource content from S3 and builds the read result.
@@ -255,8 +310,19 @@ func fetchResourceContent(ctx context.Context, cfg ManagedResourceConfig, res *r
 
 	body, _, s3Err := cfg.S3Client.GetObject(ctx, cfg.S3Bucket, res.S3Key)
 	if s3Err != nil {
+		if isObjectNotFound(s3Err) {
+			// The resource row exists but its backing object is gone: an
+			// orphaned managed resource (it still appears in resources/list).
+			// Return a distinct, actionable message instead of an opaque
+			// failure, so the caller learns the content is permanently missing
+			// (and an operator can prune or re-upload it) rather than concluding
+			// resource reads are broken.
+			slog.Warn("managed resource read: backing object missing (orphaned resource)",
+				logKeyURI, res.URI, "s3_key", res.S3Key)
+			return nil, fmt.Errorf("resource content unavailable for %q: %w (orphaned resource; remove or re-upload it)", res.URI, errResourceBlobMissing)
+		}
 		slog.Error("managed resource read: s3 get failed", logKeyError, s3Err, logKeyURI, res.URI)
-		return nil, fmt.Errorf("error reading resource content")
+		return nil, fmt.Errorf("error reading resource content for %q", res.URI)
 	}
 
 	// For text types under 1 MB, return inline. Otherwise, return as blob.

--- a/pkg/middleware/mcp_resources_test.go
+++ b/pkg/middleware/mcp_resources_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -15,10 +16,19 @@ import (
 
 type mockResourceStore struct {
 	resources map[string]*resource.Resource
+	deleted   []string // ids passed to Delete (records orphan prunes)
 }
 
 func newMockResourceStore() *mockResourceStore {
 	return &mockResourceStore{resources: make(map[string]*resource.Resource)}
+}
+
+// Delete records the id and removes the row, so mockResourceStore satisfies the
+// optional resourcePruner capability the read path uses to prune orphans.
+func (m *mockResourceStore) Delete(_ context.Context, id string) error {
+	m.deleted = append(m.deleted, id)
+	delete(m.resources, id)
+	return nil
 }
 
 func (m *mockResourceStore) List(_ context.Context, filter resource.Filter) ([]resource.Resource, int, error) {
@@ -47,6 +57,7 @@ func (m *mockResourceStore) GetByURI(_ context.Context, uri string) (*resource.R
 
 type mockBlobReader struct {
 	objects map[string][]byte
+	getErr  error // when set, GetObject returns this regardless of objects
 }
 
 func newMockBlobReader() *mockBlobReader {
@@ -54,9 +65,12 @@ func newMockBlobReader() *mockBlobReader {
 }
 
 func (m *mockBlobReader) GetObject(_ context.Context, _, key string) (body []byte, ct string, err error) {
+	if m.getErr != nil {
+		return nil, "", m.getErr
+	}
 	data, ok := m.objects[key]
 	if !ok {
-		return nil, "", fmt.Errorf("not found")
+		return nil, "", fmt.Errorf("s3 get: NoSuchKey: the specified key does not exist; status code: 404")
 	}
 	return data, "text/plain", nil
 }
@@ -747,13 +761,44 @@ func TestFetchResourceContent_NoS3(t *testing.T) {
 	}
 }
 
-func TestFetchResourceContent_S3Error(t *testing.T) {
-	blob := newMockBlobReader() // empty, so all gets fail
+// TestMCPManagedResourceMiddleware_ReadOrphaned_Prunes is the #576 self-heal:
+// reading a managed resource whose backing object is gone returns an actionable
+// "missing/orphaned" error AND prunes the dead row, so it stops appearing in
+// resources/list.
+func TestMCPManagedResourceMiddleware_ReadOrphaned_Prunes(t *testing.T) {
+	store := newMockResourceStore()
+	blob := newMockBlobReader() // empty -> GetObject returns NoSuchKey/404
 
-	cfg := ManagedResourceConfig{
-		S3Client: blob,
-		S3Bucket: "test-bucket",
+	store.resources["r1"] = &resource.Resource{
+		ID:       "r1",
+		Scope:    resource.ScopeGlobal,
+		URI:      "mcp://global/samples/orphan.csv",
+		MIMEType: "text/csv",
+		S3Key:    "resources/global/r1/orphan.csv", // no matching blob object
 	}
+
+	cfg := ManagedResourceConfig{Store: store, S3Client: blob, S3Bucket: "test-bucket", URIScheme: "mcp"}
+	next := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return nil, fmt.Errorf("should not reach next")
+	}
+	handler := MCPManagedResourceMiddleware(cfg)(next)
+
+	ctx := WithPlatformContext(context.Background(), &PlatformContext{UserID: "user-1", Roles: []string{"admin"}})
+	_, err := handler(ctx, methodReadResource, makeReadRequest(t, "mcp://global/samples/orphan.csv"))
+
+	if err == nil || !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("expected an actionable missing/orphaned error, got: %v", err)
+	}
+	// The orphaned row was pruned so it will not reappear in list.
+	if len(store.deleted) != 1 || store.deleted[0] != "r1" {
+		t.Errorf("expected orphaned resource r1 to be pruned, deleted=%v", store.deleted)
+	}
+}
+
+func TestFetchResourceContent_MissingBlobIsActionable(t *testing.T) {
+	blob := newMockBlobReader() // empty -> GetObject returns a NoSuchKey/404 error
+
+	cfg := ManagedResourceConfig{S3Client: blob, S3Bucket: "test-bucket"}
 	res := &resource.Resource{
 		URI:      "mcp://global/samples/test.csv",
 		MIMEType: "text/csv",
@@ -763,6 +808,50 @@ func TestFetchResourceContent_S3Error(t *testing.T) {
 	_, err := fetchResourceContent(context.Background(), cfg, res)
 	if err == nil {
 		t.Fatal("expected error for missing S3 object")
+	}
+	// The error names the resource and identifies it as orphaned/missing, not an
+	// opaque "error reading resource content".
+	if !strings.Contains(err.Error(), "missing") || !strings.Contains(err.Error(), res.URI) {
+		t.Errorf("missing-blob error must be actionable and name the URI, got: %q", err.Error())
+	}
+}
+
+func TestFetchResourceContent_TransientErrorIsGeneric(t *testing.T) {
+	blob := &mockBlobReader{getErr: fmt.Errorf("connection reset by peer")}
+
+	cfg := ManagedResourceConfig{S3Client: blob, S3Bucket: "test-bucket"}
+	res := &resource.Resource{URI: "mcp://global/samples/test.csv", S3Key: "k"}
+
+	_, err := fetchResourceContent(context.Background(), cfg, res)
+	if err == nil {
+		t.Fatal("expected error for transient S3 failure")
+	}
+	// A transient failure must NOT be reported as orphaned/missing.
+	if strings.Contains(err.Error(), "missing") || strings.Contains(err.Error(), "orphaned") {
+		t.Errorf("transient error must not be reported as missing/orphaned, got: %q", err.Error())
+	}
+}
+
+func TestIsObjectNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"nosuchkey", fmt.Errorf("s3 get: NoSuchKey: the specified key does not exist"), true},
+		{"status 404", fmt.Errorf("s3 get: api error, status code: 404"), true},
+		{"plain not found", fmt.Errorf("not found"), true},
+		{"connection reset", fmt.Errorf("connection reset by peer"), false},
+		{"permission denied", fmt.Errorf("s3 get: AccessDenied: access denied"), false},
+		{"timeout", fmt.Errorf("context deadline exceeded"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isObjectNotFound(tt.err); got != tt.want {
+				t.Errorf("isObjectNotFound(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

A managed resource whose backing object was deleted out-of-band stayed listed in `resources/list` but failed every read with an opaque `error reading resource content`. To an agent (or a user), an entry that the platform advertises and then cannot read reads as the resource feature being broken, when in fact the row is simply orphaned.

## Root cause

`resources/list` builds the visible set from the resource store (DB rows) and never touches blob storage, while a read fetches the backing object via `S3Client.GetObject` (`pkg/middleware/mcp_resources.go`). When the object is gone, the read returned a single generic untyped error, indistinguishable from a transient failure, and nothing ever removed the orphaned row, so it kept being listed and kept failing.

## Changes

### Actionable read error

Detect a missing-object `GetObject` failure (`NoSuchKey` / `404` / not-found signatures, via `isObjectNotFound`) and return a distinct, URI-named error that identifies the resource as orphaned and tells the operator to remove or re-upload it. The `mcp-s3` client wraps the underlying AWS/SeaweedFS error without a typed not-found, so detection is by the standard not-found signatures in the wrapped message. Transient or other failures keep a generic error and are explicitly not misreported as missing.

### Self-healing prune

On a confirmed missing blob, `handleManagedRead` best-effort deletes the dead row through an optional `resourcePruner` capability (which the configured `resource.Store` implements; the narrower `ResourceListProvider` does not require it, so the read path type-asserts). This closes the list/read divergence: the orphan stops appearing in `resources/list` the moment it is accessed.

It is deliberately conservative:

- runs only on a confirmed not-found (`errResourceBlobMissing`), never on a transient failure, so a momentary S3 hiccup cannot delete a valid resource;
- costs nothing in the common case (no per-`list` HEAD calls, no background job);
- a prune failure is logged but not surfaced, since the read already returned the actionable error.

A truly proactive sweep of never-read orphans would need a background reconciliation job; the self-heal-on-access covers the realistic agent flow (list, pick one, read it).

## Tests

- `ReadOrphaned_Prunes`: reading an orphaned resource through the real middleware returns the actionable "missing/orphaned" error AND prunes the dead row.
- `MissingBlobIsActionable` and `TransientErrorIsGeneric`: the two error shapes, including that a transient failure is not reported as missing.
- `IsObjectNotFound`: table over the not-found signatures vs transient/permission errors.

## Verification

`make verify` green (fmt, race tests, lint, security, semgrep, codeql, coverage, patch coverage, realdb, dead-code, mutation, release-check).

Closes #576
