### PR TITLE
feat(admin): surface gateway connection health in the connections UI (#584)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2514,7 +2514,7 @@ The dry-run endpoint accepts a sample `{ args, response, user }` and returns the
 
 ## Failure isolation
 
-A gateway upstream that's unreachable at startup logs a warning, records zero tools for that connection, and does not block platform startup. Other connections keep working. A connection that becomes unhealthy at runtime returns tool-error results prefixed `upstream:<connection>:` so the LLM can self-correct, and the audit log captures the failure with the same event shape as a successful call.
+A gateway upstream that's unreachable at startup logs a warning, records zero tools for that connection, and does not block platform startup. Other connections keep working. A connection that becomes unhealthy at runtime returns tool-error results prefixed `upstream:<connection>:` so the LLM can self-correct, and the audit log captures the failure with the same event shape as a successful call. The per-connection reachability (reachable, last successful call time, last error) is surfaced identically by the `list_connections` MCP tool and the admin connections API/UI via a shared wire shape, so the operator and the model never see conflicting health for the same connection. This reachability signal ("did the last forwarded call work?") is distinct from the gateway status endpoint's session-level `healthy` flag ("is the upstream session established?"): a live session whose most recent call failed with a transport error stays `healthy:true` at `/status` but reports unreachable in the connections list. The status endpoint backs the OAuth/session panel and is not rendered as connection health.
 
 ---
 

--- a/docs/server/admin-api.md
+++ b/docs/server/admin-api.md
@@ -187,11 +187,31 @@ Returns all toolkit connections with their tools.
       "name": "prod",
       "connection": "prod-trino",
       "tools": ["trino_query", "trino_describe_table"]
+    },
+    {
+      "kind": "mcp",
+      "name": "vendor-crm",
+      "connection": "vendor-crm",
+      "tools": ["vendor-crm__search"],
+      "health": {
+        "reachable": false,
+        "last_success": "2026-06-09T12:00:00Z",
+        "last_error": "dial tcp: connection refused"
+      }
     }
   ],
-  "total": 1
+  "total": 2
 }
 ```
+
+The optional `health` object reports a gateway (`mcp` kind) upstream's runtime
+reachability: `reachable` (live session with no failed last call),
+`last_success` (RFC3339 UTC time of the last successful forwarded call, omitted
+when none), and `last_error` (most recent call or connect failure). It is
+present only for connection kinds that hold a live session and is the same
+state the `list_connections` MCP tool reports, so the admin UI and the tool
+never show conflicting health for the same connection. Kinds without
+reachability tracking omit the field.
 
 ## Index Jobs Endpoints
 

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -10475,6 +10475,9 @@ const docTemplate = `{
                     "type": "string",
                     "example": "acme-warehouse"
                 },
