### PR TITLE
feat(feedback): dedicated manage_feedback MCP tool for agent review/respond (#618)

### DIFF
--- a/docs/knowledge/overview.md
+++ b/docs/knowledge/overview.md
@@ -194,7 +194,7 @@ The source field is optional when calling `capture_insight`. When omitted, it de
 
 Human feedback threads (left on portal artifacts via `manage_artifact`) connect to the knowledge loop, so an agent can resolve a thread by capturing the insight it represents and the chain stays visible end to end: **thread → insight → changeset → `target_urn`**.
 
-**Resolving a thread into an insight.** `capture_insight` accepts an optional `thread_ids` array. When supplied, each named thread has its `insight_id` set, an `insight_linked` event appended to its timeline, and its status moved to `resolved`. Linking is **authorized with the same owns-or-edit check as `resolve_thread`**: a thread the caller could not resolve via `manage_artifact` (one on an artifact they neither own nor can edit) is refused and reported as unlinked, so `capture_insight` is not a back door around the access model. The call is best-effort (a link failure never fails the capture) and the result reports the outcome so the agent can detect a mistyped, unauthorized, or already-resolved thread:
+**Resolving a thread into an insight.** `capture_insight` accepts an optional `thread_ids` array. When supplied, each named thread has its `insight_id` set, an `insight_linked` event appended to its timeline, and its status moved to `resolved`. Linking is **authorized with the same owns-or-edit check as `manage_feedback resolve`**: a thread the caller could not resolve (one on an artifact they neither own nor can edit) is refused and reported as unlinked, so `capture_insight` is not a back door around the access model. The call is best-effort (a link failure never fails the capture) and the result reports the outcome so the agent can detect a mistyped, unauthorized, or already-resolved thread:
 
 | Field | Meaning |
 |-------|---------|
@@ -203,7 +203,7 @@ Human feedback threads (left on portal artifacts via `manage_artifact`) connect 
 
 Both fields are omitted entirely when `thread_ids` is not supplied, so a capture without threads is unchanged.
 
-**Working threads from the agent.** `manage_artifact` gains thread actions (no new tools): `list_threads` (filter by target, status, `requires_resolution`, `validation_state`), `get_thread`, `reply_thread`, `resolve_thread`, and `request_validation`. These are scoped to artifacts the caller **owns or can edit** (admins see all; standalone threads are readable by any authenticated caller and moderated by the thread author or an admin).
+**Working threads from the agent.** The dedicated `manage_feedback` tool gives agents a discoverable home for feedback: `list` (with no target = all pending feedback across the assets and collections the caller owns or can edit AND the general channel, unresolved, excluding their own threads, plus any awaiting their validation; with a target = threads on that one asset/collection/prompt, filterable by status, `requires_resolution`, `validation_state`), `get`, `reply`, `resolve`, `request_validation`, and `respond_validation`. These are scoped to artifacts the caller **owns or can edit** (admins see all; standalone/general threads are readable by any authenticated caller and moderated by the thread author or an admin). Calling `list` with no target is the "review and act on any pending feedback" entry point.
 
 **Reading the chain.** `GET /api/v1/portal/threads/{id}/chain` returns the resolved chain for a thread: its `insight_id` and the changesets that insight produced (each with `target_urn`, `change_type`, and rollback state). The portal feedback panel renders this as a "Knowledge chain" section on a resolved thread.
 
@@ -211,7 +211,7 @@ Both fields are omitted entirely when `thread_ids` is not supplied, so a capture
 
 The loop closes with SME validation and worklists so nothing is dropped.
 
-**Validation response.** After `request_validation` routes a request to the feedback author, that author confirms or disputes it: `manage_artifact action=respond_validation` (with `validation_result` = `validated`|`disputed` and an optional `validation_reason`), or `POST /api/v1/portal/threads/{id}/validation` from the portal. Both record a `validation_result` event and set `validation_state`; **disputing re-opens the thread** so it returns to the practitioner worklist. Only the feedback author (or an admin) may respond.
+**Validation response.** After `request_validation` routes a request to the feedback author, that author confirms or disputes it: `manage_feedback action=respond_validation` (with `validation_result` = `validated`|`disputed` and an optional `validation_reason`), or `POST /api/v1/portal/threads/{id}/validation` from the portal. Both record a `validation_result` event and set `validation_state`; **disputing re-opens the thread** so it returns to the practitioner worklist. Only the feedback author (or an admin) may respond.
 
 **Worklists / inbox.** Two self-scoped views:
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -352,7 +352,7 @@ When `workflow.require_discovery_before_query` is disabled (default), the platfo
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `portal.enabled` | bool | `false` | Enable portal toolkit and save_artifact/manage_artifact tools |
+| `portal.enabled` | bool | `false` | Enable portal toolkit and save_artifact/manage_artifact/manage_feedback tools |
 | `portal.s3_connection` | string | - | Name of the S3 toolkit instance for artifact storage |
 | `portal.s3_bucket` | string | `portal-assets` | S3 bucket for artifact content |
 | `portal.s3_prefix` | string | `artifacts/` | Key prefix within the bucket |
@@ -1487,7 +1487,7 @@ Response includes asset_id, portal_url (if public_base_url configured), provenan
 
 ### manage_artifact
 
-List, retrieve, update, delete, or relevance-search saved artifacts. Ownership enforced — users can only modify or find their own artifacts.
+List, retrieve, update, delete, or relevance-search saved artifacts (and manage collections). Ownership enforced — users can only modify or find their own artifacts. Human feedback on artifacts is handled by the separate `manage_feedback` tool.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
@@ -1695,7 +1695,7 @@ Records domain knowledge shared during a session.
 }
 ```
 
-When `thread_ids` is supplied, the response also includes `linked_thread_count` and `unlinked_thread_ids` (the IDs that matched no open thread, or that the caller is not authorized to resolve); both are omitted when `thread_ids` is absent. Linking is gated by the same owns-or-edit check as `resolve_thread` (it is not a back door around the access model), is best-effort, and never fails the capture.
+When `thread_ids` is supplied, the response also includes `linked_thread_count` and `unlinked_thread_ids` (the IDs that matched no open thread, or that the caller is not authorized to resolve); both are omitted when `thread_ids` is absent. Linking is gated by the same owns-or-edit check as `manage_feedback resolve` (it is not a back door around the access model), is best-effort, and never fails the capture.
 
 The tool also registers an MCP prompt `knowledge_capture_guidance` that provides AI agents with guidance on when to capture insights.
 
@@ -1704,12 +1704,12 @@ The tool also registers an MCP prompt `knowledge_capture_guidance` that provides
 Human feedback threads on portal artifacts connect to the knowledge loop: an agent resolves a thread by capturing the insight it represents, and the chain stays visible end to end (**thread → insight → changeset → `target_urn`**).
 
 - **`capture_insight` `thread_ids`** links threads to the captured insight (see above).
-- **`manage_artifact` thread actions** (no new tools): `list_threads` (filter by target, status, `requires_resolution`, `validation_state`), `get_thread`, `reply_thread`, `resolve_thread`, `request_validation`. Scoped to artifacts the caller owns or can edit; admins see all; standalone threads are readable by any authenticated caller and moderated by the thread author or an admin.
+- **`manage_feedback` tool** (the dedicated, discoverable home for agent feedback): `list`, `get`, `reply`, `resolve`, `request_validation`, `respond_validation`. **`list` with no target is the cross-artifact entry point** — it returns the caller's pending feedback across the assets and collections they own or can edit AND the shared general channel (unresolved threads they did not author, plus any awaiting their validation), so an agent can "review and act on any pending feedback" in one call; `list` with an `asset_id`/`collection_id`/`prompt_id` or `target_type=standalone` scopes to one target (filter by status, `requires_resolution`, `validation_state`). Scoped to artifacts the caller owns or can edit; admins see all; standalone/general threads are readable by any authenticated caller and resolved by the thread author or an admin. (These six actions previously lived on `manage_artifact`; they were moved to `manage_feedback` so agents discover feedback by tool name.)
 - **`GET /api/v1/portal/threads/{id}/chain`** returns a thread's resolved chain: its `insight_id` and the changesets that insight produced (each with `target_urn`, `change_type`, rollback state). The portal feedback panel renders this as a "Knowledge chain" section.
 
 ### Validation & sign-off (Phase 3)
 
-- **Validation response**: after `request_validation` routes a request to the feedback author, that author confirms or disputes it via `manage_artifact action=respond_validation` (`validation_result` = `validated`|`disputed`, optional `validation_reason`) or `POST /api/v1/portal/threads/{id}/validation`. Both append a `validation_result` event and set `validation_state`; **disputing re-opens the thread**. Only the author (or an admin) may respond.
+- **Validation response**: after `request_validation` routes a request to the feedback author, that author confirms or disputes it via `manage_feedback action=respond_validation` (`validation_result` = `validated`|`disputed`, optional `validation_reason`) or `POST /api/v1/portal/threads/{id}/validation`. Both append a `validation_result` event and set `validation_state`; **disputing re-opens the thread**. Only the author (or an admin) may respond.
 - **Worklists**: `GET /api/v1/portal/worklist/practitioner` (open resolution-required threads across artifacts the caller owns/can edit) and `GET /api/v1/portal/worklist/sme` (threads awaiting the caller's validation).
 - **Activity feed**: `GET /api/v1/portal/feedback/activity` returns every feedback thread across the assets, collections, and prompts the caller can view (owned or shared, any permission), most recent activity first, each row enriched with the target's display label (`target_label`) so the client links straight back to the item. It is scoped server-side to the caller's reachable set and never discloses feedback on items they cannot see; global-prompt threads the caller did not author are excluded so the feed stays personal. With no push-notification system, this feed (plus a sidebar badge counting the caller's open worklist) is how a user discovers new feedback.
 - **Sign-off**: `GET /api/v1/portal/assets/{id}/signoff` and `.../collections/{id}/signoff` return `signed_off` of `stakeholders` (N = distinct approvers; M = owner + active share grantees), rendered as "signed off by N of M".

--- a/docs/server/tools.md
+++ b/docs/server/tools.md
@@ -47,7 +47,8 @@ mcp-data-platform provides tools from five integrated toolkits. Each tool can be
 | Memory | `memory_manage` | Create, update, forget, list memories (opt-in per persona) |
 | Memory | `memory_recall` | Multi-strategy memory retrieval (entity, semantic, lexical, graph, auto) |
 | Portal | `save_artifact` | Save an AI-generated artifact (JSX, HTML, SVG, etc.) |
-| Portal | `manage_artifact` | List, get, update, delete, or relevance-search saved artifacts |
+| Portal | `manage_artifact` | List, get, update, delete, or relevance-search saved artifacts and collections |
+| Portal | `manage_feedback` | Review and respond to human feedback (list pending across everything, get, reply, resolve, request/respond validation) |
 | Platform | `platform_find_tools` | Find the most relevant tools for a natural-language task, ranked by semantic similarity (persona-scoped) |
 
 ---
@@ -739,6 +740,38 @@ List, retrieve, update, or delete saved artifacts. All mutations enforce ownersh
 - **update**: Change name, description, tags, or replace content
 - **delete**: Soft-delete an artifact
 - **search**: Rank the caller's own assets by relevance to `query`. Uses the same hybrid (vector + lexical) ranking as the prompt and Knowledge & Memory search: weighted hybrid when an embedding provider is configured, automatic lexical-only fallback otherwise. Returns each match with a `score` and reports `ranking` (`hybrid` or `lexical`). Scoped server-side to the caller's own assets by `owner_id` — the same ownership key the asset library and update/delete checks use, so search returns exactly what you see in the library — and fails closed when the caller has no identity, so a user can never find an asset they cannot view.
+
+---
+
+### manage_feedback
+
+Review and respond to human feedback on your work. Feedback is its own tool (rather than actions on `manage_artifact`) so an agent discovers it by name. Threads live on an asset, collection, or prompt, or on the shared general channel.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `action` | string | Yes | - | list, get, reply, resolve, request_validation, respond_validation |
+| `asset_id` / `collection_id` / `prompt_id` | string | No | - | Scope a `list` to one artifact |
+| `target_type` | string | No | - | `standalone` scopes a `list` to the general channel |
+| `thread_id` | string | Conditional | - | Required for get, reply, resolve, request_validation, respond_validation |
+| `body` | string | Conditional | - | Reply text (required for reply) |
+| `status` / `validation_state` / `requires_resolution` | - | No | - | Filters for a targeted `list` |
+| `validation_result` | string | Conditional | - | `validated` or `disputed` (required for respond_validation) |
+| `validation_reason` | string | No | - | Optional reason recorded on the validation event |
+| `limit` / `offset` | integer | No | 50 | Pagination |
+
+**Actions:**
+
+- **list (no target)**: The entry point for "review and act on any pending feedback." Returns the caller's pending feedback across **the assets and collections they own or can edit AND the shared general channel** — unresolved threads they did not author — plus any threads awaiting their validation. Newest first. (Prompt-thread feedback is reached by targeting the prompt with `prompt_id`, admin-only; it is not part of the no-target feed.)
+- **list (with a target)**: Threads on one asset/collection/prompt or the standalone channel, filterable by status / validation_state / requires_resolution.
+- **get**: One thread plus its full event timeline.
+- **reply**: Append a comment to a thread.
+- **resolve**: Mark a thread resolved.
+- **request_validation**: Route a validation request to the thread author.
+- **respond_validation**: The thread author (or an admin) records `validated`/`disputed`; disputing re-opens the thread.
+
+**Access:** scoped to artifacts the caller owns or can edit (admins see all). General-channel threads are readable and replyable by any authenticated caller, and resolved only by the thread author or an admin. `capture_insight thread_ids=[...]` folds a thread into the knowledge loop and resolves it, gated by the same owns-or-edit check.
 
 ---
 

--- a/pkg/portal/feedback_activity_handler.go
+++ b/pkg/portal/feedback_activity_handler.go
@@ -103,10 +103,11 @@ func (t activityTargets) empty() bool {
 func (h *Handler) viewableActivityTargets(ctx context.Context, user *User) (activityTargets, error) {
 	var t activityTargets
 	var err error
-	if t.assetIDs, err = h.gatherAssetIDs(ctx, user, keepAnyShare); err != nil {
+	g := h.targetGatherer(user)
+	if t.assetIDs, err = g.AssetIDs(ctx, KeepAnyShare); err != nil {
 		return activityTargets{}, err
 	}
-	if t.collIDs, err = h.gatherCollectionIDs(ctx, user, keepAnyShare); err != nil {
+	if t.collIDs, err = g.CollectionIDs(ctx, KeepAnyShare); err != nil {
 		return activityTargets{}, err
 	}
 	if t.promptIDs, err = h.viewablePromptIDs(ctx, user); err != nil {

--- a/pkg/portal/thread_filter_test.go
+++ b/pkg/portal/thread_filter_test.go
@@ -1,0 +1,83 @@
+package portal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyThreadFilterConditions checks the SQL conditions for the #618 filter
+// additions (standalone inclusion, unresolved, author exclusion) and the
+// existing target-id OR, by building the query and inspecting the SQL/args.
+func TestApplyThreadFilterConditions(t *testing.T) {
+	tests := []struct {
+		name      string
+		filter    ThreadFilter
+		wantSQL   []string
+		wantArgs  []any
+		absentSQL []string
+	}{
+		{
+			name:      "empty filter adds no conditions",
+			filter:    ThreadFilter{},
+			absentSQL: []string{"target_type", "status", "author_id"},
+		},
+		{
+			name:    "unresolved excludes terminal statuses",
+			filter:  ThreadFilter{Unresolved: true},
+			wantSQL: []string{"t.status NOT IN"},
+			// resolved + wont_fix are the two terminal statuses.
+			wantArgs: []any{ThreadStatusResolved, ThreadStatusWontFix},
+		},
+		{
+			name:    "exclude author by id and email",
+			filter:  ThreadFilter{ExcludeAuthorID: "u1", ExcludeAuthorEmail: "U1@Example.com"},
+			wantSQL: []string{"t.author_id <>", "LOWER(t.author_email) <> LOWER("},
+		},
+		{
+			name:    "include standalone alone matches the channel",
+			filter:  ThreadFilter{IncludeStandalone: true},
+			wantSQL: []string{"t.target_type ="},
+			// the standalone OR term binds the standalone discriminator
+			wantArgs: []any{targetTypeStandalone},
+		},
+		{
+			name: "artifact ids OR standalone",
+			filter: ThreadFilter{
+				TargetAssetIDs:    []string{"a1", "a2"},
+				IncludeStandalone: true,
+			},
+			wantSQL: []string{"t.asset_id IN", "t.target_type ="},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qb := applyThreadFilter(psq.Select("t.id").From("portal_threads t"), tt.filter)
+			sql, args, err := qb.ToSql()
+			require.NoError(t, err)
+			for _, want := range tt.wantSQL {
+				assert.Contains(t, sql, want, "sql: %s", sql)
+			}
+			for _, absent := range tt.absentSQL {
+				assert.NotContains(t, sql, absent, "sql: %s", sql)
+			}
+			for _, wantArg := range tt.wantArgs {
+				assert.Contains(t, args, wantArg, "args: %v", args)
+			}
+		})
+	}
+}
+
+// TestApplyThreadFilterExcludeAuthorEmailLowercases verifies the excluded email
+// is matched case-insensitively (mirrors the inclusive author filter).
+func TestApplyThreadFilterExcludeAuthorEmailLowercases(t *testing.T) {
+	qb := applyThreadFilter(psq.Select("t.id").From("portal_threads t"),
+		ThreadFilter{ExcludeAuthorEmail: "Owner@Example.com"})
+	sql, args, err := qb.ToSql()
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(sql, "LOWER(t.author_email) <> LOWER("), "sql: %s", sql)
+	assert.Contains(t, args, "Owner@Example.com")
+}

--- a/pkg/portal/thread_store.go
+++ b/pkg/portal/thread_store.go
@@ -181,8 +181,19 @@ type ThreadFilter struct {
 	TargetAssetIDs      []string
 	TargetCollectionIDs []string
 	TargetPromptIDs     []string
-	Limit               int
-	Offset              int
+	// IncludeStandalone adds standalone-channel threads to the target-id OR group
+	// (used by the agent feedback feed, which spans the caller's artifacts AND the
+	// shared general channel). On its own it matches all standalone threads.
+	IncludeStandalone bool
+	// Unresolved restricts to threads in a non-terminal status (anything other
+	// than resolved or wont_fix), i.e. feedback that still needs attention.
+	Unresolved bool
+	// ExcludeAuthorID / ExcludeAuthorEmail drop threads opened by this user, so a
+	// caller's own threads are not surfaced as feedback awaiting their action.
+	ExcludeAuthorID    string
+	ExcludeAuthorEmail string
+	Limit              int
+	Offset             int
 }
 
 const (
@@ -775,9 +786,26 @@ func applyThreadFilter(qb sq.SelectBuilder, f ThreadFilter) sq.SelectBuilder {
 	if f.ValidationState != "" {
 		qb = qb.Where(sq.Eq{"t.validation_state": f.ValidationState})
 	}
+	if f.Unresolved {
+		qb = qb.Where(sq.NotEq{"t.status": []string{ThreadStatusResolved, ThreadStatusWontFix}})
+	}
 	qb = applyThreadAuthorFilter(qb, f)
+	qb = applyThreadAuthorExcludeFilter(qb, f)
 	if or := threadTargetIDsCond(f); or != nil {
 		qb = qb.Where(or)
+	}
+	return qb
+}
+
+// applyThreadAuthorExcludeFilter drops threads opened by the excluded user (by
+// id or case-insensitive email), so the agent feed never lists the caller's own
+// threads as feedback awaiting their action.
+func applyThreadAuthorExcludeFilter(qb sq.SelectBuilder, f ThreadFilter) sq.SelectBuilder {
+	if f.ExcludeAuthorID != "" {
+		qb = qb.Where(sq.NotEq{"t.author_id": f.ExcludeAuthorID})
+	}
+	if f.ExcludeAuthorEmail != "" {
+		qb = qb.Where(sq.Expr("LOWER(t.author_email) <> LOWER(?)", f.ExcludeAuthorEmail))
 	}
 	return qb
 }
@@ -805,7 +833,8 @@ func applyThreadAuthorFilter(qb sq.SelectBuilder, f ThreadFilter) sq.SelectBuild
 // given asset, collection, or prompt ids (used by the worklist and the activity
 // feed, which span many targets). Returns nil when no id set is populated.
 func threadTargetIDsCond(f ThreadFilter) sq.Sqlizer {
-	if len(f.TargetAssetIDs) == 0 && len(f.TargetCollectionIDs) == 0 && len(f.TargetPromptIDs) == 0 {
+	if len(f.TargetAssetIDs) == 0 && len(f.TargetCollectionIDs) == 0 &&
+		len(f.TargetPromptIDs) == 0 && !f.IncludeStandalone {
 		return nil
 	}
 	or := sq.Or{}
@@ -817,6 +846,9 @@ func threadTargetIDsCond(f ThreadFilter) sq.Sqlizer {
 	}
 	if len(f.TargetPromptIDs) > 0 {
 		or = append(or, sq.Eq{"t.prompt_id": f.TargetPromptIDs})
+	}
+	if f.IncludeStandalone {
+		or = append(or, sq.Eq{"t.target_type": targetTypeStandalone})
 	}
 	return or
 }

--- a/pkg/portal/thread_targets.go
+++ b/pkg/portal/thread_targets.go
@@ -1,0 +1,106 @@
+package portal
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// Shared target gathering for cross-artifact feedback views. The REST worklist
+// and activity feed (#617) and the manage_feedback MCP tool (#618) all need the
+// set of asset/collection ids a caller owns or holds a share on. Centralized
+// here so the policy lives in one place rather than forked per surface.
+
+// targetGatherCap bounds how many owned/shared artifacts a single gather pulls,
+// so a caller with an enormous library cannot issue an unbounded query.
+const targetGatherCap = 1000
+
+// ShareKeep decides whether a share grant counts toward a gathered target set.
+// KeepEditorShares is the "I can act on it" scope (worklist, MCP agent); KeepAnyShare
+// is the "I can view it" scope (activity feed).
+type ShareKeep func(SharePermission) bool
+
+// KeepEditorShares keeps only editor-permission shares.
+func KeepEditorShares(p SharePermission) bool { return p == PermissionEditor }
+
+// KeepAnyShare keeps shares at any permission.
+func KeepAnyShare(SharePermission) bool { return true }
+
+// TargetGatherer gathers the asset/collection ids a single user can reach,
+// bundling the stores and identity so callers (REST worklist/activity feed, the
+// manage_feedback MCP tool) build it once and ask for asset or collection ids
+// with the desired share scope.
+type TargetGatherer struct {
+	Assets      AssetStore
+	Collections CollectionStore
+	Shares      ShareStore
+	UserID      string
+	Email       string
+}
+
+// AssetIDs returns the ids of assets the user owns plus shared assets whose
+// permission satisfies keep.
+func (g TargetGatherer) AssetIDs(ctx context.Context, keep ShareKeep) ([]string, error) {
+	var ids []string
+	if g.Assets != nil {
+		owned, total, err := g.Assets.List(ctx, AssetFilter{OwnerID: g.UserID, Limit: targetGatherCap})
+		if err != nil {
+			return nil, fmt.Errorf("listing owned assets: %w", err)
+		}
+		warnIfTargetsTruncated(total, "owned assets", g.UserID)
+		for _, a := range owned {
+			ids = append(ids, a.ID)
+		}
+	}
+	if g.Shares != nil {
+		shared, total, err := g.Shares.ListSharedWithUser(ctx, g.UserID, g.Email, targetGatherCap, 0)
+		if err != nil {
+			return nil, fmt.Errorf("listing shared assets: %w", err)
+		}
+		warnIfTargetsTruncated(total, "shared assets", g.UserID)
+		for _, s := range shared {
+			if keep(s.Permission) {
+				ids = append(ids, s.Asset.ID)
+			}
+		}
+	}
+	return ids, nil
+}
+
+// CollectionIDs returns the ids of collections the user owns plus shared
+// collections whose permission satisfies keep.
+func (g TargetGatherer) CollectionIDs(ctx context.Context, keep ShareKeep) ([]string, error) {
+	var ids []string
+	if g.Collections != nil {
+		owned, total, err := g.Collections.List(ctx, CollectionFilter{OwnerID: g.UserID, Limit: targetGatherCap})
+		if err != nil {
+			return nil, fmt.Errorf("listing owned collections: %w", err)
+		}
+		warnIfTargetsTruncated(total, "owned collections", g.UserID)
+		for _, c := range owned {
+			ids = append(ids, c.ID)
+		}
+	}
+	if g.Shares != nil {
+		shared, total, err := g.Shares.ListSharedCollectionsWithUser(ctx, g.UserID, g.Email, targetGatherCap, 0)
+		if err != nil {
+			return nil, fmt.Errorf("listing shared collections: %w", err)
+		}
+		warnIfTargetsTruncated(total, "shared collections", g.UserID)
+		for _, s := range shared {
+			if keep(s.Permission) {
+				ids = append(ids, s.Collection.ID)
+			}
+		}
+	}
+	return ids, nil
+}
+
+// warnIfTargetsTruncated logs when a user's owned/shared set exceeds the cap, so
+// the silent omission of artifacts past the cap is observable to operators.
+func warnIfTargetsTruncated(total int, kind, userID string) {
+	if total > targetGatherCap {
+		slog.Warn("feedback target set truncated; some artifacts are omitted",
+			"kind", kind, "user", userID, "total", total, "cap", targetGatherCap)
+	}
+}

--- a/pkg/portal/worklist_handler.go
+++ b/pkg/portal/worklist_handler.go
@@ -2,8 +2,6 @@ package portal
 
 import (
 	"context"
-	"fmt"
-	"log/slog"
 	"net/http"
 )
 
@@ -99,94 +97,28 @@ func (h *Handler) writeWorklist(w http.ResponseWriter, r *http.Request, filter T
 
 // ownedOrEditableTargets returns the ids of every asset and collection the user
 // owns or holds an active editor share on (the worklist's "I can act on it"
-// scope). The feedback activity feed reuses gatherAssetIDs/gatherCollectionIDs
-// with keepAnyShare for its broader "I can view it" scope.
+// scope). Delegates to the shared gather helpers; the activity feed uses the
+// same helpers with KeepAnyShare for its broader "I can view it" scope.
 func (h *Handler) ownedOrEditableTargets(ctx context.Context, user *User) (assetIDs, collIDs []string, err error) {
-	assetIDs, err = h.gatherAssetIDs(ctx, user, keepEditorShare)
+	g := h.targetGatherer(user)
+	assetIDs, err = g.AssetIDs(ctx, KeepEditorShares)
 	if err != nil {
 		return nil, nil, err
 	}
-	collIDs, err = h.gatherCollectionIDs(ctx, user, keepEditorShare)
+	collIDs, err = g.CollectionIDs(ctx, KeepEditorShares)
 	if err != nil {
 		return nil, nil, err
 	}
 	return assetIDs, collIDs, nil
 }
 
-// keepEditorShare keeps only editor-permission shares (worklist scope).
-func keepEditorShare(p SharePermission) bool { return p == PermissionEditor }
-
-// keepAnyShare keeps shares at any permission (activity-feed view scope).
-func keepAnyShare(SharePermission) bool { return true }
-
-// gatherAssetIDs returns the assets the user owns plus the shared assets whose
-// permission satisfies keepShare. The keepShare predicate is the only
-// difference between the worklist (editor) and the activity feed (any) scopes.
-func (h *Handler) gatherAssetIDs(ctx context.Context, user *User, keepShare func(SharePermission) bool) ([]string, error) {
-	var ids []string
-	if h.deps.AssetStore != nil {
-		owned, total, err := h.deps.AssetStore.List(ctx, AssetFilter{OwnerID: user.UserID, Limit: worklistTargetCap})
-		if err != nil {
-			return nil, fmt.Errorf("listing owned assets: %w", err)
-		}
-		warnIfTruncated(total, "owned assets", user.UserID)
-		for _, a := range owned {
-			ids = append(ids, a.ID)
-		}
-	}
-	if h.deps.ShareStore != nil {
-		shared, total, err := h.deps.ShareStore.ListSharedWithUser(ctx, user.UserID, user.Email, worklistTargetCap, 0)
-		if err != nil {
-			return nil, fmt.Errorf("listing shared assets: %w", err)
-		}
-		warnIfTruncated(total, "shared assets", user.UserID)
-		for _, s := range shared {
-			if keepShare(s.Permission) {
-				ids = append(ids, s.Asset.ID)
-			}
-		}
-	}
-	return ids, nil
-}
-
-// gatherCollectionIDs returns the collections the user owns plus the shared
-// collections whose permission satisfies keepShare.
-func (h *Handler) gatherCollectionIDs(ctx context.Context, user *User, keepShare func(SharePermission) bool) ([]string, error) {
-	var ids []string
-	if h.deps.CollectionStore != nil {
-		owned, total, err := h.deps.CollectionStore.List(ctx, CollectionFilter{OwnerID: user.UserID, Limit: worklistTargetCap})
-		if err != nil {
-			return nil, fmt.Errorf("listing owned collections: %w", err)
-		}
-		warnIfTruncated(total, "owned collections", user.UserID)
-		for _, c := range owned {
-			ids = append(ids, c.ID)
-		}
-	}
-	if h.deps.ShareStore != nil {
-		shared, total, err := h.deps.ShareStore.ListSharedCollectionsWithUser(ctx, user.UserID, user.Email, worklistTargetCap, 0)
-		if err != nil {
-			return nil, fmt.Errorf("listing shared collections: %w", err)
-		}
-		warnIfTruncated(total, "shared collections", user.UserID)
-		for _, s := range shared {
-			if keepShare(s.Permission) {
-				ids = append(ids, s.Collection.ID)
-			}
-		}
-	}
-	return ids, nil
-}
-
-// worklistTargetCap bounds how many owned/shared artifacts the worklist gathers.
-const worklistTargetCap = 1000
-
-// warnIfTruncated logs when a user's owned/shared set exceeds the worklist cap,
-// so the silent omission of artifacts past the cap is at least observable to
-// operators (the worklist's purpose is that no feedback is dropped).
-func warnIfTruncated(total int, kind, userID string) {
-	if total > worklistTargetCap {
-		slog.Warn("worklist target set truncated; some artifacts are omitted",
-			"kind", kind, "user", userID, "total", total, "cap", worklistTargetCap)
+// targetGatherer builds a TargetGatherer from the handler's stores for the user.
+func (h *Handler) targetGatherer(user *User) TargetGatherer {
+	return TargetGatherer{
+		Assets:      h.deps.AssetStore,
+		Collections: h.deps.CollectionStore,
+		Shares:      h.deps.ShareStore,
+		UserID:      user.UserID,
+		Email:       user.Email,
 	}
 }

--- a/pkg/toolkits/knowledge/schemas.go
+++ b/pkg/toolkits/knowledge/schemas.go
@@ -84,7 +84,7 @@ var captureInsightSchema = json.RawMessage(`{
     },
     "thread_ids": {
       "type": "array",
-      "description": "IDs of feedback thread(s) this insight resolves. Each linked thread is marked resolved, records an insight_linked event, and carries this insight's id. Obtain thread IDs from manage_artifact action=list_threads.",
+      "description": "IDs of feedback thread(s) this insight resolves. Each linked thread is marked resolved, records an insight_linked event, and carries this insight's id. Obtain thread IDs from manage_feedback action=list.",
       "items": {"type": "string"},
       "maxItems": 50
     }

