### PR TITLE
fix(catalogs): handle embedded source kind without crashing the panel

### DIFF
--- a/ui/src/api/admin/hooks.ts
+++ b/ui/src/api/admin/hooks.ts
@@ -715,7 +715,12 @@ export interface APICatalogSummary {
 export interface APICatalogSpec {
   spec_name: string;
   content?: string;
-  source_kind: "inline" | "upload" | "url";
+  // "embedded" specs are bundled from a connection's own toolkit and
+  // re-seeded at every startup (see pkg/toolkits/apigateway/catalog
+  // SourceEmbedded and seedAdminSelfConnection), so portal edits/deletes
+  // do not persist; the portal treats them as read-only. Keep this union
+  // in sync with the backend's source-kind constants.
+  source_kind: "inline" | "upload" | "url" | "embedded";
   source_url?: string;
   etag?: string;
   // Operator-set per-spec URL prefix applied at api_list_endpoints

--- a/ui/src/pages/settings/CatalogsPanel.test.tsx
+++ b/ui/src/pages/settings/CatalogsPanel.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { SourceBadge } from "./CatalogsPanel";
+
+describe("SourceBadge", () => {
+  it("renders a label and icon for every known source kind", () => {
+    const cases: Array<{ kind: "inline" | "upload" | "url" | "embedded"; label: string }> = [
+      { kind: "inline", label: "inline" },
+      { kind: "upload", label: "upload" },
+      { kind: "url", label: "URL" },
+      { kind: "embedded", label: "embedded" },
+    ];
+    for (const { kind, label } of cases) {
+      const { unmount } = render(<SourceBadge kind={kind} />);
+      expect(screen.getByText(label)).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  // Regression: an embedded spec (re-seeded from the platform self-connection)
+  // previously crashed the whole catalogs page because SourceBadge indexed a
+  // three-key map and read `.icon` off undefined. It must render, not throw.
+  it("does not throw for embedded specs", () => {
+    expect(() => render(<SourceBadge kind="embedded" />)).not.toThrow();
+  });
+
+  // Any future backend source_kind must degrade to a plain badge showing the
+  // raw kind rather than crashing the page.
+  it("degrades gracefully for an unknown source kind", () => {
+    const kind = "future-kind" as unknown as "inline";
+    expect(() => render(<SourceBadge kind={kind} />)).not.toThrow();
+    expect(screen.getByText("future-kind")).toBeInTheDocument();
+  });
+});

--- a/ui/src/pages/settings/CatalogsPanel.tsx
+++ b/ui/src/pages/settings/CatalogsPanel.tsx
@@ -6,6 +6,7 @@ import {
   Copy,
   FileText,
   Link as LinkIcon,
+  Package,
   Plus,
   RefreshCw,
   Trash2,
@@ -799,6 +800,9 @@ function SpecsManager({ catalogID, isReadOnly }: { catalogID: string; isReadOnly
           {specs.map((s) => {
             const status = statusByName[s.spec_name];
             const failed = status?.job_status === "failed";
+            // Embedded specs are re-seeded from their toolkit at startup, so
+            // edits/deletes here do not persist; present them as read-only.
+            const specReadOnly = isReadOnly || s.source_kind === "embedded";
             return (
               <li key={s.spec_name} className="flex items-center gap-3 px-3 py-2 text-sm">
                 <span className="flex-1 truncate font-mono">{s.spec_name}</span>
@@ -809,7 +813,7 @@ function SpecsManager({ catalogID, isReadOnly }: { catalogID: string; isReadOnly
                     fetched {new Date(s.last_fetched_at).toLocaleString()}
                   </span>
                 )}
-                {!isReadOnly && (
+                {!specReadOnly && (
                   <div className="flex gap-1">
                     {failed && (
                       <button
@@ -1087,12 +1091,16 @@ function CatalogEmbeddingHealthBanner({
   );
 }
 
-function SourceBadge({ kind, url }: { kind: APICatalogSpec["source_kind"]; url?: string }) {
-  const config = {
+export function SourceBadge({ kind, url }: { kind: APICatalogSpec["source_kind"]; url?: string }) {
+  const configs: Record<string, { icon: typeof FileText; label: string; tone: string }> = {
     inline: { icon: FileText, label: "inline", tone: "bg-muted text-muted-foreground" },
     upload: { icon: Upload, label: "upload", tone: "bg-blue-100 text-blue-900 dark:bg-blue-950/30 dark:text-blue-200" },
     url: { icon: LinkIcon, label: "URL", tone: "bg-green-100 text-green-900 dark:bg-green-950/30 dark:text-green-200" },
-  }[kind];
+    embedded: { icon: Package, label: "embedded", tone: "bg-purple-100 text-purple-900 dark:bg-purple-950/30 dark:text-purple-200" },
+  };
+  // Fall back to the raw kind for any value the backend adds later, so an
+  // unknown source_kind degrades to a plain badge instead of crashing the page.
+  const config = configs[kind] ?? { icon: FileText, label: kind || "unknown", tone: "bg-muted text-muted-foreground" };
   const Icon = config.icon;
   return (
     <span


### PR DESCRIPTION
## Problem

The API catalogs panel crashed with `Cannot read properties of undefined (reading 'icon')` and unmounted the entire page. Reproduced on a production install (v1.83.0) when viewing catalogs.

Root cause: `SourceBadge` indexed a three-key map (`inline`/`upload`/`url`) and read `.icon` off the result. The backend defines a fourth source kind, `embedded` (`pkg/toolkits/apigateway/catalog/catalog.go`), and the platform self-connection seeds an `embedded` spec at every startup (`seedAdminSelfConnection`). For such a spec `config` was `undefined`, so `config.icon` threw and React unwound the whole catalogs view. The TypeScript union omitted `embedded`, so the missing case was invisible to the type checker.

## Fix

- `SourceBadge`: add the `embedded` case (Package icon) and fall back to a plain badge for any unrecognized kind, so a future backend `source_kind` can no longer take down the page.
- `APICatalogSpec.source_kind`: add `embedded` to the union and document that it must track the backend constants.
- Embedded specs are now read-only in the spec row (no edit/delete/refresh). They are re-seeded from their toolkit at startup, so portal edits did not persist and editing one rewrote it to `inline`.
- New `CatalogsPanel.test.tsx` covers all four kinds plus the unknown-kind fallback as a regression guard.

## Verification

UI suite green: `typecheck` PASS, `eslint` clean, `vitest` 163/163 (3 new). The embedded UI bundle is built by CI from source (the `dist` embed dirs are `.gitkeep`-only), so no rebuilt bundle is committed.