### PR TITLE
fix(portal): let shared editors edit assets, not just owners (#611)

### DIFF
--- a/pkg/portal/handler.go
+++ b/pkg/portal/handler.go
@@ -785,8 +785,13 @@ func (h *Handler) updateAsset(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, errAssetNotFound)
 		return
 	}
-	if asset.OwnerID != user.UserID {
-		writeError(w, http.StatusForbidden, "only the owner can update this asset")
+	if asset.DeletedAt != nil {
+		writeError(w, http.StatusGone, errAssetDeleted)
+		return
+	}
+	// Owner or an active editor share may update metadata, matching the content
+	// update path (updateAssetContent): an editor can edit a shared asset.
+	if !h.canEditAsset(w, r, id, asset, user) {
 		return
 	}
 

--- a/pkg/portal/handler_test.go
+++ b/pkg/portal/handler_test.go
@@ -887,6 +887,42 @@ func TestUpdateAssetNotOwner(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
+func TestUpdateAssetEditorShareAllowed(t *testing.T) {
+	// A non-owner with an active editor share may update metadata (#611).
+	asset := &Asset{ID: "a1", OwnerID: "other"}
+	shares := &mockShareStore{listByAsset: []Share{{SharedWithUserID: "u1", Permission: PermissionEditor}}}
+	h := newTestHandler(&mockAssetStore{getAsset: asset}, shares, &mockS3Client{}, &User{UserID: "u1"})
+
+	body := `{"name":"Edited by editor","description":"d","tags":["t"]}`
+	req := httptest.NewRequestWithContext(context.Background(), "PUT", "/api/v1/portal/assets/a1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestUpdateAssetViewerShareDenied(t *testing.T) {
+	// A viewer share is not enough to edit metadata.
+	asset := &Asset{ID: "a1", OwnerID: "other"}
+	shares := &mockShareStore{listByAsset: []Share{{SharedWithUserID: "u1", Permission: PermissionViewer}}}
+	h := newTestHandler(&mockAssetStore{getAsset: asset}, shares, &mockS3Client{}, &User{UserID: "u1"})
+
+	body := `{"name":"x"}`
+	req := httptest.NewRequestWithContext(context.Background(), "PUT", "/api/v1/portal/assets/a1", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestUpdateAssetDeleted(t *testing.T) {
+	now := time.Now()
+	asset := &Asset{ID: "a1", OwnerID: "u1", DeletedAt: &now}
+	h := newTestHandler(&mockAssetStore{getAsset: asset}, &mockShareStore{}, &mockS3Client{}, &User{UserID: "u1"})
+	req := httptest.NewRequestWithContext(context.Background(), "PUT", "/api/v1/portal/assets/a1", strings.NewReader(`{"name":"x"}`))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusGone, w.Code)
+}
+
 func TestUpdateAssetNotFound(t *testing.T) {
 	h := newTestHandler(
 		&mockAssetStore{getErr: fmt.Errorf("not found")},

--- a/ui/src/components/AssetViewer.test.tsx
+++ b/ui/src/components/AssetViewer.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { AssetViewer } from "./AssetViewer";
+
+const stubMutation = () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false, isError: false }) as never;
+
+function markdownAsset(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "a1",
+    owner_id: "owner",
+    owner_email: "owner@example.com",
+    name: "Notes",
+    description: "",
+    content_type: "text/markdown",
+    s3_bucket: "b",
+    s3_key: "k",
+    size_bytes: 4,
+    tags: [],
+    provenance: {},
+    current_version: 1,
+    created_at: "2026-06-01T00:00:00Z",
+    updated_at: "2026-06-01T00:00:00Z",
+    ...overrides,
+  } as never;
+}
+
+function renderViewer(props: Record<string, unknown>) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <AssetViewer
+        asset={markdownAsset()}
+        content={"# hi"}
+        isLoading={false}
+        contentUrl=""
+        onBack={() => {}}
+        onNavigate={() => {}}
+        updateMutation={stubMutation()}
+        deleteMutation={stubMutation()}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("AssetViewer metadata edit affordance (#611)", () => {
+  it("shows the Edit button to a shared editor", () => {
+    renderViewer({ isOwner: false, sharePermission: "editor" });
+    fireEvent.click(screen.getByTitle("Show details"));
+    expect(screen.getByTitle("Edit")).toBeInTheDocument();
+  });
+
+  it("hides the Edit button from a shared viewer", () => {
+    renderViewer({ isOwner: false, sharePermission: "viewer" });
+    fireEvent.click(screen.getByTitle("Show details"));
+    expect(screen.queryByTitle("Edit")).not.toBeInTheDocument();
+  });
+
+  it("shows the Edit button to the owner", () => {
+    renderViewer({ isOwner: true });
+    fireEvent.click(screen.getByTitle("Show details"));
+    expect(screen.getByTitle("Edit")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/AssetViewer.tsx
+++ b/ui/src/components/AssetViewer.tsx
@@ -490,7 +490,7 @@ export function AssetViewer({
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <h3 className="text-sm font-medium">Details</h3>
-                  {isOwner && (
+                  {(isOwner || isSharedEditor) && (
                     <button
                       type="button"
                       onClick={startEdit}


### PR DESCRIPTION
Closes #611.

## Problem

A user with an active **editor** share on an asset saw the **Shared (Editor)** badge but had no way to edit it. The permission was recognized correctly; the edit affordance for metadata (name, description, tags) was gated to the owner at both layers:

- **Backend:** `updateAsset` (`PUT /api/v1/portal/assets/{id}`) checked `asset.OwnerID != user.UserID` and returned 403 "only the owner can update this asset" — even though the sibling content path (`updateAssetContent`) already authorized editors via `canEditAsset`.
- **Frontend:** the metadata edit (Pencil) button in `AssetViewer` was gated `{isOwner && …}`, so an editor never saw it. The component already computed `isSharedEditor` but did not use it here.

Content editing already permitted editors (`updateAssetContent` uses `canEditAsset`, the UI wires the content mutation for editors, and Markdown is recognized as text), so closing the metadata gap makes shared assets fully editable by their editors.

## Fix

- `updateAsset` now authorizes **owner or active editor share** via `canEditAsset` (the same predicate as `updateAssetContent`), and adds the missing soft-deleted `410 Gone` guard that the content path has. An editor share must be active (not revoked, not expired) and `editor` (a viewer is still denied). Only name/description/tags are mutable; ownership, sharing, and deletion remain separate, owner-gated operations.
- `AssetViewer`: the metadata edit button is gated on `(isOwner || isSharedEditor)`.

## Tests

- Backend (`handler_test.go`): editor share → 200, viewer share → 403, non-owner without a share → 403 (unchanged), soft-deleted → 410.
- Frontend (`AssetViewer.test.tsx`, new): the Edit button is shown to a shared editor and to the owner, and hidden from a shared viewer, asserted through the real rendered component.

## Verification

`make verify` green end to end: race tests, lint (0 new issues), gosec, govulncheck, semgrep, CodeQL (no new blocking), patch coverage 100% (5/5 changed lines), GoReleaser dry-run. Ran the adversarial `/code-review` before commit; it surfaced one consistency gap (the deleted-asset guard), fixed here.