### PR TITLE
fix(portal): render React artifacts under namespaced mount aliases

### DIFF
--- a/ui/src/components/renderers/JsxRenderer.test.tsx
+++ b/ui/src/components/renderers/JsxRenderer.test.tsx
@@ -2,10 +2,16 @@ import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { render } from "@testing-library/react";
 import {
   JsxRenderer,
+  buildJsxIframeHtml,
   transformJsx,
   findComponentName,
   escapeScriptClose,
 } from "./JsxRenderer";
+
+// Count top-level `import React` default-binding declarations. The namespaced
+// alias `import * as __artifactReact` must NOT match.
+const countReactDefaultImports = (html: string): number =>
+  (html.match(/import\s+React\b/g) ?? []).length;
 
 // jsdom does not implement URL.createObjectURL; provide a stub.
 let originalCreateObjectURL: typeof URL.createObjectURL;
@@ -127,6 +133,50 @@ describe("JsxRenderer", () => {
       <JsxRenderer content="function App() { return <div>Hello</div>; }" />,
     );
     expect(URL.createObjectURL).toHaveBeenCalled();
+  });
+});
+
+describe("buildJsxIframeHtml: duplicate React declaration (issue #625)", () => {
+  it("does not inject a second React import when artifact already imports React", () => {
+    // The artifact imports React and does not self-mount, so it takes the
+    // auto-mount path. Before the fix this produced two `import React` lines
+    // and a "Identifier 'React' has already been declared" SyntaxError.
+    const code = `import React from 'react';
+export default function App() { return <div>Hello</div>; }`;
+    const html = buildJsxIframeHtml(code);
+    // Only the artifact's own React import remains; the injected helper uses a
+    // namespaced alias that does not collide.
+    expect(countReactDefaultImports(html)).toBe(1);
+    expect(html).toContain("import * as __artifactReact from 'react'");
+    expect(html).toContain("__artifactReact.createElement(App)");
+  });
+
+  it("injects no bare React import when artifact does not import React", () => {
+    const code = `export default function App() { return <div>Hi</div>; }`;
+    const html = buildJsxIframeHtml(code);
+    expect(countReactDefaultImports(html)).toBe(0);
+    expect(html).toContain(
+      "import { createRoot as __artifactCreateRoot } from 'react-dom/client'",
+    );
+    expect(html).toContain("__artifactCreateRoot(document.getElementById('root'))");
+  });
+
+  it("leaves self-mounting artifacts untouched (no injected helpers)", () => {
+    const code = `import React from 'react';
+import { createRoot } from 'react-dom/client';
+function App() { return <div>Hello</div>; }
+createRoot(document.getElementById('root')).render(<App />);`;
+    const html = buildJsxIframeHtml(code);
+    // Only the artifact's own React import; no namespaced helper injection.
+    expect(countReactDefaultImports(html)).toBe(1);
+    expect(html).not.toContain("__artifactReact");
+    expect(html).not.toContain("__artifactCreateRoot");
+  });
+
+  it("returns a transform-error document for invalid syntax", () => {
+    const html = buildJsxIframeHtml("function {{{");
+    expect(html).toContain("<pre id=\"e\"");
+    expect(html).not.toContain("__artifactReact");
   });
 });
 

--- a/ui/src/components/renderers/JsxRenderer.tsx
+++ b/ui/src/components/renderers/JsxRenderer.tsx
@@ -106,24 +106,31 @@ function showError(text, tag, style) {
   root.appendChild(el);
 }`;
 
-export function JsxRenderer({ content }: { content: string }) {
-  const blobUrl = useMemo(() => {
-    let transformed: string;
-    try {
-      transformed = escapeScriptClose(transformJsx(content));
-    } catch (e) {
-      // If Sucrase fails, show the error in the iframe via textContent (safe).
-      const errMsg =
-        e instanceof Error ? e.message : "JSX transform failed";
-      const html = `<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body><pre id="e" style="${ERROR_STYLE}"></pre>
+/**
+ * Build the full iframe HTML document for a JSX artifact.
+ *
+ * Mount helpers are imported under collision-proof namespaced aliases
+ * (`__artifactReact`, `__artifactCreateRoot`) rather than the bare `React` /
+ * `createRoot` identifiers. Sucrase's automatic JSX runtime preserves the
+ * artifact's own imports, so injecting a bare `import React from 'react'`
+ * would clash with an artifact that already imports React and produce
+ * `SyntaxError: Identifier 'React' has already been declared`.
+ */
+export function buildJsxIframeHtml(content: string): string {
+  let transformed: string;
+  try {
+    transformed = escapeScriptClose(transformJsx(content));
+  } catch (e) {
+    // If Sucrase fails, show the error in the iframe via textContent (safe).
+    const errMsg = e instanceof Error ? e.message : "JSX transform failed";
+    return `<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body><pre id="e" style="${ERROR_STYLE}"></pre>
 <script>document.getElementById('e').textContent=${JSON.stringify(errMsg)};</script></body></html>`;
-      return URL.createObjectURL(new Blob([html], { type: "text/html;charset=utf-8" }));
-    }
+  }
 
