### PR TITLE
feat(injection): default-on enrichment and deliver it in structured output (#571, #574)

### DIFF
--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -273,10 +273,14 @@ query:
     #   warehouse: rdbms      # DataHub "warehouse" → Trino "rdbms"
     #   datalake: iceberg     # DataHub "datalake" → Trino "iceberg"
 
-# Cross-injection
+# Cross-injection. The four enrichment flags default to true (the platform's
+# core differentiator is on by default; each is read-only and no-ops without its
+# provider). Set a flag to false to disable that direction.
 injection:
-  trino_semantic_enrichment: true
-  datahub_query_enrichment: true
+  # trino_semantic_enrichment: true     # Default: true
+  # datahub_query_enrichment: true      # Default: true
+  # s3_semantic_enrichment: true        # Default: true
+  # datahub_storage_enrichment: true    # Default: true
 
   # Search schema preview
   # Adds a bounded column-name+type preview to datahub_search query_context

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -624,9 +624,9 @@ The `database` store requires `database.dsn`. Database-backed sessions survive r
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `trino_semantic_enrichment` | bool | false | Add DataHub context to Trino results |
-| `datahub_query_enrichment` | bool | false | Add Trino availability to DataHub results |
-| `s3_semantic_enrichment` | bool | false | Add DataHub context to S3 results |
+| `trino_semantic_enrichment` | bool | true | Add DataHub context to Trino results (default on; set false to disable) |
+| `datahub_query_enrichment` | bool | true | Add Trino availability to DataHub results (default on; set false to disable) |
+| `s3_semantic_enrichment` | bool | true | Add DataHub context to S3 results (default on; set false to disable) |
 | `unwrap_json` | bool | true | Auto-unwrap single-row VARCHAR-of-JSON results (e.g. from raw_query) |
 | `column_context_filtering` | bool | true | Limit column enrichment to SQL-referenced columns |
 | `search_schema_preview` | bool | true | Add bounded column-name+type preview to datahub_search query_context |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -601,14 +601,14 @@ icons:
 
 ## Resource Links Configuration
 
-DataHub search results and entity responses automatically include MCP resource links when resource templates are enabled. These links allow clients to navigate directly to related schema, glossary, and availability resources.
+DataHub search results and entity responses automatically include MCP resource links when resource templates are enabled. `resources.enabled` defaults to `true` (read-only template serving); set it to `false` to disable. These links allow clients to navigate directly to related schema, glossary, and availability resources.
 
 ```yaml
 resources:
-  enabled: true
+  enabled: true   # default: true; set false to disable
 ```
 
-When `resources.enabled: true`, DataHub tools include links to:
+When `resources.enabled` is on (the default), DataHub tools include links to:
 
 - `schema://{catalog}.{schema}/{table}` — table schema details
 - `glossary://{term}` — glossary term definitions

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -570,10 +570,10 @@ injection:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `trino_semantic_enrichment` | bool | `false` | Enrich Trino results with DataHub metadata |
-| `datahub_query_enrichment` | bool | `false` | Add query availability to DataHub search results |
-| `s3_semantic_enrichment` | bool | `false` | Enrich S3 results with DataHub metadata |
-| `datahub_storage_enrichment` | bool | `false` | Add S3 availability to DataHub results |
+| `trino_semantic_enrichment` | bool | `true` | Enrich Trino results with DataHub metadata. Default on; read-only and no-ops without a semantic provider. Set `false` to disable. |
+| `datahub_query_enrichment` | bool | `true` | Add query availability to DataHub search results. Default on; set `false` to disable. |
+| `s3_semantic_enrichment` | bool | `true` | Enrich S3 results with DataHub metadata. Default on; set `false` to disable. |
+| `datahub_storage_enrichment` | bool | `true` | Add S3 availability to DataHub results. Default on; set `false` to disable. |
 | `unwrap_json` | bool | `true` | Auto-unwrap single-row VARCHAR-of-JSON results |
 | `column_context_filtering` | bool | `true` | Limit column enrichment to SQL-referenced columns |
 | `session_dedup.enabled` | bool | `true` | Whether session dedup is active |

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
 	github.com/txn2/mcp-datahub v1.9.0
 	github.com/txn2/mcp-s3 v1.3.0
-	github.com/txn2/mcp-trino v1.3.0
+	github.com/txn2/mcp-trino v1.3.1
 	github.com/yosida95/uritemplate/v3 v3.0.2
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.66.0

--- a/go.sum
+++ b/go.sum
@@ -311,8 +311,8 @@ github.com/txn2/mcp-datahub v1.9.0 h1:lIumj10Jjv7pfV12KWzXOdI1P0x40dZzXspYpoErsW
 github.com/txn2/mcp-datahub v1.9.0/go.mod h1:zNhJ1JJoVrwIC8DU9fTywVSdCjG7gnnrzbNWL746JYM=
 github.com/txn2/mcp-s3 v1.3.0 h1:T2FlZGSU5pJi78ts+rE9kzZpIg1HD/lciwWqInYXXO0=
 github.com/txn2/mcp-s3 v1.3.0/go.mod h1:sI18zzBkOxGO07DSHap7baPwtEEw+pYBJhT1BGQnYRc=
-github.com/txn2/mcp-trino v1.3.0 h1:QKoNzm/WeRTE6RJ++pAeOCwwxd3L5M4XWNb/XniYnCQ=
-github.com/txn2/mcp-trino v1.3.0/go.mod h1:e9niXtowe/ji8QADqH3i352tkxEXo4KKkcHnG2KxIHs=
+github.com/txn2/mcp-trino v1.3.1 h1:A9Ki3Q7S+soLKCOKuVXCi/DO2dvgZRh7h+mDPT1WOCw=
+github.com/txn2/mcp-trino v1.3.1/go.mod h1:CDKJ6xAZFepno29H5xROSHFpprFtuuPy6gtAQKoeoi0=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/pkg/middleware/mcp_enrichment.go
+++ b/pkg/middleware/mcp_enrichment.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -107,7 +108,67 @@ func applyEnrichment(
 
 	appendDiscoveryNoteIfNeeded(enrichedResult, pc, enricher.cfg.WorkflowTracker)
 
+	// Mirror every platform-added enrichment block into the structured result so
+	// MCP clients that render only structured output still receive the semantic
+	// context, memories, and discovery note (#571). The text blocks are kept for
+	// content-rendering clients.
+	mirrorEnrichmentToStructured(enrichedResult, beforeLen)
+
 	return enrichedResult, nil
+}
+
+// mirrorEnrichmentToStructured copies the JSON enrichment blocks the middleware
+// appended to result.Content (at indices >= fromIndex) into
+// result.StructuredContent, so a client that surfaces only structured output
+// still receives them. Each platform block is a JSON object with named top-level
+// keys (semantic_context, column_context, related_memories, discovery_note,
+// metadata_reference, ...), which merge cleanly. Resource links and non-JSON
+// blocks are skipped. Best-effort: any failure leaves the result unchanged.
+func mirrorEnrichmentToStructured(result *mcp.CallToolResult, fromIndex int) {
+	if result == nil || fromIndex < 0 || fromIndex >= len(result.Content) {
+		return
+	}
+	added := map[string]any{}
+	for _, c := range result.Content[fromIndex:] {
+		tc, ok := c.(*mcp.TextContent)
+		if !ok {
+			continue
+		}
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(tc.Text), &obj); err != nil {
+			continue
+		}
+		maps.Copy(added, obj)
+	}
+	if len(added) == 0 {
+		return
+	}
+	base := structuredAsMap(result.StructuredContent)
+	maps.Copy(base, added)
+	result.StructuredContent = base
+}
+
+// structuredAsMap returns sc as a map[string]any: the value itself if already a
+// map, a JSON round-trip of a typed struct, or a fresh map when nil or not
+// convertible. The original typed structured value is replaced by this map so
+// the enrichment keys can be added without an OutputSchema constraint (the
+// composed trino tools register none).
+func structuredAsMap(sc any) map[string]any {
+	if sc == nil {
+		return map[string]any{}
+	}
+	if m, ok := sc.(map[string]any); ok {
+		return m
+	}
+	data, err := json.Marshal(sc)
+	if err != nil {
+		return map[string]any{}
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil || m == nil {
+		return map[string]any{}
+	}
+	return m
 }
 
 // appendDiscoveryNoteIfNeeded appends a soft discovery note to enriched results

--- a/pkg/middleware/mcp_enrichment_structured_test.go
+++ b/pkg/middleware/mcp_enrichment_structured_test.go
@@ -1,0 +1,144 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/semantic"
+)
+
+// TestEnrichment_MergesSemanticContextIntoStructured verifies #571: the Trino
+// semantic context the middleware appends as a text block is also folded into
+// the structured result (merged alongside the tool's own structured fields),
+// while the text block is kept for content-rendering clients.
+func TestEnrichment_MergesSemanticContextIntoStructured(t *testing.T) {
+	mockProvider := &mockSemanticProvider{
+		getTableContextFunc: func(_ context.Context, _ semantic.TableIdentifier) (*semantic.TableContext, error) {
+			return &semantic.TableContext{Description: "User accounts table", Tags: []string{"pii"}}, nil
+		},
+	}
+	mw := MCPSemanticEnrichmentMiddleware(mockProvider, nil, nil,
+		EnrichmentConfig{EnrichTrinoResults: true}, nil)
+
+	handler := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return &mcp.CallToolResult{
+			Content:           []mcp.Content{&mcp.TextContent{Text: "id | bigint"}},
+			StructuredContent: map[string]any{"columns": []string{"id", "name"}},
+		}, nil
+	}
+	req := createServerRequest(t, enrichTestDescribeTable, map[string]any{
+		"catalog": "t", "schema": "p", "table": "u",
+	})
+
+	result, err := mw(handler)(context.Background(), enrichTestMethodToolsCall, req)
+	require.NoError(t, err)
+	cr, ok := result.(*mcp.CallToolResult)
+	require.True(t, ok)
+
+	// Text enrichment block still present (additive).
+	require.GreaterOrEqual(t, len(cr.Content), 2)
+
+	// Structured content now carries the semantic context alongside the original.
+	sc, ok := cr.StructuredContent.(map[string]any)
+	require.True(t, ok, "structured content should be a map, got %T", cr.StructuredContent)
+	assert.Contains(t, sc, "columns", "original structured fields preserved")
+	require.Contains(t, sc, "semantic_context", "semantic context folded into structured")
+	scJSON, _ := json.Marshal(sc["semantic_context"])
+	assert.Contains(t, string(scJSON), "User accounts table")
+}
+
+func TestStructuredAsMap(t *testing.T) {
+	assert.Empty(t, structuredAsMap(nil), "nil yields an empty map")
+
+	m := map[string]any{"a": float64(1)}
+	assert.Equal(t, m, structuredAsMap(m), "an existing map is returned as-is")
+
+	type out struct {
+		Table string `json:"table"`
+	}
+	got := structuredAsMap(out{Table: "x"})
+	assert.Equal(t, "x", got["table"], "a typed struct round-trips to a map")
+
+	assert.Empty(t, structuredAsMap([]int{1, 2}), "a non-object value yields an empty map")
+}
+
+func TestMirrorEnrichmentToStructured_EdgeCases(t *testing.T) {
+	// nil result and an out-of-range fromIndex are no-ops (no panic).
+	mirrorEnrichmentToStructured(nil, 0)
+	r := &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "x"}}}
+	mirrorEnrichmentToStructured(r, 5)
+	assert.Nil(t, r.StructuredContent)
+
+	// Resource links and non-JSON text blocks are skipped; nothing is folded.
+	r2 := &mcp.CallToolResult{Content: []mcp.Content{
+		&mcp.ResourceLink{URI: "schema://x"},
+		&mcp.TextContent{Text: "not json"},
+	}}
+	mirrorEnrichmentToStructured(r2, 0)
+	assert.Nil(t, r2.StructuredContent, "no JSON enrichment blocks means structured content is untouched")
+}
+
+// TestEnrichment_StructuredViaAssembledServer is the #571 acceptance: boot a
+// real mcp.Server with the enrichment middleware via AddReceivingMiddleware,
+// call trino_describe_table over an in-memory transport, and assert the result
+// the CLIENT receives carries the semantic context in StructuredContent (and the
+// text block is still present). The in-process test cannot prove the assembled
+// SDK wiring delivers the merged structured content over the wire.
+func TestEnrichment_StructuredViaAssembledServer(t *testing.T) {
+	mockProvider := &mockSemanticProvider{
+		getTableContextFunc: func(_ context.Context, _ semantic.TableIdentifier) (*semantic.TableContext, error) {
+			return &semantic.TableContext{Description: "Sales fact table", Tags: []string{"finance"}}, nil
+		},
+	}
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "enrich-test", Version: "v0"}, nil)
+	server.AddTool(&mcp.Tool{
+		Name:        "trino_describe_table",
+		Description: "describe",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}, func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{
+			Content:           []mcp.Content{&mcp.TextContent{Text: "id | bigint"}},
+			StructuredContent: map[string]any{"table": "sales", "columns": []string{"id"}},
+		}, nil
+	})
+	server.AddReceivingMiddleware(MCPSemanticEnrichmentMiddleware(
+		mockProvider, nil, nil, EnrichmentConfig{EnrichTrinoResults: true}, nil))
+
+	ctx := context.Background()
+	t1, t2 := mcp.NewInMemoryTransports()
+	_, err := server.Connect(ctx, t1, nil)
+	require.NoError(t, err)
+	client := mcp.NewClient(&mcp.Implementation{Name: "c", Version: "v0"}, nil)
+	sess, err := client.Connect(ctx, t2, nil)
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	res, err := sess.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "trino_describe_table",
+		Arguments: map[string]any{"catalog": "warehouse", "schema": "public", "table": "sales"},
+	})
+	require.NoError(t, err)
+
+	// Structured content reaches the client with the folded semantic context.
+	scJSON, err := json.Marshal(res.StructuredContent)
+	require.NoError(t, err)
+	assert.Contains(t, string(scJSON), "semantic_context", "structured result carries semantic context")
+	assert.Contains(t, string(scJSON), "Sales fact table")
+	assert.Contains(t, string(scJSON), "table", "original structured fields preserved")
+
+	// The text enrichment block is still present for content-rendering clients.
+	var foundText bool
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcp.TextContent); ok && strings.Contains(tc.Text, "semantic_context") {
+			foundText = true
+		}
+	}
+	assert.True(t, foundText, "text enrichment block still present")
+}

