### PR TITLE
feat(verify): structural maintainability gates (#594)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,7 @@ linters:
     - revive             # Fast, extensible linter (AI guardrails)
     - gocyclo            # Cyclomatic complexity
     - gocognit           # Cognitive complexity
+    - dupl               # Cross-file copy-paste duplication (structural gate, #594)
     - nakedret           # Naked returns in long functions
     - prealloc           # Slice preallocation suggestions
     - predeclared        # Shadowing predeclared identifiers
@@ -45,6 +46,9 @@ linters:
     - errorlint          # Error wrapping issues
     - wrapcheck          # Ensure errors from external packages are wrapped
     - thelper            # Test helper issues
+
+    # ===== Architecture =====
+    - depguard           # Import-boundary / layering enforcement (structural gate, #594)
 
     # ===== Security =====
     - gosec              # Security issues (OWASP)
@@ -88,6 +92,49 @@ linters:
 
     nestif:
       min-complexity: 5
+
+    # dupl flags cross-file copy-paste (structural gate, #594). The
+    # threshold is in tokens; 150 is the upstream default and a
+    # deliberately permissive starting point. CI runs only-new-issues,
+    # so the handful of pre-existing clones are grandfathered and only
+    # NEW duplication fails the gate. Ratchet the threshold DOWN in a
+    # follow-up once the existing clones are consolidated.
+    dupl:
+      threshold: 150
+
+    # depguard enforces module-import boundaries that the Go compiler
+    # does not (it only forbids cycles, not layering violations). The
+    # rules below are derived from the CURRENT import graph so they are
+    # green on day one; tighten them in follow-ups. See CONTRIBUTING.md
+    # ("Structural maintainability gates") for the rationale and how to
+    # adjust. list-mode lax = everything is allowed except the denials.
+    depguard:
+      rules:
+        # pkg/admin is the top composition leaf: it wires handlers onto
+        # the assembled platform and is imported ONLY by cmd/. Nothing
+        # lower in the stack (toolkits, providers, middleware, platform)
+        # may reach up into it. A toolkit importing pkg/admin fails here.
+        admin-is-a-leaf:
+          list-mode: lax
+          files:
+            - "**/*.go"
+            - "!**/*_test.go"
+            - "!**/cmd/**"
+          deny:
+            - pkg: github.com/txn2/mcp-data-platform/pkg/admin
+              desc: "pkg/admin is a top-level composition leaf wired only by cmd/; lower layers must not import it (see CONTRIBUTING.md)."
+        # Toolkits sit BELOW the platform facade: platform composes
+        # toolkits, never the reverse. A toolkit importing pkg/platform
+        # would invert the dependency and create the kind of fan-out the
+        # gate exists to stop.
+        toolkits-do-not-import-platform:
+          list-mode: lax
+          files:
+            - "**/pkg/toolkits/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: github.com/txn2/mcp-data-platform/pkg/platform
+              desc: "toolkits are a lower layer than pkg/platform; importing it inverts the toolkit->platform layering (see CONTRIBUTING.md)."
 
     gocritic:
       enabled-tags:
@@ -331,6 +378,13 @@ linters:
         linters:
           - gocognit
           - gocyclo
+
+      # Test files legitimately repeat fixture/setup blocks; dupl on test
+      # bodies would punish standard table-driven and arrange-act-assert
+      # structure. Production duplication is still gated.
+      - path: _test\.go
+        linters:
+          - dupl
 
       - path: _test\.go
         linters:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,6 +200,58 @@ go tool cover -html=coverage.out
 go test -race ./pkg/platform/...
 ```
 
+## Structural maintainability gates
+
+The `gocyclo`, `gocognit`, `nestif`, and `revive` rules all evaluate code
+*inside* a single function or file. They keep individual functions simple but
+say nothing about how packages relate to each other. Three additional gates
+police structure rather than per-function complexity, so the codebase stays
+maintainable as features accrete. Each was landed green against the tree at the
+time and is meant to be **ratcheted tighter in follow-up PRs**, never relaxed to
+make a violation pass.
+
+### 1. Import boundaries (`depguard`)
+
+The Go compiler forbids import cycles but not layering violations. `depguard`
+(configured in `.golangci.yml` under `linters.settings.depguard`) declares which
+packages may import which. The current rules, derived from the real import graph:
+
+- **`admin-is-a-leaf`** — `pkg/admin` is the top composition layer, wired in only
+  by `cmd/`. Nothing lower in the stack (toolkits, providers, middleware,
+  `pkg/platform`) may import it. A toolkit that imports `pkg/admin` fails lint.
+- **`toolkits-do-not-import-platform`** — toolkits sit below the platform facade
+  (`pkg/platform` composes toolkits, never the reverse), so a toolkit importing
+  `pkg/platform` is rejected.
+
+To tighten: add a rule (or a `deny` entry) for the next boundary you want to
+lock down, confirm `golangci-lint run --enable-only depguard ./...` is still
+green, then commit. To verify the gate bites, temporarily add a denied import
+and run the same command.
+
+### 2. Cross-file duplication (`dupl`)
+
+`dupl` flags copy-pasted blocks across files (threshold 150 tokens, the
+permissive upstream default). This mechanically enforces our shared-abstraction
+principle: per-kind forking ("Mirror of X, kept separate") is a code smell. CI
+runs `only-new-issues`, so the handful of pre-existing clones are grandfathered
+and only **new** duplication fails the gate. Ratchet the threshold down in a
+follow-up once existing clones are consolidated. Test files are exempt
+(table-driven and arrange-act-assert structure legitimately repeats).
+
+### 3. Package-size budget (`TestPackageSizeBudget`)
+
+Every per-function gate is satisfied by a god-package built from a hundred
+small, low-complexity functions. `TestPackageSizeBudget` (in
+`package_budget_test.go`) caps the size of a package as a whole: no package under
+`pkg/` may exceed **13,000 non-generated LOC** or **35 non-generated files**.
+Generated files (those carrying a `Code generated ... DO NOT EDIT.` marker) are
+excluded so embedded specs do not masquerade as hand-written code.
+
+The budgets sit just above today's largest package (`pkg/admin`, ~12.1k LOC, 27
+files). They are **ceilings to ratchet down**, not numbers to raise: if a package
+hits the budget, decompose it into cohesive sub-packages rather than bumping the
+constant. Run it with `go test -run TestPackageSizeBudget .`.
+
 ## Security
 
 - Never commit secrets or credentials

--- a/package_budget_test.go
+++ b/package_budget_test.go
@@ -1,0 +1,204 @@
+// Package verify enforces project-level structural invariants.
+//
+// This file adds the package-size budget gate (issue #594): a structural
+// backstop that the per-function complexity linters cannot provide. Every
+// gocyclo/gocognit/revive rule evaluates code INSIDE a single function, so a
+// god-package assembled from a hundred small, low-complexity functions passes
+// all of them. This test caps the size of a package as a whole, forcing
+// decomposition before a package grows too large to reason about in isolation.
+//
+// The budgets are deliberately set ABOVE today's largest package so the gate
+// is green on the current tree and purely additive. They are ceilings to
+// ratchet DOWN over time (in separate follow-up PRs), not numbers to raise
+// when a package bumps against them: hitting the budget is the signal to
+// decompose the package, not to relax the gate.
+//
+// Generated files (those carrying a "Code generated ... DO NOT EDIT." marker)
+// are excluded from the count, so an embedded spec like internal/apidocs does
+// not masquerade as hand-written code (#594, item 4).
+//
+// Run: go test -run TestPackageSizeBudget .
+package mcp_data_platform_test
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// maxPackageLOC caps non-generated, non-test lines per package under
+	// pkg/. The largest package today (pkg/admin) is ~12.1k LOC; this
+	// ceiling leaves headroom so the gate is green now, then ratchets down.
+	maxPackageLOC = 13000
+
+	// maxPackageFiles caps non-generated, non-test .go files per package
+	// under pkg/. The largest today (pkg/middleware, pkg/admin) hold 27
+	// files; this ceiling leaves headroom and pressures decomposition.
+	maxPackageFiles = 35
+)
+
+// generatedMarkerRe matches the canonical "generated code" line that Go
+// tooling (swag, mockgen, stringer, protoc-gen-go, etc.) emits. A file
+// carrying this marker is excluded from the budget.
+var generatedMarkerRe = regexp.MustCompile(`^// Code generated .* DO NOT EDIT\.$`)
+
+// packageSize accumulates the non-generated, non-test footprint of one package.
+type packageSize struct {
+	loc   int
+	files int
+}
+
+// TestPackageSizeBudget fails when any package under pkg/ exceeds the LOC or
+// file-count budget, counting only hand-written, non-test source.
+//
+// This is the structural counterpart to the per-function complexity gates:
+// those bound the inside of a function, this bounds the size of a package.
+// If it fails, decompose the offending package into cohesive sub-packages —
+// do not raise the budget (that defeats the gate). See CONTRIBUTING.md,
+// "Structural maintainability gates".
+func TestPackageSizeBudget(t *testing.T) {
+	projectRoot, err := filepath.Abs(".")
+	require.NoError(t, err)
+
+	pkgDir := filepath.Join(projectRoot, "pkg")
+	sizes := map[string]*packageSize{}
+
+	walkErr := filepath.Walk(pkgDir, func(path string, info os.FileInfo, fErr error) error {
+		if fErr != nil {
+			return fErr
+		}
+		if info.IsDir() || !strings.HasSuffix(info.Name(), ".go") || strings.HasSuffix(info.Name(), "_test.go") {
+			return nil
+		}
+		generated, loc, countErr := countGoFile(path)
+		if countErr != nil {
+			return countErr
+		}
+		if generated {
+			return nil
+		}
+		dir := filepath.Dir(path)
+		rel, relErr := filepath.Rel(projectRoot, dir)
+		if relErr != nil {
+			return fmt.Errorf("computing relative path for %s: %w", dir, relErr)
+		}
+		ps, ok := sizes[rel]
+		if !ok {
+			ps = &packageSize{}
+			sizes[rel] = ps
+		}
+		ps.loc += loc
+		ps.files++
+		return nil
+	})
+	require.NoError(t, walkErr)
+	require.NotEmpty(t, sizes, "should find packages under pkg/")
+
+	var violations []string
+	for pkg, ps := range sizes {
+		if ps.loc > maxPackageLOC {
+			violations = append(violations, fmt.Sprintf(
+				"%s: %d LOC exceeds budget of %d (decompose the package; do not raise the budget)",
+				pkg, ps.loc, maxPackageLOC))
+		}
+		if ps.files > maxPackageFiles {
+			violations = append(violations, fmt.Sprintf(
+				"%s: %d files exceeds budget of %d (decompose the package; do not raise the budget)",
+				pkg, ps.files, maxPackageFiles))
+		}
+	}
+	sort.Strings(violations)
+
+	require.Empty(t, violations,
+		"package size budget exceeded:\n  %s", strings.Join(violations, "\n  "))
+}
+
+// TestCountGoFile exercises generated-marker detection and line counting
+// directly. No package under pkg/ currently carries a generated marker, so
+// this is the unit that proves generated files are excluded from the budget
+// (#594, item 4) and that line counting is correct.
+func TestCountGoFile(t *testing.T) {
+	tests := []struct {
+		name          string
+		content       string
+		wantGenerated bool
+		wantLOC       int
+	}{
+		{
+			name:          "hand-written file is counted",
+			content:       "package x\n\nfunc f() {}\n",
+			wantGenerated: false,
+			wantLOC:       3,
+		},
+		{
+			name:          "swag-style generated marker is detected",
+			content:       "// Code generated by swaggo/swag. DO NOT EDIT.\npackage docs\n",
+			wantGenerated: true,
+			wantLOC:       2,
+		},
+		{
+			name:          "marker after a build constraint is still detected",
+			content:       "//go:build ignore\n\n// Code generated by mockgen. DO NOT EDIT.\npackage m\n",
+			wantGenerated: true,
+			wantLOC:       4,
+		},
+		{
+			name:          "a comment that merely mentions generated code is not a marker",
+			content:       "package x\n// this is not Code generated by anything\n",
+			wantGenerated: false,
+			wantLOC:       2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "f.go")
+			require.NoError(t, os.WriteFile(path, []byte(tt.content), 0o600))
+
+			generated, loc, err := countGoFile(path)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantGenerated, generated)
+			require.Equal(t, tt.wantLOC, loc)
+		})
+	}
+}
+
+// TestCountGoFile_MissingFile covers the open-error path.
+func TestCountGoFile_MissingFile(t *testing.T) {
+	_, _, err := countGoFile(filepath.Join(t.TempDir(), "does-not-exist.go"))
+	require.Error(t, err)
+}
+
+// countGoFile reports whether path is a generated file and, if not, how many
+// lines it contains. Generated files are detected by the canonical
+// "Code generated ... DO NOT EDIT." marker, which by convention appears before
+// the package clause; scanning the whole file is cheap and avoids missing a
+// marker placed after a build-constraint or license header.
+func countGoFile(path string) (generated bool, loc int, err error) {
+	f, err := os.Open(path) //nolint:gosec // test reads project source files
+	if err != nil {
+		return false, 0, fmt.Errorf("opening %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if generatedMarkerRe.MatchString(strings.TrimSpace(line)) {
+			generated = true
+		}
+		loc++
+	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		return false, 0, fmt.Errorf("scanning %s: %w", path, scanErr)
+	}
+	return generated, loc, nil
+}


