### PR TITLE
feat(portal): theme-aware thumbnails and configurable OIDC login label

### DIFF
--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -348,6 +348,8 @@ tuning:
 # portal:
 #   enabled: true                                             # single flag to enable portal SPA + API
 #   title: "My Data Platform"                                 # sidebar/branding title (default: "MCP Data Platform")
+#   tagline: "Sign in to access the platform."                # login-screen subtitle (default: "Sign in to access the platform.")
+#   oidc_button_label: "Sign in with ACME Keycloak"           # login-screen SSO button text (default: "Sign in with OIDC")
 #   logo: https://example.com/logo.svg                        # logo URL, used if no light/dark specified
 #   logo_light: https://example.com/logo-dark.svg             # logo for light theme
 #   logo_dark: https://example.com/logo-white.svg             # logo for dark theme

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3073,7 +3073,7 @@ into a polished experience, and saved assets gained preview thumbnails and full
 version history so nothing is ever lost.
 
 - **A polished sharing experience.** A large investment in the public viewer: dark mode, expiration notices, sharing by email with permission levels, "save to my assets," view counts, and branded headers on shared links.
-- **Preview thumbnails and version history.** Saved assets get automatic preview thumbnails and full version history, including the ability to revert to an earlier version.
+- **Preview thumbnails and version history.** Saved assets get automatic preview thumbnails and full version history, including the ability to revert to an earlier version. Markdown and CSV previews are captured in both light and dark variants so the asset grid matches the active theme; self-themed content (HTML, JSX, SVG) uses a single preview in both modes, and public shares always use the light variant.
 - **One-click prompt workflows.** A reusable prompt system with categories and workflow prompts.
 - **Spreadsheet exports.** Save and download results as CSV.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -383,6 +383,8 @@ Branding fields have moved to the `portal:` section:
 |-------|------|---------|-------------|
 | `portal.enabled` | bool | `false` | Enable portal SPA frontend and artifact API |
 | `portal.title` | string | `MCP Data Platform` | Sidebar/branding title text |
+| `portal.tagline` | string | `Sign in to access the platform.` | Login-screen subtitle text |
+| `portal.oidc_button_label` | string | `Sign in with OIDC` | Login-screen SSO button text (e.g. "Sign in with ACME Keycloak") |
 | `portal.logo` | string | `""` | Logo URL (fallback for both themes) |
 | `portal.logo_light` | string | `""` | Logo URL for light theme |
 | `portal.logo_dark` | string | `""` | Logo URL for dark theme |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -650,6 +650,8 @@ The asset portal persists AI-generated artifacts (JSX dashboards, HTML reports, 
 portal:
   enabled: true
   title: "ACME Data Platform"                    # Sidebar/branding title
+  tagline: "Sign in to access your data."        # Login-screen subtitle
+  oidc_button_label: "Sign in with ACME Keycloak" # Login-screen SSO button text
   logo: https://example.com/logo.svg             # Logo URL (fallback for both themes)
   logo_light: https://example.com/logo-light.svg # Logo for light theme
   logo_dark: https://example.com/logo-dark.svg   # Logo for dark theme
@@ -674,6 +676,8 @@ portal:
 |--------|------|---------|-------------|
 | `portal.enabled` | bool | `false` | Enable the portal SPA frontend and artifact API |
 | `portal.title` | string | `MCP Data Platform` | Sidebar/branding title text |
+| `portal.tagline` | string | `Sign in to access the platform.` | Login-screen subtitle text |
+| `portal.oidc_button_label` | string | `Sign in with OIDC` | Login-screen SSO button text (set to a name your users recognize, e.g. "Sign in with ACME Keycloak") |
 | `portal.logo` | string | `""` | URL to logo image (used for both themes if no theme-specific logo is set) |
 | `portal.logo_light` | string | `""` | URL to logo for light theme (overrides `logo`) |
 | `portal.logo_dark` | string | `""` | URL to logo for dark theme (overrides `logo`) |

--- a/docs/server/portal-user.md
+++ b/docs/server/portal-user.md
@@ -32,6 +32,7 @@ Features:
 - **Filters** — Content type dropdown (HTML, JSX, SVG, Markdown, CSV) and tag filter
 - **View toggle** — Switch between grid (card thumbnails) and table view; preference persisted to localStorage
 - **Grid cards** — 4:3 thumbnail previews with content type icon, tags, collection badges, file size, and sharing indicators
+- **Theme-aware thumbnails** — Markdown and CSV previews are captured in both light and dark variants, and the grid shows the one matching your active theme. Self-themed content (HTML, JSX, SVG) carries its own colors, so a single preview is used in both modes. Public shares always use the light variant.
 - **Table rows** — Sortable columns for name, type, tags, collections, size, sharing, and creation date
 
 ### Asset Viewer

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -7469,7 +7469,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Downloads the asset's PNG thumbnail image.",
+                "description": "Downloads the asset's PNG thumbnail image. The dark variant\nfalls back to the light/default thumbnail when none was captured.",
                 "produces": [
                     "image/png"
                 ],
@@ -7484,6 +7484,16 @@ const docTemplate = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "light",
+                            "dark"
+                        ],
+                        "type": "string",
+                        "description": "Thumbnail variant",
+                        "name": "variant",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -7558,6 +7568,16 @@ const docTemplate = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "light",
+                            "dark"
+                        ],
+                        "type": "string",
+                        "description": "Thumbnail variant",
+                        "name": "variant",
+                        "in": "query"
                     },
                     {
                         "description": "PNG image data",
@@ -14386,6 +14406,11 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "thumbnail_dark_s3_key": {
+                    "description": "ThumbnailDarkS3Key holds the dark-mode thumbnail variant. Only populated\nfor content types rendered on a forced background (markdown, CSV); types\nwith a built-in theme (HTML, JSX, SVG) reuse ThumbnailS3Key in both modes.\nEmpty means callers should fall back to ThumbnailS3Key.",
+                    "type": "string",
+                    "example": "assets/01HK7R8Z/thumbnail_dark.png"
+                },
                 "thumbnail_s3_key": {
                     "type": "string",
                     "example": "assets/01HK7R8Z/thumb.png"
@@ -14982,6 +15007,11 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "thumbnail_dark_s3_key": {
+                    "description": "ThumbnailDarkS3Key holds the dark-mode thumbnail variant. Only populated\nfor content types rendered on a forced background (markdown, CSV); types\nwith a built-in theme (HTML, JSX, SVG) reuse ThumbnailS3Key in both modes.\nEmpty means callers should fall back to ThumbnailS3Key.",
+                    "type": "string",
+                    "example": "assets/01HK7R8Z/thumbnail_dark.png"
                 },
                 "thumbnail_s3_key": {
                     "type": "string",

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -7463,7 +7463,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Downloads the asset's PNG thumbnail image.",
+                "description": "Downloads the asset's PNG thumbnail image. The dark variant\nfalls back to the light/default thumbnail when none was captured.",
                 "produces": [
                     "image/png"
                 ],
@@ -7478,6 +7478,16 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "light",
+                            "dark"
+                        ],
+                        "type": "string",
+                        "description": "Thumbnail variant",
+                        "name": "variant",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -7552,6 +7562,16 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "light",
+                            "dark"
+                        ],
+                        "type": "string",
+                        "description": "Thumbnail variant",
+                        "name": "variant",
+                        "in": "query"
                     },
                     {
                         "description": "PNG image data",
@@ -14380,6 +14400,11 @@
                         "type": "string"
                     }
                 },
