### PR TITLE
perf(portal): batch thumbnail-queue refetch and lazy-load grid images

### DIFF
--- a/ui/src/components/AuthImg.test.tsx
+++ b/ui/src/components/AuthImg.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+// In cookie-auth mode useAuthSrc returns the URL as-is; mock it so the test
+// focuses on the <img> attributes AuthImg sets.
+vi.mock("@/hooks/useAuthSrc", () => ({ useAuthSrc: (url: string | undefined) => url }));
+
+import { AuthImg } from "./AuthImg";
+
+describe("AuthImg", () => {
+  it("defaults to lazy loading and async decoding", () => {
+    const { container } = render(<AuthImg src="/x.png" alt="" />);
+    const img = container.querySelector("img")!;
+    expect(img.getAttribute("loading")).toBe("lazy");
+    expect(img.getAttribute("decoding")).toBe("async");
+  });
+
+  it("lets callers override the loading attribute", () => {
+    const { container } = render(<AuthImg src="/x.png" alt="" loading="eager" />);
+    expect(container.querySelector("img")!.getAttribute("loading")).toBe("eager");
+  });
+});

--- a/ui/src/components/AuthImg.tsx
+++ b/ui/src/components/AuthImg.tsx
@@ -11,5 +11,8 @@ type Props = Omit<React.ImgHTMLAttributes<HTMLImageElement>, "src"> & {
 export function AuthImg({ src, ...props }: Props) {
   const resolvedSrc = useAuthSrc(src);
   if (!resolvedSrc) return null;
-  return <img src={resolvedSrc} {...props} />;
+  // Default to lazy/async so off-screen grid thumbnails don't all fetch and
+  // decode on mount (a full grid otherwise loads every thumbnail at once).
+  // Defaults come before the spread so callers can still override them.
+  return <img loading="lazy" decoding="async" src={resolvedSrc} {...props} />;
 }

--- a/ui/src/components/ThumbnailQueue.test.tsx
+++ b/ui/src/components/ThumbnailQueue.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useEffect } from "react";
+import { render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Asset } from "@/api/portal/types";
+
+// apiFetchRaw is used to fetch each asset's content before capture.
+const { fetchRaw, captureMode } = vi.hoisted(() => ({
+  fetchRaw: vi.fn(),
+  captureMode: { value: "captured" as "captured" | "failed" },
+}));
+vi.mock("@/api/portal/client", () => ({ apiFetchRaw: fetchRaw }));
+
+// Stand in for the real capturer (html2canvas is browser-only). Reports a
+// captured or failed result per asset as soon as it renders. Keying the effect
+// on assetId (not the callback) makes it fire once per asset regardless of how
+// the queue mounts/unmounts the generator between items.
+vi.mock("./ThumbnailGenerator", () => ({
+  ThumbnailGenerator: ({
+    assetId,
+    onCaptured,
+    onFailed,
+  }: {
+    assetId: string;
+    onCaptured?: () => void;
+    onFailed?: () => void;
+  }) => {
+    useEffect(() => {
+      if (captureMode.value === "failed") onFailed?.();
+      else onCaptured?.();
+    }, [assetId, onCaptured, onFailed]);
+    return null;
+  },
+}));
+
+import { ThumbnailQueue } from "./ThumbnailQueue";
+
+function asset(id: string): Asset {
+  return {
+    id,
+    owner_id: "u1",
+    owner_email: "u1@example.com",
+    name: id,
+    content_type: "text/html",
+    s3_bucket: "b",
+    s3_key: `k/${id}`,
+    thumbnail_s3_key: "", // missing -> needs a thumbnail
+    size_bytes: 1,
+    tags: [],
+    provenance: {} as Asset["provenance"],
+    session_id: "",
+    current_version: 1,
+    created_at: "",
+    updated_at: "",
+  };
+}
+
+describe("ThumbnailQueue invalidation batching", () => {
+  beforeEach(() => {
+    fetchRaw.mockReset();
+    fetchRaw.mockResolvedValue({ ok: true, text: () => Promise.resolve("<html></html>") });
+    captureMode.value = "captured";
+  });
+
+  it("invalidates the asset list once after a batch of captures, not per capture", async () => {
+    const qc = new QueryClient();
+    const invalidate = vi.spyOn(qc, "invalidateQueries").mockResolvedValue();
+
+    const assets = [asset("a"), asset("b"), asset("c")];
+
+    render(
+      <QueryClientProvider client={qc}>
+        <ThumbnailQueue assets={assets} />
+      </QueryClientProvider>,
+    );
+
+    // All three assets get fetched + captured.
+    await waitFor(() => expect(fetchRaw).toHaveBeenCalledTimes(3));
+
+    // The asset list is invalidated exactly once for the whole drain, not once
+    // per capture (which is the storm this fix removes).
+    await waitFor(() =>
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: ["assets"] }),
+    );
+    expect(invalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invalidate when every capture fails (nothing to refresh)", async () => {
+    captureMode.value = "failed";
+    const qc = new QueryClient();
+    const invalidate = vi.spyOn(qc, "invalidateQueries").mockResolvedValue();
+
+    const assets = [asset("a"), asset("b"), asset("c")];
+
+    render(
+      <QueryClientProvider client={qc}>
+        <ThumbnailQueue assets={assets} />
+      </QueryClientProvider>,
+    );
+
+    // All three are processed (fetched) but report failure, so the queue drains
+    // with dirtyRef never set and must not trigger a refetch.
+    await waitFor(() => expect(fetchRaw).toHaveBeenCalledTimes(3));
+    // Let the drain effect run after the final advance.
+    await waitFor(() => expect(invalidate).not.toHaveBeenCalled());
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/ThumbnailQueue.tsx
+++ b/ui/src/components/ThumbnailQueue.tsx
@@ -22,6 +22,13 @@ export function ThumbnailQueue({ assets }: Props) {
   const [queue, setQueue] = useState<Asset[]>([]);
   const [current, setCurrent] = useState<{ asset: Asset; content: string } | null>(null);
   const processedRef = useRef(new Set<string>());
+  // Set when a capture uploads during the current drain cycle. We refresh the
+  // asset list exactly once when the queue goes idle, rather than after every
+  // capture: a per-capture invalidation refetched the list and re-rendered the
+  // grid on each thumbnail, which tore down and re-requested every <img> (and
+  // aborted in-flight loads) so thumbnails never settled. Batching collapses a
+  // backfill of N thumbnails into a single refetch.
+  const dirtyRef = useRef(false);
 
   // Build the queue of assets needing thumbnails, excluding already-processed
   // ones. A themeable asset (markdown/CSV) needs capture until BOTH the light
@@ -68,14 +75,26 @@ export function ThumbnailQueue({ assets }: Props) {
   }, []);
 
   const handleCaptured = useCallback(() => {
-    void qc.invalidateQueries({ queryKey: ["assets"] });
-    advance();
-  }, [qc, advance]);
-
-  const handleFailed = useCallback(() => {
-    // Move on to the next asset without invalidating
+    // Defer the asset-list refresh to the drain effect below so a batch of
+    // captures triggers a single refetch instead of one per capture.
+    dirtyRef.current = true;
     advance();
   }, [advance]);
+
+  const handleFailed = useCallback(() => {
+    // Move on to the next asset without marking dirty.
+    advance();
+  }, [advance]);
+
+  // Refresh the asset list once, when the queue has fully drained and at least
+  // one capture uploaded. This flips the freshly captured assets from the
+  // placeholder icon to their thumbnail in a single grid re-render.
+  useEffect(() => {
+    if (!current && queue.length === 0 && dirtyRef.current) {
+      dirtyRef.current = false;
+      void qc.invalidateQueries({ queryKey: ["assets"] });
+    }
+  }, [current, queue.length, qc]);
 
   if (!current) return null;
 


### PR DESCRIPTION
## Summary

Fixes a portal asset-grid performance problem where the grid was slow and thumbnails were re-requested repeatedly instead of caching. Two independent causes, both in the React frontend:

1. The thumbnail queue invalidated the asset list after **every single** capture, causing a refetch and grid re-render per thumbnail.
2. The grid `<img>` had no lazy loading, so a full grid fetched and decoded every thumbnail (including off-screen) on mount.

This builds on v1.86.3, whose theme-aware (light/dark) thumbnails left every existing markdown/CSV asset needing a one-time dark-variant backfill, which turned both issues from mild into acute.

## Evidence

A HAR capture from a production instance's asset grid showed, in a ~5 second window:

- **219 thumbnail requests for only 51 unique thumbnails** (each fetched ~5x).
- **41 requests aborted** mid-load (status 0).
- Each thumbnail took **~891ms median** to serve (the backend reads the PNG from S3 and serves it).
- The responses carried a correct `Cache-Control: private, max-age=3600`, yet the same URL was re-requested 4-5 times in 3 seconds.

The same URL being re-requested that many times means the grid was tearing down and recreating its `<img>` elements faster than the slow thumbnails could load, so the loads were aborted before they could settle or cache.

## Root cause and fix

### 1. Per-capture invalidation storm

`ThumbnailQueue` called `qc.invalidateQueries(["assets"])` inside `handleCaptured`, so each captured thumbnail refetched the whole asset list and re-rendered the grid. During a backfill of N thumbnails that is N refetches and N grid re-renders, each one re-requesting (and aborting) in-flight image loads.

The fix defers the refresh: a `dirtyRef` records that a capture uploaded, and a drain effect fires a single `invalidateQueries(["assets"])` once the queue is empty. A batch of N captures now produces **one** refetch. Failed captures do not set `dirtyRef`, so a drain with no successful capture does not refetch.

### 2. No lazy image loading

`AuthImg` (used by the asset grid and three collection grids) rendered a plain `<img>`, so the browser fetched and decoded every thumbnail on mount regardless of viewport. It now defaults to `loading="lazy"` and `decoding="async"` (placed before the prop spread so callers can still override). Off-screen thumbnails load only when scrolled into view, capping the request burst to what is visible.

## Tests

- `ThumbnailQueue.test.tsx`: asserts N captures produce exactly **one** invalidation (the previous code produced N), and that a batch where every capture fails produces **zero** invalidations.
- `AuthImg.test.tsx`: asserts the `loading="lazy"` / `decoding="async"` defaults and that a caller can override them.

## Scope and tradeoffs

- This is frontend-only: no Go, no migration, no API or schema change.
- It does not change the ~900ms-per-thumbnail backend latency (the backend reads each PNG from S3 and serves it). Cutting the request count is the larger lever; the backend path is unchanged here.
- Thumbnails now populate together when a capture batch finishes rather than trickling in one by one. For the one-time dark-variant backfill that means placeholder icons until the batch completes, then they all appear.

## Verified locally

- `tsc` clean, eslint clean, full vitest suite passes (203 tests).
