### PR TITLE
feat(threads): validation/signoff lifecycle + worklists (#603)

### DIFF
--- a/docs/knowledge/overview.md
+++ b/docs/knowledge/overview.md
@@ -207,6 +207,19 @@ Both fields are omitted entirely when `thread_ids` is not supplied, so a capture
 
 **Reading the chain.** `GET /api/v1/portal/threads/{id}/chain` returns the resolved chain for a thread: its `insight_id` and the changesets that insight produced (each with `target_urn`, `change_type`, and rollback state). The portal feedback panel renders this as a "Knowledge chain" section on a resolved thread.
 
+## Validation & Sign-off
+
+The loop closes with SME validation and worklists so nothing is dropped.
+
+**Validation response.** After `request_validation` routes a request to the feedback author, that author confirms or disputes it: `manage_artifact action=respond_validation` (with `validation_result` = `validated`|`disputed` and an optional `validation_reason`), or `POST /api/v1/portal/threads/{id}/validation` from the portal. Both record a `validation_result` event and set `validation_state`; **disputing re-opens the thread** so it returns to the practitioner worklist. Only the feedback author (or an admin) may respond.
+
+**Worklists / inbox.** Two self-scoped views:
+
+- `GET /api/v1/portal/worklist/practitioner` — open, resolution-required threads across every artifact the caller owns or can edit.
+- `GET /api/v1/portal/worklist/sme` — threads awaiting the caller's validation (validation requests routed back to them).
+
+**Sign-off aggregation.** `GET /api/v1/portal/assets/{id}/signoff` and `.../collections/{id}/signoff` return `signed_off` (N: distinct users who left an approval event on the artifact's threads) of `stakeholders` (M: the owner plus active share grantees). The portal renders this as "signed off by N of M".
+
 ## AI Agent Guidance
 
 The toolkit registers an MCP prompt called `knowledge_capture_guidance` that tells AI assistants when to capture insights. The prompt covers:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1707,6 +1707,12 @@ Human feedback threads on portal artifacts connect to the knowledge loop: an age
 - **`manage_artifact` thread actions** (no new tools): `list_threads` (filter by target, status, `requires_resolution`, `validation_state`), `get_thread`, `reply_thread`, `resolve_thread`, `request_validation`. Scoped to artifacts the caller owns or can edit; admins see all; standalone threads are readable by any authenticated caller and moderated by the thread author or an admin.
 - **`GET /api/v1/portal/threads/{id}/chain`** returns a thread's resolved chain: its `insight_id` and the changesets that insight produced (each with `target_urn`, `change_type`, rollback state). The portal feedback panel renders this as a "Knowledge chain" section.
 
+### Validation & sign-off (Phase 3)
+
+- **Validation response**: after `request_validation` routes a request to the feedback author, that author confirms or disputes it via `manage_artifact action=respond_validation` (`validation_result` = `validated`|`disputed`, optional `validation_reason`) or `POST /api/v1/portal/threads/{id}/validation`. Both append a `validation_result` event and set `validation_state`; **disputing re-opens the thread**. Only the author (or an admin) may respond.
+- **Worklists**: `GET /api/v1/portal/worklist/practitioner` (open resolution-required threads across artifacts the caller owns/can edit) and `GET /api/v1/portal/worklist/sme` (threads awaiting the caller's validation).
+- **Sign-off**: `GET /api/v1/portal/assets/{id}/signoff` and `.../collections/{id}/signoff` return `signed_off` of `stakeholders` (N = distinct approvers; M = owner + active share grantees), rendered as "signed off by N of M".
+
 ## apply_knowledge Tool
 
 Admin-only tool for reviewing and applying captured insights. Requires the `admin` persona.

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -7158,6 +7158,61 @@ const docTemplate = `{
                 }
             }
         },
+        "/portal/assets/{id}/signoff": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Count of stakeholders who signed off (N) out of the total stakeholders (M = owner + active share grantees).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "Asset sign-off summary",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Asset ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.signoffSummary"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/assets/{id}/thumbnail": {
             "get": {
                 "security": [
@@ -8249,6 +8304,61 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/collections/{id}/signoff": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Count of stakeholders who signed off (N) out of the total stakeholders (M = owner + active share grantees).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "Collection sign-off summary",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Collection ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.signoffSummary"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/portal.problemDetail"
                         }
@@ -10043,6 +10153,165 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/threads/{id}/validation": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "The feedback author marks a thread validated or disputed (with an optional reason). Disputing re-opens the thread.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "Respond to a validation request",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Thread ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Validation outcome",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/portal.respondValidationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.Thread"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/worklist/practitioner": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Open, resolution-required feedback threads across every artifact the caller owns or can edit.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "Practitioner worklist",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.paginatedResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/worklist/sme": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Threads awaiting the caller's validation (validation requests routed back to the feedback author).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "SME validation worklist",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.paginatedResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/portal.problemDetail"
                         }
@@ -14687,6 +14956,18 @@ const docTemplate = `{
                 }
             }
         },
+        "portal.respondValidationRequest": {
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "type": "string"
+                },
+                "result": {
+                    "description": "validated | disputed",
+                    "type": "string"
+                }
+            }
+        },
         "portal.setSectionsRequest": {
             "type": "object",
             "properties": {
@@ -14707,6 +14988,17 @@ const docTemplate = `{
                 "share_url": {
                     "type": "string",
                     "example": "https://platform.example.com/portal/view/abc123"
+                }
+            }
+        },
+        "portal.signoffSummary": {
+            "type": "object",
+            "properties": {
+                "signed_off": {
+                    "type": "integer"
+                },
+                "stakeholders": {
+                    "type": "integer"
                 }
             }
         },

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -7152,6 +7152,61 @@
                 }
             }
         },
+        "/portal/assets/{id}/signoff": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Count of stakeholders who signed off (N) out of the total stakeholders (M = owner + active share grantees).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "Asset sign-off summary",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Asset ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.signoffSummary"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/assets/{id}/thumbnail": {
             "get": {
                 "security": [
@@ -8243,6 +8298,61 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/collections/{id}/signoff": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Count of stakeholders who signed off (N) out of the total stakeholders (M = owner + active share grantees).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "Collection sign-off summary",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Collection ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.signoffSummary"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/portal.problemDetail"
                         }
@@ -10037,6 +10147,165 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/threads/{id}/validation": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "The feedback author marks a thread validated or disputed (with an optional reason). Disputing re-opens the thread.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "Respond to a validation request",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Thread ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Validation outcome",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/portal.respondValidationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.Thread"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/worklist/practitioner": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Open, resolution-required feedback threads across every artifact the caller owns or can edit.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "Practitioner worklist",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.paginatedResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/worklist/sme": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Threads awaiting the caller's validation (validation requests routed back to the feedback author).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "SME validation worklist",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.paginatedResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/portal.problemDetail"
                         }
@@ -14681,6 +14950,18 @@
                 }
             }
         },
+        "portal.respondValidationRequest": {
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "type": "string"
+                },
+                "result": {
+                    "description": "validated | disputed",
+                    "type": "string"
+                }
+            }
+        },
         "portal.setSectionsRequest": {
             "type": "object",
             "properties": {
@@ -14701,6 +14982,17 @@
                 "share_url": {
                     "type": "string",
                     "example": "https://platform.example.com/portal/view/abc123"
+                }
+            }
+        },
+        "portal.signoffSummary": {
+            "type": "object",
+            "properties": {
+                "signed_off": {
+                    "type": "integer"
+                },
+                "stakeholders": {
+                    "type": "integer"
                 }
             }
         },

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -3086,6 +3086,14 @@ definitions:
       type:
         type: string
     type: object
+  portal.respondValidationRequest:
+    properties:
+      reason:
+        type: string
+      result:
+        description: validated | disputed
+        type: string
+    type: object
   portal.setSectionsRequest:
     properties:
       sections:
@@ -3100,6 +3108,13 @@ definitions:
       share_url:
         example: https://platform.example.com/portal/view/abc123
         type: string
+    type: object
+  portal.signoffSummary:
+    properties:
+      signed_off:
+        type: integer
+      stakeholders:
+        type: integer
     type: object
   portal.statusResponse:
     properties:
@@ -7828,6 +7843,41 @@ paths:
       summary: Create asset share
       tags:
       - Shares
+  /portal/assets/{id}/signoff:
+    get:
+      description: Count of stakeholders who signed off (N) out of the total stakeholders
+        (M = owner + active share grantees).
+      parameters:
+      - description: Asset ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/portal.signoffSummary'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Asset sign-off summary
+      tags:
+      - Feedback
   /portal/assets/{id}/thumbnail:
     get:
       description: Downloads the asset's PNG thumbnail image.
@@ -8530,6 +8580,41 @@ paths:
       summary: Create collection share
       tags:
       - Shares
+  /portal/collections/{id}/signoff:
+    get:
+      description: Count of stakeholders who signed off (N) out of the total stakeholders
+        (M = owner + active share grantees).
+      parameters:
+      - description: Collection ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/portal.signoffSummary'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Collection sign-off summary
+      tags:
+      - Feedback
   /portal/collections/{id}/thumbnail:
     get:
       description: Downloads the collection's PNG thumbnail image.
@@ -9690,6 +9775,57 @@ paths:
       summary: Add a thread event
       tags:
       - Feedback
+  /portal/threads/{id}/validation:
+    post:
+      consumes:
+      - application/json
+      description: The feedback author marks a thread validated or disputed (with
+        an optional reason). Disputing re-opens the thread.
+      parameters:
+      - description: Thread ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Validation outcome
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/portal.respondValidationRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/portal.Thread'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Respond to a validation request
+      tags:
+      - Feedback
   /portal/threads/counts:
     get:
       description: Returns a map of target id to open-thread count for list-page badges.
@@ -9731,6 +9867,56 @@ paths:
       - ApiKeyAuth: []
       - BearerAuth: []
       summary: Count open threads per target
+      tags:
+      - Feedback
+  /portal/worklist/practitioner:
+    get:
+      description: Open, resolution-required feedback threads across every artifact
+        the caller owns or can edit.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/portal.paginatedResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Practitioner worklist
+      tags:
+      - Feedback
+  /portal/worklist/sme:
+    get:
+      description: Threads awaiting the caller's validation (validation requests routed
+        back to the feedback author).
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/portal.paginatedResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: SME validation worklist
       tags:
       - Feedback
   /resources:

--- a/pkg/portal/handler_test.go
+++ b/pkg/portal/handler_test.go
@@ -71,6 +71,8 @@ type mockShareStore struct {
 	getByTokenErr  error
 	listByAsset    []Share
 	listByAssetE   error
+	listByColl     []Share
+	listByCollE    error
 	sharedWithRes  []SharedAsset
 	sharedWithTot  int
 	sharedWithErr  error
@@ -117,8 +119,8 @@ func (m *mockShareStore) ListActiveShareSummaries(_ context.Context, _ []string)
 	return m.summaries, m.summariesErr
 }
 
-func (*mockShareStore) ListByCollection(_ context.Context, _ string) ([]Share, error) {
-	return nil, nil
+func (m *mockShareStore) ListByCollection(_ context.Context, _ string) ([]Share, error) {
+	return m.listByColl, m.listByCollE
 }
 
 func (m *mockShareStore) ListByPrompt(_ context.Context, _ string) ([]Share, error) {

--- a/pkg/portal/signoff_handler.go
+++ b/pkg/portal/signoff_handler.go
@@ -1,0 +1,130 @@
+package portal
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Sign-off aggregation (Phase 3 / #603). "Signed off by N of M stakeholders",
+// where N is the number of distinct users who left an approval event on the
+// artifact's threads and M is the artifact owner plus its active share grantees.
+
+// signoffSummary is the response for an artifact's sign-off aggregation.
+type signoffSummary struct {
+	SignedOff    int `json:"signed_off"`
+	Stakeholders int `json:"stakeholders"`
+}
+
+// assetSignoff handles GET /api/v1/portal/assets/{id}/signoff.
+//
+// @Summary      Asset sign-off summary
+// @Description  Count of stakeholders who signed off (N) out of the total stakeholders (M = owner + active share grantees).
+// @Tags         Feedback
+// @Produce      json
+// @Param        id  path  string  true  "Asset ID"
+// @Success      200  {object}  signoffSummary
+// @Failure      401  {object}  problemDetail
+// @Failure      403  {object}  problemDetail
+// @Failure      404  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/assets/{id}/signoff [get]
+func (h *Handler) assetSignoff(w http.ResponseWriter, r *http.Request) {
+	user := GetUser(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, errAuthRequired)
+		return
+	}
+	id := r.PathValue("id")
+	asset, err := h.deps.AssetStore.Get(r.Context(), id)
+	if err != nil || asset == nil || asset.DeletedAt != nil {
+		writeError(w, http.StatusNotFound, "asset not found")
+		return
+	}
+	if !h.canViewAsset(w, r, id, asset, user) {
+		return
+	}
+	shares, err := h.deps.ShareStore.ListByAsset(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load shares")
+		return
+	}
+	h.writeSignoff(w, r, targetTypeAsset, id, stakeholderCount(asset.OwnerID, asset.OwnerEmail, shares))
+}
+
+// collectionSignoff handles GET /api/v1/portal/collections/{id}/signoff.
+//
+// @Summary      Collection sign-off summary
+// @Description  Count of stakeholders who signed off (N) out of the total stakeholders (M = owner + active share grantees).
+// @Tags         Feedback
+// @Produce      json
+// @Param        id  path  string  true  "Collection ID"
+// @Success      200  {object}  signoffSummary
+// @Failure      401  {object}  problemDetail
+// @Failure      403  {object}  problemDetail
+// @Failure      404  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/collections/{id}/signoff [get]
+func (h *Handler) collectionSignoff(w http.ResponseWriter, r *http.Request) {
+	user := GetUser(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, errAuthRequired)
+		return
+	}
+	id := r.PathValue("id")
+	coll, err := h.deps.CollectionStore.Get(r.Context(), id)
+	if err != nil || coll == nil || coll.DeletedAt != nil {
+		writeError(w, http.StatusNotFound, "collection not found")
+		return
+	}
+	if coll.OwnerID != user.UserID && !h.userIsAdmin(user) && h.collectionSharePermission(r, id, user) == "" {
+		writeError(w, http.StatusForbidden, "you do not have access to this collection")
+		return
+	}
+	shares, err := h.deps.ShareStore.ListByCollection(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load shares")
+		return
+	}
+	h.writeSignoff(w, r, targetTypeCollection, id, stakeholderCount(coll.OwnerID, coll.OwnerEmail, shares))
+}
+
+// writeSignoff counts sign-offs and writes the N-of-M summary. signed_off is
+// clamped to the stakeholder count (m) so the badge can never read "N of M"
+// with N > M (an approval from someone outside owner+grantees, e.g. a
+// collection-inherited viewer, must not over-report).
+func (h *Handler) writeSignoff(w http.ResponseWriter, r *http.Request, targetType, id string, m int) {
+	n, err := h.deps.ThreadStore.CountSignoffs(r.Context(), targetType, id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to count sign-offs")
+		return
+	}
+	if n > m {
+		n = m
+	}
+	writeJSON(w, http.StatusOK, signoffSummary{SignedOff: n, Stakeholders: m})
+}
+
+// stakeholderCount returns M: the artifact owner (always 1) plus the number of
+// distinct users holding an active share, excluding the owner themselves — by
+// id OR email, since a self-share may be recorded by either (an owner who
+// self-shares must not be counted twice).
+func stakeholderCount(ownerID, ownerEmail string, shares []Share) int {
+	ownerKey := strings.ToLower(ownerEmail)
+	seen := make(map[string]struct{}, len(shares))
+	for _, s := range shares {
+		if !isShareActive(s) {
+			continue
+		}
+		key := s.SharedWithUserID
+		if key == "" {
+			key = strings.ToLower(s.SharedWithEmail)
+		}
+		if key == "" || key == ownerID || (ownerKey != "" && key == ownerKey) {
+			continue
+		}
+		seen[key] = struct{}{}
+	}
+	return 1 + len(seen)
+}

--- a/pkg/portal/signoff_handler_test.go
+++ b/pkg/portal/signoff_handler_test.go
@@ -1,0 +1,125 @@
+package portal
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStakeholderCount(t *testing.T) {
+	// owner(1) + distinct active grantees (g1, g2); duplicate and revoked excluded.
+	shares := []Share{
+		{SharedWithUserID: "g1"},
+		{SharedWithUserID: "g2"},
+		{SharedWithUserID: "g1"},
+		{SharedWithUserID: "g3", Revoked: true},
+		{SharedWithEmail: ""}, // no identity: skipped
+	}
+	assert.Equal(t, 3, stakeholderCount("owner1", "owner1@x", shares))
+	assert.Equal(t, 1, stakeholderCount("owner1", "owner1@x", nil)) // owner only
+	// An owner who self-shares is not double-counted (by id or by email).
+	assert.Equal(t, 1, stakeholderCount("owner1", "owner1@x", []Share{{SharedWithUserID: "owner1"}}))
+	assert.Equal(t, 1, stakeholderCount("uuid-owner", "owner@x", []Share{{SharedWithEmail: "Owner@X"}}))
+}
+
+func TestAssetSignoff(t *testing.T) {
+	threads := &mockThreadStore{signoffCount: 2}
+	assets := &mockAssetStore{getAsset: &Asset{ID: "asset_1", OwnerID: "u1"}}
+	shares := &mockShareStore{listByAsset: []Share{{SharedWithUserID: "g1"}, {SharedWithUserID: "g2"}}}
+	h := newThreadHandlerFull(threads, assets, shares, nil, nil, &User{UserID: "u1", Email: "u1@example.com"})
+
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/assets/asset_1/signoff", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp signoffSummary
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 2, resp.SignedOff)
+	assert.Equal(t, 3, resp.Stakeholders) // owner + g1 + g2
+}
+
+func TestAssetSignoffClampsSignedOff(t *testing.T) {
+	// More distinct approvers than stakeholders (e.g. a collection-inherited
+	// viewer approved) must not over-report: signed_off is clamped to M.
+	threads := &mockThreadStore{signoffCount: 5}
+	assets := &mockAssetStore{getAsset: &Asset{ID: "asset_1", OwnerID: "u1"}}
+	h := newThreadHandlerFull(threads, assets, &mockShareStore{}, nil, nil, &User{UserID: "u1"})
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/assets/asset_1/signoff", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp signoffSummary
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Stakeholders)
+	assert.Equal(t, 1, resp.SignedOff) // clamped from 5 to M=1
+}
+
+func TestAssetSignoffNotFound(t *testing.T) {
+	assets := &mockAssetStore{getErr: assert.AnError}
+	h := newThreadHandlerFull(&mockThreadStore{}, assets, &mockShareStore{}, nil, nil, &User{UserID: "u1"})
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/assets/nope/signoff", nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestAssetSignoffViewDenied(t *testing.T) {
+	assets := &mockAssetStore{getAsset: &Asset{ID: "asset_1", OwnerID: "other"}}
+	h := newThreadHandlerFull(&mockThreadStore{}, assets, &mockShareStore{}, nil, nil, &User{UserID: "u1", Email: "u1@example.com"})
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/assets/asset_1/signoff", nil)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestAssetSignoffUnauthorized(t *testing.T) {
+	h := newThreadHandlerFull(&mockThreadStore{}, &mockAssetStore{}, &mockShareStore{}, nil, nil, nil)
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/assets/asset_1/signoff", nil)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestCollectionSignoff(t *testing.T) {
+	threads := &mockThreadStore{signoffCount: 1}
+	colls := &mockCollectionStore{getResult: &Collection{ID: "col_1", OwnerID: "u1"}}
+	h := newThreadHandlerFull(threads, &mockAssetStore{}, &mockShareStore{}, colls, nil, &User{UserID: "u1", Email: "u1@example.com"})
+
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/collections/col_1/signoff", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp signoffSummary
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.SignedOff)
+	assert.Equal(t, 1, resp.Stakeholders) // owner only (no collection shares)
+}
+
+func TestAssetSignoffCountError(t *testing.T) {
+	threads := &mockThreadStore{signoffErr: assert.AnError}
+	assets := &mockAssetStore{getAsset: &Asset{ID: "asset_1", OwnerID: "u1"}}
+	h := newThreadHandlerFull(threads, assets, &mockShareStore{}, nil, nil, &User{UserID: "u1"})
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/assets/asset_1/signoff", nil)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestCollectionSignoffNotFound(t *testing.T) {
+	colls := &mockCollectionStore{getErr: assert.AnError}
+	h := newThreadHandlerFull(&mockThreadStore{}, &mockAssetStore{}, &mockShareStore{}, colls, nil, &User{UserID: "u1"})
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/collections/nope/signoff", nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCollectionSignoffAdmin(t *testing.T) {
+	threads := &mockThreadStore{signoffCount: 0}
+	colls := &mockCollectionStore{getResult: &Collection{ID: "col_1", OwnerID: "other"}}
+	h := newThreadHandlerFull(threads, &mockAssetStore{}, &mockShareStore{}, colls, nil, &User{UserID: "admin1", Roles: []string{"admin"}})
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/collections/col_1/signoff", nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCollectionSignoffShareError(t *testing.T) {
+	colls := &mockCollectionStore{getResult: &Collection{ID: "col_1", OwnerID: "u1"}}
+	shares := &mockShareStore{listByCollE: assert.AnError}
+	h := newThreadHandlerFull(&mockThreadStore{}, &mockAssetStore{}, shares, colls, nil, &User{UserID: "u1"})
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/collections/col_1/signoff", nil)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestCollectionSignoffDenied(t *testing.T) {
+	colls := &mockCollectionStore{getResult: &Collection{ID: "col_1", OwnerID: "other"}}
+	h := newThreadHandlerFull(&mockThreadStore{}, &mockAssetStore{}, &mockShareStore{}, colls, nil, &User{UserID: "u1"})
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/collections/col_1/signoff", nil)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}

--- a/pkg/portal/store.go
+++ b/pkg/portal/store.go
@@ -732,6 +732,7 @@ func (s *postgresShareStore) ListSharedWithUser(ctx context.Context, userID, ema
 		JOIN portal_assets pa ON ps.asset_id = pa.id
 		WHERE (ps.shared_with_user_id = $1 OR ($2 != '' AND LOWER(ps.shared_with_email) = LOWER($2)))
 		  AND ps.revoked = FALSE AND pa.deleted_at IS NULL
+		  AND (ps.expires_at IS NULL OR ps.expires_at > NOW())
 	`
 	var total int
 	if err := s.db.QueryRowContext(ctx, countQuery, userID, email).Scan(&total); err != nil { //nolint:gosec // query is a constant with parameterized placeholders
@@ -755,6 +756,7 @@ func (s *postgresShareStore) ListSharedWithUser(ctx context.Context, userID, ema
 		JOIN portal_assets pa ON ps.asset_id = pa.id
 		WHERE (ps.shared_with_user_id = $1 OR ($2 != '' AND LOWER(ps.shared_with_email) = LOWER($2)))
 		  AND ps.revoked = FALSE AND pa.deleted_at IS NULL
+		  AND (ps.expires_at IS NULL OR ps.expires_at > NOW())
 		ORDER BY ps.created_at DESC
 		LIMIT $3 OFFSET $4
 	`
@@ -841,6 +843,7 @@ func (s *postgresShareStore) ListSharedCollectionsWithUser(ctx context.Context, 
 		JOIN portal_collections pc ON ps.collection_id = pc.id
 		WHERE (ps.shared_with_user_id = $1 OR ($2 != '' AND LOWER(ps.shared_with_email) = LOWER($2)))
 		  AND ps.revoked = FALSE AND pc.deleted_at IS NULL
+		  AND (ps.expires_at IS NULL OR ps.expires_at > NOW())
 	`
 	var total int
 	if err := s.db.QueryRowContext(ctx, countQuery, userID, email).Scan(&total); err != nil { //nolint:gosec // constant query
@@ -862,6 +865,7 @@ func (s *postgresShareStore) ListSharedCollectionsWithUser(ctx context.Context, 
 		JOIN portal_collections pc ON ps.collection_id = pc.id
 		WHERE (ps.shared_with_user_id = $1 OR ($2 != '' AND LOWER(ps.shared_with_email) = LOWER($2)))
 		  AND ps.revoked = FALSE AND pc.deleted_at IS NULL
+		  AND (ps.expires_at IS NULL OR ps.expires_at > NOW())
 		ORDER BY ps.created_at DESC
 		LIMIT $3 OFFSET $4
 	`

--- a/pkg/portal/thread_handler.go
+++ b/pkg/portal/thread_handler.go
@@ -40,6 +40,11 @@ func (h *Handler) registerThreadRoutes() {
 	h.mux.HandleFunc("GET /api/v1/portal/threads/{id}/events", h.listThreadEvents)
 	h.mux.HandleFunc("GET /api/v1/portal/threads/{id}/chain", h.getThreadChain)
 	h.mux.HandleFunc("POST /api/v1/portal/threads/{id}/events", h.appendThreadEvent)
+	h.mux.HandleFunc("GET /api/v1/portal/worklist/practitioner", h.practitionerWorklist)
+	h.mux.HandleFunc("GET /api/v1/portal/worklist/sme", h.smeWorklist)
+	h.mux.HandleFunc("GET /api/v1/portal/assets/{id}/signoff", h.assetSignoff)
+	h.mux.HandleFunc("GET /api/v1/portal/collections/{id}/signoff", h.collectionSignoff)
+	h.mux.HandleFunc("POST /api/v1/portal/threads/{id}/validation", h.respondValidation)
 }
 
 // --- request/response types ---
@@ -409,8 +414,13 @@ func (h *Handler) updateThread(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid status")
 		return
 	}
-	if req.ValidationState != nil && !ValidThreadValidationState(*req.ValidationState) {
-		writeError(w, http.StatusBadRequest, "invalid validation_state")
+	// validation_state is owned by the validation lifecycle (#603): it carries an
+	// author-only gate, a validation_result event, and re-open-on-dispute. The
+	// generic moderator PATCH must not set it directly, or an owner/editor who is
+	// not the feedback author could self-validate with none of those invariants.
+	if req.ValidationState != nil {
+		writeError(w, http.StatusBadRequest,
+			"validation_state cannot be set here; use POST /api/v1/portal/threads/{id}/validation")
 		return
 	}
 

--- a/pkg/portal/thread_handler_test.go
+++ b/pkg/portal/thread_handler_test.go
@@ -24,6 +24,7 @@ type mockThreadStore struct {
 	listResult        []ThreadWithMeta
 	listTotal         int
 	listErr           error
+	lastListFilter    ThreadFilter
 	getResult         *Thread
 	getErr            error
 	events            []ThreadEvent
@@ -42,6 +43,11 @@ type mockThreadStore struct {
 	linkErr           error
 	validatedThreadID string
 	validateErr       error
+	respondedThreadID string
+	respondedResult   string
+	respondErr        error
+	signoffCount      int
+	signoffErr        error
 	lastCreated       *Thread
 }
 
@@ -56,7 +62,8 @@ func (m *mockThreadStore) CreateThread(_ context.Context, t Thread, _ ThreadEven
 	return &t, nil
 }
 
-func (m *mockThreadStore) ListThreads(_ context.Context, _ ThreadFilter) ([]ThreadWithMeta, int, error) {
+func (m *mockThreadStore) ListThreads(_ context.Context, f ThreadFilter) ([]ThreadWithMeta, int, error) {
+	m.lastListFilter = f
 	return m.listResult, m.listTotal, m.listErr
 }
 
@@ -90,6 +97,10 @@ func (m *mockThreadStore) CountOpenByTargets(_ context.Context, _ string, ids []
 	return m.counts, m.countErr
 }
 
+func (m *mockThreadStore) CountSignoffs(_ context.Context, _, _ string) (int, error) {
+	return m.signoffCount, m.signoffErr
+}
+
 func (m *mockThreadStore) LinkInsight(_ context.Context, threadIDs []string, insightID, _, _ string) ([]string, error) {
 	m.linkedThreadIDs = threadIDs
 	m.linkedInsightID = insightID
@@ -105,6 +116,12 @@ func (m *mockThreadStore) LinkInsight(_ context.Context, threadIDs []string, ins
 func (m *mockThreadStore) RequestValidation(_ context.Context, id, _, _ string) error {
 	m.validatedThreadID = id
 	return m.validateErr
+}
+
+func (m *mockThreadStore) RespondValidation(_ context.Context, id string, resp ValidationResponse, _, _ string) error {
+	m.respondedThreadID = id
+	m.respondedResult = resp.Result
+	return m.respondErr
 }
 
 func newThreadTestHandler(threads *mockThreadStore, assets *mockAssetStore, shares *mockShareStore, user *User) *Handler {
@@ -269,6 +286,17 @@ func TestUpdateThreadInvalidStatus(t *testing.T) {
 	bogus := "bogus"
 	w := doThreadReq(t, h, http.MethodPatch, "/api/v1/portal/threads/thr_1", updateThreadRequest{Status: &bogus})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdateThreadRejectsValidationState(t *testing.T) {
+	// The generic moderator PATCH must not set validation_state; that bypasses
+	// the author-only validation gate, the validation_result event, and re-open.
+	threads := &mockThreadStore{getResult: &Thread{ID: "thr_1", TargetType: targetTypeStandalone, AuthorID: "u1"}}
+	h := newThreadTestHandler(threads, &mockAssetStore{}, &mockShareStore{}, &User{UserID: "u1"})
+	vs := ValidationStateValidated
+	w := doThreadReq(t, h, http.MethodPatch, "/api/v1/portal/threads/thr_1", updateThreadRequest{ValidationState: &vs})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Nil(t, threads.lastUpdate) // never reached the store
 }
 
 func TestUpdateThreadNonModeratorDenied(t *testing.T) {

--- a/pkg/portal/thread_store.go
+++ b/pkg/portal/thread_store.go
@@ -165,8 +165,21 @@ type ThreadFilter struct {
 	Status             string
 	RequiresResolution *bool
 	ValidationState    string
-	Limit              int
-	Offset             int
+	// AuthorID / AuthorEmail restrict to threads opened by this user (used by the
+	// SME "awaiting my validation" worklist). When both are set the match is an
+	// OR (id or case-insensitive email), matching how respond-permission resolves
+	// the author, so a thread answerable by the caller cannot be missing from
+	// their worklist.
+	AuthorID    string
+	AuthorEmail string
+	// TargetAssetIDs / TargetCollectionIDs restrict to threads on any of the
+	// given assets OR collections (used by the practitioner worklist, which
+	// spans every artifact the caller owns or can edit). When either is set the
+	// match is an OR across the two target types.
+	TargetAssetIDs      []string
+	TargetCollectionIDs []string
+	Limit               int
+	Offset              int
 }
 
 const (
@@ -176,9 +189,10 @@ const (
 
 // Shared literals (kept as constants to satisfy the no-magic-string lint).
 const (
-	errBeginTx  = "begin tx: %w"
-	errCommitTx = "commit: %w"
-	eventIDKind = "evt" // newThreadID prefix for event ids
+	errBeginTx      = "begin tx: %w"
+	errCommitTx     = "commit: %w"
+	errRowsAffected = "checking rows affected: %w"
+	eventIDKind     = "evt" // newThreadID prefix for event ids
 )
 
 // EffectiveLimit returns the clamped page size, applying the default when unset.
@@ -229,10 +243,16 @@ type ThreadStore interface {
 	// RequestValidation moves a thread to validation_state=pending and records a
 	// validation_request event, atomically.
 	RequestValidation(ctx context.Context, id, actorID, actorEmail string) error
+	// RespondValidation records an SME's validation outcome (validated/disputed),
+	// appends a validation_result event, and re-opens the thread when disputed.
+	RespondValidation(ctx context.Context, id string, resp ValidationResponse, actorID, actorEmail string) error
 	// CountOpenByTargets returns, per target id, the number of open (non-deleted)
 	// threads. targetType must be asset/collection/prompt. Callers are
 	// responsible for restricting ids to those the requester may see.
 	CountOpenByTargets(ctx context.Context, targetType string, ids []string) (map[string]int, error)
+	// CountSignoffs returns the number of distinct users who left an approval
+	// (signoff) event on any thread targeting the given asset/collection.
+	CountSignoffs(ctx context.Context, targetType, targetID string) (int, error)
 }
 
 // --- PostgreSQL ThreadStore ---
@@ -455,7 +475,7 @@ func (s *postgresThreadStore) SoftDeleteThread(ctx context.Context, id string) e
 	}
 	affected, err := res.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("checking rows affected: %w", err)
+		return fmt.Errorf(errRowsAffected, err)
 	}
 	if affected == 0 {
 		return fmt.Errorf("thread not found or already deleted: %s", id)
@@ -513,7 +533,7 @@ func linkInsightToThreadTx(ctx context.Context, tx *sql.Tx, id, insightID string
 	}
 	affected, err := res.RowsAffected()
 	if err != nil {
-		return false, fmt.Errorf("checking rows affected: %w", err)
+		return false, fmt.Errorf(errRowsAffected, err)
 	}
 	if affected == 0 {
 		return false, nil // missing or deleted thread: skip
@@ -548,7 +568,7 @@ func (s *postgresThreadStore) RequestValidation(ctx context.Context, id, actorID
 	}
 	affected, err := res.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("checking rows affected: %w", err)
+		return fmt.Errorf(errRowsAffected, err)
 	}
 	if affected == 0 {
 		return fmt.Errorf("thread not found or already deleted: %s", id)
@@ -569,6 +589,81 @@ func (s *postgresThreadStore) RequestValidation(ctx context.Context, id, actorID
 		return fmt.Errorf(errCommitTx, err)
 	}
 	return nil
+}
+
+// ValidationResponse is an SME's answer to a validation request (Phase 3 / #603).
+type ValidationResponse struct {
+	Result string // ValidationStateValidated or ValidationStateDisputed
+	Reason string // optional; recorded on the validation_result event
+}
+
+// RespondValidation records an SME's validation outcome on a thread: it sets
+// validation_state to validated/disputed, appends a validation_result event
+// (carrying the result and reason), and — when disputed — re-opens the thread so
+// it returns to the practitioner's worklist. All in one transaction.
+func (s *postgresThreadStore) RespondValidation(ctx context.Context, id string, resp ValidationResponse, actorID, actorEmail string) error { //nolint:revive // interface impl
+	// Defense in depth: the column has no DB CHECK, so reject any result other
+	// than the two terminal outcomes before it reaches validation_state.
+	if resp.Result != ValidationStateValidated && resp.Result != ValidationStateDisputed {
+		return fmt.Errorf("invalid validation result: %q", resp.Result)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf(errBeginTx, err)
+	}
+	defer tx.Rollback() //nolint:errcheck // commit below on success
+
+	// The thread must be awaiting validation: a response only answers a prior
+	// request, so the state machine is request(pending) -> respond. The
+	// validation_state = 'pending' precondition enforces it atomically (so an
+	// author cannot "dispute" — and thereby re-open — a thread no one asked to
+	// validate). Disputing re-opens the thread (#603); validating leaves status.
+	query := `UPDATE portal_threads SET validation_state = $1, updated_at = NOW()
+	          WHERE id = $2 AND deleted_at IS NULL AND validation_state = $3`
+	args := []any{resp.Result, id, ValidationStatePending}
+	if resp.Result == ValidationStateDisputed {
+		query = `UPDATE portal_threads SET validation_state = $1, status = $2, updated_at = NOW()
+		         WHERE id = $3 AND deleted_at IS NULL AND validation_state = $4`
+		args = []any{resp.Result, ThreadStatusOpen, id, ValidationStatePending}
+	}
+	res, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("responding to validation: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf(errRowsAffected, err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("thread not found or not awaiting validation: %s", id)
+	}
+
+	evt := ThreadEvent{
+		ID:          newThreadID(eventIDKind),
+		ThreadID:    id,
+		EventType:   EventTypeValidationResult,
+		AuthorID:    actorID,
+		AuthorEmail: actorEmail,
+		Metadata:    validationResultMetadata(resp),
+	}
+	if err := insertEventTx(ctx, tx, evt); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf(errCommitTx, err)
+	}
+	return nil
+}
+
+// validationResultMetadata builds the JSON metadata for a validation_result event.
+func validationResultMetadata(resp ValidationResponse) json.RawMessage {
+	m := map[string]string{"result": resp.Result}
+	if resp.Reason != "" {
+		m["reason"] = resp.Reason
+	}
+	b, _ := json.Marshal(m) //nolint:errcheck // map of strings cannot fail
+	return b
 }
 
 // insightLinkedMetadata builds the JSON metadata for an insight_linked event.
@@ -614,6 +709,28 @@ func (s *postgresThreadStore) CountOpenByTargets(ctx context.Context, targetType
 	return counts, nil
 }
 
+// CountSignoffs returns the number of distinct users who left an approval
+// (signoff) event on any thread targeting the given asset/collection (Phase 3 /
+// #603). This is the "N" in "signed off by N of M stakeholders".
+func (s *postgresThreadStore) CountSignoffs(ctx context.Context, targetType, targetID string) (int, error) { //nolint:revive // interface impl
+	column, err := targetColumn(targetType)
+	if err != nil {
+		return 0, err
+	}
+	// #nosec G201 -- column is from targetColumn(), a fixed asset_id/collection_id/prompt_id allowlist, never user input
+	query := fmt.Sprintf(`
+		SELECT COUNT(DISTINCT e.author_id)
+		FROM portal_thread_events e
+		JOIN portal_threads t ON t.id = e.thread_id
+		WHERE t.%s = $1 AND t.deleted_at IS NULL AND e.event_type = $2
+	`, column)
+	var n int
+	if err := s.db.QueryRowContext(ctx, query, targetID, EventTypeApproval).Scan(&n); err != nil {
+		return 0, fmt.Errorf("counting signoffs: %w", err)
+	}
+	return n, nil
+}
+
 // --- helpers ---
 
 func targetColumn(targetType string) (string, error) {
@@ -654,6 +771,27 @@ func applyThreadFilter(qb sq.SelectBuilder, f ThreadFilter) sq.SelectBuilder {
 	}
 	if f.ValidationState != "" {
 		qb = qb.Where(sq.Eq{"t.validation_state": f.ValidationState})
+	}
+	switch {
+	case f.AuthorID != "" && f.AuthorEmail != "":
+		qb = qb.Where(sq.Or{
+			sq.Eq{"t.author_id": f.AuthorID},
+			sq.Expr("LOWER(t.author_email) = LOWER(?)", f.AuthorEmail),
+		})
+	case f.AuthorID != "":
+		qb = qb.Where(sq.Eq{"t.author_id": f.AuthorID})
+	case f.AuthorEmail != "":
+		qb = qb.Where(sq.Expr("LOWER(t.author_email) = LOWER(?)", f.AuthorEmail))
+	}
+	if len(f.TargetAssetIDs) > 0 || len(f.TargetCollectionIDs) > 0 {
+		or := sq.Or{}
+		if len(f.TargetAssetIDs) > 0 {
+			or = append(or, sq.Eq{"t.asset_id": f.TargetAssetIDs})
+		}
+		if len(f.TargetCollectionIDs) > 0 {
+			or = append(or, sq.Eq{"t.collection_id": f.TargetCollectionIDs})
+		}
+		qb = qb.Where(or)
 	}
 	return qb
 }

--- a/pkg/portal/thread_store_test.go
+++ b/pkg/portal/thread_store_test.go
@@ -404,6 +404,95 @@ func TestThreadStoreRequestValidation(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestThreadStoreRespondValidation(t *testing.T) {
+	t.Run("validated leaves status unchanged", func(t *testing.T) {
+		store, mock := newThreadStoreMock(t)
+		mock.ExpectBegin()
+		mock.ExpectExec("UPDATE portal_threads SET validation_state = \\$1, updated_at").
+			WithArgs(ValidationStateValidated, "thr_1", ValidationStatePending).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec("INSERT INTO portal_thread_events").WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectCommit()
+		err := store.RespondValidation(context.Background(), "thr_1",
+			ValidationResponse{Result: ValidationStateValidated}, "sme", "sme@example.com")
+		require.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("disputed re-opens the thread", func(t *testing.T) {
+		store, mock := newThreadStoreMock(t)
+		mock.ExpectBegin()
+		// Disputing sets validation_state AND status=open in the same update.
+		mock.ExpectExec("UPDATE portal_threads SET validation_state = \\$1, status = \\$2").
+			WithArgs(ValidationStateDisputed, ThreadStatusOpen, "thr_1", ValidationStatePending).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec("INSERT INTO portal_thread_events").WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectCommit()
+		err := store.RespondValidation(context.Background(), "thr_1",
+			ValidationResponse{Result: ValidationStateDisputed, Reason: "still wrong"}, "sme", "sme@example.com")
+		require.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		store, mock := newThreadStoreMock(t)
+		mock.ExpectBegin()
+		mock.ExpectExec("UPDATE portal_threads SET validation_state").
+			WithArgs(ValidationStateValidated, "missing", ValidationStatePending).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectRollback()
+		err := store.RespondValidation(context.Background(), "missing",
+			ValidationResponse{Result: ValidationStateValidated}, "sme", "sme@example.com")
+		require.Error(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("begin error", func(t *testing.T) {
+		store, mock := newThreadStoreMock(t)
+		mock.ExpectBegin().WillReturnError(errors.New("begin boom"))
+		require.Error(t, store.RespondValidation(context.Background(), "t1",
+			ValidationResponse{Result: ValidationStateValidated}, "sme", "sme@example.com"))
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("commit error", func(t *testing.T) {
+		store, mock := newThreadStoreMock(t)
+		mock.ExpectBegin()
+		mock.ExpectExec("UPDATE portal_threads SET validation_state").
+			WithArgs(ValidationStateValidated, "t1", ValidationStatePending).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec("INSERT INTO portal_thread_events").WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectCommit().WillReturnError(errors.New("commit boom"))
+		require.Error(t, store.RespondValidation(context.Background(), "t1",
+			ValidationResponse{Result: ValidationStateValidated}, "sme", "sme@example.com"))
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestThreadStoreCountSignoffs(t *testing.T) {
+	store, mock := newThreadStoreMock(t)
+	mock.ExpectQuery("SELECT COUNT\\(DISTINCT e.author_id\\)").
+		WithArgs("asset_1", EventTypeApproval).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(3))
+	n, err := store.CountSignoffs(context.Background(), "asset", "asset_1")
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestThreadStoreCountSignoffsBadTarget(t *testing.T) {
+	store, _ := newThreadStoreMock(t)
+	_, err := store.CountSignoffs(context.Background(), "bogus", "x")
+	require.Error(t, err)
+}
+
+func TestValidationResultMetadata(t *testing.T) {
+	assert.JSONEq(t, `{"result":"validated"}`,
+		string(validationResultMetadata(ValidationResponse{Result: ValidationStateValidated})))
+	assert.JSONEq(t, `{"result":"disputed","reason":"no"}`,
+		string(validationResultMetadata(ValidationResponse{Result: ValidationStateDisputed, Reason: "no"})))
+}
+
 func TestThreadStoreRequestValidationNotFound(t *testing.T) {
 	store, mock := newThreadStoreMock(t)
 	mock.ExpectBegin()

--- a/pkg/portal/validation_handler.go
+++ b/pkg/portal/validation_handler.go
@@ -1,0 +1,92 @@
+package portal
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// respondValidationRequest is the body for POST /threads/{id}/validation.
+type respondValidationRequest struct {
+	Result string `json:"result"` // validated | disputed
+	Reason string `json:"reason,omitempty"`
+}
+
+// respondValidation handles POST /api/v1/portal/threads/{id}/validation
+// (Phase 3 / #603): the original feedback author records a validation outcome.
+// Disputing re-opens the thread. This is the human counterpart of the
+// manage_artifact respond_validation action.
+//
+// @Summary      Respond to a validation request
+// @Description  The feedback author marks a thread validated or disputed (with an optional reason). Disputing re-opens the thread.
+// @Tags         Feedback
+// @Accept       json
+// @Produce      json
+// @Param        id    path  string                    true  "Thread ID"
+// @Param        body  body  respondValidationRequest  true  "Validation outcome"
+// @Success      200  {object}  Thread
+// @Failure      400  {object}  problemDetail
+// @Failure      401  {object}  problemDetail
+// @Failure      403  {object}  problemDetail
+// @Failure      404  {object}  problemDetail
+// @Failure      500  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/threads/{id}/validation [post]
+func (h *Handler) respondValidation(w http.ResponseWriter, r *http.Request) {
+	user, thread := h.loadThreadForValidationResponse(w, r)
+	if thread == nil {
+		return
+	}
+	var req respondValidationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Result != ValidationStateValidated && req.Result != ValidationStateDisputed {
+		writeError(w, http.StatusBadRequest, "result must be 'validated' or 'disputed'")
+		return
+	}
+	if err := h.deps.ThreadStore.RespondValidation(r.Context(), thread.ID,
+		ValidationResponse(req), user.UserID, user.Email); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to record validation")
+		return
+	}
+	updated, err := h.deps.ThreadStore.GetThread(r.Context(), thread.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load updated thread")
+		return
+	}
+	writeJSON(w, http.StatusOK, updated)
+}
+
+// loadThreadForValidationResponse fetches the thread and verifies the caller is
+// its author (or an admin) — the only party allowed to answer a validation
+// request. Writes the error and returns nil on failure.
+func (h *Handler) loadThreadForValidationResponse(w http.ResponseWriter, r *http.Request) (*User, *Thread) {
+	user := GetUser(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, errAuthRequired)
+		return nil, nil
+	}
+	thread, err := h.deps.ThreadStore.GetThread(r.Context(), r.PathValue("id"))
+	if err != nil || thread == nil {
+		writeError(w, http.StatusNotFound, "thread not found")
+		return nil, nil
+	}
+	if !h.userIsAdmin(user) && !isThreadAuthor(user, thread) {
+		writeError(w, http.StatusForbidden, "only the feedback author can respond to a validation request")
+		return nil, nil
+	}
+	return user, thread
+}
+
+// isThreadAuthor reports whether the user authored the thread, matching by user
+// id or case-insensitive email (the same predicate as the manage_artifact
+// respond_validation action, so the two surfaces agree on who the author is).
+func isThreadAuthor(user *User, thread *Thread) bool {
+	if thread.AuthorID == user.UserID {
+		return true
+	}
+	return user.Email != "" && strings.EqualFold(thread.AuthorEmail, user.Email)
+}

--- a/pkg/portal/validation_handler_test.go
+++ b/pkg/portal/validation_handler_test.go
@@ -1,0 +1,80 @@
+package portal
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func authoredThread() *mockThreadStore {
+	return &mockThreadStore{getResult: &Thread{
+		ID: "thr_1", TargetType: targetTypeAsset, AssetID: "asset_1",
+		AuthorID: "sme1", AuthorEmail: "sme1@example.com", Status: ThreadStatusResolved,
+	}}
+}
+
+func TestRespondValidationAuthorValidates(t *testing.T) {
+	threads := authoredThread()
+	h := newThreadHandlerFull(threads, &mockAssetStore{}, &mockShareStore{}, nil, nil, &User{UserID: "sme1", Email: "sme1@example.com"})
+	w := doThreadReq(t, h, http.MethodPost, "/api/v1/portal/threads/thr_1/validation",
+		respondValidationRequest{Result: "validated"})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "validated", threads.respondedResult)
+}
+
+func TestRespondValidationAuthorDisputes(t *testing.T) {
+	threads := authoredThread()
+	h := newThreadHandlerFull(threads, &mockAssetStore{}, &mockShareStore{}, nil, nil, &User{UserID: "sme1"})
+	w := doThreadReq(t, h, http.MethodPost, "/api/v1/portal/threads/thr_1/validation",
+		respondValidationRequest{Result: "disputed", Reason: "still wrong"})
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "disputed", threads.respondedResult)
+}
+
+func TestRespondValidationNonAuthorDenied(t *testing.T) {
+	h := newThreadHandlerFull(authoredThread(), &mockAssetStore{}, &mockShareStore{}, nil, nil, &User{UserID: "other"})
+	w := doThreadReq(t, h, http.MethodPost, "/api/v1/portal/threads/thr_1/validation",
+		respondValidationRequest{Result: "validated"})
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestRespondValidationBadResult(t *testing.T) {
+	h := newThreadHandlerFull(authoredThread(), &mockAssetStore{}, &mockShareStore{}, nil, nil, &User{UserID: "sme1"})
+	w := doThreadReq(t, h, http.MethodPost, "/api/v1/portal/threads/thr_1/validation",
+		respondValidationRequest{Result: "maybe"})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestRespondValidationNotFound(t *testing.T) {
+	threads := &mockThreadStore{getErr: assert.AnError}
+	h := newThreadHandlerFull(threads, &mockAssetStore{}, &mockShareStore{}, nil, nil, &User{UserID: "sme1"})
+	w := doThreadReq(t, h, http.MethodPost, "/api/v1/portal/threads/nope/validation",
+		respondValidationRequest{Result: "validated"})
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestRespondValidationUnauthorized(t *testing.T) {
+	h := newThreadHandlerFull(authoredThread(), &mockAssetStore{}, &mockShareStore{}, nil, nil, nil)
+	w := doThreadReq(t, h, http.MethodPost, "/api/v1/portal/threads/thr_1/validation",
+		respondValidationRequest{Result: "validated"})
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestRespondValidationStoreError(t *testing.T) {
+	threads := authoredThread()
+	threads.respondErr = assert.AnError
+	h := newThreadHandlerFull(threads, &mockAssetStore{}, &mockShareStore{}, nil, nil, &User{UserID: "sme1"})
+	w := doThreadReq(t, h, http.MethodPost, "/api/v1/portal/threads/thr_1/validation",
+		respondValidationRequest{Result: "validated"})
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestRespondValidationAdmin(t *testing.T) {
+	threads := authoredThread()
+	h := newThreadHandlerFull(threads, &mockAssetStore{}, &mockShareStore{}, nil, nil, &User{UserID: "admin1", Roles: []string{"admin"}})
+	w := doThreadReq(t, h, http.MethodPost, "/api/v1/portal/threads/thr_1/validation",
+		respondValidationRequest{Result: "validated"})
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/pkg/portal/validation_signoff_realdb_integration_test.go
+++ b/pkg/portal/validation_signoff_realdb_integration_test.go
@@ -1,0 +1,145 @@
+//go:build integration
+
+package portal
+
+// Real-Postgres acceptance for the Phase 3 validation/signoff lifecycle (#603).
+// Exercises behavior sqlmock cannot: the real RespondValidation transaction
+// (state + re-open + event), the DISTINCT approval-author count, and the
+// worklist filters (author/validation_state and the asset-OR-collection set).
+// Verified by read-back. Run under `make test-realdb`.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/internal/testdb"
+)
+
+// Guards the expires_at filter added to ListSharedWithUser (so an expired editor
+// share cannot leak back into the worklist or "shared with me").
+func TestRealDB_ExpiredEditorShareExcluded(t *testing.T) {
+	db := testdb.New(t)
+	ctx := context.Background()
+	seedAsset(t, db, "asset_active", realdbThreadOwner)
+	seedAsset(t, db, "asset_expired", realdbThreadOwner)
+	shareStore := NewPostgresShareStore(db)
+	const grantee = "grantee-user"
+	past := time.Now().Add(-time.Hour)
+
+	require.NoError(t, shareStore.Insert(ctx, Share{
+		ID: "shr_active", AssetID: "asset_active", Token: "tok_active", CreatedBy: "owner@example.com",
+		SharedWithUserID: grantee, Permission: PermissionEditor,
+	}))
+	require.NoError(t, shareStore.Insert(ctx, Share{
+		ID: "shr_expired", AssetID: "asset_expired", Token: "tok_expired", CreatedBy: "owner@example.com",
+		SharedWithUserID: grantee, Permission: PermissionEditor, ExpiresAt: &past,
+	}))
+
+	shared, _, err := shareStore.ListSharedWithUser(ctx, grantee, "grantee@example.com", 100, 0)
+	require.NoError(t, err)
+	var ids []string
+	for _, s := range shared {
+		ids = append(ids, s.Asset.ID)
+	}
+	assert.Contains(t, ids, "asset_active")
+	assert.NotContains(t, ids, "asset_expired", "expired editor share must be excluded")
+}
+
+func TestRealDB_ValidationSignoffWorklist(t *testing.T) {
+	db := testdb.New(t)
+	ctx := context.Background()
+	store := NewPostgresThreadStore(db)
+	seedAsset(t, db, "asset_p3", realdbThreadOwner)
+	const sme = "sme-user"
+
+	mk := func(id string, status string) {
+		_, err := store.CreateThread(ctx, Thread{
+			ID: id, Kind: ThreadKindCorrection, TargetType: targetTypeAsset, AssetID: "asset_p3",
+			RequiresResolution: true, AuthorID: sme, AuthorEmail: "sme@example.com", Status: status,
+		}, ThreadEvent{ID: id + "_e1", ThreadID: id, EventType: EventTypeComment, AuthorID: sme, AuthorEmail: "sme@example.com", Body: "x"})
+		require.NoError(t, err)
+	}
+	mk("thr_disp", ThreadStatusResolved)
+	mk("thr_val", ThreadStatusResolved)
+
+	// 1. request validation -> pending (read-back).
+	require.NoError(t, store.RequestValidation(ctx, "thr_disp", sme, "sme@example.com"))
+	got, err := store.GetThread(ctx, "thr_disp")
+	require.NoError(t, err)
+	assert.Equal(t, ValidationStatePending, got.ValidationState)
+
+	// 2. dispute -> disputed + re-opened + validation_result event (read-back).
+	require.NoError(t, store.RespondValidation(ctx, "thr_disp",
+		ValidationResponse{Result: ValidationStateDisputed, Reason: "still wrong"}, sme, "sme@example.com"))
+	got, err = store.GetThread(ctx, "thr_disp")
+	require.NoError(t, err)
+	assert.Equal(t, ValidationStateDisputed, got.ValidationState)
+	assert.Equal(t, ThreadStatusOpen, got.Status, "dispute must re-open the thread")
+	events, err := store.ListEvents(ctx, "thr_disp")
+	require.NoError(t, err)
+	assert.True(t, hasEvent(events, EventTypeValidationResult), "expected a validation_result event")
+
+	// 3. responding to a thread that was never submitted for validation is
+	//    rejected (the state machine requires a pending request first).
+	require.Error(t, store.RespondValidation(ctx, "thr_val",
+		ValidationResponse{Result: ValidationStateValidated}, sme, "sme@example.com"),
+		"respond must require validation_state=pending")
+
+	// ...so request it, then validate -> validated, status unchanged (read-back).
+	require.NoError(t, store.RequestValidation(ctx, "thr_val", sme, "sme@example.com"))
+	require.NoError(t, store.RespondValidation(ctx, "thr_val",
+		ValidationResponse{Result: ValidationStateValidated}, sme, "sme@example.com"))
+	got, err = store.GetThread(ctx, "thr_val")
+	require.NoError(t, err)
+	assert.Equal(t, ValidationStateValidated, got.ValidationState)
+	assert.Equal(t, ThreadStatusResolved, got.Status, "validating must not re-open")
+
+	// 4. sign-off: two DISTINCT approvers on the asset's threads -> N = 2.
+	for _, a := range []struct{ id, author string }{{"ap1", "a1"}, {"ap2", "a2"}, {"ap3", "a1"}} {
+		_, err := store.AppendEvent(ctx, ThreadEvent{ID: a.id, ThreadID: "thr_val", EventType: EventTypeApproval, AuthorID: a.author, AuthorEmail: a.author + "@x"})
+		require.NoError(t, err)
+	}
+	n, err := store.CountSignoffs(ctx, targetTypeAsset, "asset_p3")
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	// 5. SME worklist: pending validation requests authored by the SME.
+	mk("thr_pending", ThreadStatusResolved)
+	require.NoError(t, store.RequestValidation(ctx, "thr_pending", sme, "sme@example.com"))
+	smeList, _, err := store.ListThreads(ctx, ThreadFilter{AuthorID: sme, ValidationState: ValidationStatePending})
+	require.NoError(t, err)
+	smeIDs := idsOf(smeList)
+	assert.Contains(t, smeIDs, "thr_pending")
+	assert.NotContains(t, smeIDs, "thr_val", "validated thread is not awaiting validation")
+
+	// 6. practitioner worklist: open + requires_resolution on the owned asset.
+	requires := true
+	pracList, _, err := store.ListThreads(ctx, ThreadFilter{
+		TargetAssetIDs: []string{"asset_p3"}, Status: ThreadStatusOpen, RequiresResolution: &requires,
+	})
+	require.NoError(t, err)
+	pracIDs := idsOf(pracList)
+	assert.Contains(t, pracIDs, "thr_disp", "disputed thread re-opened and still requires resolution")
+	assert.NotContains(t, pracIDs, "thr_val", "resolved thread is not open")
+}
+
+func hasEvent(events []ThreadEvent, eventType string) bool {
+	for _, e := range events {
+		if e.EventType == eventType {
+			return true
+		}
+	}
+	return false
+}
+
+func idsOf(ts []ThreadWithMeta) []string {
+	out := make([]string, len(ts))
+	for i, t := range ts {
+		out[i] = t.ID
+	}
+	return out
+}

--- a/pkg/portal/worklist_handler.go
+++ b/pkg/portal/worklist_handler.go
@@ -1,0 +1,179 @@
+package portal
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+)
+
+// Worklists / inbox (Phase 3 / #603). Two self-scoped cross-artifact views so
+// no feedback is dropped:
+//   - practitioner: open threads that require resolution across every artifact
+//     the caller owns or can edit.
+//   - SME: threads awaiting the caller's validation (validation_state=pending on
+//     threads the caller authored, i.e. the requests routed back to them).
+
+// practitionerWorklist handles GET /api/v1/portal/worklist/practitioner.
+//
+// @Summary      Practitioner worklist
+// @Description  Open, resolution-required feedback threads across every artifact the caller owns or can edit.
+// @Tags         Feedback
+// @Produce      json
+// @Success      200  {object}  paginatedResponse
+// @Failure      401  {object}  problemDetail
+// @Failure      500  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/worklist/practitioner [get]
+func (h *Handler) practitionerWorklist(w http.ResponseWriter, r *http.Request) {
+	user := GetUser(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, errAuthRequired)
+		return
+	}
+	assetIDs, collIDs, err := h.ownedOrEditableTargets(r.Context(), user)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to resolve your artifacts")
+		return
+	}
+	// No artifacts: nothing to do (do not fall through to an unscoped query).
+	if len(assetIDs) == 0 && len(collIDs) == 0 {
+		writeJSON(w, http.StatusOK, paginatedResponse{Data: []ThreadWithMeta{}, Limit: defaultThreadLimit})
+		return
+	}
+	requires := true
+	filter := ThreadFilter{
+		TargetAssetIDs:      assetIDs,
+		TargetCollectionIDs: collIDs,
+		Status:              ThreadStatusOpen,
+		RequiresResolution:  &requires,
+		Limit:               intParam(r, paramLimit, defaultThreadLimit),
+		Offset:              intParam(r, paramOffset, 0),
+	}
+	h.writeWorklist(w, r, filter)
+}
+
+// smeWorklist handles GET /api/v1/portal/worklist/sme.
+//
+// @Summary      SME validation worklist
+// @Description  Threads awaiting the caller's validation (validation requests routed back to the feedback author).
+// @Tags         Feedback
+// @Produce      json
+// @Success      200  {object}  paginatedResponse
+// @Failure      401  {object}  problemDetail
+// @Failure      500  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/worklist/sme [get]
+func (h *Handler) smeWorklist(w http.ResponseWriter, r *http.Request) {
+	user := GetUser(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, errAuthRequired)
+		return
+	}
+	filter := ThreadFilter{
+		AuthorID:        user.UserID,
+		AuthorEmail:     user.Email,
+		ValidationState: ValidationStatePending,
+		Limit:           intParam(r, paramLimit, defaultThreadLimit),
+		Offset:          intParam(r, paramOffset, 0),
+	}
+	h.writeWorklist(w, r, filter)
+}
+
+// writeWorklist runs a worklist filter and writes the paginated result.
+func (h *Handler) writeWorklist(w http.ResponseWriter, r *http.Request, filter ThreadFilter) {
+	threads, total, err := h.deps.ThreadStore.ListThreads(r.Context(), filter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load worklist")
+		return
+	}
+	if threads == nil {
+		threads = []ThreadWithMeta{}
+	}
+	writeJSON(w, http.StatusOK, paginatedResponse{
+		Data: threads, Total: total, Limit: filter.EffectiveLimit(), Offset: filter.Offset,
+	})
+}
+
+// ownedOrEditableTargets returns the ids of every asset and collection the user
+// owns or holds an active editor share on.
+func (h *Handler) ownedOrEditableTargets(ctx context.Context, user *User) (assetIDs, collIDs []string, err error) {
+	assetIDs, err = h.ownedOrEditableAssetIDs(ctx, user)
+	if err != nil {
+		return nil, nil, err
+	}
+	collIDs, err = h.ownedOrEditableCollectionIDs(ctx, user)
+	if err != nil {
+		return nil, nil, err
+	}
+	return assetIDs, collIDs, nil
+}
+
+func (h *Handler) ownedOrEditableAssetIDs(ctx context.Context, user *User) ([]string, error) {
+	var ids []string
+	if h.deps.AssetStore != nil {
+		owned, total, err := h.deps.AssetStore.List(ctx, AssetFilter{OwnerID: user.UserID, Limit: worklistTargetCap})
+		if err != nil {
+			return nil, fmt.Errorf("listing owned assets: %w", err)
+		}
+		warnIfTruncated(total, "owned assets", user.UserID)
+		for _, a := range owned {
+			ids = append(ids, a.ID)
+		}
+	}
+	if h.deps.ShareStore != nil {
+		shared, total, err := h.deps.ShareStore.ListSharedWithUser(ctx, user.UserID, user.Email, worklistTargetCap, 0)
+		if err != nil {
+			return nil, fmt.Errorf("listing shared assets: %w", err)
+		}
+		warnIfTruncated(total, "shared assets", user.UserID)
+		for _, s := range shared {
+			if s.Permission == PermissionEditor {
+				ids = append(ids, s.Asset.ID)
+			}
+		}
+	}
+	return ids, nil
+}
+
+func (h *Handler) ownedOrEditableCollectionIDs(ctx context.Context, user *User) ([]string, error) {
+	var ids []string
+	if h.deps.CollectionStore != nil {
+		owned, total, err := h.deps.CollectionStore.List(ctx, CollectionFilter{OwnerID: user.UserID, Limit: worklistTargetCap})
+		if err != nil {
+			return nil, fmt.Errorf("listing owned collections: %w", err)
+		}
+		warnIfTruncated(total, "owned collections", user.UserID)
+		for _, c := range owned {
+			ids = append(ids, c.ID)
+		}
+	}
+	if h.deps.ShareStore != nil {
+		shared, total, err := h.deps.ShareStore.ListSharedCollectionsWithUser(ctx, user.UserID, user.Email, worklistTargetCap, 0)
+		if err != nil {
+			return nil, fmt.Errorf("listing shared collections: %w", err)
+		}
+		warnIfTruncated(total, "shared collections", user.UserID)
+		for _, s := range shared {
+			if s.Permission == PermissionEditor {
+				ids = append(ids, s.Collection.ID)
+			}
+		}
+	}
+	return ids, nil
+}
+
+// worklistTargetCap bounds how many owned/shared artifacts the worklist gathers.
+const worklistTargetCap = 1000
+
+// warnIfTruncated logs when a user's owned/shared set exceeds the worklist cap,
+// so the silent omission of artifacts past the cap is at least observable to
+// operators (the worklist's purpose is that no feedback is dropped).
+func warnIfTruncated(total int, kind, userID string) {
+	if total > worklistTargetCap {
+		slog.Warn("worklist target set truncated; some artifacts are omitted",
+			"kind", kind, "user", userID, "total", total, "cap", worklistTargetCap)
+	}
+}

--- a/pkg/portal/worklist_handler_test.go
+++ b/pkg/portal/worklist_handler_test.go
@@ -1,0 +1,94 @@
+package portal
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSMEWorklist(t *testing.T) {
+	threads := &mockThreadStore{listResult: []ThreadWithMeta{
+		{Thread: Thread{ID: "thr_1", TargetType: targetTypeAsset, AssetID: "asset_1", ValidationState: ValidationStatePending}},
+	}, listTotal: 1}
+	h := newThreadHandlerFull(threads, &mockAssetStore{}, &mockShareStore{}, nil, nil, &User{UserID: "sme1", Email: "sme1@example.com"})
+
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/worklist/sme", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	// The filter scopes to threads the caller authored (by id or email) that are
+	// awaiting validation, matching how respond-permission resolves the author.
+	assert.Equal(t, "sme1", threads.lastListFilter.AuthorID)
+	assert.Equal(t, "sme1@example.com", threads.lastListFilter.AuthorEmail)
+	assert.Equal(t, ValidationStatePending, threads.lastListFilter.ValidationState)
+
+	var resp paginatedResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+}
+
+func TestSMEWorklistUnauthorized(t *testing.T) {
+	h := newThreadHandlerFull(&mockThreadStore{}, &mockAssetStore{}, &mockShareStore{}, nil, nil, nil)
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/worklist/sme", nil)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestPractitionerWorklist(t *testing.T) {
+	threads := &mockThreadStore{listResult: []ThreadWithMeta{
+		{Thread: Thread{ID: "thr_1", TargetType: targetTypeAsset, AssetID: "asset_owned", RequiresResolution: true}},
+	}, listTotal: 1}
+	assets := &mockAssetStore{listRes: []Asset{{ID: "asset_owned", OwnerID: "u1"}}}
+	shares := &mockShareStore{sharedWithRes: []SharedAsset{
+		{Asset: Asset{ID: "asset_edit"}, Permission: PermissionEditor},
+		{Asset: Asset{ID: "asset_view"}, Permission: PermissionViewer}, // must be excluded
+	}}
+	colls := &mockCollectionStore{listResult: []Collection{{ID: "col_owned", OwnerID: "u1"}}}
+	h := newThreadHandlerFull(threads, assets, shares, colls, nil, &User{UserID: "u1", Email: "u1@example.com"})
+
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/worklist/practitioner", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	f := threads.lastListFilter
+	// Owned + editor-shared assets are included; viewer-shared is not.
+	assert.ElementsMatch(t, []string{"asset_owned", "asset_edit"}, f.TargetAssetIDs)
+	assert.Equal(t, []string{"col_owned"}, f.TargetCollectionIDs)
+	assert.Equal(t, ThreadStatusOpen, f.Status)
+	require.NotNil(t, f.RequiresResolution)
+	assert.True(t, *f.RequiresResolution)
+}
+
+func TestSMEWorklistStoreError(t *testing.T) {
+	threads := &mockThreadStore{listErr: assert.AnError}
+	h := newThreadHandlerFull(threads, &mockAssetStore{}, &mockShareStore{}, nil, nil, &User{UserID: "sme1"})
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/worklist/sme", nil)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestPractitionerWorklistTargetError(t *testing.T) {
+	assets := &mockAssetStore{listErr: assert.AnError}
+	h := newThreadHandlerFull(&mockThreadStore{}, assets, &mockShareStore{}, &mockCollectionStore{}, nil, &User{UserID: "u1"})
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/worklist/practitioner", nil)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestPractitionerWorklistUnauthorized(t *testing.T) {
+	h := newThreadHandlerFull(&mockThreadStore{}, &mockAssetStore{}, &mockShareStore{}, &mockCollectionStore{}, nil, nil)
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/worklist/practitioner", nil)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestPractitionerWorklistNoArtifacts(t *testing.T) {
+	threads := &mockThreadStore{}
+	h := newThreadHandlerFull(threads, &mockAssetStore{}, &mockShareStore{}, &mockCollectionStore{}, nil, &User{UserID: "u1", Email: "u1@example.com"})
+
+	w := doThreadReq(t, h, http.MethodGet, "/api/v1/portal/worklist/practitioner", nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	// With no owned/editable artifacts the store is NOT queried unscoped.
+	assert.Empty(t, threads.lastListFilter.TargetAssetIDs)
+	assert.Empty(t, threads.lastListFilter.TargetCollectionIDs)
+
+	var resp paginatedResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 0, resp.Total)
+}

--- a/pkg/toolkits/portal/schemas.go
+++ b/pkg/toolkits/portal/schemas.go
@@ -43,7 +43,7 @@ var manageArtifactSchema = json.RawMessage(`{
   "properties": {
     "action": {
       "type": "string",
-      "description": "Action to perform. Asset actions: list, get, update, delete, list_versions, revert, search. Collection actions: create_collection, list_collections, get_collection, update_collection, delete_collection, set_sections. Feedback actions: list_threads (scope by asset_id/collection_id/prompt_id or target_type=standalone; optional status/validation_state/requires_resolution filters), get_thread, reply_thread, resolve_thread, request_validation"
+      "description": "Action to perform. Asset actions: list, get, update, delete, list_versions, revert, search. Collection actions: create_collection, list_collections, get_collection, update_collection, delete_collection, set_sections. Feedback actions: list_threads (scope by asset_id/collection_id/prompt_id or target_type=standalone; optional status/validation_state/requires_resolution filters), get_thread, reply_thread, resolve_thread, request_validation, respond_validation (the feedback author records validated/disputed via validation_result)"
     },
     "asset_id": {
       "type": "string",
@@ -156,6 +156,15 @@ var manageArtifactSchema = json.RawMessage(`{
     "requires_resolution": {
       "type": "boolean",
       "description": "Filter list_threads to threads that do (true) or do not (false) require resolution"
+    },
+    "validation_result": {
+      "type": "string",
+      "enum": ["validated", "disputed"],
+      "description": "For respond_validation: the SME's outcome on a validation request"
+    },
+    "validation_reason": {
+      "type": "string",
+      "description": "For respond_validation: optional reason, recorded on the validation_result event (useful when disputed)"
     }
   }
 }`)

--- a/pkg/toolkits/portal/thread_actions.go
+++ b/pkg/toolkits/portal/thread_actions.go
@@ -130,6 +130,48 @@ func (t *Toolkit) handleRequestValidation(ctx context.Context, input manageArtif
 	return jsonResult(map[string]any{"thread_id": thread.ID, "validation_state": portal.ValidationStatePending})
 }
 
+// handleRespondValidation records the SME's answer to a validation request.
+// Unlike the other moderation actions, the responder is the original feedback
+// author (the SME the request was routed to), not the artifact owner.
+func (t *Toolkit) handleRespondValidation(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+	if t.threadStore == nil {
+		return errorResult(threadsUnavail), nil, nil
+	}
+	if input.ThreadID == "" {
+		return errorResult("thread_id is required"), nil, nil
+	}
+	if input.ValidationResult != portal.ValidationStateValidated && input.ValidationResult != portal.ValidationStateDisputed {
+		return errorResult("validation_result must be 'validated' or 'disputed'"), nil, nil
+	}
+	thread, err := t.threadStore.GetThread(ctx, input.ThreadID)
+	if err != nil {
+		return errorResult("thread not found: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
+	}
+	if !t.callerIsThreadAuthor(ctx, thread) {
+		return errorResult("only the feedback author can respond to a validation request"), nil, nil
+	}
+	resp := portal.ValidationResponse{Result: input.ValidationResult, Reason: input.ValidationReason}
+	if err := t.threadStore.RespondValidation(ctx, thread.ID, resp, resolveOwnerID(ctx), resolveOwnerEmail(ctx)); err != nil {
+		return errorResult("failed to respond to validation: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
+	}
+	return jsonResult(map[string]any{"thread_id": thread.ID, "validation_state": input.ValidationResult})
+}
+
+// callerIsThreadAuthor reports whether the caller authored the thread (or is an
+// admin). Fails closed for the anonymous sentinel so an unauthenticated caller
+// cannot match an anonymously-authored thread.
+func (t *Toolkit) callerIsThreadAuthor(ctx context.Context, thread *portal.Thread) bool {
+	if t.isAdmin(ctx) {
+		return true
+	}
+	actorID := resolveOwnerID(ctx)
+	if actorID == anonymousUserName {
+		return false
+	}
+	return thread.AuthorID == actorID ||
+		(thread.AuthorEmail != "" && strings.EqualFold(thread.AuthorEmail, resolveOwnerEmail(ctx)))
+}
+
 // LinkInsight implements the knowledge ThreadLinker bridge with authorization.
 // capture_insight calls this with the thread_ids an insight resolves. The agent
 // surface must not be able to resolve a thread it could not resolve through

--- a/pkg/toolkits/portal/thread_actions_test.go
+++ b/pkg/toolkits/portal/thread_actions_test.go
@@ -37,8 +37,10 @@ type fakeThreadStore struct {
 	lastUpdate *portal.ThreadUpdate
 	updateErr  error
 
-	validatedID string
-	validateErr error
+	validatedID     string
+	validateErr     error
+	respondedResult string
+	respondErr      error
 }
 
 func (*fakeThreadStore) CreateThread(_ context.Context, t portal.Thread, _ portal.ThreadEvent) (*portal.Thread, error) {
@@ -84,9 +86,16 @@ func (f *fakeThreadStore) RequestValidation(_ context.Context, id, _, _ string) 
 	return f.validateErr
 }
 
+func (f *fakeThreadStore) RespondValidation(_ context.Context, _ string, resp portal.ValidationResponse, _, _ string) error {
+	f.respondedResult = resp.Result
+	return f.respondErr
+}
+
 func (*fakeThreadStore) CountOpenByTargets(_ context.Context, _ string, _ []string) (map[string]int, error) {
 	return nil, nil //nolint:nilnil // test stub
 }
+
+func (*fakeThreadStore) CountSignoffs(_ context.Context, _, _ string) (int, error) { return 0, nil }
 
 var _ portal.ThreadStore = (*fakeThreadStore)(nil)
 
@@ -445,6 +454,77 @@ func TestHandleRequestValidation(t *testing.T) {
 		fts := &fakeThreadStore{getResult: thread, validateErr: errors.New("boom")}
 		tk := threadToolkit(t, fts, nil)
 		res, _, _ := tk.handleRequestValidation(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		assert.True(t, res.IsError)
+	})
+}
+
+// --- handleRespondValidation -------------------------------------------------
+
+func TestHandleRespondValidation(t *testing.T) {
+	// The responder is the thread author (the SME the request was routed to).
+	authored := &portal.Thread{ID: "t1", TargetType: "asset", AssetID: "asset_1", AuthorID: ownerID, AuthorEmail: ownerEmail}
+
+	t.Run("author validates", func(t *testing.T) {
+		fts := &fakeThreadStore{getResult: authored}
+		tk := threadToolkit(t, fts, nil)
+		res, _, err := tk.handleRespondValidation(ownerCtx(), manageArtifactInput{ThreadID: "t1", ValidationResult: "validated"})
+		require.NoError(t, err)
+		assert.False(t, res.IsError)
+		assert.Equal(t, "validated", fts.respondedResult)
+		assert.Equal(t, "validated", decodeResult(t, res)["validation_state"])
+	})
+
+	t.Run("author disputes with reason", func(t *testing.T) {
+		fts := &fakeThreadStore{getResult: authored}
+		tk := threadToolkit(t, fts, nil)
+		res, _, _ := tk.handleRespondValidation(ownerCtx(),
+			manageArtifactInput{ThreadID: "t1", ValidationResult: "disputed", ValidationReason: "still wrong"})
+		assert.False(t, res.IsError)
+		assert.Equal(t, "disputed", fts.respondedResult)
+	})
+
+	t.Run("admin can respond", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{getResult: authored}, nil)
+		res, _, _ := tk.handleRespondValidation(adminCtx(), manageArtifactInput{ThreadID: "t1", ValidationResult: "validated"})
+		assert.False(t, res.IsError)
+	})
+
+	t.Run("non-author denied", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{getResult: authored}, nil)
+		res, _, _ := tk.handleRespondValidation(strangerCtx(), manageArtifactInput{ThreadID: "t1", ValidationResult: "validated"})
+		assert.True(t, res.IsError)
+		assert.Contains(t, decodeResult(t, res)["error"], "only the feedback author")
+	})
+
+	t.Run("invalid validation_result", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{getResult: authored}, nil)
+		res, _, _ := tk.handleRespondValidation(ownerCtx(), manageArtifactInput{ThreadID: "t1", ValidationResult: "maybe"})
+		assert.True(t, res.IsError)
+		assert.Contains(t, decodeResult(t, res)["error"], "must be 'validated' or 'disputed'")
+	})
+
+	t.Run("missing thread_id", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{}, nil)
+		res, _, _ := tk.handleRespondValidation(ownerCtx(), manageArtifactInput{ValidationResult: "validated"})
+		assert.True(t, res.IsError)
+	})
+
+	t.Run("thread not found", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{getErr: errors.New("nope")}, nil)
+		res, _, _ := tk.handleRespondValidation(ownerCtx(), manageArtifactInput{ThreadID: "t1", ValidationResult: "validated"})
+		assert.True(t, res.IsError)
+	})
+
+	t.Run("store error", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{getResult: authored, respondErr: errors.New("boom")}, nil)
+		res, _, _ := tk.handleRespondValidation(ownerCtx(), manageArtifactInput{ThreadID: "t1", ValidationResult: "validated"})
+		assert.True(t, res.IsError)
+	})
+
+	t.Run("anonymous caller cannot respond", func(t *testing.T) {
+		anonAuthored := &portal.Thread{ID: "t1", TargetType: "asset", AssetID: "asset_1", AuthorID: "anonymous"}
+		tk := threadToolkit(t, &fakeThreadStore{getResult: anonAuthored}, nil)
+		res, _, _ := tk.handleRespondValidation(context.Background(), manageArtifactInput{ThreadID: "t1", ValidationResult: "validated"})
 		assert.True(t, res.IsError)
 	})
 }

