### PR TITLE
feat(prompts): index and search static prompts; fix Indexing card empty state

### DIFF
--- a/pkg/admin/prompt_handler.go
+++ b/pkg/admin/prompt_handler.go
@@ -41,6 +41,9 @@ const (
 	promptPathID       = "id"
 	errMsgGetPrompt    = "failed to get prompt"
 	errMsgPromptNotErr = "prompt not found"
+	// errMsgSystemPromptReadOnly is returned when a caller tries to mutate a
+	// prompt ingested from server configuration (source=system).
+	errMsgSystemPromptReadOnly = "this prompt is defined in server configuration and is read-only"
 )
 
 // adminPromptCreateRequest is the request body for creating a prompt.
@@ -97,6 +100,10 @@ func (h *Handler) listPrompts(w http.ResponseWriter, r *http.Request) {
 	filter := prompt.ListFilter{
 		Scope:  q.Get("scope"),
 		Search: q.Get("search"),
+		// Ingested static prompts (source=system) are surfaced read-only via
+		// mergeSystemPrompts below (synthetic IDs); exclude the store rows so
+		// they are not shown as editable database prompts or double-counted.
+		ExcludeSource: prompt.SourceSystem,
 	}
 	if owner := q.Get("owner_email"); owner != "" {
 		filter.OwnerEmail = owner
@@ -326,6 +333,10 @@ func (h *Handler) updatePrompt(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, errMsgPromptNotErr)
 		return
 	}
+	if existing.Source == prompt.SourceSystem {
+		writeError(w, http.StatusForbidden, errMsgSystemPromptReadOnly)
+		return
+	}
 
 	var req adminPromptUpdateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -532,6 +543,10 @@ func (h *Handler) deletePrompt(w http.ResponseWriter, r *http.Request) {
 	}
 	if existing == nil {
 		writeError(w, http.StatusNotFound, errMsgPromptNotErr)
+		return
+	}
+	if existing.Source == prompt.SourceSystem {
+		writeError(w, http.StatusForbidden, errMsgSystemPromptReadOnly)
 		return
 	}
 

--- a/pkg/admin/prompt_handler_test.go
+++ b/pkg/admin/prompt_handler_test.go
@@ -277,6 +277,32 @@ func TestDeletePrompt_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
+func TestUpdatePrompt_SystemRowReadOnly(t *testing.T) {
+	h, store, _ := newTestPromptHandler()
+	store.prompts["sys"] = &prompt.Prompt{ID: "uuid-sys", Name: "sys", Scope: prompt.ScopeGlobal, Source: prompt.SourceSystem, Content: "orig"}
+
+	newContent := "hacked"
+	bodyBytes, _ := json.Marshal(adminPromptUpdateRequest{Content: &newContent})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/v1/admin/prompts/uuid-sys", bytes.NewReader(bodyBytes))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, "orig", store.prompts["sys"].Content, "system prompt must be unchanged")
+}
+
+func TestDeletePrompt_SystemRowReadOnly(t *testing.T) {
+	h, store, _ := newTestPromptHandler()
+	store.prompts["sys"] = &prompt.Prompt{ID: "uuid-sys", Name: "sys", Scope: prompt.ScopeGlobal, Source: prompt.SourceSystem}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/v1/admin/prompts/uuid-sys", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, store.prompts, "sys", "system prompt must not be deleted")
+}
+
 func TestCreatePrompt_StoreError(t *testing.T) {
 	h, store, _ := newTestPromptHandler()
 	store.createErr = fmt.Errorf("db error")

--- a/pkg/platform/prompt_dynamic_serving_test.go
+++ b/pkg/platform/prompt_dynamic_serving_test.go
@@ -34,6 +34,39 @@ func TestListVisiblePrompts_ScopePrefixesAndScoping(t *testing.T) {
 	assert.False(t, names["personal-bob"], "another user's personal prompt must not be visible")
 }
 
+func TestListVisiblePrompts_ExcludesSystemRows(t *testing.T) {
+	// Ingested static prompts (source=system) are served under their bare name
+	// via AddPrompt; they must not also appear as a global- prefixed entry.
+	p, store := newTestPlatformWithPromptStore()
+	store.prompts["g1"] = &prompt.Prompt{Name: "g1", Scope: prompt.ScopeGlobal, Source: prompt.SourceOperator, Enabled: true}
+	store.prompts["sys"] = &prompt.Prompt{Name: "sys", Scope: prompt.ScopeGlobal, Source: prompt.SourceSystem, Enabled: true}
+
+	out := p.listVisiblePrompts(context.Background(), "", nil)
+	names := map[string]bool{}
+	for _, pr := range out {
+		names[pr.Name] = true
+	}
+	assert.True(t, names["global-g1"], "operator global prompt is served")
+	assert.False(t, names["global-sys"], "system row must not be served as a global- duplicate")
+}
+
+func TestRegisterDatabasePrompts_SkipsSystemRows(t *testing.T) {
+	p, store := newTestPlatformWithPromptStore()
+	store.prompts["op"] = &prompt.Prompt{Name: "op", Scope: prompt.ScopeGlobal, Source: prompt.SourceOperator, Enabled: true}
+	store.prompts["sys"] = &prompt.Prompt{Name: "sys", Scope: prompt.ScopeGlobal, Source: prompt.SourceSystem, Enabled: true}
+
+	p.registerDatabasePrompts()
+
+	infos := map[string]bool{}
+	p.promptInfosMu.RLock()
+	for _, i := range p.promptInfos {
+		infos[i.Name] = true
+	}
+	p.promptInfosMu.RUnlock()
+	assert.True(t, infos["op"], "operator database prompt registered for admin listing")
+	assert.False(t, infos["sys"], "system row must be skipped (already served via AddPrompt)")
+}
+
 func TestPromptServing_AnonymousIsFailClosed(t *testing.T) {
 	// An anonymous caller (empty email, no personas) sees only globals and can
 	// fetch only globals, never personal or persona prompts.

--- a/pkg/platform/prompt_ingest.go
+++ b/pkg/platform/prompt_ingest.go
@@ -1,0 +1,127 @@
+package platform
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/txn2/mcp-data-platform/pkg/prompt"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+)
+
+// ingestStaticPrompts mirrors the platform's statically-registered prompts
+// (operator config + built-in workflow + toolkit prompts) into the prompt store
+// as read-only, system-sourced rows so the existing embedding indexer and
+// manage_prompt search cover them, exactly like database-authored prompts.
+//
+// Static prompts are otherwise served only as MCP protocol prompts (AddPrompt)
+// and never reach the store, so on a deployment whose prompts are all static the
+// prompt index and semantic search are empty (#593). The ingested rows are
+// scope=global, status=approved (operator-trusted, no review), source=system.
+// They are excluded from the prompts/list runtime path (already served via
+// AddPrompt) and from registerDatabasePrompts, and are read-only via
+// manage_prompt.
+//
+// Must run after all static prompts are registered into promptInfos and before
+// registerDatabasePrompts (which would otherwise add database prompts to
+// promptInfos and cause them to be re-ingested as system rows).
+func (p *Platform) ingestStaticPrompts(ctx context.Context) {
+	if p.promptStore == nil {
+		return
+	}
+
+	infos := p.staticPromptInfos()
+	wanted := make(map[string]bool, len(infos))
+
+	for _, info := range infos {
+		if info.Name == "" {
+			continue
+		}
+		wanted[info.Name] = true
+		p.upsertSystemPrompt(ctx, info)
+	}
+
+	p.pruneStaleSystemPrompts(ctx, wanted)
+
+	if len(wanted) > 0 {
+		slog.Info("ingested static prompts for indexing and search", "count", len(wanted))
+	}
+}
+
+// upsertSystemPrompt creates or refreshes the system row for one static prompt.
+// A name already owned by a non-system prompt is left untouched so ingestion
+// never clobbers user/admin-authored prompts.
+func (p *Platform) upsertSystemPrompt(ctx context.Context, info registry.PromptInfo) {
+	desired := systemPromptFromInfo(info)
+
+	existing, err := p.promptStore.Get(ctx, info.Name)
+	if err != nil {
+		slog.Warn("ingest static prompt: lookup failed", promptLogKey, info.Name, logKeyError, err)
+		return
+	}
+	switch {
+	case existing == nil:
+		if err := p.promptStore.Create(ctx, desired); err != nil {
+			slog.Warn("ingest static prompt: create failed", promptLogKey, info.Name, logKeyError, err)
+		}
+	case existing.Source == prompt.SourceSystem:
+		desired.ID = existing.ID
+		if err := p.promptStore.Update(ctx, desired); err != nil {
+			slog.Warn("ingest static prompt: update failed", promptLogKey, info.Name, logKeyError, err)
+		}
+	default:
+		slog.Warn("ingest static prompt: name already used by a non-system prompt; skipping",
+			promptLogKey, info.Name, "source", existing.Source)
+	}
+}
+
+// staticPromptInfos is the set of statically-registered prompts (operator config
+// + workflow, held in promptInfos) plus toolkit-described prompts. It must be
+// read before registerDatabasePrompts pollutes promptInfos with database prompts.
+func (p *Platform) staticPromptInfos() []registry.PromptInfo {
+	toolkit := p.collectToolkitPromptInfos()
+	p.promptInfosMu.RLock()
+	infos := make([]registry.PromptInfo, 0, len(p.promptInfos)+len(toolkit))
+	infos = append(infos, p.promptInfos...)
+	p.promptInfosMu.RUnlock()
+	return append(infos, toolkit...)
+}
+
+// systemPromptFromInfo maps a registered prompt's metadata to a read-only,
+// approved, global system prompt row suitable for indexing and search.
+func systemPromptFromInfo(info registry.PromptInfo) *prompt.Prompt {
+	args := make([]prompt.Argument, 0, len(info.Arguments))
+	for _, a := range info.Arguments {
+		args = append(args, prompt.Argument{Name: a.Name, Description: a.Description, Required: a.Required})
+	}
+	return &prompt.Prompt{
+		Name:        info.Name,
+		DisplayName: info.Name,
+		Description: info.Description,
+		Content:     info.Content,
+		Arguments:   args,
+		Category:    info.Category,
+		Scope:       prompt.ScopeGlobal,
+		Source:      prompt.SourceSystem,
+		Status:      prompt.StatusApproved,
+		Enabled:     true,
+	}
+}
+
+// pruneStaleSystemPrompts deletes system-sourced prompt rows whose name is no
+// longer in the registered static set, so removing a prompt from config or the
+// build reconciles the store on the next startup.
+func (p *Platform) pruneStaleSystemPrompts(ctx context.Context, wanted map[string]bool) {
+	rows, err := p.promptStore.List(ctx, prompt.ListFilter{Source: prompt.SourceSystem})
+	if err != nil {
+		slog.Warn("ingest static prompt: list system prompts failed", logKeyError, err)
+		return
+	}
+	for i := range rows {
+		if wanted[rows[i].Name] {
+			continue
+		}
+		if err := p.promptStore.DeleteByID(ctx, rows[i].ID); err != nil {
+			slog.Warn("ingest static prompt: prune failed", "name", rows[i].Name, logKeyError, err)
+		}
+	}
+}

--- a/pkg/platform/prompt_ingest_realdb_integration_test.go
+++ b/pkg/platform/prompt_ingest_realdb_integration_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+package platform
+
+// Real-Postgres proof for #593: the assembled ingestion path writes the
+// platform's static prompts into the store and they become searchable, exactly
+// like database-authored prompts. This exercises ingestStaticPrompts against a
+// real pgvector database (not a mock), then ranks the result through the real
+// store searcher, closing the loop that unit tests with a mock store cannot.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/internal/testdb"
+	"github.com/txn2/mcp-data-platform/pkg/prompt"
+	pgstore "github.com/txn2/mcp-data-platform/pkg/prompt/postgres"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+)
+
+func TestIngestStaticPrompts_RealDB_Searchable(t *testing.T) {
+	store := pgstore.New(testdb.New(t))
+	ctx := context.Background()
+
+	p := &Platform{
+		promptStore:     store,
+		toolkitRegistry: registry.NewRegistry(),
+		promptInfos: []registry.PromptInfo{
+			{Name: "explore-available-data", Description: "Discover what datasets are available in the catalog", Content: "Explore data about {topic}."},
+			{Name: "create-interactive-dashboard", Description: "Build a dashboard and save it", Content: "Create a dashboard about {topic}."},
+		},
+	}
+
+	p.ingestStaticPrompts(ctx)
+
+	// Stored as read-only, approved, global system rows.
+	got, err := store.Get(ctx, "explore-available-data")
+	require.NoError(t, err)
+	require.NotNil(t, got, "static prompt ingested into the store")
+	assert.Equal(t, prompt.SourceSystem, got.Source)
+	assert.Equal(t, prompt.StatusApproved, got.Status)
+	assert.Equal(t, prompt.ScopeGlobal, got.Scope)
+
+	// Lexically searchable (no embedding provider needed) through the real store
+	// searcher, the same path manage_prompt search uses.
+	results, err := store.Search(ctx, prompt.SearchQuery{QueryText: "discover datasets catalog", Limit: 5})
+	require.NoError(t, err)
+	found := false
+	for _, r := range results {
+		if r.Prompt.Name == "explore-available-data" {
+			found = true
+		}
+	}
+	assert.True(t, found, "ingested static prompt is returned by the real store search")
+
+	// Re-running ingest is idempotent (no duplicate system rows).
+	p.ingestStaticPrompts(ctx)
+	system, err := store.List(ctx, prompt.ListFilter{Source: prompt.SourceSystem})
+	require.NoError(t, err)
+	assert.Len(t, system, 2, "re-ingest does not duplicate system rows")
+}

--- a/pkg/platform/prompt_ingest_test.go
+++ b/pkg/platform/prompt_ingest_test.go
@@ -1,0 +1,168 @@
+package platform
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/txn2/mcp-data-platform/pkg/prompt"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+)
+
+// newIngestTestPlatform builds a platform with an in-memory prompt store, a
+// toolkit registry carrying one PromptDescriber toolkit, and the given
+// platform-level static prompt infos already collected into promptInfos.
+func newIngestTestPlatform(platformInfos, toolkitInfos []registry.PromptInfo) (*Platform, *mockPlatformPromptStore) {
+	store := newMockPlatformPromptStore()
+	reg := registry.NewRegistry()
+	_ = reg.Register(&mockToolkitWithPrompts{
+		mockToolkit: mockToolkit{kind: "knowledge", name: "primary"},
+		prompts:     toolkitInfos,
+	})
+	p := &Platform{
+		config:          &Config{Admin: AdminConfig{Persona: "admin"}},
+		mcpServer:       mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil),
+		promptStore:     store,
+		toolkitRegistry: reg,
+		promptInfos:     platformInfos,
+	}
+	return p, store
+}
+
+func TestIngestStaticPrompts(t *testing.T) {
+	platformInfos := []registry.PromptInfo{
+		{Name: "explore-data", Description: "Discover data", Content: "Explore {topic}", Category: "workflow"},
+	}
+	toolkitInfos := []registry.PromptInfo{
+		{Name: "capture-knowledge", Description: "Record insights", Content: "Capture", Category: "toolkit"},
+	}
+	p, store := newIngestTestPlatform(platformInfos, toolkitInfos)
+
+	p.ingestStaticPrompts(context.Background())
+
+	// Both the platform and toolkit static prompts are ingested as read-only,
+	// approved, global system rows ready for indexing.
+	for _, name := range []string{"explore-data", "capture-knowledge"} {
+		got, _ := store.Get(context.Background(), name)
+		if got == nil {
+			t.Fatalf("prompt %q not ingested", name)
+		}
+		if got.Source != prompt.SourceSystem {
+			t.Errorf("%q source = %q, want %q", name, got.Source, prompt.SourceSystem)
+		}
+		if got.Status != prompt.StatusApproved {
+			t.Errorf("%q status = %q, want %q", name, got.Status, prompt.StatusApproved)
+		}
+		if got.Scope != prompt.ScopeGlobal {
+			t.Errorf("%q scope = %q, want %q", name, got.Scope, prompt.ScopeGlobal)
+		}
+		if !got.Enabled {
+			t.Errorf("%q should be enabled", name)
+		}
+	}
+
+	// Idempotent: a second run does not duplicate rows.
+	p.ingestStaticPrompts(context.Background())
+	all, _ := store.List(context.Background(), prompt.ListFilter{Source: prompt.SourceSystem})
+	if len(all) != 2 {
+		t.Errorf("after re-ingest, system rows = %d, want 2", len(all))
+	}
+}
+
+func TestIngestStaticPrompts_SkipsNonSystemName(t *testing.T) {
+	infos := []registry.PromptInfo{{Name: "shared-name", Description: "from config", Content: "x"}}
+	p, store := newIngestTestPlatform(infos, nil)
+
+	// A user/admin already owns this global name (non-system).
+	store.prompts["shared-name"] = &prompt.Prompt{
+		ID: "user-1", Name: "shared-name", Scope: prompt.ScopeGlobal,
+		Source: prompt.SourceOperator, Description: "user owned", Content: "user content",
+	}
+
+	p.ingestStaticPrompts(context.Background())
+
+	got, _ := store.Get(context.Background(), "shared-name")
+	if got.Source != prompt.SourceOperator || got.Description != "user owned" {
+		t.Errorf("ingest clobbered a non-system prompt: %+v", got)
+	}
+}
+
+func TestIngestStaticPrompts_PrunesStaleSystemRows(t *testing.T) {
+	infos := []registry.PromptInfo{{Name: "current", Description: "d", Content: "c"}}
+	p, store := newIngestTestPlatform(infos, nil)
+
+	// A system row from a prior build that is no longer registered.
+	store.prompts["removed"] = &prompt.Prompt{
+		ID: "sys-removed", Name: "removed", Scope: prompt.ScopeGlobal, Source: prompt.SourceSystem,
+	}
+
+	p.ingestStaticPrompts(context.Background())
+
+	if got, _ := store.Get(context.Background(), "removed"); got != nil {
+		t.Errorf("stale system prompt %q was not pruned", "removed")
+	}
+	if got, _ := store.Get(context.Background(), "current"); got == nil {
+		t.Error("current static prompt should remain")
+	}
+}
+
+func TestIngestStaticPrompts_StoreErrorsAreNonFatal(t *testing.T) {
+	infos := []registry.PromptInfo{{
+		Name: "p1", Description: "d", Content: "c",
+		Arguments: []registry.PromptArgumentInfo{{Name: "topic", Description: "subject", Required: true}},
+	}}
+
+	// Create failure: ingest logs and continues; nothing is stored.
+	p, store := newIngestTestPlatform(infos, nil)
+	store.createErr = assert.AnError
+	p.ingestStaticPrompts(context.Background())
+	if got, _ := store.Get(context.Background(), "p1"); got != nil {
+		t.Error("nothing should be stored when create fails")
+	}
+
+	// Lookup failure: ingest logs and continues without panicking.
+	p2, store2 := newIngestTestPlatform(infos, nil)
+	store2.getErr = assert.AnError
+	p2.ingestStaticPrompts(context.Background())
+
+	// Prune list failure: the upsert still creates the row.
+	p3, store3 := newIngestTestPlatform(infos, nil)
+	store3.listErr = assert.AnError
+	p3.ingestStaticPrompts(context.Background())
+	if got, _ := store3.Get(context.Background(), "p1"); got == nil {
+		t.Error("p1 should be created even when the prune list fails")
+	}
+
+	// Prune delete failure: ingest logs and continues.
+	p4, store4 := newIngestTestPlatform(infos, nil)
+	store4.prompts["stale"] = &prompt.Prompt{
+		ID: "x", Name: "stale", Scope: prompt.ScopeGlobal, Source: prompt.SourceSystem,
+	}
+	store4.deleteErr = assert.AnError
+	p4.ingestStaticPrompts(context.Background())
+}
+
+func TestHandlePromptUpdate_SystemRowReadOnly(t *testing.T) {
+	p, store := newTestPlatformWithPromptStore()
+	store.prompts["sys-prompt"] = &prompt.Prompt{
+		ID: "s1", Name: "sys-prompt", Scope: prompt.ScopeGlobal,
+		Source: prompt.SourceSystem, Status: prompt.StatusApproved, Enabled: true,
+	}
+	r, _, _ := p.handlePromptUpdate(adminCtx(), managePromptInput{Name: "sys-prompt", Description: "hacked"})
+	assert.True(t, r.IsError)
+	assert.Contains(t, resultText(r), "read-only")
+	assert.Equal(t, "", store.prompts["sys-prompt"].Description, "system row must be unchanged")
+}
+
+func TestHandlePromptDelete_SystemRowReadOnly(t *testing.T) {
+	p, store := newTestPlatformWithPromptStore()
+	store.prompts["sys-prompt"] = &prompt.Prompt{
+		ID: "s1", Name: "sys-prompt", Scope: prompt.ScopeGlobal, Source: prompt.SourceSystem,
+	}
+	r, _, _ := p.handlePromptDelete(adminCtx(), managePromptInput{Name: "sys-prompt"})
+	assert.True(t, r.IsError)
+	assert.Contains(t, resultText(r), "read-only")
+	assert.Contains(t, store.prompts, "sys-prompt", "system row must not be deleted")
+}

--- a/pkg/platform/prompt_tool.go
+++ b/pkg/platform/prompt_tool.go
@@ -192,6 +192,9 @@ func (p *Platform) handlePromptUpdate(ctx context.Context, input managePromptInp
 	if existing == nil {
 		return promptErrorResult(fmt.Sprintf("prompt %q not found", input.Name)), nil, nil
 	}
+	if existing.Source == prompt.SourceSystem {
+		return promptErrorResult("this prompt is defined in server configuration or built in and is read-only; edit it in config"), nil, nil
+	}
 
 	email := resolveEmail(ctx)
 	if !p.isAdminPersona(ctx) {
@@ -303,6 +306,9 @@ func (p *Platform) handlePromptDelete(ctx context.Context, input managePromptInp
 	}
 	if existing == nil {
 		return promptErrorResult(fmt.Sprintf("prompt %q not found", input.Name)), nil, nil
+	}
+	if existing.Source == prompt.SourceSystem {
+		return promptErrorResult("this prompt is defined in server configuration or built in and is read-only; remove it from config"), nil, nil
 	}
 
 	email := resolveEmail(ctx)

--- a/pkg/platform/prompt_tool_test.go
+++ b/pkg/platform/prompt_tool_test.go
@@ -108,6 +108,12 @@ func (m *mockPlatformPromptStore) List(_ context.Context, f prompt.ListFilter) (
 		if f.OwnerEmail != "" && p.OwnerEmail != f.OwnerEmail {
 			continue
 		}
+		if f.Source != "" && p.Source != f.Source {
+			continue
+		}
+		if f.ExcludeSource != "" && p.Source == f.ExcludeSource {
+			continue
+		}
 		result = append(result, *p)
 	}
 	return result, nil

--- a/pkg/platform/prompts.go
+++ b/pkg/platform/prompts.go
@@ -43,6 +43,11 @@ func (p *Platform) registerPlatformPrompts() {
 		p.registerPromptWithCategory(promptCfg, "custom")
 	}
 	p.registerWorkflowPrompts()
+	// Mirror the static prompts registered above into the store (as read-only
+	// system rows) so they are embedded and searchable (#593). Must run before
+	// registerDatabasePrompts so database prompts are not added to promptInfos
+	// and re-ingested as system rows.
+	p.ingestStaticPrompts(context.Background())
 	p.registerDatabasePrompts()
 }
 
@@ -383,11 +388,19 @@ func (p *Platform) registerDatabasePrompts() {
 		return
 	}
 
+	registered := 0
 	for i := range prompts {
+		// System rows are the ingested static prompts (#593): they are already
+		// served via AddPrompt and exist in the store only for indexing/search,
+		// so they must not be re-registered as database prompts.
+		if prompts[i].Source == prompt.SourceSystem {
+			continue
+		}
 		p.registerDatabasePrompt(&prompts[i])
+		registered++
 	}
-	if len(prompts) > 0 {
-		slog.Info("loaded prompts from database", "count", len(prompts))
+	if registered > 0 {
+		slog.Info("loaded prompts from database", "count", registered)
 	}
 }
 
@@ -521,6 +534,12 @@ func (p *Platform) listScopedDescriptors(ctx context.Context, filter prompt.List
 	}
 	out := make([]*mcp.Prompt, 0, len(prompts))
 	for i := range prompts {
+		// System rows (ingested static prompts, #593) are already served under
+		// their bare name via AddPrompt; skip them here so prompts/list does not
+		// show a duplicate global- entry.
+		if prompts[i].Source == prompt.SourceSystem {
+			continue
+		}
 		out = append(out, promptDescriptor(prefix+prompts[i].Name, &prompts[i]))
 	}
 	return out
@@ -622,7 +641,9 @@ func (p *Platform) getOwnedPersonalPrompt(ctx context.Context, email, bare strin
 // getGlobalPrompt renders the global prompt of the bare name.
 func (p *Platform) getGlobalPrompt(ctx context.Context, bare string, args map[string]string) (*mcp.GetPromptResult, bool) {
 	pr, err := p.promptStore.Get(ctx, bare)
-	if err != nil || pr == nil || !pr.Enabled || pr.Scope != prompt.ScopeGlobal {
+	// System rows are ingested static prompts already served under their bare
+	// name via AddPrompt; do not also serve them under the global- prefix.
+	if err != nil || pr == nil || !pr.Enabled || pr.Scope != prompt.ScopeGlobal || pr.Source == prompt.SourceSystem {
 		return nil, false
 	}
 	return p.renderPrompt(pr, args)

--- a/pkg/portal/prompt_handler.go
+++ b/pkg/portal/prompt_handler.go
@@ -128,10 +128,13 @@ func (h *Handler) listMyPrompts(w http.ResponseWriter, r *http.Request) {
 		personal = []prompt.Prompt{}
 	}
 
-	// Get global prompts
+	// Get global prompts. Ingested static prompts (source=system) are added
+	// separately by systemPrompts below; exclude the store rows here so they are
+	// not listed twice or shown as editable global prompts.
 	available, err := h.deps.PromptStore.List(r.Context(), prompt.ListFilter{
-		Scope:   prompt.ScopeGlobal,
-		Enabled: &enabled,
+		Scope:         prompt.ScopeGlobal,
+		Enabled:       &enabled,
+		ExcludeSource: prompt.SourceSystem,
 	})
 	if err != nil {
 		available = []prompt.Prompt{}
@@ -212,12 +215,19 @@ func (h *Handler) searchMyPrompts(w http.ResponseWriter, r *http.Request) {
 		writePortalError(w, http.StatusInternalServerError, "failed to search prompts")
 		return
 	}
-	if scored == nil {
-		scored = []prompt.ScoredPrompt{}
+	// Ingested static prompts (source=system) are searchable for agents via the
+	// MCP manage_prompt tool, but the portal surfaces them in its dedicated
+	// system-prompt list rather than in a user's own prompt search.
+	results := make([]prompt.ScoredPrompt, 0, len(scored))
+	for _, sp := range scored {
+		if sp.Prompt.Source == prompt.SourceSystem {
+			continue
+		}
+		results = append(results, sp)
 	}
 
 	writePortalJSON(w, http.StatusOK, paginatedResponse{
-		Data: scored, Total: len(scored), Limit: limit, Offset: 0,
+		Data: results, Total: len(results), Limit: limit, Offset: 0,
 	})
 }
 

--- a/pkg/portal/prompt_search_test.go
+++ b/pkg/portal/prompt_search_test.go
@@ -95,6 +95,30 @@ func TestSearchMyPrompts_Success(t *testing.T) {
 	assert.Equal(t, 5, store.gotQuery.Limit)
 }
 
+func TestSearchMyPrompts_ExcludesSystemPrompts(t *testing.T) {
+	// Ingested static prompts (source=system) are searchable for agents via
+	// manage_prompt, but the portal omits them from a user's own prompt search.
+	result := []prompt.ScoredPrompt{
+		{Prompt: prompt.Prompt{ID: "p-1", Name: "daily-sales", Source: prompt.SourceOperator}, Score: 0.91},
+		{Prompt: prompt.Prompt{ID: "sys-1", Name: "explore-data", Source: prompt.SourceSystem}, Score: 0.88},
+	}
+	h, _ := newSearchablePortalHandler(result)
+	req := withUser(httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/api/v1/portal/prompts/search?q=data", http.NoBody), "alice@example.com")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Data  []prompt.ScoredPrompt `json:"data"`
+		Total int                   `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+	require.Len(t, resp.Data, 1)
+	assert.Equal(t, "daily-sales", resp.Data[0].Prompt.Name)
+}
+
 func TestSearchMyPrompts_AdminFlag(t *testing.T) {
 	h, store := newSearchablePortalHandler(nil)
 	req := withUser(httptest.NewRequestWithContext(context.Background(), http.MethodGet,

--- a/pkg/prompt/postgres/store.go
+++ b/pkg/prompt/postgres/store.go
@@ -307,6 +307,16 @@ func buildWhere(f prompt.ListFilter) (clause string, params []any) {
 		args = append(args, *f.ReviewRequested)
 		idx++
 	}
+	if f.Source != "" {
+		conds = append(conds, fmt.Sprintf("source = $%d", idx))
+		args = append(args, f.Source)
+		idx++
+	}
+	if f.ExcludeSource != "" {
+		conds = append(conds, fmt.Sprintf("source <> $%d", idx))
+		args = append(args, f.ExcludeSource)
+		idx++
+	}
 	if f.Search != "" {
 		conds = append(conds, fmt.Sprintf(
 			"(name ILIKE $%d OR display_name ILIKE $%d OR description ILIKE $%d)",

--- a/pkg/prompt/postgres/store_realdb_integration_test.go
+++ b/pkg/prompt/postgres/store_realdb_integration_test.go
@@ -106,6 +106,41 @@ func TestStore_Create_RealDB_RoundTrip(t *testing.T) {
 	})
 }
 
+// TestStore_ListSourceFilters_RealDB exercises the Source and ExcludeSource
+// filters against real Postgres (#593): ingested static prompts (source=system)
+// must be hideable from human-facing list queries and selectable for the
+// reconciler's prune.
+func TestStore_ListSourceFilters_RealDB(t *testing.T) {
+	store := New(testdb.New(t))
+	ctx := context.Background()
+
+	require.NoError(t, store.Create(ctx, &prompt.Prompt{
+		Name: "op-global", Content: "x", Scope: prompt.ScopeGlobal,
+		Source: prompt.SourceOperator, Status: prompt.StatusApproved, Enabled: true,
+	}))
+	require.NoError(t, store.Create(ctx, &prompt.Prompt{
+		Name: "sys-global", Content: "y", Scope: prompt.ScopeGlobal,
+		Source: prompt.SourceSystem, Status: prompt.StatusApproved, Enabled: true,
+	}))
+
+	names := func(ps []prompt.Prompt) []string {
+		out := make([]string, 0, len(ps))
+		for _, p := range ps {
+			out = append(out, p.Name)
+		}
+		return out
+	}
+
+	excl, err := store.List(ctx, prompt.ListFilter{ExcludeSource: prompt.SourceSystem})
+	require.NoError(t, err)
+	assert.Contains(t, names(excl), "op-global")
+	assert.NotContains(t, names(excl), "sys-global")
+
+	only, err := store.List(ctx, prompt.ListFilter{Source: prompt.SourceSystem})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sys-global"}, names(only))
+}
+
 // TestStore_SearchLexical_RealDB_Differentiates is the #587 regression for
 // prompt search: lexical ranking must differentiate two single-match prompts
 // (exact short match outranking a long single-mention) rather than collapsing

--- a/pkg/prompt/postgres/store_test.go
+++ b/pkg/prompt/postgres/store_test.go
@@ -269,6 +269,23 @@ func TestList_NoFilter(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestBuildWhere_SourceFilters(t *testing.T) {
+	clause, args := buildWhere(prompt.ListFilter{Source: prompt.SourceSystem})
+	assert.Contains(t, clause, "source = $1")
+	assert.Equal(t, []any{prompt.SourceSystem}, args)
+
+	clause, args = buildWhere(prompt.ListFilter{ExcludeSource: prompt.SourceSystem})
+	assert.Contains(t, clause, "source <> $1")
+	assert.Equal(t, []any{prompt.SourceSystem}, args)
+
+	// Both, plus a following Search, keep correct placeholder numbering.
+	clause, args = buildWhere(prompt.ListFilter{Source: prompt.SourceOperator, ExcludeSource: prompt.SourceSystem, Search: "x"})
+	assert.Contains(t, clause, "source = $1")
+	assert.Contains(t, clause, "source <> $2")
+	assert.Contains(t, clause, "$3")
+	assert.Equal(t, []any{prompt.SourceOperator, prompt.SourceSystem, "%x%"}, args)
+}
+
 func TestList_WithScopeFilter(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -280,6 +280,8 @@ type ListFilter struct {
 	Enabled         *bool    // filter by enabled state
 	Search          string   // free-text search on name, display_name, description
 	ReviewRequested *bool    // filter by pending promotion request (admin queue)
+	Source          string   // include only this origin (operator, agent, system); "" for all
+	ExcludeSource   string   // exclude this origin (e.g. "system" to hide ingested static prompts)
 }
 
 // Store defines the interface for prompt persistence.

--- a/ui/src/pages/assets/MyAssetsPage.test.tsx
+++ b/ui/src/pages/assets/MyAssetsPage.test.tsx
@@ -1,15 +1,19 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MyAssetsPage } from "./MyAssetsPage";
 
-// Mock the useAssets hook
+// Mock the asset hooks. useSearchAssets is called unconditionally by the page
+// (its result is only read while a search is active); stub it with a safe idle
+// default so these share-icon tests render without a live query.
 vi.mock("@/api/portal/hooks", () => ({
   useAssets: vi.fn(),
+  useSearchAssets: vi.fn(() => ({ data: undefined, isLoading: false })),
 }));
 
-import { useAssets } from "@/api/portal/hooks";
+import { useAssets, useSearchAssets } from "@/api/portal/hooks";
 const mockUseAssets = vi.mocked(useAssets);
+const mockUseSearchAssets = vi.mocked(useSearchAssets);
 
 function wrapper({ children }: { children: React.ReactNode }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -104,37 +108,44 @@ describe("MyAssetsPage: share icons overlay on card thumbnail", () => {
     expect(screen.getByTitle("Has public link")).toBeInTheDocument();
   });
 
-  it("searching does not crash when an asset has no description", () => {
-    // Regression: the API serializes description with `omitempty`, so an
-    // asset with no description arrives as undefined. The client-side search
-    // filter called `description.toLowerCase()` unguarded and crashed the
-    // page the moment the user typed anything.
+  it("renders ranked search results without crashing on a missing description", () => {
+    // Search is server-side (useSearchAssets). The API serializes description
+    // with `omitempty`, so a ranked result can arrive with description
+    // undefined; rendering it must not crash. Typing debounces 300ms before the
+    // ranked results replace the browse list.
     mockUseAssets.mockReturnValue({
-      data: {
-        // The search term below must NOT match the name, so the filter
-        // falls through to the (undefined) description term that crashed.
-        data: [makeAsset({ name: "Annual Summary", description: undefined })],
-        total: 1,
-        limit: 50,
-        offset: 0,
-        share_summaries: {},
-      },
+      data: { data: [makeAsset({ name: "Annual Summary" })], total: 1, limit: 50, offset: 0, share_summaries: {} },
       isLoading: false,
     } as unknown as ReturnType<typeof useAssets>);
+    mockUseSearchAssets.mockReturnValue({
+      data: {
+        data: [{ asset: makeAsset({ id: "r1", name: "Revenue Report", description: undefined }), score: 0.9 }],
+      },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useSearchAssets>);
 
-    render(<MyAssetsPage onNavigate={vi.fn()} />, { wrapper });
-    expect(screen.getByText("Annual Summary")).toBeInTheDocument();
+    vi.useFakeTimers();
+    try {
+      render(<MyAssetsPage onNavigate={vi.fn()} />, { wrapper });
+      expect(screen.getByText("Annual Summary")).toBeInTheDocument();
 
-    // Typing a query that matches neither the name nor the absent description
-    // forces evaluation of the description branch of the filter.
-    expect(() =>
-      fireEvent.change(screen.getByPlaceholderText("Search assets..."), {
-        target: { value: "revenue" },
-      }),
-    ).not.toThrow();
+      expect(() =>
+        fireEvent.change(screen.getByPlaceholderText("Search assets by meaning..."), {
+          target: { value: "revenue" },
+        }),
+      ).not.toThrow();
 
-    // The descriptionless, non-matching asset is filtered out without crashing.
-    expect(screen.queryByText("Annual Summary")).not.toBeInTheDocument();
+      // Advance past the 300ms debounce so the ranked results take over.
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // The descriptionless ranked result renders; the browse list is replaced.
+      expect(screen.getByText("Revenue Report")).toBeInTheDocument();
+      expect(screen.queryByText("Annual Summary")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("no share icons when share_summaries is empty", () => {

--- a/ui/src/pages/indexing/IndexingPage.test.tsx
+++ b/ui/src/pages/indexing/IndexingPage.test.tsx
@@ -197,6 +197,33 @@ describe("IndexingPage", () => {
     expect(screen.queryByText(/Units by last run/i)).not.toBeInTheDocument();
   });
 
+  it("renders a kind with nothing to index as one coherent empty state", () => {
+    summaryState = {
+      data: {
+        provider: summary.provider,
+        kinds: [
+          {
+            kind: "prompts",
+            verdict: "healthy",
+            pending: 0,
+            running: 0,
+            succeeded: 0,
+            failed: 0,
+            unresolved_failures: 0,
+            coverage: { indexed: 0, expected: 0, expected_known: true },
+          },
+        ],
+      },
+      isLoading: false,
+    };
+    render(<IndexingPage />);
+    // A kind with zero items renders a single coherent "nothing to index" line,
+    // never the contradictory "not yet indexed" + "fully indexed" pairing.
+    expect(screen.getByText(/nothing to index/i)).toBeInTheDocument();
+    expect(screen.queryByText(/not yet indexed/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/fully indexed/i)).not.toBeInTheDocument();
+  });
+
   it("renders failure triage from the failures endpoint with timestamps", () => {
     render(<IndexingPage />);
     expect(screen.getByText(/embed batch: provider timeout/i)).toBeInTheDocument();

--- a/ui/src/pages/indexing/IndexingPage.tsx
+++ b/ui/src/pages/indexing/IndexingPage.tsx
@@ -18,6 +18,7 @@ import {
   useReindex,
   useDismissFailure,
   type IndexKindSummary,
+  type IndexCoverage,
   type IndexJob,
   type IndexFailedUnit,
   type IndexVerdict,
@@ -182,6 +183,17 @@ function VerdictBadge({ verdict }: { verdict: IndexVerdict }) {
   );
 }
 
+// coverageEmpty reports whether a kind genuinely has nothing to index: a
+// known-ratio kind whose expected and indexed are both zero, or an indexed-only
+// kind with nothing indexed. Such a kind must render one coherent "nothing to
+// index" state rather than three independent defaults that contradict each other
+// ("not yet indexed" vs "fully indexed" vs "Up to date").
+function coverageEmpty(cov?: IndexCoverage): boolean {
+  if (!cov) return false;
+  if (cov.expected_known) return cov.expected === 0 && cov.indexed === 0;
+  return cov.indexed === 0;
+}
+
 // coverageLine renders the vector-coverage family (how much is indexed),
 // labelled "Vectors" so it never reads as a job count. expected_known
 // distinguishes a real ratio from a continuously-syncing kind.
@@ -190,13 +202,15 @@ function CoverageLine({ summary }: { summary: IndexKindSummary }) {
   if (!cov) {
     return <span className="text-xs text-muted-foreground">Vectors: coverage n/a</span>;
   }
+  if (coverageEmpty(cov)) {
+    // Nothing to index. One coherent line; syncedText suppresses its footer so
+    // the card never pairs "nothing to index" with "fully indexed".
+    return <span className="text-xs text-muted-foreground">Vectors: nothing to index</span>;
+  }
   if (!cov.expected_known) {
     // No fixed denominator (e.g. tools, sized by the live registry). Once
     // anything is indexed it is in sync, so render a full bar to match the
-    // ratio-known kinds visually; an empty corpus shows no bar.
-    if (cov.indexed === 0) {
-      return <span className="text-xs text-muted-foreground">Vectors: not yet indexed</span>;
-    }
+    // ratio-known kinds visually (the empty case is handled above).
     return (
       <div className="space-y-1">
         <div className="flex items-center justify-between text-xs">
@@ -215,9 +229,7 @@ function CoverageLine({ summary }: { summary: IndexKindSummary }) {
       </div>
     );
   }
-  if (cov.expected === 0 && cov.indexed === 0) {
-    return <span className="text-xs text-muted-foreground">Vectors: not yet indexed</span>;
-  }
+  // expected_known with expected > 0 (the empty case is handled above).
   const pct = cov.expected > 0 ? Math.round((cov.indexed / cov.expected) * 100) : 100;
   return (
     <div className="space-y-1">
@@ -261,7 +273,9 @@ function nowText(summary: IndexKindSummary): string {
 // to report and the verdict already says it is up to date.
 function syncedText(summary: IndexKindSummary): string {
   if (!summary.last_activity) {
-    return "fully indexed";
+    // A kind with nothing to index has no "fully indexed" story to tell; saying
+    // so would contradict the "nothing to index" coverage line.
+    return coverageEmpty(summary.coverage) ? "" : "fully indexed";
   }
   return `last indexed ${relTime(summary.last_activity)}`;
 }


### PR DESCRIPTION
Closes #593

## Problem

Static prompts (operator-configured `server.prompts`, plus the built-in workflow and toolkit prompts) were registered **only** as MCP protocol prompts via `mcpServer.AddPrompt` and were never written to the prompt store. Both the embedding indexer (`pkg/prompt/promptindex`) and `manage_prompt search` operate solely on the store, so:

- On a deployment whose prompts are entirely static config, `manage_prompt search` returned nothing and the prompts embedding index was empty even though prompts existed.
- The admin Indexing card rendered three contradictory phrases for the empty prompts kind: "Up to date" + "Vectors: not yet indexed" + "fully indexed".

Reproduced live: `manage_prompt list` returned `count: 0` and the prompts Indexing card was contradictory.

## Approach (A): ingest static prompts as read-only store rows

Mirror the registered static prompts into the store as `source=system`, `scope=global`, `status=approved`, `enabled=true` rows so the **existing** indexer, coverage, and `manage_prompt search` cover them with no new index/search machinery. No schema migration is needed — the `prompts` table already has `source` (CHECK includes `system`) and `status` (`approved`).

- New `ingestStaticPrompts` (`pkg/platform/prompt_ingest.go`) runs in `registerPlatformPrompts`, **after** static registration populates `promptInfos` and **before** `registerDatabasePrompts` (so database prompts are not re-ingested as system rows).
- Reconciled on every startup: upsert by name; a name already owned by a non-system prompt is left untouched (never clobbers user/admin prompts); system rows no longer registered are pruned.
- New `ListFilter.Source` / `ExcludeSource` drive the queries.

## Containment: system rows are internal, not a new human-facing prompt

System rows exist only for indexing/search. They are excluded from, and read-only on, every other prompt surface (these gaps were found by an adversarial review of the first cut and are all covered by tests):

| Surface | Handling |
|---|---|
| MCP `prompts/list` (`listScopedDescriptors`) | exclude system rows (served unprefixed via `AddPrompt`; no `global-<name>` duplicate) |
| MCP `prompts/get` prefixed (`getGlobalPrompt`) | do not serve system rows under the `global-` prefix |
| `registerDatabasePrompts` | skip system rows (already statically served) |
| `manage_prompt update` / `delete` | reject system rows (read-only) |
| Admin REST `update` / `delete` | reject system rows (read-only); `approve`/`reject` were already gated by `ReviewRequested` |
| Admin REST list / count | exclude system rows (surfaced read-only via the existing synthetic `mergeSystemPrompts`) |
| Portal list (`listMyPrompts`) and search (`searchMyPrompts`) | exclude system rows (portal surfaces them in its dedicated system list) |
| MCP `manage_prompt list` / `search` | **include** system rows, read-only — this is the feature |

## UI

`ui/src/pages/indexing/IndexingPage.tsx`: a kind with nothing to index now renders one coherent empty state ("Vectors: nothing to index", no contradictory "fully indexed" footer) instead of three conflicting phrases. Populated kinds are unchanged.

Also fixes `ui/src/pages/assets/MyAssetsPage.test.tsx`, which mocked the asset hooks without `useSearchAssets` and still asserted a removed client-side `description` filter; rewritten for the new debounced server-side search. Full UI suite is green (158 tests).

## Verification

- Unit: ingest/reconcile/skip-non-system/prune; read-only guards (MCP and admin REST); serving and list/search exclusions; `buildWhere` source filters; UI empty state.
- Real Postgres (`test-realdb` gate):
  - `TestIngestStaticPrompts_RealDB_Searchable` runs the actual `ingestStaticPrompts` path against a pgvector DB and asserts the static prompt is stored as a system/approved/global row and is returned by the **real store searcher** (the same path `manage_prompt search` uses), idempotent on re-run.
  - `TestStore_ListSourceFilters_RealDB` exercises `Source` / `ExcludeSource` against real Postgres.
- `make verify` passes end to end (fmt, race tests, lint, security/govulncheck, semgrep, CodeQL, coverage incl. patch coverage 97.8%, mutation, GoReleaser dry-run).

## Notes

- No migration; reuses existing `source` and `status` columns.
- No change to how protocol prompts are served or to prompt names clients see.
- Once released and deployed, `manage_prompt search` returns the static prompts and the prompts Indexing card reflects their coverage; the feature is already proven end-to-end against real Postgres above.