--- a/pkg/toolkits/portal/schemas.go
+++ b/pkg/toolkits/portal/schemas.go
@@ -43,7 +43,7 @@ var manageArtifactSchema = json.RawMessage(`{
   "properties": {
     "action": {
       "type": "string",
-      "description": "Action to perform. Asset actions: list, get, update, delete, list_versions, revert, search. Collection actions: create_collection, list_collections, get_collection, update_collection, delete_collection, set_sections. Feedback actions: list_threads (scope by asset_id/collection_id/prompt_id or target_type=standalone; optional status/validation_state/requires_resolution filters), get_thread, reply_thread, resolve_thread, request_validation, respond_validation (the feedback author records validated/disputed via validation_result)"
+      "description": "Action to perform. Asset actions: list, get, update, delete, list_versions, revert, search. Collection actions: create_collection, list_collections, get_collection, update_collection, delete_collection, set_sections. (Human feedback on artifacts is handled by the separate manage_feedback tool.)"
     },
     "asset_id": {
       "type": "string",
@@ -128,43 +128,72 @@ var manageArtifactSchema = json.RawMessage(`{
           }
         }
       }
+    }
+  }
+}`)
+
+// manageFeedbackSchema is the JSON Schema for the manage_feedback tool input.
+var manageFeedbackSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["action"],
+  "additionalProperties": false,
+  "properties": {
+    "action": {
+      "type": "string",
+      "description": "Action to perform. list (with NO target = your pending feedback across the assets and collections you own or can edit AND the general channel, newest first, excluding your own threads, plus threads awaiting your validation; with a target = threads on that one asset/collection/prompt or the standalone channel). get (one thread + its timeline). reply (post a comment). resolve (mark resolved). request_validation (route a validation request to the thread author). respond_validation (the thread author records validated/disputed via validation_result)."
+    },
+    "asset_id": {
+      "type": "string",
+      "description": "Scope list to one asset, or unused for thread-id actions"
+    },
+    "collection_id": {
+      "type": "string",
+      "description": "Scope list to one collection"
     },
     "prompt_id": {
       "type": "string",
-      "description": "Prompt ID target for list_threads (feedback on a prompt)"
+      "description": "Scope list to one prompt"
     },
     "target_type": {
       "type": "string",
-      "description": "Thread target scope for list_threads. Use 'standalone' for general feedback not tied to an artifact"
+      "description": "Use 'standalone' to scope list to the general channel (feedback not tied to an artifact)"
     },
     "thread_id": {
       "type": "string",
-      "description": "Feedback thread ID (required for get_thread, reply_thread, resolve_thread, request_validation)"
+      "description": "Feedback thread ID (required for get, reply, resolve, request_validation, respond_validation)"
     },
     "body": {
       "type": "string",
-      "description": "Reply text (required for reply_thread)"
+      "description": "Reply text (required for reply)"
     },
     "status": {
       "type": "string",
-      "description": "Filter list_threads by thread status (open, answered, resolved, wont_fix, acknowledged)"
+      "description": "Filter a targeted list by thread status (open, answered, resolved, wont_fix, acknowledged)"
     },
     "validation_state": {
       "type": "string",
-      "description": "Filter list_threads by validation state (none, pending, validated, disputed)"
+      "description": "Filter a targeted list by validation state (none, pending, validated, disputed)"
     },
     "requires_resolution": {
       "type": "boolean",
-      "description": "Filter list_threads to threads that do (true) or do not (false) require resolution"
+      "description": "Filter a targeted list to threads that do (true) or do not (false) require resolution"
     },
     "validation_result": {
       "type": "string",
       "enum": ["validated", "disputed"],
-      "description": "For respond_validation: the SME's outcome on a validation request"
+      "description": "For respond_validation: the author's outcome on a validation request"
     },
     "validation_reason": {
       "type": "string",
-      "description": "For respond_validation: optional reason, recorded on the validation_result event (useful when disputed)"
+      "description": "For respond_validation: optional reason recorded on the validation_result event (useful when disputed)"
+    },
+    "limit": {
+      "type": "integer",
+      "description": "Max results (default 50, max 200)"
+    },
+    "offset": {
+      "type": "integer",
+      "description": "Offset for paginated results"
     }
   }
 }`)

