### PR TITLE
test(gates): assert read-back and exercise the real assembled system (#582)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,15 +514,15 @@ build-with-ui: frontend-build build
 
 E2E_COMPOSE := docker compose -f docker-compose.e2e.yml
 
-## e2e-up: Start E2E test environment (PostgreSQL, Trino, MinIO)
+## e2e-up: Start E2E test environment (PostgreSQL, Trino, SeaweedFS)
 e2e-up:
 	@echo "Starting E2E test environment..."
 	@echo "NOTE: For full E2E tests, also run 'datahub docker quickstart' separately"
-	$(E2E_COMPOSE) up -d postgres trino minio
+	$(E2E_COMPOSE) up -d postgres trino seaweedfs
 	@echo "Waiting for services to be healthy..."
 	@./scripts/wait-for-services.sh
 	@echo "Running setup containers..."
-	$(E2E_COMPOSE) up minio-setup trino-setup
+	$(E2E_COMPOSE) up seaweedfs-setup trino-setup
 	@echo "E2E environment is ready!"
 
 ## e2e-down: Stop E2E test environment
@@ -571,7 +571,7 @@ e2e-logs:
 ## e2e-clean: Remove all E2E artifacts and volumes
 e2e-clean: e2e-down
 	@echo "Cleaning E2E artifacts..."
-	@docker volume rm -f mcp-data-platform_postgres_data mcp-data-platform_minio_data 2>/dev/null || true
+	@docker volume rm -f mcp-data-platform_postgres_data mcp-data-platform_seaweedfs_data 2>/dev/null || true
 	@echo "E2E cleanup complete."
 
 # =============================================================================

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -13,7 +13,9 @@
 services:
   # PostgreSQL for OAuth/Audit storage
   postgres:
-    image: postgres:16-alpine
+    # pgvector image: the platform's embedded migrations create the `vector`
+    # extension (000031+), so a plain postgres image fails platform startup.
+    image: pgvector/pgvector:pg16
     container_name: e2e-postgres
     environment:
       POSTGRES_USER: platform

--- a/pkg/toolkits/knowledge/changeset_store_realdb_integration_test.go
+++ b/pkg/toolkits/knowledge/changeset_store_realdb_integration_test.go
@@ -1,0 +1,87 @@
+//go:build integration
+
+package knowledge
+
+// Real-Postgres round-trip test for the changeset store. postgresChangesetStore
+// is the apply_knowledge persistence path: it marshals map/slice fields to JSONB
+// columns, scans them back, and toggles rollback state with a conditional
+// UPDATE. None of that is exercised against a real engine by the in-memory
+// store tests, so a JSONB/enum/constraint mismatch or a broken rollback guard
+// would ship green. This asserts write -> read-back -> list -> rollback against
+// the actual schema (migration 000008).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/internal/testdb"
+)
+
+func TestChangesetStore_RealDB_RoundTripAndRollback(t *testing.T) {
+	store := NewPostgresChangesetStore(testdb.New(t))
+	ctx := context.Background()
+
+	const urn = "urn:li:dataset:(urn:li:dataPlatform:trino,memory.e2e_test.test_orders,PROD)"
+	cs := Changeset{
+		ID:               "cs_realdb_1",
+		TargetURN:        urn,
+		ChangeType:       "update_description",
+		PreviousValue:    map[string]any{"description": "old"},
+		NewValue:         map[string]any{"description": "new"},
+		SourceInsightIDs: []string{"ins_a", "ins_b"},
+		ApprovedBy:       "admin@example.com",
+		AppliedBy:        "admin@example.com",
+	}
+	require.NoError(t, store.InsertChangeset(ctx, cs), "insert changeset")
+
+	// Read-back: every JSONB column must round-trip to the written value.
+	got, err := store.GetChangeset(ctx, cs.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, cs.ID, got.ID)
+	assert.Equal(t, cs.TargetURN, got.TargetURN)
+	assert.Equal(t, cs.ChangeType, got.ChangeType)
+	assert.Equal(t, "old", got.PreviousValue["description"])
+	assert.Equal(t, "new", got.NewValue["description"])
+	assert.Equal(t, []string{"ins_a", "ins_b"}, got.SourceInsightIDs)
+	assert.Equal(t, cs.ApprovedBy, got.ApprovedBy)
+	assert.Equal(t, cs.AppliedBy, got.AppliedBy)
+	assert.False(t, got.RolledBack, "freshly inserted changeset is not rolled back")
+	assert.False(t, got.CreatedAt.IsZero(), "created_at default must populate")
+
+	// List by the target URN finds it; the not-rolled-back filter includes it.
+	notRolledBack := false
+	list, total, err := store.ListChangesets(ctx, ChangesetFilter{EntityURN: urn, RolledBack: &notRolledBack})
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, list, 1)
+	assert.Equal(t, cs.ID, list[0].ID)
+
+	// The rolled-back filter excludes it while it is still active.
+	rolledBack := true
+	_, total, err = store.ListChangesets(ctx, ChangesetFilter{EntityURN: urn, RolledBack: &rolledBack})
+	require.NoError(t, err)
+	assert.Equal(t, 0, total, "active changeset must not appear under a rolled_back=true filter")
+
+	// Rollback flips the state columns.
+	require.NoError(t, store.RollbackChangeset(ctx, cs.ID, "operator@example.com"))
+	got, err = store.GetChangeset(ctx, cs.ID)
+	require.NoError(t, err)
+	assert.True(t, got.RolledBack, "rolled_back column must be set")
+	assert.Equal(t, "operator@example.com", got.RolledBackBy)
+	require.NotNil(t, got.RolledBackAt, "rolled_back_at must populate")
+
+	// After rollback it appears under the rolled_back=true filter.
+	rolled, total, err := store.ListChangesets(ctx, ChangesetFilter{EntityURN: urn, RolledBack: &rolledBack})
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, rolled, 1)
+	assert.Equal(t, cs.ID, rolled[0].ID)
+
+	// A second rollback is a no-op guarded by the WHERE rolled_back = FALSE clause.
+	err = store.RollbackChangeset(ctx, cs.ID, "operator@example.com")
+	require.Error(t, err, "double rollback must report not-found/already-rolled-back")
+}