+                "thumbnail_dark_s3_key": {
+                    "description": "ThumbnailDarkS3Key holds the dark-mode thumbnail variant. Only populated\nfor content types rendered on a forced background (markdown, CSV); types\nwith a built-in theme (HTML, JSX, SVG) reuse ThumbnailS3Key in both modes.\nEmpty means callers should fall back to ThumbnailS3Key.",
+                    "type": "string",
+                    "example": "assets/01HK7R8Z/thumbnail_dark.png"
+                },
                 "thumbnail_s3_key": {
                     "type": "string",
                     "example": "assets/01HK7R8Z/thumb.png"
@@ -14976,6 +15001,11 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "thumbnail_dark_s3_key": {
+                    "description": "ThumbnailDarkS3Key holds the dark-mode thumbnail variant. Only populated\nfor content types rendered on a forced background (markdown, CSV); types\nwith a built-in theme (HTML, JSX, SVG) reuse ThumbnailS3Key in both modes.\nEmpty means callers should fall back to ThumbnailS3Key.",
+                    "type": "string",
+                    "example": "assets/01HK7R8Z/thumbnail_dark.png"
                 },
                 "thumbnail_s3_key": {
                     "type": "string",

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -2443,6 +2443,14 @@ definitions:
         items:
           type: string
         type: array
+      thumbnail_dark_s3_key:
+        description: |-
+          ThumbnailDarkS3Key holds the dark-mode thumbnail variant. Only populated
+          for content types rendered on a forced background (markdown, CSV); types
+          with a built-in theme (HTML, JSX, SVG) reuse ThumbnailS3Key in both modes.
+          Empty means callers should fall back to ThumbnailS3Key.
+        example: assets/01HK7R8Z/thumbnail_dark.png
+        type: string
       thumbnail_s3_key:
         example: assets/01HK7R8Z/thumb.png
         type: string
@@ -2855,6 +2863,14 @@ definitions:
         items:
           type: string
         type: array
+      thumbnail_dark_s3_key:
+        description: |-
+          ThumbnailDarkS3Key holds the dark-mode thumbnail variant. Only populated
+          for content types rendered on a forced background (markdown, CSV); types
+          with a built-in theme (HTML, JSX, SVG) reuse ThumbnailS3Key in both modes.
+          Empty means callers should fall back to ThumbnailS3Key.
+        example: assets/01HK7R8Z/thumbnail_dark.png
+        type: string
       thumbnail_s3_key:
         example: assets/01HK7R8Z/thumb.png
         type: string
@@ -8115,12 +8131,21 @@ paths:
       - Feedback
   /portal/assets/{id}/thumbnail:
     get:
-      description: Downloads the asset's PNG thumbnail image.
+      description: |-
+        Downloads the asset's PNG thumbnail image. The dark variant
+        falls back to the light/default thumbnail when none was captured.
       parameters:
       - description: Asset ID
         in: path
         name: id
         required: true
+        type: string
+      - description: Thumbnail variant
+        enum:
+        - light
+        - dark
+        in: query
+        name: variant
         type: string
       produces:
       - image/png
@@ -8168,6 +8193,13 @@ paths:
         in: path
         name: id
         required: true
+        type: string
+      - description: Thumbnail variant
+        enum:
+        - light
+        - dark
+        in: query
+        name: variant
         type: string
       - description: PNG image data
         in: body

--- a/pkg/admin/system.go
+++ b/pkg/admin/system.go
@@ -92,6 +92,7 @@ type publicBrandingResponse struct {
 	Version         string `json:"version" example:"1.55.11"`
 	PortalTitle     string `json:"portal_title" example:"ACME Data Platform"`
 	PortalTagline   string `json:"portal_tagline" example:"Sign in to access your data."`
+	OIDCButtonLabel string `json:"oidc_button_label" example:"Sign in with ACME Keycloak"`
 	PortalLogo      string `json:"portal_logo" example:"https://example.com/logo.svg"`
 	PortalLogoLight string `json:"portal_logo_light" example:"https://example.com/logo-light.svg"`
 	PortalLogoDark  string `json:"portal_logo_dark" example:"https://example.com/logo-dark.svg"`
@@ -108,6 +109,7 @@ func (h *Handler) getPublicBranding(w http.ResponseWriter, _ *http.Request) {
 		resp.Name = h.deps.Config.Server.Name
 		resp.PortalTitle = h.deps.Config.Portal.Title
 		resp.PortalTagline = h.deps.Config.Portal.Tagline
+		resp.OIDCButtonLabel = h.deps.Config.Portal.OIDCButtonLabel
 		resp.PortalLogo = h.deps.Config.Portal.Logo
 		resp.PortalLogoLight = h.deps.Config.Portal.LogoLight
 		resp.PortalLogoDark = h.deps.Config.Portal.LogoDark

--- a/pkg/admin/system_test.go
+++ b/pkg/admin/system_test.go
@@ -131,6 +131,7 @@ func TestGetPublicBranding(t *testing.T) {
 		cfg := testConfig()
 		cfg.Server.Name = "acme-platform"
 		cfg.Portal.Title = "ACME Admin"
+		cfg.Portal.OIDCButtonLabel = "Sign in with ACME Keycloak"
 		cfg.Portal.Logo = "https://cdn.example.com/acme-logo.svg"
 		cfg.Portal.LogoLight = "https://cdn.example.com/acme-light.svg"
 		cfg.Portal.LogoDark = "https://cdn.example.com/acme-dark.svg"
@@ -147,6 +148,7 @@ func TestGetPublicBranding(t *testing.T) {
 		assert.Equal(t, "acme-platform", body.Name)
 		assert.NotEmpty(t, body.Version)
 		assert.Equal(t, "ACME Admin", body.PortalTitle)
+		assert.Equal(t, "Sign in with ACME Keycloak", body.OIDCButtonLabel)
 		assert.Equal(t, "https://cdn.example.com/acme-logo.svg", body.PortalLogo)
 		assert.Equal(t, "https://cdn.example.com/acme-light.svg", body.PortalLogoLight)
 		assert.Equal(t, "https://cdn.example.com/acme-dark.svg", body.PortalLogoDark)

--- a/pkg/database/migrate/migrate_realpg_test.go
+++ b/pkg/database/migrate/migrate_realpg_test.go
@@ -14,7 +14,7 @@ import (
 
 // expectedFinalVersion is the highest migration the embedded set defines. Bump
 // this when adding a migration so the gate asserts the full set applied.
-const expectedFinalVersion = 67
+const expectedFinalVersion = 68
 
 // TestMigrationsAgainstRealPostgres applies the embedded migrations to a real
 // PostgreSQL (pgvector) instance and exercises the full lifecycle: up, seed,

--- a/pkg/database/migrate/migrate_unit_test.go
+++ b/pkg/database/migrate/migrate_unit_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	migrateTestFileCount    = 134
+	migrateTestFileCount    = 136
 	migrateTestSuccess      = "success"
 	migrateTestFactoryError = "factory error"
 )

--- a/pkg/database/migrate/migrations/000068_portal_asset_thumbnail_dark.down.sql
+++ b/pkg/database/migrate/migrations/000068_portal_asset_thumbnail_dark.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE portal_assets DROP COLUMN IF EXISTS thumbnail_dark_s3_key;

--- a/pkg/database/migrate/migrations/000068_portal_asset_thumbnail_dark.up.sql
+++ b/pkg/database/migrate/migrations/000068_portal_asset_thumbnail_dark.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE portal_assets ADD COLUMN thumbnail_dark_s3_key TEXT NOT NULL DEFAULT '';

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -194,20 +194,21 @@ const (
 // PortalConfig configures the asset portal for saving AI-generated artifacts.
 // Enabled by default when a database is available. Set enabled: false to disable.
 type PortalConfig struct {
-	Enabled        *bool                 `yaml:"enabled"`
-	Title          string                `yaml:"title"`            // sidebar/branding title (default: "MCP Data Platform")
-	Tagline        string                `yaml:"tagline"`          // login-screen subtitle (default: "Sign in to access the platform.")
-	Logo           string                `yaml:"logo"`             // URL to logo (fallback for both themes)
-	LogoLight      string                `yaml:"logo_light"`       // URL to logo for light theme
-	LogoDark       string                `yaml:"logo_dark"`        // URL to logo for dark theme
-	S3Connection   string                `yaml:"s3_connection"`    // name of the S3 toolkit instance to use
-	S3Bucket       string                `yaml:"s3_bucket"`        // bucket for artifact storage (default: "portal-assets")
-	S3Prefix       string                `yaml:"s3_prefix"`        // key prefix within the bucket (default: "artifacts/")
-	PublicBaseURL  string                `yaml:"public_base_url"`  // base URL for portal links (e.g., "https://portal.example.com")
-	MaxContentSize int                   `yaml:"max_content_size"` // max artifact size in bytes (default: 10MB)
-	Implementor    ImplementorConfig     `yaml:"implementor"`      // optional implementor brand (far-left header zone)
-	RateLimit      PortalRateLimitConfig `yaml:"rate_limit"`
-	Export         PortalExportConfig    `yaml:"export"` // trino_export configuration
+	Enabled         *bool                 `yaml:"enabled"`
+	Title           string                `yaml:"title"`             // sidebar/branding title (default: "MCP Data Platform")
+	Tagline         string                `yaml:"tagline"`           // login-screen subtitle (default: "Sign in to access the platform.")
+	OIDCButtonLabel string                `yaml:"oidc_button_label"` // login-screen SSO button text (default: "Sign in with OIDC")
+	Logo            string                `yaml:"logo"`              // URL to logo (fallback for both themes)
+	LogoLight       string                `yaml:"logo_light"`        // URL to logo for light theme
+	LogoDark        string                `yaml:"logo_dark"`         // URL to logo for dark theme
+	S3Connection    string                `yaml:"s3_connection"`     // name of the S3 toolkit instance to use
+	S3Bucket        string                `yaml:"s3_bucket"`         // bucket for artifact storage (default: "portal-assets")
+	S3Prefix        string                `yaml:"s3_prefix"`         // key prefix within the bucket (default: "artifacts/")
+	PublicBaseURL   string                `yaml:"public_base_url"`   // base URL for portal links (e.g., "https://portal.example.com")
+	MaxContentSize  int                   `yaml:"max_content_size"`  // max artifact size in bytes (default: 10MB)
+	Implementor     ImplementorConfig     `yaml:"implementor"`       // optional implementor brand (far-left header zone)
+	RateLimit       PortalRateLimitConfig `yaml:"rate_limit"`
+	Export          PortalExportConfig    `yaml:"export"` // trino_export configuration
 }
 
 // PortalExportConfig configures the trino_export tool.

--- a/pkg/portal/asset_search.go
+++ b/pkg/portal/asset_search.go
@@ -16,7 +16,7 @@ var _ AssetSearcher = (*postgresAssetStore)(nil)
 // assetScanDest order so the scan cannot drift from the query. It matches the
 // list-path projection (queryAssets) plus the COALESCE on idempotency_key.
 const assetSearchColumns = `id, owner_id, owner_email, name, description, content_type, ` +
-	`s3_bucket, s3_key, thumbnail_s3_key, size_bytes, tags, provenance, session_id, ` +
+	`s3_bucket, s3_key, thumbnail_s3_key, thumbnail_dark_s3_key, size_bytes, tags, provenance, session_id, ` +
 	`current_version, created_at, updated_at, deleted_at, COALESCE(idempotency_key, '')`
 
 // assetFTSExpr is the full-text expression the lexical arm matches and ranks

--- a/pkg/portal/asset_search_test.go
+++ b/pkg/portal/asset_search_test.go
@@ -15,7 +15,7 @@ import (
 // assetSearchColumns / assetScanDest order. sqlmock scans positionally.
 var assetSearchCols = []string{
 	"id", "owner_id", "owner_email", "name", "description", "content_type",
-	"s3_bucket", "s3_key", "thumbnail_s3_key", "size_bytes", "tags", "provenance",
+	"s3_bucket", "s3_key", "thumbnail_s3_key", "thumbnail_dark_s3_key", "size_bytes", "tags", "provenance",
 	"session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
 }
 
@@ -23,7 +23,7 @@ func addAssetRow(rows *sqlmock.Rows, id, name string, extra ...driverValueList) 
 	now := time.Now()
 	base := []driver.Value{
 		id, "u1", "alice@example.com", name, "desc", "text/html",
-		"bucket", "key", "", int64(10), []byte(`["t"]`), []byte(`{}`),
+		"bucket", "key", "", "", int64(10), []byte(`["t"]`), []byte(`{}`),
 		"", 1, now, now, nil, "",
 	}
 	for _, e := range extra {
@@ -166,7 +166,7 @@ func TestSearchAssets_HybridScanError(t *testing.T) {
 	now := time.Now()
 	rows := sqlmock.NewRows(append(append([]string{}, assetSearchCols...), "vec_score", "lex_match")).
 		AddRow("a-1", "u1", "alice@example.com", "n", "d", "text/html",
-			"b", "k", "", int64(1), []byte("not json"), []byte(`{}`),
+			"b", "k", "", "", int64(1), []byte("not json"), []byte(`{}`),
 			"", 1, now, now, nil, "", 0.5, true)
 	mock.ExpectQuery("UNION ALL").WillReturnRows(rows)
 

--- a/pkg/portal/collection_store_test.go
+++ b/pkg/portal/collection_store_test.go
@@ -546,13 +546,13 @@ func TestGetByIDsSuccess(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{
 		"id", "owner_id", "owner_email", "name", "description", "content_type", "s3_bucket", "s3_key",
-		"thumbnail_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version",
+		"thumbnail_s3_key", "thumbnail_dark_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version",
 		"created_at", "updated_at", "deleted_at", "idempotency_key",
 	}).
 		AddRow("a1", "u1", "u1@test.com", "Asset 1", "desc1", "text/html", "bucket", "k1",
-			"", int64(100), tags, prov, "s1", 1, now, now, nil, "").
+			"", "", int64(100), tags, prov, "s1", 1, now, now, nil, "").
 		AddRow("a2", "u1", "u1@test.com", "Asset 2", "desc2", "image/svg+xml", "bucket", "k2",
-			"thumb.png", int64(200), tags, prov, "s1", 1, now, now, nil, "")
+			"thumb.png", "", int64(200), tags, prov, "s1", 1, now, now, nil, "")
 
 	mock.ExpectQuery("SELECT .+ FROM portal_assets WHERE id").
 		WithArgs(sqlmock.AnyArg()).

--- a/pkg/portal/handler.go
+++ b/pkg/portal/handler.go
@@ -600,8 +600,9 @@ func (h *Handler) updateAssetContent(w http.ResponseWriter, r *http.Request) {
 // @Tags         Assets
 // @Accept       png
 // @Produce      json
-// @Param        id    path  string  true  "Asset ID"
-// @Param        body  body  []byte  true  "PNG image data"
+// @Param        id       path   string  true   "Asset ID"
+// @Param        variant  query  string  false  "Thumbnail variant"  Enums(light, dark)
+// @Param        body     body   []byte  true   "PNG image data"
 // @Success      200  {object}  statusResponse
 // @Failure      400  {object}  problemDetail
 // @Failure      401  {object}  problemDetail
@@ -641,7 +642,12 @@ func (h *Handler) uploadThumbnail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	thumbKey := DeriveThumbnailKey(asset.S3Key)
+	variant, ok := parseThumbnailVariant(w, r)
+	if !ok {
+		return
+	}
+
+	thumbKey := DeriveThumbnailKeyVariant(asset.S3Key, variant)
 	if err := h.deps.S3Client.PutObject(r.Context(), asset.S3Bucket, thumbKey, data, mimeTypePNG); err != nil {
 		writeError(w, http.StatusServiceUnavailable, "failed to upload thumbnail")
 		return
@@ -649,6 +655,9 @@ func (h *Handler) uploadThumbnail(w http.ResponseWriter, r *http.Request) {
 
 	id := r.PathValue(pathKeyID)
 	updates := AssetUpdate{ThumbnailS3Key: &thumbKey}
+	if variant == thumbnailVariantDark {
+		updates = AssetUpdate{ThumbnailDarkS3Key: &thumbKey}
+	}
 	if err := h.deps.AssetStore.Update(r.Context(), id, updates); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update asset metadata")
 		return
@@ -689,10 +698,12 @@ func (h *Handler) requireOwnedAsset(w http.ResponseWriter, r *http.Request) (*As
 // getThumbnail handles GET /api/v1/portal/assets/{id}/thumbnail.
 //
 // @Summary      Get asset thumbnail
-// @Description  Downloads the asset's PNG thumbnail image.
+// @Description  Downloads the asset's PNG thumbnail image. The dark variant
+// @Description  falls back to the light/default thumbnail when none was captured.
 // @Tags         Assets
 // @Produce      png
-// @Param        id  path  string  true  "Asset ID"
+// @Param        id       path   string  true   "Asset ID"
+// @Param        variant  query  string  false  "Thumbnail variant"  Enums(light, dark)
 // @Success      200  {file}  binary
 // @Failure      401  {object}  problemDetail
 // @Failure      403  {object}  problemDetail
@@ -726,7 +737,13 @@ func (h *Handler) getThumbnail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if asset.ThumbnailS3Key == "" {
+	variant, ok := parseThumbnailVariant(w, r)
+	if !ok {
+		return
+	}
+
+	thumbKey := resolveThumbnailKey(asset, variant)
+	if thumbKey == "" {
 		writeError(w, http.StatusNotFound, "no thumbnail available")
 		return
 	}
@@ -736,7 +753,7 @@ func (h *Handler) getThumbnail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, _, err := h.deps.S3Client.GetObject(r.Context(), asset.S3Bucket, asset.ThumbnailS3Key)
+	data, _, err := h.deps.S3Client.GetObject(r.Context(), asset.S3Bucket, thumbKey)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to retrieve thumbnail")
 		return
@@ -749,13 +766,61 @@ func (h *Handler) getThumbnail(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(data) // #nosec G705 -- content served as image/png, not rendered as HTML
 }
 
-// DeriveThumbnailKey replaces the filename in an S3 key with "thumbnail.png".
+// Thumbnail variant identifiers and the S3 filenames they map to. Light is the
+// default/shared variant (used by single-theme content and public shares); dark
+// is captured only for content rendered on a forced background (markdown, CSV).
+const (
+	thumbnailVariantLight  = "light"
+	thumbnailVariantDark   = "dark"
+	thumbnailLightFilename = "thumbnail.png"
+	thumbnailDarkFilename  = "thumbnail_dark.png"
+)
+
+// parseThumbnailVariant reads the optional ?variant= query parameter. An empty
+// value defaults to light. Any value other than "light" or "dark" is rejected
+// with 400. Returns the normalized variant and true on success; on failure it
+// writes the error response and returns false.
+func parseThumbnailVariant(w http.ResponseWriter, r *http.Request) (string, bool) {
+	switch r.URL.Query().Get("variant") {
+	case "", thumbnailVariantLight:
+		return thumbnailVariantLight, true
+	case thumbnailVariantDark:
+		return thumbnailVariantDark, true
+	default:
+		writeError(w, http.StatusBadRequest, "variant must be 'light' or 'dark'")
+		return "", false
+	}
+}
+
+// resolveThumbnailKey returns the stored S3 key to serve for the requested
+// variant. The dark variant falls back to the light/default key when no dark
+// variant has been captured (built-in-theme types only ever store light).
+func resolveThumbnailKey(asset *Asset, variant string) string {
+	if variant == thumbnailVariantDark && asset.ThumbnailDarkS3Key != "" {
+		return asset.ThumbnailDarkS3Key
+	}
+	return asset.ThumbnailS3Key
+}
+
+// DeriveThumbnailKey replaces the filename in an S3 key with "thumbnail.png"
+// (the light/default variant).
 func DeriveThumbnailKey(s3Key string) string {
+	return DeriveThumbnailKeyVariant(s3Key, thumbnailVariantLight)
+}
+
+// DeriveThumbnailKeyVariant replaces the filename in an S3 key with the
+// thumbnail filename for the given variant ("dark" -> thumbnail_dark.png,
+// anything else -> thumbnail.png).
+func DeriveThumbnailKeyVariant(s3Key, variant string) string {
+	filename := thumbnailLightFilename
+	if variant == thumbnailVariantDark {
+		filename = thumbnailDarkFilename
+	}
 	idx := strings.LastIndex(s3Key, "/")
 	if idx < 0 {
-		return "thumbnail.png"
+		return filename
 	}
-	return s3Key[:idx+1] + "thumbnail.png"
+	return s3Key[:idx+1] + filename
 }
 
 // updateAssetRequest is the request body for updating an asset.

--- a/pkg/portal/handler_test.go
+++ b/pkg/portal/handler_test.go
@@ -23,14 +23,15 @@ import (
 // --- Mock stores for handler tests ---
 
 type mockAssetStore struct {
-	insertErr error
-	getAsset  *Asset
-	getErr    error
-	listRes   []Asset
-	listTotal int
-	listErr   error
-	updateErr error
-	deleteErr error
+	insertErr  error
+	getAsset   *Asset
+	getErr     error
+	listRes    []Asset
+	listTotal  int
+	listErr    error
+	updateErr  error
+	deleteErr  error
+	lastUpdate *AssetUpdate // captures the most recent Update payload
 }
 
 func (m *mockAssetStore) Insert(_ context.Context, _ Asset) error { return m.insertErr }
@@ -58,7 +59,8 @@ func (m *mockAssetStore) List(_ context.Context, _ AssetFilter) ([]Asset, int, e
 	return m.listRes, m.listTotal, m.listErr
 }
 
-func (m *mockAssetStore) Update(_ context.Context, _ string, _ AssetUpdate) error {
+func (m *mockAssetStore) Update(_ context.Context, _ string, u AssetUpdate) error {
+	m.lastUpdate = &u
 	return m.updateErr
 }
 func (m *mockAssetStore) SoftDelete(_ context.Context, _ string) error { return m.deleteErr }
@@ -163,9 +165,12 @@ type mockS3Client struct {
 	getErr    error
 	putErr    error
 	deleteErr error
+	putKey    string // captures the key of the most recent PutObject
+	getKey    string // captures the key of the most recent GetObject
 }
 
-func (m *mockS3Client) PutObject(_ context.Context, _, _ string, _ []byte, _ string) error {
+func (m *mockS3Client) PutObject(_ context.Context, _, key string, _ []byte, _ string) error {
+	m.putKey = key
 	return m.putErr
 }
 
@@ -174,7 +179,8 @@ func (m *mockS3Client) PutObjectStream(_ context.Context, _, _ string, body io.R
 	return n, m.putErr
 }
 
-func (m *mockS3Client) GetObject(_ context.Context, _, _ string) (body []byte, contentType string, err error) {
+func (m *mockS3Client) GetObject(_ context.Context, _, key string) (body []byte, contentType string, err error) {
+	m.getKey = key
 	return m.getData, m.getCT, m.getErr
 }
 func (m *mockS3Client) DeleteObject(_ context.Context, _, _ string) error { return m.deleteErr }
@@ -2552,6 +2558,25 @@ func TestDeriveThumbnailKey(t *testing.T) {
 	}
 }
 
+func TestDeriveThumbnailKeyVariant(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		variant string
+		want    string
+	}{
+		{"light prefixed", "portal/u1/a1/content.html", "light", "portal/u1/a1/thumbnail.png"},
+		{"dark prefixed", "portal/u1/a1/content.html", "dark", "portal/u1/a1/thumbnail_dark.png"},
+		{"dark no prefix", "content.html", "dark", "thumbnail_dark.png"},
+		{"unknown variant defaults to light", "a/b/c.md", "weird", "a/b/thumbnail.png"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, DeriveThumbnailKeyVariant(tt.input, tt.variant))
+		})
+	}
+}
+
 // --- uploadThumbnail ---
 
 func TestUploadThumbnailSuccess(t *testing.T) {
@@ -2570,6 +2595,48 @@ func TestUploadThumbnailSuccess(t *testing.T) {
 	h.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "portal/u1/a1/thumbnail.png", s3.putKey, "light upload writes the default key")
+}
+
+func TestUploadThumbnailDarkVariant(t *testing.T) {
+	now := time.Now()
+	asset := &Asset{
+		ID: "a1", OwnerID: "u1", Name: "Test", S3Bucket: "b", S3Key: "portal/u1/a1/content.md",
+		ContentType: "text/markdown", Tags: []string{}, Provenance: Provenance{}, CreatedAt: now, UpdatedAt: now,
+	}
+	s3 := &mockS3Client{}
+	store := &mockAssetStore{getAsset: asset}
+	h := newTestHandler(store, &mockShareStore{}, s3, &User{UserID: "u1"})
+
+	body := strings.NewReader(strings.Repeat("x", 100))
+	req := httptest.NewRequestWithContext(context.Background(), "PUT", "/api/v1/portal/assets/a1/thumbnail?variant=dark", body)
+	req.Header.Set("Content-Type", "image/png")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "portal/u1/a1/thumbnail_dark.png", s3.putKey, "dark upload writes the dark key")
+	require.NotNil(t, store.lastUpdate)
+	require.NotNil(t, store.lastUpdate.ThumbnailDarkS3Key)
+	assert.Equal(t, "portal/u1/a1/thumbnail_dark.png", *store.lastUpdate.ThumbnailDarkS3Key)
+	assert.Nil(t, store.lastUpdate.ThumbnailS3Key, "dark upload must not touch the light key")
+}
+
+func TestUploadThumbnailInvalidVariant(t *testing.T) {
+	now := time.Now()
+	asset := &Asset{
+		ID: "a1", OwnerID: "u1", S3Bucket: "b", S3Key: "portal/u1/a1/content.md",
+		Tags: []string{}, Provenance: Provenance{}, CreatedAt: now, UpdatedAt: now,
+	}
+	h := newTestHandler(&mockAssetStore{getAsset: asset}, &mockShareStore{}, &mockS3Client{}, &User{UserID: "u1"})
+
+	body := strings.NewReader(strings.Repeat("x", 100))
+	req := httptest.NewRequestWithContext(context.Background(), "PUT", "/api/v1/portal/assets/a1/thumbnail?variant=sepia", body)
+	req.Header.Set("Content-Type", "image/png")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestUploadThumbnailUnauth(t *testing.T) {
@@ -2748,6 +2815,45 @@ func TestGetThumbnailSuccess(t *testing.T) {
 	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
 	assert.Equal(t, "private, max-age=3600", w.Header().Get("Cache-Control"))
 	assert.Equal(t, "PNG-DATA", w.Body.String())
+}
+
+func TestGetThumbnailDarkVariant(t *testing.T) {
+	now := time.Now()
+	asset := &Asset{
+		ID: "a1", OwnerID: "u1", S3Bucket: "b",
+		ThumbnailS3Key:     "portal/u1/a1/thumbnail.png",
+		ThumbnailDarkS3Key: "portal/u1/a1/thumbnail_dark.png",
+		Tags:               []string{}, Provenance: Provenance{}, CreatedAt: now, UpdatedAt: now,
+	}
+	s3 := &mockS3Client{getData: []byte("DARK-PNG"), getCT: "image/png"}
+	h := newTestHandler(&mockAssetStore{getAsset: asset}, &mockShareStore{}, s3, &User{UserID: "u1"})
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/api/v1/portal/assets/a1/thumbnail?variant=dark", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "portal/u1/a1/thumbnail_dark.png", s3.getKey, "dark request serves the dark key")
+}
+
+func TestGetThumbnailDarkFallsBackToLight(t *testing.T) {
+	now := time.Now()
+	asset := &Asset{
+		ID: "a1", OwnerID: "u1", S3Bucket: "b",
+		ThumbnailS3Key:     "portal/u1/a1/thumbnail.png",
+		ThumbnailDarkS3Key: "", // no dark variant captured
+		Tags:               []string{}, Provenance: Provenance{}, CreatedAt: now, UpdatedAt: now,
+	}
+	s3 := &mockS3Client{getData: []byte("LIGHT-PNG"), getCT: "image/png"}
+	h := newTestHandler(&mockAssetStore{getAsset: asset}, &mockShareStore{}, s3, &User{UserID: "u1"})
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/api/v1/portal/assets/a1/thumbnail?variant=dark", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "portal/u1/a1/thumbnail.png", s3.getKey, "dark request falls back to the light key when no dark exists")
+	assert.Equal(t, "LIGHT-PNG", w.Body.String())
 }
 
 func TestGetThumbnailNoThumbnail(t *testing.T) {

--- a/pkg/portal/store.go
+++ b/pkg/portal/store.go
@@ -160,7 +160,7 @@ func (s *postgresAssetStore) Insert(ctx context.Context, asset Asset) error { //
 func (s *postgresAssetStore) Get(ctx context.Context, id string) (*Asset, error) { //nolint:revive // interface impl
 	query := `
 		SELECT id, owner_id, owner_email, name, description, content_type, s3_bucket, s3_key,
-		       thumbnail_s3_key, size_bytes, tags, provenance, session_id, current_version,
+		       thumbnail_s3_key, thumbnail_dark_s3_key, size_bytes, tags, provenance, session_id, current_version,
 		       created_at, updated_at, deleted_at, COALESCE(idempotency_key, '')
 		FROM portal_assets WHERE id = $1
 	`
@@ -170,7 +170,7 @@ func (s *postgresAssetStore) Get(ctx context.Context, id string) (*Asset, error)
 
 	err := s.db.QueryRowContext(ctx, query, id).Scan(
 		&asset.ID, &asset.OwnerID, &asset.OwnerEmail, &asset.Name, &asset.Description,
-		&asset.ContentType, &asset.S3Bucket, &asset.S3Key, &asset.ThumbnailS3Key, &asset.SizeBytes,
+		&asset.ContentType, &asset.S3Bucket, &asset.S3Key, &asset.ThumbnailS3Key, &asset.ThumbnailDarkS3Key, &asset.SizeBytes,
 		&tags, &prov, &asset.SessionID, &asset.CurrentVersion, &asset.CreatedAt, &asset.UpdatedAt, &deletedAt,
 		&asset.IdempotencyKey,
 	)
@@ -192,7 +192,7 @@ func (s *postgresAssetStore) Get(ctx context.Context, id string) (*Asset, error)
 func (s *postgresAssetStore) GetByIdempotencyKey(ctx context.Context, ownerID, key string) (*Asset, error) { //nolint:revive // interface impl
 	query := `
 		SELECT id, owner_id, owner_email, name, description, content_type, s3_bucket, s3_key,
-		       thumbnail_s3_key, size_bytes, tags, provenance, session_id, current_version,
+		       thumbnail_s3_key, thumbnail_dark_s3_key, size_bytes, tags, provenance, session_id, current_version,
 		       created_at, updated_at, deleted_at, COALESCE(idempotency_key, '')
 		FROM portal_assets
 		WHERE owner_id = $1 AND idempotency_key = $2 AND deleted_at IS NULL
@@ -203,7 +203,7 @@ func (s *postgresAssetStore) GetByIdempotencyKey(ctx context.Context, ownerID, k
 
 	err := s.db.QueryRowContext(ctx, query, ownerID, key).Scan(
 		&asset.ID, &asset.OwnerID, &asset.OwnerEmail, &asset.Name, &asset.Description,
-		&asset.ContentType, &asset.S3Bucket, &asset.S3Key, &asset.ThumbnailS3Key, &asset.SizeBytes,
+		&asset.ContentType, &asset.S3Bucket, &asset.S3Key, &asset.ThumbnailS3Key, &asset.ThumbnailDarkS3Key, &asset.SizeBytes,
 		&tags, &prov, &asset.SessionID, &asset.CurrentVersion, &asset.CreatedAt, &asset.UpdatedAt, &deletedAt,
 		&asset.IdempotencyKey,
 	)
@@ -229,7 +229,7 @@ func (s *postgresAssetStore) GetByIDs(ctx context.Context, ids []string) (map[st
 
 	query := `
 		SELECT id, owner_id, owner_email, name, description, content_type, s3_bucket, s3_key,
-		       thumbnail_s3_key, size_bytes, tags, provenance, session_id, current_version,
+		       thumbnail_s3_key, thumbnail_dark_s3_key, size_bytes, tags, provenance, session_id, current_version,
 		       created_at, updated_at, deleted_at, COALESCE(idempotency_key, '')
 		FROM portal_assets WHERE id = ANY($1) AND deleted_at IS NULL
 	`
@@ -247,7 +247,7 @@ func (s *postgresAssetStore) GetByIDs(ctx context.Context, ids []string) (map[st
 
 		if err := rows.Scan(
 			&asset.ID, &asset.OwnerID, &asset.OwnerEmail, &asset.Name, &asset.Description,
-			&asset.ContentType, &asset.S3Bucket, &asset.S3Key, &asset.ThumbnailS3Key, &asset.SizeBytes,
+			&asset.ContentType, &asset.S3Bucket, &asset.S3Key, &asset.ThumbnailS3Key, &asset.ThumbnailDarkS3Key, &asset.SizeBytes,
 			&tags, &prov, &asset.SessionID, &asset.CurrentVersion, &asset.CreatedAt, &asset.UpdatedAt, &deletedAt,
 			&asset.IdempotencyKey,
 		); err != nil {
@@ -309,7 +309,7 @@ func (s *postgresAssetStore) queryAssets(ctx context.Context, filter AssetFilter
 	limit := filter.EffectiveLimit()
 	selectQB := applyAssetFilter(psq.Select(
 		"id", "owner_id", "owner_email", "name", "description", "content_type", "s3_bucket", "s3_key",
-		"thumbnail_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version",
+		"thumbnail_s3_key", "thumbnail_dark_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version",
 		"created_at", "updated_at", "deleted_at", "COALESCE(idempotency_key, '')",
 	).From("portal_assets"), filter).
 		Where("deleted_at IS NULL").
@@ -430,6 +430,34 @@ func (s *postgresAssetStore) Update(ctx context.Context, id string, updates Asse
 	return nil
 }
 
+// applyScalarUpdates sets the non-indexed scalar columns (content type, storage
+// keys, size, and the light/dark thumbnail keys) that do not affect the search
+// embedding. Returns the builder and whether any column was set.
+func applyScalarUpdates(qb sq.UpdateBuilder, updates AssetUpdate) (sq.UpdateBuilder, bool) {
+	changed := false
+	if updates.ContentType != "" {
+		qb = qb.Set("content_type", updates.ContentType)
+		changed = true
+	}
+	if updates.S3Key != "" {
+		qb = qb.Set("s3_key", updates.S3Key)
+		changed = true
+	}
+	if updates.HasContent {
+		qb = qb.Set("size_bytes", updates.SizeBytes)
+		changed = true
+	}
+	if updates.ThumbnailS3Key != nil {
+		qb = qb.Set("thumbnail_s3_key", *updates.ThumbnailS3Key)
+		changed = true
+	}
+	if updates.ThumbnailDarkS3Key != nil {
+		qb = qb.Set("thumbnail_dark_s3_key", *updates.ThumbnailDarkS3Key)
+		changed = true
+	}
+	return qb, changed
+}
+
 func applyUpdateFields(qb sq.UpdateBuilder, updates AssetUpdate) (sq.UpdateBuilder, error) {
 	hasUpdates := false
 	indexedChanged := false
@@ -452,20 +480,9 @@ func applyUpdateFields(qb sq.UpdateBuilder, updates AssetUpdate) (sq.UpdateBuild
 		hasUpdates = true
 		indexedChanged = true
 	}
-	if updates.ContentType != "" {
-		qb = qb.Set("content_type", updates.ContentType)
-		hasUpdates = true
-	}
-	if updates.S3Key != "" {
-		qb = qb.Set("s3_key", updates.S3Key)
-		hasUpdates = true
-	}
-	if updates.HasContent {
-		qb = qb.Set("size_bytes", updates.SizeBytes)
-		hasUpdates = true
-	}
-	if updates.ThumbnailS3Key != nil {
-		qb = qb.Set("thumbnail_s3_key", *updates.ThumbnailS3Key)
+	var scalarChanged bool
+	qb, scalarChanged = applyScalarUpdates(qb, updates)
+	if scalarChanged {
 		hasUpdates = true
 	}
 	if !hasUpdates {
@@ -748,7 +765,7 @@ func (s *postgresShareStore) ListSharedWithUser(ctx context.Context, userID, ema
 
 	selectQuery := `
 		SELECT pa.id, pa.owner_id, pa.owner_email, pa.name, pa.description, pa.content_type,
-		       pa.s3_bucket, pa.s3_key, pa.thumbnail_s3_key, pa.size_bytes, pa.tags, pa.provenance,
+		       pa.s3_bucket, pa.s3_key, pa.thumbnail_s3_key, pa.thumbnail_dark_s3_key, pa.size_bytes, pa.tags, pa.provenance,
 		       pa.session_id, pa.current_version, pa.created_at, pa.updated_at, pa.deleted_at,
 		       COALESCE(pa.idempotency_key, ''),
 		       ps.id, COALESCE(NULLIF(pa.owner_email, ''), ps.created_by), ps.created_at, ps.permission
@@ -775,7 +792,7 @@ func (s *postgresShareStore) ListSharedWithUser(ctx context.Context, userID, ema
 
 		if err := rows.Scan(
 			&sa.Asset.ID, &sa.Asset.OwnerID, &sa.Asset.OwnerEmail, &sa.Asset.Name, &sa.Asset.Description,
-			&sa.Asset.ContentType, &sa.Asset.S3Bucket, &sa.Asset.S3Key, &sa.Asset.ThumbnailS3Key, &sa.Asset.SizeBytes,
+			&sa.Asset.ContentType, &sa.Asset.S3Bucket, &sa.Asset.S3Key, &sa.Asset.ThumbnailS3Key, &sa.Asset.ThumbnailDarkS3Key, &sa.Asset.SizeBytes,
 			&tags, &prov, &sa.Asset.SessionID, &sa.Asset.CurrentVersion,
 			&sa.Asset.CreatedAt, &sa.Asset.UpdatedAt, &deletedAt, &sa.Asset.IdempotencyKey,
 			&sa.ShareID, &sa.SharedBy, &sa.SharedAt, &sa.Permission,
@@ -1169,7 +1186,7 @@ func applyAssetFilter(qb sq.SelectBuilder, filter AssetFilter) sq.SelectBuilder 
 func assetScanDest(a *Asset, tags, prov *[]byte, deletedAt *sql.NullTime) []any {
 	return []any{
 		&a.ID, &a.OwnerID, &a.OwnerEmail, &a.Name, &a.Description,
-		&a.ContentType, &a.S3Bucket, &a.S3Key, &a.ThumbnailS3Key, &a.SizeBytes,
+		&a.ContentType, &a.S3Bucket, &a.S3Key, &a.ThumbnailS3Key, &a.ThumbnailDarkS3Key, &a.SizeBytes,
 		tags, prov, &a.SessionID, &a.CurrentVersion, &a.CreatedAt, &a.UpdatedAt, deletedAt,
 		&a.IdempotencyKey,
 	}
@@ -1280,7 +1297,7 @@ func (s *postgresVersionStore) CreateVersion(ctx context.Context, version AssetV
 
 	updateQuery := `
 		UPDATE portal_assets
-		SET current_version = $1, s3_key = $2, content_type = $3, size_bytes = $4, thumbnail_s3_key = '', updated_at = NOW()
+		SET current_version = $1, s3_key = $2, content_type = $3, size_bytes = $4, thumbnail_s3_key = '', thumbnail_dark_s3_key = '', updated_at = NOW()
 		WHERE id = $5
 	`
 	_, err = tx.ExecContext(ctx, updateQuery,

--- a/pkg/portal/store_test.go
+++ b/pkg/portal/store_test.go
@@ -100,10 +100,10 @@ func TestPostgresAssetStoreGetNullTags(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{
 		"id", "owner_id", "owner_email", "name", "description", "content_type", "s3_bucket", "s3_key",
-		"thumbnail_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
+		"thumbnail_s3_key", "thumbnail_dark_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
 	}).AddRow(
 		"abc123", "user1", "user1@example.com", "Untagged", "", "application/json", "portal", "key1",
-		"", int64(42), []byte("null"), prov, "", 1, now, now, nil, "",
+		"", "", int64(42), []byte("null"), prov, "", 1, now, now, nil, "",
 	)
 
 	mock.ExpectQuery("SELECT .+ FROM portal_assets WHERE id").
@@ -130,10 +130,10 @@ func TestPostgresAssetStoreGet(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{
 		"id", "owner_id", "owner_email", "name", "description", "content_type", "s3_bucket", "s3_key",
-		"thumbnail_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
+		"thumbnail_s3_key", "thumbnail_dark_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
 	}).AddRow(
 		"abc123", "user1", "user1@example.com", "Test", "desc", "text/html", "portal", "key1",
-		"", int64(512), tags, prov, "sess1", 1, now, now, nil, "",
+		"", "", int64(512), tags, prov, "sess1", 1, now, now, nil, "",
 	)
 
 	mock.ExpectQuery("SELECT .+ FROM portal_assets WHERE id").
@@ -178,10 +178,10 @@ func TestPostgresAssetStoreGetByIdempotencyKey(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{
 		"id", "owner_id", "owner_email", "name", "description", "content_type", "s3_bucket", "s3_key",
-		"thumbnail_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
+		"thumbnail_s3_key", "thumbnail_dark_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
 	}).AddRow(
 		"abc123", "user1", "user1@example.com", "Export", "desc", "text/csv", "portal", "key1",
-		"", int64(1024), tags, prov, "sess1", 1, now, now, nil, "dedup-key-1",
+		"", "", int64(1024), tags, prov, "sess1", 1, now, now, nil, "dedup-key-1",
 	)
 
 	mock.ExpectQuery("SELECT .+ FROM portal_assets WHERE owner_id").
@@ -262,10 +262,10 @@ func TestPostgresAssetStoreList(t *testing.T) {
 	// Select query
 	dataRows := sqlmock.NewRows([]string{
 		"id", "owner_id", "owner_email", "name", "description", "content_type", "s3_bucket", "s3_key",
-		"thumbnail_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
+		"thumbnail_s3_key", "thumbnail_dark_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
 	}).AddRow(
 		"abc123", "user1", "", "Test", "", "text/html", "portal", "key1",
-		"", int64(100), tags, prov, "", 1, now, now, nil, "",
+		"", "", int64(100), tags, prov, "", 1, now, now, nil, "",
 	)
 	mock.ExpectQuery("SELECT .+ FROM portal_assets").WillReturnRows(dataRows)
 
@@ -368,6 +368,23 @@ func TestPostgresAssetStoreUpdateThumbnailKey(t *testing.T) {
 
 	thumbKey := "portal/u1/a1/thumbnail.png"
 	err = store.Update(context.Background(), "abc123", AssetUpdate{ThumbnailS3Key: &thumbKey})
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPostgresAssetStoreUpdateThumbnailDarkKey(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	store := NewPostgresAssetStore(db)
+
+	// The query must set the dark column specifically.
+	mock.ExpectExec("UPDATE portal_assets SET thumbnail_dark_s3_key").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	darkKey := "portal/u1/a1/thumbnail_dark.png"
+	err = store.Update(context.Background(), "abc123", AssetUpdate{ThumbnailDarkS3Key: &darkKey})
 	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -827,10 +844,10 @@ func TestPostgresAssetStoreListWithOffset(t *testing.T) {
 
 	dataRows := sqlmock.NewRows([]string{
 		"id", "owner_id", "owner_email", "name", "description", "content_type", "s3_bucket", "s3_key",
-		"thumbnail_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
+		"thumbnail_s3_key", "thumbnail_dark_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
 	}).AddRow(
 		"abc123", "user1", "", "Test", "", "text/html", "portal", "key1",
-		"", int64(100), tags, prov, "", 1, time.Now(), time.Now(), nil, "",
+		"", "", int64(100), tags, prov, "", 1, time.Now(), time.Now(), nil, "",
 	)
 	mock.ExpectQuery("SELECT .+ FROM portal_assets").WillReturnRows(dataRows)
 
@@ -858,7 +875,7 @@ func TestPostgresAssetStoreListFilterByTag(t *testing.T) {
 	mock.ExpectQuery("SELECT .+ FROM portal_assets").WillReturnRows(
 		sqlmock.NewRows([]string{
 			"id", "owner_id", "owner_email", "name", "description", "content_type", "s3_bucket", "s3_key",
-			"thumbnail_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
+			"thumbnail_s3_key", "thumbnail_dark_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
 		}),
 	)
 
@@ -879,7 +896,7 @@ func TestPostgresAssetStoreListFilterByContentType(t *testing.T) {
 	mock.ExpectQuery("SELECT .+ FROM portal_assets").WillReturnRows(
 		sqlmock.NewRows([]string{
 			"id", "owner_id", "owner_email", "name", "description", "content_type", "s3_bucket", "s3_key",
-			"thumbnail_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
+			"thumbnail_s3_key", "thumbnail_dark_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
 		}),
 	)
 
@@ -900,7 +917,7 @@ func TestPostgresAssetStoreListFilterBySearch(t *testing.T) {
 	mock.ExpectQuery("SELECT .+ FROM portal_assets").WillReturnRows(
 		sqlmock.NewRows([]string{
 			"id", "owner_id", "owner_email", "name", "description", "content_type", "s3_bucket", "s3_key",
-			"thumbnail_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
+			"thumbnail_s3_key", "thumbnail_dark_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
 		}),
 	)
 
@@ -1066,11 +1083,11 @@ func TestPostgresShareStoreListSharedWithUser(t *testing.T) {
 	// Select query
 	dataRows := sqlmock.NewRows([]string{
 		"id", "owner_id", "owner_email", "name", "description", "content_type", "s3_bucket", "s3_key",
-		"thumbnail_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
+		"thumbnail_s3_key", "thumbnail_dark_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
 		"share_id", "created_by", "share_created_at", "permission",
 	}).AddRow(
 		"abc123", "user1", "user1@example.com", "Shared Asset", "desc", "text/html", "portal", "key1",
-		"", int64(512), tags, prov, "sess1", 1, now, now, nil, "",
+		"", "", int64(512), tags, prov, "sess1", 1, now, now, nil, "",
 		"share1", "user1", now, "viewer",
 	)
 
@@ -1144,7 +1161,7 @@ func TestPostgresShareStoreListSharedWithUserDefaults(t *testing.T) {
 		WithArgs("user2", "", defaultLimit, 0).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "owner_id", "owner_email", "name", "description", "content_type", "s3_bucket", "s3_key",
-			"thumbnail_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
+			"thumbnail_s3_key", "thumbnail_dark_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
 			"share_id", "created_by", "share_created_at", "permission",
 		}))
 
@@ -1170,7 +1187,7 @@ func TestPostgresShareStoreListSharedWithUserMaxLimit(t *testing.T) {
 		WithArgs("user2", "", maxLimit, 0).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "owner_id", "owner_email", "name", "description", "content_type", "s3_bucket", "s3_key",
-			"thumbnail_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
+			"thumbnail_s3_key", "thumbnail_dark_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
 			"share_id", "created_by", "share_created_at", "permission",
 		}))
 
@@ -1259,10 +1276,10 @@ func TestPostgresAssetStoreGetWithDeletedAt(t *testing.T) {
 
 	rows := sqlmock.NewRows([]string{
 		"id", "owner_id", "owner_email", "name", "description", "content_type", "s3_bucket", "s3_key",
-		"thumbnail_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
+		"thumbnail_s3_key", "thumbnail_dark_s3_key", "size_bytes", "tags", "provenance", "session_id", "current_version", "created_at", "updated_at", "deleted_at", "idempotency_key",
 	}).AddRow(
 		"abc123", "user1", "", "Test", "desc", "text/html", "portal", "key1",
-		"", int64(512), tags, prov, "sess1", 1, now, now, deletedAt, "",
+		"", "", int64(512), tags, prov, "sess1", 1, now, now, deletedAt, "",
 	)
 
 	mock.ExpectQuery("SELECT .+ FROM portal_assets WHERE id").

--- a/pkg/portal/types.go
+++ b/pkg/portal/types.go
@@ -22,25 +22,30 @@ type AssetCollectionRef struct {
 
 // Asset represents a persisted AI-generated artifact.
 type Asset struct {
-	ID             string               `json:"id" example:"asset_01HK7R8Z8M0Y6A5G1R6FQ2VQNK"`
-	OwnerID        string               `json:"owner_id" example:"550e8400-e29b-41d4-a716-446655440000"`
-	OwnerEmail     string               `json:"owner_email" example:"alice@example.com"`
-	Name           string               `json:"name" example:"Q4 Revenue Dashboard"`
-	Description    string               `json:"description,omitempty" example:"Interactive revenue breakdown by region"`
-	ContentType    string               `json:"content_type" example:"text/html"`
-	S3Bucket       string               `json:"s3_bucket" example:"portal-assets"`
-	S3Key          string               `json:"s3_key" example:"assets/01HK7R8Z/content.html"`
-	ThumbnailS3Key string               `json:"thumbnail_s3_key,omitempty" example:"assets/01HK7R8Z/thumb.png"`
-	SizeBytes      int64                `json:"size_bytes" example:"4200"`
-	Tags           []string             `json:"tags"`
-	Provenance     Provenance           `json:"provenance"`
-	SessionID      string               `json:"session_id,omitempty" example:"sess_abc123"`
-	IdempotencyKey string               `json:"idempotency_key,omitempty" example:"export-2026-04-18-abc123"`
-	CurrentVersion int                  `json:"current_version" example:"1"`
-	Collections    []AssetCollectionRef `json:"collections,omitempty"`
-	CreatedAt      time.Time            `json:"created_at"`
-	UpdatedAt      time.Time            `json:"updated_at"`
-	DeletedAt      *time.Time           `json:"deleted_at,omitempty"`
+	ID             string `json:"id" example:"asset_01HK7R8Z8M0Y6A5G1R6FQ2VQNK"`
+	OwnerID        string `json:"owner_id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	OwnerEmail     string `json:"owner_email" example:"alice@example.com"`
+	Name           string `json:"name" example:"Q4 Revenue Dashboard"`
+	Description    string `json:"description,omitempty" example:"Interactive revenue breakdown by region"`
+	ContentType    string `json:"content_type" example:"text/html"`
+	S3Bucket       string `json:"s3_bucket" example:"portal-assets"`
+	S3Key          string `json:"s3_key" example:"assets/01HK7R8Z/content.html"`
+	ThumbnailS3Key string `json:"thumbnail_s3_key,omitempty" example:"assets/01HK7R8Z/thumb.png"`
+	// ThumbnailDarkS3Key holds the dark-mode thumbnail variant. Only populated
+	// for content types rendered on a forced background (markdown, CSV); types
+	// with a built-in theme (HTML, JSX, SVG) reuse ThumbnailS3Key in both modes.
+	// Empty means callers should fall back to ThumbnailS3Key.
+	ThumbnailDarkS3Key string               `json:"thumbnail_dark_s3_key,omitempty" example:"assets/01HK7R8Z/thumbnail_dark.png"`
+	SizeBytes          int64                `json:"size_bytes" example:"4200"`
+	Tags               []string             `json:"tags"`
+	Provenance         Provenance           `json:"provenance"`
+	SessionID          string               `json:"session_id,omitempty" example:"sess_abc123"`
+	IdempotencyKey     string               `json:"idempotency_key,omitempty" example:"export-2026-04-18-abc123"`
+	CurrentVersion     int                  `json:"current_version" example:"1"`
+	Collections        []AssetCollectionRef `json:"collections,omitempty"`
+	CreatedAt          time.Time            `json:"created_at"`
+	UpdatedAt          time.Time            `json:"updated_at"`
+	DeletedAt          *time.Time           `json:"deleted_at,omitempty"`
 }
 
 // AssetVersion records a single version of an asset's content.
@@ -193,14 +198,15 @@ func (f *AssetFilter) EffectiveLimit() int {
 // AssetUpdate holds mutable fields for updating an asset.
 // Pointer fields distinguish "no change" (nil) from "clear to empty" (pointer to "").
 type AssetUpdate struct {
-	Name           *string  `json:"name,omitempty"`
-	Description    *string  `json:"description,omitempty"`
-	Tags           []string `json:"tags,omitempty"`
-	ContentType    string   `json:"content_type,omitempty"`
-	S3Key          string   `json:"s3_key,omitempty"`
-	SizeBytes      int64    `json:"size_bytes,omitempty"`
-	ThumbnailS3Key *string  `json:"thumbnail_s3_key,omitempty"`
-	HasContent     bool     `json:"-"` // set when content replacement provides SizeBytes (even if 0)
+	Name               *string  `json:"name,omitempty"`
+	Description        *string  `json:"description,omitempty"`
+	Tags               []string `json:"tags,omitempty"`
+	ContentType        string   `json:"content_type,omitempty"`
+	S3Key              string   `json:"s3_key,omitempty"`
+	SizeBytes          int64    `json:"size_bytes,omitempty"`
+	ThumbnailS3Key     *string  `json:"thumbnail_s3_key,omitempty"`
+	ThumbnailDarkS3Key *string  `json:"thumbnail_dark_s3_key,omitempty"`
+	HasContent         bool     `json:"-"` // set when content replacement provides SizeBytes (even if 0)
 }
 
 // maxNameLength is the maximum length for asset names.

--- a/ui/src/api/portal/hooks.ts
+++ b/ui/src/api/portal/hooks.ts
@@ -45,6 +45,7 @@ export interface Branding {
   version: string;
   portal_title: string;
   portal_tagline?: string;
+  oidc_button_label?: string;
   portal_logo: string;
   portal_logo_light: string;
   portal_logo_dark: string;

--- a/ui/src/api/portal/types.ts
+++ b/ui/src/api/portal/types.ts
@@ -15,6 +15,9 @@ export interface Asset {
   s3_bucket: string;
   s3_key: string;
   thumbnail_s3_key?: string;
+  // Dark-mode thumbnail variant. Only present for themeable content types
+  // (markdown, CSV); other types reuse thumbnail_s3_key in both modes.
+  thumbnail_dark_s3_key?: string;
   size_bytes: number;
   tags: string[];
   provenance: Provenance;

--- a/ui/src/api/portal/types.ts
+++ b/ui/src/api/portal/types.ts
@@ -160,15 +160,6 @@ export interface SharedCollection {
   permission: SharePermission;
 }
 
-export interface Branding {
-  name: string;
-  version: string;
-  portal_title: string;
-  portal_logo: string;
-  portal_logo_light: string;
-  portal_logo_dark: string;
-}
-
 // Activity types (user-scoped audit metrics)
 export interface ActivityOverview {
   total_calls: number;

--- a/ui/src/components/LoginForm.test.tsx
+++ b/ui/src/components/LoginForm.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Hold the branding payload the mocked hook returns, so each test can vary it.
+const { branding } = vi.hoisted(() => ({ branding: { value: null as unknown } }));
+vi.mock("@/api/portal/hooks", () => ({
+  useBranding: () => ({ data: branding.value }),
+}));
+
+import { LoginForm } from "./LoginForm";
+
+// jsdom has no matchMedia; LoginForm reads it for theme detection.
+beforeEach(() => {
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }) as unknown as typeof window.matchMedia;
+});
+
+describe("LoginForm OIDC button label", () => {
+  beforeEach(() => {
+    branding.value = null;
+  });
+
+  it("shows the default label when no override is configured", () => {
+    branding.value = { oidc_enabled: true };
+    render(<LoginForm />);
+    expect(screen.getByText("Sign in with OIDC")).toBeInTheDocument();
+  });
+
+  it("shows the configured override label instead of the default", () => {
+    branding.value = { oidc_enabled: true, oidc_button_label: "Sign in with ACME Keycloak" };
+    render(<LoginForm />);
+    expect(screen.getByText("Sign in with ACME Keycloak")).toBeInTheDocument();
+    expect(screen.queryByText("Sign in with OIDC")).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/LoginForm.tsx
+++ b/ui/src/components/LoginForm.tsx
@@ -1,11 +1,12 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useAuthStore } from "@/stores/auth";
-import { useThemeStore } from "@/stores/theme";
+import { useResolvedDark } from "@/stores/theme";
 import { useBranding } from "@/api/portal/hooks";
 import { LogIn } from "lucide-react";
 
 const DEFAULT_PORTAL_TITLE = "MCP Data Platform";
 const DEFAULT_PORTAL_TAGLINE = "Sign in to access the platform.";
+const DEFAULT_OIDC_BUTTON_LABEL = "Sign in with OIDC";
 
 const AUTH_ERROR_MESSAGES: Record<string, string> = {
   access_denied: "Access was denied by the identity provider.",
@@ -50,28 +51,11 @@ export function LoginForm() {
   const loginOIDC = useAuthStore((s) => s.loginOIDC);
   const { data: branding } = useBranding();
 
-  const theme = useThemeStore((s) => s.theme);
-  const [isDark, setIsDark] = useState(
-    () =>
-      theme === "dark" ||
-      (theme === "system" &&
-        typeof window !== "undefined" &&
-        window.matchMedia("(prefers-color-scheme: dark)").matches),
-  );
-  useEffect(() => {
-    if (theme !== "system") {
-      setIsDark(theme === "dark");
-      return;
-    }
-    const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    const update = () => setIsDark(mq.matches);
-    update();
-    mq.addEventListener("change", update);
-    return () => mq.removeEventListener("change", update);
-  }, [theme]);
+  const isDark = useResolvedDark();
 
   const portalTitle = branding?.portal_title || DEFAULT_PORTAL_TITLE;
   const portalTagline = branding?.portal_tagline || DEFAULT_PORTAL_TAGLINE;
+  const oidcButtonLabel = branding?.oidc_button_label || DEFAULT_OIDC_BUTTON_LABEL;
   const portalLogo = resolveLogo(branding ?? undefined, isDark);
   const oidcEnabled = branding?.oidc_enabled ?? false;
 
@@ -137,7 +121,7 @@ export function LoginForm() {
             className="mb-3 flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
           >
             <LogIn className="h-4 w-4" />
-            Sign in with OIDC
+            {oidcButtonLabel}
           </button>
         )}
 

--- a/ui/src/components/ThumbnailGenerator.tsx
+++ b/ui/src/components/ThumbnailGenerator.tsx
@@ -15,6 +15,8 @@ import {
   buildJsxThumbnailHtml,
   captureIframe,
   uploadThumbnail,
+  isThemeable,
+  type ThumbnailVariant,
 } from "@/lib/thumbnail";
 
 interface Props {
@@ -159,8 +161,148 @@ function IframeCapture({
   );
 }
 
+/** Color tokens for one thumbnail color scheme. */
+interface ProseTokens {
+  bg: string;
+  fg: string;
+  codeBg: string;
+  border: string;
+  blockquoteBorder: string;
+  muted: string;
+  link: string;
+  thBg: string;
+  evenRow: string;
+}
+
+interface Scheme {
+  variant: ThumbnailVariant;
+  mermaidTheme: "default" | "dark";
+  tokens: ProseTokens;
+}
+
+const LIGHT_SCHEME: Scheme = {
+  variant: "light",
+  mermaidTheme: "default",
+  tokens: {
+    bg: "#ffffff",
+    fg: "#111827",
+    codeBg: "#f3f4f6",
+    border: "#d1d5db",
+    blockquoteBorder: "#d1d5db",
+    muted: "#6b7280",
+    link: "#2563eb",
+    thBg: "#f1f5f9",
+    evenRow: "#f8fafc",
+  },
+};
+
+// Dark tokens mirror the portal's shadcn dark palette (card #020817,
+// foreground #f8fafc) so the captured thumbnail blends into the dark card.
+const DARK_SCHEME: Scheme = {
+  variant: "dark",
+  mermaidTheme: "dark",
+  tokens: {
+    bg: "#020817",
+    fg: "#f8fafc",
+    codeBg: "#1e293b",
+    border: "#334155",
+    blockquoteBorder: "#475569",
+    muted: "#94a3b8",
+    link: "#60a5fa",
+    thBg: "#1e293b",
+    evenRow: "#0f172a",
+  },
+};
+
+function markdownProseCss(t: ProseTokens): string {
+  return `
+    .thumb-prose h1 { font-size: 1.5em; font-weight: 700; margin: 0.5em 0 0.25em; }
+    .thumb-prose h2 { font-size: 1.25em; font-weight: 600; margin: 0.5em 0 0.25em; }
+    .thumb-prose h3 { font-size: 1.1em; font-weight: 600; margin: 0.4em 0 0.2em; }
+    .thumb-prose p { margin: 0.4em 0; }
+    .thumb-prose ul, .thumb-prose ol { padding-left: 1.5em; margin: 0.4em 0; }
+    .thumb-prose code { background: ${t.codeBg}; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.9em; }
+    .thumb-prose pre { background: ${t.codeBg}; padding: 0.5em; border-radius: 4px; overflow: auto; margin: 0.4em 0; }
+    .thumb-prose blockquote { border-left: 3px solid ${t.blockquoteBorder}; padding-left: 0.75em; margin: 0.4em 0; color: ${t.muted}; }
+    .thumb-prose a { color: ${t.link}; text-decoration: underline; }
+    .thumb-prose table { border-collapse: collapse; margin: 0.4em 0; }
+    .thumb-prose th, .thumb-prose td { border: 1px solid ${t.border}; padding: 0.25em 0.5em; font-size: 0.9em; }
+  `;
+}
+
+function csvProseCss(t: ProseTokens): string {
+  return `
+    .thumb-prose table { border-collapse: collapse; margin: 0.4em 0; width: 100%; }
+    .thumb-prose th, .thumb-prose td { border: 1px solid ${t.border}; padding: 0.25em 0.5em; font-size: 0.85em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 120px; }
+    .thumb-prose th { background: ${t.thBg}; font-weight: 600; }
+    .thumb-prose tr:nth-child(even) { background: ${t.evenRow}; }
+  `;
+}
+
+const SETTLE_SELECTOR = "p, h1, h2, h3, li, pre, blockquote, table, svg";
+
+/** Resolves once the container has rendered capturable content. */
+function waitForContent(container: HTMLElement): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (container.querySelector(SETTLE_SELECTOR)) {
+      resolve();
+      return;
+    }
+    const observer = new MutationObserver(() => {
+      if (container.querySelector(SETTLE_SELECTOR)) {
+        observer.disconnect();
+        resolve();
+      }
+    });
+    observer.observe(container, { childList: true, subtree: true });
+  });
+}
+
+/** Replaces mermaid code blocks in a container with rendered SVG in the given theme. */
+async function renderMermaidIn(
+  container: HTMLElement,
+  theme: "default" | "dark",
+  idPrefix: string,
+): Promise<void> {
+  const blocks = container.querySelectorAll<HTMLElement>("code.language-mermaid");
+  if (blocks.length === 0) return;
+  mermaid.initialize({ startOnLoad: false, theme, fontFamily: "system-ui, sans-serif" });
+  for (let i = 0; i < blocks.length; i++) {
+    const codeEl = blocks[i]!;
+    const preEl = codeEl.parentElement;
+    if (!preEl || preEl.tagName !== "PRE") continue;
+    try {
+      const { svg } = await mermaid.render(`${idPrefix}-${i}`, codeEl.textContent || "");
+      const wrapper = document.createElement("div");
+      wrapper.innerHTML = svg;
+      wrapper.style.display = "flex";
+      wrapper.style.justifyContent = "center";
+      wrapper.style.margin = "0.5em 0";
+      preEl.replaceWith(wrapper);
+    } catch {
+      // Leave as code block on failure
+    }
+  }
+}
+
+/** Captures a container to a PNG blob on the given background color. */
+async function captureContainer(container: HTMLElement, bg: string): Promise<Blob> {
+  const canvas = await html2canvas(container, {
+    width: THUMB_WIDTH,
+    height: THUMB_HEIGHT,
+    scale: 1,
+    logging: false,
+    backgroundColor: bg,
+  });
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((b) => (b ? resolve(b) : reject(new Error("toBlob returned null"))), "image/png");
+  });
+}
+
 /**
- * Captures same-origin DOM content (Markdown/SVG) using html2canvas.
+ * Captures same-origin DOM content (Markdown/CSV/SVG) using html2canvas.
+ * Themeable types (markdown, CSV) are captured twice (light + dark) and uploaded
+ * to their respective variants; SVG carries its own colors and is captured once.
  */
 function DomCapture({
   assetId,
@@ -175,11 +317,18 @@ function DomCapture({
   onCaptured?: () => void;
   onFailed?: () => void;
 }) {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRefs = useRef<(HTMLDivElement | null)[]>([]);
   const capturedRef = useRef(false);
 
-  const isSvg = contentType.toLowerCase().includes("svg");
-  const isCsvThumb = contentType.toLowerCase().includes("csv");
+  const ct = contentType.toLowerCase();
+  const isSvg = ct.includes("svg");
+  const isCsvThumb = ct.includes("csv");
+
+  // Themeable types capture both schemes; single-theme types capture light only.
+  const schemes = useMemo<Scheme[]>(
+    () => (isThemeable(contentType) ? [LIGHT_SCHEME, DARK_SCHEME] : [LIGHT_SCHEME]),
+    [contentType],
+  );
 
   const csvTable = useMemo(() => {
     if (!isCsvThumb) return null;
@@ -199,75 +348,28 @@ function DomCapture({
   );
 
   const doCapture = useCallback(async () => {
-    if (capturedRef.current || !containerRef.current) return;
+    if (capturedRef.current) return;
     capturedRef.current = true;
     try {
-      const canvas = await html2canvas(containerRef.current, {
-        width: THUMB_WIDTH,
-        height: THUMB_HEIGHT,
-        scale: 1,
-        logging: false,
-      });
-      const blob = await new Promise<Blob>((resolve, reject) => {
-        canvas.toBlob((b) => (b ? resolve(b) : reject(new Error("toBlob returned null"))), "image/png");
-      });
-      await uploadThumbnail(assetId, blob);
+      for (let i = 0; i < schemes.length; i++) {
+        const container = containerRefs.current[i];
+        const scheme = schemes[i];
+        if (!container || !scheme) continue;
+        await waitForContent(container);
+        await renderMermaidIn(container, scheme.mermaidTheme, `thumb-mermaid-${scheme.variant}`);
+        // Let layout settle after mermaid SVGs are inserted
+        await new Promise((r) => requestAnimationFrame(r));
+        const blob = await captureContainer(container, scheme.tokens.bg);
+        await uploadThumbnail(assetId, blob, scheme.variant);
+      }
       onCaptured?.();
     } catch {
       onFailed?.();
     }
-  }, [assetId, onCaptured, onFailed]);
+  }, [assetId, schemes, onCaptured, onFailed]);
 
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    // Capture as non-null for the async closure (TS can't narrow across await).
-    const container: HTMLDivElement = el;
-
-    async function renderMermaidAndCapture() {
-      // Wait for ReactMarkdown to render child nodes
-      await new Promise<void>((resolve) => {
-        if (container.querySelector("p, h1, h2, h3, li, pre, blockquote, table, svg")) {
-          resolve();
-          return;
-        }
-        const observer = new MutationObserver(() => {
-          if (container.querySelector("p, h1, h2, h3, li, pre, blockquote, table, svg")) {
-            observer.disconnect();
-            resolve();
-          }
-        });
-        observer.observe(container, { childList: true, subtree: true });
-      });
-
-      // Render mermaid code blocks if present
-      const mermaidBlocks = container.querySelectorAll<HTMLElement>("code.language-mermaid");
-      if (mermaidBlocks.length > 0) {
-        mermaid.initialize({ startOnLoad: false, theme: "default", fontFamily: "system-ui, sans-serif" });
-        for (let i = 0; i < mermaidBlocks.length; i++) {
-          const codeEl = mermaidBlocks[i]!;
-          const preEl = codeEl.parentElement;
-          if (!preEl || preEl.tagName !== "PRE") continue;
-          try {
-            const { svg } = await mermaid.render(`thumb-mermaid-${i}`, codeEl.textContent || "");
-            const wrapper = document.createElement("div");
-            wrapper.innerHTML = svg;
-            wrapper.style.display = "flex";
-            wrapper.style.justifyContent = "center";
-            wrapper.style.margin = "0.5em 0";
-            preEl.replaceWith(wrapper);
-          } catch {
-            // Leave as code block on failure
-          }
-        }
-      }
-
-      // Let layout settle after mermaid SVGs are inserted
-      await new Promise((r) => requestAnimationFrame(r));
-      void doCapture();
-    }
-
-    void renderMermaidAndCapture();
+    void doCapture();
   }, [doCapture]);
 
   // Timeout: if capture hasn't completed, give up
@@ -282,80 +384,66 @@ function DomCapture({
   }, [onFailed]);
 
   return (
-    <div
-      ref={containerRef}
-      style={{
-        position: "fixed",
-        left: -9999,
-        top: -9999,
-        width: THUMB_WIDTH,
-        height: THUMB_HEIGHT,
-        overflow: "hidden",
-        pointerEvents: "none",
-        background: "white",
-        color: "black",
-        fontSize: 12,
-        padding: 16,
-        lineHeight: 1.6,
-        fontFamily: "system-ui, -apple-system, sans-serif",
-      }}
-      aria-hidden="true"
-    >
-      {isCsvThumb && csvTable ? (
-        <div>
-          <style>{`
-            .thumb-prose table { border-collapse: collapse; margin: 0.4em 0; width: 100%; }
-            .thumb-prose th, .thumb-prose td { border: 1px solid #d1d5db; padding: 0.25em 0.5em; font-size: 0.85em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 120px; }
-            .thumb-prose th { background: #f1f5f9; font-weight: 600; }
-            .thumb-prose tr:nth-child(even) { background: #f8fafc; }
-          `}</style>
-          <div className="thumb-prose">
-            <table>
-              <thead>
-                <tr>
-                  {csvTable.cols.map((col) => (
-                    <th key={col}>{col}</th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {csvTable.rows.map((row, i) => (
-                  <tr key={i}>
-                    {csvTable.cols.map((col) => (
-                      <td key={col}>{String(row[col] ?? "")}</td>
-                    ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      ) : isSvg ? (
-        <div dangerouslySetInnerHTML={{ __html: sanitizedSvg }} />
-      ) : (
+    <>
+      {schemes.map((scheme, i) => (
         <div
-          style={{
-            maxWidth: "none",
+          key={scheme.variant}
+          ref={(el) => {
+            containerRefs.current[i] = el;
           }}
+          style={{
+            position: "fixed",
+            left: -9999,
+            top: -9999,
+            width: THUMB_WIDTH,
+            height: THUMB_HEIGHT,
+            overflow: "hidden",
+            pointerEvents: "none",
+            background: scheme.tokens.bg,
+            color: scheme.tokens.fg,
+            fontSize: 12,
+            padding: 16,
+            lineHeight: 1.6,
+            fontFamily: "system-ui, -apple-system, sans-serif",
+          }}
+          aria-hidden="true"
         >
-          <style>{`
-            .thumb-prose h1 { font-size: 1.5em; font-weight: 700; margin: 0.5em 0 0.25em; }
-            .thumb-prose h2 { font-size: 1.25em; font-weight: 600; margin: 0.5em 0 0.25em; }
-            .thumb-prose h3 { font-size: 1.1em; font-weight: 600; margin: 0.4em 0 0.2em; }
-            .thumb-prose p { margin: 0.4em 0; }
-            .thumb-prose ul, .thumb-prose ol { padding-left: 1.5em; margin: 0.4em 0; }
-            .thumb-prose code { background: #f3f4f6; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.9em; }
-            .thumb-prose pre { background: #f3f4f6; padding: 0.5em; border-radius: 4px; overflow: auto; margin: 0.4em 0; }
-            .thumb-prose blockquote { border-left: 3px solid #d1d5db; padding-left: 0.75em; margin: 0.4em 0; color: #6b7280; }
-            .thumb-prose a { color: #2563eb; text-decoration: underline; }
-            .thumb-prose table { border-collapse: collapse; margin: 0.4em 0; }
-            .thumb-prose th, .thumb-prose td { border: 1px solid #d1d5db; padding: 0.25em 0.5em; font-size: 0.9em; }
-          `}</style>
-          <div className="thumb-prose">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
-          </div>
+          {isCsvThumb && csvTable ? (
+            <div>
+              <style>{csvProseCss(scheme.tokens)}</style>
+              <div className="thumb-prose">
+                <table>
+                  <thead>
+                    <tr>
+                      {csvTable.cols.map((col) => (
+                        <th key={col}>{col}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {csvTable.rows.map((row, ri) => (
+                      <tr key={ri}>
+                        {csvTable.cols.map((col) => (
+                          <td key={col}>{String(row[col] ?? "")}</td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          ) : isSvg ? (
+            <div dangerouslySetInnerHTML={{ __html: sanitizedSvg }} />
+          ) : (
+            <div style={{ maxWidth: "none" }}>
+              <style>{markdownProseCss(scheme.tokens)}</style>
+              <div className="thumb-prose">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+              </div>
+            </div>
+          )}
         </div>
-      )}
-    </div>
+      ))}
+    </>
   );
 }

--- a/ui/src/components/ThumbnailGenerator.tsx
+++ b/ui/src/components/ThumbnailGenerator.tsx
@@ -196,8 +196,11 @@ const LIGHT_SCHEME: Scheme = {
   },
 };
 
-// Dark tokens mirror the portal's shadcn dark palette (card #020817,
-// foreground #f8fafc) so the captured thumbnail blends into the dark card.
+// Dark tokens mirror the portal's shadcn dark palette so the captured thumbnail
+// blends into the dark card. html2canvas needs concrete colors (it cannot
+// resolve CSS custom properties off-DOM), so these are hardcoded; keep them in
+// sync with the `.dark` block in src/index.css (--card -> #020817,
+// --card-foreground -> #f8fafc, --border/--muted/...) if that palette changes.
 const DARK_SCHEME: Scheme = {
   variant: "dark",
   mermaidTheme: "dark",
@@ -214,6 +217,14 @@ const DARK_SCHEME: Scheme = {
   },
 };
 
+// tableBaseCss is the table border/spacing shared by the markdown and CSV prose
+// variants; each adds its own cell sizing on top.
+function tableBaseCss(t: ProseTokens): string {
+  return `
+    .thumb-prose table { border-collapse: collapse; margin: 0.4em 0; }
+    .thumb-prose th, .thumb-prose td { border: 1px solid ${t.border}; padding: 0.25em 0.5em; }`;
+}
+
 function markdownProseCss(t: ProseTokens): string {
   return `
     .thumb-prose h1 { font-size: 1.5em; font-weight: 700; margin: 0.5em 0 0.25em; }
@@ -225,15 +236,16 @@ function markdownProseCss(t: ProseTokens): string {
     .thumb-prose pre { background: ${t.codeBg}; padding: 0.5em; border-radius: 4px; overflow: auto; margin: 0.4em 0; }
     .thumb-prose blockquote { border-left: 3px solid ${t.blockquoteBorder}; padding-left: 0.75em; margin: 0.4em 0; color: ${t.muted}; }
     .thumb-prose a { color: ${t.link}; text-decoration: underline; }
-    .thumb-prose table { border-collapse: collapse; margin: 0.4em 0; }
-    .thumb-prose th, .thumb-prose td { border: 1px solid ${t.border}; padding: 0.25em 0.5em; font-size: 0.9em; }
+    ${tableBaseCss(t)}
+    .thumb-prose th, .thumb-prose td { font-size: 0.9em; }
   `;
 }
 
 function csvProseCss(t: ProseTokens): string {
   return `
-    .thumb-prose table { border-collapse: collapse; margin: 0.4em 0; width: 100%; }
-    .thumb-prose th, .thumb-prose td { border: 1px solid ${t.border}; padding: 0.25em 0.5em; font-size: 0.85em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 120px; }
+    ${tableBaseCss(t)}
+    .thumb-prose table { width: 100%; }
+    .thumb-prose th, .thumb-prose td { font-size: 0.85em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 120px; }
     .thumb-prose th { background: ${t.thBg}; font-weight: 600; }
     .thumb-prose tr:nth-child(even) { background: ${t.evenRow}; }
   `;
@@ -350,20 +362,30 @@ function DomCapture({
   const doCapture = useCallback(async () => {
     if (capturedRef.current) return;
     capturedRef.current = true;
-    try {
-      for (let i = 0; i < schemes.length; i++) {
-        const container = containerRefs.current[i];
-        const scheme = schemes[i];
-        if (!container || !scheme) continue;
+    // Capture each variant independently so a failure on one (e.g. the dark
+    // pass throwing in html2canvas) does not discard a variant that already
+    // uploaded. Report success if ANY variant landed, so the queue invalidates
+    // and shows what we have; a still-missing variant is re-queued on next load.
+    let anySucceeded = false;
+    for (let i = 0; i < schemes.length; i++) {
+      const container = containerRefs.current[i];
+      const scheme = schemes[i];
+      if (!container || !scheme) continue;
+      try {
         await waitForContent(container);
         await renderMermaidIn(container, scheme.mermaidTheme, `thumb-mermaid-${scheme.variant}`);
         // Let layout settle after mermaid SVGs are inserted
         await new Promise((r) => requestAnimationFrame(r));
         const blob = await captureContainer(container, scheme.tokens.bg);
         await uploadThumbnail(assetId, blob, scheme.variant);
+        anySucceeded = true;
+      } catch {
+        // Skip this variant; other variants and a later retry can still fill it.
       }
+    }
+    if (anySucceeded) {
       onCaptured?.();
-    } catch {
+    } else {
       onFailed?.();
     }
   }, [assetId, schemes, onCaptured, onFailed]);

--- a/ui/src/components/ThumbnailQueue.tsx
+++ b/ui/src/components/ThumbnailQueue.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { apiFetchRaw } from "@/api/portal/client";
 import type { Asset } from "@/api/portal/types";
-import { isThumbnailSupported } from "@/lib/thumbnail";
+import { isThumbnailSupported, isThemeable } from "@/lib/thumbnail";
 import { ThumbnailGenerator } from "./ThumbnailGenerator";
 
 interface Props {
@@ -23,14 +23,18 @@ export function ThumbnailQueue({ assets }: Props) {
   const [current, setCurrent] = useState<{ asset: Asset; content: string } | null>(null);
   const processedRef = useRef(new Set<string>());
 
-  // Build the queue of assets needing thumbnails, excluding already-processed ones
+  // Build the queue of assets needing thumbnails, excluding already-processed
+  // ones. A themeable asset (markdown/CSV) needs capture until BOTH the light
+  // and dark variants exist; single-theme types need only the light variant.
   useEffect(() => {
-    const needsThumbnail = assets.filter(
-      (a) =>
-        !a.thumbnail_s3_key &&
-        isThumbnailSupported(a.content_type) &&
-        !processedRef.current.has(a.id),
-    );
+    const needsThumbnail = assets.filter((a) => {
+      if (!isThumbnailSupported(a.content_type) || processedRef.current.has(a.id)) {
+        return false;
+      }
+      const missingLight = !a.thumbnail_s3_key;
+      const missingDark = isThemeable(a.content_type) && !a.thumbnail_dark_s3_key;
+      return missingLight || missingDark;
+    });
     setQueue(needsThumbnail);
     setCurrent(null);
   }, [assets]);

--- a/ui/src/lib/thumbnail.test.ts
+++ b/ui/src/lib/thumbnail.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { buildJsxThumbnailHtml, injectCaptureScript } from "./thumbnail";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { fetchRaw } = vi.hoisted(() => ({ fetchRaw: vi.fn() }));
+vi.mock("@/api/portal/client", () => ({ apiFetchRaw: fetchRaw }));
+
+import { buildJsxThumbnailHtml, injectCaptureScript, isThemeable, uploadThumbnail } from "./thumbnail";
 
 // Count top-level `import React` default-binding declarations. The namespaced
 // alias `import * as __artifactReact` must NOT match.
@@ -56,5 +60,43 @@ describe("injectCaptureScript", () => {
     const out = injectCaptureScript(html);
     expect(out.startsWith(html)).toBe(true);
     expect(out).toContain("thumbnail-ready");
+  });
+});
+
+describe("isThemeable", () => {
+  it("is true for content rendered on a forced background", () => {
+    expect(isThemeable("text/markdown")).toBe(true);
+    expect(isThemeable("text/csv")).toBe(true);
+    expect(isThemeable("TEXT/MARKDOWN")).toBe(true);
+  });
+
+  it("is false for self-themed content types", () => {
+    for (const ct of ["text/html", "text/jsx", "image/svg+xml", "image/png"]) {
+      expect(isThemeable(ct)).toBe(false);
+    }
+  });
+});
+
+describe("uploadThumbnail", () => {
+  beforeEach(() => {
+    fetchRaw.mockReset();
+    fetchRaw.mockResolvedValue({ ok: true });
+  });
+
+  it("uploads the light variant with no query param by default", async () => {
+    await uploadThumbnail("ast-1", new Blob(["x"]));
+    expect(fetchRaw).toHaveBeenCalledTimes(1);
+    expect(fetchRaw.mock.calls[0]![0]).toBe("/assets/ast-1/thumbnail");
+    expect(fetchRaw.mock.calls[0]![1]).toMatchObject({ method: "PUT" });
+  });
+
+  it("appends ?variant=dark for the dark variant", async () => {
+    await uploadThumbnail("ast-1", new Blob(["x"]), "dark");
+    expect(fetchRaw.mock.calls[0]![0]).toBe("/assets/ast-1/thumbnail?variant=dark");
+  });
+
+  it("throws when the upload response is not ok", async () => {
+    fetchRaw.mockResolvedValue({ ok: false });
+    await expect(uploadThumbnail("ast-1", new Blob(["x"]))).rejects.toThrow("Failed to upload thumbnail");
   });
 });

--- a/ui/src/lib/thumbnail.ts
+++ b/ui/src/lib/thumbnail.ts
@@ -77,11 +77,21 @@ export async function captureIframe(iframe: HTMLIFrameElement): Promise<Blob> {
 }
 
 
+/** Thumbnail color-scheme variant. Light is the default/shared variant. */
+export type ThumbnailVariant = "light" | "dark";
+
 /**
- * Upload a PNG thumbnail blob for an asset.
+ * Upload a PNG thumbnail blob for an asset. The optional variant selects the
+ * color scheme; "dark" is only captured for themeable content types (see
+ * isThemeable). Defaults to the light/shared variant.
  */
-export async function uploadThumbnail(assetId: string, blob: Blob): Promise<void> {
-  const res = await apiFetchRaw(`/assets/${assetId}/thumbnail`, {
+export async function uploadThumbnail(
+  assetId: string,
+  blob: Blob,
+  variant: ThumbnailVariant = "light",
+): Promise<void> {
+  const query = variant === "dark" ? "?variant=dark" : "";
+  const res = await apiFetchRaw(`/assets/${assetId}/thumbnail${query}`, {
     method: "PUT",
     headers: { "Content-Type": "image/png" },
     body: blob,
@@ -164,7 +174,7 @@ setTimeout(function() {
   <script type="importmap">${importMap}</script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
-    body { font-family: system-ui, sans-serif; padding: 16px; }
+    body { font-family: system-ui, sans-serif; }
   </style>
 </head>
 <body>
@@ -194,4 +204,15 @@ ${mountSection}
 export function isThumbnailSupported(contentType: string): boolean {
   const ct = contentType.toLowerCase();
   return ct.includes("html") || ct.includes("jsx") || ct.includes("svg") || ct.includes("markdown") || ct.includes("csv");
+}
+
+/**
+ * Returns true if the content type is rendered on a forced (non-themed)
+ * background and therefore needs a separate dark-mode thumbnail. HTML, JSX, and
+ * SVG carry their own colors, so they reuse the single light/default thumbnail
+ * in both modes.
+ */
+export function isThemeable(contentType: string): boolean {
+  const ct = contentType.toLowerCase();
+  return ct.includes("markdown") || ct.includes("csv");
 }

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -1436,15 +1436,24 @@ export const handlers = [
     if (!asset) {
       return HttpResponse.json({ detail: "Not found" }, { status: 404 });
     }
+    const variant = new URL(request.url).searchParams.get("variant");
     const buffer = await request.arrayBuffer();
-    thumbnailStore.set(asset.id, buffer);
-    asset.thumbnail_s3_key = `thumbnails/${asset.id}.png`;
+    if (variant === "dark") {
+      thumbnailStore.set(`${asset.id}:dark`, buffer);
+      asset.thumbnail_dark_s3_key = `thumbnails/${asset.id}_dark.png`;
+    } else {
+      thumbnailStore.set(asset.id, buffer);
+      asset.thumbnail_s3_key = `thumbnails/${asset.id}.png`;
+    }
     return new HttpResponse(null, { status: 204 });
   }),
 
-  http.get(`${PORTAL_BASE}/assets/:id/thumbnail`, ({ params }) => {
+  http.get(`${PORTAL_BASE}/assets/:id/thumbnail`, ({ params, request }) => {
     const id = params.id as string;
-    const buffer = thumbnailStore.get(id);
+    const variant = new URL(request.url).searchParams.get("variant");
+    // Dark variant falls back to the light buffer when none was captured.
+    const buffer =
+      variant === "dark" ? (thumbnailStore.get(`${id}:dark`) ?? thumbnailStore.get(id)) : thumbnailStore.get(id);
     if (buffer) {
       return new HttpResponse(buffer, {
         headers: { "Content-Type": "image/png" },

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -609,6 +609,7 @@ export const handlers = [
       name: mockSystemInfo.name,
       version: mockSystemInfo.version,
       portal_title: mockSystemInfo.portal_title,
+      oidc_button_label: "", // empty -> portal falls back to the default "Sign in with OIDC"
       portal_logo: mockSystemInfo.portal_logo,
       portal_logo_light: mockSystemInfo.portal_logo_light,
       portal_logo_dark: mockSystemInfo.portal_logo_dark,

--- a/ui/src/pages/assets/MyAssetsPage.tsx
+++ b/ui/src/pages/assets/MyAssetsPage.tsx
@@ -10,6 +10,7 @@ import { formatBytes } from "@/lib/format";
 import { ThumbnailQueue } from "@/components/ThumbnailQueue";
 import { AuthImg } from "@/components/AuthImg";
 import { AssetPreviewModal } from "@/components/AssetPreviewModal";
+import { useResolvedDark } from "@/stores/theme";
 
 const VIEW_STORAGE_KEY = "asset-view-mode";
 type ViewMode = "grid" | "table";
@@ -64,6 +65,7 @@ function contentTypeBadgeColor(ct: string) {
 }
 
 export function MyAssetsPage({ onNavigate }: Props) {
+  const isDark = useResolvedDark();
   const [scope, setScope] = useState<Scope>(getStoredScope);
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -223,7 +225,9 @@ export function MyAssetsPage({ onNavigate }: Props) {
                 <div className="w-full aspect-[4/3] bg-muted">
                   {asset.thumbnail_s3_key ? (
                     <AuthImg
-                      src={`/api/v1/portal/assets/${asset.id}/thumbnail`}
+                      src={`/api/v1/portal/assets/${asset.id}/thumbnail${
+                        isDark && asset.thumbnail_dark_s3_key ? "?variant=dark" : ""
+                      }`}
                       alt=""
                       className="w-full h-full object-cover object-top"
                     />

--- a/ui/src/stores/theme.ts
+++ b/ui/src/stores/theme.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { create } from "zustand";
 
 type Theme = "light" | "dark" | "system";
@@ -46,6 +47,26 @@ if (typeof window !== "undefined" && typeof window.matchMedia === "function") {
       applyTheme("system");
     }
   });
+}
+
+/**
+ * useResolvedDark returns whether dark mode is currently active, resolving the
+ * "system" setting against the OS preference and re-rendering when either the
+ * stored theme or the OS preference changes.
+ */
+export function useResolvedDark(): boolean {
+  const theme = useThemeStore((s) => s.theme);
+  const [systemDark, setSystemDark] = useState(prefersDark);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => setSystemDark(mq.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  return theme === "dark" || (theme === "system" && systemDark);
 }
 
 export const useThemeStore = create<ThemeState>((set) => ({


### PR DESCRIPTION
## Summary

Three portal UI enhancements:

1. **Theme-aware (light/dark) asset thumbnails** so previews stop looking jarring in a dark-mode portal.
2. **White-frame fix** on JSX/dashboard thumbnails.
3. **Configurable OIDC sign-in button label** for deployments whose users do not recognize the term "OIDC".

## 1. Theme-aware asset thumbnails

Markdown and CSV thumbnails were captured on a forced white background, so they looked out of place in a dark-mode grid. Now markdown and CSV assets (the types rendered on a forced background) capture two variants, light and dark, and the grid serves the one matching the active theme. Self-themed content (HTML, JSX, SVG) carries its own colors, so it keeps a single capture reused in both modes. Public shares always serve the light variant.

```mermaid
flowchart LR
    A[Asset in grid] --> B{Content type?}
    B -->|markdown / csv| C{Active theme?}
    B -->|html / jsx / svg| D[Single capture]
    C -->|dark and dark variant exists| E[thumbnail_dark.png]
    C -->|light| F[thumbnail.png]
    D --> F
```

**Backend**
- Migration `000068` adds a nullable `thumbnail_dark_s3_key` column to `portal_assets`; the existing `thumbnail_s3_key` stays as the light/default. The dark variant is stored at `<prefix>/thumbnail_dark.png`.
- The column is wired through every asset read path (`Get`, `GetByIDs`, `GetByIdempotencyKey`, list/search via the shared scan-dest and column constants, shared-with-me, and collection batch get), each at a matching SELECT/Scan ordinal.
- `PUT`/`GET /api/v1/portal/assets/{id}/thumbnail` take an optional `?variant=dark` query param (defaults to light). A dark `GET` falls back to the light key when no dark variant was captured; an unknown variant returns `400`.
- Creating a new asset version clears both thumbnail keys.
- Public/shared thumbnail endpoints are unchanged and continue to serve the light variant.

**Frontend**
- `DomCapture` renders markdown/CSV twice with light and dark prose stylesheets and the matching mermaid theme, uploading each to its variant. Each variant is captured independently, so a failure on one does not discard a variant that already uploaded.
- `ThumbnailQueue` re-queues a themeable asset until both variants exist.
- `MyAssetsPage` requests `?variant=dark` when dark mode is active and a dark variant exists, via a new `useResolvedDark()` hook in the theme store.
- Dark thumbnail tokens mirror the portal's dark palette (`src/index.css`); they are hardcoded because html2canvas cannot resolve CSS custom properties off-DOM.

## 2. White-frame fix

The JSX thumbnail wrapper applied `padding: 16px` over a default (white) body background, so dashboards that paint their own dark background showed a white border in the captured image. Dropping the padding lets content render edge to edge, so the artifact's own background reaches all four edges. The fix is theme-neutral (no background is forced).

## 3. Configurable OIDC login button label

The login screen hardcoded "Sign in with OIDC". Added `portal.oidc_button_label` (default `Sign in with OIDC`), served through the public branding endpoint and rendered by the login screen with the same default-fallback pattern as the existing title and tagline.

```yaml
portal:
  oidc_button_label: "Sign in with ACME Keycloak"
```

## Migration

`000068_portal_asset_thumbnail_dark` adds a nullable column with default `''`. It is additive and backward compatible: existing thumbnails remain valid as the light variant. The down migration drops the column.

## Code-review follow-ups (second commit)

A high-effort review of the branch produced five fixes, all included here:
- Capture each thumbnail variant independently (partial-failure handling above).
- `LoginForm` uses the shared `useResolvedDark()` hook instead of a duplicate inline theme-resolution effect.
- Removed a dead, divergent `Branding` interface in `api/portal/types.ts`; the `hooks.ts` definition is the single source consumers use.
- Extracted shared table styling (`tableBaseCss`) from the markdown and CSV thumbnail prose builders.
- Documented why the dark thumbnail palette is hardcoded and where to keep it in sync.

## Verified locally

- Go: `go build ./...`, `go vet`, and tests for `pkg/portal`, `pkg/admin`, and `pkg/database/migrate` pass; the anti-vaporware gates pass; `golangci-lint --new-from-rev=main` reports 0 new issues.
- Swagger regenerated (`make swagger`); branding/config docs and `llms-full.txt` updated.
- Frontend: `tsc` clean, eslint clean, full vitest suite passes. New tests cover `isThemeable`, the `uploadThumbnail` variant, the handler variant/fallback, the store dark-key update, `DeriveThumbnailKeyVariant`, and the login button label.

CI runs the complete `make verify` suite (including the DB-gated and security/mutation checks) on this PR.