+                "health": {
+                    "$ref": "#/definitions/toolkit.ConnectionHealthWire"
+                },
                 "hidden_tools": {
                     "type": "array",
                     "items": {
@@ -14152,6 +14155,20 @@ const docTemplate = `{
                 "total": {
                     "type": "integer",
                     "example": 42
+                }
+            }
+        },
+        "toolkit.ConnectionHealthWire": {
+            "type": "object",
+            "properties": {
+                "last_error": {
+                    "type": "string"
+                },
+                "last_success": {
+                    "type": "string"
+                },
+                "reachable": {
+                    "type": "boolean"
                 }
             }
         }

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -10469,6 +10469,9 @@
                     "type": "string",
                     "example": "acme-warehouse"
                 },
+                "health": {
+                    "$ref": "#/definitions/toolkit.ConnectionHealthWire"
+                },
                 "hidden_tools": {
                     "type": "array",
                     "items": {
@@ -14146,6 +14149,20 @@
                 "total": {
                     "type": "integer",
                     "example": 42
+                }
+            }
+        },
+        "toolkit.ConnectionHealthWire": {
+            "type": "object",
+            "properties": {
+                "last_error": {
+                    "type": "string"
+                },
+                "last_success": {
+                    "type": "string"
+                },
+                "reachable": {
+                    "type": "boolean"
                 }
             }
         }

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -415,6 +415,8 @@ definitions:
       connection:
         example: acme-warehouse
         type: string
+      health:
+        $ref: '#/definitions/toolkit.ConnectionHealthWire'
       hidden_tools:
         items:
           type: string
@@ -3150,6 +3152,15 @@ definitions:
       total:
         example: 42
         type: integer
+    type: object
+  toolkit.ConnectionHealthWire:
+    properties:
+      last_error:
+        type: string
+      last_success:
+        type: string
+      reachable:
+        type: boolean
     type: object
 host: localhost:8080
 info:

--- a/pkg/admin/connection_handler.go
+++ b/pkg/admin/connection_handler.go
@@ -291,15 +291,16 @@ func (h *Handler) deleteConnectionInstance(w http.ResponseWriter, r *http.Reques
 
 // effectiveConnection merges a live toolkit connection with its DB instance (if any).
 type effectiveConnection struct {
-	Kind        string         `json:"kind" example:"trino"`
-	Name        string         `json:"name" example:"acme-warehouse"`
-	Connection  string         `json:"connection" example:"acme-warehouse"`
-	Description string         `json:"description,omitempty" example:"Production data warehouse"`
-	Source      string         `json:"source" example:"file"` // "file", "database", or "both"
-	Tools       []string       `json:"tools" example:"trino_query,trino_describe_table"`
-	Config      map[string]any `json:"config,omitempty"`
-	CreatedBy   string         `json:"created_by,omitempty" example:"admin@example.com"`
-	UpdatedAt   *time.Time     `json:"updated_at,omitempty"`
+	Kind        string                        `json:"kind" example:"trino"`
+	Name        string                        `json:"name" example:"acme-warehouse"`
+	Connection  string                        `json:"connection" example:"acme-warehouse"`
+	Description string                        `json:"description,omitempty" example:"Production data warehouse"`
+	Source      string                        `json:"source" example:"file"` // "file", "database", or "both"
+	Tools       []string                      `json:"tools" example:"trino_query,trino_describe_table"`
+	Config      map[string]any                `json:"config,omitempty"`
+	CreatedBy   string                        `json:"created_by,omitempty" example:"admin@example.com"`
+	UpdatedAt   *time.Time                    `json:"updated_at,omitempty"`
+	Health      *toolkit.ConnectionHealthWire `json:"health,omitempty"`
 }
 
 // listEffectiveConnections returns the merged view of file-configured and DB-managed connections.
@@ -329,6 +330,7 @@ type liveConnectionInfo struct {
 	description            string
 	tools                  []string
 	config                 map[string]any
+	health                 *toolkit.ConnectionHealthWire
 }
 
 // collectLiveConnections returns info for running data toolkit instances (trino, s3).
@@ -366,6 +368,7 @@ func (h *Handler) expandMultiConnections(live []liveConnectionInfo, tk registry.
 		info := liveConnectionInfo{
 			kind: tk.Kind(), name: conn.Name, connection: conn.Name,
 			description: conn.Description, tools: tools,
+			health: conn.Health.Wire(),
 		}
 		info.config = h.lookupToolkitInstanceConfig(tk.Kind(), conn.Name)
 		live = append(live, info)
@@ -429,6 +432,9 @@ func mergeConnections(live []liveConnectionInfo, dbInstances []platform.Connecti
 		ec := effectiveConnection{
 			Kind: l.kind, Name: l.name, Connection: l.connection, Source: platform.SourceFile, Tools: l.tools,
 			Description: l.description, Config: l.config, CreatedBy: connectionCreatorSystem,
+			// Health reflects the live runtime session; a DB-only instance
+			// (handled in the loop below) has no session, so health stays nil.
+			Health: l.health,
 		}
 		if inst, ok := dbMap[key]; ok {
 			ec.Source = platform.SourceBoth

--- a/pkg/admin/connection_handler_test.go
+++ b/pkg/admin/connection_handler_test.go
@@ -625,6 +625,96 @@ func TestListEffectiveConnections(t *testing.T) {
 		assert.Equal(t, "both", body[1].Source)
 		assert.Equal(t, "DB override for ES", body[1].Description, "DB description overrides file")
 	})
+
+	t.Run("gateway connection health is surfaced", func(t *testing.T) {
+		reg := &mockToolkitRegistry{
+			rawToolkits: []registry.Toolkit{
+				mockMultiConnectionToolkit{
+					mockToolkit: mockToolkit{
+						kind: "mcp", name: "gateway", connection: "gateway",
+						tools: []string{"vendor_echo"},
+					},
+					connections: []toolkit.ConnectionDetail{
+						{
+							Name: "up", Description: "reachable upstream",
+							Health: &toolkit.ConnectionHealth{
+								Reachable: true, LastSuccessUnix: 1_700_000_000,
+							},
+						},
+						{
+							Name: "down", Description: "unreachable upstream",
+							Health: &toolkit.ConnectionHealth{
+								Reachable: false, LastError: "dial tcp: connection refused",
+							},
+						},
+					},
+				},
+			},
+		}
+		h := NewHandler(Deps{
+			Config:          testConfig(),
+			ToolkitRegistry: reg,
+			ConfigStore:     &mockConfigStore{mode: "database"},
+		}, nil)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/admin/connection-instances/effective", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var body []effectiveConnection
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+		require.Len(t, body, 2)
+
+		byName := make(map[string]effectiveConnection, len(body))
+		for _, ec := range body {
+			byName[ec.Name] = ec
+		}
+
+		up := byName["up"]
+		require.NotNil(t, up.Health, "reachable connection must carry health")
+		assert.True(t, up.Health.Reachable)
+		assert.Equal(t, "2023-11-14T22:13:20Z", up.Health.LastSuccess, "unix success formatted as RFC3339 UTC")
+		assert.Empty(t, up.Health.LastError)
+
+		down := byName["down"]
+		require.NotNil(t, down.Health, "unreachable connection must carry health")
+		assert.False(t, down.Health.Reachable)
+		assert.Equal(t, "dial tcp: connection refused", down.Health.LastError)
+		assert.Empty(t, down.Health.LastSuccess, "no success time when never reachable")
+	})
+
+	t.Run("connection without health tracking omits the field", func(t *testing.T) {
+		reg := &mockToolkitRegistry{
+			rawToolkits: []registry.Toolkit{
+				mockMultiConnectionToolkit{
+					mockToolkit: mockToolkit{
+						kind: "trino", name: "warehouse", connection: "warehouse",
+						tools: []string{"trino_query"},
+					},
+					connections: []toolkit.ConnectionDetail{
+						{Name: "warehouse", Description: "no health"},
+					},
+				},
+			},
+		}
+		h := NewHandler(Deps{
+			Config:          testConfig(),
+			ToolkitRegistry: reg,
+			ConfigStore:     &mockConfigStore{mode: "database"},
+		}, nil)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/admin/connection-instances/effective", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var body []effectiveConnection
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+		require.Len(t, body, 1)
+		assert.Nil(t, body[0].Health, "toolkits that do not track reachability omit health")
+	})
 }
 
 func TestMergeConnections(t *testing.T) {

--- a/pkg/admin/system.go
+++ b/pkg/admin/system.go
@@ -249,11 +249,12 @@ func (h *Handler) buildToolTitleMap(r *http.Request) map[string]string {
 // .length / .map on the wire value, and several toolkits (notably
 // gateway with no live upstream) return nil from Tools().
 type connectionInfo struct {
-	Kind        string   `json:"kind" example:"trino"`
-	Name        string   `json:"name" example:"acme-warehouse"`
-	Connection  string   `json:"connection" example:"acme-warehouse"`
-	Tools       []string `json:"tools" example:"trino_query,trino_describe_table,trino_browse"`
-	HiddenTools []string `json:"hidden_tools"`
+	Kind        string                        `json:"kind" example:"trino"`
+	Name        string                        `json:"name" example:"acme-warehouse"`
+	Connection  string                        `json:"connection" example:"acme-warehouse"`
+	Tools       []string                      `json:"tools" example:"trino_query,trino_describe_table,trino_browse"`
+	HiddenTools []string                      `json:"hidden_tools"`
+	Health      *toolkit.ConnectionHealthWire `json:"health,omitempty"`
 }
 
 // MarshalJSON enforces the non-nil wire invariant for Tools and
@@ -311,6 +312,7 @@ func (h *Handler) listConnections(w http.ResponseWriter, _ *http.Request) {
 						Connection:  conn.Name,
 						Tools:       tools,
 						HiddenTools: hidden,
+						Health:      conn.Health.Wire(),
 					})
 				}
 				continue

--- a/pkg/admin/system_test.go
+++ b/pkg/admin/system_test.go
@@ -535,4 +535,59 @@ func TestListConnections(t *testing.T) {
 			assert.NotContains(t, raw, fmt.Sprintf("%q:null", field), "%s must never be null on the wire", field)
 		}
 	})
+
+	// A gateway upstream's reachability must reach the /admin/connections
+	// surface, identically to list_connections, so operators see the same
+	// health in the admin UI and the MCP tool. A connection without health
+	// tracking (no live session) omits the field.
+	t.Run("gateway connection health is surfaced", func(t *testing.T) {
+		mt := mockMultiConnectionToolkit{
+			mockToolkit: mockToolkit{
+				kind: "mcp", name: "gateway", connection: "gateway",
+				tools: []string{"vendor_echo"},
+			},
+			connections: []toolkit.ConnectionDetail{
+				{
+					Name: "up",
+					Health: &toolkit.ConnectionHealth{
+						Reachable: true, LastSuccessUnix: 1_700_000_000,
+					},
+				},
+				{
+					Name: "down",
+					Health: &toolkit.ConnectionHealth{
+						Reachable: false, LastError: "connection refused",
+					},
+				},
+				{Name: "untracked"},
+			},
+		}
+		reg := &mockToolkitRegistry{rawToolkits: []registry.Toolkit{mt}}
+		h := NewHandler(Deps{ToolkitRegistry: reg}, nil)
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/admin/connections", http.NoBody)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var body connectionListResponse
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+
+		byName := make(map[string]connectionInfo, len(body.Connections))
+		for _, c := range body.Connections {
+			byName[c.Name] = c
+		}
+
+		up := byName["up"]
+		require.NotNil(t, up.Health)
+		assert.True(t, up.Health.Reachable)
+		assert.Equal(t, "2023-11-14T22:13:20Z", up.Health.LastSuccess)
+
+		down := byName["down"]
+		require.NotNil(t, down.Health)
+		assert.False(t, down.Health.Reachable)
+		assert.Equal(t, "connection refused", down.Health.LastError)
+
+		assert.Nil(t, byName["untracked"].Health, "no health struct means no health on the wire")
+	})
 }

--- a/pkg/platform/connections_tool.go
+++ b/pkg/platform/connections_tool.go
@@ -3,7 +3,6 @@ package platform
 import (
 	"context"
 	"encoding/json"
-	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -20,24 +19,15 @@ import (
 // rather than only via a downstream tool failing with "no catalog
 // configured".
 type connectionEntry struct {
-	Kind              string            `json:"kind"`
-	Name              string            `json:"name"`
-	Connection        string            `json:"connection"`
-	Description       string            `json:"description,omitempty"`
-	IsDefault         bool              `json:"is_default,omitempty"`
-	DataHubSourceName string            `json:"datahub_source_name,omitempty"`
-	CatalogID         string            `json:"catalog_id,omitempty"`
-	OperationCount    int               `json:"operation_count,omitempty"`
-	Health            *connectionHealth `json:"health,omitempty"`
-}
-
-// connectionHealth is the runtime reachability of a connection, surfaced for
-// gateway kinds that hold a live upstream session so an evicted or dead
-// upstream is visible from list_connections.
-type connectionHealth struct {
-	Reachable   bool   `json:"reachable"`
-	LastSuccess string `json:"last_success,omitempty"`
-	LastError   string `json:"last_error,omitempty"`
+	Kind              string                        `json:"kind"`
+	Name              string                        `json:"name"`
+	Connection        string                        `json:"connection"`
+	Description       string                        `json:"description,omitempty"`
+	IsDefault         bool                          `json:"is_default,omitempty"`
+	DataHubSourceName string                        `json:"datahub_source_name,omitempty"`
+	CatalogID         string                        `json:"catalog_id,omitempty"`
+	OperationCount    int                           `json:"operation_count,omitempty"`
+	Health            *toolkit.ConnectionHealthWire `json:"health,omitempty"`
 }
 
 // listConnectionsOutput is the JSON response for the list_connections tool.
@@ -111,16 +101,7 @@ func (p *Platform) entriesFromLister(entries []connectionEntry, tk registry.Tool
 		if src := p.connectionSources.ForConnection(tk.Kind(), conn.Name); src != nil {
 			entry.DataHubSourceName = src.DataHubSourceName
 		}
-		if conn.Health != nil {
-			h := &connectionHealth{
-				Reachable: conn.Health.Reachable,
-				LastError: conn.Health.LastError,
-			}
-			if conn.Health.LastSuccessUnix > 0 {
-				h.LastSuccess = time.Unix(conn.Health.LastSuccessUnix, 0).UTC().Format(time.RFC3339)
-			}
-			entry.Health = h
-		}
+		entry.Health = conn.Health.Wire()
 		entries = append(entries, entry)
 	}
 	return entries

--- a/pkg/toolkit/connection.go
+++ b/pkg/toolkit/connection.go
@@ -4,6 +4,8 @@
 // toolkit implementations themselves.
 package toolkit
 
+import "time"
+
 // ConnectionDetail provides information about a single connection within a toolkit.
 //
 // CatalogID and OperationCount are optional and only populated by toolkits
@@ -27,15 +29,51 @@ type ConnectionDetail struct {
 }
 
 // ConnectionHealth is the runtime reachability of a gateway upstream.
+//
+// Reachability is observed passively from forwarded traffic, not from an active
+// background probe: a transport error or timeout on a forwarded call marks the
+// connection unreachable, and it is cleared by the next successful call (or a
+// re-dial). So an idle connection that saw one transient failure can read
+// unreachable until traffic resumes, even though its session is alive. A
+// tool-level error (e.g. bad arguments) is NOT a transport failure and does not
+// affect reachability.
 type ConnectionHealth struct {
 	// Reachable is true when the connection has a live session and its most
-	// recent interaction did not end in an unrecovered error.
+	// recent forwarded call did not end in an unrecovered transport error.
 	Reachable bool
 	// LastSuccessUnix is the unix-seconds time of the last successful
 	// forwarded call (or the initial connect). Zero when none has succeeded.
 	LastSuccessUnix int64
 	// LastError is the most recent call or connect failure, empty when healthy.
 	LastError string
+}
+
+// ConnectionHealthWire is the JSON wire shape for ConnectionHealth, shared by
+// every operator surface (the list_connections MCP tool and the admin
+// connections API) so they report identical reachability for the same
+// connection by construction rather than by two copies happening to agree.
+type ConnectionHealthWire struct {
+	Reachable   bool   `json:"reachable"`
+	LastSuccess string `json:"last_success,omitempty"`
+	LastError   string `json:"last_error,omitempty"`
+}
+
+// Wire renders runtime health into its JSON wire shape, formatting the last
+// success time as RFC3339 UTC (omitted when no call has ever succeeded).
+// Returns nil for a nil receiver so connections that do not track
+// reachability omit the field entirely.
+func (h *ConnectionHealth) Wire() *ConnectionHealthWire {
+	if h == nil {
+		return nil
+	}
+	w := &ConnectionHealthWire{
+		Reachable: h.Reachable,
+		LastError: h.LastError,
+	}
+	if h.LastSuccessUnix > 0 {
+		w.LastSuccess = time.Unix(h.LastSuccessUnix, 0).UTC().Format(time.RFC3339)
+	}
+	return w
 }
 
 // ConnectionLister is an optional interface for toolkits that manage multiple

--- a/pkg/toolkit/connection_test.go
+++ b/pkg/toolkit/connection_test.go
@@ -2,6 +2,51 @@ package toolkit
 
 import "testing"
 
+// TestConnectionHealth_Wire verifies the wire conversion: nil passthrough, the
+// RFC3339 UTC formatting of a positive unix time, and the omission of the
+// success time when none has been recorded. This is the single formatter every
+// operator surface (list_connections MCP tool, admin API) renders through, so
+// the contract is asserted here rather than in each consumer.
+func TestConnectionHealth_Wire(t *testing.T) {
+	if got := (*ConnectionHealth)(nil).Wire(); got != nil {
+		t.Errorf("nil health Wire() = %+v, want nil", got)
+	}
+
+	reachable := (&ConnectionHealth{
+		Reachable:       true,
+		LastSuccessUnix: 1_700_000_000,
+	}).Wire()
+	if reachable == nil {
+		t.Fatal("Wire() = nil for reachable health")
+	}
+	if !reachable.Reachable {
+		t.Error("Reachable = false, want true")
+	}
+	if reachable.LastSuccess != "2023-11-14T22:13:20Z" {
+		t.Errorf("LastSuccess = %q, want RFC3339 UTC", reachable.LastSuccess)
+	}
+	if reachable.LastError != "" {
+		t.Errorf("LastError = %q, want empty", reachable.LastError)
+	}
+
+	down := (&ConnectionHealth{
+		Reachable: false,
+		LastError: "dial tcp: connection refused",
+	}).Wire()
+	if down == nil {
+		t.Fatal("Wire() = nil for unreachable health")
+	}
+	if down.Reachable {
+		t.Error("Reachable = true, want false")
+	}
+	if down.LastSuccess != "" {
+		t.Errorf("LastSuccess = %q, want empty when never succeeded", down.LastSuccess)
+	}
+	if down.LastError != "dial tcp: connection refused" {
+		t.Errorf("LastError = %q", down.LastError)
+	}
+}
+
 // TestConnectionDetailFields verifies the ConnectionDetail struct fields.
 func TestConnectionDetailFields(t *testing.T) {
 	d := ConnectionDetail{

--- a/pkg/toolkits/gateway/toolkit.go
+++ b/pkg/toolkits/gateway/toolkit.go
@@ -905,6 +905,18 @@ func (t *Toolkit) Status(ctx context.Context, name string) *ConnectionStatus {
 		t.mu.RUnlock()
 		return nil
 	}
+	// Healthy means a live upstream session exists (the connection dialed and
+	// holds a client). This is intentionally DISTINCT from the per-connection
+	// reachability that ListConnections / list_connections surface
+	// (ConnectionHealth.Reachable = session exists AND the last forwarded call
+	// did not error): a live session whose most recent call failed with a
+	// non-session transport error stays Healthy here but reports unreachable
+	// there. Status answers "is the session up?" for the OAuth/session panel;
+	// the connections list answers "did the last call work?". The admin
+	// connections UI and list_connections both read the reachability signal
+	// (via the shared toolkit.ConnectionHealthWire), so the two
+	// operator-facing surfaces agree; this session-level flag is a separate
+	// axis and is not rendered as connection health.
 	healthy := u.client != nil
 	cfg := u.config
 	tools := append([]string(nil), u.toolNames...)

--- a/pkg/toolkits/gateway/toolkit_test.go
+++ b/pkg/toolkits/gateway/toolkit_test.go
@@ -1271,6 +1271,66 @@ func TestListConnections_SurfacesHealth(t *testing.T) {
 	assert.NotEmpty(t, h.LastError)
 }
 
+// TestStatus_HealthyIsSessionLevel_DistinctFromReachability guards the
+// intentional distinction between the two health axes: Status().Healthy means
+// "a live upstream session exists", while list_connections reachability means
+// "session exists AND the last forwarded call did not error". After a forwarded
+// call fails with a non-session transport error, the session is still alive, so
+// Status().Healthy stays true while list_connections reports unreachable. The
+// admin connections UI and list_connections both read the reachability signal
+// (shared ConnectionHealthWire), so the operator-facing surfaces still agree;
+// Status' session-level flag is a separate, non-rendered axis.
+func TestStatus_HealthyIsSessionLevel_DistinctFromReachability(t *testing.T) {
+	srv := mcp.NewServer(&mcp.Implementation{Name: "upstream", Version: "0.0.1"}, nil)
+	type echoArgs struct {
+		Message string `json:"message"`
+	}
+	mcp.AddTool(srv, &mcp.Tool{Name: toolEcho, Description: "echo"},
+		func(_ context.Context, _ *mcp.CallToolRequest, a echoArgs) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "echo:" + a.Message}}}, nil, nil
+		})
+	ts := httptest.NewServer(mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return srv }, nil))
+
+	tk := New("primary")
+	t.Cleanup(func() { _ = tk.Close() })
+	if err := tk.AddConnection(connCRM, connectionConfig(ts.URL, connCRM)); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+
+	// After a successful connect both axes agree: session up, last call ok.
+	status := tk.Status(context.Background(), connCRM)
+	require.NotNil(t, status)
+	assert.True(t, status.Healthy, "status healthy after connect")
+	h := healthFor(tk.ListConnections(), connCRM)
+	require.NotNil(t, h)
+	assert.True(t, h.Reachable, "reachable after connect")
+
+	// Take the upstream down and forward a call: it fails unrecoverably.
+	ts.CloseClientConnections()
+	ts.Close()
+	tk.mu.RLock()
+	u := tk.connections[connCRM]
+	tk.mu.RUnlock()
+	handler := tk.makeForwarder(u, toolEcho, localCRMEcho)
+	res, err := handler(context.Background(), &mcp.CallToolRequest{Params: &mcp.CallToolParamsRaw{
+		Name:      toolEcho,
+		Arguments: json.RawMessage(`{"message":"x"}`),
+	}})
+	require.NoError(t, err)
+	require.True(t, res.IsError)
+
+	// The session object still exists, so Status().Healthy stays true, but the
+	// connection is no longer reachable (last call errored). The two axes
+	// intentionally diverge here.
+	status = tk.Status(context.Background(), connCRM)
+	require.NotNil(t, status)
+	assert.True(t, status.Healthy, "session-level Healthy stays true while the client is non-nil")
+	h = healthFor(tk.ListConnections(), connCRM)
+	require.NotNil(t, h)
+	assert.False(t, h.Reachable, "reachability flips false after an unrecoverable call failure")
+	assert.NotEmpty(t, h.LastError)
+}
+
 // TestForwarder_RemovedConnectionDoesNotReconnect guards the reconnect leak:
 // once a connection is removed, an in-flight forwarder must report the upstream
 // as unavailable rather than re-dialing and resurrecting a session that Close

--- a/ui/src/api/admin/hooks.ts
+++ b/ui/src/api/admin/hooks.ts
@@ -1431,6 +1431,15 @@ export function useEffectiveConnections() {
   return useQuery({
     queryKey: ["connection-instances", "effective"],
     queryFn: () => apiFetch<import("./types").EffectiveConnection[]>("/connection-instances/effective"),
+    // Poll so the gateway reachability badge reflects an upstream going
+    // down or recovering at runtime, matching the cadence of the adjacent
+    // OAuth-health badge (useConnectionsOAuthHealth). Without this the
+    // badge would be static after load (the query is otherwise only
+    // invalidated by connection create/delete), defeating its purpose of
+    // surfacing a dead upstream from the list. A background refetch does
+    // not clobber an in-progress edit: the editor holds its own form
+    // state and only reads the connection for dirty comparison.
+    refetchInterval: 10000,
   });
 }
 

--- a/ui/src/api/admin/types.ts
+++ b/ui/src/api/admin/types.ts
@@ -46,6 +46,9 @@ export interface ConnectionInfo {
   connection: string;
   tools: string[];
   hidden_tools: string[];
+  // Present for gateway (mcp) connections; mirrors the Go connectionInfo
+  // and swagger admin.connectionInfo shape. See ConnectionHealth.
+  health?: ConnectionHealth;
 }
 
 export interface ConnectionListResponse {
@@ -487,6 +490,16 @@ export interface PromptListResponse {
   total: number;
 }
 
+// ConnectionHealth is a gateway upstream's runtime reachability, mirroring the
+// list_connections MCP tool's health shape so the admin UI and the tool report
+// the same state for the same connection. Present only for connection kinds
+// that hold a live session (gateway); omitted otherwise.
+export interface ConnectionHealth {
+  reachable: boolean;
+  last_success?: string;
+  last_error?: string;
+}
+
 export interface EffectiveConnection {
   kind: string;
   name: string;
@@ -497,6 +510,7 @@ export interface EffectiveConnection {
   config?: Record<string, unknown>;
   created_by?: string;
   updated_at?: string;
+  health?: ConnectionHealth;
 }
 
 // ---------------------------------------------------------------------------

--- a/ui/src/pages/settings/ConnectionsPanel.tsx
+++ b/ui/src/pages/settings/ConnectionsPanel.tsx
@@ -8,7 +8,10 @@ import {
   useSystemInfo,
   useConnectionsOAuthHealth,
 } from "@/api/admin/hooks";
-import type { ConnectionOAuthHealthSummary } from "@/api/admin/types";
+import type {
+  ConnectionHealth,
+  ConnectionOAuthHealthSummary,
+} from "@/api/admin/types";
 import type { EffectiveConnection } from "@/api/admin/types";
 import { cn } from "@/lib/utils";
 import {
@@ -78,6 +81,87 @@ function ConnectionOAuthHealthBadge({
     );
   }
   return null;
+}
+
+// GatewayHealthBadge renders the runtime reachability of a gateway upstream on
+// the connection list. Present only when the backend reports health (gateway
+// kinds with a live session). Mirrors the list_connections MCP tool: reachable
+// shows green, unreachable shows red with the last error in the tooltip so an
+// operator sees a dead upstream from the list without clicking in.
+function GatewayHealthBadge({
+  health,
+}: {
+  health: ConnectionHealth | undefined;
+}) {
+  if (!health) return null;
+  if (health.reachable) {
+    const tooltip = health.last_success
+      ? `Reachable. Last successful call ${new Date(health.last_success).toLocaleString()}.`
+      : "Reachable.";
+    return (
+      <span
+        className="shrink-0 inline-flex items-center gap-1 rounded px-1 py-0 text-xs font-medium bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+        title={tooltip}
+        aria-label={tooltip}
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+        reachable
+      </span>
+    );
+  }
+  const tooltip = health.last_error
+    ? `Unreachable: ${health.last_error}`
+    : "Unreachable.";
+  return (
+    <span
+      className="shrink-0 inline-flex items-center gap-1 rounded px-1 py-0 text-xs font-medium bg-destructive/10 text-destructive"
+      title={tooltip}
+      aria-label={tooltip}
+    >
+      <span className="h-1.5 w-1.5 rounded-full bg-destructive" />
+      unreachable
+    </span>
+  );
+}
+
+// GatewayHealthDetail renders the full reachability detail for a selected
+// gateway connection: reachable/unreachable, the last successful call time,
+// and the last error. Surfaces in the detail pane so an operator diagnosing a
+// failing upstream sees the reason without leaving the connection editor.
+function GatewayHealthDetail({ health }: { health: ConnectionHealth }) {
+  return (
+    <div className="rounded-md border p-4">
+      <div className="mb-3 flex items-center gap-2">
+        {health.reachable ? (
+          <Check className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+        ) : (
+          <AlertCircle className="h-4 w-4 text-destructive" />
+        )}
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Reachability
+        </h3>
+        <GatewayHealthBadge health={health} />
+      </div>
+      <dl className="space-y-2 text-xs">
+        <div className="flex justify-between gap-4">
+          <dt className="text-muted-foreground">Last successful call</dt>
+          <dd className="font-mono">
+            {health.last_success
+              ? new Date(health.last_success).toLocaleString()
+              : "never"}
+          </dd>
+        </div>
+        {health.last_error && (
+          <div className="flex justify-between gap-4">
+            <dt className="text-muted-foreground">Last error</dt>
+            <dd className="font-mono text-destructive break-all text-right">
+              {health.last_error}
+            </dd>
+          </div>
+        )}
+      </dl>
+    </div>
+  );
 }
 
 // APICatalogPicker renders the dropdown that points an api-kind
@@ -368,9 +452,12 @@ export function ConnectionsPanel() {
                       <span className="block truncate font-mono text-sm font-medium">
                         {c.name}
                       </span>
-                      {showHealth && (
-                        <div className="mt-1">
-                          <ConnectionOAuthHealthBadge health={health} />
+                      {(showHealth || c.health) && (
+                        <div className="mt-1 flex flex-wrap items-center gap-1">
+                          {showHealth && (
+                            <ConnectionOAuthHealthBadge health={health} />
+                          )}
+                          <GatewayHealthBadge health={c.health} />
                         </div>
                       )}
                       {c.description && (
@@ -631,6 +718,13 @@ function ConnectionViewer({
           connectionName={connection.name}
           onClose={() => setRulesOpen(false)}
         />
+      )}
+
+      {/* Runtime reachability for gateway upstreams. Same state the
+          list_connections MCP tool reports, so the admin UI and the tool
+          never disagree about whether an upstream is up. */}
+      {connection.health && (
+        <GatewayHealthDetail health={connection.health} />
       )}
 
       {/* OAuth status — shown for every connection kind that supports


### PR DESCRIPTION
## Summary

Surfaces per-connection gateway reachability in the admin connections UI and reconciles it with the existing health signals, closing #584.

Before this change, `ConnectionDetail.Health` (reachable, last_success, last_error) was returned by the gateway's `ListConnections()` and rendered by the `list_connections` MCP tool, but the admin UI ignored it. An evicted or dead upstream was only observable when a downstream tool call failed. Now the admin connections panel shows it directly.

## What changed

### Shared health wire shape (single source of truth)
The `list_connections` MCP tool already mapped `toolkit.ConnectionHealth` into an RFC3339-formatted JSON shape. Rather than duplicate that mapping in the admin layer, this PR extracts a shared `toolkit.ConnectionHealthWire` type and a `(*ConnectionHealth).Wire()` method on the zero-dependency `pkg/toolkit` package, and routes both surfaces through it:
- `pkg/toolkit/connection.go:43-69` — `ConnectionHealthWire` + `Wire()` (nil receiver passthrough; `last_success` omitted when no call has succeeded).
- `pkg/platform/connections_tool.go:104` — the `list_connections` tool now calls `conn.Health.Wire()` (deleted its private copy of the struct + formatting).

So the admin UI and `list_connections` report identical health for the same connection by construction, not by two copies happening to agree.

### Admin API
- `pkg/admin/connection_handler.go` — `effectiveConnection` gains a `health` field, populated from `conn.Health.Wire()` for live gateway connections (`GET /admin/connection-instances/effective`). A DB-only instance with no live session has no health.
- `pkg/admin/system.go` — `connectionInfo` gains the same `health` field (`GET /admin/connections`).

### UI
- `ui/src/pages/settings/ConnectionsPanel.tsx` — a reachability badge on each connection list row (green `reachable` / red `unreachable` with the last error in the tooltip) and a "Reachability" detail card in the selected-connection pane (last successful call time, last error).
- `ui/src/api/admin/hooks.ts:1430` — `useEffectiveConnections` now polls (`refetchInterval: 10000`, matching the adjacent OAuth-health badge) so the reachability badge reflects an upstream going down or recovering at runtime instead of being static after page load. A background refetch does not clobber an in-progress edit: the editor holds its own form state and only reads the connection for dirty comparison.
- `ui/src/api/admin/types.ts` — `ConnectionHealth` type added; `health?` added to `EffectiveConnection` and `ConnectionInfo`.

### Reconciling the two definitions of "healthy"
The issue noted that gateway `Status().Healthy` (`client != nil`, i.e. a session exists) and `ConnectionHealth.Reachable` (`client != nil && last call did not error`) disagree after a forwarded call fails with a non-session error.

The two operator-facing surfaces the issue cares about (the admin connections UI and `list_connections`) both read the reachability signal via the shared `ConnectionHealthWire`, so they agree by construction. The gateway `/status` endpoint's `Healthy` flag is a distinct, session-level signal ("is the upstream session established?") that backs the OAuth/session panel and is not rendered as connection health. This PR documents that distinction rather than collapsing the two axes (`pkg/toolkits/gateway/toolkit.go:908-921`), and documents the passive nature of reachability (observed from forwarded traffic, cleared by the next successful call) on the shared type (`pkg/toolkit/connection.go:29-37`).

## Acceptance criteria
- The admin connections view shows gateway reachability, last successful call time, and last error.
- A connection that is up shows reachable; one whose last call failed shows unreachable with the reason.
- The admin UI and `list_connections` report the same health state for the same connection (shared `ConnectionHealthWire`).

## Tests
- `pkg/toolkit/connection_test.go` — `Wire()` unit test (nil, formatted success time, omitted-when-zero), 100% coverage of the new method.
- `pkg/admin/connection_handler_test.go`, `pkg/admin/system_test.go` — health surfacing on both endpoints (reachable / unreachable / untracked omits the field).
- `pkg/toolkits/gateway/toolkit_test.go` — `TestStatus_HealthyIsSessionLevel_DistinctFromReachability` guards the intentional divergence: after an unrecoverable call failure the session-level `Healthy` stays true while reachability flips false.

## Docs
- `docs/server/admin-api.md` — documents the `health` object on `GET /admin/connections`.
- `docs/llms-full.txt` — documents the reachability-vs-session distinction.
- Swagger regenerated (`internal/apidocs/`).

`make verify` passes (race tests, ≥80% total and patch coverage, lint, gosec, semgrep, CodeQL, mutation, GoReleaser dry-run).