--- a/pkg/toolkits/knowledge/memory_adapter_realdb_integration_test.go
+++ b/pkg/toolkits/knowledge/memory_adapter_realdb_integration_test.go
@@ -1,0 +1,89 @@
+//go:build integration
+
+package knowledge
+
+// Real-Postgres round-trip for the capture_insight -> recall_insight path.
+// Captured insights persist as knowledge-dimension memory records through
+// memoryInsightAdapter, and recall_insight reads them back via the adapter's
+// lexical Search. The underlying memory store has its own RealDB test, but the
+// insight<->record mapping (status mapping, owner/dimension scoping, the
+// metadata round-trip) is adapter logic that nothing exercises against a real
+// engine. This asserts capture -> Get -> List -> Search read-back on real
+// Postgres.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/internal/testdb"
+	"github.com/txn2/mcp-data-platform/pkg/memory"
+)
+
+func TestMemoryInsightAdapter_RealDB_CaptureRecallRoundTrip(t *testing.T) {
+	adapter := NewMemoryInsightAdapter(memory.NewPostgresStore(testdb.New(t)))
+	ctx := context.Background()
+
+	const owner = "analyst@example.com"
+	ins := Insight{
+		ID:          "ins_realdb_1",
+		CapturedBy:  owner,
+		Source:      "agent_discovery",
+		Category:    "business_context",
+		InsightText: "The transactions table is partitioned by transaction_date.",
+		Confidence:  "high",
+		Status:      StatusPending,
+	}
+	require.NoError(t, adapter.Insert(ctx, ins), "capture_insight write path")
+
+	// Read-back by ID: the record-to-insight mapping must reproduce the fields.
+	got, err := adapter.Get(ctx, ins.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, ins.ID, got.ID)
+	assert.Equal(t, ins.InsightText, got.InsightText)
+	assert.Equal(t, ins.Category, got.Category)
+	assert.Equal(t, ins.Confidence, got.Confidence)
+	assert.Equal(t, StatusPending, got.Status, "a freshly captured insight reads back as pending")
+
+	// Read-back via List, scoped to the owner (knowledge dimension is enforced
+	// by the adapter). The pending insight must appear.
+	list, _, err := adapter.List(ctx, InsightFilter{CapturedBy: owner, Status: StatusPending})
+	require.NoError(t, err)
+	assert.True(t, containsInsight(list, ins.ID), "captured insight must appear in the owner's pending list")
+
+	// Read-back via the recall_insight path: the adapter's lexical Search must
+	// find it by a distinctive term, owner-scoped, against the real tsvector.
+	searcher, ok := adapter.(InsightSearcher)
+	require.True(t, ok, "memory-backed adapter implements InsightSearcher")
+	scored, err := searcher.Search(ctx, InsightSearchQuery{
+		QueryText:  "partitioned",
+		CapturedBy: owner,
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	found := false
+	for _, s := range scored {
+		if s.Insight.ID == ins.ID {
+			found = true
+			assert.Greater(t, s.Score, 0.0, "lexical match must score above zero")
+		}
+	}
+	assert.True(t, found, "recall_insight must read back the captured insight via lexical search")
+
+	// A different owner must not see it (owner scoping is enforced in SQL).
+	other, _, err := adapter.List(ctx, InsightFilter{CapturedBy: "stranger@example.com", Status: StatusPending})
+	require.NoError(t, err)
+	assert.False(t, containsInsight(other, ins.ID), "another owner must not see the insight")
+}
+
+func containsInsight(insights []Insight, id string) bool {
+	for _, in := range insights {
+		if in.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/scripts/wait-for-services.sh
+++ b/scripts/wait-for-services.sh
@@ -34,9 +34,11 @@ wait_for_service "PostgreSQL" \
 wait_for_service "Trino" \
     "docker exec e2e-trino trino --execute 'SELECT 1'"
 
-# Wait for MinIO
-wait_for_service "MinIO" \
-    "docker exec e2e-minio mc ready local 2>/dev/null || curl -sf http://localhost:9000/minio/health/live"
+# Wait for SeaweedFS (S3-compatible gateway on :9000). A plain connectivity
+# probe: the gateway answers with an HTTP status (200/403) once up, so a
+# successful connection — not a 2xx — is the readiness signal.
+wait_for_service "SeaweedFS (S3)" \
+    "curl -s -o /dev/null http://localhost:9000"
 
 # Wait for DataHub (if using datahub quickstart)
 if docker ps --format '{{.Names}}' | grep -q "datahub-gms"; then

--- a/test/e2e/cross_injection_test.go
+++ b/test/e2e/cross_injection_test.go
@@ -262,7 +262,7 @@ func TestDataHubToS3Enrichment(t *testing.T) {
 				return
 			}
 
-			// Verify storage context is present (availability depends on MinIO connectivity)
+			// Verify storage context is present (availability depends on SeaweedFS connectivity)
 			sc := helpers.AssertHasStorageContext(t, result)
 			if sc == nil {
 				t.Error("expected storage_context to be present")

--- a/test/e2e/enrichment_realserver_test.go
+++ b/test/e2e/enrichment_realserver_test.go
@@ -1,0 +1,142 @@
+//go:build integration
+
+package e2e
+
+// End-to-end enrichment + documented-parameter assertions through the REAL
+// assembled server. Unlike cross_injection_test.go (which mocks the tool result
+// and exercises only the enrichment middleware), this drives an in-process MCP
+// session against the platform's own mcp.Server, so the real trino_describe_table
+// / datahub_search handlers run the real query -> URN -> enrichment path the way
+// a deployed client does.
+//
+// The include_sample parameter assertion needs only Trino (make e2e-up). The
+// semantic/query enrichment assertions need DataHub seeded with
+// test/e2e/testdata/datahub (make e2e-seed) and skip cleanly when DataHub is
+// not reachable.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/test/e2e/helpers"
+)
+
+// The seeded e2e fixture: Trino table memory.e2e_test.test_orders, mirrored in
+// DataHub (test/e2e/testdata/datahub/datasets.json) with owners alice/bob and
+// the ecommerce tag/domain.
+const (
+	enrichCatalog = "memory"
+	enrichSchema  = "e2e_test"
+	enrichTable   = "test_orders"
+)
+
+func TestEnrichment_RealAssembledServer(t *testing.T) {
+	cfg := helpers.DefaultE2EConfig()
+	ctx, cancel := helpers.TestContext(cfg.Timeout)
+	defer cancel()
+
+	tp, err := helpers.NewTestPlatform(ctx, cfg)
+	require.NoError(t, err, "build assembled platform")
+	defer func() { _ = tp.Close() }()
+
+	// Start registers every toolkit's tools (and the platform-level tools) on
+	// the MCP server and runs the lifecycle callbacks — the step a deployment
+	// performs before serving. Without it the server has no tools to call.
+	require.NoError(t, tp.Platform.Start(ctx), "start assembled platform")
+
+	session, err := helpers.ConnectInMemory(ctx, tp.MCPServer())
+	require.NoError(t, err, "connect in-process MCP session to the assembled server")
+	defer func() { _ = session.Close() }()
+
+	// Documented-parameter effect: include_sample is Trino-only, so this runs
+	// with just make e2e-up and proves the real handler executed through the
+	// full middleware chain (not a mock result).
+	t.Run("include_sample parameter has an observable effect", func(t *testing.T) {
+		with := describeTable(t, ctx, session, true)
+		sample, _ := with["sample"].([]any)
+		assert.NotEmpty(t, sample, "include_sample=true must return sample rows for a populated table")
+
+		without := describeTable(t, ctx, session, false)
+		emptySample, _ := without["sample"].([]any)
+		assert.Empty(t, emptySample, "include_sample=false must omit sample rows")
+	})
+
+	// Trino -> DataHub: the describe result must carry the seeded semantic
+	// context (owners/tags) when DataHub is up.
+	t.Run("trino_describe_table is enriched with semantic context", func(t *testing.T) {
+		if helpers.SkipIfDataHubUnavailable(cfg) {
+			t.Skip("DataHub not reachable; run `datahub docker quickstart` + `make e2e-seed` for enrichment assertions")
+		}
+		res := callTool(t, ctx, session, "trino_describe_table", map[string]any{
+			"catalog": enrichCatalog, "schema": enrichSchema, "table": enrichTable,
+		})
+		sc := helpers.AssertHasSemanticContext(t, res)
+		helpers.AssertOwnerPresent(t, sc, "urn:li:corpuser:alice")
+		helpers.AssertOwnerPresent(t, sc, "urn:li:corpuser:bob")
+		helpers.AssertTagPresent(t, sc, "ecommerce")
+	})
+
+	// DataHub -> Trino: a datahub_search result must carry query availability
+	// (query_context) for the seeded dataset when DataHub is up.
+	t.Run("datahub_search is enriched with query context", func(t *testing.T) {
+		if helpers.SkipIfDataHubUnavailable(cfg) {
+			t.Skip("DataHub not reachable; run `datahub docker quickstart` + `make e2e-seed` for enrichment assertions")
+		}
+		res := callTool(t, ctx, session, "datahub_search", map[string]any{
+			"query":    "test_orders",
+			"platform": "trino",
+		})
+		helpers.AssertHasQueryContext(t, res)
+	})
+}
+
+// describeTable calls trino_describe_table through the session and returns the
+// parsed structured result (columns, sample, ...).
+func describeTable(t *testing.T, ctx context.Context, s *mcp.ClientSession, includeSample bool) map[string]any {
+	t.Helper()
+	res := callTool(t, ctx, s, "trino_describe_table", map[string]any{
+		"catalog":        enrichCatalog,
+		"schema":         enrichSchema,
+		"table":          enrichTable,
+		"include_sample": includeSample,
+	})
+	return structuredMap(t, res)
+}
+
+// structuredMap returns a tool result's structured output as a map. The
+// describe tool returns a typed DescribeTableOutput (columns, sample, ...) in
+// StructuredContent; the text content is a markdown rendering, so parse the
+// structured field for assertions.
+func structuredMap(t *testing.T, res *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	require.NotNil(t, res.StructuredContent, "tool result has no structured content")
+	b, err := json.Marshal(res.StructuredContent)
+	require.NoError(t, err, "marshal structured content")
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(b, &out), "unmarshal structured content")
+	return out
+}
+
+// callTool invokes a tool over the in-process session and fails on a transport
+// or tool-level error.
+func callTool(t *testing.T, ctx context.Context, s *mcp.ClientSession, name string, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	res, err := s.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: args})
+	require.NoError(t, err, "%s transport error", name)
+	require.False(t, res.IsError, "%s returned a tool error: %s", name, firstText(res))
+	return res
+}
+
+func firstText(res *mcp.CallToolResult) string {
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			return tc.Text
+		}
+	}
+	return ""
+}