--- a/pkg/toolkits/portal/thread_actions.go
+++ b/pkg/toolkits/portal/thread_actions.go
@@ -37,9 +37,14 @@ const (
 	threadsUnavail = "feedback threads are not available"
 )
 
-func (t *Toolkit) handleListThreads(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+func (t *Toolkit) handleListThreads(ctx context.Context, input manageFeedbackInput) (*mcp.CallToolResult, any, error) {
 	if t.threadStore == nil {
 		return errorResult(threadsUnavail), nil, nil
+	}
+	// No target at all: return the caller's pending feedback across everything
+	// (the discovery entry point — "review any pending feedback").
+	if !hasThreadTarget(input) {
+		return t.handleListPendingFeedback(ctx, input)
 	}
 	targetType, ok := threadScopeFromInput(input)
 	if !ok {
@@ -69,7 +74,96 @@ func (t *Toolkit) handleListThreads(ctx context.Context, input manageArtifactInp
 	return jsonResult(map[string]any{"threads": threads, fieldTotal: total})
 }
 
-func (t *Toolkit) handleGetThread(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+// hasThreadTarget reports whether the input scopes feedback to a single target
+// (an object id or target_type). When false, list returns the cross-artifact
+// pending feed.
+func hasThreadTarget(input manageFeedbackInput) bool {
+	return input.TargetType != "" || input.AssetID != "" ||
+		input.CollectionID != "" || input.PromptID != ""
+}
+
+// handleListPendingFeedback returns the caller's pending feedback across every
+// artifact they own or can edit AND the shared general channel: unresolved
+// threads they did not author, plus threads awaiting their validation. This is
+// the agent's entry point for "review and act on any pending feedback".
+func (t *Toolkit) handleListPendingFeedback(ctx context.Context, input manageFeedbackInput) (*mcp.CallToolResult, any, error) {
+	uid, email := resolveOwnerID(ctx), resolveOwnerEmail(ctx)
+
+	g := portal.TargetGatherer{
+		Assets:      t.assetStore,
+		Collections: t.collectionStore,
+		Shares:      t.shareStore,
+		UserID:      uid,
+		Email:       email,
+	}
+	assetIDs, err := g.AssetIDs(ctx, portal.KeepEditorShares)
+	if err != nil {
+		return errorResult("failed to gather your artifacts: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+	collIDs, err := g.CollectionIDs(ctx, portal.KeepEditorShares)
+	if err != nil {
+		return errorResult("failed to gather your artifacts: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	filter := portal.ThreadFilter{
+		TargetAssetIDs:      assetIDs,
+		TargetCollectionIDs: collIDs,
+		IncludeStandalone:   true,
+		Unresolved:          true,
+		Limit:               input.Limit,
+		Offset:              input.Offset,
+	}
+	// Exclude the caller's own threads so they are not surfaced as feedback
+	// awaiting their action. Skip for an unauthenticated caller: excluding the
+	// "anonymous" sentinel would drop genuinely anonymous general-channel posts.
+	if uid != anonymousUserName {
+		filter.ExcludeAuthorID = uid
+		filter.ExcludeAuthorEmail = email
+	}
+
+	pending, pendingTotal, err := t.threadStore.ListThreads(ctx, filter)
+	if err != nil {
+		return errorResult("failed to list pending feedback: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	awaiting, awaitingTotal := t.awaitingMyValidation(ctx, uid, email)
+
+	return jsonResult(map[string]any{
+		"pending":                   normalizeThreads(pending),
+		"pending_total":             pendingTotal,
+		"awaiting_my_validation":    normalizeThreads(awaiting),
+		"awaiting_validation_total": awaitingTotal,
+	})
+}
+
+// awaitingMyValidation returns threads where the caller is the author and a
+// validation request is pending (the SME queue), plus the true total (which may
+// exceed the returned page). Returns nil for an unauthenticated caller so the
+// anonymous sentinel never matches.
+func (t *Toolkit) awaitingMyValidation(ctx context.Context, uid, email string) (threads []portal.ThreadWithMeta, total int) {
+	if uid == anonymousUserName {
+		return nil, 0
+	}
+	threads, total, err := t.threadStore.ListThreads(ctx, portal.ThreadFilter{
+		AuthorID:        uid,
+		AuthorEmail:     email,
+		ValidationState: portal.ValidationStatePending,
+	})
+	if err != nil {
+		return nil, 0
+	}
+	return threads, total
+}
+
+// normalizeThreads converts a nil slice to an empty one for stable JSON output.
+func normalizeThreads(threads []portal.ThreadWithMeta) []portal.ThreadWithMeta {
+	if threads == nil {
+		return []portal.ThreadWithMeta{}
+	}
+	return threads
+}
+
+func (t *Toolkit) handleGetThread(ctx context.Context, input manageFeedbackInput) (*mcp.CallToolResult, any, error) {
 	thread, errRes := t.loadThread(ctx, input.ThreadID, false)
 	if errRes != nil {
 		return errRes, nil, nil
@@ -84,9 +178,9 @@ func (t *Toolkit) handleGetThread(ctx context.Context, input manageArtifactInput
 	return jsonResult(map[string]any{"thread": thread, "events": events})
 }
 
-func (t *Toolkit) handleReplyThread(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+func (t *Toolkit) handleReplyThread(ctx context.Context, input manageFeedbackInput) (*mcp.CallToolResult, any, error) {
 	if strings.TrimSpace(input.Body) == "" {
-		return errorResult("body is required for reply_thread"), nil, nil
+		return errorResult("body is required for the reply action"), nil, nil
 	}
 	thread, errRes := t.loadThread(ctx, input.ThreadID, false)
 	if errRes != nil {
@@ -106,7 +200,7 @@ func (t *Toolkit) handleReplyThread(ctx context.Context, input manageArtifactInp
 	return jsonResult(evt)
 }
 
-func (t *Toolkit) handleResolveThread(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+func (t *Toolkit) handleResolveThread(ctx context.Context, input manageFeedbackInput) (*mcp.CallToolResult, any, error) {
 	thread, errRes := t.loadThread(ctx, input.ThreadID, true)
 	if errRes != nil {
 		return errRes, nil, nil
@@ -119,7 +213,7 @@ func (t *Toolkit) handleResolveThread(ctx context.Context, input manageArtifactI
 	return jsonResult(map[string]any{"thread_id": thread.ID, "status": resolved})
 }
 
-func (t *Toolkit) handleRequestValidation(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+func (t *Toolkit) handleRequestValidation(ctx context.Context, input manageFeedbackInput) (*mcp.CallToolResult, any, error) {
 	thread, errRes := t.loadThread(ctx, input.ThreadID, true)
 	if errRes != nil {
 		return errRes, nil, nil
@@ -133,7 +227,7 @@ func (t *Toolkit) handleRequestValidation(ctx context.Context, input manageArtif
 // handleRespondValidation records the SME's answer to a validation request.
 // Unlike the other moderation actions, the responder is the original feedback
 // author (the SME the request was routed to), not the artifact owner.
-func (t *Toolkit) handleRespondValidation(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
+func (t *Toolkit) handleRespondValidation(ctx context.Context, input manageFeedbackInput) (*mcp.CallToolResult, any, error) {
 	if t.threadStore == nil {
 		return errorResult(threadsUnavail), nil, nil
 	}
@@ -325,7 +419,7 @@ func (t *Toolkit) canEditCollection(ctx context.Context, id string) bool {
 }
 
 // threadScopeFromInput resolves the single target scope for list_threads.
-func threadScopeFromInput(input manageArtifactInput) (string, bool) {
+func threadScopeFromInput(input manageFeedbackInput) (string, bool) {
 	n := countNonEmpty(input.AssetID, input.CollectionID, input.PromptID)
 	if input.TargetType == threadTargetStandalone {
 		return threadTargetStandalone, n == 0

--- a/pkg/toolkits/portal/thread_actions_test.go
+++ b/pkg/toolkits/portal/thread_actions_test.go
@@ -20,10 +20,11 @@ import (
 // fakeThreadStore implements portal.ThreadStore with configurable returns and
 // captured inputs for the manage_artifact thread actions.
 type fakeThreadStore struct {
-	listResult []portal.ThreadWithMeta
-	listTotal  int
-	listErr    error
-	lastFilter portal.ThreadFilter
+	listResult  []portal.ThreadWithMeta
+	listTotal   int
+	listErr     error
+	lastFilter  portal.ThreadFilter
+	listFilters []portal.ThreadFilter // every filter passed to ListThreads, in order
 
 	getResult *portal.Thread
 	getErr    error
@@ -49,6 +50,7 @@ func (*fakeThreadStore) CreateThread(_ context.Context, t portal.Thread, _ porta
 
 func (f *fakeThreadStore) ListThreads(_ context.Context, filter portal.ThreadFilter) ([]portal.ThreadWithMeta, int, error) {
 	f.lastFilter = filter
+	f.listFilters = append(f.listFilters, filter)
 	return f.listResult, f.listTotal, f.listErr
 }
 
@@ -160,6 +162,15 @@ func (*fakeShareStore) IncrementAccess(_ context.Context, _ string) error { retu
 
 var _ portal.ShareStore = (*fakeShareStore)(nil)
 
+// errShareStore fails the shared-asset lookup so the pending gather errors.
+type errShareStore struct{ fakeShareStore }
+
+func (*errShareStore) ListSharedWithUser(_ context.Context, _, _ string, _, _ int) ([]portal.SharedAsset, int, error) {
+	return nil, 0, errors.New("share boom")
+}
+
+var _ portal.ShareStore = (*errShareStore)(nil)
+
 // --- helpers ----------------------------------------------------------------
 
 const (
@@ -215,17 +226,17 @@ func decodeResult(t *testing.T, res *mcp.CallToolResult) map[string]any {
 func TestThreadScopeFromInput(t *testing.T) {
 	tests := []struct {
 		name   string
-		input  manageArtifactInput
+		input  manageFeedbackInput
 		want   string
 		wantOK bool
 	}{
-		{"standalone no ids", manageArtifactInput{TargetType: "standalone"}, "standalone", true},
-		{"standalone with asset id", manageArtifactInput{TargetType: "standalone", AssetID: "a"}, "standalone", false},
-		{"asset only", manageArtifactInput{AssetID: "a"}, "asset", true},
-		{"collection only", manageArtifactInput{CollectionID: "c"}, "collection", true},
-		{"prompt only", manageArtifactInput{PromptID: "p"}, "prompt", true},
-		{"no ids, not standalone", manageArtifactInput{}, "", false},
-		{"two ids", manageArtifactInput{AssetID: "a", CollectionID: "c"}, "", false},
+		{"standalone no ids", manageFeedbackInput{TargetType: "standalone"}, "standalone", true},
+		{"standalone with asset id", manageFeedbackInput{TargetType: "standalone", AssetID: "a"}, "standalone", false},
+		{"asset only", manageFeedbackInput{AssetID: "a"}, "asset", true},
+		{"collection only", manageFeedbackInput{CollectionID: "c"}, "collection", true},
+		{"prompt only", manageFeedbackInput{PromptID: "p"}, "prompt", true},
+		{"no ids, not standalone", manageFeedbackInput{}, "", false},
+		{"two ids", manageFeedbackInput{AssetID: "a", CollectionID: "c"}, "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -249,21 +260,67 @@ func TestCountNonEmpty(t *testing.T) {
 func TestHandleListThreads(t *testing.T) {
 	t.Run("store unavailable", func(t *testing.T) {
 		tk := New(Config{Name: "test", S3Bucket: "b"}) // no ThreadStore
-		res, _, err := tk.handleListThreads(ownerCtx(), manageArtifactInput{AssetID: "asset_1"})
+		res, _, err := tk.handleListThreads(ownerCtx(), manageFeedbackInput{AssetID: "asset_1"})
 		require.NoError(t, err)
 		assert.True(t, res.IsError)
 		assert.Contains(t, decodeResult(t, res)["error"], "not available")
 	})
 
-	t.Run("scope error", func(t *testing.T) {
-		tk := threadToolkit(t, &fakeThreadStore{}, nil)
-		res, _, _ := tk.handleListThreads(ownerCtx(), manageArtifactInput{})
+	t.Run("no target lists pending across everything", func(t *testing.T) {
+		fts := &fakeThreadStore{
+			listTotal:  3,
+			listResult: []portal.ThreadWithMeta{{Thread: portal.Thread{ID: "thr_1"}}},
+		}
+		tk := threadToolkit(t, fts, nil)
+		res, _, err := tk.handleListThreads(ownerCtx(), manageFeedbackInput{})
+		require.NoError(t, err)
+		assert.False(t, res.IsError)
+		// First ListThreads call is the pending query: my owned/editable artifacts
+		// + the general channel, unresolved, excluding my own threads.
+		require.GreaterOrEqual(t, len(fts.listFilters), 1)
+		pf := fts.listFilters[0]
+		assert.True(t, pf.IncludeStandalone)
+		assert.True(t, pf.Unresolved)
+		assert.Equal(t, ownerID, pf.ExcludeAuthorID)
+		assert.Equal(t, ownerEmail, pf.ExcludeAuthorEmail)
+		assert.Contains(t, pf.TargetAssetIDs, "asset_1")
+		assert.Contains(t, pf.TargetCollectionIDs, "collection_1")
+		// Second call is the awaiting-my-validation query.
+		require.Len(t, fts.listFilters, 2)
+		assert.Equal(t, portal.ValidationStatePending, fts.listFilters[1].ValidationState)
+		assert.Equal(t, ownerID, fts.listFilters[1].AuthorID)
+
+		body := decodeResult(t, res)
+		assert.Contains(t, body, "pending")
+		assert.Contains(t, body, "awaiting_my_validation")
+	})
+
+	t.Run("no target, anonymous skips validation queue", func(t *testing.T) {
+		fts := &fakeThreadStore{}
+		tk := threadToolkit(t, fts, nil)
+		res, _, _ := tk.handleListThreads(context.Background(), manageFeedbackInput{})
+		assert.False(t, res.IsError)
+		// Anonymous: pending query runs, but the validation queue is skipped.
+		assert.Len(t, fts.listFilters, 1)
+	})
+
+	t.Run("no target, gather error", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{}, &errShareStore{})
+		res, _, _ := tk.handleListThreads(ownerCtx(), manageFeedbackInput{})
 		assert.True(t, res.IsError)
+		assert.Contains(t, decodeResult(t, res)["error"], "gather")
+	})
+
+	t.Run("no target, pending store error", func(t *testing.T) {
+		tk := threadToolkit(t, &fakeThreadStore{listErr: errors.New("boom")}, nil)
+		res, _, _ := tk.handleListThreads(ownerCtx(), manageFeedbackInput{})
+		assert.True(t, res.IsError)
+		assert.Contains(t, decodeResult(t, res)["error"], "pending feedback")
 	})
 
 	t.Run("access denied for non-owner non-editor", func(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{}, nil)
-		res, _, _ := tk.handleListThreads(strangerCtx(), manageArtifactInput{AssetID: "asset_1"})
+		res, _, _ := tk.handleListThreads(strangerCtx(), manageFeedbackInput{AssetID: "asset_1"})
 		assert.True(t, res.IsError)
 		assert.Contains(t, decodeResult(t, res)["error"], "own or can edit")
 	})
@@ -272,7 +329,7 @@ func TestHandleListThreads(t *testing.T) {
 		fts := &fakeThreadStore{listTotal: 2}
 		tk := threadToolkit(t, fts, nil)
 		req := true
-		res, _, err := tk.handleListThreads(ownerCtx(), manageArtifactInput{
+		res, _, err := tk.handleListThreads(ownerCtx(), manageFeedbackInput{
 			AssetID: "asset_1", RequiresResolution: &req, ValidationState: "pending",
 		})
 		require.NoError(t, err)
@@ -287,37 +344,37 @@ func TestHandleListThreads(t *testing.T) {
 	t.Run("editor share grants access", func(t *testing.T) {
 		shares := &fakeShareStore{assetShare: &portal.Share{Permission: portal.PermissionEditor}}
 		tk := threadToolkit(t, &fakeThreadStore{}, shares)
-		res, _, _ := tk.handleListThreads(strangerCtx(), manageArtifactInput{AssetID: "asset_1"})
+		res, _, _ := tk.handleListThreads(strangerCtx(), manageFeedbackInput{AssetID: "asset_1"})
 		assert.False(t, res.IsError)
 	})
 
 	t.Run("admin sees any target", func(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{}, nil)
-		res, _, _ := tk.handleListThreads(adminCtx(), manageArtifactInput{AssetID: "asset_1"})
+		res, _, _ := tk.handleListThreads(adminCtx(), manageFeedbackInput{AssetID: "asset_1"})
 		assert.False(t, res.IsError)
 	})
 
 	t.Run("store error", func(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{listErr: errors.New("boom")}, nil)
-		res, _, _ := tk.handleListThreads(ownerCtx(), manageArtifactInput{AssetID: "asset_1"})
+		res, _, _ := tk.handleListThreads(ownerCtx(), manageFeedbackInput{AssetID: "asset_1"})
 		assert.True(t, res.IsError)
 	})
 
 	t.Run("standalone scope open to any authed caller", func(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{}, nil)
-		res, _, _ := tk.handleListThreads(strangerCtx(), manageArtifactInput{TargetType: "standalone"})
+		res, _, _ := tk.handleListThreads(strangerCtx(), manageFeedbackInput{TargetType: "standalone"})
 		assert.False(t, res.IsError)
 	})
 
 	t.Run("collection owner lists", func(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{}, nil)
-		res, _, _ := tk.handleListThreads(ownerCtx(), manageArtifactInput{CollectionID: "collection_1"})
+		res, _, _ := tk.handleListThreads(ownerCtx(), manageFeedbackInput{CollectionID: "collection_1"})
 		assert.False(t, res.IsError)
 	})
 
 	t.Run("prompt scope denied for non-admin", func(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{}, nil)
-		res, _, _ := tk.handleListThreads(ownerCtx(), manageArtifactInput{PromptID: "p1"})
+		res, _, _ := tk.handleListThreads(ownerCtx(), manageFeedbackInput{PromptID: "p1"})
 		assert.True(t, res.IsError)
 	})
 }
@@ -327,21 +384,21 @@ func TestHandleListThreads(t *testing.T) {
 func TestHandleGetThread(t *testing.T) {
 	t.Run("missing thread_id", func(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{}, nil)
-		res, _, _ := tk.handleGetThread(ownerCtx(), manageArtifactInput{})
+		res, _, _ := tk.handleGetThread(ownerCtx(), manageFeedbackInput{})
 		assert.True(t, res.IsError)
 		assert.Contains(t, decodeResult(t, res)["error"], "thread_id is required")
 	})
 
 	t.Run("not found", func(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{getErr: errors.New("nope")}, nil)
-		res, _, _ := tk.handleGetThread(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		res, _, _ := tk.handleGetThread(ownerCtx(), manageFeedbackInput{ThreadID: "t1"})
 		assert.True(t, res.IsError)
 	})
 
 	t.Run("access denied", func(t *testing.T) {
 		fts := &fakeThreadStore{getResult: &portal.Thread{ID: "t1", TargetType: "asset", AssetID: "asset_1"}}
 		tk := threadToolkit(t, fts, nil)
-		res, _, _ := tk.handleGetThread(strangerCtx(), manageArtifactInput{ThreadID: "t1"})
+		res, _, _ := tk.handleGetThread(strangerCtx(), manageFeedbackInput{ThreadID: "t1"})
 		assert.True(t, res.IsError)
 		assert.Contains(t, decodeResult(t, res)["error"], "own or can edit")
 	})
@@ -352,7 +409,7 @@ func TestHandleGetThread(t *testing.T) {
 			events:    []portal.ThreadEvent{{ID: "evt_1", EventType: portal.EventTypeComment}},
 		}
 		tk := threadToolkit(t, fts, nil)
-		res, _, err := tk.handleGetThread(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		res, _, err := tk.handleGetThread(ownerCtx(), manageFeedbackInput{ThreadID: "t1"})
 		require.NoError(t, err)
 		assert.False(t, res.IsError)
 		m := decodeResult(t, res)
@@ -366,7 +423,7 @@ func TestHandleGetThread(t *testing.T) {
 			eventsErr: errors.New("boom"),
 		}
 		tk := threadToolkit(t, fts, nil)
-		res, _, _ := tk.handleGetThread(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		res, _, _ := tk.handleGetThread(ownerCtx(), manageFeedbackInput{ThreadID: "t1"})
 		assert.True(t, res.IsError)
 	})
 }
@@ -378,7 +435,7 @@ func TestHandleReplyThread(t *testing.T) {
 
 	t.Run("empty body", func(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, nil)
-		res, _, _ := tk.handleReplyThread(ownerCtx(), manageArtifactInput{ThreadID: "t1", Body: "  "})
+		res, _, _ := tk.handleReplyThread(ownerCtx(), manageFeedbackInput{ThreadID: "t1", Body: "  "})
 		assert.True(t, res.IsError)
 		assert.Contains(t, decodeResult(t, res)["error"], "body is required")
 	})
@@ -386,7 +443,7 @@ func TestHandleReplyThread(t *testing.T) {
 	t.Run("success appends a comment", func(t *testing.T) {
 		fts := &fakeThreadStore{getResult: thread}
 		tk := threadToolkit(t, fts, nil)
-		res, _, err := tk.handleReplyThread(ownerCtx(), manageArtifactInput{ThreadID: "t1", Body: "looks good"})
+		res, _, err := tk.handleReplyThread(ownerCtx(), manageFeedbackInput{ThreadID: "t1", Body: "looks good"})
 		require.NoError(t, err)
 		assert.False(t, res.IsError)
 	})
@@ -394,7 +451,7 @@ func TestHandleReplyThread(t *testing.T) {
 	t.Run("append error", func(t *testing.T) {
 		fts := &fakeThreadStore{getResult: thread, appendErr: errors.New("boom")}
 		tk := threadToolkit(t, fts, nil)
-		res, _, _ := tk.handleReplyThread(ownerCtx(), manageArtifactInput{ThreadID: "t1", Body: "x"})
+		res, _, _ := tk.handleReplyThread(ownerCtx(), manageFeedbackInput{ThreadID: "t1", Body: "x"})
 		assert.True(t, res.IsError)
 	})
 }
@@ -407,7 +464,7 @@ func TestHandleResolveThread(t *testing.T) {
 	t.Run("owner resolves", func(t *testing.T) {
 		fts := &fakeThreadStore{getResult: thread}
 		tk := threadToolkit(t, fts, nil)
-		res, _, err := tk.handleResolveThread(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		res, _, err := tk.handleResolveThread(ownerCtx(), manageFeedbackInput{ThreadID: "t1"})
 		require.NoError(t, err)
 		assert.False(t, res.IsError)
 		require.NotNil(t, fts.lastUpdate)
@@ -418,21 +475,21 @@ func TestHandleResolveThread(t *testing.T) {
 	t.Run("update error", func(t *testing.T) {
 		fts := &fakeThreadStore{getResult: thread, updateErr: errors.New("boom")}
 		tk := threadToolkit(t, fts, nil)
-		res, _, _ := tk.handleResolveThread(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		res, _, _ := tk.handleResolveThread(ownerCtx(), manageFeedbackInput{ThreadID: "t1"})
 		assert.True(t, res.IsError)
 	})
 
 	t.Run("standalone non-author denied", func(t *testing.T) {
 		standalone := &portal.Thread{ID: "t2", TargetType: "standalone", AuthorID: ownerID, AuthorEmail: ownerEmail}
 		tk := threadToolkit(t, &fakeThreadStore{getResult: standalone}, nil)
-		res, _, _ := tk.handleResolveThread(strangerCtx(), manageArtifactInput{ThreadID: "t2"})
+		res, _, _ := tk.handleResolveThread(strangerCtx(), manageFeedbackInput{ThreadID: "t2"})
 		assert.True(t, res.IsError)
 	})
 
 	t.Run("standalone author allowed", func(t *testing.T) {
 		standalone := &portal.Thread{ID: "t2", TargetType: "standalone", AuthorID: ownerID, AuthorEmail: ownerEmail}
 		tk := threadToolkit(t, &fakeThreadStore{getResult: standalone}, nil)
-		res, _, _ := tk.handleResolveThread(ownerCtx(), manageArtifactInput{ThreadID: "t2"})
+		res, _, _ := tk.handleResolveThread(ownerCtx(), manageFeedbackInput{ThreadID: "t2"})
 		assert.False(t, res.IsError)
 	})
 }
@@ -443,7 +500,7 @@ func TestHandleRequestValidation(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		fts := &fakeThreadStore{getResult: thread}
 		tk := threadToolkit(t, fts, nil)
-		res, _, err := tk.handleRequestValidation(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		res, _, err := tk.handleRequestValidation(ownerCtx(), manageFeedbackInput{ThreadID: "t1"})
 		require.NoError(t, err)
 		assert.False(t, res.IsError)
 		assert.Equal(t, "t1", fts.validatedID)
@@ -453,7 +510,7 @@ func TestHandleRequestValidation(t *testing.T) {
 	t.Run("store error", func(t *testing.T) {
 		fts := &fakeThreadStore{getResult: thread, validateErr: errors.New("boom")}
 		tk := threadToolkit(t, fts, nil)
-		res, _, _ := tk.handleRequestValidation(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		res, _, _ := tk.handleRequestValidation(ownerCtx(), manageFeedbackInput{ThreadID: "t1"})
 		assert.True(t, res.IsError)
 	})
 }
@@ -467,7 +524,7 @@ func TestHandleRespondValidation(t *testing.T) {
 	t.Run("author validates", func(t *testing.T) {
 		fts := &fakeThreadStore{getResult: authored}
 		tk := threadToolkit(t, fts, nil)
-		res, _, err := tk.handleRespondValidation(ownerCtx(), manageArtifactInput{ThreadID: "t1", ValidationResult: "validated"})
+		res, _, err := tk.handleRespondValidation(ownerCtx(), manageFeedbackInput{ThreadID: "t1", ValidationResult: "validated"})
 		require.NoError(t, err)
 		assert.False(t, res.IsError)
 		assert.Equal(t, "validated", fts.respondedResult)
@@ -478,53 +535,53 @@ func TestHandleRespondValidation(t *testing.T) {
 		fts := &fakeThreadStore{getResult: authored}
 		tk := threadToolkit(t, fts, nil)
 		res, _, _ := tk.handleRespondValidation(ownerCtx(),
-			manageArtifactInput{ThreadID: "t1", ValidationResult: "disputed", ValidationReason: "still wrong"})
+			manageFeedbackInput{ThreadID: "t1", ValidationResult: "disputed", ValidationReason: "still wrong"})
 		assert.False(t, res.IsError)
 		assert.Equal(t, "disputed", fts.respondedResult)
 	})
 
 	t.Run("admin can respond", func(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{getResult: authored}, nil)
-		res, _, _ := tk.handleRespondValidation(adminCtx(), manageArtifactInput{ThreadID: "t1", ValidationResult: "validated"})
+		res, _, _ := tk.handleRespondValidation(adminCtx(), manageFeedbackInput{ThreadID: "t1", ValidationResult: "validated"})
 		assert.False(t, res.IsError)
 	})
 
 	t.Run("non-author denied", func(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{getResult: authored}, nil)
-		res, _, _ := tk.handleRespondValidation(strangerCtx(), manageArtifactInput{ThreadID: "t1", ValidationResult: "validated"})
+		res, _, _ := tk.handleRespondValidation(strangerCtx(), manageFeedbackInput{ThreadID: "t1", ValidationResult: "validated"})
 		assert.True(t, res.IsError)
 		assert.Contains(t, decodeResult(t, res)["error"], "only the feedback author")
 	})
 
 	t.Run("invalid validation_result", func(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{getResult: authored}, nil)
-		res, _, _ := tk.handleRespondValidation(ownerCtx(), manageArtifactInput{ThreadID: "t1", ValidationResult: "maybe"})
+		res, _, _ := tk.handleRespondValidation(ownerCtx(), manageFeedbackInput{ThreadID: "t1", ValidationResult: "maybe"})
 		assert.True(t, res.IsError)
 		assert.Contains(t, decodeResult(t, res)["error"], "must be 'validated' or 'disputed'")
 	})
 
 	t.Run("missing thread_id", func(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{}, nil)
-		res, _, _ := tk.handleRespondValidation(ownerCtx(), manageArtifactInput{ValidationResult: "validated"})
+		res, _, _ := tk.handleRespondValidation(ownerCtx(), manageFeedbackInput{ValidationResult: "validated"})
 		assert.True(t, res.IsError)
 	})
 
 	t.Run("thread not found", func(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{getErr: errors.New("nope")}, nil)
-		res, _, _ := tk.handleRespondValidation(ownerCtx(), manageArtifactInput{ThreadID: "t1", ValidationResult: "validated"})
+		res, _, _ := tk.handleRespondValidation(ownerCtx(), manageFeedbackInput{ThreadID: "t1", ValidationResult: "validated"})
 		assert.True(t, res.IsError)
 	})
 
 	t.Run("store error", func(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{getResult: authored, respondErr: errors.New("boom")}, nil)
-		res, _, _ := tk.handleRespondValidation(ownerCtx(), manageArtifactInput{ThreadID: "t1", ValidationResult: "validated"})
+		res, _, _ := tk.handleRespondValidation(ownerCtx(), manageFeedbackInput{ThreadID: "t1", ValidationResult: "validated"})
 		assert.True(t, res.IsError)
 	})
 
 	t.Run("anonymous caller cannot respond", func(t *testing.T) {
 		anonAuthored := &portal.Thread{ID: "t1", TargetType: "asset", AssetID: "asset_1", AuthorID: "anonymous"}
 		tk := threadToolkit(t, &fakeThreadStore{getResult: anonAuthored}, nil)
-		res, _, _ := tk.handleRespondValidation(context.Background(), manageArtifactInput{ThreadID: "t1", ValidationResult: "validated"})
+		res, _, _ := tk.handleRespondValidation(context.Background(), manageFeedbackInput{ThreadID: "t1", ValidationResult: "validated"})
 		assert.True(t, res.IsError)
 	})
 }
@@ -594,7 +651,7 @@ func TestThreadAccessModel(t *testing.T) {
 	t.Run("collection owner allowed", func(t *testing.T) {
 		thread := &portal.Thread{ID: "t1", TargetType: "collection", CollectionID: "collection_1"}
 		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, nil)
-		res, _, _ := tk.handleResolveThread(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		res, _, _ := tk.handleResolveThread(ownerCtx(), manageFeedbackInput{ThreadID: "t1"})
 		assert.False(t, res.IsError)
 	})
 
@@ -602,14 +659,14 @@ func TestThreadAccessModel(t *testing.T) {
 		thread := &portal.Thread{ID: "t1", TargetType: "collection", CollectionID: "collection_1"}
 		shares := &fakeShareStore{collPerm: portal.PermissionEditor}
 		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, shares)
-		res, _, _ := tk.handleResolveThread(strangerCtx(), manageArtifactInput{ThreadID: "t1"})
+		res, _, _ := tk.handleResolveThread(strangerCtx(), manageFeedbackInput{ThreadID: "t1"})
 		assert.False(t, res.IsError)
 	})
 
 	t.Run("collection stranger denied", func(t *testing.T) {
 		thread := &portal.Thread{ID: "t1", TargetType: "collection", CollectionID: "collection_1"}
 		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, nil)
-		res, _, _ := tk.handleResolveThread(strangerCtx(), manageArtifactInput{ThreadID: "t1"})
+		res, _, _ := tk.handleResolveThread(strangerCtx(), manageFeedbackInput{ThreadID: "t1"})
 		assert.True(t, res.IsError)
 	})
 
@@ -617,10 +674,10 @@ func TestThreadAccessModel(t *testing.T) {
 		thread := &portal.Thread{ID: "t1", TargetType: "prompt", PromptID: "p1"}
 		tk := threadToolkit(t, &fakeThreadStore{getResult: thread}, nil)
 		// owner of an unrelated asset is not admin: denied.
-		res, _, _ := tk.handleGetThread(ownerCtx(), manageArtifactInput{ThreadID: "t1"})
+		res, _, _ := tk.handleGetThread(ownerCtx(), manageFeedbackInput{ThreadID: "t1"})
 		assert.True(t, res.IsError)
 		// admin: allowed.
-		res, _, _ = tk.handleGetThread(adminCtx(), manageArtifactInput{ThreadID: "t1"})
+		res, _, _ = tk.handleGetThread(adminCtx(), manageFeedbackInput{ThreadID: "t1"})
 		assert.False(t, res.IsError)
 	})
 
@@ -653,14 +710,14 @@ func TestThreadAccessModel(t *testing.T) {
 		tk := threadToolkit(t, &fakeThreadStore{getResult: standalone}, nil)
 		// context.Background() carries no PlatformContext, so resolveOwnerID is the
 		// "anonymous" sentinel; the guard must fail closed despite the id matching.
-		res, _, _ := tk.handleResolveThread(context.Background(), manageArtifactInput{ThreadID: "t1"})
+		res, _, _ := tk.handleResolveThread(context.Background(), manageFeedbackInput{ThreadID: "t1"})
 		assert.True(t, res.IsError)
 	})
 
 	t.Run("standalone non-moderate readable by anyone", func(t *testing.T) {
 		thread := &portal.Thread{ID: "t1", TargetType: "standalone", AuthorID: ownerID}
 		tk := threadToolkit(t, &fakeThreadStore{getResult: thread, events: []portal.ThreadEvent{}}, nil)
-		res, _, _ := tk.handleGetThread(strangerCtx(), manageArtifactInput{ThreadID: "t1"})
+		res, _, _ := tk.handleGetThread(strangerCtx(), manageFeedbackInput{ThreadID: "t1"})
 		assert.False(t, res.IsError)
 	})
 }

--- a/pkg/toolkits/portal/toolkit.go
+++ b/pkg/toolkits/portal/toolkit.go
@@ -22,8 +22,9 @@ import (
 )
 
 const (
-	saveToolName   = "save_artifact"
-	manageToolName = "manage_artifact"
+	saveToolName     = "save_artifact"
+	manageToolName   = "manage_artifact"
+	feedbackToolName = "manage_feedback"
 
 	// Prompt names registered by the portal toolkit.
 	saveAssetPromptName  = "save-this-as-an-asset"
@@ -56,14 +57,14 @@ const (
 	actionSetSections      = "set_sections"
 	actionSearch           = "search"
 
-	// Feedback thread actions (Phase 2 / #602). No new tools: these extend the
-	// existing manage_artifact dispatch.
-	actionListThreads       = "list_threads"
-	actionGetThread         = "get_thread"
-	actionReplyThread       = "reply_thread"
-	actionResolveThread     = "resolve_thread"
-	actionRequestValidation = "request_validation"
-	actionRespondValidation = "respond_validation"
+	// manage_feedback action names (#618). Feedback is its own tool so agents can
+	// discover it by name; these are the values of its "action" field.
+	fbActionList              = "list"
+	fbActionGet               = "get"
+	fbActionReply             = "reply"
+	fbActionResolve           = "resolve"
+	fbActionRequestValidation = "request_validation"
+	fbActionRespondValidation = "respond_validation"
 
 	// JSON field names used in MCP tool result payloads.
 	fieldAssetID = "asset_id"
@@ -106,17 +107,29 @@ type manageArtifactInput struct {
 	// Query (search action) ranks the caller's assets by relevance to a
 	// free-text query instead of the substring Search filter.
 	Query string `json:"query,omitempty"`
+}
 
-	// Feedback thread fields (Phase 2 / #602).
-	PromptID           string `json:"prompt_id,omitempty"`
-	TargetType         string `json:"target_type,omitempty"`
-	ThreadID           string `json:"thread_id,omitempty"`
-	Body               string `json:"body,omitempty"`
+// manageFeedbackInput defines the input for manage_feedback (#618).
+type manageFeedbackInput struct {
+	Action       string `json:"action"`
+	AssetID      string `json:"asset_id,omitempty"`
+	CollectionID string `json:"collection_id,omitempty"`
+	PromptID     string `json:"prompt_id,omitempty"`
+	TargetType   string `json:"target_type,omitempty"`
+	ThreadID     string `json:"thread_id,omitempty"`
+	Body         string `json:"body,omitempty"`
+
+	// Filters for a targeted list.
 	Status             string `json:"status,omitempty"`
 	ValidationState    string `json:"validation_state,omitempty"`
 	RequiresResolution *bool  `json:"requires_resolution,omitempty"`
-	ValidationResult   string `json:"validation_result,omitempty"`
-	ValidationReason   string `json:"validation_reason,omitempty"`
+
+	// respond_validation outcome.
+	ValidationResult string `json:"validation_result,omitempty"`
+	ValidationReason string `json:"validation_reason,omitempty"`
+
+	Limit  int `json:"limit,omitempty"`
+	Offset int `json:"offset,omitempty"`
 }
 
 // sectionInput defines a collection section in MCP tool input.
@@ -175,6 +188,7 @@ type Toolkit struct {
 	maxContentSize  int
 	embedder        embedding.Provider
 	actions         map[string]manageActionHandler
+	feedbackActions map[string]feedbackActionHandler
 
 	semanticProvider semantic.Provider
 	queryProvider    query.Provider
@@ -213,6 +227,7 @@ func New(cfg Config) *Toolkit {
 		embedder:        cfg.Embedder,
 	}
 	tk.actions = tk.buildActions()
+	tk.feedbackActions = tk.buildFeedbackActions()
 	return tk
 }
 
@@ -242,19 +257,31 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:  manageToolName,
 		Title: "Manage Artifact",
-		Description: "Manages saved artifacts, collections, and human feedback. " +
+		Description: "Manages saved artifacts and collections. " +
 			"Asset actions: list, get, update, delete, list_versions, revert, search. " +
 			"Collection actions: create_collection, list_collections, get_collection, " +
 			"update_collection, delete_collection, set_sections. " +
-			"Feedback actions: list_threads, get_thread, reply_thread, resolve_thread, " +
-			"request_validation, respond_validation (review and respond to feedback left on your artifacts; " +
-			"capture_insight thread_ids=[...] links a thread to the insight that resolves it). " +
 			"Note: 'list' returns full metadata including provenance for each asset. " +
 			"Use 'get' with a specific asset_id for content retrieval. " +
 			"Use 'search' with a 'query' to rank your assets by relevance (semantic + " +
-			"keyword) instead of paging the whole list.",
+			"keyword) instead of paging the whole list. " +
+			"Human feedback on artifacts is handled by the separate manage_feedback tool.",
 		InputSchema: manageArtifactSchema,
 	}, t.handleManageArtifact)
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:  feedbackToolName,
+		Title: "Manage Feedback",
+		Description: "Reviews and responds to human feedback on your work. " +
+			"Call action=list with NO target to get all pending feedback across the assets and collections you own " +
+			"or can edit AND the shared general channel (newest first, excluding your own threads, plus any " +
+			"awaiting your validation) — use this to 'review and act on any pending feedback'. " +
+			"Call action=list with an asset_id/collection_id/prompt_id (or target_type=standalone) to scope to one target. " +
+			"Other actions: get (a thread + its timeline), reply (post a comment), resolve (mark resolved), " +
+			"request_validation, respond_validation (the thread author records validated/disputed via validation_result). " +
+			"capture_insight thread_ids=[...] folds a thread into the knowledge loop and resolves it.",
+		InputSchema: manageFeedbackSchema,
+	}, t.handleManageFeedback)
 
 	t.registerPrompts(s)
 }
@@ -327,7 +354,7 @@ const showAssetsPromptContent = `List my saved assets and artifacts.
 
 // Tools returns the list of tool names provided by this toolkit.
 func (*Toolkit) Tools() []string {
-	return []string{saveToolName, manageToolName}
+	return []string{saveToolName, manageToolName, feedbackToolName}
 }
 
 // SetSemanticProvider sets the semantic metadata provider.
@@ -423,6 +450,20 @@ func (t *Toolkit) handleSaveArtifact(ctx context.Context, _ *mcp.CallToolRequest
 // manageActionHandler is a function that handles a manage_artifact action.
 type manageActionHandler func(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error)
 
+// feedbackActionHandler is a function that handles a manage_feedback action.
+type feedbackActionHandler func(ctx context.Context, input manageFeedbackInput) (*mcp.CallToolResult, any, error)
+
+// handleManageFeedback dispatches to the appropriate manage_feedback action.
+func (t *Toolkit) handleManageFeedback(ctx context.Context, _ *mcp.CallToolRequest, input manageFeedbackInput) (*mcp.CallToolResult, any, error) {
+	handler, ok := t.feedbackActions[input.Action]
+	if !ok {
+		return errorResult(fmt.Sprintf(
+			"invalid action %q: must be one of: list, get, reply, resolve, request_validation, respond_validation",
+			input.Action)), nil, nil
+	}
+	return handler(ctx, input)
+}
+
 // buildActions constructs the action dispatch table, called once during New().
 func (t *Toolkit) buildActions() map[string]manageActionHandler {
 	return map[string]manageActionHandler{
@@ -439,13 +480,18 @@ func (t *Toolkit) buildActions() map[string]manageActionHandler {
 		actionDeleteCollection: t.handleDeleteCollection,
 		actionSetSections:      t.handleSetSections,
 		actionSearch:           t.handleSearch,
+	}
+}
 
-		actionListThreads:       t.handleListThreads,
-		actionGetThread:         t.handleGetThread,
-		actionReplyThread:       t.handleReplyThread,
-		actionResolveThread:     t.handleResolveThread,
-		actionRequestValidation: t.handleRequestValidation,
-		actionRespondValidation: t.handleRespondValidation,
+// buildFeedbackActions constructs the manage_feedback dispatch table (#618).
+func (t *Toolkit) buildFeedbackActions() map[string]feedbackActionHandler {
+	return map[string]feedbackActionHandler{
+		fbActionList:              t.handleListThreads,
+		fbActionGet:               t.handleGetThread,
+		fbActionReply:             t.handleReplyThread,
+		fbActionResolve:           t.handleResolveThread,
+		fbActionRequestValidation: t.handleRequestValidation,
+		fbActionRespondValidation: t.handleRespondValidation,
 	}
 }
 
@@ -455,8 +501,7 @@ func (t *Toolkit) handleManageArtifact(ctx context.Context, _ *mcp.CallToolReque
 	if !ok {
 		return errorResult(fmt.Sprintf(
 			"invalid action %q: must be one of: list, get, update, delete, list_versions, revert, search, "+
-				"create_collection, list_collections, get_collection, update_collection, delete_collection, set_sections, "+
-				"list_threads, get_thread, reply_thread, resolve_thread, request_validation, respond_validation",
+				"create_collection, list_collections, get_collection, update_collection, delete_collection, set_sections",
 			input.Action)), nil, nil
 	}
 	return handler(ctx, input)

--- a/pkg/toolkits/portal/toolkit_test.go
+++ b/pkg/toolkits/portal/toolkit_test.go
@@ -55,7 +55,7 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, "portal", tk.Kind())
 	assert.Equal(t, "test", tk.Name())
 	assert.Equal(t, "", tk.Connection())
-	assert.Equal(t, []string{saveToolName, manageToolName}, tk.Tools())
+	assert.Equal(t, []string{saveToolName, manageToolName, feedbackToolName}, tk.Tools())
 	assert.NoError(t, tk.Close())
 }
 
@@ -519,6 +519,8 @@ func (s *inMemoryAssetStore) GetByIdempotencyKey(_ context.Context, ownerID, key
 func TestRegisterTools(t *testing.T) {
 	tk := New(Config{Name: "test", S3Bucket: "bucket"})
 
+	// AddTool validates each tool's input schema, so a bad manageFeedbackSchema
+	// would panic here.
 	server := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "0.0.1"}, nil)
 	tk.RegisterTools(server)
 
@@ -526,6 +528,7 @@ func TestRegisterTools(t *testing.T) {
 	tools := tk.Tools()
 	assert.Contains(t, tools, saveToolName)
 	assert.Contains(t, tools, manageToolName)
+	assert.Contains(t, tools, feedbackToolName)
 }
 
 func TestSetProviders(t *testing.T) {


### PR DESCRIPTION
Closes #618.

## Why

Agents could already review and respond to feedback *on a named artifact* (the feedback actions added in #602/#603 lived on `manage_artifact`), but there was no way to **discover** what feedback is pending, and general (standalone-channel) feedback was unreachable. So a prompt like "review and act on any pending feedback" forced the agent to enumerate every artifact and poll each one, and it never saw general notes.

This is the agent/MCP counterpart to #617 (the human portal worklist + activity feed). The workflow: the operator builds reports/exports/dashboards/docs with the agent, shares them with a team member, the team member leaves feedback (on an asset, or a general note like "we acquired a company and brand X is now part of our product line"), and the operator asks the agent to review and reply to/act on all of it in one pass.

## What changed

### New `manage_feedback` tool
A dedicated, discoverable tool (not buried sub-actions of `manage_artifact`) with rich actions — the consolidated pattern, not tool explosion, and it fits the `manage_*` convention:

- **`list` with no target** — the entry point. Returns the caller's pending feedback across the **assets and collections they own or can edit AND the shared general channel** (unresolved threads they did not author), plus any threads awaiting their validation, newest first. This is the "review and act on any pending feedback" call.
- **`list` with a target** (`asset_id`/`collection_id`/`prompt_id` or `target_type=standalone`) — threads on that one target, filterable by status / `validation_state` / `requires_resolution`.
- **`get`** — a thread plus its event timeline.
- **`reply`** — append a comment.
- **`resolve`** — mark resolved.
- **`request_validation` / `respond_validation`** — route and answer validation requests.

Agent loop: `list` (no target) → `get` → `reply`/`resolve`/`respond_validation`, and `capture_insight thread_ids=[...]` folds a thread into the knowledge loop and resolves it.

### Moved off `manage_artifact` (breaking change to that tool)
The six feedback actions were **moved** into `manage_feedback` (single home, no duplication). `manage_artifact`'s description, schema, and invalid-action message were slimmed; its feedback input fields moved to a new `manageFeedbackInput`. The `LinkInsight`/`ThreadLinker` bridge and `capture_insight thread_ids` flow are unchanged.

### Shared and reused, not forked
- `ThreadFilter` gains `IncludeStandalone`, `Unresolved`, and `ExcludeAuthorID`/`ExcludeAuthorEmail`; `applyThreadFilter` extracts an author-exclude helper and `threadTargetIDsCond` now ORs in the standalone channel.
- The owned/shared asset+collection gather is extracted into one shared `TargetGatherer` type in `pkg/portal`, now used by the REST worklist, the #617 activity feed, and this tool — replacing the previously forked copies.

## Permissions
Reuse existing gates, no new model: owner/editor for artifact threads (admins see all); the general channel is readable and replyable by any authenticated caller and resolved only by the thread author or an admin. Prompt-thread feedback stays admin-only and is reached by targeting the prompt (`prompt_id`) — it is **not** in the no-target feed (the toolkit has no prompt store); documented so the "every artifact" claim isn't overstated.

## Testing
- `make verify` green (tests, coverage, patch + full lint, security, mutation, doc-check, swagger-check, GoReleaser dry-run).
- New tests: SQL filter-condition tests for the new `ThreadFilter` fields; the cross-artifact pending list (scoping, anonymous guard, store/gather errors); the shared gather; and tool registration against a real `mcp.Server`. Existing feedback handler tests retargeted to `manage_feedback`.
- Adversarial `/code-review` run before verify; applied fixes: corrected the SME validation-queue undercount (reports the true total), guarded the anonymous caller, fixed a stale `reply_thread` error string, and corrected docs that overclaimed "every artifact".
- Docs updated: `docs/server/tools.md`, `docs/knowledge/overview.md`, `docs/llms.txt`, `docs/llms-full.txt`, and schema prose.

## Notes for review
- The `list` response has two shapes by design: targeted returns `{threads, total}`; no-target returns `{pending, pending_total, awaiting_my_validation, awaiting_validation_total}`.
- `Unresolved` means status not in (`resolved`, `wont_fix`); `acknowledged` is intentionally still surfaced (it is not a terminal/dismiss state — `wont_fix` is).
- Verified by unit/integration tests + `make verify`; not yet exercised against a live deployment (needs the new binary running).