### PR DESCRIPTION
Closes #594.

## Summary

Adds three gates that police architecture rather than per-function complexity. Each is **green against the current tree** (purely additive, no refactoring) and is meant to be **ratcheted tighter in follow-up PRs**, never relaxed to make a violation pass. No Makefile change is needed: the lint gates ride on the existing `lint` target and the budget test on `make test`.

## Gates

### 1. Import boundaries (`depguard`, `.golangci.yml`)
Two rules derived from the real import graph, so they pass today and fail the *next* violation:
- **`admin-is-a-leaf`** — `pkg/admin` is the top composition layer, imported only by `cmd/` today; nothing lower (toolkits, providers, middleware, `pkg/platform`) may import it.
- **`toolkits-do-not-import-platform`** — toolkits sit below the platform facade; a toolkit importing `pkg/platform` inverts the layering and is rejected.

The issue's `pkg/platform → pkg/portal` example was intentionally left out: `pkg/platform` imports `pkg/portal` today, so banning it would not be green. Deferred to a ratchet follow-up, per the issue's rollout notes.

### 2. Cross-file duplication (`dupl`, `.golangci.yml`)
Threshold 150 tokens (permissive upstream default), test files exempt. CI's `only-new-issues` grandfathers the ~11 pre-existing clones; new copy-paste fails.