--- a/test/e2e/helpers/platform.go
+++ b/test/e2e/helpers/platform.go
@@ -68,7 +68,12 @@ func buildPlatformConfig(e2eCfg *E2EConfig) *platform.Config {
 			DataHubStorageEnrichment: new(true),
 		},
 		Toolkits: map[string]any{
+			// enabled:true is required per kind: the registry loader skips any
+			// toolkit kind that does not set it (loader.LoadFromMap). Without
+			// this the trino/datahub/s3 toolkits load nothing and their tools
+			// never register on the assembled server.
 			"trino": map[string]any{
+				"enabled": true,
 				"instances": map[string]any{
 					"e2e": map[string]any{
 						"host":            e2eCfg.TrinoHost,
@@ -81,14 +86,22 @@ func buildPlatformConfig(e2eCfg *E2EConfig) *platform.Config {
 				},
 			},
 			"datahub": map[string]any{
+				"enabled": true,
 				"instances": map[string]any{
 					"e2e": map[string]any{
-						"url":   e2eCfg.DataHubURL,
-						"token": e2eCfg.DataHubToken,
+						"url": e2eCfg.DataHubURL,
+						// The datahub provider requires a non-empty token at
+						// construction. Default a placeholder so the assembled
+						// platform still builds when DataHub is not configured,
+						// letting Trino/S3 assertions run; enrichment assertions
+						// gate on real reachability and skip in that case. A real
+						// E2E_DATAHUB_TOKEN takes precedence for full runs.
+						"token": orDefault(e2eCfg.DataHubToken, "e2e-placeholder-token"),
 					},
 				},
 			},
 			"s3": map[string]any{
+				"enabled": true,
 				"instances": map[string]any{
 					"e2e": map[string]any{
 						"endpoint":          e2eCfg.S3Endpoint,
@@ -103,7 +116,35 @@ func buildPlatformConfig(e2eCfg *E2EConfig) *platform.Config {
 		Database: platform.DatabaseConfig{
 			DSN: e2eCfg.PostgresDSN,
 		},
+		// Allow an anonymous caller mapped to an allow-all admin persona so a
+		// test driving the assembled server over an in-process session is
+		// authorized. Personas are deny-by-default (DefaultPersona denies "*"),
+		// so without this every tool call through the real middleware chain
+		// would be rejected before reaching the handler. Tests that bypass the
+		// authorizer (calling the enrichment middleware directly) are unaffected.
+		Auth: platform.AuthConfig{
+			AllowAnonymous: true,
+		},
+		Personas: platform.PersonasConfig{
+			Definitions: map[string]platform.PersonaDef{
+				"admin": {
+					DisplayName: "E2E Admin",
+					Roles:       []string{"admin"},
+					Tools:       platform.ToolRulesDef{Allow: []string{"*"}},
+					Connections: platform.ConnectionRulesDef{Allow: []string{"*"}},
+				},
+			},
+			DefaultPersona: "admin",
+		},
 	}
+}
+
+// orDefault returns v when non-empty, otherwise def.
+func orDefault(v, def string) string {
+	if v == "" {
+		return def
+	}
+	return v
 }
 
 // Close closes the test platform.
@@ -142,9 +183,12 @@ func TestContext(timeout time.Duration) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), timeout)
 }
 
-// SkipIfDataHubUnavailable skips the test if DataHub is not available.
+// SkipIfDataHubUnavailable reports whether DataHub is not actually reachable, so
+// enrichment tests skip cleanly instead of failing when it is down. It probes
+// the real endpoint rather than only checking that a URL is configured
+// (IsDataHubAvailable is always true because the URL has a default).
 func SkipIfDataHubUnavailable(cfg *E2EConfig) bool {
-	return !cfg.IsDataHubAvailable()
+	return !DataHubReachable(cfg)
 }
 
 // MockMCPRequest implements mcp.Request for E2E testing.

--- a/test/e2e/helpers/session.go
+++ b/test/e2e/helpers/session.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ConnectInMemory wires an in-process MCP client session to the assembled
+// server via paired in-memory transports. Calls made on the returned session
+// run through the full receiving-middleware chain (auth, authz, audit,
+// enrichment) and the real registered tool handlers — the path a deployed
+// client takes — so a test can assert end-to-end behavior the
+// call-the-middleware-directly pattern cannot. The server session runs in the
+// background until the client session is closed.
+func ConnectInMemory(ctx context.Context, srv *mcp.Server) (*mcp.ClientSession, error) {
+	if srv == nil {
+		return nil, fmt.Errorf("nil server")
+	}
+	serverT, clientT := mcp.NewInMemoryTransports()
+	if _, err := srv.Connect(ctx, serverT, nil); err != nil {
+		return nil, fmt.Errorf("server connect: %w", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "e2e-inproc", Version: "1.0.0"}, nil)
+	cs, err := client.Connect(ctx, clientT, nil)
+	if err != nil {
+		return nil, fmt.Errorf("client connect: %w", err)
+	}
+	return cs, nil
+}
+
+// DataHubReachable reports whether the configured DataHub endpoint accepts a TCP
+// connection within a short timeout. IsDataHubAvailable only checks that a URL
+// is configured (it has a default, so it is always true); this probes the real
+// service, so an enrichment assertion can skip cleanly when DataHub is not up
+// rather than fail. The Trino-only assertions need no DataHub and do not gate on
+// this.
+func DataHubReachable(cfg *E2EConfig) bool {
+	if cfg == nil || cfg.DataHubURL == "" {
+		return false
+	}
+	u, err := url.Parse(cfg.DataHubURL)
+	if err != nil {
+		return false
+	}
+	host := u.Host
+	if host == "" {
+		host = cfg.DataHubURL
+	}
+	if u.Port() == "" {
+		host = net.JoinHostPort(u.Hostname(), "8080")
+	}
+	conn, err := net.DialTimeout("tcp", host, 2*time.Second)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/test/e2e/init/postgres/01_init.sql
+++ b/test/e2e/init/postgres/01_init.sql
@@ -1,81 +1,11 @@
 -- E2E Test Database Initialization
--- Creates schema for OAuth and Audit tables
-
--- OAuth tables (simplified for testing)
-CREATE TABLE IF NOT EXISTS oauth_clients (
-    id VARCHAR(255) PRIMARY KEY,
-    secret_hash VARCHAR(255) NOT NULL,
-    name VARCHAR(255) NOT NULL,
-    redirect_uris TEXT[] NOT NULL DEFAULT '{}',
-    grant_types TEXT[] NOT NULL DEFAULT '{}',
-    response_types TEXT[] NOT NULL DEFAULT '{}',
-    scopes TEXT[] NOT NULL DEFAULT '{}',
-    token_endpoint_auth_method VARCHAR(50) DEFAULT 'client_secret_basic',
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
-);
-
-CREATE TABLE IF NOT EXISTS oauth_authorization_codes (
-    code VARCHAR(255) PRIMARY KEY,
-    client_id VARCHAR(255) NOT NULL REFERENCES oauth_clients(id),
-    user_id VARCHAR(255) NOT NULL,
-    redirect_uri TEXT NOT NULL,
-    scope TEXT,
-    code_challenge VARCHAR(255),
-    code_challenge_method VARCHAR(10),
-    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
-);
-
-CREATE TABLE IF NOT EXISTS oauth_access_tokens (
-    token VARCHAR(255) PRIMARY KEY,
-    client_id VARCHAR(255) NOT NULL REFERENCES oauth_clients(id),
-    user_id VARCHAR(255) NOT NULL,
-    scope TEXT,
-    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
-);
-
-CREATE TABLE IF NOT EXISTS oauth_refresh_tokens (
-    token VARCHAR(255) PRIMARY KEY,
-    access_token VARCHAR(255) NOT NULL REFERENCES oauth_access_tokens(token),
-    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
-);
-
--- Audit tables
-CREATE TABLE IF NOT EXISTS audit_logs (
-    id BIGSERIAL PRIMARY KEY,
-    timestamp TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    request_id VARCHAR(255) NOT NULL,
-    user_id VARCHAR(255),
-    user_email VARCHAR(255),
-    persona_name VARCHAR(100),
-    tool_name VARCHAR(255) NOT NULL,
-    toolkit_kind VARCHAR(100),
-    toolkit_name VARCHAR(255),
-    connection_name VARCHAR(255),
-    success BOOLEAN NOT NULL,
-    error_message TEXT,
-    duration_ms INTEGER,
-    metadata JSONB
-);
-
-CREATE INDEX IF NOT EXISTS idx_audit_logs_timestamp ON audit_logs(timestamp DESC);
-CREATE INDEX IF NOT EXISTS idx_audit_logs_user_id ON audit_logs(user_id);
-CREATE INDEX IF NOT EXISTS idx_audit_logs_tool_name ON audit_logs(tool_name);
-
--- Insert test OAuth client
-INSERT INTO oauth_clients (id, secret_hash, name, redirect_uris, grant_types, scopes)
-VALUES (
-    'e2e-test-client',
-    '$2a$10$abcdefghijklmnopqrstuvwxyz123456789', -- bcrypt hash placeholder
-    'E2E Test Client',
-    ARRAY['http://localhost:3000/callback'],
-    ARRAY['authorization_code', 'refresh_token'],
-    ARRAY['read', 'write']
-) ON CONFLICT (id) DO NOTHING;
-
--- Grant statement for test purposes
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO platform;
-GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO platform;
+--
+-- Intentionally minimal. The platform owns its schema through the embedded
+-- golang-migrate migrations it runs at startup (oauth, audit, knowledge,
+-- memory, resources, the `vector` extension, etc.). This file previously
+-- pre-created simplified OAuth/audit tables, which then conflicted with those
+-- migrations ("column ... does not exist") and prevented the assembled platform
+-- from starting against the e2e database — defeating the gate. Let migrations
+-- be the single source of truth; this file only needs to leave a clean database
+-- (created by the compose POSTGRES_DB env) for them to populate.
+SELECT 1;

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -107,22 +107,31 @@ func TestSmoke_WriteToolsRoundTrip(t *testing.T) {
 
 	t.Run("manage_prompt create", func(t *testing.T) {
 		name := fmt.Sprintf("smoke-prompt-%d", stamp)
+		content := fmt.Sprintf("Smoke test prompt body %d.", stamp)
 		out := call(t, ctx, s, "manage_prompt", map[string]any{
 			"command": "create",
 			"name":    name,
-			"content": "Smoke test prompt body.",
+			"content": content,
 			"scope":   "personal",
 		})
 		if out["status"] != "created" {
 			t.Fatalf("manage_prompt create: unexpected result: %v", out)
+		}
+		// Read-back: the write must be retrievable with the content intact.
+		got := call(t, ctx, s, "manage_prompt", map[string]any{
+			"command": "get", "name": name, "scope": "personal",
+		})
+		if got["content"] != content {
+			t.Fatalf("manage_prompt read-back: content mismatch: got %q want %q", got["content"], content)
 		}
 		// Cleanup.
 		callRaw(ctx, s, "manage_prompt", map[string]any{"command": "delete", "name": name, "scope": "personal"})
 	})
 
 	t.Run("save_artifact", func(t *testing.T) {
+		name := fmt.Sprintf("smoke-artifact-%d", stamp)
 		out := call(t, ctx, s, "save_artifact", map[string]any{
-			"name":         fmt.Sprintf("smoke-artifact-%d", stamp),
+			"name":         name,
 			"content":      "# Smoke\nLive smoke artifact.",
 			"content_type": "text/markdown",
 		})
@@ -130,13 +139,25 @@ func TestSmoke_WriteToolsRoundTrip(t *testing.T) {
 		if id == "" {
 			t.Fatalf("save_artifact: no asset_id in result: %v", out)
 		}
+		// Read-back: the asset must be retrievable with its metadata intact.
+		got := call(t, ctx, s, "manage_artifact", map[string]any{"action": "get", "asset_id": id})
+		if got["name"] != name {
+			t.Fatalf("save_artifact read-back: name mismatch: got %q want %q", got["name"], name)
+		}
+		if got["content_type"] != "text/markdown" {
+			t.Fatalf("save_artifact read-back: content_type mismatch: got %v", got["content_type"])
+		}
+		if size, _ := got["size_bytes"].(float64); size <= 0 {
+			t.Fatalf("save_artifact read-back: size_bytes not persisted: %v", got["size_bytes"])
+		}
 		callRaw(ctx, s, "manage_artifact", map[string]any{"action": "delete", "asset_id": id})
 	})
 
 	t.Run("capture_insight", func(t *testing.T) {
+		marker := fmt.Sprintf("smokeinsight%d", stamp)
 		out := call(t, ctx, s, "capture_insight", map[string]any{
 			"category":     "business_context",
-			"insight_text": "Smoke test insight: this is a synthetic live-smoke record.",
+			"insight_text": fmt.Sprintf("Smoke test insight %s: synthetic live-smoke record.", marker),
 			"confidence":   "low",
 			"source":       "agent_discovery",
 		})
@@ -144,15 +165,21 @@ func TestSmoke_WriteToolsRoundTrip(t *testing.T) {
 		if id == "" {
 			t.Fatalf("capture_insight: no insight_id in result: %v", out)
 		}
+		// Read-back: recall_insight must find the captured record by its marker.
+		got := call(t, ctx, s, "recall_insight", map[string]any{"query": marker, "limit": float64(10)})
+		if !recallContainsID(got, "insights", "insight", id) {
+			t.Fatalf("capture_insight read-back: recall_insight did not return id %s: %v", id, got)
+		}
 		callRaw(ctx, s, "apply_knowledge", map[string]any{
 			"action": "reject", "insight_ids": []string{id}, "review_notes": "smoke cleanup",
 		})
 	})
 
 	t.Run("memory_manage remember", func(t *testing.T) {
+		marker := fmt.Sprintf("smokememory%d", stamp)
 		out := call(t, ctx, s, "memory_manage", map[string]any{
 			"command":    "remember",
-			"content":    "Smoke test memory: synthetic live-smoke preference record.",
+			"content":    fmt.Sprintf("Smoke test memory %s: synthetic preference record.", marker),
 			"dimension":  "preference",
 			"confidence": "low",
 		})
@@ -160,6 +187,124 @@ func TestSmoke_WriteToolsRoundTrip(t *testing.T) {
 		if id == "" {
 			t.Fatalf("memory_manage remember: no id in result: %v", out)
 		}
+		// Read-back: memory_recall must return the freshly remembered record.
+		// memory_recall serializes each hit as a memory.ScoredRecord, whose
+		// fields carry no json tags, so the nested object key is "Record"
+		// (capitalized), not "record".
+		got := call(t, ctx, s, "memory_recall", map[string]any{
+			"query": marker, "include_stale": true, "limit": float64(10),
+		})
+		if !recallContainsID(got, "memories", "Record", id) {
+			t.Fatalf("memory_manage read-back: memory_recall did not return id %s: %v", id, got)
+		}
 		callRaw(ctx, s, "memory_manage", map[string]any{"command": "forget", "id": id})
 	})
+}
+
+// probe calls a read-only tool and returns a non-nil error only when the call
+// fails (transport error or a tool-level IsError). Empty results are healthy:
+// liveness is "the toolkit answered", not "the toolkit has data".
+func probe(ctx context.Context, s *mcp.ClientSession, name string, args map[string]any) error {
+	res, err := s.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: args})
+	if err != nil {
+		return fmt.Errorf("transport error: %w", err)
+	}
+	if res.IsError {
+		return fmt.Errorf("tool error: %s", firstText(res))
+	}
+	return nil
+}
+
+// TestSmoke_ToolkitLiveness asserts that every toolkit the deployment reports as
+// configured can actually answer one read-only call, and that every gateway
+// connection reporting runtime health is reachable. A dark toolkit or a dead
+// upstream — the class of failure that shipped silently before — fails the gate
+// at deploy time instead of when a user hits it. Toolkit kinds the deployment
+// does not run are skipped, so the gate is portable across deployments.
+func TestSmoke_ToolkitLiveness(t *testing.T) {
+	s, ctx := smokeSession(t)
+
+	info := call(t, ctx, s, "platform_info", map[string]any{})
+	kindsRaw, _ := info["toolkits"].([]any)
+	if len(kindsRaw) == 0 {
+		t.Fatalf("platform_info reported no toolkits: %v", info)
+	}
+	present := make(map[string]bool, len(kindsRaw))
+	for _, k := range kindsRaw {
+		if ks, ok := k.(string); ok {
+			present[ks] = true
+		}
+	}
+
+	// One cheap read-only probe per toolkit kind. The platform kind is already
+	// exercised by the platform_info call above; the gateway kinds (mcp, api)
+	// are probed per-connection via list_connections health below.
+	probes := []struct {
+		kind, tool string
+		args       map[string]any
+	}{
+		{"trino", "trino_browse", map[string]any{}},
+		{"datahub", "datahub_search", map[string]any{"query": "*"}},
+		{"s3", "s3_list_buckets", map[string]any{}},
+		{"memory", "memory_recall", map[string]any{"query": "liveness"}},
+		{"knowledge", "recall_insight", map[string]any{"query": "liveness"}},
+		{"portal", "manage_artifact", map[string]any{"action": "list"}},
+	}
+	for _, p := range probes {
+		if !present[p.kind] {
+			continue
+		}
+		if err := probe(ctx, s, p.tool, p.args); err != nil {
+			t.Errorf("toolkit %q is dark: %s failed: %v", p.kind, p.tool, err)
+		}
+	}
+
+	// Gateway/API connections expose runtime reachability via list_connections
+	// (the health surface from #584). A connection that reports an error is a
+	// dead upstream and fails the gate. A connection that is simply unreachable
+	// with no error (e.g. an authorization_code connection awaiting its first
+	// sign-in) is not flagged: it never made a call, so it is pending, not dark.
+	conns := call(t, ctx, s, "list_connections", map[string]any{})
+	entries, _ := conns["connections"].([]any)
+	for _, e := range entries {
+		m, ok := e.(map[string]any)
+		if !ok {
+			continue
+		}
+		health, ok := m["health"].(map[string]any)
+		if !ok {
+			continue // kinds without reachability tracking
+		}
+		reachable, _ := health["reachable"].(bool)
+		lastErr, _ := health["last_error"].(string)
+		if !reachable && lastErr != "" {
+			t.Errorf("connection %v/%v is unreachable: %s", m["kind"], m["name"], lastErr)
+		}
+	}
+}
+
+// recallContainsID reports whether a recall-style response contains an item
+// whose nested object carries the given id. Recall tools wrap each hit as
+// {<arrayKey>: [{<objKey>: {id: ...}}]} (e.g. insights[].insight.id,
+// memories[].Record.id), so the read-back matches the created id exactly rather
+// than relying on result ordering.
+func recallContainsID(resp map[string]any, arrayKey, objKey, id string) bool {
+	items, ok := resp[arrayKey].([]any)
+	if !ok {
+		return false
+	}
+	for _, it := range items {
+		m, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+		obj, ok := m[objKey].(map[string]any)
+		if !ok {
+			continue
+		}
+		if obj["id"] == id {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

Makes the smoke, real-DB, and e2e gates assert reality — write **then read back and verify**, and exercise the **real assembled server** — instead of only checking that a write returned success. Closes #582.

Several runtime defects shipped because nothing asserted "write, then read back, then check the read matches," and because enrichment was asserted with a mock provider / mock tool result rather than through the deployed wiring (the same class as the prompt NULL-array defect: mocked SQL passed, real Postgres rejected).

## Smoke gate (`make smoke`, live server)

`test/smoke/smoke_test.go`:
- Every write-tool subtest now reads back what it wrote and asserts the content matches: `manage_prompt` create→`get`, `save_artifact`→`manage_artifact get`, `capture_insight`→`recall_insight`, `memory_manage remember`→`memory_recall`. Content is uniquely stamped so the read-back matches the created id exactly.
- New `TestSmoke_ToolkitLiveness`: discovers live kinds via `platform_info.toolkits`, runs one read-only probe per kind (a tool error = a dark toolkit fails the gate), and asserts every gateway connection reporting health is reachable via the `list_connections` health surface (from #584). This is the build-time complement to that runtime surface — exactly the dead-upstream case the issue calls out.

## Real-DB gate (`make verify`, real Postgres)

Two real-SQL write paths had zero real-Postgres coverage; both now do write→read-back round-trips (verified passing):
- `pkg/toolkits/knowledge/changeset_store_realdb_integration_test.go` — `postgresChangesetStore`: insert → get (every JSONB column) → list (filtered by `RolledBack`) → rollback → re-read → double-rollback guard.
- `pkg/toolkits/knowledge/memory_adapter_realdb_integration_test.go` — `capture_insight`→`recall_insight` through `memoryInsightAdapter`: insert, then read back via `Get`/`List`/lexical `Search` with owner + knowledge-dimension scoping.

## E2E enrichment (`make e2e`, real assembled server)

`test/e2e/enrichment_realserver_test.go`: the existing `cross_injection_test.go` mocks the tool **result** and exercises only the enrichment middleware. This new test drives an **in-process MCP session against the platform's own `mcp.Server`** (`Start` + `mcp.NewInMemoryTransports` + an allow-anonymous admin persona), so the **real** `trino_describe_table` / `datahub_search` handlers run the real query → URN → enrichment path a deployed client takes. It asserts:
- the `include_sample` parameter has an observable effect (Trino-only — runs with just `make e2e-up`);
- `trino_describe_table` carries the seeded `semantic_context` (owners/tags) and `datahub_search` carries `query_context` (skip cleanly when DataHub is not reachable).

## E2E harness repair

The e2e gate **could not start** before this PR (so it never actually exercised the assembled system). Fixed:
- `docker-compose.e2e.yml`: Postgres `postgres:16-alpine` → `pgvector/pgvector:pg16` — the embedded migrations create the `vector` extension, so a plain image fails platform startup.
- `test/e2e/init/postgres/01_init.sql`: stop pre-creating OAuth/audit tables with a stale schema that conflicted with the migrations (`column ... does not exist`); the embedded migrations own the schema.
- `Makefile` (`e2e-up`, `e2e-clean`) and `scripts/wait-for-services.sh`: `minio` → `seaweedfs` service names and readiness probe (the compose file uses SeaweedFS).
- `test/e2e/helpers`: `SkipIfDataHubUnavailable` now probes real reachability (it was always false because the URL has a default, so enrichment tests failed instead of skipping); a placeholder DataHub token so the platform builds when DataHub is unconfigured (a real `E2E_DATAHUB_TOKEN` takes precedence); **`enabled: true`** on the trino/datahub/s3 toolkit configs — the registry loader skips any kind without it, so those toolkits were silently registering zero tools; new `ConnectInMemory` and `DataHubReachable` helpers.

## Notes

- No production code changes.
- Validation: the RealDB tests pass under `make test-realdb`; the e2e Trino path (`include_sample`) is validated live through the real assembled server; the DataHub enrichment assertions reuse the existing assertion helpers and run under full `make e2e` with DataHub seeded (`make e2e-seed`).
- `make verify` passes (race tests, ≥80% total + patch coverage, lint, gosec, semgrep, CodeQL, mutation, GoReleaser dry-run).