--- a/pkg/toolkits/portal/toolkit.go
+++ b/pkg/toolkits/portal/toolkit.go
@@ -63,6 +63,7 @@ const (
 	actionReplyThread       = "reply_thread"
 	actionResolveThread     = "resolve_thread"
 	actionRequestValidation = "request_validation"
+	actionRespondValidation = "respond_validation"
 
 	// JSON field names used in MCP tool result payloads.
 	fieldAssetID = "asset_id"
@@ -114,6 +115,8 @@ type manageArtifactInput struct {
 	Status             string `json:"status,omitempty"`
 	ValidationState    string `json:"validation_state,omitempty"`
 	RequiresResolution *bool  `json:"requires_resolution,omitempty"`
+	ValidationResult   string `json:"validation_result,omitempty"`
+	ValidationReason   string `json:"validation_reason,omitempty"`
 }
 
 // sectionInput defines a collection section in MCP tool input.
@@ -244,7 +247,7 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 			"Collection actions: create_collection, list_collections, get_collection, " +
 			"update_collection, delete_collection, set_sections. " +
 			"Feedback actions: list_threads, get_thread, reply_thread, resolve_thread, " +
-			"request_validation (review and respond to feedback left on your artifacts; " +
+			"request_validation, respond_validation (review and respond to feedback left on your artifacts; " +
 			"capture_insight thread_ids=[...] links a thread to the insight that resolves it). " +
 			"Note: 'list' returns full metadata including provenance for each asset. " +
 			"Use 'get' with a specific asset_id for content retrieval. " +
@@ -442,6 +445,7 @@ func (t *Toolkit) buildActions() map[string]manageActionHandler {
 		actionReplyThread:       t.handleReplyThread,
 		actionResolveThread:     t.handleResolveThread,
 		actionRequestValidation: t.handleRequestValidation,
+		actionRespondValidation: t.handleRespondValidation,
 	}
 }
 