-    if (hasMountCode(content)) {
-      // Self-mounting path: content has its own createRoot/render call.
-      // Inject transformed code with import map so bare specifiers resolve.
-      const html = `<!DOCTYPE html>
+  if (hasMountCode(content)) {
+    // Self-mounting path: content has its own createRoot/render call.
+    // Inject transformed code with import map so bare specifiers resolve.
+    return `<!DOCTYPE html>
 <html>
 <head>
   <meta charset="UTF-8">
@@ -148,16 +155,15 @@ ${transformed}
   </script>
 </body>
 </html>`;
-      return URL.createObjectURL(new Blob([html], { type: "text/html;charset=utf-8" }));
-    }
+  }
 
-    // Auto-mount path: detect component name and render it.
-    const componentName = findComponentName(content);
-    const mountCall = componentName
-      ? `createRoot(document.getElementById('root')).render(React.createElement(${componentName}));`
-      : `showError('No component found. Use export default function MyComponent() {...}', 'p', 'color:#f59e0b;padding:16px;font-family:system-ui');`;
+  // Auto-mount path: detect component name and render it.
+  const componentName = findComponentName(content);
+  const mountCall = componentName
+    ? `__artifactCreateRoot(document.getElementById('root')).render(__artifactReact.createElement(${componentName}));`
+    : `showError('No component found. Use export default function MyComponent() {...}', 'p', 'color:#f59e0b;padding:16px;font-family:system-ui');`;
 
-    const html = `<!DOCTYPE html>
+  return `<!DOCTYPE html>
 <html>
 <head>
   <meta charset="UTF-8">
@@ -171,8 +177,8 @@ ${transformed}
 <body>
   <div id="root"></div>
   <script type="module">
-import React from 'react';
-import { createRoot } from 'react-dom/client';
+import * as __artifactReact from 'react';
+import { createRoot as __artifactCreateRoot } from 'react-dom/client';
 
 ${SHOW_ERROR_FN}
 window.onerror = function(msg, src, line, col, err) {
@@ -192,7 +198,14 @@ try {
   </script>
 </body>
 </html>`;
-    return URL.createObjectURL(new Blob([html], { type: "text/html;charset=utf-8" }));
+}
+
+export function JsxRenderer({ content }: { content: string }) {
+  const blobUrl = useMemo(() => {
+    const html = buildJsxIframeHtml(content);
+    return URL.createObjectURL(
+      new Blob([html], { type: "text/html;charset=utf-8" }),
+    );
   }, [content]);
 
   useEffect(() => {

--- a/ui/src/lib/thumbnail.test.ts
+++ b/ui/src/lib/thumbnail.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { buildJsxThumbnailHtml, injectCaptureScript } from "./thumbnail";
+
+// Count top-level `import React` default-binding declarations. The namespaced
+// alias `import * as __artifactReact` must NOT match.
+const countReactDefaultImports = (html: string): number =>
+  (html.match(/import\s+React\b/g) ?? []).length;
+
+describe("buildJsxThumbnailHtml: duplicate React declaration (issue #625)", () => {
+  it("does not inject a second React import when artifact already imports React", () => {
+    const code = `import React from 'react';
+export default function App() { return <div>Hello</div>; }`;
+    const html = buildJsxThumbnailHtml(code);
+    expect(countReactDefaultImports(html)).toBe(1);
+    expect(html).toContain("import * as __artifactReact from 'react'");
+    expect(html).toContain("__artifactReact.createElement(App)");
+  });
+
+  it("injects no bare React import when artifact does not import React", () => {
+    const code = `export default function App() { return <div>Hi</div>; }`;
+    const html = buildJsxThumbnailHtml(code);
+    expect(countReactDefaultImports(html)).toBe(0);
+    expect(html).toContain(
+      "import { createRoot as __artifactCreateRoot } from 'react-dom/client'",
+    );
+  });
+
+  it("leaves self-mounting artifacts untouched (no injected helpers)", () => {
+    const code = `import React from 'react';
+import { createRoot } from 'react-dom/client';
+function App() { return <div>Hello</div>; }
+createRoot(document.getElementById('root')).render(<App />);`;
+    const html = buildJsxThumbnailHtml(code);
+    expect(countReactDefaultImports(html)).toBe(1);
+    expect(html).not.toContain("__artifactReact");
+    expect(html).not.toContain("__artifactCreateRoot");
+  });
+
+  it("returns a notifier document on transform failure", () => {
+    const html = buildJsxThumbnailHtml("function {{{");
+    expect(html).toContain("thumbnail-ready");
+    expect(html).not.toContain("__artifactReact");
+  });
+});
+
+describe("injectCaptureScript", () => {
+  it("inserts the ready notifier before </body>", () => {
+    const html = "<html><body><div>content</div></body></html>";
+    const out = injectCaptureScript(html);
+    expect(out).toContain("thumbnail-ready");
+    expect(out.indexOf("thumbnail-ready")).toBeLessThan(out.indexOf("</body>"));
+  });
+
+  it("appends the notifier when no </body> is present", () => {
+    const html = "<div>content</div>";
+    const out = injectCaptureScript(html);
+    expect(out.startsWith(html)).toBe(true);
+    expect(out).toContain("thumbnail-ready");
+  });
+});

--- a/ui/src/lib/thumbnail.ts
+++ b/ui/src/lib/thumbnail.ts
@@ -135,15 +135,18 @@ export function buildJsxThumbnailHtml(content: string): string {
     /\bReactDOM\s*\.\s*render\s*\(/.test(content);
 
   const componentName = findComponentName(content);
+  // Mount helpers use collision-proof namespaced aliases so an artifact that
+  // already imports React (preserved by Sucrase's automatic runtime) does not
+  // produce "Identifier 'React' has already been declared". See JsxRenderer.
   const mountSection = hasMountCode
     ? transformed
-    : `import React from 'react';
-import { createRoot } from 'react-dom/client';
+    : `import * as __artifactReact from 'react';
+import { createRoot as __artifactCreateRoot } from 'react-dom/client';
 
 ${transformed}
 
 try {
-  ${componentName ? `createRoot(document.getElementById('root')).render(React.createElement(${componentName}));` : ""}
+  ${componentName ? `__artifactCreateRoot(document.getElementById('root')).render(__artifactReact.createElement(${componentName}));` : ""}
 } catch(e) {
   document.getElementById('root').textContent = e.message;
 }`;


### PR DESCRIPTION
Fixes #625.

## Problem

React component artifacts failed to render with `Uncaught SyntaxError: Identifier 'React' has already been declared` whenever the artifact source contained an explicit `import React from 'react'` and did not mount itself. The same defect existed in the thumbnail generator, so both the viewer and its thumbnail broke for this entire class of artifacts.

## Root cause

`JsxRenderer.tsx` selects a render path via `hasMountCode()`. An artifact that imports React but does not call `createRoot()`/`ReactDOM.render()` takes the auto-mount path, which unconditionally prepended:

```js
import React from 'react';
import { createRoot } from 'react-dom/client';
```

`transformJsx` uses Sucrase with `jsxRuntime: "automatic"`, which preserves the artifact's own imports (it only adds the `react/jsx-runtime` import). The module therefore ended up with two top-level `React` bindings, which is a hard `SyntaxError`, so nothing mounted and the artifact rendered blank. `buildJsxThumbnailHtml()` injected the identical prelude and had the same defect.

## Fix

Inject the mount helpers under collision-proof namespaced aliases instead of the bare identifiers, in both `JsxRenderer.tsx` and `thumbnail.ts`:

```js
import * as __artifactReact from 'react';
import { createRoot as __artifactCreateRoot } from 'react-dom/client';
...
__artifactCreateRoot(document.getElementById('root'))
  .render(__artifactReact.createElement(ComponentName));
```

This is more robust than stripping the artifact's `import React`, which would also have to handle `import React, { useState }`, namespace imports, and `ReactDOM` aliases. `createElement` is a named export on the esm.sh react@19 module namespace (same path `useState` already resolves through), so `__artifactReact.createElement` behaves identically to the previous `React.createElement`.

The iframe-HTML construction was extracted into a pure, exported `buildJsxIframeHtml(content)` so the generated document can be asserted directly in tests.

## Tests

Regression tests in `JsxRenderer.test.tsx` and a new `thumbnail.test.ts` assert that the auto-mount output:
- has at most one top-level `import React` (the artifact's own, when present),
- uses the namespaced helpers, and
- leaves self-mount and no-import artifacts unchanged.

## Verification

- `tsc -b` clean
- `eslint` clean
- `vitest run` 192/192 pass
- `vite build` succeeds

## Out of scope

`JsxRenderer.tsx` and `thumbnail.ts` duplicate the iframe-HTML prelude (CSP, import map, mount helpers), which is why this fix had to be applied in two places. Consolidating them behind a shared builder is a worthwhile follow-up but is left out of this change to keep the fix focused.