--- a/pkg/middleware/session_cache.go
+++ b/pkg/middleware/session_cache.go
@@ -35,6 +35,7 @@ type SessionEnrichmentCache struct {
 	entryTTL       time.Duration
 	sessionTimeout time.Duration
 	done           chan struct{}
+	stopOnce       sync.Once
 
 	// Cumulative token counters for diagnostics.
 	tokensFull    atomic.Int64
@@ -145,9 +146,10 @@ func (c *SessionEnrichmentCache) StartCleanup(interval time.Duration) {
 	}()
 }
 
-// Stop stops the background cleanup goroutine.
+// Stop stops the background cleanup goroutine. It is idempotent: multiple calls
+// (e.g. Platform.Close invoked more than once) close the done channel exactly once.
 func (c *SessionEnrichmentCache) Stop() {
-	close(c.done)
+	c.stopOnce.Do(func() { close(c.done) })
 }
 
 // SessionCount returns the number of tracked sessions.

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -468,10 +468,15 @@ type StorageConfig struct {
 
 // InjectionConfig configures cross-injection.
 type InjectionConfig struct {
-	TrinoSemanticEnrichment  bool               `yaml:"trino_semantic_enrichment"`
-	DataHubQueryEnrichment   bool               `yaml:"datahub_query_enrichment"`
-	S3SemanticEnrichment     bool               `yaml:"s3_semantic_enrichment"`
-	DataHubStorageEnrichment bool               `yaml:"datahub_storage_enrichment"`
+	// The four cross-injection flags default to true (nil = enabled). They are
+	// the platform's core differentiator and are read-only: each no-ops safely
+	// when its provider (semantic / query / storage) is absent, so defaulting on
+	// is safe and removes the need to opt every deployment into enrichment. Set
+	// the flag to false explicitly to disable. Read via the Is*Enabled helpers.
+	TrinoSemanticEnrichment  *bool              `yaml:"trino_semantic_enrichment"`
+	DataHubQueryEnrichment   *bool              `yaml:"datahub_query_enrichment"`
+	S3SemanticEnrichment     *bool              `yaml:"s3_semantic_enrichment"`
+	DataHubStorageEnrichment *bool              `yaml:"datahub_storage_enrichment"`
 	EstimateRowCounts        bool               `yaml:"estimate_row_counts"`
 	SessionDedup             SessionDedupConfig `yaml:"session_dedup"`
 
@@ -531,6 +536,31 @@ func (c *InjectionConfig) IsColumnContextFilteringEnabled() bool {
 		return true
 	}
 	return *c.ColumnContextFiltering
+}
+
+// IsTrinoSemanticEnrichmentEnabled reports whether Trino results are enriched
+// with semantic context, defaulting to true when not explicitly set. The
+// enrichment no-ops when no semantic provider is configured.
+func (c *InjectionConfig) IsTrinoSemanticEnrichmentEnabled() bool {
+	return c.TrinoSemanticEnrichment == nil || *c.TrinoSemanticEnrichment
+}
+
+// IsDataHubQueryEnrichmentEnabled reports whether DataHub results are enriched
+// with query/availability context, defaulting to true when not explicitly set.
+func (c *InjectionConfig) IsDataHubQueryEnrichmentEnabled() bool {
+	return c.DataHubQueryEnrichment == nil || *c.DataHubQueryEnrichment
+}
+
+// IsS3SemanticEnrichmentEnabled reports whether S3 results are enriched with
+// semantic context, defaulting to true when not explicitly set.
+func (c *InjectionConfig) IsS3SemanticEnrichmentEnabled() bool {
+	return c.S3SemanticEnrichment == nil || *c.S3SemanticEnrichment
+}
+
+// IsDataHubStorageEnrichmentEnabled reports whether DataHub results are enriched
+// with storage context, defaulting to true when not explicitly set.
+func (c *InjectionConfig) IsDataHubStorageEnrichmentEnabled() bool {
+	return c.DataHubStorageEnrichment == nil || *c.DataHubStorageEnrichment
 }
 
 // defaultSchemaPreviewMaxColumns is the default cap for schema preview columns.
@@ -737,9 +767,18 @@ type CSPAppConfig struct {
 
 // ResourcesConfig configures MCP resource templates and managed resources.
 type ResourcesConfig struct {
-	Enabled bool                `yaml:"enabled"` // gates schema/glossary/availability templates
+	// Enabled gates the schema/glossary/availability resource templates and the
+	// DataHub->Trino resource links (ResourceLinksEnabled). Read-only serving, so
+	// it defaults to true (nil = enabled); set false to disable. Read via IsEnabled.
+	Enabled *bool               `yaml:"enabled"`
 	Custom  []CustomResourceDef `yaml:"custom"`  // always registered when non-empty
 	Managed ManagedResourcesCfg `yaml:"managed"` // human-uploaded resources via portal
+}
+
+// IsEnabled reports whether the resource templates and DataHub->Trino resource
+// links are served, defaulting to true when not explicitly set.
+func (c *ResourcesConfig) IsEnabled() bool {
+	return c.Enabled == nil || *c.Enabled
 }
 
 // defaultManagedResourcesS3Bucket is the default S3 bucket for managed resources.

--- a/pkg/platform/config_test.go
+++ b/pkg/platform/config_test.go
@@ -573,14 +573,26 @@ func TestConfigTypes_PersonaDef(t *testing.T) {
 }
 
 func TestConfigTypes_InjectionConfig(t *testing.T) {
-	cfg := InjectionConfig{
-		TrinoSemanticEnrichment:  true,
-		DataHubQueryEnrichment:   true,
-		S3SemanticEnrichment:     true,
-		DataHubStorageEnrichment: true,
+	// The four cross-injection flags default to enabled when unset (#571): an
+	// operator should not have to opt every deployment into the core feature.
+	var def InjectionConfig
+	if !def.IsTrinoSemanticEnrichmentEnabled() {
+		t.Error("TrinoSemanticEnrichment should default enabled")
 	}
-	if !cfg.TrinoSemanticEnrichment {
-		t.Error("TrinoSemanticEnrichment = false")
+	if !def.IsDataHubQueryEnrichmentEnabled() {
+		t.Error("DataHubQueryEnrichment should default enabled")
+	}
+	if !def.IsS3SemanticEnrichmentEnabled() {
+		t.Error("S3SemanticEnrichment should default enabled")
+	}
+	if !def.IsDataHubStorageEnrichmentEnabled() {
+		t.Error("DataHubStorageEnrichment should default enabled")
+	}
+
+	// An explicit false disables.
+	off := InjectionConfig{TrinoSemanticEnrichment: new(false)}
+	if off.IsTrinoSemanticEnrichmentEnabled() {
+		t.Error("explicit false should disable TrinoSemanticEnrichment")
 	}
 }
 

--- a/pkg/platform/info_tool.go
+++ b/pkg/platform/info_tool.go
@@ -62,13 +62,19 @@ type KnowledgeApplyInfo struct {
 
 // buildFeatures constructs the Features struct from platform config.
 func (p *Platform) buildFeatures() Features {
+	// Enrichment is reported on only when both its flag is enabled (default-on)
+	// AND the provider that performs it is configured. Reporting it on without a
+	// provider would mislead an agent into expecting context the platform cannot
+	// produce. Trino/S3 enrichment draws on the semantic provider; DataHub query
+	// enrichment on the query provider; DataHub storage enrichment on storage.
 	f := Features{
-		SemanticEnrichment: p.config.Injection.TrinoSemanticEnrichment || p.config.Injection.S3SemanticEnrichment,
-		QueryEnrichment:    p.config.Injection.DataHubQueryEnrichment,
-		StorageEnrichment:  p.config.Injection.DataHubStorageEnrichment,
-		AuditLogging:       !isExplicitlyDisabled(p.config.Audit.Enabled),
-		KnowledgeCapture:   !isExplicitlyDisabled(p.config.Knowledge.Enabled),
-		ManagedResources:   p.resourceStore != nil,
+		SemanticEnrichment: p.semanticProvider != nil &&
+			(p.config.Injection.IsTrinoSemanticEnrichmentEnabled() || p.config.Injection.IsS3SemanticEnrichmentEnabled()),
+		QueryEnrichment:   p.queryProvider != nil && p.config.Injection.IsDataHubQueryEnrichmentEnabled(),
+		StorageEnrichment: p.storageProvider != nil && p.config.Injection.IsDataHubStorageEnrichmentEnabled(),
+		AuditLogging:      !isExplicitlyDisabled(p.config.Audit.Enabled),
+		KnowledgeCapture:  !isExplicitlyDisabled(p.config.Knowledge.Enabled),
+		ManagedResources:  p.resourceStore != nil,
 	}
 
 	if p.config.Knowledge.Apply.Enabled {

--- a/pkg/platform/info_tool_test.go
+++ b/pkg/platform/info_tool_test.go
@@ -11,7 +11,10 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
+	"github.com/txn2/mcp-data-platform/pkg/query"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/semantic"
+	"github.com/txn2/mcp-data-platform/pkg/storage"
 )
 
 const (
@@ -56,8 +59,8 @@ func TestHandleInfo(t *testing.T) {
 					"datahub": map[string]any{},
 				},
 				Injection: InjectionConfig{
-					TrinoSemanticEnrichment: true,
-					DataHubQueryEnrichment:  true,
+					TrinoSemanticEnrichment: new(true),
+					DataHubQueryEnrichment:  new(true),
 				},
 				Audit: AuditConfig{
 					Enabled: new(true),
@@ -135,10 +138,10 @@ func TestInfoFeatures(t *testing.T) {
 			Version: testInfoVersion,
 		},
 		Injection: InjectionConfig{
-			TrinoSemanticEnrichment:  true,
-			DataHubQueryEnrichment:   true,
-			S3SemanticEnrichment:     false,
-			DataHubStorageEnrichment: true,
+			TrinoSemanticEnrichment:  new(true),
+			DataHubQueryEnrichment:   new(true),
+			S3SemanticEnrichment:     new(false),
+			DataHubStorageEnrichment: new(true),
 		},
 		Audit: AuditConfig{
 			Enabled: new(true),
@@ -146,9 +149,12 @@ func TestInfoFeatures(t *testing.T) {
 	}
 
 	p := &Platform{
-		config:          &config,
-		personaRegistry: persona.NewRegistry(),
-		toolkitRegistry: registry.NewRegistry(),
+		config:           &config,
+		personaRegistry:  persona.NewRegistry(),
+		toolkitRegistry:  registry.NewRegistry(),
+		semanticProvider: semantic.NewNoopProvider(),
+		queryProvider:    query.NewNoopProvider(),
+		storageProvider:  storage.NewNoopProvider(),
 	}
 	result, _, err := p.handleInfo(context.Background(), &mcp.CallToolRequest{})
 
@@ -159,6 +165,32 @@ func TestInfoFeatures(t *testing.T) {
 	assert.True(t, info.Features.QueryEnrichment, "query enrichment should be enabled")
 	assert.True(t, info.Features.StorageEnrichment, "storage enrichment should be enabled")
 	assert.True(t, info.Features.AuditLogging, "audit logging should be enabled")
+}
+
+// TestInfoFeatures_EnrichmentReportedOffWithoutProvider verifies the honesty
+// gate: with enrichment flags default-on (nil) but no providers configured,
+// platform_info must NOT report enrichment as enabled, since nothing would be
+// produced. The agent should not be told it has context it cannot receive.
+func TestInfoFeatures_EnrichmentReportedOffWithoutProvider(t *testing.T) {
+	config := Config{
+		Server: ServerConfig{Name: "feature-test", Version: testInfoVersion},
+		// Injection left zero-value: every enrichment flag is nil => default-on.
+	}
+
+	p := &Platform{
+		config:          &config,
+		personaRegistry: persona.NewRegistry(),
+		toolkitRegistry: registry.NewRegistry(),
+		// No providers configured.
+	}
+	result, _, err := p.handleInfo(context.Background(), &mcp.CallToolRequest{})
+
+	require.NoError(t, err)
+	info := requireInfoFromResult(t, result)
+
+	assert.False(t, info.Features.SemanticEnrichment, "no semantic provider => not reported")
+	assert.False(t, info.Features.QueryEnrichment, "no query provider => not reported")
+	assert.False(t, info.Features.StorageEnrichment, "no storage provider => not reported")
 }
 
 func TestInfoConfigVersion(t *testing.T) {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -2605,7 +2605,7 @@ func (p *Platform) buildServerCapabilities() *mcp.ServerCapabilities {
 	}
 
 	// Resources are available when templates or managed resources are enabled.
-	if p.config.Resources.Enabled || p.resourceStore != nil || len(p.config.Resources.Custom) > 0 {
+	if p.config.Resources.IsEnabled() || p.resourceStore != nil || len(p.config.Resources.Custom) > 0 {
 		caps.Resources = &mcp.ResourceCapabilities{ListChanged: true}
 	}
 
@@ -2619,10 +2619,10 @@ func (p *Platform) buildServerCapabilities() *mcp.ServerCapabilities {
 
 // addEnrichmentMiddleware adds the semantic enrichment middleware if any injection is configured.
 func (p *Platform) addEnrichmentMiddleware() {
-	needsEnrichment := p.config.Injection.TrinoSemanticEnrichment ||
-		p.config.Injection.DataHubQueryEnrichment ||
-		p.config.Injection.S3SemanticEnrichment ||
-		p.config.Injection.DataHubStorageEnrichment
+	needsEnrichment := p.config.Injection.IsTrinoSemanticEnrichmentEnabled() ||
+		p.config.Injection.IsDataHubQueryEnrichmentEnabled() ||
+		p.config.Injection.IsS3SemanticEnrichmentEnabled() ||
+		p.config.Injection.IsDataHubStorageEnrichmentEnabled()
 
 	if !needsEnrichment {
 		return
@@ -2649,11 +2649,11 @@ func (p *Platform) addEnrichmentMiddleware() {
 // optional session dedup cache setup.
 func (p *Platform) buildEnrichmentConfig() middleware.EnrichmentConfig {
 	cfg := middleware.EnrichmentConfig{
-		EnrichTrinoResults:          p.config.Injection.TrinoSemanticEnrichment,
-		EnrichDataHubResults:        p.config.Injection.DataHubQueryEnrichment,
-		EnrichS3Results:             p.config.Injection.S3SemanticEnrichment,
-		EnrichDataHubStorageResults: p.config.Injection.DataHubStorageEnrichment,
-		ResourceLinksEnabled:        p.config.Resources.Enabled,
+		EnrichTrinoResults:          p.config.Injection.IsTrinoSemanticEnrichmentEnabled(),
+		EnrichDataHubResults:        p.config.Injection.IsDataHubQueryEnrichmentEnabled(),
+		EnrichS3Results:             p.config.Injection.IsS3SemanticEnrichmentEnabled(),
+		EnrichDataHubStorageResults: p.config.Injection.IsDataHubStorageEnrichmentEnabled(),
+		ResourceLinksEnabled:        p.config.Resources.IsEnabled(),
 		ColumnContextFiltering:      p.config.Injection.IsColumnContextFilteringEnabled(),
 		SearchSchemaPreview:         p.config.Injection.IsSearchSchemaPreviewEnabled(),
 		SchemaPreviewMaxColumns:     p.config.Injection.EffectiveSchemaPreviewMaxColumns(),

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -361,8 +361,8 @@ func TestMCPMiddlewareWithEnrichment(t *testing.T) {
 		Query:    QueryConfig{Provider: testProviderNoop},
 		Storage:  StorageConfig{Provider: testProviderNoop},
 		Injection: InjectionConfig{
-			TrinoSemanticEnrichment: true,
-			DataHubQueryEnrichment:  true,
+			TrinoSemanticEnrichment: new(true),
+			DataHubQueryEnrichment:  new(true),
 		},
 		Audit: AuditConfig{
 			Enabled: new(true),
@@ -3359,13 +3359,13 @@ func TestBuildServerCapabilities(t *testing.T) {
 			config:        Config{},
 			wantTools:     true,
 			wantLogging:   true,
-			wantResources: false,
+			wantResources: true,
 			wantPrompts:   true,
 		},
 		{
 			name: "resources enabled",
 			config: Config{
-				Resources: ResourcesConfig{Enabled: true},
+				Resources: ResourcesConfig{Enabled: new(true)},
 			},
 			wantTools:     true,
 			wantLogging:   true,
@@ -3381,7 +3381,7 @@ func TestBuildServerCapabilities(t *testing.T) {
 			},
 			wantTools:     true,
 			wantLogging:   true,
-			wantResources: false,
+			wantResources: true,
 			wantPrompts:   true,
 		},
 		{
@@ -3391,7 +3391,7 @@ func TestBuildServerCapabilities(t *testing.T) {
 			},
 			wantTools:     true,
 			wantLogging:   true,
-			wantResources: false,
+			wantResources: true,
 			wantPrompts:   true,
 		},
 		{
@@ -3401,18 +3401,30 @@ func TestBuildServerCapabilities(t *testing.T) {
 			},
 			wantTools:     true,
 			wantLogging:   true,
-			wantResources: false,
+			wantResources: true,
 			wantPrompts:   true,
 		},
 		{
 			name: "all capabilities enabled",
 			config: Config{
-				Resources: ResourcesConfig{Enabled: true},
+				Resources: ResourcesConfig{Enabled: new(true)},
 				Knowledge: KnowledgeConfig{Enabled: new(true)},
 			},
 			wantTools:     true,
 			wantLogging:   true,
 			wantResources: true,
+			wantPrompts:   true,
+		},
+		{
+			// Resources default on (#571 default-on); explicit false with no
+			// managed store or custom resources reports the capability absent.
+			name: "resources explicitly disabled",
+			config: Config{
+				Resources: ResourcesConfig{Enabled: new(false)},
+			},
+			wantTools:     true,
+			wantLogging:   true,
+			wantResources: false,
 			wantPrompts:   true,
 		},
 	}

--- a/pkg/platform/resource_templates.go
+++ b/pkg/platform/resource_templates.go
@@ -25,7 +25,7 @@ const (
 // registerResourceTemplates registers all MCP resource templates.
 // Only called when resources.enabled is true.
 func (p *Platform) registerResourceTemplates() {
-	if !p.config.Resources.Enabled {
+	if !p.config.Resources.IsEnabled() {
 		return
 	}
 

--- a/pkg/platform/resource_templates_test.go
+++ b/pkg/platform/resource_templates_test.go
@@ -457,7 +457,7 @@ func TestRegisterResourceTemplates(t *testing.T) {
 	t.Run("disabled", func(_ *testing.T) {
 		s := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "v0.1"}, nil)
 		p := &Platform{
-			config:    &Config{Resources: ResourcesConfig{Enabled: false}},
+			config:    &Config{Resources: ResourcesConfig{Enabled: new(false)}},
 			mcpServer: s,
 		}
 		p.registerResourceTemplates()
@@ -467,7 +467,7 @@ func TestRegisterResourceTemplates(t *testing.T) {
 	t.Run("enabled", func(_ *testing.T) {
 		s := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "v0.1"}, nil)
 		p := &Platform{
-			config:    &Config{Resources: ResourcesConfig{Enabled: true}},
+			config:    &Config{Resources: ResourcesConfig{Enabled: new(true)}},
 			mcpServer: s,
 		}
 		p.registerResourceTemplates()

--- a/test/e2e/helpers/platform.go
+++ b/test/e2e/helpers/platform.go
@@ -62,10 +62,10 @@ func buildPlatformConfig(e2eCfg *E2EConfig) *platform.Config {
 			Instance: "e2e",
 		},
 		Injection: platform.InjectionConfig{
-			TrinoSemanticEnrichment:  true,
-			DataHubQueryEnrichment:   true,
-			S3SemanticEnrichment:     true,
-			DataHubStorageEnrichment: true,
+			TrinoSemanticEnrichment:  new(true),
+			DataHubQueryEnrichment:   new(true),
+			S3SemanticEnrichment:     new(true),
+			DataHubStorageEnrichment: new(true),
 		},
 		Toolkits: map[string]any{
 			"trino": map[string]any{


### PR DESCRIPTION
## Summary

The platform's core differentiator, semantic cross-injection, was **opt-in**: the four injection flags and managed resources defaulted to off because they were plain `bool`s, so every deployment had to know to switch each one on. And the enrichment that did fire was attached only as **text content blocks**, which MCP clients that render a tool's structured output alone silently drop.

This PR does two things:

1. **Makes the safe, read-only features default-on** so operators get the platform's value without per-flag config.
2. **Delivers enrichment and sample data in `StructuredContent`** so structured-only clients actually receive it.

Closes #571. Closes #574.

## Part 1 — Default-on for important features

Each flag below moves from `bool` (default off) to `*bool` with an `Is<Name>Enabled()` helper that returns true when unset. An operator opts out with `enabled: false`.

| Flag | Why it is safe to default on |
|---|---|
| `injection.trino_semantic_enrichment` | read-only; no-ops without a semantic provider |
| `injection.datahub_query_enrichment` | read-only; no-ops without a query provider |
| `injection.s3_semantic_enrichment` | read-only; no-ops without a semantic provider |
| `injection.datahub_storage_enrichment` | read-only; no-ops without a storage provider |
| `resources.enabled` | read-only serving of schema/availability/glossary resource templates |

**Explicitly kept opt-in** (audited, not flipped): mutating (`knowledge.apply`), security/deployment-specific (`oauth.*`, `auth.*`, `tls.*`), cost (`injection.estimate_row_counts`), heuristic (`injection.semantic_fallback`), and the client-capability/friction gates (`elicitation.*`, session/workflow gates). Already default-on (no change): `unwrap_json`, `column_context_filtering`, `search_schema_preview`, session dedup, MCP apps, admin, and the auto-when-DB set.

All read sites updated to the helpers (`info_tool.go`, `platform.go` enrichment gate + `EnrichmentConfig`, `resource_templates.go`). `configs/platform.yaml` and the docs (`docs/server/configuration.md`, `docs/reference/configuration.md`, `docs/llms-full.txt`) state the new defaults.

## Part 2 — Fold enrichment into StructuredContent (#571)

Verified on a live deployment that Trino enrichment **fires** (`enrichment_applied: true, match_kind: urn`); the gap was delivery, not firing. The text block is dropped by structured-only clients.

`mirrorEnrichmentToStructured` (in `pkg/middleware/mcp_enrichment.go`) folds the platform-added blocks (`semantic_context`, `column_context`, `related_memories`, `discovery_note`, `metadata_reference`) into the result's `StructuredContent`, **once and centrally** in `applyEnrichment`, rather than at each of the ~11 append sites. The original `len(Content)` is captured before any platform additions, so only platform blocks are folded, never the tool's own content. The text blocks are kept (additive), so text-rendering clients see no change.

`structuredAsMap` converts a typed structured value to `map[string]any` via a JSON round-trip so enrichment keys can be merged alongside the tool's own fields (nil becomes a fresh map; resource links and non-JSON blocks are skipped).

## Part 3 — Sample in structured output (#574)

Bumps **mcp-trino v1.3.0 -> v1.3.1** (txn2/mcp-trino#71), which populates `DescribeTableOutput.Sample`. With the platform's structured fold and the bumped toolkit, `trino_describe_table` with `include_sample=true` now surfaces sample rows to structured-only clients.

## Review fixes folded in

- **`platform_info` honesty gate** (`info_tool.go`): `buildFeatures` now reports an enrichment feature on only when its flag is enabled **and** the provider that performs it is configured. With default-on flags, reporting `semantic_enrichment: true` on a deployment with no semantic provider would mislead an agent into expecting context it cannot receive.
- **`SessionEnrichmentCache.Stop()` idempotent** (`sync.Once`): default-on enrichment exposed a double-close panic on repeated `Platform.Close()`.

## Tests

- `TestEnrichment_StructuredViaAssembledServer` — the #571 acceptance: boots a real `mcp.Server` with the enrichment middleware via `AddReceivingMiddleware` + in-memory transport, calls `trino_describe_table`, and asserts the client receives `semantic_context` in `StructuredContent` with the text block still present.
- `TestEnrichment_MergesSemanticContextIntoStructured`, `TestStructuredAsMap`, `TestMirrorEnrichmentToStructured_EdgeCases` — in-process merge and edge branches.
- `TestInfoFeatures_EnrichmentReportedOffWithoutProvider` — flags default-on but no providers reports enrichment off; existing `TestInfoFeatures` wires noop providers so the on-case still asserts true.
- Config tests assert each flipped flag defaults true when unset and is honored when set false; `TestBuildServerCapabilities` updated for default-on resources plus an explicit-disabled case.

## Verification

- `make verify` green end to end (tools-check, fmt, real-DB gate, race tests, patch lint 0 issues, gosec/govulncheck, semgrep, codeql, coverage >= 80%, patch coverage, mutation, release-check).
- `/code-review` (7 finder angles + verify) run on this branch; the one confirmed finding (the `platform_info` honesty gap) is fixed above.