### PR TITLE
fix(feedback): address adversarial review of the feedback UI (#601)

### DIFF
--- a/docs/server/portal-user.md
+++ b/docs/server/portal-user.md
@@ -152,7 +152,7 @@ Feedback is organized into **threads**. A thread targets one asset, collection, 
 
 ### The feedback panel
 
-Open the **Feedback** button in an asset, collection, or prompt viewer to slide out the feedback panel. It lists the threads on that item with their kind, status, and activity, and a header counts how many are open and how many still need resolution. Selecting a text passage in a markdown or plain-text asset before opening **New** lets you anchor your feedback to that selection.
+Open the **Feedback** button in an asset, collection, or prompt viewer to slide out the feedback panel. It lists the threads on that item with their kind, status, and activity, and a header counts how many are open and how many still need resolution. Selecting a text passage in markdown or plain-text content (an asset or a prompt) before opening **New** lets you anchor your feedback to that selection.
 
 ![Asset feedback panel](../images/screenshots/light/user-asset-feedback-light.webp#only-light)![Asset feedback panel](../images/screenshots/dark/user-asset-feedback-dark.webp#only-dark)
 

--- a/pkg/portal/thread_handler.go
+++ b/pkg/portal/thread_handler.go
@@ -420,8 +420,12 @@ func (h *Handler) threadCounts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ids := splitIDs(r.URL.Query().Get(paramIDs))
+	// Reject (rather than silently truncate) an oversized id list: truncation
+	// would drop badges for owned items past the cap with no signal. The badge
+	// caller sends one page of ids, so hitting this means the client is wrong.
 	if len(ids) > maxThreadCountIDs {
-		ids = ids[:maxThreadCountIDs]
+		writeError(w, http.StatusBadRequest, "too many ids")
+		return
 	}
 	if !h.userIsAdmin(user) {
 		ids = h.filterOwnedTargets(r, targetType, ids, user)
@@ -455,6 +459,9 @@ func (h *Handler) filterOwnedTargets(r *http.Request, targetType string, ids []s
 }
 
 func (h *Handler) ownedAssetIDs(r *http.Request, ids []string, user *User) []string {
+	if h.deps.AssetStore == nil {
+		return nil
+	}
 	assets, err := h.deps.AssetStore.GetByIDs(r.Context(), ids)
 	if err != nil {
 		return nil

--- a/pkg/portal/thread_handler_test.go
+++ b/pkg/portal/thread_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -300,6 +301,18 @@ func TestThreadCountsAdminUnfiltered(t *testing.T) {
 	var got map[string]int
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
 	assert.Equal(t, 1, got["asset_x"])
+}
+
+func TestThreadCountsTooManyIDs(t *testing.T) {
+	threads := &mockThreadStore{counts: map[string]int{}}
+	h := newThreadTestHandler(threads, &mockAssetStore{}, &mockShareStore{}, &User{UserID: "u1"})
+	ids := make([]string, maxThreadCountIDs+1)
+	for i := range ids {
+		ids[i] = "a"
+	}
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/threads/counts?target_type=asset&ids="+strings.Join(ids, ","), nil)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Nil(t, threads.lastCountIDs, "oversized request must not reach the count query")
 }
 
 func TestThreadCountsBadTargetType(t *testing.T) {

--- a/pkg/portal/thread_handler_test.go
+++ b/pkg/portal/thread_handler_test.go
@@ -315,6 +315,21 @@ func TestThreadCountsTooManyIDs(t *testing.T) {
 	assert.Nil(t, threads.lastCountIDs, "oversized request must not reach the count query")
 }
 
+func TestThreadCountsNilAssetStore(t *testing.T) {
+	// A non-admin asset-count request with no AssetStore wired must not panic;
+	// ownedAssetIDs returns no owned ids, so the count query sees an empty set.
+	threads := &mockThreadStore{counts: map[string]int{}}
+	h := NewHandler(Deps{
+		ThreadStore: threads,
+		ShareStore:  &mockShareStore{},
+		AdminRoles:  []string{"admin"},
+		RateLimit:   RateLimitConfig{RequestsPerMinute: 600, BurstSize: 100},
+	}, testAuthMiddleware(&User{UserID: "u1"}))
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/threads/counts?target_type=asset&ids=a1,a2", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, threads.lastCountIDs, "no AssetStore means no owned ids reach the count query")
+}
+
 func TestThreadCountsBadTargetType(t *testing.T) {
 	h := newThreadTestHandler(&mockThreadStore{}, &mockAssetStore{}, &mockShareStore{}, &User{UserID: "u1"})
 	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/threads/counts?target_type=prompt&ids=x", nil)

--- a/ui/src/api/portal/hooks.ts
+++ b/ui/src/api/portal/hooks.ts
@@ -905,10 +905,10 @@ export function useThreadCounts(
   const sorted = [...ids].sort();
   return useQuery({
     queryKey: ["thread-counts", targetType, sorted],
-    queryFn: () =>
-      apiFetch<ThreadCounts>(
-        `/threads/counts?target_type=${targetType}&ids=${sorted.join(",")}`,
-      ),
+    queryFn: () => {
+      const sp = new URLSearchParams({ target_type: targetType, ids: sorted.join(",") });
+      return apiFetch<ThreadCounts>(`/threads/counts?${sp.toString()}`);
+    },
     enabled: sorted.length > 0,
   });
 }

--- a/ui/src/components/feedback/NewThreadForm.tsx
+++ b/ui/src/components/feedback/NewThreadForm.tsx
@@ -37,9 +37,11 @@ export function NewThreadForm({ target, availableAnchor, onCancel, onCreated }: 
   const [useAnchor, setUseAnchor] = useState(true);
   const create = useCreateThread();
 
-  // Text-quote anchoring is offered for asset targets when the user has a live
-  // selection inside the content. Other targets are object-level in this view.
-  const canAnchor = target.type === "asset" && !!availableAnchor;
+  // Text-quote anchoring is offered for asset and prompt targets (both render
+  // their content through the anchorable markdown/plain-text renderers) when
+  // the user has a live selection. Collections and standalone are object-level.
+  const canAnchor =
+    (target.type === "asset" || target.type === "prompt") && !!availableAnchor;
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/ui/src/components/feedback/ThreadDetail.tsx
+++ b/ui/src/components/feedback/ThreadDetail.tsx
@@ -39,6 +39,10 @@ function eventSummary(e: ThreadEvent): string | null {
       return "approved";
     case "rejection":
       return "rejected";
+    case "validation_request":
+      return "requested validation";
+    case "validation_result":
+      return "recorded a validation result";
     case "insight_linked":
       return "linked an insight";
     case "changeset_linked":
@@ -91,7 +95,8 @@ export function ThreadDetail({ threadId, canModerate, onBack, onDeleted }: Props
         {mayModerate && (
           <button
             onClick={() => del.mutate(threadId, { onSuccess: onDeleted })}
-            className="ml-auto rounded p-1 text-destructive hover:bg-destructive/10"
+            disabled={del.isPending}
+            className="ml-auto rounded p-1 text-destructive hover:bg-destructive/10 disabled:opacity-50"
             aria-label="Delete thread"
             title="Delete"
           >
@@ -99,6 +104,9 @@ export function ThreadDetail({ threadId, canModerate, onBack, onDeleted }: Props
           </button>
         )}
       </div>
+      {del.isError && (
+        <p className="border-b px-3 py-1.5 text-xs text-destructive">Failed to delete this thread.</p>
+      )}
 
       {/* Title + meta */}
       <div className="border-b p-3">

--- a/ui/src/components/feedback/useTextQuoteAnchor.ts
+++ b/ui/src/components/feedback/useTextQuoteAnchor.ts
@@ -25,16 +25,19 @@ function buildTextQuote(): TextQuoteAnchor | null {
   const container = closestAnchorable(sel.anchorNode);
   if (!container || !closestAnchorable(sel.focusNode)) return null;
 
-  // prefix/suffix come from the first occurrence of the selected text. For a
-  // phrase that repeats in the container this may describe the wrong instance;
-  // the exact quote is still captured, and re-resolution/highlighting is a
-  // later enhancement, so first-match is acceptable here.
+  // Cap the quote first, then derive prefix/suffix relative to the *capped*
+  // quote so exact/prefix/suffix stay internally consistent even for long
+  // selections. prefix/suffix come from the first occurrence of the quote; for
+  // a phrase that repeats this may describe the wrong instance, but the exact
+  // quote is still captured and re-resolution/highlighting is a later
+  // enhancement, so first-match is acceptable here.
+  const quote = exact.slice(0, MAX_QUOTE);
   const full = container.textContent ?? "";
-  const idx = full.indexOf(exact);
-  const anchor: TextQuoteAnchor = { type: "text_quote", exact: exact.slice(0, MAX_QUOTE) };
+  const idx = full.indexOf(quote);
+  const anchor: TextQuoteAnchor = { type: "text_quote", exact: quote };
   if (idx >= 0) {
     const prefix = full.slice(Math.max(0, idx - CONTEXT_LEN), idx);
-    const suffix = full.slice(idx + exact.length, idx + exact.length + CONTEXT_LEN);
+    const suffix = full.slice(idx + quote.length, idx + quote.length + CONTEXT_LEN);
     if (prefix) anchor.prefix = prefix;
     if (suffix) anchor.suffix = suffix;
   }


### PR DESCRIPTION
Follow-up fixes from running the full adversarial `/code-review` over the feedback UI that landed in #605. The review found **no critical or security issues** (owner-scoping is correct and fail-closed, MSW routing is correct, no production-reachable nil-deref); these are correctness and robustness improvements, plus one doc/code reconciliation. A second `/code-review` over this fix branch returned clean.

## Changes

### Backend (`pkg/portal/thread_handler.go`)
- **`GET /threads/counts` now rejects an oversized id list with `400`** instead of silently truncating to the cap. Silent truncation dropped open-thread badges for owned items past the cap with no signal. The badge caller only ever sends one page of ids (list endpoints cap at 200), so this is a defensive guard the real client never trips. Covered by `TestThreadCountsTooManyIDs`.
- **`ownedAssetIDs` now guards a nil `AssetStore`**, matching the existing `ownedCollectionIDs` nil-guard. Not reachable through the shipped wiring, but removes a latent panic for a direct caller and restores symmetry.

### UI
- **Delete failures are surfaced** in the thread drawer (`ThreadDetail.tsx`). A failed delete previously left the view stuck with no feedback; now it shows an error and disables the button while pending. This matches how the reply path already reports errors.
- **`eventSummary` labels `validation_request` / `validation_result`** timeline events instead of letting them fall through to "commented".
- **`useThreadCounts` builds its query string with `URLSearchParams`** so ids are encoded (consistent with `useThreads`), rather than raw interpolation.
- **`useTextQuoteAnchor` caps the quote first** and derives `prefix`/`suffix` from the capped quote, so `exact`/`prefix`/`suffix` stay internally consistent for selections longer than the 400-char cap.
- **Anchoring now works on prompt targets.** Prompt content renders through the same anchorable markdown renderer as assets, so `NewThreadForm.canAnchor` is extended from asset-only to asset-or-prompt. The backend already stores anchors for any target. Collections and the standalone channel remain object-level (their content can also produce a selection, so the explicit allow-list is the correct gate rather than keying off "a selection exists").

### Docs
- `docs/server/portal-user.md` updated so the anchoring claim ("an asset or a prompt") matches the code after the `canAnchor` change.

## Verification

- Go: `make lint` (0 patch issues), `gosec`, `go test ./pkg/portal`.
- UI: `tsc`, `eslint`, 160 vitest tests, production build, and the feedback interactive Playwright spec (open / create / reply / resolve / standalone).
- Full multi-agent `/code-review` run twice (on the merged #605 to find these, and on this fix branch to confirm it is clean).

Part of #601.