@@ -452,7 +456,7 @@ func (t *Toolkit) handleManageArtifact(ctx context.Context, _ *mcp.CallToolReque
 		return errorResult(fmt.Sprintf(
 			"invalid action %q: must be one of: list, get, update, delete, list_versions, revert, search, "+
 				"create_collection, list_collections, get_collection, update_collection, delete_collection, set_sections, "+
-				"list_threads, get_thread, reply_thread, resolve_thread, request_validation",
+				"list_threads, get_thread, reply_thread, resolve_thread, request_validation, respond_validation",
 			input.Action)), nil, nil
 	}
 	return handler(ctx, input)

--- a/ui/src/api/portal/hooks.ts
+++ b/ui/src/api/portal/hooks.ts
@@ -34,7 +34,7 @@ import type {
   ThreadAnchor,
   ThreadChain,
   ThreadCounts,
-  ValidationState,
+  SignoffSummary,
 } from "./types";
 
 // --- Branding (unauthenticated) ---
@@ -899,6 +899,55 @@ export function useThreadEvents(id: string) {
   });
 }
 
+// Worklists / inbox (#603). Practitioner = open resolution-required threads on
+// my artifacts; SME = threads awaiting my validation.
+export function usePractitionerWorklist(enabled = true) {
+  return useQuery({
+    queryKey: ["worklist", "practitioner"],
+    queryFn: () => apiFetch<PaginatedResponse<ThreadWithMeta>>(`/worklist/practitioner`),
+    enabled,
+  });
+}
+
+export function useSMEWorklist(enabled = true) {
+  return useQuery({
+    queryKey: ["worklist", "sme"],
+    queryFn: () => apiFetch<PaginatedResponse<ThreadWithMeta>>(`/worklist/sme`),
+    enabled,
+  });
+}
+
+// useSignoff fetches "signed off by N of M" for an asset or collection (#603).
+export function useSignoff(targetType: "assets" | "collections", id: string, enabled = true) {
+  return useQuery({
+    queryKey: ["signoff", targetType, id],
+    queryFn: () => apiFetch<SignoffSummary>(`/${targetType}/${id}/signoff`),
+    enabled: !!id && enabled,
+  });
+}
+
+// useRespondValidation lets the feedback author mark a thread validated/disputed
+// (#603). Disputing re-opens the thread server-side.
+export function useRespondValidation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      threadId,
+      result,
+      reason,
+    }: {
+      threadId: string;
+      result: "validated" | "disputed";
+      reason?: string;
+    }) =>
+      apiFetch<Thread>(`/threads/${threadId}/validation`, {
+        method: "POST",
+        body: JSON.stringify({ result, reason }),
+      }),
+    onSuccess: () => invalidateThreadQueries(qc),
+  });
+}
+
 // useThreadChain fetches the resolved thread -> insight -> changeset chain
 // (#602). Only enabled once a thread has been linked to an insight; an
 // unlinked thread has nothing to show and we avoid the round-trip.
