### PR TITLE
fix(catalogs): debounce + visual feedback for spec retry/refresh

### DIFF
--- a/ui/src/pages/settings/CatalogsPanel.test.tsx
+++ b/ui/src/pages/settings/CatalogsPanel.test.tsx
@@ -1,7 +1,41 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { act, render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-import { SourceBadge } from "./CatalogsPanel";
+const h = vi.hoisted(() => ({
+  retryMutate: vi.fn(),
+  refreshMutate: vi.fn(),
+}));
+
+// Override only the hooks SpecsManager consumes; keep everything else real.
+vi.mock("@/api/admin/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/admin/hooks")>();
+  return {
+    ...actual,
+    useManualRetryEmbedding: () => ({ mutate: h.retryMutate, isPending: false }),
+    useRefreshAPICatalogSpec: () => ({ mutate: h.refreshMutate, isPending: false }),
+    useDeleteAPICatalogSpec: () => ({ mutate: vi.fn(), isPending: false }),
+    useAPICatalogEmbeddingHealth: () => ({ data: undefined }),
+    useAPICatalogEmbeddingStatuses: () => ({
+      data: { specs: [{ spec_name: "petstore", job_status: "failed" }] },
+    }),
+  };
+});
+
+// The spec list is fetched with a direct apiFetch in a useEffect; stub it.
+vi.mock("@/api/admin/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/admin/client")>();
+  return {
+    ...actual,
+    apiFetch: vi.fn((url: string) =>
+      url.includes("/specs")
+        ? Promise.resolve({ specs: [{ spec_name: "petstore", source_kind: "inline" }] })
+        : Promise.resolve({}),
+    ),
+  };
+});
+
+import { SourceBadge, SpecsManager } from "./CatalogsPanel";
 
 describe("SourceBadge", () => {
   it("renders a label and icon for every known source kind", () => {
@@ -31,5 +65,59 @@ describe("SourceBadge", () => {
     const kind = "future-kind" as unknown as "inline";
     expect(() => render(<SourceBadge kind={kind} />)).not.toThrow();
     expect(screen.getByText("future-kind")).toBeInTheDocument();
+  });
+});
+
+describe("SpecsManager retry debounce", () => {
+  function renderManager() {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(
+      <QueryClientProvider client={qc}>
+        <SpecsManager catalogID="cat1" isReadOnly={false} />
+      </QueryClientProvider>,
+    );
+  }
+
+  // Regression: a slow re-embed gave no feedback, so operators clicked Retry
+  // repeatedly and queued duplicate jobs against the same spec. Two clicks in
+  // the SAME tick (before React commits the disabled state) must be stopped by
+  // the synchronous inFlightRetryRef guard, not just by the disabled attribute.
+  // Both raw clicks are dispatched inside one act() so no re-render (and so no
+  // disabled commit) happens between them; only the ref guard can block the
+  // second. The mutate mock never settles, so the row stays busy.
+  it("the synchronous ref guard collapses a same-tick double click to one mutation", async () => {
+    h.retryMutate.mockClear();
+    renderManager();
+
+    const retry = await screen.findByRole("button", { name: /^retry$/i });
+    act(() => {
+      retry.click();
+      retry.click();
+    });
+
+    expect(h.retryMutate).toHaveBeenCalledTimes(1);
+    expect(await screen.findByRole("button", { name: /retrying/i })).toBeDisabled();
+  });
+
+  // Once the mutation settles, onSettled must clear the in-flight entry so the
+  // button re-enables and a later click can fire a fresh mutation. Without this
+  // the row would be stuck disabled forever.
+  it("re-enables the button after the mutation settles", async () => {
+    h.retryMutate.mockReset();
+    // First call resolves immediately via its onSettled; capture later calls too.
+    h.retryMutate.mockImplementation((_vars, opts?: { onSettled?: () => void }) => {
+      opts?.onSettled?.();
+    });
+    renderManager();
+
+    const retry = await screen.findByRole("button", { name: /^retry$/i });
+    fireEvent.click(retry);
+
+    // onSettled ran synchronously, so the row is enabled again as "Retry".
+    const reenabled = await screen.findByRole("button", { name: /^retry$/i });
+    expect(reenabled).not.toBeDisabled();
+
+    fireEvent.click(reenabled);
+    expect(h.retryMutate).toHaveBeenCalledTimes(2);
   });
 });

--- a/ui/src/pages/settings/CatalogsPanel.tsx
+++ b/ui/src/pages/settings/CatalogsPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertCircle,
   BookOpen,
@@ -728,7 +728,7 @@ function CatalogEditor({
 // SpecsManager + SpecModal
 // ---------------------------------------------------------------------------
 
-function SpecsManager({ catalogID, isReadOnly }: { catalogID: string; isReadOnly: boolean }) {
+export function SpecsManager({ catalogID, isReadOnly }: { catalogID: string; isReadOnly: boolean }) {
   const [specs, setSpecs] = useState<APICatalogSpec[]>([]);
   const [loading, setLoading] = useState(false);
   const [refreshCounter, setRefreshCounter] = useState(0);
@@ -740,6 +740,129 @@ function SpecsManager({ catalogID, isReadOnly }: { catalogID: string; isReadOnly
   const refresh = useRefreshAPICatalogSpec();
   const manualRetry = useManualRetryEmbedding();
   const del = useDeleteAPICatalogSpec();
+  // Per-spec in-flight tracking. TanStack's mutation.isPending is a
+  // single bit shared across every spec row, so it cannot say "this
+  // row is the one mid-mutation". We track pending spec names locally
+  // so each row's button disables + changes label without affecting
+  // its siblings. The ref pair holds the synchronous truth: a rapid
+  // click that arrives before React commits the disabled state still
+  // hits the ref guard at the top of the handler and short-circuits,
+  // instead of firing a duplicate mutation against the same spec.
+  const inFlightRetryRef = useRef<Set<string>>(new Set());
+  const inFlightRefreshRef = useRef<Set<string>>(new Set());
+  const [pendingRetry, setPendingRetry] = useState<Set<string>>(new Set());
+  const [pendingRefresh, setPendingRefresh] = useState<Set<string>>(new Set());
+  // Inline status banner. Auto-clears after a short delay on success;
+  // stays until dismissed on error so the operator can read the
+  // failure (previously a failed retry/refresh was silent).
+  const [statusMessage, setStatusMessage] = useState<{
+    kind: "success" | "error";
+    text: string;
+  } | null>(null);
+  // The auto-clear timer is held in a ref so a newer action can cancel
+  // a still-pending clear before scheduling its own; otherwise an old
+  // success timer could clear a newer banner ahead of its window.
+  const statusTimerRef = useRef<number | null>(null);
+
+  const clearStatusTimer = useCallback(() => {
+    if (statusTimerRef.current !== null) {
+      window.clearTimeout(statusTimerRef.current);
+      statusTimerRef.current = null;
+    }
+  }, []);
+
+  const showStatus = useCallback(
+    (msg: { kind: "success" | "error"; text: string }, autoClearMs?: number) => {
+      clearStatusTimer();
+      setStatusMessage(msg);
+      if (autoClearMs !== undefined) {
+        statusTimerRef.current = window.setTimeout(() => {
+          setStatusMessage(null);
+          statusTimerRef.current = null;
+        }, autoClearMs);
+      }
+    },
+    [clearStatusTimer],
+  );
+
+  const dismissStatus = useCallback(() => {
+    clearStatusTimer();
+    setStatusMessage(null);
+  }, [clearStatusTimer]);
+
+  // Unmount cleanup: a timer that fires after the component is gone
+  // would setState on an unmounted component.
+  useEffect(() => clearStatusTimer, [clearStatusTimer]);
+
+  const handleRetry = (specName: string) => {
+    if (inFlightRetryRef.current.has(specName)) {
+      return; // synchronous debounce against rapid double-clicks
+    }
+    inFlightRetryRef.current.add(specName);
+    setPendingRetry(new Set(inFlightRetryRef.current));
+    dismissStatus();
+    manualRetry.mutate(
+      { catalogID, specName },
+      {
+        onSuccess: (data) => {
+          setRefreshCounter((n) => n + 1);
+          showStatus(
+            {
+              kind: "success",
+              text: data.created
+                ? `Re-embedding queued for "${specName}".`
+                : `"${specName}" is already queued for re-embedding.`,
+            },
+            4000,
+          );
+        },
+        onError: (err) => {
+          showStatus({
+            kind: "error",
+            text: `Retry "${specName}" failed: ${err.message}`,
+          });
+        },
+        onSettled: () => {
+          inFlightRetryRef.current.delete(specName);
+          setPendingRetry(new Set(inFlightRetryRef.current));
+        },
+      },
+    );
+  };
+
+  const handleRefresh = (specName: string) => {
+    if (inFlightRefreshRef.current.has(specName)) {
+      return; // synchronous debounce against rapid double-clicks
+    }
+    inFlightRefreshRef.current.add(specName);
+    setPendingRefresh(new Set(inFlightRefreshRef.current));
+    dismissStatus();
+    refresh.mutate(
+      { catalogID, specName },
+      {
+        onSuccess: () => {
+          setRefreshCounter((n) => n + 1);
+          showStatus(
+            {
+              kind: "success",
+              text: `Refreshed "${specName}" from upstream URL.`,
+            },
+            4000,
+          );
+        },
+        onError: (err) => {
+          showStatus({
+            kind: "error",
+            text: `Refresh "${specName}" failed: ${err.message}`,
+          });
+        },
+        onSettled: () => {
+          inFlightRefreshRef.current.delete(specName);
+          setPendingRefresh(new Set(inFlightRefreshRef.current));
+        },
+      },
+    );
+  };
   // The job-queue-backed embedding state polls every 5s while
   // the panel is mounted. The badge updates as the worker
   // progresses; the catalog header summary reflects pending /
@@ -789,6 +912,28 @@ function SpecsManager({ catalogID, isReadOnly }: { catalogID: string; isReadOnly
 
       {health && <CatalogEmbeddingHealthBanner health={health} />}
 
+      {statusMessage && (
+        <div
+          role={statusMessage.kind === "error" ? "alert" : "status"}
+          className={cn(
+            "flex items-start justify-between gap-3 rounded-md border px-3 py-2 text-xs",
+            statusMessage.kind === "success" &&
+              "border-emerald-500/30 bg-emerald-50 text-emerald-900 dark:bg-emerald-500/10 dark:text-emerald-200",
+            statusMessage.kind === "error" &&
+              "border-destructive/40 bg-destructive/10 text-destructive",
+          )}
+        >
+          <span>{statusMessage.text}</span>
+          <button
+            type="button"
+            onClick={dismissStatus}
+            className="text-xs underline-offset-2 hover:underline"
+          >
+            dismiss
+          </button>
+        </div>
+      )}
+
       {loading ? (
         <div className="text-sm text-muted-foreground">Loading…</div>
       ) : specs.length === 0 ? (
@@ -818,31 +963,25 @@ function SpecsManager({ catalogID, isReadOnly }: { catalogID: string; isReadOnly
                     {failed && (
                       <button
                         type="button"
-                        onClick={() =>
-                          manualRetry.mutate(
-                            { catalogID, specName: s.spec_name },
-                            { onSuccess: () => setRefreshCounter((n) => n + 1) },
-                          )
-                        }
+                        onClick={() => handleRetry(s.spec_name)}
+                        disabled={pendingRetry.has(s.spec_name)}
                         title={`Retry embedding (last error: ${status?.job_last_error ?? "unknown"})`}
-                        className="rounded px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
+                        className="rounded px-2 py-1 text-xs text-destructive hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-60"
                       >
-                        Retry
+                        {pendingRetry.has(s.spec_name) ? "Retrying…" : "Retry"}
                       </button>
                     )}
                     {s.source_kind === "url" && (
                       <button
                         type="button"
-                        onClick={() =>
-                          refresh.mutate(
-                            { catalogID, specName: s.spec_name },
-                            { onSuccess: () => setRefreshCounter((n) => n + 1) },
-                          )
-                        }
-                        title="Refresh from URL"
-                        className="rounded p-1 hover:bg-muted"
+                        onClick={() => handleRefresh(s.spec_name)}
+                        disabled={pendingRefresh.has(s.spec_name)}
+                        title={pendingRefresh.has(s.spec_name) ? "Refreshing…" : "Refresh from URL"}
+                        className="rounded p-1 hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
                       >
-                        <RefreshCw className="h-4 w-4" />
+                        <RefreshCw
+                          className={cn("h-4 w-4", pendingRefresh.has(s.spec_name) && "animate-spin")}
+                        />
                       </button>
                     )}
                     <button


### PR DESCRIPTION
## Problem

In the API catalog spec list, clicking **Retry** (the failed-embedding escape hatch) or the URL **Refresh** icon gave no indication anything was happening. The mutation fired, the button stayed in its idle state, and only the embedding badge would eventually flip when the backend returned. Operators clicked repeatedly out of frustration, queuing duplicate embedding jobs against the same spec. A failed retry/refresh was also silent.

## Fix

Per-spec in-flight tracking with synchronous debounce and visible feedback, applied to both mutating buttons in `SpecsManager`:

- **Per-spec in-flight tracking.** TanStack's `mutation.isPending` is a single bit shared across every row, so it cannot say which row is mid-mutation. A local `Set<string>` (plus a `useRef` holding the synchronous truth) tracks in-flight spec names per action, so one row can show busy without affecting its siblings, and concurrent retries on different rows are handled correctly.
- **Synchronous debounce.** A ref guard at the top of `handleRetry`/`handleRefresh` short-circuits a same-tick second click before React commits the `disabled` state, so a rapid click train fires one mutation, not ten.
- **Visual feedback.** Retry becomes "Retrying…" and disables; the refresh icon spins and disables.
- **Inline status banner** above the spec list: success auto-dismisses after 4s, errors persist until dismissed so the operator can read the failure. The auto-clear timer is held in a ref and cleared before scheduling a new one and on unmount, so a stale timer cannot clobber a newer message.

## Tests

- A same-tick double click collapses to exactly one mutation. This exercises the synchronous ref guard specifically (both clicks dispatched in one `act()` so no re-render commits `disabled` between them); verified to fail if the guard is removed.
- The button re-enables after the mutation settles, and a later click fires a fresh mutation (covers the `onSettled` cleanup path).
- `SourceBadge` renders all four source kinds plus the unknown-kind fallback (carried over from #607).

## Verification

UI suite green: `typecheck` PASS, `eslint` clean, `vitest` 165/165. Ran the full adversarial `/code-review` before commit; it surfaced two real issues that are fixed here: the success banner originally used near-white `text-emerald-100` on a near-white `bg-emerald-500/10` (unreadable in light mode, now matches the sibling banners with light-mode colors + a `dark:` variant), and the debounce test originally only proved the `disabled` attribute rather than the ref guard.

## Notes

This re-applies a long-stale local UX branch onto current `main` (the older base had a since-removed "Re-embed" button; the pattern is adapted to the current Retry and Refresh buttons).