### PR TITLE
feat(threads): agent review bridge into the knowledge loop (#602)

### DIFF
--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -889,6 +889,9 @@ func wirePortalOptionalDeps(deps *portal.Deps, p *platform.Platform) {
 	if p.KnowledgeInsightStore() != nil {
 		deps.InsightStore = p.KnowledgeInsightStore()
 	}
+	if p.KnowledgeChangesetStore() != nil {
+		deps.ChangesetReader = p.KnowledgeChangesetStore()
+	}
 	if p.MemoryStore() != nil {
 		deps.MemoryStore = p.MemoryStore()
 	}

--- a/docs/knowledge/overview.md
+++ b/docs/knowledge/overview.md
@@ -190,6 +190,23 @@ Insights track where the knowledge came from via the `source` field:
 
 The source field is optional when calling `capture_insight`. When omitted, it defaults to `user`.
 
+## Feedback Bridge
+
+Human feedback threads (left on portal artifacts via `manage_artifact`) connect to the knowledge loop, so an agent can resolve a thread by capturing the insight it represents and the chain stays visible end to end: **thread → insight → changeset → `target_urn`**.
+
+**Resolving a thread into an insight.** `capture_insight` accepts an optional `thread_ids` array. When supplied, each named thread has its `insight_id` set, an `insight_linked` event appended to its timeline, and its status moved to `resolved`. Linking is **authorized with the same owns-or-edit check as `resolve_thread`**: a thread the caller could not resolve via `manage_artifact` (one on an artifact they neither own nor can edit) is refused and reported as unlinked, so `capture_insight` is not a back door around the access model. The call is best-effort (a link failure never fails the capture) and the result reports the outcome so the agent can detect a mistyped, unauthorized, or already-resolved thread:
+
+| Field | Meaning |
+|-------|---------|
+| `linked_thread_count` | how many of the supplied `thread_ids` were linked |
+| `unlinked_thread_ids` | the `thread_ids` that matched no open thread (omitted when all linked) |
+
+Both fields are omitted entirely when `thread_ids` is not supplied, so a capture without threads is unchanged.
+
+**Working threads from the agent.** `manage_artifact` gains thread actions (no new tools): `list_threads` (filter by target, status, `requires_resolution`, `validation_state`), `get_thread`, `reply_thread`, `resolve_thread`, and `request_validation`. These are scoped to artifacts the caller **owns or can edit** (admins see all; standalone threads are readable by any authenticated caller and moderated by the thread author or an admin).
+
+**Reading the chain.** `GET /api/v1/portal/threads/{id}/chain` returns the resolved chain for a thread: its `insight_id` and the changesets that insight produced (each with `target_urn`, `change_type`, and rollback state). The portal feedback panel renders this as a "Knowledge chain" section on a resolved thread.
+
 ## AI Agent Guidance
 
 The toolkit registers an MCP prompt called `knowledge_capture_guidance` that tells AI assistants when to capture insights. The prompt covers:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1673,6 +1673,7 @@ Records domain knowledge shared during a session.
 | `entity_urns` | array | No | DataHub URNs this insight relates to (max 10) |
 | `related_columns` | array | No | Columns related to this insight (max 20) |
 | `suggested_actions` | array | No | Proposed catalog changes (max 5) |
+| `thread_ids` | array | No | Feedback thread IDs this insight resolves; each is linked (insight_id set, `insight_linked` event, status `resolved`) |
 
 **Suggested action types:** `update_description`, `add_tag`, `remove_tag`, `add_glossary_term`, `flag_quality_issue`, `add_documentation`, `add_curated_query`, `set_structured_property`, `remove_structured_property`, `raise_incident`, `resolve_incident`, `add_context_document`, `update_context_document`, `remove_context_document`
 
@@ -1694,7 +1695,17 @@ Records domain knowledge shared during a session.
 }
 ```
 
+When `thread_ids` is supplied, the response also includes `linked_thread_count` and `unlinked_thread_ids` (the IDs that matched no open thread, or that the caller is not authorized to resolve); both are omitted when `thread_ids` is absent. Linking is gated by the same owns-or-edit check as `resolve_thread` (it is not a back door around the access model), is best-effort, and never fails the capture.
+
 The tool also registers an MCP prompt `knowledge_capture_guidance` that provides AI agents with guidance on when to capture insights.
+
+## Feedback Bridge
+
+Human feedback threads on portal artifacts connect to the knowledge loop: an agent resolves a thread by capturing the insight it represents, and the chain stays visible end to end (**thread → insight → changeset → `target_urn`**).
+
+- **`capture_insight` `thread_ids`** links threads to the captured insight (see above).
+- **`manage_artifact` thread actions** (no new tools): `list_threads` (filter by target, status, `requires_resolution`, `validation_state`), `get_thread`, `reply_thread`, `resolve_thread`, `request_validation`. Scoped to artifacts the caller owns or can edit; admins see all; standalone threads are readable by any authenticated caller and moderated by the thread author or an admin.
+- **`GET /api/v1/portal/threads/{id}/chain`** returns a thread's resolved chain: its `insight_id` and the changesets that insight produced (each with `target_urn`, `change_type`, rollback state). The portal feedback panel renders this as a "Knowledge chain" section.
 
 ## apply_knowledge Tool
 

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -9863,6 +9863,61 @@ const docTemplate = `{
                 }
             }
         },