@@ -984,7 +1033,8 @@ export interface UpdateThreadInput {
   id: string;
   status?: ThreadStatus;
   requires_resolution?: boolean;
-  validation_state?: ValidationState;
+  // validation_state is intentionally not settable via the generic update:
+  // validation transitions go through useRespondValidation (#603).
 }
 
 export function useUpdateThread() {

--- a/ui/src/api/portal/types.ts
+++ b/ui/src/api/portal/types.ts
@@ -372,6 +372,12 @@ export interface ThreadEvent {
 // Open-thread counts keyed by target id (for list-page badges).
 export type ThreadCounts = Record<string, number>;
 
+// Sign-off aggregation for an artifact (#603): N signed off of M stakeholders.
+export interface SignoffSummary {
+  signed_off: number;
+  stakeholders: number;
+}
+
 // A changeset in a thread's resolved knowledge chain (#602).
 export interface ThreadChainChangeset {
   id: string;

--- a/ui/src/components/feedback/InboxPanel.test.tsx
+++ b/ui/src/components/feedback/InboxPanel.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("@/api/portal/hooks", () => ({
+  usePractitionerWorklist: vi.fn(),
+  useSMEWorklist: vi.fn(),
+}));
+
+import { InboxPanel } from "./InboxPanel";
+import { usePractitionerWorklist, useSMEWorklist } from "@/api/portal/hooks";
+
+const mockPractitioner = vi.mocked(usePractitionerWorklist);
+const mockSME = vi.mocked(useSMEWorklist);
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "t1",
+    kind: "correction",
+    target_type: "asset",
+    asset_id: "a1",
+    author_id: "sme@example.com",
+    author_email: "sme@example.com",
+    status: "open",
+    requires_resolution: true,
+    validation_state: "none",
+    title: "Churn is actually retention",
+    created_at: "2026-06-04T13:00:00Z",
+    updated_at: "2026-06-04T13:00:00Z",
+    event_count: 1,
+    last_event_at: "2026-06-04T13:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("InboxPanel", () => {
+  it("shows practitioner worklist items and opens a thread", () => {
+    mockPractitioner.mockReturnValue({ data: { data: [row()], total: 1 }, isLoading: false, isError: false } as never);
+    mockSME.mockReturnValue({ data: { data: [], total: 0 }, isLoading: false, isError: false } as never);
+    const onOpen = vi.fn();
+
+    render(<InboxPanel onOpenThread={onOpen} />);
+    expect(screen.getByText("Churn is actually retention")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Churn is actually retention"));
+    expect(onOpen).toHaveBeenCalledWith("t1");
+  });
+
+  it("switches to the SME tab and shows the empty state", () => {
+    mockPractitioner.mockReturnValue({ data: { data: [row()], total: 1 }, isLoading: false, isError: false } as never);
+    mockSME.mockReturnValue({ data: { data: [], total: 0 }, isLoading: false, isError: false } as never);
+
+    render(<InboxPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /awaiting my validation/i }));
+    expect(screen.getByText(/all caught up/i)).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/feedback/InboxPanel.tsx
+++ b/ui/src/components/feedback/InboxPanel.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import { Inbox, ClipboardCheck } from "lucide-react";
+import { usePractitionerWorklist, useSMEWorklist } from "@/api/portal/hooks";
+import { cn } from "@/lib/utils";
+import { KIND_LABEL, STATUS_CHIP, STATUS_LABEL, formatRelative } from "./meta";
+
+type Tab = "practitioner" | "sme";
+
+// InboxPanel is the feedback worklist / inbox (#603): two self-scoped tabs so
+// nothing is dropped — open work that needs the practitioner's resolution, and
+// validation requests awaiting the SME's response.
+export function InboxPanel({ onOpenThread }: { onOpenThread?: (id: string) => void }) {
+  const [tab, setTab] = useState<Tab>("practitioner");
+  const practitioner = usePractitionerWorklist();
+  const sme = useSMEWorklist();
+  const active = tab === "practitioner" ? practitioner : sme;
+  const threads = active.data?.data ?? [];
+
+  const tabBtn = (key: Tab, label: string, total: number | undefined, Icon: typeof Inbox) => (
+    <button
+      type="button"
+      onClick={() => setTab(key)}
+      className={cn(
+        "flex flex-1 items-center justify-center gap-1.5 border-b-2 px-3 py-2 text-xs font-medium",
+        tab === key ? "border-primary text-foreground" : "border-transparent text-muted-foreground hover:text-foreground",
+      )}
+    >
+      <Icon className="h-3.5 w-3.5" /> {label}
+      {total ? <span className="rounded-full bg-muted px-1.5 text-[10px]">{total}</span> : null}
+    </button>
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex">
+        {tabBtn("practitioner", "Needs resolution", practitioner.data?.total, Inbox)}
+        {tabBtn("sme", "Awaiting my validation", sme.data?.total, ClipboardCheck)}
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        {active.isLoading && <p className="p-3 text-xs text-muted-foreground">Loading…</p>}
+        {active.isError && <p className="p-3 text-xs text-destructive">Failed to load your worklist.</p>}
+        {!active.isLoading && !active.isError && threads.length === 0 && (
+          <p className="p-4 text-sm text-muted-foreground">Nothing here. You're all caught up.</p>
+        )}
+        <ul className="divide-y">
+          {threads.map((t) => (
+            <li key={t.id}>
+              <button
+                type="button"
+                onClick={() => onOpenThread?.(t.id)}
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent"
+              >
+                <span className="shrink-0 text-xs text-muted-foreground">{KIND_LABEL[t.kind]}</span>
+                <span className="min-w-0 flex-1 truncate">{t.title || "(untitled feedback)"}</span>
+                <span className={cn("shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium", STATUS_CHIP[t.status])}>
+                  {STATUS_LABEL[t.status]}
+                </span>
+                {t.last_event_at && (
+                  <span className="shrink-0 text-[10px] text-muted-foreground">{formatRelative(t.last_event_at)}</span>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/feedback/SignoffBadge.test.tsx
+++ b/ui/src/components/feedback/SignoffBadge.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/api/portal/hooks", () => ({ useSignoff: vi.fn() }));
+
+import { SignoffBadge } from "./SignoffBadge";
+import { useSignoff } from "@/api/portal/hooks";
+
+const mockUseSignoff = vi.mocked(useSignoff);
+
+describe("SignoffBadge", () => {
+  it("renders 'signed off by N of M'", () => {
+    mockUseSignoff.mockReturnValue({ data: { signed_off: 1, stakeholders: 3 } } as never);
+    render(<SignoffBadge targetType="assets" id="a1" />);
+    expect(screen.getByText(/signed off by 1 of 3/i)).toBeInTheDocument();
+  });
+
+  it("renders nothing until the summary loads", () => {
+    mockUseSignoff.mockReturnValue({ data: undefined } as never);
+    const { container } = render(<SignoffBadge targetType="collections" id="c1" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/ui/src/components/feedback/SignoffBadge.tsx
+++ b/ui/src/components/feedback/SignoffBadge.tsx
@@ -1,0 +1,32 @@
+import { CheckCircle2 } from "lucide-react";
+import { useSignoff } from "@/api/portal/hooks";
+import { cn } from "@/lib/utils";
+
+// SignoffBadge renders "signed off by N of M stakeholders" for an asset or
+// collection (#603). Hidden until the summary loads.
+export function SignoffBadge({
+  targetType,
+  id,
+  enabled = true,
+}: {
+  targetType: "assets" | "collections";
+  id: string;
+  enabled?: boolean;
+}) {
+  const { data } = useSignoff(targetType, id, enabled);
+  if (!data) return null;
+  const complete = data.signed_off >= data.stakeholders;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs",
+        complete
+          ? "bg-emerald-50 text-emerald-900 dark:bg-emerald-500/10 dark:text-emerald-200"
+          : "bg-muted text-muted-foreground",
+      )}
+      title="Distinct stakeholders who approved out of owner + active share grantees"
+    >
+      <CheckCircle2 className="h-3 w-3" /> Signed off by {data.signed_off} of {data.stakeholders}
+    </span>
+  );
+}

--- a/ui/src/components/feedback/ThreadDetail.test.tsx
+++ b/ui/src/components/feedback/ThreadDetail.test.tsx
@@ -8,6 +8,7 @@ vi.mock("@/api/portal/hooks", () => ({
   useAppendThreadEvent: vi.fn(() => ({ mutate: vi.fn(), isPending: false, isError: false })),
   useUpdateThread: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useDeleteThread: vi.fn(() => ({ mutate: vi.fn(), isPending: false, isError: false })),
+  useRespondValidation: vi.fn(() => ({ mutate: vi.fn(), isPending: false, isError: false })),
 }));
 
 vi.mock("@/stores/auth", () => ({
@@ -15,11 +16,13 @@ vi.mock("@/stores/auth", () => ({
     sel({ user: { email: "viewer@example.com", is_admin: false } }),
 }));
 
+import { fireEvent } from "@testing-library/react";
 import { ThreadDetail } from "./ThreadDetail";
-import { useThread, useThreadChain } from "@/api/portal/hooks";
+import { useThread, useThreadChain, useRespondValidation } from "@/api/portal/hooks";
 
 const mockUseThread = vi.mocked(useThread);
 const mockUseThreadChain = vi.mocked(useThreadChain);
+const mockUseRespondValidation = vi.mocked(useRespondValidation);
 
 function baseThread(overrides: Record<string, unknown> = {}) {
   return {
@@ -86,5 +89,34 @@ describe("ThreadDetail knowledge chain", () => {
     render(<ThreadDetail threadId="t1" canModerate={false} onBack={() => {}} onDeleted={() => {}} />);
 
     expect(screen.getByText(/no catalog changes applied/i)).toBeInTheDocument();
+  });
+});
+
+describe("ThreadDetail validation control (#603)", () => {
+  it("lets the feedback author validate or dispute a pending request", () => {
+    const respond = vi.fn();
+    mockUseRespondValidation.mockReturnValue({ mutate: respond, isPending: false, isError: false } as never);
+    mockUseThreadChain.mockReturnValue({ data: undefined, isLoading: false } as never);
+    // Author matches the mocked auth user; validation is pending.
+    mockUseThread.mockReturnValue({
+      data: baseThread({ author_email: "viewer@example.com", validation_state: "pending" }),
+    } as never);
+
+    render(<ThreadDetail threadId="t1" canModerate={false} onBack={() => {}} onDeleted={() => {}} />);
+
+    expect(screen.getByText(/your validation was requested/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /validate/i }));
+    expect(respond).toHaveBeenCalledWith({ threadId: "t1", result: "validated", reason: undefined });
+  });
+
+  it("hides the control when the viewer is not the author", () => {
+    mockUseRespondValidation.mockReturnValue({ mutate: vi.fn(), isPending: false, isError: false } as never);
+    mockUseThreadChain.mockReturnValue({ data: undefined, isLoading: false } as never);
+    mockUseThread.mockReturnValue({
+      data: baseThread({ author_email: "someone-else@example.com", validation_state: "pending" }),
+    } as never);
+
+    render(<ThreadDetail threadId="t1" canModerate={false} onBack={() => {}} onDeleted={() => {}} />);
+    expect(screen.queryByText(/your validation was requested/i)).not.toBeInTheDocument();
   });
 });

--- a/ui/src/components/feedback/ThreadDetail.tsx
+++ b/ui/src/components/feedback/ThreadDetail.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
-import { ArrowLeft, Trash2, Quote, GitBranch } from "lucide-react";
+import { ArrowLeft, Trash2, Quote, GitBranch, CheckCircle2, XCircle } from "lucide-react";
 import {
   useThread,
   useThreadEvents,
   useThreadChain,
   useAppendThreadEvent,
   useUpdateThread,
+  useRespondValidation,
   useDeleteThread,
 } from "@/api/portal/hooks";
 import type { ThreadEvent, ThreadStatus } from "@/api/portal/types";
@@ -102,11 +103,16 @@ export function ThreadDetail({ threadId, canModerate, onBack, onDeleted }: Props
   const append = useAppendThreadEvent();
   const update = useUpdateThread();
   const del = useDeleteThread();
+  const respondValidation = useRespondValidation();
   const me = useAuthStore((s) => s.user);
   const [reply, setReply] = useState("");
+  const [disputeReason, setDisputeReason] = useState("");
 
   const isAuthor = !!me?.email && thread?.author_email === me.email;
   const mayModerate = canModerate || !!me?.is_admin || isAuthor;
+
+  const respond = (result: "validated" | "disputed") =>
+    respondValidation.mutate({ threadId, result, reason: result === "disputed" ? disputeReason.trim() : undefined });
 
   const postReply = (e: React.FormEvent) => {
     e.preventDefault();
@@ -171,6 +177,44 @@ export function ThreadDetail({ threadId, canModerate, onBack, onDeleted }: Props
       {/* Knowledge chain (shown once the thread is linked to a captured insight) */}
       {thread.insight_id && (
         <KnowledgeChainPanel threadId={threadId} insightId={thread.insight_id} />
+      )}
+
+      {/* Validation request: the feedback author confirms or disputes (#603) */}
+      {thread.validation_state === "pending" && isAuthor && (
+        <div className="border-b bg-amber-500/10 p-3">
+          <p className="mb-2 text-xs font-medium text-amber-700 dark:text-amber-300">
+            Your validation was requested: is this resolved correctly?
+          </p>
+          <textarea
+            value={disputeReason}
+            onChange={(e) => setDisputeReason(e.target.value)}
+            rows={2}
+            placeholder="Reason (required to dispute)…"
+            className="w-full resize-y rounded-md border bg-background px-2 py-1.5 text-xs"
+          />
+          <div className="mt-2 flex gap-2">
+            <button
+              type="button"
+              onClick={() => respond("validated")}
+              disabled={respondValidation.isPending}
+              className="inline-flex items-center gap-1 rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+            >
+              <CheckCircle2 className="h-3.5 w-3.5" /> Validate
+            </button>
+            <button
+              type="button"
+              onClick={() => respond("disputed")}
+              disabled={respondValidation.isPending || !disputeReason.trim()}
+              className="inline-flex items-center gap-1 rounded-md border border-destructive/40 px-3 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50"
+              title={!disputeReason.trim() ? "Add a reason to dispute" : "Dispute and re-open"}
+            >
+              <XCircle className="h-3.5 w-3.5" /> Dispute
+            </button>
+          </div>
+          {respondValidation.isError && (
+            <p className="mt-1 text-xs text-destructive">Failed to record your response.</p>
+          )}
+        </div>
       )}
 
       {/* Timeline */}

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -1634,6 +1634,32 @@ export const handlers = [
     );
   }),
 
+  // Worklists / inbox (#603).
+  http.get(`${PORTAL_BASE}/worklist/practitioner`, () => {
+    const data = portalThreads.filter((t) => t.status === "open" && t.requires_resolution && !t.deleted_at);
+    return HttpResponse.json({ data, total: data.length, limit: 50, offset: 0 });
+  }),
+  http.get(`${PORTAL_BASE}/worklist/sme`, () => {
+    const data = portalThreads.filter((t) => t.validation_state === "pending" && !t.deleted_at);
+    return HttpResponse.json({ data, total: data.length, limit: 50, offset: 0 });
+  }),
+
+  // Sign-off aggregation (#603).
+  http.get(`${PORTAL_BASE}/assets/:id/signoff`, () => HttpResponse.json({ signed_off: 1, stakeholders: 3 })),
+  http.get(`${PORTAL_BASE}/collections/:id/signoff`, () => HttpResponse.json({ signed_off: 2, stakeholders: 2 })),
+
+  // Validation response (#603): the author validates/disputes; dispute re-opens.
+  http.post(`${PORTAL_BASE}/threads/:id/validation`, async ({ params, request }) => {
+    const id = params.id as string;
+    const body = (await request.json()) as { result: string; reason?: string };
+    const thread = portalThreads.find((t) => t.id === id);
+    if (!thread) return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+    thread.validation_state = body.result as typeof thread.validation_state;
+    if (body.result === "disputed") thread.status = "open";
+    thread.updated_at = new Date().toISOString();
+    return HttpResponse.json(thread);
+  }),
+
   http.post(`${PORTAL_BASE}/threads/:id/events`, async ({ params, request }) => {
     const id = params.id as string;
     const body = (await request.json()) as Record<string, unknown>;


### PR DESCRIPTION
Phase 3 of the feedback epic (#600), and its final child. Closes the loop with SME validation, sign-off aggregation, and worklists so nothing is dropped — with **no new MCP tools**.

## What it does

**Validation response.** After `request_validation` (Phase 2) routes a request to the feedback author, that author confirms or disputes it:
- `manage_artifact action=respond_validation` (`validation_result` = `validated`|`disputed`, optional `validation_reason`), or `POST /api/v1/portal/threads/{id}/validation` from the portal.
- Both set `validation_state`, append a `validation_result` event, and **disputing re-opens the thread** so it returns to the practitioner worklist.
- Gated to the feedback author (matched by id **or** case-insensitive email) or an admin, and requires `validation_state=pending` (a response only answers a prior request — enforced atomically in SQL). The generic `PATCH /threads/{id}` can no longer set `validation_state`, so it cannot bypass this gate.

**Worklists / inbox** (cross-artifact, self-scoped):
- `GET /api/v1/portal/worklist/practitioner` — open, resolution-required threads across every artifact the caller owns or can edit.
- `GET /api/v1/portal/worklist/sme` — threads awaiting the caller's validation (matched by author id or email).

**Sign-off aggregation.**
- `GET /api/v1/portal/assets|collections/{id}/signoff` → "signed off by N of M": N = distinct users who left an approval event on the artifact's threads; M = owner + active share grantees (owner not double-counted by id or email; `signed_off` clamped to M). Share-listing queries now exclude expired shares.

**UI:** a validate/dispute control in `ThreadDetail` (shown to the author on a pending request), an `InboxPanel` with practitioner + SME tabs, and a `SignoffBadge`.

## Tests

- Unit coverage for the handlers, the store methods (`RespondValidation`, `CountSignoffs`), and the access gates (author-only, owner/editor, anonymous fail-closed).
- **Real-DB acceptance test** (run under `make test-realdb`), all verified by read-back: validate/dispute → `validation_state` + `validation_result` event; dispute re-opens; the `pending` precondition is enforced; N-of-M via real `COUNT(DISTINCT)`; both worklist filters; and an expired editor share is excluded from `ListSharedWithUser`.
- UI unit tests for the inbox, signoff badge, and validation control.

## Verification

`make verify` green end to end: race tests, lint (0 new issues), gosec, govulncheck, semgrep, CodeQL (no new blocking), patch coverage 83.6%, `test-realdb`, GoReleaser dry-run. Ran the full adversarial `/code-review` twice before commit; the second pass caught five real edge-case issues (the validation state-machine precondition, a sign-off owner double-count, an SME-worklist author-match inconsistency, an untested expired-share filter, and silent worklist truncation), all fixed here.

## Epic

This finishes #600. With #601 (Phase 1) and #602 (Phase 2) already merged, the human feedback → knowledge → validation loop is complete.