### 3. Package-size budget (`TestPackageSizeBudget`, `package_budget_test.go`)
No package under `pkg/` may exceed **13,000 non-generated LOC** or **35 non-generated files**. Files carrying a `Code generated ... DO NOT EDIT.` marker are excluded. Largest today: `pkg/admin` at 12,085 LOC / 27 files. The budget is a one-way ceiling to ratchet down (contract baked into the failure message and docs: decompose, do not raise the number).

## Acceptance criteria (#594)
- [x] `depguard` configured, green on the current tree; a toolkit importing `pkg/admin` fails (verified with a throwaway package).
- [x] `dupl` enabled; an intentionally duplicated block across two files is reported (verified).
- [x] Package-budget test passes now, excludes generated files, and fails when a package is pushed past the budget (verified by temporarily lowering the threshold).
- [x] Generated files excluded from the budget (unit-tested in `TestCountGoFile`).
- [x] `make verify` green.
- [x] Gates documented (rationale + thresholds + how to ratchet) in `CONTRIBUTING.md`.

## Verification
- `make verify` — `=== All checks passed ===` (exit 0), including lint `0 issues`, full coverage/mutation/CodeQL/semgrep/gosec/govulncheck and GoReleaser dry-run.

## Follow-up
First ratchet-down (13,000 → 11,500, forcing decomposition of `pkg/admin` and `pkg/platform`) tracked in #636, reviewed on its own so this PR stays additive.