### PR TITLE
deps: bump github.com/txn2/mcp-datahub to v1.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/ollama v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
-	github.com/txn2/mcp-datahub v1.8.1
+	github.com/txn2/mcp-datahub v1.9.0
 	github.com/txn2/mcp-s3 v1.3.0
 	github.com/txn2/mcp-trino v1.3.0
 	github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/tmc/langchaingo v0.1.5 h1:PNPFu54wn5uVPRt9GS/quRwdFZW4omSab9/dcFAsGmU
 github.com/tmc/langchaingo v0.1.5/go.mod h1:RLtnUED/hH2v765vdjS9Z6gonErZAXURuJHph0BttqM=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v1.8.1 h1:nQGpL5UC7nXR1Gm6LqMOwgv6bRRsnFYWO5G3VvdG5/I=
-github.com/txn2/mcp-datahub v1.8.1/go.mod h1:+GPUNirzhGDEUGiSsebuxToLriUygkugHkwDYrFiDKY=
+github.com/txn2/mcp-datahub v1.9.0 h1:lIumj10Jjv7pfV12KWzXOdI1P0x40dZzXspYpoErsWc=
+github.com/txn2/mcp-datahub v1.9.0/go.mod h1:zNhJ1JJoVrwIC8DU9fTywVSdCjG7gnnrzbNWL746JYM=
 github.com/txn2/mcp-s3 v1.3.0 h1:T2FlZGSU5pJi78ts+rE9kzZpIg1HD/lciwWqInYXXO0=
 github.com/txn2/mcp-s3 v1.3.0/go.mod h1:sI18zzBkOxGO07DSHap7baPwtEEw+pYBJhT1BGQnYRc=
 github.com/txn2/mcp-trino v1.3.0 h1:QKoNzm/WeRTE6RJ++pAeOCwwxd3L5M4XWNb/XniYnCQ=


### PR DESCRIPTION
Closes #577

## What

Bumps `github.com/txn2/mcp-datahub` v1.8.1 -> v1.9.0.

mcp-datahub v1.9.0 makes `datahub_get_data_product` return a data product's constituent datasets in the `assets` field, fetched via the DataHub `DataProduct.entities` resolver (best-effort: a DataHub instance without the resolver returns the product without members rather than failing the lookup). Each asset is an object with `urn`, `name`, and `type`. Before v1.9.0 the tool described "constituent datasets" and "member datasets" but never returned them.

## Why no code changes

The platform composes the upstream DataHub toolkit, so `datahub_get_data_product` output flows through unchanged. The platform does not reference `types.DataProduct.Assets`, so the upstream field shape change (`[]string` -> `[]Entity`) does not affect the build. `go build ./...` and `make verify` pass.

## Verification

- `make verify` passes end to end (fmt, race tests, lint, security/govulncheck, coverage, mutation, GoReleaser dry-run).
- The bug was reproduced on a live instance before the upstream fix: `datahub_get_data_product` returned no `assets` for an existing data product.
- Post-deploy confirmation: after this bump deploys, data products will list their member datasets in `assets`.

## Diff

`go.mod` / `go.sum` only.