+        "/portal/threads/{id}/chain": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the insight a thread was captured into and the changeset(s) that applied it (thread -\u003e insight -\u003e changeset -\u003e target_urn).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "Resolve a thread's knowledge chain",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Thread ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.threadChainResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/threads/{id}/events": {
             "get": {
                 "security": [
@@ -14661,6 +14716,43 @@ const docTemplate = `{
                 "status": {
                     "type": "string",
                     "example": "updated"
+                }
+            }
+        },
+        "portal.threadChainChangeset": {
+            "type": "object",
+            "properties": {
+                "change_type": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "rolled_back": {
+                    "type": "boolean"
+                },
+                "target_urn": {
+                    "type": "string"
+                }
+            }
+        },
+        "portal.threadChainResponse": {
+            "type": "object",
+            "properties": {
+                "changesets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/portal.threadChainChangeset"
+                    }
+                },
+                "insight_id": {
+                    "type": "string"
+                },
+                "thread_id": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -9857,6 +9857,61 @@
                 }
             }
         },
+        "/portal/threads/{id}/chain": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the insight a thread was captured into and the changeset(s) that applied it (thread -> insight -> changeset -> target_urn).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "Resolve a thread's knowledge chain",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Thread ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.threadChainResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/threads/{id}/events": {
             "get": {
                 "security": [
@@ -14655,6 +14710,43 @@
                 "status": {
                     "type": "string",
                     "example": "updated"
+                }
+            }
+        },
+        "portal.threadChainChangeset": {
+            "type": "object",
+            "properties": {
+                "change_type": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "rolled_back": {
+                    "type": "boolean"
+                },
+                "target_urn": {
+                    "type": "string"
+                }
+            }
+        },
+        "portal.threadChainResponse": {
+            "type": "object",
+            "properties": {
+                "changesets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/portal.threadChainChangeset"
+                    }
+                },
+                "insight_id": {
+                    "type": "string"
+                },
+                "thread_id": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -3107,6 +3107,30 @@ definitions:
         example: updated
         type: string
     type: object
+  portal.threadChainChangeset:
+    properties:
+      change_type:
+        type: string
+      created_at:
+        type: string
+      id:
+        type: string
+      rolled_back:
+        type: boolean
+      target_urn:
+        type: string
+    type: object
+  portal.threadChainResponse:
+    properties:
+      changesets:
+        items:
+          $ref: '#/definitions/portal.threadChainChangeset'
+        type: array
+      insight_id:
+        type: string
+      thread_id:
+        type: string
+    type: object
   portal.updateAssetRequest:
     properties:
       description:
@@ -9541,6 +9565,41 @@ paths:
       - ApiKeyAuth: []
       - BearerAuth: []
       summary: Update a feedback thread
+      tags:
+      - Feedback
+  /portal/threads/{id}/chain:
+    get:
+      description: Returns the insight a thread was captured into and the changeset(s)
+        that applied it (thread -> insight -> changeset -> target_urn).
+      parameters:
+      - description: Thread ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/portal.threadChainResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Resolve a thread's knowledge chain
       tags:
       - Feedback
   /portal/threads/{id}/events:

--- a/pkg/platform/feedback_bridge_realdb_integration_test.go
+++ b/pkg/platform/feedback_bridge_realdb_integration_test.go
@@ -1,0 +1,188 @@
+//go:build integration
+
+package platform
+
+// Real-Postgres proof for the Phase 2 feedback bridge (#602). It drives the
+// real assembled MCP server (capture_insight over an in-memory transport) wired
+// to the real Postgres thread store as the ThreadLinker, then verifies by
+// READ-BACK that the tool call wrote insight_id onto the thread, appended an
+// insight_linked event, and resolved the thread. It then proves the reverse
+// direction: a changeset whose source_insight_ids contains that insight id is
+// retrievable through the same JSONB-containment query getThreadChain uses, so
+// the thread -> insight -> changeset -> target_urn chain holds end to end.
+//
+// This exercises behavior mocks cannot: the real LinkInsight transaction, the
+// real event read-back, and the real `source_insight_ids @> ?::jsonb` filter.
+// Run under `make test-realdb`.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/internal/testdb"
+	"github.com/txn2/mcp-data-platform/pkg/memory"
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/portal"
+	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
+	portalkit "github.com/txn2/mcp-data-platform/pkg/toolkits/portal"
+)
+
+func TestRealDB_FeedbackBridge_CaptureLinksThreadAndChain(t *testing.T) {
+	db := testdb.New(t)
+	ctx := context.Background()
+
+	const owner = "550e8400-e29b-41d4-a716-446655440000"
+
+	// Real stores.
+	assetStore := portal.NewPostgresAssetStore(db)
+	threadStore := portal.NewPostgresThreadStore(db)
+	// Production always backs insights with the memory store (migration 000031
+	// drops knowledge_insights); mirror that exactly so we exercise the real path.
+	insightStore := knowledgekit.NewMemoryInsightAdapter(memory.NewPostgresStore(db))
+	csStore := knowledgekit.NewPostgresChangesetStore(db)
+
+	// Seed an asset and a feedback thread on it.
+	require.NoError(t, assetStore.Insert(ctx, portal.Asset{
+		ID: "asset_bridge", OwnerID: owner, OwnerEmail: "owner@example.com", Name: "asset_bridge",
+		ContentType: "text/markdown", S3Bucket: "b", S3Key: "k", Tags: []string{}, CurrentVersion: 1,
+	}))
+	_, err := threadStore.CreateThread(ctx,
+		portal.Thread{
+			ID: "thr_bridge", Kind: portal.ThreadKindCorrection, TargetType: "asset",
+			AssetID: "asset_bridge", RequiresResolution: true,
+			AuthorID: "sme", AuthorEmail: "sme@example.com",
+		},
+		portal.ThreadEvent{
+			ID: "evt_bridge_1", ThreadID: "thr_bridge", EventType: portal.EventTypeComment,
+			AuthorID: "sme", AuthorEmail: "sme@example.com", Body: "this column is mislabeled",
+		},
+	)
+	require.NoError(t, err)
+
+	// A second asset+thread owned by a DIFFERENT user. The caller below is the
+	// owner of asset_bridge, not this one, so the bridge must refuse to link it.
+	const otherOwner = "11111111-2222-3333-4444-555555555555"
+	require.NoError(t, assetStore.Insert(ctx, portal.Asset{
+		ID: "asset_other", OwnerID: otherOwner, OwnerEmail: "other@example.com", Name: "asset_other",
+		ContentType: "text/markdown", S3Bucket: "b", S3Key: "k", Tags: []string{}, CurrentVersion: 1,
+	}))
+	_, err = threadStore.CreateThread(ctx,
+		portal.Thread{
+			ID: "thr_other", Kind: portal.ThreadKindCorrection, TargetType: "asset",
+			AssetID: "asset_other", AuthorID: "sme", AuthorEmail: "sme@example.com",
+		},
+		portal.ThreadEvent{
+			ID: "evt_other_1", ThreadID: "thr_other", EventType: portal.EventTypeComment,
+			AuthorID: "sme", AuthorEmail: "sme@example.com", Body: "unrelated",
+		},
+	)
+	require.NoError(t, err)
+
+	// Assemble the real MCP server with capture_insight, wired to the real
+	// portal toolkit as the bridge so thread linking is gated by the same
+	// owns-or-edit access check as resolve_thread.
+	portalTk := portalkit.New(portalkit.Config{
+		Name: "test", S3Bucket: "b",
+		AssetStore:      assetStore,
+		ThreadStore:     threadStore,
+		ShareStore:      portal.NewNoopShareStore(),
+		CollectionStore: portal.NewNoopCollectionStore(),
+	})
+	tk, err := knowledgekit.New("test", insightStore)
+	require.NoError(t, err)
+	tk.SetThreadLinker(portalTk)
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
+	// Inject the asset owner's identity the way the real MCP auth middleware
+	// would, so the bridge's per-thread authorization can run.
+	server.AddReceivingMiddleware(func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			ctx = middleware.WithPlatformContext(ctx, &middleware.PlatformContext{
+				UserID: owner, UserEmail: "owner@example.com",
+			})
+			return next(ctx, method, req)
+		}
+	})
+	tk.RegisterTools(server)
+
+	ct, st := mcp.NewInMemoryTransports()
+	serverSess, err := server.Connect(ctx, st, nil)
+	require.NoError(t, err)
+	defer func() { _ = serverSess.Close() }()
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0"}, nil)
+	clientSess, err := client.Connect(ctx, ct, nil)
+	require.NoError(t, err)
+	defer func() { _ = clientSess.Close() }()
+
+	// Call capture_insight with thread_ids through the real protocol path.
+	callRes, err := clientSess.CallTool(ctx, &mcp.CallToolParams{
+		Name: "capture_insight",
+		Arguments: map[string]any{
+			"category":     "data_quality",
+			"insight_text": "The churn column actually measures monthly active retention.",
+			// Includes a thread on an asset the caller does NOT own: the bridge
+			// must link only the owned one and report the other as unlinked.
+			"thread_ids": []string{"thr_bridge", "thr_other"},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, callRes.IsError, "capture_insight failed: %+v", callRes.Content)
+
+	tc, ok := callRes.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	var out struct {
+		InsightID         string   `json:"insight_id"`
+		LinkedThreadCount int      `json:"linked_thread_count"`
+		UnlinkedThreadIDs []string `json:"unlinked_thread_ids"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &out))
+	require.NotEmpty(t, out.InsightID)
+	assert.Equal(t, 1, out.LinkedThreadCount)
+	// thr_other belongs to another owner: the authorization gate refused it.
+	assert.Equal(t, []string{"thr_other"}, out.UnlinkedThreadIDs)
+
+	// And the unauthorized thread was NOT mutated.
+	otherThread, err := threadStore.GetThread(ctx, "thr_other")
+	require.NoError(t, err)
+	assert.Empty(t, otherThread.InsightID)
+	assert.NotEqual(t, portal.ThreadStatusResolved, otherThread.Status)
+
+	// READ-BACK 1: the tool call set insight_id and resolved the thread.
+	gotThread, err := threadStore.GetThread(ctx, "thr_bridge")
+	require.NoError(t, err)
+	assert.Equal(t, out.InsightID, gotThread.InsightID)
+	assert.Equal(t, portal.ThreadStatusResolved, gotThread.Status)
+
+	// READ-BACK 2: an insight_linked event was appended, readable through the store.
+	events, err := threadStore.ListEvents(ctx, "thr_bridge")
+	require.NoError(t, err)
+	var sawLinked bool
+	for _, e := range events {
+		if e.EventType == portal.EventTypeInsightLinked {
+			sawLinked = true
+		}
+	}
+	assert.True(t, sawLinked, "expected an insight_linked event on the thread timeline")
+
+	// Reverse direction: a changeset sourced from that insight (as apply_knowledge
+	// records) is retrievable by the same JSONB-containment query getThreadChain
+	// uses, closing thread -> insight -> changeset -> target_urn.
+	require.NoError(t, csStore.InsertChangeset(ctx, knowledgekit.Changeset{
+		ID:               "cs_bridge",
+		TargetURN:        "urn:li:dataset:(urn:li:dataPlatform:trino,hive.sales.churn,PROD)",
+		ChangeType:       "update_description",
+		SourceInsightIDs: []string{out.InsightID},
+		AppliedBy:        "admin",
+	}))
+
+	chain, _, err := csStore.ListChangesets(ctx, knowledgekit.ChangesetFilter{SourceInsightID: out.InsightID})
+	require.NoError(t, err)
+	require.Len(t, chain, 1)
+	assert.Equal(t, "cs_bridge", chain[0].ID)
+	assert.Equal(t, "urn:li:dataset:(urn:li:dataPlatform:trino,hive.sales.churn,PROD)", chain[0].TargetURN)
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -220,6 +220,7 @@ type Platform struct {
 	portalVersionStore      portal.VersionStore
 	portalCollectionStore   portal.CollectionStore
 	portalThreadStore       portal.ThreadStore
+	portalToolkit           *portalkit.Toolkit
 	portalS3Client          portal.S3Client
 	provenanceTracker       *middleware.ProvenanceTracker
 	resolvedBrandLogoSVG    string // cached SVG from portal.logo or mcpapps config
@@ -355,10 +356,13 @@ func (p *Platform) initExtensions() error {
 	if err := p.initPortal(); err != nil {
 		return err
 	}
-	// Bridge the feedback thread store into capture_insight (Phase 2 / #602).
-	// Portal creates the thread store, so this is wired after both init.
-	if p.knowledgeToolkit != nil && p.portalThreadStore != nil {
-		p.knowledgeToolkit.SetThreadLinker(p.portalThreadStore)
+	// Bridge feedback threads into capture_insight (Phase 2 / #602). The linker
+	// is the portal toolkit, not the raw thread store, so capture_insight's
+	// thread linking is gated by the same owns-or-edit access check as
+	// resolve_thread (the toolkit authorizes each thread before linking).
+	// Portal creates the toolkit, so this is wired after both init.
+	if p.knowledgeToolkit != nil && p.portalToolkit != nil {
+		p.knowledgeToolkit.SetThreadLinker(p.portalToolkit)
 	}
 	if err := p.initManagedResources(); err != nil {
 		return err
@@ -1657,6 +1661,7 @@ func (p *Platform) initPortal() error {
 		MaxContentSize:  p.config.Portal.MaxContentSize,
 		Embedder:        p.embeddingProv,
 	})
+	p.portalToolkit = tk
 
 	if err := p.toolkitRegistry.Register(tk); err != nil {
 		return fmt.Errorf("registering portal toolkit: %w", err)

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -188,6 +188,7 @@ type Platform struct {
 	// Knowledge stores (exposed for admin API)
 	knowledgeInsightStore   knowledgekit.InsightStore
 	knowledgeChangesetStore knowledgekit.ChangesetStore
+	knowledgeToolkit        *knowledgekit.Toolkit
 	knowledgeDataHubWriter  knowledgekit.DataHubWriter
 
 	// Memory layer
@@ -353,6 +354,11 @@ func (p *Platform) initExtensions() error {
 	}
 	if err := p.initPortal(); err != nil {
 		return err
+	}
+	// Bridge the feedback thread store into capture_insight (Phase 2 / #602).
+	// Portal creates the thread store, so this is wired after both init.
+	if p.knowledgeToolkit != nil && p.portalThreadStore != nil {
+		p.knowledgeToolkit.SetThreadLinker(p.portalThreadStore)
 	}
 	if err := p.initManagedResources(); err != nil {
 		return err
@@ -1527,6 +1533,7 @@ func (p *Platform) initKnowledge() error {
 	if err != nil {
 		return fmt.Errorf("creating knowledge toolkit: %w", err)
 	}
+	p.knowledgeToolkit = tk
 
 	// Wire memory store for embedding generation on capture_insight.
 	if p.memoryStore != nil && p.embeddingProv != nil {
@@ -1642,6 +1649,7 @@ func (p *Platform) initPortal() error {
 		ShareStore:      p.portalShareStore,
 		VersionStore:    p.portalVersionStore,
 		CollectionStore: p.portalCollectionStore,
+		ThreadStore:     p.portalThreadStore,
 		S3Client:        s3Client,
 		S3Bucket:        p.config.Portal.S3Bucket,
 		S3Prefix:        p.config.Portal.S3Prefix,

--- a/pkg/portal/handler.go
+++ b/pkg/portal/handler.go
@@ -58,6 +58,12 @@ type InsightReader interface {
 	Stats(ctx context.Context, filter knowledge.InsightFilter) (*knowledge.InsightStats, error)
 }
 
+// ChangesetReader provides read access to knowledge changesets, used to surface
+// the thread -> insight -> changeset chain on a feedback thread (Phase 2).
+type ChangesetReader interface {
+	ListChangesets(ctx context.Context, filter knowledge.ChangesetFilter) ([]knowledge.Changeset, int, error)
+}
+
 // MemoryReader provides read-only access to user memory records. The
 // search methods back the portal's per-user "my knowledge" search: both
 // queries are scoped to the caller via CreatedBy server-side, so a user
@@ -102,6 +108,7 @@ type Deps struct {
 	PromptInfoProvider PromptInfoProvider
 	AuditMetrics       AuditMetrics
 	InsightStore       InsightReader
+	ChangesetReader    ChangesetReader
 	MemoryStore        MemoryReader
 	EmbeddingProvider  embedding.Provider
 	PersonaResolver    PersonaResolver

--- a/pkg/portal/thread_chain_test.go
+++ b/pkg/portal/thread_chain_test.go
@@ -1,0 +1,100 @@
+package portal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
+)
+
+type mockChangesetReader struct {
+	changesets []knowledge.Changeset
+	err        error
+	gotFilter  knowledge.ChangesetFilter
+}
+
+func (m *mockChangesetReader) ListChangesets(_ context.Context, f knowledge.ChangesetFilter) ([]knowledge.Changeset, int, error) {
+	m.gotFilter = f
+	return m.changesets, len(m.changesets), m.err
+}
+
+func chainHandler(threads *mockThreadStore, reader ChangesetReader, user *User) *Handler {
+	return NewHandler(Deps{
+		AssetStore:      ownedAsset("u1"),
+		ShareStore:      &mockShareStore{},
+		ThreadStore:     threads,
+		ChangesetReader: reader,
+		AdminRoles:      []string{"admin"},
+		RateLimit:       RateLimitConfig{RequestsPerMinute: 600, BurstSize: 100},
+	}, testAuthMiddleware(user))
+}
+
+func assetThreadStore(insightID string) *mockThreadStore {
+	return &mockThreadStore{getResult: &Thread{
+		ID: "t1", TargetType: targetTypeAsset, AssetID: "asset_1", InsightID: insightID,
+	}}
+}
+
+func TestGetThreadChain(t *testing.T) {
+	user := &User{UserID: "u1", Email: "u1@example.com"}
+
+	t.Run("returns the thread -> insight -> changeset chain", func(t *testing.T) {
+		reader := &mockChangesetReader{changesets: []knowledge.Changeset{
+			{ID: "cs_1", TargetURN: "urn:li:dataset:x", ChangeType: "update_description"},
+		}}
+		h := chainHandler(assetThreadStore("ins_1"), reader, user)
+		w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/threads/t1/chain", nil)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp threadChainResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "ins_1", resp.InsightID)
+		require.Len(t, resp.Changesets, 1)
+		assert.Equal(t, "cs_1", resp.Changesets[0].ID)
+		assert.Equal(t, "urn:li:dataset:x", resp.Changesets[0].TargetURN)
+		// The reader is queried by the thread's insight id (the JSONB containment).
+		assert.Equal(t, "ins_1", reader.gotFilter.SourceInsightID)
+	})
+
+	t.Run("thread with no insight id returns empty chain and skips the reader", func(t *testing.T) {
+		reader := &mockChangesetReader{}
+		h := chainHandler(assetThreadStore(""), reader, user)
+		w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/threads/t1/chain", nil)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp threadChainResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Empty(t, resp.Changesets)
+		assert.Equal(t, "", reader.gotFilter.SourceInsightID) // reader never called
+	})
+
+	t.Run("nil changeset reader returns empty chain", func(t *testing.T) {
+		h := chainHandler(assetThreadStore("ins_1"), nil, user)
+		w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/threads/t1/chain", nil)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp threadChainResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Empty(t, resp.Changesets)
+	})
+
+	t.Run("changeset reader error returns 500", func(t *testing.T) {
+		reader := &mockChangesetReader{err: errors.New("boom")}
+		h := chainHandler(assetThreadStore("ins_1"), reader, user)
+		w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/threads/t1/chain", nil)
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("non-owner is denied", func(t *testing.T) {
+		stranger := &User{UserID: "u2", Email: "u2@example.com"}
+		h := chainHandler(assetThreadStore("ins_1"), &mockChangesetReader{}, stranger)
+		w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/threads/t1/chain", nil)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+}

--- a/pkg/portal/thread_handler.go
+++ b/pkg/portal/thread_handler.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/txn2/mcp-data-platform/pkg/prompt"
+	"github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
 )
 
 const (
@@ -36,6 +38,7 @@ func (h *Handler) registerThreadRoutes() {
 	h.mux.HandleFunc("PATCH /api/v1/portal/threads/{id}", h.updateThread)
 	h.mux.HandleFunc("DELETE /api/v1/portal/threads/{id}", h.deleteThread)
 	h.mux.HandleFunc("GET /api/v1/portal/threads/{id}/events", h.listThreadEvents)
+	h.mux.HandleFunc("GET /api/v1/portal/threads/{id}/chain", h.getThreadChain)
 	h.mux.HandleFunc("POST /api/v1/portal/threads/{id}/events", h.appendThreadEvent)
 }
 
@@ -255,6 +258,67 @@ func (h *Handler) listThreadEvents(w http.ResponseWriter, r *http.Request) {
 		events = []ThreadEvent{}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"data": events})
+}
+
+// threadChainChangeset is the changeset view surfaced on a thread's chain.
+type threadChainChangeset struct {
+	ID         string    `json:"id"`
+	TargetURN  string    `json:"target_urn"`
+	ChangeType string    `json:"change_type"`
+	CreatedAt  time.Time `json:"created_at"`
+	RolledBack bool      `json:"rolled_back"`
+}
+
+// threadChainResponse is the resolved knowledge chain for a thread: the insight
+// it was captured into and the changeset(s) that applied that insight.
+type threadChainResponse struct {
+	ThreadID   string                 `json:"thread_id"`
+	InsightID  string                 `json:"insight_id,omitempty"`
+	Changesets []threadChainChangeset `json:"changesets"`
+}
+
+// getThreadChain handles GET /api/v1/portal/threads/{id}/chain.
+//
+// @Summary      Resolve a thread's knowledge chain
+// @Description  Returns the insight a thread was captured into and the changeset(s) that applied it (thread -> insight -> changeset -> target_urn).
+// @Tags         Feedback
+// @Produce      json
+// @Param        id  path  string  true  "Thread ID"
+// @Success      200  {object}  threadChainResponse
+// @Failure      401  {object}  problemDetail
+// @Failure      403  {object}  problemDetail
+// @Failure      404  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/threads/{id}/chain [get]
+func (h *Handler) getThreadChain(w http.ResponseWriter, r *http.Request) {
+	_, thread := h.loadThreadForRead(w, r)
+	if thread == nil {
+		return
+	}
+	resp := threadChainResponse{
+		ThreadID:   thread.ID,
+		InsightID:  thread.InsightID,
+		Changesets: []threadChainChangeset{},
+	}
+	if thread.InsightID != "" && h.deps.ChangesetReader != nil {
+		changesets, _, err := h.deps.ChangesetReader.ListChangesets(r.Context(),
+			knowledge.ChangesetFilter{SourceInsightID: thread.InsightID})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to load changesets")
+			return
+		}
+		for _, cs := range changesets {
+			resp.Changesets = append(resp.Changesets, threadChainChangeset{
+				ID:         cs.ID,
+				TargetURN:  cs.TargetURN,
+				ChangeType: cs.ChangeType,
+				CreatedAt:  cs.CreatedAt,
+				RolledBack: cs.RolledBack,
+			})
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // appendThreadEvent handles POST /api/v1/portal/threads/{id}/events.

--- a/pkg/portal/thread_handler_test.go
+++ b/pkg/portal/thread_handler_test.go
@@ -38,6 +38,7 @@ type mockThreadStore struct {
 	lastCountIDs      []string
 	linkedThreadIDs   []string
 	linkedInsightID   string
+	linkedReturn      []string
 	linkErr           error
 	validatedThreadID string
 	validateErr       error
@@ -89,10 +90,16 @@ func (m *mockThreadStore) CountOpenByTargets(_ context.Context, _ string, ids []
 	return m.counts, m.countErr
 }
 
-func (m *mockThreadStore) LinkInsight(_ context.Context, threadIDs []string, insightID, _, _ string) error {
+func (m *mockThreadStore) LinkInsight(_ context.Context, threadIDs []string, insightID, _, _ string) ([]string, error) {
 	m.linkedThreadIDs = threadIDs
 	m.linkedInsightID = insightID
-	return m.linkErr
+	if m.linkErr != nil {
+		return nil, m.linkErr
+	}
+	if m.linkedReturn != nil {
+		return m.linkedReturn, nil
+	}
+	return threadIDs, nil
 }
 
 func (m *mockThreadStore) RequestValidation(_ context.Context, id, _, _ string) error {

--- a/pkg/portal/thread_handler_test.go
+++ b/pkg/portal/thread_handler_test.go
@@ -19,24 +19,29 @@ import (
 
 // mockThreadStore is a controllable ThreadStore for handler tests.
 type mockThreadStore struct {
-	created      *Thread
-	createErr    error
-	listResult   []ThreadWithMeta
-	listTotal    int
-	listErr      error
-	getResult    *Thread
-	getErr       error
-	events       []ThreadEvent
-	eventsErr    error
-	appended     *ThreadEvent
-	appendErr    error
-	updateErr    error
-	lastUpdate   *ThreadUpdate
-	deleteErr    error
-	counts       map[string]int
-	countErr     error
-	lastCountIDs []string
-	lastCreated  *Thread
+	created           *Thread
+	createErr         error
+	listResult        []ThreadWithMeta
+	listTotal         int
+	listErr           error
+	getResult         *Thread
+	getErr            error
+	events            []ThreadEvent
+	eventsErr         error
+	appended          *ThreadEvent
+	appendErr         error
+	updateErr         error
+	lastUpdate        *ThreadUpdate
+	deleteErr         error
+	counts            map[string]int
+	countErr          error
+	lastCountIDs      []string
+	linkedThreadIDs   []string
+	linkedInsightID   string
+	linkErr           error
+	validatedThreadID string
+	validateErr       error
+	lastCreated       *Thread
 }
 
 func (m *mockThreadStore) CreateThread(_ context.Context, t Thread, _ ThreadEvent) (*Thread, error) {
@@ -82,6 +87,17 @@ func (m *mockThreadStore) SoftDeleteThread(_ context.Context, _ string) error { 
 func (m *mockThreadStore) CountOpenByTargets(_ context.Context, _ string, ids []string) (map[string]int, error) {
 	m.lastCountIDs = ids
 	return m.counts, m.countErr
+}
+
+func (m *mockThreadStore) LinkInsight(_ context.Context, threadIDs []string, insightID, _, _ string) error {
+	m.linkedThreadIDs = threadIDs
+	m.linkedInsightID = insightID
+	return m.linkErr
+}
+
+func (m *mockThreadStore) RequestValidation(_ context.Context, id, _, _ string) error {
+	m.validatedThreadID = id
+	return m.validateErr
 }
 
 func newThreadTestHandler(threads *mockThreadStore, assets *mockAssetStore, shares *mockShareStore, user *User) *Handler {

--- a/pkg/portal/thread_store.go
+++ b/pkg/portal/thread_store.go
@@ -174,6 +174,13 @@ const (
 	maxThreadLimit     = 200
 )
 
+// Shared literals (kept as constants to satisfy the no-magic-string lint).
+const (
+	errBeginTx  = "begin tx: %w"
+	errCommitTx = "commit: %w"
+	eventIDKind = "evt" // newThreadID prefix for event ids
+)
+
 // EffectiveLimit returns the clamped page size, applying the default when unset.
 func (f *ThreadFilter) EffectiveLimit() int {
 	if f.Limit <= 0 {
@@ -214,9 +221,11 @@ type ThreadStore interface {
 	// LinkInsight links one or more threads to a captured insight: it sets
 	// insight_id, appends an insight_linked event, and transitions the thread to
 	// resolved, atomically per thread. Threads that are missing or already
-	// deleted are skipped. This is the bridge from feedback into the knowledge
-	// loop (Phase 2 / #602).
-	LinkInsight(ctx context.Context, threadIDs []string, insightID, actorID, actorEmail string) error
+	// deleted are skipped. It returns the IDs of the threads that were actually
+	// linked, so the caller can detect (and report) thread_ids that matched
+	// nothing. This is the bridge from feedback into the knowledge loop
+	// (Phase 2 / #602).
+	LinkInsight(ctx context.Context, threadIDs []string, insightID, actorID, actorEmail string) ([]string, error)
 	// RequestValidation moves a thread to validation_state=pending and records a
 	// validation_request event, atomically.
 	RequestValidation(ctx context.Context, id, actorID, actorEmail string) error
@@ -240,7 +249,7 @@ func NewPostgresThreadStore(db *sql.DB) ThreadStore {
 func (s *postgresThreadStore) CreateThread(ctx context.Context, t Thread, first ThreadEvent) (*Thread, error) { //nolint:revive // interface impl
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, fmt.Errorf("begin tx: %w", err)
+		return nil, fmt.Errorf(errBeginTx, err)
 	}
 	defer tx.Rollback() //nolint:errcheck // commit below on success
 
@@ -265,7 +274,7 @@ func (s *postgresThreadStore) CreateThread(ctx context.Context, t Thread, first 
 	}
 
 	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit: %w", err)
+		return nil, fmt.Errorf(errCommitTx, err)
 	}
 	return &t, nil
 }
@@ -375,7 +384,7 @@ func (s *postgresThreadStore) ListEvents(ctx context.Context, threadID string) (
 func (s *postgresThreadStore) AppendEvent(ctx context.Context, e ThreadEvent) (*ThreadEvent, error) { //nolint:revive // interface impl
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, fmt.Errorf("begin tx: %w", err)
+		return nil, fmt.Errorf(errBeginTx, err)
 	}
 	defer tx.Rollback() //nolint:errcheck // commit below on success
 
@@ -386,7 +395,7 @@ func (s *postgresThreadStore) AppendEvent(ctx context.Context, e ThreadEvent) (*
 		return nil, err
 	}
 	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit: %w", err)
+		return nil, fmt.Errorf(errCommitTx, err)
 	}
 	// created_at was assigned by the DB default; re-read is unnecessary for the
 	// caller, which already holds the event it submitted.
@@ -396,7 +405,7 @@ func (s *postgresThreadStore) AppendEvent(ctx context.Context, e ThreadEvent) (*
 func (s *postgresThreadStore) UpdateThread(ctx context.Context, id string, u ThreadUpdate, actorID, actorEmail string) error { //nolint:revive // interface impl
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return fmt.Errorf(errBeginTx, err)
 	}
 	defer tx.Rollback() //nolint:errcheck // commit below on success
 
@@ -419,7 +428,7 @@ func (s *postgresThreadStore) UpdateThread(ctx context.Context, id string, u Thr
 	// view never shows a status with no corresponding event.
 	if u.Status != nil && *u.Status != oldStatus {
 		evt := ThreadEvent{
-			ID:          newThreadID("evt"),
+			ID:          newThreadID(eventIDKind),
 			ThreadID:    id,
 			EventType:   statusChangeEventType(*u.Status),
 			AuthorID:    actorID,
@@ -432,7 +441,7 @@ func (s *postgresThreadStore) UpdateThread(ctx context.Context, id string, u Thr
 	}
 
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit: %w", err)
+		return fmt.Errorf(errCommitTx, err)
 	}
 	return nil
 }
@@ -454,54 +463,79 @@ func (s *postgresThreadStore) SoftDeleteThread(ctx context.Context, id string) e
 	return nil
 }
 
-func (s *postgresThreadStore) LinkInsight(ctx context.Context, threadIDs []string, insightID, actorID, actorEmail string) error { //nolint:revive // interface impl
+func (s *postgresThreadStore) LinkInsight(ctx context.Context, threadIDs []string, insightID, actorID, actorEmail string) ([]string, error) { //nolint:revive // interface impl
 	if len(threadIDs) == 0 || insightID == "" {
-		return nil
+		return nil, nil
 	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return nil, fmt.Errorf(errBeginTx, err)
 	}
 	defer tx.Rollback() //nolint:errcheck // commit below on success
 
+	linked := make([]string, 0, len(threadIDs))
+	seen := make(map[string]struct{}, len(threadIDs))
 	for _, id := range threadIDs {
-		res, err := tx.ExecContext(ctx,
-			`UPDATE portal_threads SET insight_id = $1, status = $2, updated_at = NOW()
-			 WHERE id = $3 AND deleted_at IS NULL`,
-			insightID, ThreadStatusResolved, id)
+		if _, dup := seen[id]; dup {
+			continue // de-dupe: a repeated id must not double-link or double-count
+		}
+		seen[id] = struct{}{}
+		ok, err := linkInsightToThreadTx(ctx, tx, id, insightID, threadActor{actorID, actorEmail})
 		if err != nil {
-			return fmt.Errorf("linking insight to thread %s: %w", id, err)
+			return nil, err
 		}
-		affected, err := res.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("checking rows affected: %w", err)
-		}
-		if affected == 0 {
-			continue // missing or deleted thread: skip
-		}
-		evt := ThreadEvent{
-			ID:          newThreadID("evt"),
-			ThreadID:    id,
-			EventType:   EventTypeInsightLinked,
-			AuthorID:    actorID,
-			AuthorEmail: actorEmail,
-			Metadata:    insightLinkedMetadata(insightID),
-		}
-		if err := insertEventTx(ctx, tx, evt); err != nil {
-			return err
+		if ok {
+			linked = append(linked, id)
 		}
 	}
 
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit: %w", err)
+		return nil, fmt.Errorf(errCommitTx, err)
 	}
-	return nil
+	return linked, nil
+}
+
+// threadActor identifies who performed a thread mutation.
+type threadActor struct {
+	id    string
+	email string
+}
+
+// linkInsightToThreadTx links one thread to the insight inside tx, returning
+// false (and no error) when the thread is missing or already deleted.
+func linkInsightToThreadTx(ctx context.Context, tx *sql.Tx, id, insightID string, actor threadActor) (bool, error) {
+	res, err := tx.ExecContext(ctx,
+		`UPDATE portal_threads SET insight_id = $1, status = $2, updated_at = NOW()
+		 WHERE id = $3 AND deleted_at IS NULL`,
+		insightID, ThreadStatusResolved, id)
+	if err != nil {
+		return false, fmt.Errorf("linking insight to thread %s: %w", id, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("checking rows affected: %w", err)
+	}
+	if affected == 0 {
+		return false, nil // missing or deleted thread: skip
+	}
+	evt := ThreadEvent{
+		ID:          newThreadID(eventIDKind),
+		ThreadID:    id,
+		EventType:   EventTypeInsightLinked,
+		AuthorID:    actor.id,
+		AuthorEmail: actor.email,
+		Metadata:    insightLinkedMetadata(insightID),
+	}
+	if err := insertEventTx(ctx, tx, evt); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (s *postgresThreadStore) RequestValidation(ctx context.Context, id, actorID, actorEmail string) error { //nolint:revive // interface impl
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
+		return fmt.Errorf(errBeginTx, err)
 	}
 	defer tx.Rollback() //nolint:errcheck // commit below on success
 
@@ -521,7 +555,7 @@ func (s *postgresThreadStore) RequestValidation(ctx context.Context, id, actorID
 	}
 
 	evt := ThreadEvent{
-		ID:          newThreadID("evt"),
+		ID:          newThreadID(eventIDKind),
 		ThreadID:    id,
 		EventType:   EventTypeValidationRequest,
 		AuthorID:    actorID,
@@ -532,7 +566,7 @@ func (s *postgresThreadStore) RequestValidation(ctx context.Context, id, actorID
 	}
 
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit: %w", err)
+		return fmt.Errorf(errCommitTx, err)
 	}
 	return nil
 }
@@ -789,7 +823,7 @@ func newThreadID(prefix string) string {
 // NewThreadEventID returns a unique id for a thread event. Exported so callers
 // outside the package (the portal toolkit) can mint event ids for AppendEvent.
 func NewThreadEventID() string {
-	return newThreadID("evt")
+	return newThreadID(eventIDKind)
 }
 
 func statusOrDefault(status string) string {

--- a/pkg/portal/thread_store.go
+++ b/pkg/portal/thread_store.go
@@ -157,14 +157,16 @@ type ThreadWithMeta struct {
 
 // ThreadFilter selects threads for listing.
 type ThreadFilter struct {
-	TargetType   string
-	AssetID      string
-	CollectionID string
-	PromptID     string
-	Kind         string
-	Status       string
-	Limit        int
-	Offset       int
+	TargetType         string
+	AssetID            string
+	CollectionID       string
+	PromptID           string
+	Kind               string
+	Status             string
+	RequiresResolution *bool
+	ValidationState    string
+	Limit              int
+	Offset             int
 }
 
 const (
@@ -209,6 +211,15 @@ type ThreadStore interface {
 	UpdateThread(ctx context.Context, id string, u ThreadUpdate, actorID, actorEmail string) error
 	// SoftDeleteThread marks a thread deleted.
 	SoftDeleteThread(ctx context.Context, id string) error
+	// LinkInsight links one or more threads to a captured insight: it sets
+	// insight_id, appends an insight_linked event, and transitions the thread to
+	// resolved, atomically per thread. Threads that are missing or already
+	// deleted are skipped. This is the bridge from feedback into the knowledge
+	// loop (Phase 2 / #602).
+	LinkInsight(ctx context.Context, threadIDs []string, insightID, actorID, actorEmail string) error
+	// RequestValidation moves a thread to validation_state=pending and records a
+	// validation_request event, atomically.
+	RequestValidation(ctx context.Context, id, actorID, actorEmail string) error
 	// CountOpenByTargets returns, per target id, the number of open (non-deleted)
 	// threads. targetType must be asset/collection/prompt. Callers are
 	// responsible for restricting ids to those the requester may see.
@@ -443,6 +454,95 @@ func (s *postgresThreadStore) SoftDeleteThread(ctx context.Context, id string) e
 	return nil
 }
 
+func (s *postgresThreadStore) LinkInsight(ctx context.Context, threadIDs []string, insightID, actorID, actorEmail string) error { //nolint:revive // interface impl
+	if len(threadIDs) == 0 || insightID == "" {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // commit below on success
+
+	for _, id := range threadIDs {
+		res, err := tx.ExecContext(ctx,
+			`UPDATE portal_threads SET insight_id = $1, status = $2, updated_at = NOW()
+			 WHERE id = $3 AND deleted_at IS NULL`,
+			insightID, ThreadStatusResolved, id)
+		if err != nil {
+			return fmt.Errorf("linking insight to thread %s: %w", id, err)
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("checking rows affected: %w", err)
+		}
+		if affected == 0 {
+			continue // missing or deleted thread: skip
+		}
+		evt := ThreadEvent{
+			ID:          newThreadID("evt"),
+			ThreadID:    id,
+			EventType:   EventTypeInsightLinked,
+			AuthorID:    actorID,
+			AuthorEmail: actorEmail,
+			Metadata:    insightLinkedMetadata(insightID),
+		}
+		if err := insertEventTx(ctx, tx, evt); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+
+func (s *postgresThreadStore) RequestValidation(ctx context.Context, id, actorID, actorEmail string) error { //nolint:revive // interface impl
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // commit below on success
+
+	res, err := tx.ExecContext(ctx,
+		`UPDATE portal_threads SET validation_state = $1, updated_at = NOW()
+		 WHERE id = $2 AND deleted_at IS NULL`,
+		ValidationStatePending, id)
+	if err != nil {
+		return fmt.Errorf("requesting validation: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("checking rows affected: %w", err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("thread not found or already deleted: %s", id)
+	}
+
+	evt := ThreadEvent{
+		ID:          newThreadID("evt"),
+		ThreadID:    id,
+		EventType:   EventTypeValidationRequest,
+		AuthorID:    actorID,
+		AuthorEmail: actorEmail,
+	}
+	if err := insertEventTx(ctx, tx, evt); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+
+// insightLinkedMetadata builds the JSON metadata for an insight_linked event.
+func insightLinkedMetadata(insightID string) json.RawMessage {
+	b, _ := json.Marshal(map[string]string{"insight_id": insightID}) //nolint:errcheck // map of strings cannot fail
+	return b
+}
+
 func (s *postgresThreadStore) CountOpenByTargets(ctx context.Context, targetType string, ids []string) (map[string]int, error) { //nolint:revive // interface impl
 	counts := make(map[string]int)
 	if len(ids) == 0 {
@@ -514,6 +614,12 @@ func applyThreadFilter(qb sq.SelectBuilder, f ThreadFilter) sq.SelectBuilder {
 	}
 	if f.Status != "" {
 		qb = qb.Where(sq.Eq{"t.status": f.Status})
+	}
+	if f.RequiresResolution != nil {
+		qb = qb.Where(sq.Eq{"t.requires_resolution": *f.RequiresResolution})
+	}
+	if f.ValidationState != "" {
+		qb = qb.Where(sq.Eq{"t.validation_state": f.ValidationState})
 	}
 	return qb
 }
@@ -678,6 +784,12 @@ var threadSelectColumns = strings.Join(threadColumnNames, ", ")
 // newThreadID returns a prefixed unique id (e.g. "thr_<uuid>", "evt_<uuid>").
 func newThreadID(prefix string) string {
 	return prefix + "_" + uuid.New().String()
+}
+
+// NewThreadEventID returns a unique id for a thread event. Exported so callers
+// outside the package (the portal toolkit) can mint event ids for AppendEvent.
+func NewThreadEventID() string {
+	return newThreadID("evt")
 }
 
 func statusOrDefault(status string) string {

--- a/pkg/portal/thread_store_test.go
+++ b/pkg/portal/thread_store_test.go
@@ -287,6 +287,67 @@ func TestTargetColumn(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestThreadStoreLinkInsight(t *testing.T) {
+	store, mock := newThreadStoreMock(t)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE portal_threads SET insight_id").
+		WithArgs("ins_1", ThreadStatusResolved, "thr_1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO portal_thread_events").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE portal_threads SET insight_id").
+		WithArgs("ins_1", ThreadStatusResolved, "thr_missing").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	err := store.LinkInsight(context.Background(), []string{"thr_1", "thr_missing"}, "ins_1", "u1", "u1@example.com")
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestThreadStoreLinkInsightNoop(t *testing.T) {
+	store, _ := newThreadStoreMock(t)
+	require.NoError(t, store.LinkInsight(context.Background(), nil, "ins_1", "u", "e"))
+	require.NoError(t, store.LinkInsight(context.Background(), []string{"t"}, "", "u", "e"))
+}
+
+func TestThreadStoreRequestValidation(t *testing.T) {
+	store, mock := newThreadStoreMock(t)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE portal_threads SET validation_state").
+		WithArgs(ValidationStatePending, "thr_1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO portal_thread_events").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	require.NoError(t, store.RequestValidation(context.Background(), "thr_1", "u1", "u1@example.com"))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestThreadStoreRequestValidationNotFound(t *testing.T) {
+	store, mock := newThreadStoreMock(t)
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE portal_threads SET validation_state").
+		WithArgs(ValidationStatePending, "missing").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+	require.Error(t, store.RequestValidation(context.Background(), "missing", "u1", "u1@example.com"))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestInsightLinkedMetadata(t *testing.T) {
+	var m map[string]string
+	require.NoError(t, json.Unmarshal(insightLinkedMetadata("ins_9"), &m))
+	assert.Equal(t, "ins_9", m["insight_id"])
+}
+
+func TestNewThreadEventID(t *testing.T) {
+	id := NewThreadEventID()
+	assert.Contains(t, id, "evt_")
+	assert.NotEqual(t, id, NewThreadEventID())
+}
+
 // --- pure helpers ---
 
 func TestStatusAndValidationDefaults(t *testing.T) {

--- a/pkg/portal/thread_store_test.go
+++ b/pkg/portal/thread_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -300,15 +301,93 @@ func TestThreadStoreLinkInsight(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
-	err := store.LinkInsight(context.Background(), []string{"thr_1", "thr_missing"}, "ins_1", "u1", "u1@example.com")
+	linked, err := store.LinkInsight(context.Background(), []string{"thr_1", "thr_missing"}, "ins_1", "u1", "u1@example.com")
 	require.NoError(t, err)
+	// thr_1 linked (1 row affected); thr_missing skipped (0 rows affected).
+	assert.Equal(t, []string{"thr_1"}, linked)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestThreadStoreLinkInsightNoop(t *testing.T) {
 	store, _ := newThreadStoreMock(t)
-	require.NoError(t, store.LinkInsight(context.Background(), nil, "ins_1", "u", "e"))
-	require.NoError(t, store.LinkInsight(context.Background(), []string{"t"}, "", "u", "e"))
+	linked, err := store.LinkInsight(context.Background(), nil, "ins_1", "u", "e")
+	require.NoError(t, err)
+	assert.Nil(t, linked)
+	linked, err = store.LinkInsight(context.Background(), []string{"t"}, "", "u", "e")
+	require.NoError(t, err)
+	assert.Nil(t, linked)
+}
+
+func TestThreadStoreLinkInsightErrors(t *testing.T) {
+	t.Run("begin error", func(t *testing.T) {
+		store, mock := newThreadStoreMock(t)
+		mock.ExpectBegin().WillReturnError(errors.New("begin boom"))
+		_, err := store.LinkInsight(context.Background(), []string{"t1"}, "ins_1", "u", "e")
+		require.Error(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("update exec error", func(t *testing.T) {
+		store, mock := newThreadStoreMock(t)
+		mock.ExpectBegin()
+		mock.ExpectExec("UPDATE portal_threads SET insight_id").
+			WithArgs("ins_1", ThreadStatusResolved, "t1").
+			WillReturnError(errors.New("exec boom"))
+		mock.ExpectRollback()
+		_, err := store.LinkInsight(context.Background(), []string{"t1"}, "ins_1", "u", "e")
+		require.Error(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("commit error", func(t *testing.T) {
+		store, mock := newThreadStoreMock(t)
+		mock.ExpectBegin()
+		mock.ExpectExec("UPDATE portal_threads SET insight_id").
+			WithArgs("ins_1", ThreadStatusResolved, "t1").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec("INSERT INTO portal_thread_events").WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectCommit().WillReturnError(errors.New("commit boom"))
+		_, err := store.LinkInsight(context.Background(), []string{"t1"}, "ins_1", "u", "e")
+		require.Error(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestThreadStoreLinkInsightDeduplicates(t *testing.T) {
+	store, mock := newThreadStoreMock(t)
+	mock.ExpectBegin()
+	// A repeated id must produce exactly ONE update + one event, not two.
+	mock.ExpectExec("UPDATE portal_threads SET insight_id").
+		WithArgs("ins_1", ThreadStatusResolved, "thr_1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO portal_thread_events").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	linked, err := store.LinkInsight(context.Background(), []string{"thr_1", "thr_1"}, "ins_1", "u1", "u1@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"thr_1"}, linked)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestThreadStoreRequestValidationErrors(t *testing.T) {
+	t.Run("begin error", func(t *testing.T) {
+		store, mock := newThreadStoreMock(t)
+		mock.ExpectBegin().WillReturnError(errors.New("begin boom"))
+		require.Error(t, store.RequestValidation(context.Background(), "t1", "u", "e"))
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("commit error", func(t *testing.T) {
+		store, mock := newThreadStoreMock(t)
+		mock.ExpectBegin()
+		mock.ExpectExec("UPDATE portal_threads SET validation_state").
+			WithArgs(ValidationStatePending, "t1").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec("INSERT INTO portal_thread_events").WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectCommit().WillReturnError(errors.New("commit boom"))
+		require.Error(t, store.RequestValidation(context.Background(), "t1", "u", "e"))
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
 }
 
 func TestThreadStoreRequestValidation(t *testing.T) {

--- a/pkg/toolkits/knowledge/changeset_store.go
+++ b/pkg/toolkits/knowledge/changeset_store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -126,6 +127,10 @@ func applyChangesetFilter(qb sq.SelectBuilder, filter ChangesetFilter) sq.Select
 	}
 	if filter.RolledBack != nil {
 		qb = qb.Where(sq.Eq{"rolled_back": *filter.RolledBack})
+	}
+	if filter.SourceInsightID != "" {
+		// JSONB array containment: does source_insight_ids contain this id?
+		qb = qb.Where(sq.Expr("source_insight_ids @> ?::jsonb", strconv.Quote(filter.SourceInsightID)))
 	}
 	return qb
 }

--- a/pkg/toolkits/knowledge/schemas.go
+++ b/pkg/toolkits/knowledge/schemas.go
@@ -81,6 +81,12 @@ var captureInsightSchema = json.RawMessage(`{
         }
       },
       "maxItems": 5
+    },
+    "thread_ids": {
+      "type": "array",
+      "description": "IDs of feedback thread(s) this insight resolves. Each linked thread is marked resolved, records an insight_linked event, and carries this insight's id. Obtain thread IDs from manage_artifact action=list_threads.",
+      "items": {"type": "string"},
+      "maxItems": 50
     }
   }
 }`)

--- a/pkg/toolkits/knowledge/thread_link_test.go
+++ b/pkg/toolkits/knowledge/thread_link_test.go
@@ -1,0 +1,147 @@
+package knowledge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+)
+
+// fakeLinker is a configurable ThreadLinker for capture_insight tests.
+type fakeLinker struct {
+	gotThreadIDs []string
+	gotInsightID string
+	linkedReturn []string
+	err          error
+}
+
+func (f *fakeLinker) LinkInsight(_ context.Context, threadIDs []string, insightID, _, _ string) ([]string, error) {
+	f.gotThreadIDs = threadIDs
+	f.gotInsightID = insightID
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.linkedReturn, f.err
+}
+
+func captureOutput(t *testing.T, res *mcp.CallToolResult) captureInsightOutput {
+	t.Helper()
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	var out captureInsightOutput
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &out))
+	return out
+}
+
+func TestCaptureInsight_ThreadLink(t *testing.T) {
+	t.Run("links and reports unlinked thread ids", func(t *testing.T) {
+		spy := &fullSpyStore{}
+		tk, err := New(testName, spy)
+		require.NoError(t, err)
+		linker := &fakeLinker{linkedReturn: []string{"thr_1"}} // thr_2 not linked
+		tk.SetThreadLinker(linker)
+
+		res, _, callErr := tk.handleCaptureInsight(context.Background(), nil, captureInsightInput{
+			Category:    testCategory,
+			InsightText: testInsightText,
+			ThreadIDs:   []string{"thr_1", "thr_2"},
+		})
+		require.Nil(t, callErr)
+		require.False(t, res.IsError)
+		require.Len(t, spy.Insights, 1)
+
+		out := captureOutput(t, res)
+		// The linker was called with the insight's own id.
+		assert.Equal(t, out.InsightID, linker.gotInsightID)
+		assert.Equal(t, []string{"thr_1", "thr_2"}, linker.gotThreadIDs)
+		assert.Equal(t, 1, out.LinkedThreadCount)
+		assert.Equal(t, []string{"thr_2"}, out.UnlinkedThreadIDs)
+	})
+
+	t.Run("no thread_ids leaves output unchanged (no regression)", func(t *testing.T) {
+		spy := &fullSpyStore{}
+		tk, err := New(testName, spy)
+		require.NoError(t, err)
+		linker := &fakeLinker{}
+		tk.SetThreadLinker(linker)
+
+		res, _, callErr := tk.handleCaptureInsight(context.Background(), nil, captureInsightInput{
+			Category:    testCategory,
+			InsightText: testInsightText,
+		})
+		require.Nil(t, callErr)
+		require.False(t, res.IsError)
+
+		// Linker not invoked; result carries no thread fields.
+		assert.Nil(t, linker.gotThreadIDs)
+		out := captureOutput(t, res)
+		assert.Equal(t, 0, out.LinkedThreadCount)
+		assert.Nil(t, out.UnlinkedThreadIDs)
+
+		// And the raw JSON omits the thread fields entirely.
+		tc := res.Content[0].(*mcp.TextContent) //nolint:errcheck // test assertion
+		assert.NotContains(t, tc.Text, "linked_thread_count")
+		assert.NotContains(t, tc.Text, "unlinked_thread_ids")
+	})
+
+	t.Run("link failure does not fail the capture; all reported unlinked", func(t *testing.T) {
+		spy := &fullSpyStore{}
+		tk, err := New(testName, spy)
+		require.NoError(t, err)
+		tk.SetThreadLinker(&fakeLinker{err: errors.New("db down")})
+
+		res, _, callErr := tk.handleCaptureInsight(context.Background(), nil, captureInsightInput{
+			Category:    testCategory,
+			InsightText: testInsightText,
+			ThreadIDs:   []string{"thr_1"},
+		})
+		require.Nil(t, callErr)
+		require.False(t, res.IsError) // best-effort: insight still captured
+		require.Len(t, spy.Insights, 1)
+
+		out := captureOutput(t, res)
+		assert.Equal(t, 0, out.LinkedThreadCount)
+		assert.Equal(t, []string{"thr_1"}, out.UnlinkedThreadIDs)
+	})
+
+	t.Run("thread_ids supplied but no linker wired reports all unlinked", func(t *testing.T) {
+		spy := &fullSpyStore{}
+		tk, err := New(testName, spy)
+		require.NoError(t, err)
+		// No SetThreadLinker call.
+
+		res, _, callErr := tk.handleCaptureInsight(context.Background(), nil, captureInsightInput{
+			Category:    testCategory,
+			InsightText: testInsightText,
+			ThreadIDs:   []string{"thr_1", "thr_2"},
+		})
+		require.Nil(t, callErr)
+		require.False(t, res.IsError)
+
+		out := captureOutput(t, res)
+		assert.Equal(t, 0, out.LinkedThreadCount)
+		assert.Equal(t, []string{"thr_1", "thr_2"}, out.UnlinkedThreadIDs)
+	})
+}
+
+func TestMissingFrom(t *testing.T) {
+	assert.Nil(t, missingFrom(nil, []string{"a"}))
+	assert.Equal(t, []string{"b"}, missingFrom([]string{"a", "b"}, []string{"a"}))
+	assert.Nil(t, missingFrom([]string{"a"}, []string{"a"}))
+}
+
+func TestInsightActor(t *testing.T) {
+	id, email := insightActor(nil)
+	assert.Equal(t, "", id)
+	assert.Equal(t, "", email)
+
+	id, email = insightActor(&middleware.PlatformContext{UserID: "u1", UserEmail: "u1@example.com"})
+	assert.Equal(t, "u1", id)
+	assert.Equal(t, "u1@example.com", email)
+}

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -54,6 +54,10 @@ type captureInsightInput struct {
 	EntityURNs       []string          `json:"entity_urns,omitempty"`
 	RelatedColumns   []RelatedColumn   `json:"related_columns,omitempty"`
 	SuggestedActions []SuggestedAction `json:"suggested_actions,omitempty"`
+	// ThreadIDs links this insight back to the feedback thread(s) it resolves
+	// (Phase 2 / #602). Each linked thread gets insight_id set, an
+	// insight_linked event, and a transition to resolved. Optional.
+	ThreadIDs []string `json:"thread_ids,omitempty"`
 }
 
 // captureInsightOutput is the success response.
@@ -101,6 +105,31 @@ type Toolkit struct {
 	queryProvider    query.Provider
 
 	promptCreator PromptCreator
+
+	// threadLinker bridges captured insights back to feedback threads
+	// (Phase 2 / #602). Optional; nil disables thread linking.
+	threadLinker ThreadLinker
+}
+
+// ThreadLinker links a captured insight back to the feedback thread(s) it
+// resolved. Satisfied by the portal thread store; kept as a minimal interface
+// here so the knowledge toolkit does not depend on the portal package.
+type ThreadLinker interface {
+	LinkInsight(ctx context.Context, threadIDs []string, insightID, actorID, actorEmail string) error
+}
+
+// SetThreadLinker wires the feedback-thread bridge used by capture_insight.
+func (t *Toolkit) SetThreadLinker(tl ThreadLinker) {
+	t.threadLinker = tl
+}
+
+// insightActor extracts the actor id/email recorded on the insight_linked
+// thread event from the platform context.
+func insightActor(pc *middleware.PlatformContext) (actorID, actorEmail string) {
+	if pc == nil {
+		return "", ""
+	}
+	return pc.UserID, pc.UserEmail
 }
 
 // New creates a new knowledge toolkit.
@@ -282,6 +311,16 @@ func (t *Toolkit) handleCaptureInsight(ctx context.Context, _ *mcp.CallToolReque
 	// Persist
 	if err := t.store.Insert(ctx, insight); err != nil {
 		return errorResult("failed to save insight: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
+	}
+
+	// Bridge the insight back to any feedback threads it resolves (Phase 2).
+	// Best-effort: a thread-link failure must not fail the capture, since the
+	// insight is already persisted.
+	if t.threadLinker != nil && len(input.ThreadIDs) > 0 {
+		actorID, actorEmail := insightActor(pc)
+		if linkErr := t.threadLinker.LinkInsight(ctx, input.ThreadIDs, id, actorID, actorEmail); linkErr != nil {
+			slog.Warn("failed to link insight to threads", "id", id, "threads", input.ThreadIDs, "error", linkErr)
+		}
 	}
 
 	// Generate embedding for the memory record only when a real

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -65,6 +65,11 @@ type captureInsightOutput struct {
 	InsightID string `json:"insight_id"`
 	Status    string `json:"status"`
 	Message   string `json:"message"`
+	// LinkedThreadCount / UnlinkedThreadIDs report the outcome of the optional
+	// thread_ids bridge (Phase 2 / #602). Both are omitted when no thread_ids
+	// were supplied, so a capture without thread_ids is byte-for-byte unchanged.
+	LinkedThreadCount int      `json:"linked_thread_count,omitempty"`
+	UnlinkedThreadIDs []string `json:"unlinked_thread_ids,omitempty"`
 }
 
 // applyKnowledgeInput defines the input schema for the apply_knowledge tool.
@@ -115,7 +120,7 @@ type Toolkit struct {
 // resolved. Satisfied by the portal thread store; kept as a minimal interface
 // here so the knowledge toolkit does not depend on the portal package.
 type ThreadLinker interface {
-	LinkInsight(ctx context.Context, threadIDs []string, insightID, actorID, actorEmail string) error
+	LinkInsight(ctx context.Context, threadIDs []string, insightID, actorID, actorEmail string) ([]string, error)
 }
 
 // SetThreadLinker wires the feedback-thread bridge used by capture_insight.
@@ -315,12 +320,23 @@ func (t *Toolkit) handleCaptureInsight(ctx context.Context, _ *mcp.CallToolReque
 
 	// Bridge the insight back to any feedback threads it resolves (Phase 2).
 	// Best-effort: a thread-link failure must not fail the capture, since the
-	// insight is already persisted.
+	// insight is already persisted. The result reports which thread_ids actually
+	// linked so the agent can tell when a supplied id matched nothing.
+	linkedThreadCount := 0
+	var unlinkedThreadIDs []string
 	if t.threadLinker != nil && len(input.ThreadIDs) > 0 {
 		actorID, actorEmail := insightActor(pc)
-		if linkErr := t.threadLinker.LinkInsight(ctx, input.ThreadIDs, id, actorID, actorEmail); linkErr != nil {
+		linked, linkErr := t.threadLinker.LinkInsight(ctx, input.ThreadIDs, id, actorID, actorEmail)
+		if linkErr != nil {
 			slog.Warn("failed to link insight to threads", "id", id, "threads", input.ThreadIDs, "error", linkErr)
+			unlinkedThreadIDs = input.ThreadIDs
+		} else {
+			linkedThreadCount = len(linked)
+			unlinkedThreadIDs = missingFrom(input.ThreadIDs, linked)
 		}
+	} else if len(input.ThreadIDs) > 0 {
+		// thread_ids supplied but no linker wired: nothing linked.
+		unlinkedThreadIDs = input.ThreadIDs
 	}
 
 	// Generate embedding for the memory record only when a real
@@ -339,7 +355,25 @@ func (t *Toolkit) handleCaptureInsight(ctx context.Context, _ *mcp.CallToolReque
 	}
 
 	// Return success
-	return successResult(id)
+	return successResult(id, linkedThreadCount, unlinkedThreadIDs)
+}
+
+// missingFrom returns the entries of want that are not present in got.
+func missingFrom(want, got []string) []string {
+	if len(want) == 0 {
+		return nil
+	}
+	present := make(map[string]struct{}, len(got))
+	for _, g := range got {
+		present[g] = struct{}{}
+	}
+	var missing []string
+	for _, w := range want {
+		if _, ok := present[w]; !ok {
+			missing = append(missing, w)
+		}
+	}
+	return missing
 }
 
 // handleApplyKnowledge dispatches to the appropriate action handler.
@@ -1093,12 +1127,16 @@ func errorResult(msg string) *mcp.CallToolResult {
 	}
 }
 
-// successResult creates a success CallToolResult.
-func successResult(insightID string) (*mcp.CallToolResult, any, error) {
+// successResult creates a success CallToolResult. linkedThreadCount and
+// unlinkedThreadIDs report the optional thread_ids bridge outcome; both are
+// zero/nil (and omitted from the JSON) for a capture without thread_ids.
+func successResult(insightID string, linkedThreadCount int, unlinkedThreadIDs []string) (*mcp.CallToolResult, any, error) {
 	output := captureInsightOutput{
-		InsightID: insightID,
-		Status:    StatusPending,
-		Message:   "Insight captured. It will be reviewed by a data catalog administrator.",
+		InsightID:         insightID,
+		Status:            StatusPending,
+		Message:           "Insight captured. It will be reviewed by a data catalog administrator.",
+		LinkedThreadCount: linkedThreadCount,
+		UnlinkedThreadIDs: unlinkedThreadIDs,
 	}
 
 	data, err := json.Marshal(output)

--- a/pkg/toolkits/knowledge/toolkit_test.go
+++ b/pkg/toolkits/knowledge/toolkit_test.go
@@ -1140,7 +1140,7 @@ func TestErrorResult(t *testing.T) {
 }
 
 func TestSuccessResult(t *testing.T) {
-	result, _, err := successResult("abc123")
+	result, _, err := successResult("abc123", 0, nil)
 	require.Nil(t, err)
 	require.False(t, result.IsError)
 	require.NotEmpty(t, result.Content)

--- a/pkg/toolkits/knowledge/types.go
+++ b/pkg/toolkits/knowledge/types.go
@@ -385,13 +385,16 @@ type Changeset struct {
 
 // ChangesetFilter defines filtering criteria for listing changesets.
 type ChangesetFilter struct {
-	EntityURN  string
-	AppliedBy  string
-	Since      *time.Time
-	Until      *time.Time
-	RolledBack *bool
-	Limit      int
-	Offset     int
+	EntityURN string
+	AppliedBy string
+	// SourceInsightID filters to changesets whose source_insight_ids array
+	// contains this insight id (the thread -> insight -> changeset bridge).
+	SourceInsightID string
+	Since           *time.Time
+	Until           *time.Time
+	RolledBack      *bool
+	Limit           int
+	Offset          int
 }
 
 // EffectiveLimit returns the limit to use, applying defaults and caps.

--- a/pkg/toolkits/portal/schemas.go
+++ b/pkg/toolkits/portal/schemas.go
@@ -43,7 +43,7 @@ var manageArtifactSchema = json.RawMessage(`{
   "properties": {
     "action": {
       "type": "string",
-      "description": "Action to perform. Asset actions: list, get, update, delete, list_versions, revert, search. Collection actions: create_collection, list_collections, get_collection, update_collection, delete_collection, set_sections"
+      "description": "Action to perform. Asset actions: list, get, update, delete, list_versions, revert, search. Collection actions: create_collection, list_collections, get_collection, update_collection, delete_collection, set_sections. Feedback actions: list_threads (scope by asset_id/collection_id/prompt_id or target_type=standalone; optional status/validation_state/requires_resolution filters), get_thread, reply_thread, resolve_thread, request_validation"
     },
     "asset_id": {
       "type": "string",
@@ -128,6 +128,34 @@ var manageArtifactSchema = json.RawMessage(`{
           }
         }
       }
+    },
+    "prompt_id": {
+      "type": "string",
+      "description": "Prompt ID target for list_threads (feedback on a prompt)"
+    },
+    "target_type": {
+      "type": "string",
+      "description": "Thread target scope for list_threads. Use 'standalone' for general feedback not tied to an artifact"
+    },
+    "thread_id": {
+      "type": "string",
+      "description": "Feedback thread ID (required for get_thread, reply_thread, resolve_thread, request_validation)"
+    },
+    "body": {
+      "type": "string",
+      "description": "Reply text (required for reply_thread)"
+    },
+    "status": {
+      "type": "string",
+      "description": "Filter list_threads by thread status (open, answered, resolved, wont_fix, acknowledged)"
+    },
+    "validation_state": {
+      "type": "string",
+      "description": "Filter list_threads by validation state (none, pending, validated, disputed)"
+    },
+    "requires_resolution": {
+      "type": "boolean",
+      "description": "Filter list_threads to threads that do (true) or do not (false) require resolution"
     }
   }
 }`)

--- a/pkg/toolkits/portal/thread_actions.go
+++ b/pkg/toolkits/portal/thread_actions.go
@@ -1,0 +1,235 @@
+package portal
+
+import (
+	"context"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/portal"
+)
+
+// Feedback thread actions for manage_artifact (Phase 2 / #602). These are
+// additional actions on the existing tool, not new tools.
+//
+// Access model (the portal toolkit is the practitioner's agent surface, so it
+// is owner-centric and has no prompt store):
+//   - admin: full access.
+//   - asset / collection target: the caller must own the target artifact.
+//   - standalone target: any authenticated caller may read and reply; only the
+//     thread author (or an admin) may resolve / request validation.
+//   - prompt target: admin only (the toolkit cannot verify prompt ownership).
+
+const (
+	threadTargetAsset      = "asset"
+	threadTargetCollection = "collection"
+	threadTargetPrompt     = "prompt"
+	threadTargetStandalone = "standalone"
+
+	threadScopeErr = "specify target_type=standalone or exactly one of asset_id, collection_id, prompt_id"
+	threadsUnavail = "feedback threads are not available"
+)
+
+func (t *Toolkit) handleListThreads(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+	if t.threadStore == nil {
+		return errorResult(threadsUnavail), nil, nil
+	}
+	targetType, ok := threadScopeFromInput(input)
+	if !ok {
+		return errorResult(threadScopeErr), nil, nil
+	}
+	if !t.callerCanAccessTarget(ctx, targetType, input.AssetID, input.CollectionID) {
+		return errorResult("you can only view feedback on artifacts you own"), nil, nil
+	}
+
+	threads, total, err := t.threadStore.ListThreads(ctx, portal.ThreadFilter{
+		TargetType:         targetType,
+		AssetID:            input.AssetID,
+		CollectionID:       input.CollectionID,
+		PromptID:           input.PromptID,
+		Status:             input.Status,
+		ValidationState:    input.ValidationState,
+		RequiresResolution: input.RequiresResolution,
+		Limit:              input.Limit,
+		Offset:             input.Offset,
+	})
+	if err != nil {
+		return errorResult("failed to list threads: " + err.Error()), nil, nil
+	}
+	if threads == nil {
+		threads = []portal.ThreadWithMeta{}
+	}
+	return jsonResult(map[string]any{"threads": threads, fieldTotal: total})
+}
+
+func (t *Toolkit) handleGetThread(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+	thread, errRes := t.loadThread(ctx, input.ThreadID, false)
+	if errRes != nil {
+		return errRes, nil, nil
+	}
+	events, err := t.threadStore.ListEvents(ctx, thread.ID)
+	if err != nil {
+		return errorResult("failed to load thread events: " + err.Error()), nil, nil
+	}
+	if events == nil {
+		events = []portal.ThreadEvent{}
+	}
+	return jsonResult(map[string]any{"thread": thread, "events": events})
+}
+
+func (t *Toolkit) handleReplyThread(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+	if strings.TrimSpace(input.Body) == "" {
+		return errorResult("body is required for reply_thread"), nil, nil
+	}
+	thread, errRes := t.loadThread(ctx, input.ThreadID, false)
+	if errRes != nil {
+		return errRes, nil, nil
+	}
+	evt, err := t.threadStore.AppendEvent(ctx, portal.ThreadEvent{
+		ID:          portal.NewThreadEventID(),
+		ThreadID:    thread.ID,
+		EventType:   portal.EventTypeComment,
+		AuthorID:    resolveOwnerID(ctx),
+		AuthorEmail: resolveOwnerEmail(ctx),
+		Body:        input.Body,
+	})
+	if err != nil {
+		return errorResult("failed to reply: " + err.Error()), nil, nil
+	}
+	return jsonResult(evt)
+}
+
+func (t *Toolkit) handleResolveThread(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+	thread, errRes := t.loadThread(ctx, input.ThreadID, true)
+	if errRes != nil {
+		return errRes, nil, nil
+	}
+	resolved := portal.ThreadStatusResolved
+	if err := t.threadStore.UpdateThread(ctx, thread.ID,
+		portal.ThreadUpdate{Status: &resolved}, resolveOwnerID(ctx), resolveOwnerEmail(ctx)); err != nil {
+		return errorResult("failed to resolve thread: " + err.Error()), nil, nil
+	}
+	return jsonResult(map[string]any{"thread_id": thread.ID, "status": resolved})
+}
+
+func (t *Toolkit) handleRequestValidation(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+	thread, errRes := t.loadThread(ctx, input.ThreadID, true)
+	if errRes != nil {
+		return errRes, nil, nil
+	}
+	if err := t.threadStore.RequestValidation(ctx, thread.ID, resolveOwnerID(ctx), resolveOwnerEmail(ctx)); err != nil {
+		return errorResult("failed to request validation: " + err.Error()), nil, nil
+	}
+	return jsonResult(map[string]any{"thread_id": thread.ID, "validation_state": portal.ValidationStatePending})
+}
+
+// --- access helpers ---
+
+// loadThread fetches a thread and verifies the caller may act on it. moderate
+// distinguishes read/reply access from resolve/validation access. Returns an
+// error result (and nil thread) on failure.
+func (t *Toolkit) loadThread(ctx context.Context, threadID string, moderate bool) (*portal.Thread, *mcp.CallToolResult) {
+	if t.threadStore == nil {
+		return nil, errorResult(threadsUnavail)
+	}
+	if threadID == "" {
+		return nil, errorResult("thread_id is required")
+	}
+	thread, err := t.threadStore.GetThread(ctx, threadID)
+	if err != nil {
+		return nil, errorResult("thread not found: " + err.Error())
+	}
+	if !t.callerCanActOnThread(ctx, thread, moderate) {
+		return nil, errorResult("you can only act on feedback for artifacts you own")
+	}
+	return thread, nil
+}
+
+func (t *Toolkit) isAdmin(ctx context.Context) bool {
+	pc := middleware.GetPlatformContext(ctx)
+	return pc != nil && pc.IsAdmin
+}
+
+// callerCanAccessTarget gates list_threads on a target scope.
+func (t *Toolkit) callerCanAccessTarget(ctx context.Context, targetType, assetID, collectionID string) bool {
+	if t.isAdmin(ctx) {
+		return true
+	}
+	switch targetType {
+	case threadTargetStandalone:
+		return true
+	case threadTargetAsset:
+		return t.ownsAsset(ctx, assetID)
+	case threadTargetCollection:
+		return t.ownsCollection(ctx, collectionID)
+	default: // prompt: admin only (handled above)
+		return false
+	}
+}
+
+// callerCanActOnThread gates per-thread read/reply (moderate=false) and
+// resolve/request_validation (moderate=true).
+func (t *Toolkit) callerCanActOnThread(ctx context.Context, thread *portal.Thread, moderate bool) bool {
+	if t.isAdmin(ctx) {
+		return true
+	}
+	switch thread.TargetType {
+	case threadTargetAsset:
+		return t.ownsAsset(ctx, thread.AssetID)
+	case threadTargetCollection:
+		return t.ownsCollection(ctx, thread.CollectionID)
+	case threadTargetStandalone:
+		if !moderate {
+			return true
+		}
+		return thread.AuthorEmail == resolveOwnerEmail(ctx) || thread.AuthorID == resolveOwnerID(ctx)
+	default: // prompt: admin only (handled above)
+		return false
+	}
+}
+
+func (t *Toolkit) ownsAsset(ctx context.Context, id string) bool {
+	if id == "" || t.assetStore == nil {
+		return false
+	}
+	a, err := t.assetStore.Get(ctx, id)
+	return err == nil && a != nil && a.DeletedAt == nil && a.OwnerID == resolveOwnerID(ctx)
+}
+
+func (t *Toolkit) ownsCollection(ctx context.Context, id string) bool {
+	if id == "" || t.collectionStore == nil {
+		return false
+	}
+	c, err := t.collectionStore.Get(ctx, id)
+	return err == nil && c != nil && c.DeletedAt == nil && c.OwnerID == resolveOwnerID(ctx)
+}
+
+// threadScopeFromInput resolves the single target scope for list_threads.
+func threadScopeFromInput(input manageArtifactInput) (string, bool) {
+	n := countNonEmpty(input.AssetID, input.CollectionID, input.PromptID)
+	if input.TargetType == threadTargetStandalone {
+		return threadTargetStandalone, n == 0
+	}
+	if n != 1 {
+		return "", false
+	}
+	switch {
+	case input.AssetID != "":
+		return threadTargetAsset, true
+	case input.CollectionID != "":
+		return threadTargetCollection, true
+	default:
+		return threadTargetPrompt, true
+	}
+}
+
+func countNonEmpty(vals ...string) int {
+	n := 0
+	for _, v := range vals {
+		if v != "" {
+			n++
+		}
+	}
+	return n
+}

--- a/pkg/toolkits/portal/thread_actions.go
+++ b/pkg/toolkits/portal/thread_actions.go
@@ -2,6 +2,7 @@ package portal
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -13,10 +14,15 @@ import (
 // Feedback thread actions for manage_artifact (Phase 2 / #602). These are
 // additional actions on the existing tool, not new tools.
 //
-// Access model (the portal toolkit is the practitioner's agent surface, so it
-// is owner-centric and has no prompt store):
+// Access model. #602 scopes these to "artifacts the caller owns or can edit".
+// The owner-or-editor check reuses the same predicate as the REST handler's
+// canEditAssetSilent / canEditCollectionSilent. This is deliberately narrower
+// than the portal's *read* surface (canAccessThreadTarget grants viewer and
+// collection-inherited shares; canModerateThread also grants the thread
+// author): the agent surface acts on artifacts the caller can edit, not merely
+// view. The same call applies to reads and writes here, by design:
 //   - admin: full access.
-//   - asset / collection target: the caller must own the target artifact.
+//   - asset / collection target: owner OR an active editor share grant.
 //   - standalone target: any authenticated caller may read and reply; only the
 //     thread author (or an admin) may resolve / request validation.
 //   - prompt target: admin only (the toolkit cannot verify prompt ownership).
@@ -40,7 +46,7 @@ func (t *Toolkit) handleListThreads(ctx context.Context, input manageArtifactInp
 		return errorResult(threadScopeErr), nil, nil
 	}
 	if !t.callerCanAccessTarget(ctx, targetType, input.AssetID, input.CollectionID) {
-		return errorResult("you can only view feedback on artifacts you own"), nil, nil
+		return errorResult("you can only view feedback on artifacts you own or can edit"), nil, nil
 	}
 
 	threads, total, err := t.threadStore.ListThreads(ctx, portal.ThreadFilter{
@@ -55,7 +61,7 @@ func (t *Toolkit) handleListThreads(ctx context.Context, input manageArtifactInp
 		Offset:             input.Offset,
 	})
 	if err != nil {
-		return errorResult("failed to list threads: " + err.Error()), nil, nil
+		return errorResult("failed to list threads: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
 	}
 	if threads == nil {
 		threads = []portal.ThreadWithMeta{}
@@ -70,7 +76,7 @@ func (t *Toolkit) handleGetThread(ctx context.Context, input manageArtifactInput
 	}
 	events, err := t.threadStore.ListEvents(ctx, thread.ID)
 	if err != nil {
-		return errorResult("failed to load thread events: " + err.Error()), nil, nil
+		return errorResult("failed to load thread events: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
 	}
 	if events == nil {
 		events = []portal.ThreadEvent{}
@@ -95,7 +101,7 @@ func (t *Toolkit) handleReplyThread(ctx context.Context, input manageArtifactInp
 		Body:        input.Body,
 	})
 	if err != nil {
-		return errorResult("failed to reply: " + err.Error()), nil, nil
+		return errorResult("failed to reply: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
 	}
 	return jsonResult(evt)
 }
@@ -108,7 +114,7 @@ func (t *Toolkit) handleResolveThread(ctx context.Context, input manageArtifactI
 	resolved := portal.ThreadStatusResolved
 	if err := t.threadStore.UpdateThread(ctx, thread.ID,
 		portal.ThreadUpdate{Status: &resolved}, resolveOwnerID(ctx), resolveOwnerEmail(ctx)); err != nil {
-		return errorResult("failed to resolve thread: " + err.Error()), nil, nil
+		return errorResult("failed to resolve thread: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
 	}
 	return jsonResult(map[string]any{"thread_id": thread.ID, "status": resolved})
 }
@@ -119,9 +125,56 @@ func (t *Toolkit) handleRequestValidation(ctx context.Context, input manageArtif
 		return errRes, nil, nil
 	}
 	if err := t.threadStore.RequestValidation(ctx, thread.ID, resolveOwnerID(ctx), resolveOwnerEmail(ctx)); err != nil {
-		return errorResult("failed to request validation: " + err.Error()), nil, nil
+		return errorResult("failed to request validation: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
 	}
 	return jsonResult(map[string]any{"thread_id": thread.ID, "validation_state": portal.ValidationStatePending})
+}
+
+// LinkInsight implements the knowledge ThreadLinker bridge with authorization.
+// capture_insight calls this with the thread_ids an insight resolves. The agent
+// surface must not be able to resolve a thread it could not resolve through
+// resolve_thread, so each thread is gated through callerCanActOnThread (the same
+// owns-or-edit / author / admin policy) using the caller identity in ctx.
+// Threads the caller may not moderate, that are missing, empty, or duplicated
+// are skipped and surface to the agent as unlinked_thread_ids. Authorized ids
+// are delegated to the thread store, which performs the link transactionally.
+func (t *Toolkit) LinkInsight(ctx context.Context, threadIDs []string, insightID, actorID, actorEmail string) ([]string, error) {
+	if t.threadStore == nil || insightID == "" || len(threadIDs) == 0 {
+		return nil, nil
+	}
+	authorized := make([]string, 0, len(threadIDs))
+	seen := make(map[string]struct{}, len(threadIDs))
+	for _, id := range threadIDs {
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		if t.callerMayLinkThread(ctx, id) {
+			authorized = append(authorized, id)
+		}
+	}
+	if len(authorized) == 0 {
+		return nil, nil
+	}
+	linked, err := t.threadStore.LinkInsight(ctx, authorized, insightID, actorID, actorEmail)
+	if err != nil {
+		return nil, fmt.Errorf("linking insight to threads: %w", err)
+	}
+	return linked, nil
+}
+
+// callerMayLinkThread reports whether the caller may resolve the named thread
+// (the same gate as resolve_thread). Missing threads return false and surface
+// to the agent as unlinked_thread_ids.
+func (t *Toolkit) callerMayLinkThread(ctx context.Context, id string) bool {
+	thread, err := t.threadStore.GetThread(ctx, id)
+	if err != nil || thread == nil {
+		return false
+	}
+	return t.callerCanActOnThread(ctx, thread, true)
 }
 
 // --- access helpers ---
@@ -141,12 +194,12 @@ func (t *Toolkit) loadThread(ctx context.Context, threadID string, moderate bool
 		return nil, errorResult("thread not found: " + err.Error())
 	}
 	if !t.callerCanActOnThread(ctx, thread, moderate) {
-		return nil, errorResult("you can only act on feedback for artifacts you own")
+		return nil, errorResult("you can only act on feedback for artifacts you own or can edit")
 	}
 	return thread, nil
 }
 
-func (t *Toolkit) isAdmin(ctx context.Context) bool {
+func (*Toolkit) isAdmin(ctx context.Context) bool {
 	pc := middleware.GetPlatformContext(ctx)
 	return pc != nil && pc.IsAdmin
 }
@@ -160,9 +213,9 @@ func (t *Toolkit) callerCanAccessTarget(ctx context.Context, targetType, assetID
 	case threadTargetStandalone:
 		return true
 	case threadTargetAsset:
-		return t.ownsAsset(ctx, assetID)
+		return t.canEditAsset(ctx, assetID)
 	case threadTargetCollection:
-		return t.ownsCollection(ctx, collectionID)
+		return t.canEditCollection(ctx, collectionID)
 	default: // prompt: admin only (handled above)
 		return false
 	}
@@ -176,33 +229,57 @@ func (t *Toolkit) callerCanActOnThread(ctx context.Context, thread *portal.Threa
 	}
 	switch thread.TargetType {
 	case threadTargetAsset:
-		return t.ownsAsset(ctx, thread.AssetID)
+		return t.canEditAsset(ctx, thread.AssetID)
 	case threadTargetCollection:
-		return t.ownsCollection(ctx, thread.CollectionID)
+		return t.canEditCollection(ctx, thread.CollectionID)
 	case threadTargetStandalone:
 		if !moderate {
 			return true
 		}
-		return thread.AuthorEmail == resolveOwnerEmail(ctx) || thread.AuthorID == resolveOwnerID(ctx)
+		actorID, actorEmail := resolveOwnerID(ctx), resolveOwnerEmail(ctx)
+		if actorID == anonymousUserName {
+			// No authenticated identity: never match a thread authored as the
+			// shared "anonymous" sentinel (fail closed, not open).
+			return false
+		}
+		return thread.AuthorEmail == actorEmail || thread.AuthorID == actorID
 	default: // prompt: admin only (handled above)
 		return false
 	}
 }
 
-func (t *Toolkit) ownsAsset(ctx context.Context, id string) bool {
-	if id == "" || t.assetStore == nil {
+// canEditAsset reports owner-or-editor access to an asset, mirroring the REST
+// handler's canEditAssetSilent (#602: "owns or can edit").
+func (t *Toolkit) canEditAsset(ctx context.Context, id string) bool {
+	if id == "" {
 		return false
 	}
 	a, err := t.assetStore.Get(ctx, id)
-	return err == nil && a != nil && a.DeletedAt == nil && a.OwnerID == resolveOwnerID(ctx)
+	if err != nil || a == nil || a.DeletedAt != nil {
+		return false
+	}
+	if a.OwnerID == resolveOwnerID(ctx) {
+		return true
+	}
+	share, err := t.shareStore.GetActiveShareForTarget(ctx, threadTargetAsset, id, resolveOwnerID(ctx), resolveOwnerEmail(ctx))
+	return err == nil && share != nil && share.Permission == portal.PermissionEditor
 }
 
-func (t *Toolkit) ownsCollection(ctx context.Context, id string) bool {
-	if id == "" || t.collectionStore == nil {
+// canEditCollection reports owner-or-editor access to a collection, mirroring
+// the REST handler's canEditCollectionSilent (#602: "owns or can edit").
+func (t *Toolkit) canEditCollection(ctx context.Context, id string) bool {
+	if id == "" {
 		return false
 	}
 	c, err := t.collectionStore.Get(ctx, id)
-	return err == nil && c != nil && c.DeletedAt == nil && c.OwnerID == resolveOwnerID(ctx)
+	if err != nil || c == nil || c.DeletedAt != nil {
+		return false
+	}
+	if c.OwnerID == resolveOwnerID(ctx) {
+		return true
+	}
+	perm, _ := t.shareStore.GetUserCollectionPermission(ctx, id, resolveOwnerID(ctx), resolveOwnerEmail(ctx))
+	return perm == portal.PermissionEditor
 }
 
 // threadScopeFromInput resolves the single target scope for list_threads.

--- a/pkg/toolkits/portal/thread_actions_test.go
+++ b/pkg/toolkits/portal/thread_actions_test.go
@@ -1,0 +1,586 @@
+package portal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/portal"
+)
+
+// --- fakes ------------------------------------------------------------------
+
+// fakeThreadStore implements portal.ThreadStore with configurable returns and
+// captured inputs for the manage_artifact thread actions.
+type fakeThreadStore struct {
+	listResult []portal.ThreadWithMeta
+	listTotal  int
+	listErr    error
+	lastFilter portal.ThreadFilter
+
+	getResult *portal.Thread
+	getErr    error
+
+	events    []portal.ThreadEvent
+	eventsErr error
+
+	appended  *portal.ThreadEvent
+	appendErr error
+
+	lastUpdate *portal.ThreadUpdate
+	updateErr  error
+
+	validatedID string
+	validateErr error
+}
+
+func (*fakeThreadStore) CreateThread(_ context.Context, t portal.Thread, _ portal.ThreadEvent) (*portal.Thread, error) {
+	return &t, nil
+}
+
+func (f *fakeThreadStore) ListThreads(_ context.Context, filter portal.ThreadFilter) ([]portal.ThreadWithMeta, int, error) {
+	f.lastFilter = filter
+	return f.listResult, f.listTotal, f.listErr
+}
+
+func (f *fakeThreadStore) GetThread(_ context.Context, _ string) (*portal.Thread, error) {
+	return f.getResult, f.getErr
+}
+
+func (f *fakeThreadStore) ListEvents(_ context.Context, _ string) ([]portal.ThreadEvent, error) {
+	return f.events, f.eventsErr
+}
+
+func (f *fakeThreadStore) AppendEvent(_ context.Context, e portal.ThreadEvent) (*portal.ThreadEvent, error) {
+	if f.appendErr != nil {
+		return nil, f.appendErr
+	}
+	if f.appended != nil {
+		return f.appended, nil
+	}
+	return &e, nil
+}
+
+func (f *fakeThreadStore) UpdateThread(_ context.Context, _ string, u portal.ThreadUpdate, _, _ string) error {
+	f.lastUpdate = &u
+	return f.updateErr
+}
+
+func (*fakeThreadStore) SoftDeleteThread(_ context.Context, _ string) error { return nil }
+
+func (*fakeThreadStore) LinkInsight(_ context.Context, ids []string, _, _, _ string) ([]string, error) {
+	return ids, nil
+}
+
+func (f *fakeThreadStore) RequestValidation(_ context.Context, id, _, _ string) error {
+	f.validatedID = id
+	return f.validateErr
+}
+
+func (*fakeThreadStore) CountOpenByTargets(_ context.Context, _ string, _ []string) (map[string]int, error) {
+	return nil, nil //nolint:nilnil // test stub
+}
+
+var _ portal.ThreadStore = (*fakeThreadStore)(nil)
+
+// fakeShareStore implements portal.ShareStore; only the two access-path methods
+// used by canEditAsset / canEditCollection return configurable values.
+type fakeShareStore struct {
+	assetShare *portal.Share
+	collPerm   portal.SharePermission
+}
+
+func (f *fakeShareStore) GetActiveShareForTarget(_ context.Context, _, _, _, _ string) (*portal.Share, error) {
+	return f.assetShare, nil
+}
+
+func (f *fakeShareStore) GetUserCollectionPermission(_ context.Context, _, _, _ string) (portal.SharePermission, error) {
+	return f.collPerm, nil
+}
+
+func (*fakeShareStore) Insert(_ context.Context, _ portal.Share) error             { return nil }
+func (*fakeShareStore) GetByID(_ context.Context, _ string) (*portal.Share, error) { return nil, nil } //nolint:nilnil // test stub
+func (*fakeShareStore) GetByToken(_ context.Context, _ string) (*portal.Share, error) {
+	return nil, nil //nolint:nilnil // test stub
+}
+
+func (*fakeShareStore) ListByAsset(_ context.Context, _ string) ([]portal.Share, error) {
+	return nil, nil
+}
+
+func (*fakeShareStore) ListByCollection(_ context.Context, _ string) ([]portal.Share, error) {
+	return nil, nil
+}
+
+func (*fakeShareStore) ListByPrompt(_ context.Context, _ string) ([]portal.Share, error) {
+	return nil, nil
+}
+
+func (*fakeShareStore) ListSharedWithUser(_ context.Context, _, _ string, _, _ int) ([]portal.SharedAsset, int, error) {
+	return nil, 0, nil
+}
+
+func (*fakeShareStore) ListSharedCollectionsWithUser(_ context.Context, _, _ string, _, _ int) ([]portal.SharedCollection, int, error) {
+	return nil, 0, nil
+}
+
+func (*fakeShareStore) ListSharedPromptsWithUser(_ context.Context, _, _ string) ([]portal.SharedPromptRef, error) {
+	return nil, nil
+}
+
+func (*fakeShareStore) ListActiveShareSummaries(_ context.Context, _ []string) (map[string]portal.ShareSummary, error) {
+	return nil, nil //nolint:nilnil // test stub
+}
+
+func (*fakeShareStore) ListActiveCollectionShareSummaries(_ context.Context, _ []string) (map[string]portal.ShareSummary, error) {
+	return nil, nil //nolint:nilnil // test stub
+}
+
+func (*fakeShareStore) GetUserAssetPermissionViaCollection(_ context.Context, _, _, _ string) (portal.SharePermission, error) {
+	return "", nil
+}
+func (*fakeShareStore) Revoke(_ context.Context, _ string) error          { return nil }
+func (*fakeShareStore) IncrementAccess(_ context.Context, _ string) error { return nil }
+
+var _ portal.ShareStore = (*fakeShareStore)(nil)
+
+// --- helpers ----------------------------------------------------------------
+
+const (
+	ownerID    = "owner1"
+	ownerEmail = "owner1@example.com"
+	otherID    = "stranger"
+)
+
+func ownerCtx() context.Context {
+	return middleware.WithPlatformContext(context.Background(),
+		&middleware.PlatformContext{UserID: ownerID, UserEmail: ownerEmail})
+}
+
+func adminCtx() context.Context {
+	return middleware.WithPlatformContext(context.Background(),
+		&middleware.PlatformContext{UserID: "admin1", IsAdmin: true})
+}
+
+func strangerCtx() context.Context {
+	return middleware.WithPlatformContext(context.Background(),
+		&middleware.PlatformContext{UserID: otherID, UserEmail: "stranger@example.com"})
+}
+
+// threadToolkit builds a portal toolkit wired with the given thread store and
+// an asset/collection/share store seeded so that `ownerID` owns asset_1 and
+// collection_1.
+func threadToolkit(t *testing.T, threads portal.ThreadStore, shares portal.ShareStore) *Toolkit {
+	t.Helper()
+	assets := newInMemoryAssetStore()
+	require.NoError(t, assets.Insert(context.Background(), portal.Asset{ID: "asset_1", OwnerID: ownerID, OwnerEmail: ownerEmail}))
+	colls := newInMemoryCollectionStore()
+	require.NoError(t, colls.Insert(context.Background(), portal.Collection{ID: "collection_1", OwnerID: ownerID}))
+	if shares == nil {
+		shares = &fakeShareStore{}
+	}
+	return New(Config{
+		Name: "test", S3Bucket: "b",
+		ThreadStore: threads, AssetStore: assets, CollectionStore: colls, ShareStore: shares,
+	})
+}
+
+func decodeResult(t *testing.T, res *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &m))
+	return m
+}
+
+// --- threadScopeFromInput / countNonEmpty -----------------------------------
+
+func TestThreadScopeFromInput(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  manageArtifactInput
+		want   string
+		wantOK bool
+	}{
+		{"standalone no ids", manageArtifactInput{TargetType: "standalone"}, "standalone", true},
+		{"standalone with asset id", manageArtifactInput{TargetType: "standalone", AssetID: "a"}, "standalone", false},
+		{"asset only", manageArtifactInput{AssetID: "a"}, "asset", true},
+		{"collection only", manageArtifactInput{CollectionID: "c"}, "collection", true},
+		{"prompt only", manageArtifactInput{PromptID: "p"}, "prompt", true},
+		{"no ids, not standalone", manageArtifactInput{}, "", false},
+		{"two ids", manageArtifactInput{AssetID: "a", CollectionID: "c"}, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := threadScopeFromInput(tt.input)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestCountNonEmpty(t *testing.T) {
+	assert.Equal(t, 0, countNonEmpty("", "", ""))
+	assert.Equal(t, 1, countNonEmpty("a", "", ""))
+	assert.Equal(t, 3, countNonEmpty("a", "b", "c"))
+}
+
+// --- handleListThreads ------------------------------------------------------
+
+func TestHandleListThreads(t *testing.T) {
+	t.Run("store unavailable", func(t *testing.T) {
+		tk := New(Config{Name: "test", S3Bucket: "b"}) // no ThreadStore
+		res, _, err := tk.handleListThreads(ownerCtx(), manageArtifactInput{AssetID: "asset_1"})
+		require.NoError(t, err)
+		assert.True(t, res.IsError)
+		assert.Contains(t, decodeResult(t, res)["error"], "not available")
+	})
+
+	t.Run("scope error", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{}, nil)
+		res, _, _ := tk.handleListThreads(ownerCtx(), manageArtifactInput{})
+		assert.True(t, res.IsError)
+	})
+
+	t.Run("access denied for non-owner non-editor", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{}, nil)
+		res, _, _ := tk.handleListThreads(strangerCtx(), manageArtifactInput{AssetID: "asset_1"})
+		assert.True(t, res.IsError)
+		assert.Contains(t, decodeResult(t, res)["error"], "own or can edit")
+	})
+
+	t.Run("owner sees threads and filter honors requires_resolution", func(t *testing.T) {
+		fts := &fakeThreadStore{listTotal: 2}
+		tk := threadToolkit(t, fts, nil)
+		req := true
+		res, _, err := tk.handleListThreads(ownerCtx(), manageArtifactInput{
+			AssetID: "asset_1", RequiresResolution: &req, ValidationState: "pending",
+		})
+		require.NoError(t, err)
+		assert.False(t, res.IsError)
+		// #602: list_threads honors the requires_resolution and validation_state filters.
+		require.NotNil(t, fts.lastFilter.RequiresResolution)
+		assert.True(t, *fts.lastFilter.RequiresResolution)
+		assert.Equal(t, "pending", fts.lastFilter.ValidationState)
+		assert.Equal(t, "asset", fts.lastFilter.TargetType)
+	})
+
+	t.Run("editor share grants access", func(t *testing.T) {
+		shares := &fakeShareStore{assetShare: &portal.Share{Permission: portal.PermissionEditor}}
+		tk := threadToolkit(t, &fakeThreadStore{}, shares)
+		res, _, _ := tk.handleListThreads(strangerCtx(), manageArtifactInput{AssetID: "asset_1"})
+		assert.False(t, res.IsError)
+	})
+
+	t.Run("admin sees any target", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{}, nil)
+		res, _, _ := tk.handleListThreads(adminCtx(), manageArtifactInput{AssetID: "asset_1"})
+		assert.False(t, res.IsError)
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{listErr: errors.New("boom")}, nil)
+		res, _, _ := tk.handleListThreads(ownerCtx(), manageArtifactInput{AssetID: "asset_1"})
+		assert.True(t, res.IsError)
+	})
+
+	t.Run("standalone scope open to any authed caller", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{}, nil)
+		res, _, _ := tk.handleListThreads(strangerCtx(), manageArtifactInput{TargetType: "standalone"})
+		assert.False(t, res.IsError)
+	})
+
+	t.Run("collection owner lists", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{}, nil)
+		res, _, _ := tk.handleListThreads(ownerCtx(), manageArtifactInput{CollectionID: "collection_1"})
+		assert.False(t, res.IsError)
+	})
+
+	t.Run("prompt scope denied for non-admin", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{}, nil)
+		res, _, _ := tk.handleListThreads(ownerCtx(), manageArtifactInput{PromptID: "p1"})
+		assert.True(t, res.IsError)
+	})
+}
+
+// --- handleGetThread --------------------------------------------------------
+
+func TestHandleGetThread(t *testing.T) {
+	t.Run("missing thread_id", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{}, nil)
+		res, _, _ := tk.handleGetThread(ownerCtx(), manageArtifactInput{})
+		assert.True(t, res.IsError)
+		assert.Contains(t, decodeResult(t, res)["error"], "thread_id is required")
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{getErr: errors.New("nope")}, nil)
+		res, _, _ := tk.handleGetThread(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		assert.True(t, res.IsError)
+	})
+
+	t.Run("access denied", func(t *testing.T) {
+		fts := &fakeThreadStore{getResult: &portal.Thread{ID: "t1", TargetType: "asset", AssetID: "asset_1"}}
+		tk := threadToolkit(t, fts, nil)
+		res, _, _ := tk.handleGetThread(strangerCtx(), manageArtifactInput{ThreadID: "t1"})
+		assert.True(t, res.IsError)
+		assert.Contains(t, decodeResult(t, res)["error"], "own or can edit")
+	})
+
+	t.Run("success returns thread and events", func(t *testing.T) {
+		fts := &fakeThreadStore{
+			getResult: &portal.Thread{ID: "t1", TargetType: "asset", AssetID: "asset_1"},
+			events:    []portal.ThreadEvent{{ID: "evt_1", EventType: portal.EventTypeComment}},
+		}
+		tk := threadToolkit(t, fts, nil)
+		res, _, err := tk.handleGetThread(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		require.NoError(t, err)
+		assert.False(t, res.IsError)
+		m := decodeResult(t, res)
+		assert.NotNil(t, m["thread"])
+		assert.NotNil(t, m["events"])
+	})
+
+	t.Run("events error", func(t *testing.T) {
+		fts := &fakeThreadStore{
+			getResult: &portal.Thread{ID: "t1", TargetType: "asset", AssetID: "asset_1"},
+			eventsErr: errors.New("boom"),
+		}
+		tk := threadToolkit(t, fts, nil)
+		res, _, _ := tk.handleGetThread(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		assert.True(t, res.IsError)
+	})
+}
+
+// --- handleReplyThread ------------------------------------------------------
+
+func TestHandleReplyThread(t *testing.T) {
+	thread := &portal.Thread{ID: "t1", TargetType: "asset", AssetID: "asset_1"}
+
+	t.Run("empty body", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, nil)
+		res, _, _ := tk.handleReplyThread(ownerCtx(), manageArtifactInput{ThreadID: "t1", Body: "  "})
+		assert.True(t, res.IsError)
+		assert.Contains(t, decodeResult(t, res)["error"], "body is required")
+	})
+
+	t.Run("success appends a comment", func(t *testing.T) {
+		fts := &fakeThreadStore{getResult: thread}
+		tk := threadToolkit(t, fts, nil)
+		res, _, err := tk.handleReplyThread(ownerCtx(), manageArtifactInput{ThreadID: "t1", Body: "looks good"})
+		require.NoError(t, err)
+		assert.False(t, res.IsError)
+	})
+
+	t.Run("append error", func(t *testing.T) {
+		fts := &fakeThreadStore{getResult: thread, appendErr: errors.New("boom")}
+		tk := threadToolkit(t, fts, nil)
+		res, _, _ := tk.handleReplyThread(ownerCtx(), manageArtifactInput{ThreadID: "t1", Body: "x"})
+		assert.True(t, res.IsError)
+	})
+}
+
+// --- handleResolveThread / handleRequestValidation --------------------------
+
+func TestHandleResolveThread(t *testing.T) {
+	thread := &portal.Thread{ID: "t1", TargetType: "asset", AssetID: "asset_1"}
+
+	t.Run("owner resolves", func(t *testing.T) {
+		fts := &fakeThreadStore{getResult: thread}
+		tk := threadToolkit(t, fts, nil)
+		res, _, err := tk.handleResolveThread(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		require.NoError(t, err)
+		assert.False(t, res.IsError)
+		require.NotNil(t, fts.lastUpdate)
+		require.NotNil(t, fts.lastUpdate.Status)
+		assert.Equal(t, portal.ThreadStatusResolved, *fts.lastUpdate.Status)
+	})
+
+	t.Run("update error", func(t *testing.T) {
+		fts := &fakeThreadStore{getResult: thread, updateErr: errors.New("boom")}
+		tk := threadToolkit(t, fts, nil)
+		res, _, _ := tk.handleResolveThread(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		assert.True(t, res.IsError)
+	})
+
+	t.Run("standalone non-author denied", func(t *testing.T) {
+		standalone := &portal.Thread{ID: "t2", TargetType: "standalone", AuthorID: ownerID, AuthorEmail: ownerEmail}
+		tk := threadToolkit(t, &fakeThreadStore{getResult: standalone}, nil)
+		res, _, _ := tk.handleResolveThread(strangerCtx(), manageArtifactInput{ThreadID: "t2"})
+		assert.True(t, res.IsError)
+	})
+
+	t.Run("standalone author allowed", func(t *testing.T) {
+		standalone := &portal.Thread{ID: "t2", TargetType: "standalone", AuthorID: ownerID, AuthorEmail: ownerEmail}
+		tk := threadToolkit(t, &fakeThreadStore{getResult: standalone}, nil)
+		res, _, _ := tk.handleResolveThread(ownerCtx(), manageArtifactInput{ThreadID: "t2"})
+		assert.False(t, res.IsError)
+	})
+}
+
+func TestHandleRequestValidation(t *testing.T) {
+	thread := &portal.Thread{ID: "t1", TargetType: "asset", AssetID: "asset_1"}
+
+	t.Run("success", func(t *testing.T) {
+		fts := &fakeThreadStore{getResult: thread}
+		tk := threadToolkit(t, fts, nil)
+		res, _, err := tk.handleRequestValidation(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		require.NoError(t, err)
+		assert.False(t, res.IsError)
+		assert.Equal(t, "t1", fts.validatedID)
+		assert.Equal(t, portal.ValidationStatePending, decodeResult(t, res)["validation_state"])
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		fts := &fakeThreadStore{getResult: thread, validateErr: errors.New("boom")}
+		tk := threadToolkit(t, fts, nil)
+		res, _, _ := tk.handleRequestValidation(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		assert.True(t, res.IsError)
+	})
+}
+
+// --- authorizing LinkInsight bridge (capture_insight gate) ------------------
+
+func TestToolkitLinkInsightAuthorizes(t *testing.T) {
+	thread := &portal.Thread{ID: "t1", TargetType: "asset", AssetID: "asset_1"}
+
+	t.Run("owner links", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, nil)
+		linked, err := tk.LinkInsight(ownerCtx(), []string{"t1"}, "ins_1", "u", "e")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"t1"}, linked)
+	})
+
+	t.Run("stranger is not authorized; nothing linked", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, nil)
+		linked, err := tk.LinkInsight(strangerCtx(), []string{"t1"}, "ins_1", "u", "e")
+		require.NoError(t, err)
+		assert.Empty(t, linked)
+	})
+
+	t.Run("editor share is authorized", func(t *testing.T) {
+		shares := &fakeShareStore{assetShare: &portal.Share{Permission: portal.PermissionEditor}}
+		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, shares)
+		linked, err := tk.LinkInsight(strangerCtx(), []string{"t1"}, "ins_1", "u", "e")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"t1"}, linked)
+	})
+
+	t.Run("admin links any", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, nil)
+		linked, err := tk.LinkInsight(adminCtx(), []string{"t1"}, "ins_1", "u", "e")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"t1"}, linked)
+	})
+
+	t.Run("missing thread skipped", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{getErr: errors.New("nope")}, nil)
+		linked, err := tk.LinkInsight(ownerCtx(), []string{"t1"}, "ins_1", "u", "e")
+		require.NoError(t, err)
+		assert.Empty(t, linked)
+	})
+
+	t.Run("dedupes and drops empty ids", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, nil)
+		linked, err := tk.LinkInsight(ownerCtx(), []string{"t1", "t1", ""}, "ins_1", "u", "e")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"t1"}, linked)
+	})
+
+	t.Run("no threads or no insight is a noop", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, nil)
+		linked, err := tk.LinkInsight(ownerCtx(), nil, "ins_1", "u", "e")
+		require.NoError(t, err)
+		assert.Nil(t, linked)
+		linked, err = tk.LinkInsight(ownerCtx(), []string{"t1"}, "", "u", "e")
+		require.NoError(t, err)
+		assert.Nil(t, linked)
+	})
+}
+
+// --- access model: collection + prompt + deleted asset ----------------------
+
+func TestThreadAccessModel(t *testing.T) {
+	t.Run("collection owner allowed", func(t *testing.T) {
+		thread := &portal.Thread{ID: "t1", TargetType: "collection", CollectionID: "collection_1"}
+		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, nil)
+		res, _, _ := tk.handleResolveThread(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		assert.False(t, res.IsError)
+	})
+
+	t.Run("collection editor allowed", func(t *testing.T) {
+		thread := &portal.Thread{ID: "t1", TargetType: "collection", CollectionID: "collection_1"}
+		shares := &fakeShareStore{collPerm: portal.PermissionEditor}
+		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, shares)
+		res, _, _ := tk.handleResolveThread(strangerCtx(), manageArtifactInput{ThreadID: "t1"})
+		assert.False(t, res.IsError)
+	})
+
+	t.Run("collection stranger denied", func(t *testing.T) {
+		thread := &portal.Thread{ID: "t1", TargetType: "collection", CollectionID: "collection_1"}
+		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, nil)
+		res, _, _ := tk.handleResolveThread(strangerCtx(), manageArtifactInput{ThreadID: "t1"})
+		assert.True(t, res.IsError)
+	})
+
+	t.Run("prompt target is admin only", func(t *testing.T) {
+		thread := &portal.Thread{ID: "t1", TargetType: "prompt", PromptID: "p1"}
+		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, nil)
+		// owner of an unrelated asset is not admin: denied.
+		res, _, _ := tk.handleGetThread(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		assert.True(t, res.IsError)
+		// admin: allowed.
+		res, _, _ = tk.handleGetThread(adminCtx(), manageArtifactInput{ThreadID: "t1"})
+		assert.False(t, res.IsError)
+	})
+
+	t.Run("missing asset id denies edit", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{}, nil)
+		assert.False(t, tk.canEditAsset(ownerCtx(), ""))
+		assert.False(t, tk.canEditCollection(ownerCtx(), ""))
+	})
+
+	t.Run("deleted asset denies edit even for owner", func(t *testing.T) {
+		assets := newInMemoryAssetStore()
+		now := time.Now()
+		require.NoError(t, assets.Insert(context.Background(),
+			portal.Asset{ID: "asset_del", OwnerID: ownerID, DeletedAt: &now}))
+		tk := New(Config{
+			Name: "test", S3Bucket: "b",
+			ThreadStore: &fakeThreadStore{}, AssetStore: assets, ShareStore: &fakeShareStore{},
+		})
+		assert.False(t, tk.canEditAsset(ownerCtx(), "asset_del"))
+	})
+
+	t.Run("unknown asset denies edit", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{}, nil)
+		assert.False(t, tk.canEditAsset(ownerCtx(), "nope"))
+		assert.False(t, tk.canEditCollection(ownerCtx(), "nope"))
+	})
+
+	t.Run("anonymous caller cannot moderate an anonymously-authored standalone thread", func(t *testing.T) {
+		standalone := &portal.Thread{ID: "t1", TargetType: "standalone", AuthorID: "anonymous", AuthorEmail: "anonymous"}
+		tk := threadToolkit(t, &fakeThreadStore{getResult: standalone}, nil)
+		// context.Background() carries no PlatformContext, so resolveOwnerID is the
+		// "anonymous" sentinel; the guard must fail closed despite the id matching.
+		res, _, _ := tk.handleResolveThread(context.Background(), manageArtifactInput{ThreadID: "t1"})
+		assert.True(t, res.IsError)
+	})
+
+	t.Run("standalone non-moderate readable by anyone", func(t *testing.T) {
+		thread := &portal.Thread{ID: "t1", TargetType: "standalone", AuthorID: ownerID}
+		tk := threadToolkit(t, &fakeThreadStore{getResult: thread, events: []portal.ThreadEvent{}}, nil)
+		res, _, _ := tk.handleGetThread(strangerCtx(), manageArtifactInput{ThreadID: "t1"})
+		assert.False(t, res.IsError)
+	})
+}

--- a/pkg/toolkits/portal/toolkit.go
+++ b/pkg/toolkits/portal/toolkit.go
@@ -56,6 +56,14 @@ const (
 	actionSetSections      = "set_sections"
 	actionSearch           = "search"
 
+	// Feedback thread actions (Phase 2 / #602). No new tools: these extend the
+	// existing manage_artifact dispatch.
+	actionListThreads       = "list_threads"
+	actionGetThread         = "get_thread"
+	actionReplyThread       = "reply_thread"
+	actionResolveThread     = "resolve_thread"
+	actionRequestValidation = "request_validation"
+
 	// JSON field names used in MCP tool result payloads.
 	fieldAssetID = "asset_id"
 	fieldMessage = "message"
@@ -97,6 +105,15 @@ type manageArtifactInput struct {
 	// Query (search action) ranks the caller's assets by relevance to a
 	// free-text query instead of the substring Search filter.
 	Query string `json:"query,omitempty"`
+
+	// Feedback thread fields (Phase 2 / #602).
+	PromptID           string `json:"prompt_id,omitempty"`
+	TargetType         string `json:"target_type,omitempty"`
+	ThreadID           string `json:"thread_id,omitempty"`
+	Body               string `json:"body,omitempty"`
+	Status             string `json:"status,omitempty"`
+	ValidationState    string `json:"validation_state,omitempty"`
+	RequiresResolution *bool  `json:"requires_resolution,omitempty"`
 }
 
 // sectionInput defines a collection section in MCP tool input.
@@ -127,6 +144,7 @@ type Config struct {
 	ShareStore      portal.ShareStore
 	VersionStore    portal.VersionStore
 	CollectionStore portal.CollectionStore
+	ThreadStore     portal.ThreadStore
 	S3Client        portal.S3Client
 	S3Bucket        string
 	S3Prefix        string
@@ -146,6 +164,7 @@ type Toolkit struct {
 	shareStore      portal.ShareStore
 	versionStore    portal.VersionStore
 	collectionStore portal.CollectionStore
+	threadStore     portal.ThreadStore
 	s3Client        portal.S3Client
 	s3Bucket        string
 	s3Prefix        string
@@ -182,6 +201,7 @@ func New(cfg Config) *Toolkit {
 		shareStore:      shareStore,
 		versionStore:    versionStore,
 		collectionStore: collectionStore,
+		threadStore:     cfg.ThreadStore,
 		s3Client:        cfg.S3Client,
 		s3Bucket:        cfg.S3Bucket,
 		s3Prefix:        cfg.S3Prefix,
@@ -219,10 +239,13 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:  manageToolName,
 		Title: "Manage Artifact",
-		Description: "Manages saved artifacts and collections. " +
+		Description: "Manages saved artifacts, collections, and human feedback. " +
 			"Asset actions: list, get, update, delete, list_versions, revert, search. " +
 			"Collection actions: create_collection, list_collections, get_collection, " +
 			"update_collection, delete_collection, set_sections. " +
+			"Feedback actions: list_threads, get_thread, reply_thread, resolve_thread, " +
+			"request_validation (review and respond to feedback left on your artifacts; " +
+			"capture_insight thread_ids=[...] links a thread to the insight that resolves it). " +
 			"Note: 'list' returns full metadata including provenance for each asset. " +
 			"Use 'get' with a specific asset_id for content retrieval. " +
 			"Use 'search' with a 'query' to rank your assets by relevance (semantic + " +
@@ -413,6 +436,12 @@ func (t *Toolkit) buildActions() map[string]manageActionHandler {
 		actionDeleteCollection: t.handleDeleteCollection,
 		actionSetSections:      t.handleSetSections,
 		actionSearch:           t.handleSearch,
+
+		actionListThreads:       t.handleListThreads,
+		actionGetThread:         t.handleGetThread,
+		actionReplyThread:       t.handleReplyThread,
+		actionResolveThread:     t.handleResolveThread,
+		actionRequestValidation: t.handleRequestValidation,
 	}
 }
 
@@ -422,7 +451,8 @@ func (t *Toolkit) handleManageArtifact(ctx context.Context, _ *mcp.CallToolReque
 	if !ok {
 		return errorResult(fmt.Sprintf(
 			"invalid action %q: must be one of: list, get, update, delete, list_versions, revert, search, "+
-				"create_collection, list_collections, get_collection, update_collection, delete_collection, set_sections",
+				"create_collection, list_collections, get_collection, update_collection, delete_collection, set_sections, "+
+				"list_threads, get_thread, reply_thread, resolve_thread, request_validation",
 			input.Action)), nil, nil
 	}
 	return handler(ctx, input)

--- a/ui/src/api/portal/hooks.ts
+++ b/ui/src/api/portal/hooks.ts
@@ -32,6 +32,7 @@ import type {
   ThreadTargetType,
   ThreadEventType,
   ThreadAnchor,
+  ThreadChain,
   ThreadCounts,
   ValidationState,
 } from "./types";
@@ -895,6 +896,17 @@ export function useThreadEvents(id: string) {
     queryFn: () =>
       apiFetch<{ data: ThreadEvent[] }>(`/threads/${id}/events`).then((r) => r.data),
     enabled: !!id,
+  });
+}
+
+// useThreadChain fetches the resolved thread -> insight -> changeset chain
+// (#602). Only enabled once a thread has been linked to an insight; an
+// unlinked thread has nothing to show and we avoid the round-trip.
+export function useThreadChain(id: string, hasInsight: boolean) {
+  return useQuery({
+    queryKey: ["thread-chain", id],
+    queryFn: () => apiFetch<ThreadChain>(`/threads/${id}/chain`),
+    enabled: !!id && hasInsight,
   });
 }
 

--- a/ui/src/api/portal/types.ts
+++ b/ui/src/api/portal/types.ts
@@ -372,6 +372,25 @@ export interface ThreadEvent {
 // Open-thread counts keyed by target id (for list-page badges).
 export type ThreadCounts = Record<string, number>;
 
+// A changeset in a thread's resolved knowledge chain (#602).
+export interface ThreadChainChangeset {
+  id: string;
+  target_urn: string;
+  change_type: string;
+  created_at: string;
+  rolled_back: boolean;
+}
+
+// The resolved thread -> insight -> changeset chain returned by
+// GET /portal/threads/{id}/chain. insight_id is empty until the thread is
+// linked to a captured insight; changesets are the applied knowledge sourced
+// from that insight.
+export interface ThreadChain {
+  thread_id: string;
+  insight_id?: string;
+  changesets: ThreadChainChangeset[];
+}
+
 // The discriminated target a feedback panel operates on. Mirrors ShareDialog's
 // target union so one panel serves asset/collection/prompt and the standalone
 // channel.

--- a/ui/src/components/feedback/ThreadDetail.test.tsx
+++ b/ui/src/components/feedback/ThreadDetail.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/api/portal/hooks", () => ({
+  useThread: vi.fn(),
+  useThreadEvents: vi.fn(() => ({ data: [], isLoading: false })),
+  useThreadChain: vi.fn(),
+  useAppendThreadEvent: vi.fn(() => ({ mutate: vi.fn(), isPending: false, isError: false })),
+  useUpdateThread: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useDeleteThread: vi.fn(() => ({ mutate: vi.fn(), isPending: false, isError: false })),
+}));
+
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: (sel: (s: { user: { email: string; is_admin: boolean } }) => unknown) =>
+    sel({ user: { email: "viewer@example.com", is_admin: false } }),
+}));
+
+import { ThreadDetail } from "./ThreadDetail";
+import { useThread, useThreadChain } from "@/api/portal/hooks";
+
+const mockUseThread = vi.mocked(useThread);
+const mockUseThreadChain = vi.mocked(useThreadChain);
+
+function baseThread(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "t1",
+    kind: "correction",
+    target_type: "asset",
+    asset_id: "a1",
+    author_id: "sme@example.com",
+    author_email: "sme@example.com",
+    status: "resolved",
+    requires_resolution: true,
+    validation_state: "none",
+    created_at: "2026-06-04T13:00:00Z",
+    updated_at: "2026-06-04T18:45:00Z",
+    ...overrides,
+  };
+}
+
+describe("ThreadDetail knowledge chain", () => {
+  it("renders the insight and changeset chain when the thread is linked", () => {
+    mockUseThread.mockReturnValue({ data: baseThread({ insight_id: "ins_abc123def456" }) } as never);
+    mockUseThreadChain.mockReturnValue({
+      data: {
+        thread_id: "t1",
+        insight_id: "ins_abc123def456",
+        changesets: [
+          {
+            id: "cs_1",
+            target_urn: "urn:li:dataset:(urn:li:dataPlatform:trino,hive.sales.churn,PROD)",
+            change_type: "update_description",
+            created_at: "2026-06-04T18:45:00Z",
+            rolled_back: false,
+          },
+        ],
+      },
+      isLoading: false,
+    } as never);
+
+    render(<ThreadDetail threadId="t1" canModerate={false} onBack={() => {}} onDeleted={() => {}} />);
+
+    expect(screen.getByText("Knowledge chain")).toBeInTheDocument();
+    expect(screen.getByText("update_description")).toBeInTheDocument();
+    expect(
+      screen.getByText("urn:li:dataset:(urn:li:dataPlatform:trino,hive.sales.churn,PROD)"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows no chain panel for a thread without an insight", () => {
+    mockUseThread.mockReturnValue({ data: baseThread() } as never);
+    mockUseThreadChain.mockReturnValue({ data: undefined, isLoading: false } as never);
+
+    render(<ThreadDetail threadId="t1" canModerate={false} onBack={() => {}} onDeleted={() => {}} />);
+
+    expect(screen.queryByText("Knowledge chain")).not.toBeInTheDocument();
+  });
+
+  it("notes when a linked insight has produced no changes yet", () => {
+    mockUseThread.mockReturnValue({ data: baseThread({ insight_id: "ins_xyz" }) } as never);
+    mockUseThreadChain.mockReturnValue({
+      data: { thread_id: "t1", insight_id: "ins_xyz", changesets: [] },
+      isLoading: false,
+    } as never);
+
+    render(<ThreadDetail threadId="t1" canModerate={false} onBack={() => {}} onDeleted={() => {}} />);
+
+    expect(screen.getByText(/no catalog changes applied/i)).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/feedback/ThreadDetail.tsx
+++ b/ui/src/components/feedback/ThreadDetail.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
-import { ArrowLeft, Trash2, Quote } from "lucide-react";
+import { ArrowLeft, Trash2, Quote, GitBranch } from "lucide-react";
 import {
   useThread,
   useThreadEvents,
+  useThreadChain,
   useAppendThreadEvent,
   useUpdateThread,
   useDeleteThread,
@@ -50,6 +51,49 @@ function eventSummary(e: ThreadEvent): string | null {
     default:
       return null;
   }
+}
+
+// KnowledgeChainPanel surfaces the thread -> insight -> changeset chain (#602):
+// once a thread is resolved by a captured insight, show the insight and any
+// knowledge changesets that insight produced (the applied data-catalog edits).
+function KnowledgeChainPanel({ threadId, insightId }: { threadId: string; insightId: string }) {
+  const { data: chain, isLoading } = useThreadChain(threadId, true);
+  return (
+    <div className="border-b bg-muted/30 p-3">
+      <div className="mb-1 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <GitBranch className="h-3.5 w-3.5" /> Knowledge chain
+      </div>
+      <p className="text-xs">
+        Resolved by insight{" "}
+        <code className="rounded bg-muted px-1 font-mono" title={insightId}>
+          {insightId.length > 14 ? `${insightId.slice(0, 14)}…` : insightId}
+        </code>
+      </p>
+      {isLoading && <p className="mt-1 text-xs text-muted-foreground">Loading applied changes…</p>}
+      {chain && chain.changesets.length === 0 && (
+        <p className="mt-1 text-xs text-muted-foreground">No catalog changes applied from this insight yet.</p>
+      )}
+      {chain && chain.changesets.length > 0 && (
+        <ul className="mt-1.5 space-y-1">
+          {chain.changesets.map((cs) => (
+            <li key={cs.id} className="flex items-start gap-1.5 text-xs">
+              <span className="shrink-0 rounded bg-primary/10 px-1 py-0.5 font-medium text-primary">
+                {cs.change_type}
+              </span>
+              <span className="min-w-0 flex-1 truncate font-mono text-muted-foreground" title={cs.target_urn}>
+                {cs.target_urn}
+              </span>
+              {cs.rolled_back && (
+                <span className="shrink-0 rounded bg-amber-500/10 px-1 py-0.5 text-amber-700 dark:text-amber-300">
+                  rolled back
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
 }
 
 export function ThreadDetail({ threadId, canModerate, onBack, onDeleted }: Props) {
@@ -123,6 +167,11 @@ export function ThreadDetail({ threadId, canModerate, onBack, onDeleted }: Props
           </p>
         )}
       </div>
+
+      {/* Knowledge chain (shown once the thread is linked to a captured insight) */}
+      {thread.insight_id && (
+        <KnowledgeChainPanel threadId={threadId} insightId={thread.insight_id} />
+      )}
 
       {/* Timeline */}
       <div className="flex-1 space-y-3 overflow-auto p-3">

--- a/ui/src/mocks/data/feedback.ts
+++ b/ui/src/mocks/data/feedback.ts
@@ -75,6 +75,26 @@ export const mockThreads: ThreadWithMeta[] = [
     last_event_at: "2026-06-05T08:30:00Z",
     last_event_type: "comment",
   },
+  // Resolved by a captured insight: demonstrates the thread -> insight ->
+  // changeset knowledge chain (#602). Resolved, so it does not add to open counts.
+  {
+    id: "thr-asset-3",
+    kind: "correction",
+    target_type: "asset",
+    asset_id: "ast-001",
+    title: "Churn is actually retention",
+    author_id: SME,
+    author_email: SME,
+    status: "resolved",
+    requires_resolution: true,
+    validation_state: "none",
+    insight_id: "ins_7f3a9b2c1d4e",
+    created_at: "2026-06-04T13:00:00Z",
+    updated_at: "2026-06-04T18:45:00Z",
+    event_count: 2,
+    last_event_at: "2026-06-04T18:45:00Z",
+    last_event_type: "insight_linked",
+  },
 ];
 
 export const mockThreadEvents: Record<string, ThreadEvent[]> = {
@@ -93,4 +113,29 @@ export const mockThreadEvents: Record<string, ThreadEvent[]> = {
   "thr-standalone-1": [
     { id: "evt-s1-1", thread_id: "thr-standalone-1", event_type: "comment", author_id: SME, author_email: SME, body: "The Monday refresh landed Tuesday again this week.", created_at: "2026-06-05T08:30:00Z" },
   ],
+  "thr-asset-3": [
+    { id: "evt-a3-1", thread_id: "thr-asset-3", event_type: "comment", author_id: SME, author_email: SME, body: "The 'churn' column measures monthly active retention, not churn.", created_at: "2026-06-04T13:00:00Z" },
+    { id: "evt-a3-2", thread_id: "thr-asset-3", event_type: "insight_linked", author_id: ME, author_email: ME, created_at: "2026-06-04T18:45:00Z" },
+  ],
+};
+
+// Resolved knowledge chains keyed by thread id (#602). Returned by
+// GET /threads/:id/chain; threads without an entry resolve to an empty chain.
+export const mockThreadChains: Record<
+  string,
+  { thread_id: string; insight_id?: string; changesets: { id: string; target_urn: string; change_type: string; created_at: string; rolled_back: boolean }[] }
+> = {
+  "thr-asset-3": {
+    thread_id: "thr-asset-3",
+    insight_id: "ins_7f3a9b2c1d4e",
+    changesets: [
+      {
+        id: "cs_9a8b7c6d5e4f",
+        target_urn: "urn:li:dataset:(urn:li:dataPlatform:trino,hive.sales.churn,PROD)",
+        change_type: "update_description",
+        created_at: "2026-06-04T18:45:00Z",
+        rolled_back: false,
+      },
+    ],
+  },
 };

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -23,7 +23,7 @@ import { mockContent } from "./data/content";
 import { mockCollections, mockSharedCollections } from "./data/collections";
 import { mockAdminPrompts, mockPortalPrompts } from "./data/prompts";
 import { mockResources } from "./data/resources";
-import { mockThreads, mockThreadEvents } from "./data/feedback";
+import { mockThreads, mockThreadEvents, mockThreadChains } from "./data/feedback";
 import { mockAPIKeys } from "./data/keys";
 import {
   mockEffectiveConfig,
@@ -1624,6 +1624,15 @@ export const handlers = [
   http.get(`${PORTAL_BASE}/threads/:id/events`, ({ params }) =>
     HttpResponse.json({ data: portalThreadEvents[params.id as string] ?? [] }),
   ),
+
+  // Resolved knowledge chain for a thread (#602). Registered before
+  // /threads/:id so the static /chain segment is not swallowed.
+  http.get(`${PORTAL_BASE}/threads/:id/chain`, ({ params }) => {
+    const id = params.id as string;
+    return HttpResponse.json(
+      mockThreadChains[id] ?? { thread_id: id, insight_id: "", changesets: [] },
+    );
+  }),
 
   http.post(`${PORTAL_BASE}/threads/:id/events`, async ({ params, request }) => {
     const id = params.id as string;


### PR DESCRIPTION
Phase 2 of the feedback epic (#600). Wires the feedback-thread substrate (#601) into the insight/knowledge loop and gives the agent a review path, with **no new MCP tools** (`manage_artifact` and `capture_insight` gain actions/params only; `Tools()` is unchanged).

## What it does

The chain stays visible end to end: **thread → insight → changeset → `target_urn`**.

- **`capture_insight` gains `thread_ids`.** Linking sets `insight_id`, appends an `insight_linked` event, and moves the thread to `resolved`. The response reports `linked_thread_count` and `unlinked_thread_ids`; both are omitted when `thread_ids` is absent (a capture without threads is byte-for-byte unchanged).
- **`manage_artifact` gains thread actions:** `list_threads` (filter by target, status, `requires_resolution`, `validation_state`), `get_thread`, `reply_thread`, `resolve_thread`, `request_validation`.
- **`GET /api/v1/portal/threads/{id}/chain`** returns a thread's resolved chain (insight + the changesets it produced, with `target_urn`/`change_type`/rollback state), surfaced in the portal feedback panel as a "Knowledge chain" section.

## Authorization

Thread actions and the `capture_insight` link path are both scoped to **artifacts the caller owns or can edit** (the same `canEditAsset`/`canEditCollection` predicate as the REST handler), with admin override; standalone threads are readable by any authenticated caller and moderated by the thread author or an admin. Critically, `capture_insight`'s linking routes through the **same** `callerCanActOnThread` gate as `resolve_thread`, so it is not a back door around the access model: a thread the caller could not resolve via `manage_artifact` is refused and reported as unlinked.

## Tests

- Unit tests for the five thread actions, the owns-or-edit gating (owner / editor-share / stranger-denied / admin / prompt-admin-only / anonymous-fail-closed), the authorizing `LinkInsight`, the `capture_insight` `thread_ids` branch (link / unlinked / no-regression / link-failure-is-best-effort), `getThreadChain`, and the store error paths.
- **Real-DB assembled-server integration test** (the #602 acceptance, run under `make test-realdb`): a real `mcp.Server` + in-memory transport calls `capture_insight` with `thread_ids`; read-back confirms `insight_id` + `insight_linked` + resolved status; a thread on an asset the caller does not own is refused and left unmutated; the changeset chain resolves via real Postgres JSONB containment. Verified by read-back, not hand-constructed input.

## UI

`useThreadChain` hook + `ThreadChain` types + the "Knowledge chain" panel in `ThreadDetail`, with an MSW fixture and component tests.

## Docs

Regenerated swagger (adds the `/chain` endpoint); feedback-bridge sections in `docs/knowledge/overview.md` and `docs/llms-full.txt`.

## Verification

`make verify` green end to end: race tests, lint (0 new issues), gosec, govulncheck, semgrep, CodeQL (no new blocking), patch coverage 91.2%, `test-realdb`, GoReleaser dry-run. Ran the full adversarial `/code-review` before commit; it caught an unguarded `capture_insight` link path (now gated as described above) plus a duplicate-`thread_ids` counting bug, both fixed here.