### PR TITLE
fix(search): fan entity_urns lookup across all entity-keyed sources (#654)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1412,13 +1412,13 @@ The universal, topology-free discovery entry point (renamed from `knowledge_sear
 
 Corpus (everything the persona can access): the technical catalog (DataHub, when configured), the caller's personal memory (non-knowledge dimensions; captured/remembered knowledge surfaces via the insights provider, so a record is never double-listed), captured insights, saved assets, prompts, API endpoints (aggregated across every API gateway connection, reusing `api_list_endpoints`'s per-connection semantic/hybrid ranking, each gateway applying its own route policy fail-closed), and connections. API endpoints and connections are in the default corpus, not behind an opt-in. Memory, insights, and assets are per-user, scoped server-side to the caller (memory and insights by email `created_by`/`captured_by`, assets by `owner_id`) and fail closed when their scope key is absent; the catalog, prompts, endpoints, and connections are shared. A search never surfaces another user's private records or a route a persona could not invoke; an anonymous caller still sees shared sources but no per-user data.
 
-A query may be text (`intent`), entity-keyed (`entity_urns`), or both. The entity path returns the caller's memory linked to those DataHub URNs, expanded along lineage.
+A query may be text (`intent`), entity-keyed (`entity_urns`), or both. The entity path unions every source linked to those DataHub URNs (the catalog entity, URN-linked insights, and the caller's URN-linked memory), expanded along lineage; per-user scope and the catalog's access rules still apply to each source.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `intent` | string | Conditional | - | Natural-language description of what is sought; provide intent, entity_urns, or both |
 | `context` | string | No | - | Optional surrounding context, folded into the intent to sharpen relevance |
-| `entity_urns` | array | Conditional | - | Exact entity-keyed lookup: the caller's memory linked to these DataHub URNs, lineage-expanded |
+| `entity_urns` | array | Conditional | - | Exact entity-keyed lookup: everything linked to these DataHub URNs (catalog entity, URN-linked insights, the caller's URN-linked memory), lineage-expanded |
 | `status` | string | No | - | Optional filter by insight review status (pending, approved, rejected, applied, superseded, rolled_back) |
 | `sources` | array | No | - | Narrow to named sources (datahub, memory, insights, assets, prompts, endpoints, connections); only narrows, never opts past scope |
 | `limit` | integer | No | 10 | Total results to display across all sources (max 50) |

--- a/docs/server/tools.md
+++ b/docs/server/tools.md
@@ -599,8 +599,9 @@ when only the top few of each source are displayed. Hits are navigational
 snippets (title, `ref`, short context line, `source`); the agent drills in with
 the scoped tool (`trino_query`, `api_invoke_endpoint`, `datahub_get_entity`).
 
-A query may be text (`intent`), entity-keyed (`entity_urns`, returning your
-memory linked to those datasets and their lineage neighbors), or both. Ranking is
+A query may be text (`intent`), entity-keyed (`entity_urns`, returning every
+source linked to those datasets and their lineage neighbors: the catalog entity,
+URN-linked insights, and your URN-linked memory), or both. Ranking is
 hybrid (semantic vector + lexical) when an embedding provider is configured and
 lexical-only otherwise; an entity-only query reports ranking `entity`. The
 response carries a `ranking` field, a `count` (total hits shown), a `groups`
@@ -614,7 +615,7 @@ and `dimension`), and a `coverage` array (`{source, matched, shown}`).
 |-----------|------|----------|---------|-------------|
 | `intent` | string | Conditional | - | Natural-language description of what you are looking for. Provide `intent`, `entity_urns`, or both |
 | `context` | string | No | - | Optional surrounding context, folded into the intent to sharpen relevance |
-| `entity_urns` | array | Conditional | - | Exact entity-keyed lookup: your memory linked to these DataHub URNs, expanded along lineage |
+| `entity_urns` | array | Conditional | - | Exact entity-keyed lookup: everything linked to these DataHub URNs (the catalog entity, insights about it, and your memory linked to it), expanded along lineage |
 | `status` | string | No | - | Optional filter by insight review status (pending, approved, rejected, applied, superseded, rolled_back) |
 | `sources` | array | No | - | Narrow the search to named sources (`datahub`, `memory`, `insights`, `assets`, `prompts`, `endpoints`, `connections`). Only narrows; never opts into a source the persona could not otherwise access |
 | `limit` | integer | No | 10 | Total results to display across all sources (max 50) |

--- a/pkg/knowledge/provider_datahub.go
+++ b/pkg/knowledge/provider_datahub.go
@@ -3,30 +3,39 @@ package knowledge
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
+	"github.com/txn2/mcp-data-platform/pkg/memory"
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
 )
 
 // SourceDatahub is the provenance label for technical-catalog hits.
 const SourceDatahub = "datahub"
 
-// tableSearcher is the catalog relevance-search capability the datahub provider
-// needs. It matches semantic.Provider's SearchTables; declared locally so the
-// provider depends on the capability and tests can supply a fake.
+// tableSearcher is the catalog capability the datahub provider needs: relevance
+// search (text path) and exact entity lookup by table identifier (entity path).
+// It matches semantic.Provider; declared locally so the provider depends on the
+// capability and tests can supply a fake.
 type tableSearcher interface {
 	SearchTables(ctx context.Context, filter semantic.SearchFilter) ([]semantic.TableSearchResult, error)
+	GetTableContext(ctx context.Context, table semantic.TableIdentifier) (*semantic.TableContext, error)
 }
 
-// DatahubProvider exposes the technical catalog (DataHub) to the router as a
-// relevance search. It is shared: the catalog is global, so it is queried for
-// every request and needs no caller identity. This folds datahub_search's
-// relevance role into search; structured catalog navigation
-// (platform/domain/tag/entity-type filters) stays in datahub_browse.
+// DatahubProvider exposes the technical catalog (DataHub) to the router. It
+// serves two query shapes: a relevance search on Intent (folding datahub_search
+// into search) and an exact entity-keyed lookup on EntityURNs that returns the
+// catalog entity itself, so handing search a dataset URN surfaces its catalog
+// entry alongside the URN-linked memory and insights. Structured catalog
+// navigation (platform/domain/tag/entity-type filters) stays in datahub_browse.
 //
-// DataHub ranks results but does not return a numeric score, so the provider
-// derives a descending positional score from the result order; the router's
-// per-provider normalization then places these on the common scale.
+// It is shared: the catalog is global, so it is queried for every request and
+// needs no caller identity.
+//
+// DataHub ranks search results but does not return a numeric score, so the
+// provider derives a descending positional score from the result order;
+// entity-keyed hits take the max score. The router's per-provider normalization
+// then places these on the common scale.
 type DatahubProvider struct {
 	searcher tableSearcher
 }
@@ -42,9 +51,65 @@ func (*DatahubProvider) Name() string { return SourceDatahub }
 // Scope marks the catalog shared (global, always queried).
 func (*DatahubProvider) Scope() Scope { return ScopeShared }
 
-// Search returns catalog entities relevant to the intent. It responds to the
-// text path only; a query with no intent yields nothing.
+// Search returns catalog entities for the query: the entities named by
+// EntityURNs (entity path) plus those relevant to Intent (text path), merged and
+// de-duplicated by URN.
 func (p *DatahubProvider) Search(ctx context.Context, q Query) ([]Hit, error) {
+	seen := make(map[string]bool)
+
+	entityHits := p.searchByEntity(ctx, q, seen)
+
+	textHits, err := p.searchByText(ctx, q, seen)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(entityHits) == 0 && len(textHits) == 0 {
+		return nil, nil
+	}
+	return append(entityHits, textHits...), nil
+}
+
+// searchByEntity fetches the catalog entity for each requested URN (already
+// lineage-expanded by the Router). A URN that does not parse as a dataset, or
+// that the catalog cannot resolve, is skipped rather than failing the search:
+// the entity set is probed across many (lineage-expanded) URNs, most of which
+// legitimately have no catalog entry, so a miss must not blank the provider.
+// Only entities the catalog actually returned (non-empty URN) yield a hit, so a
+// non-existent URN produces nothing.
+func (p *DatahubProvider) searchByEntity(ctx context.Context, q Query, seen map[string]bool) []Hit {
+	var hits []Hit
+	for _, urn := range q.EntityURNs {
+		if seen[urn] {
+			continue
+		}
+		table, err := memory.ParseURNToTable(urn)
+		if err != nil {
+			continue
+		}
+		tc, err := p.searcher.GetTableContext(ctx, table)
+		if err != nil {
+			slog.Debug("catalog entity lookup skipped", "urn", urn, "error", err)
+			continue
+		}
+		if tc == nil || tc.URN == "" {
+			continue
+		}
+		seen[urn] = true
+		hits = append(hits, Hit{
+			Text:       catalogContextText(table, tc),
+			Source:     SourceDatahub,
+			Ref:        urn,
+			Score:      entityMatchScore,
+			EntityURNs: []string{urn},
+		})
+	}
+	return hits
+}
+
+// searchByText returns catalog entities relevant to the intent. A query with no
+// intent yields nothing.
+func (p *DatahubProvider) searchByText(ctx context.Context, q Query, seen map[string]bool) ([]Hit, error) {
 	if q.Intent == "" {
 		return nil, nil
 	}
@@ -60,6 +125,10 @@ func (p *DatahubProvider) Search(ctx context.Context, q Query) ([]Hit, error) {
 	n := len(results)
 	hits := make([]Hit, 0, n)
 	for i := range results {
+		if seen[results[i].URN] {
+			continue
+		}
+		seen[results[i].URN] = true
 		hits = append(hits, Hit{
 			Text:       catalogHitText(results[i]),
 			Source:     SourceDatahub,
@@ -81,11 +150,23 @@ func positionalScore(i, n int) float64 {
 	return float64(n-i) / float64(n)
 }
 
-// catalogHitText renders a catalog entity as a knowledge snippet: its name and
-// its description when present.
+// catalogHitText renders a search-ranked catalog entity as a knowledge snippet:
+// its name and its description when present.
 func catalogHitText(r semantic.TableSearchResult) string {
-	if r.Description == "" {
-		return r.Name
+	return catalogSnippet(r.Name, r.Description)
+}
+
+// catalogContextText renders an entity-keyed catalog hit: the table's dotted
+// name and its description when present.
+func catalogContextText(table semantic.TableIdentifier, tc *semantic.TableContext) string {
+	return catalogSnippet(table.String(), tc.Description)
+}
+
+// catalogSnippet joins a catalog entity's name and optional description into one
+// knowledge snippet.
+func catalogSnippet(name, description string) string {
+	if description == "" {
+		return name
 	}
-	return strings.TrimSpace(r.Name + "\n" + r.Description)
+	return strings.TrimSpace(name + "\n" + description)
 }

--- a/pkg/knowledge/provider_datahub_test.go
+++ b/pkg/knowledge/provider_datahub_test.go
@@ -8,17 +8,40 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
 )
 
+// a valid trino dataset URN and the dotted table name memory.ParseURNToTable
+// derives from it.
+const (
+	testDatasetURN   = "urn:li:dataset:(urn:li:dataPlatform:trino,opensearch.default.os_acme_transactions,PROD)"
+	testDatasetTable = "opensearch.default.os_acme_transactions"
+)
+
+// fakeTableSearcher is a tableSearcher stub recording the text-search filter and
+// the entity table identifiers it was asked for.
 type fakeTableSearcher struct {
-	results []semantic.TableSearchResult
-	err     error
-	got     semantic.SearchFilter
-	called  bool
+	// text path
+	results      []semantic.TableSearchResult
+	searchErr    error
+	got          semantic.SearchFilter
+	searchCalled bool
+
+	// entity path
+	byTable   map[string]*semantic.TableContext // table.String() -> context
+	ctxErr    error
+	gotTables []semantic.TableIdentifier
 }
 
 func (f *fakeTableSearcher) SearchTables(_ context.Context, filter semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
-	f.called = true
+	f.searchCalled = true
 	f.got = filter
-	return f.results, f.err
+	return f.results, f.searchErr
+}
+
+func (f *fakeTableSearcher) GetTableContext(_ context.Context, table semantic.TableIdentifier) (*semantic.TableContext, error) {
+	f.gotTables = append(f.gotTables, table)
+	if f.ctxErr != nil {
+		return nil, f.ctxErr
+	}
+	return f.byTable[table.String()], nil
 }
 
 func TestDatahubProvider_Metadata(t *testing.T) {
@@ -31,19 +54,19 @@ func TestDatahubProvider_Metadata(t *testing.T) {
 	}
 }
 
-func TestDatahubProvider_NoIntentSkips(t *testing.T) {
+func TestDatahubProvider_NoIntentNoEntitySkips(t *testing.T) {
 	s := &fakeTableSearcher{}
 	p := NewDatahubProvider(s)
-	hits, err := p.Search(context.Background(), Query{EntityURNs: []string{"urn:x"}})
+	hits, err := p.Search(context.Background(), Query{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if hits != nil || s.called {
-		t.Error("datahub provider should not run without an intent")
+	if hits != nil || s.searchCalled {
+		t.Error("datahub provider should do nothing with neither intent nor entity urns")
 	}
 }
 
-func TestDatahubProvider_MapsAndRanks(t *testing.T) {
+func TestDatahubProvider_TextMapsAndRanks(t *testing.T) {
 	s := &fakeTableSearcher{
 		results: []semantic.TableSearchResult{
 			{URN: "urn:li:dataset:orders", Name: "orders", Description: "order facts"},
@@ -61,7 +84,6 @@ func TestDatahubProvider_MapsAndRanks(t *testing.T) {
 	if len(hits) != 2 {
 		t.Fatalf("len = %d, want 2", len(hits))
 	}
-	// First result ranks above the second (positional score).
 	if hits[0].Score <= hits[1].Score {
 		t.Errorf("expected descending positional score, got %v then %v", hits[0].Score, hits[1].Score)
 	}
@@ -71,17 +93,138 @@ func TestDatahubProvider_MapsAndRanks(t *testing.T) {
 	if len(hits[0].EntityURNs) != 1 || hits[0].EntityURNs[0] != "urn:li:dataset:orders" {
 		t.Errorf("hit[0] entity urns = %+v", hits[0].EntityURNs)
 	}
-	// No-description result renders as just the name.
 	if hits[1].Text != "returns" {
 		t.Errorf("hit[1] text = %q, want %q", hits[1].Text, "returns")
 	}
 }
 
-func TestDatahubProvider_SearchError(t *testing.T) {
-	p := NewDatahubProvider(&fakeTableSearcher{err: errors.New("boom")})
+func TestDatahubProvider_TextSearchError(t *testing.T) {
+	p := NewDatahubProvider(&fakeTableSearcher{searchErr: errors.New("boom")})
 	_, err := p.Search(context.Background(), Query{Intent: "q"})
 	if err == nil {
 		t.Fatal("expected error to propagate")
+	}
+}
+
+func TestDatahubProvider_EntityLookupReturnsCatalogEntity(t *testing.T) {
+	s := &fakeTableSearcher{
+		byTable: map[string]*semantic.TableContext{
+			testDatasetTable: {URN: testDatasetURN, Description: "acme transactions"},
+		},
+	}
+	p := NewDatahubProvider(s)
+	hits, err := p.Search(context.Background(), Query{EntityURNs: []string{testDatasetURN}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.searchCalled {
+		t.Error("text search must not run for an entity-only query")
+	}
+	if len(s.gotTables) != 1 || s.gotTables[0].String() != testDatasetTable {
+		t.Fatalf("entity lookup parsed wrong table: %+v", s.gotTables)
+	}
+	if len(hits) != 1 || hits[0].Source != SourceDatahub || hits[0].Ref != testDatasetURN || hits[0].Score != entityMatchScore {
+		t.Fatalf("unexpected entity hit: %+v", hits)
+	}
+	if hits[0].Text != testDatasetTable+"\nacme transactions" {
+		t.Errorf("hit text = %q", hits[0].Text)
+	}
+	if len(hits[0].EntityURNs) != 1 || hits[0].EntityURNs[0] != testDatasetURN {
+		t.Errorf("hit entity urns = %+v", hits[0].EntityURNs)
+	}
+}
+
+func TestDatahubProvider_EntityLookupNoDescriptionUsesName(t *testing.T) {
+	s := &fakeTableSearcher{
+		byTable: map[string]*semantic.TableContext{
+			testDatasetTable: {URN: testDatasetURN},
+		},
+	}
+	p := NewDatahubProvider(s)
+	hits, err := p.Search(context.Background(), Query{EntityURNs: []string{testDatasetURN}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hits) != 1 || hits[0].Text != testDatasetTable {
+		t.Errorf("expected the dotted table name as text, got %+v", hits)
+	}
+}
+
+func TestDatahubProvider_EntityLookupMissReturnsNothing(t *testing.T) {
+	// A valid URN the catalog cannot resolve (nil context) yields no hit, so a
+	// non-existent URN never produces a false match.
+	s := &fakeTableSearcher{byTable: map[string]*semantic.TableContext{}}
+	p := NewDatahubProvider(s)
+	hits, err := p.Search(context.Background(), Query{EntityURNs: []string{testDatasetURN}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Errorf("expected no hits for an unresolved URN, got %+v", hits)
+	}
+}
+
+func TestDatahubProvider_EntityLookupEmptyURNContextSkipped(t *testing.T) {
+	// A context with no URN (phantom entity) is not a real match.
+	s := &fakeTableSearcher{
+		byTable: map[string]*semantic.TableContext{testDatasetTable: {Description: "ghost"}},
+	}
+	p := NewDatahubProvider(s)
+	hits, err := p.Search(context.Background(), Query{EntityURNs: []string{testDatasetURN}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Errorf("expected no hits for an empty-URN context, got %+v", hits)
+	}
+}
+
+func TestDatahubProvider_EntityLookupSkipsUnparseableURN(t *testing.T) {
+	s := &fakeTableSearcher{}
+	p := NewDatahubProvider(s)
+	hits, err := p.Search(context.Background(), Query{EntityURNs: []string{"urn:not-a-dataset"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hits) != 0 || len(s.gotTables) != 0 {
+		t.Errorf("an unparseable URN must be skipped without a catalog call: hits=%+v tables=%+v", hits, s.gotTables)
+	}
+}
+
+func TestDatahubProvider_EntityLookupToleratesCatalogError(t *testing.T) {
+	// A catalog error on the entity path is skipped (the URN set is probed
+	// across many lineage neighbors), not surfaced as a provider failure.
+	s := &fakeTableSearcher{ctxErr: errors.New("datahub down")}
+	p := NewDatahubProvider(s)
+	hits, err := p.Search(context.Background(), Query{EntityURNs: []string{testDatasetURN}})
+	if err != nil {
+		t.Fatalf("entity-path catalog error must not fail the provider: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Errorf("expected no hits, got %+v", hits)
+	}
+}
+
+func TestDatahubProvider_EntityAndTextDedupByURN(t *testing.T) {
+	s := &fakeTableSearcher{
+		byTable: map[string]*semantic.TableContext{
+			testDatasetTable: {URN: testDatasetURN, Description: "acme transactions"},
+		},
+		results: []semantic.TableSearchResult{
+			{URN: testDatasetURN, Name: "os_acme_transactions"},
+		},
+	}
+	p := NewDatahubProvider(s)
+	hits, err := p.Search(context.Background(), Query{Intent: "transactions", EntityURNs: []string{testDatasetURN}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected the URN de-duplicated to a single hit, got %d: %+v", len(hits), hits)
+	}
+	// The entity path won; the text path skipped the already-seen URN.
+	if hits[0].Score != entityMatchScore {
+		t.Errorf("expected entity-path hit to win, got score %v", hits[0].Score)
 	}
 }
 

--- a/pkg/knowledge/provider_insights.go
+++ b/pkg/knowledge/provider_insights.go
@@ -10,17 +10,19 @@ import (
 // SourceInsights is the provenance label for insight-provider hits.
 const SourceInsights = "insights"
 
-// insightSearcher is the relevance-search capability of the insight store. It
-// matches knowledgekit.InsightSearcher; declared locally so the provider
+// insightSource is the slice of the insight store the provider needs: the
+// relevance search (text path) plus the entity-keyed list (entity path). It
+// matches knowledgekit.SearchableInsightStore; declared locally so the provider
 // depends on the capability and tests can supply a fake.
-type insightSearcher interface {
+type insightSource interface {
 	Search(ctx context.Context, q knowledgekit.InsightSearchQuery) ([]knowledgekit.ScoredInsight, error)
+	List(ctx context.Context, filter knowledgekit.InsightFilter) ([]knowledgekit.Insight, int, error)
 }
 
 // InsightsProvider exposes captured domain knowledge (insights) to the router.
 //
 // Insights are knowledge-dimension memory rows owned by the caller
-// (insight.captured_by == caller email). The underlying searcher scopes to that
+// (insight.captured_by == caller email). The underlying store scopes to that
 // owner and to the knowledge dimension, so this provider covers exactly the
 // records the MemoryProvider skips.
 //
@@ -30,12 +32,13 @@ type insightSearcher interface {
 // PR1 keeps this provider per-user. Promoting reviewed insights to ScopeShared
 // is deferred to the write-path/review work (#633).
 type InsightsProvider struct {
-	searcher insightSearcher
+	store insightSource
 }
 
-// NewInsightsProvider builds the insights provider over an insight searcher.
-func NewInsightsProvider(searcher insightSearcher) *InsightsProvider {
-	return &InsightsProvider{searcher: searcher}
+// NewInsightsProvider builds the insights provider over a searchable insight
+// store.
+func NewInsightsProvider(store insightSource) *InsightsProvider {
+	return &InsightsProvider{store: store}
 }
 
 // Name returns the provenance label.
@@ -45,18 +48,81 @@ func (*InsightsProvider) Name() string { return SourceInsights }
 // sharing is deferred.
 func (*InsightsProvider) Scope() Scope { return ScopePerUser }
 
-// Search returns the caller's captured insights ranked by relevance to the
-// intent, optionally filtered by review status. Each hit carries the insight's
-// review status and linked entity URNs as provenance. It responds to the text
-// (Intent) path only; entity-keyed lookup is served by the memory provider, so
-// a query with no intent yields nothing here. It fails closed on a missing
-// caller email rather than searching across all users.
+// Search returns the caller's captured insights. It serves both query shapes:
+// an exact entity-keyed lookup on EntityURNs (insights linked to the requested
+// datasets, lineage-expanded by the Router) and a relevance search on Intent.
+// Results from both paths are merged and de-duplicated by insight id. Each hit
+// carries the insight's review status and linked entity URNs as provenance. It
+// fails closed on a missing caller email rather than searching across all users.
 func (p *InsightsProvider) Search(ctx context.Context, q Query) ([]Hit, error) {
-	if q.Caller.Email == "" || q.Intent == "" {
+	if q.Caller.Email == "" {
 		return nil, nil
 	}
 
-	scored, err := p.searcher.Search(ctx, knowledgekit.InsightSearchQuery{
+	var hits []Hit
+	seen := make(map[string]bool)
+
+	entityHits, err := p.searchByEntity(ctx, q, seen)
+	if err != nil {
+		return nil, err
+	}
+	hits = append(hits, entityHits...)
+
+	textHits, err := p.searchByText(ctx, q, seen)
+	if err != nil {
+		return nil, err
+	}
+	hits = append(hits, textHits...)
+
+	return hits, nil
+}
+
+// searchByEntity returns the caller's insights linked to the query's entity URNs
+// (already lineage-expanded by the Router). It reuses the entity-keyed List path
+// that memory_manage(filter_entity_urn=...) relies on, scoped to the caller's
+// email and the knowledge dimension by the store. Already-seen insights are
+// skipped; when no explicit status was requested, rejected/superseded/rolled-back
+// insights are dropped so a "what do we know" lookup never surfaces retracted
+// knowledge.
+func (p *InsightsProvider) searchByEntity(ctx context.Context, q Query, seen map[string]bool) ([]Hit, error) {
+	if len(q.EntityURNs) == 0 {
+		return nil, nil
+	}
+
+	var hits []Hit
+	for _, urn := range q.EntityURNs {
+		insights, _, err := p.store.List(ctx, knowledgekit.InsightFilter{
+			EntityURN:  urn,
+			CapturedBy: q.Caller.Email,
+			Status:     q.Status,
+			Limit:      q.Limit,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("insight entity lookup: %w", err)
+		}
+		for i := range insights {
+			if seen[insights[i].ID] {
+				continue
+			}
+			if q.Status == "" && !isLiveInsightStatus(insights[i].Status) {
+				continue
+			}
+			seen[insights[i].ID] = true
+			hits = append(hits, insightHit(insights[i], entityMatchScore))
+		}
+	}
+	return hits, nil
+}
+
+// searchByText returns the caller's insights ranked by relevance to the intent,
+// optionally filtered by review status. Already-seen insights (recalled on the
+// entity path) are skipped. A query with no intent yields nothing here.
+func (p *InsightsProvider) searchByText(ctx context.Context, q Query, seen map[string]bool) ([]Hit, error) {
+	if q.Intent == "" {
+		return nil, nil
+	}
+
+	scored, err := p.store.Search(ctx, knowledgekit.InsightSearchQuery{
 		QueryText:  q.Intent,
 		Embedding:  q.Embedding,
 		CapturedBy: q.Caller.Email,
@@ -69,14 +135,36 @@ func (p *InsightsProvider) Search(ctx context.Context, q Query) ([]Hit, error) {
 
 	hits := make([]Hit, 0, len(scored))
 	for i := range scored {
-		hits = append(hits, Hit{
-			Text:       scored[i].Insight.InsightText,
-			Source:     SourceInsights,
-			Ref:        scored[i].Insight.ID,
-			Score:      scored[i].Score,
-			Status:     scored[i].Insight.Status,
-			EntityURNs: scored[i].Insight.EntityURNs,
-		})
+		if seen[scored[i].Insight.ID] {
+			continue
+		}
+		seen[scored[i].Insight.ID] = true
+		hits = append(hits, insightHit(scored[i].Insight, scored[i].Score))
 	}
 	return hits, nil
+}
+
+// insightHit maps an insight to a knowledge hit, carrying its review status and
+// linked entity URNs as provenance.
+func insightHit(in knowledgekit.Insight, score float64) Hit {
+	return Hit{
+		Text:       in.InsightText,
+		Source:     SourceInsights,
+		Ref:        in.ID,
+		Score:      score,
+		Status:     in.Status,
+		EntityURNs: in.EntityURNs,
+	}
+}
+
+// isLiveInsightStatus reports whether an insight status represents knowledge
+// still in force. Rejected, superseded, and rolled-back insights are retracted
+// and must not surface on the unfiltered entity path.
+func isLiveInsightStatus(status string) bool {
+	switch status {
+	case knowledgekit.StatusRejected, knowledgekit.StatusSuperseded, knowledgekit.StatusRolledBack:
+		return false
+	default:
+		return true
+	}
 }

--- a/pkg/knowledge/provider_insights_test.go
+++ b/pkg/knowledge/provider_insights_test.go
@@ -8,21 +8,38 @@ import (
 	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
 )
 
-type fakeInsightSearcher struct {
-	scored []knowledgekit.ScoredInsight
-	err    error
-	got    knowledgekit.InsightSearchQuery
-	called bool
+// fakeInsightStore is a SearchableInsightStore stub: it records the text-search
+// query and entity-list filters it was given and returns canned results.
+type fakeInsightStore struct {
+	// text path
+	scored       []knowledgekit.ScoredInsight
+	searchErr    error
+	gotSearch    knowledgekit.InsightSearchQuery
+	searchCalled bool
+
+	// entity path
+	byURN     map[string][]knowledgekit.Insight
+	listErr   error
+	gotFilter []knowledgekit.InsightFilter
 }
 
-func (f *fakeInsightSearcher) Search(_ context.Context, q knowledgekit.InsightSearchQuery) ([]knowledgekit.ScoredInsight, error) {
-	f.called = true
-	f.got = q
-	return f.scored, f.err
+func (f *fakeInsightStore) Search(_ context.Context, q knowledgekit.InsightSearchQuery) ([]knowledgekit.ScoredInsight, error) {
+	f.searchCalled = true
+	f.gotSearch = q
+	return f.scored, f.searchErr
+}
+
+func (f *fakeInsightStore) List(_ context.Context, filter knowledgekit.InsightFilter) ([]knowledgekit.Insight, int, error) {
+	f.gotFilter = append(f.gotFilter, filter)
+	if f.listErr != nil {
+		return nil, 0, f.listErr
+	}
+	recs := f.byURN[filter.EntityURN]
+	return recs, len(recs), nil
 }
 
 func TestInsightsProvider_Metadata(t *testing.T) {
-	p := NewInsightsProvider(&fakeInsightSearcher{})
+	p := NewInsightsProvider(&fakeInsightStore{})
 	if p.Name() != SourceInsights {
 		t.Errorf("Name = %q", p.Name())
 	}
@@ -32,24 +49,28 @@ func TestInsightsProvider_Metadata(t *testing.T) {
 }
 
 func TestInsightsProvider_FailsClosedWithoutEmail(t *testing.T) {
-	s := &fakeInsightSearcher{}
+	s := &fakeInsightStore{}
 	p := NewInsightsProvider(s)
-	hits, err := p.Search(context.Background(), Query{Caller: Caller{UserID: "uuid-only"}})
+	hits, err := p.Search(context.Background(), Query{
+		Intent:     "q",
+		EntityURNs: []string{"urn:x"},
+		Caller:     Caller{UserID: "uuid-only"},
+	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if hits != nil {
 		t.Errorf("expected no hits, got %+v", hits)
 	}
-	if s.called {
-		t.Error("searcher must not run without a caller email")
+	if s.searchCalled || len(s.gotFilter) != 0 {
+		t.Error("store must not be queried without a caller email")
 	}
 }
 
-func TestInsightsProvider_ScopesAndMaps(t *testing.T) {
-	s := &fakeInsightSearcher{
+func TestInsightsProvider_TextScopesAndMaps(t *testing.T) {
+	s := &fakeInsightStore{
 		scored: []knowledgekit.ScoredInsight{
-			{Insight: knowledgekit.Insight{ID: "i1", InsightText: "churn = ..."}, Score: 0.7},
+			{Insight: knowledgekit.Insight{ID: "i1", InsightText: "churn = ...", Status: knowledgekit.StatusApproved}, Score: 0.7},
 		},
 	}
 	p := NewInsightsProvider(s)
@@ -62,22 +83,148 @@ func TestInsightsProvider_ScopesAndMaps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if s.got.CapturedBy != "a@example.com" {
-		t.Errorf("CapturedBy = %q, want scoped to caller email", s.got.CapturedBy)
+	if s.gotSearch.CapturedBy != "a@example.com" {
+		t.Errorf("CapturedBy = %q, want scoped to caller email", s.gotSearch.CapturedBy)
 	}
-	if s.got.Limit != 5 || len(s.got.Embedding) == 0 {
-		t.Errorf("query not forwarded: %+v", s.got)
+	if s.gotSearch.Limit != 5 || len(s.gotSearch.Embedding) == 0 {
+		t.Errorf("query not forwarded: %+v", s.gotSearch)
 	}
 	if len(hits) != 1 || hits[0].Source != SourceInsights || hits[0].Ref != "i1" || hits[0].Text != "churn = ..." {
 		t.Errorf("unexpected hit mapping: %+v", hits)
 	}
+	if hits[0].Status != knowledgekit.StatusApproved {
+		t.Errorf("status not carried as provenance: %+v", hits[0])
+	}
 }
 
 func TestInsightsProvider_SearchError(t *testing.T) {
-	s := &fakeInsightSearcher{err: errors.New("boom")}
+	s := &fakeInsightStore{searchErr: errors.New("boom")}
 	p := NewInsightsProvider(s)
 	_, err := p.Search(context.Background(), Query{Intent: "q", Caller: Caller{Email: "a@example.com"}})
 	if err == nil {
 		t.Fatal("expected error to propagate")
+	}
+}
+
+func TestInsightsProvider_EntityLookupScopedToCaller(t *testing.T) {
+	urn := "urn:li:dataset:orders"
+	s := &fakeInsightStore{
+		byURN: map[string][]knowledgekit.Insight{
+			urn: {
+				{ID: "i1", InsightText: "amount is gross margin", Status: knowledgekit.StatusApproved, EntityURNs: []string{urn}},
+			},
+		},
+	}
+	p := NewInsightsProvider(s)
+	hits, err := p.Search(context.Background(), Query{
+		EntityURNs: []string{urn},
+		Caller:     Caller{Email: "a@example.com"},
+		Limit:      9,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.searchCalled {
+		t.Error("text search must not run for an entity-only query")
+	}
+	if len(s.gotFilter) != 1 {
+		t.Fatalf("expected one entity list call, got %+v", s.gotFilter)
+	}
+	got := s.gotFilter[0]
+	if got.EntityURN != urn || got.CapturedBy != "a@example.com" || got.Limit != 9 {
+		t.Errorf("entity list not scoped/forwarded: %+v", got)
+	}
+	if len(hits) != 1 || hits[0].Source != SourceInsights || hits[0].Ref != "i1" || hits[0].Score != entityMatchScore {
+		t.Errorf("unexpected entity hit: %+v", hits)
+	}
+	if len(hits[0].EntityURNs) != 1 || hits[0].EntityURNs[0] != urn {
+		t.Errorf("entity urns not carried: %+v", hits[0])
+	}
+}
+
+func TestInsightsProvider_EntityLookupDropsRetractedWhenNoStatus(t *testing.T) {
+	urn := "urn:li:dataset:orders"
+	s := &fakeInsightStore{
+		byURN: map[string][]knowledgekit.Insight{
+			urn: {
+				{ID: "live", InsightText: "kept", Status: knowledgekit.StatusApproved, EntityURNs: []string{urn}},
+				{ID: "rej", InsightText: "rejected", Status: knowledgekit.StatusRejected, EntityURNs: []string{urn}},
+				{ID: "sup", InsightText: "superseded", Status: knowledgekit.StatusSuperseded, EntityURNs: []string{urn}},
+				{ID: "rb", InsightText: "rolled back", Status: knowledgekit.StatusRolledBack, EntityURNs: []string{urn}},
+			},
+		},
+	}
+	p := NewInsightsProvider(s)
+	hits, err := p.Search(context.Background(), Query{
+		EntityURNs: []string{urn},
+		Caller:     Caller{Email: "a@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hits) != 1 || hits[0].Ref != "live" {
+		t.Errorf("expected only the live insight, got %+v", hits)
+	}
+}
+
+func TestInsightsProvider_EntityLookupKeepsRetractedWhenStatusRequested(t *testing.T) {
+	urn := "urn:li:dataset:orders"
+	s := &fakeInsightStore{
+		byURN: map[string][]knowledgekit.Insight{
+			urn: {{ID: "rej", InsightText: "rejected", Status: knowledgekit.StatusRejected, EntityURNs: []string{urn}}},
+		},
+	}
+	p := NewInsightsProvider(s)
+	hits, err := p.Search(context.Background(), Query{
+		EntityURNs: []string{urn},
+		Status:     knowledgekit.StatusRejected,
+		Caller:     Caller{Email: "a@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.gotFilter[0].Status != knowledgekit.StatusRejected {
+		t.Errorf("status not forwarded to store: %+v", s.gotFilter[0])
+	}
+	// An explicit status request is honored verbatim, so the rejected insight surfaces.
+	if len(hits) != 1 || hits[0].Ref != "rej" {
+		t.Errorf("expected the explicitly requested rejected insight, got %+v", hits)
+	}
+}
+
+func TestInsightsProvider_EntityAndTextDedup(t *testing.T) {
+	urn := "urn:li:dataset:orders"
+	dup := knowledgekit.Insight{ID: "dup", InsightText: "dup", Status: knowledgekit.StatusApproved, EntityURNs: []string{urn}}
+	s := &fakeInsightStore{
+		byURN:  map[string][]knowledgekit.Insight{urn: {dup}},
+		scored: []knowledgekit.ScoredInsight{{Insight: dup, Score: 0.5}},
+	}
+	p := NewInsightsProvider(s)
+	hits, err := p.Search(context.Background(), Query{
+		Intent:     "dup",
+		EntityURNs: []string{urn},
+		Caller:     Caller{Email: "a@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected de-duplicated single hit, got %d: %+v", len(hits), hits)
+	}
+	// The entity path scores it at the max; the text path must not re-add it.
+	if hits[0].Score != entityMatchScore {
+		t.Errorf("expected entity-path score, got %v", hits[0].Score)
+	}
+}
+
+func TestInsightsProvider_EntityListError(t *testing.T) {
+	s := &fakeInsightStore{listErr: errors.New("db down")}
+	p := NewInsightsProvider(s)
+	_, err := p.Search(context.Background(), Query{
+		EntityURNs: []string{"urn:x"},
+		Caller:     Caller{Email: "a@example.com"},
+	})
+	if err == nil {
+		t.Fatal("expected entity list error to propagate")
 	}
 }

--- a/pkg/knowledge/provider_memory.go
+++ b/pkg/knowledge/provider_memory.go
@@ -26,22 +26,14 @@ type memorySearcher interface {
 	EntityLookup(ctx context.Context, urn, persona, createdBy string) ([]memory.Record, error)
 }
 
-// LineageExpander optionally widens a set of entity URNs along lineage so an
-// entity-keyed lookup also recalls knowledge about upstream and downstream
-// datasets (the old memory_recall "graph" strategy). Implemented by an adapter
-// over the semantic provider; a nil expander disables expansion, leaving a
-// plain entity lookup.
-type LineageExpander interface {
-	Expand(ctx context.Context, urns []string) []string
-}
-
 // MemoryProvider exposes a caller's personal memory to the knowledge router.
 //
 // It is per-user: results are restricted to records the caller owns
 // (memory_records.created_by == caller email), the same identity the portal's
 // "my knowledge" search scopes on. It serves two query shapes: relevance search
-// on Intent, and an exact entity-keyed lookup on EntityURNs (optionally widened
-// along lineage when a LineageExpander is wired).
+// on Intent, and an exact entity-keyed lookup on EntityURNs. Lineage expansion
+// of the entity URNs is the Router's responsibility (so it runs once for every
+// entity-keyed provider), so this provider takes the URN set as given.
 //
 // It deliberately omits the knowledge dimension on both paths. Captured
 // insights and remembered knowledge are knowledge-dimension memory rows owned
@@ -49,14 +41,12 @@ type LineageExpander interface {
 // record. This provider covers the caller's non-knowledge memory (preferences,
 // events, entities, relationships).
 type MemoryProvider struct {
-	store   memorySearcher
-	lineage LineageExpander
+	store memorySearcher
 }
 
-// NewMemoryProvider builds the memory provider over a memory store. lineage is
-// optional; when nil, entity lookups are not expanded along lineage.
-func NewMemoryProvider(store memorySearcher, lineage LineageExpander) *MemoryProvider {
-	return &MemoryProvider{store: store, lineage: lineage}
+// NewMemoryProvider builds the memory provider over a memory store.
+func NewMemoryProvider(store memorySearcher) *MemoryProvider {
+	return &MemoryProvider{store: store}
 }
 
 // Name returns the provenance label.
@@ -95,20 +85,16 @@ func (p *MemoryProvider) Search(ctx context.Context, q Query) ([]Hit, error) {
 	return hits, nil
 }
 
-// searchByEntity recalls the caller's memory linked to the query's entity URNs,
-// widened along lineage when an expander is configured. Knowledge-dimension and
-// already-seen records are skipped.
+// searchByEntity recalls the caller's memory linked to the query's entity URNs
+// (already lineage-expanded by the Router when an expander is configured).
+// Knowledge-dimension and already-seen records are skipped.
 func (p *MemoryProvider) searchByEntity(ctx context.Context, q Query, seen map[string]bool) ([]Hit, error) {
 	if len(q.EntityURNs) == 0 {
 		return nil, nil
 	}
-	urns := q.EntityURNs
-	if p.lineage != nil {
-		urns = p.lineage.Expand(ctx, urns)
-	}
 
 	var hits []Hit
-	for _, urn := range urns {
+	for _, urn := range q.EntityURNs {
 		records, err := p.store.EntityLookup(ctx, urn, q.Caller.Persona, q.Caller.Email)
 		if err != nil {
 			return nil, fmt.Errorf("memory entity lookup: %w", err)

--- a/pkg/knowledge/provider_memory_test.go
+++ b/pkg/knowledge/provider_memory_test.go
@@ -42,16 +42,8 @@ func (f *fakeMemoryStore) EntityLookup(_ context.Context, urn, persona, createdB
 	return f.entity[urn], nil
 }
 
-// fakeLineage expands every input urn to itself plus a fixed neighbor.
-type fakeLineage struct{ neighbor string }
-
-func (l fakeLineage) Expand(_ context.Context, urns []string) []string {
-	out := append([]string{}, urns...)
-	return append(out, l.neighbor)
-}
-
 func TestMemoryProvider_Metadata(t *testing.T) {
-	p := NewMemoryProvider(&fakeMemoryStore{}, nil)
+	p := NewMemoryProvider(&fakeMemoryStore{})
 	if p.Name() != SourceMemory {
 		t.Errorf("Name = %q", p.Name())
 	}
@@ -62,7 +54,7 @@ func TestMemoryProvider_Metadata(t *testing.T) {
 
 func TestMemoryProvider_FailsClosedWithoutEmail(t *testing.T) {
 	store := &fakeMemoryStore{}
-	p := NewMemoryProvider(store, nil)
+	p := NewMemoryProvider(store)
 	hits, err := p.Search(context.Background(), Query{Intent: "q", EntityURNs: []string{"urn:x"}, Caller: Caller{UserID: "uuid-only"}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -81,7 +73,7 @@ func TestMemoryProvider_HybridWhenEmbeddingPresent(t *testing.T) {
 			{Record: memory.Record{ID: "m1", Content: "hello", Dimension: memory.DimensionPreference}, Score: 0.9},
 		},
 	}
-	p := NewMemoryProvider(store, nil)
+	p := NewMemoryProvider(store)
 	hits, err := p.Search(context.Background(), Query{
 		Intent:    "q",
 		Embedding: []float32{0.1},
@@ -117,7 +109,7 @@ func TestMemoryProvider_LexicalWhenNoEmbedding(t *testing.T) {
 			{Record: memory.Record{ID: "m2", Content: "x", Dimension: memory.DimensionEvent}, Score: 0.3},
 		},
 	}
-	p := NewMemoryProvider(store, nil)
+	p := NewMemoryProvider(store)
 	_, err := p.Search(context.Background(), Query{Intent: "q", Caller: Caller{Email: "a@example.com"}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -139,7 +131,7 @@ func TestMemoryProvider_EntityLookupScopedToCaller(t *testing.T) {
 			},
 		},
 	}
-	p := NewMemoryProvider(store, nil)
+	p := NewMemoryProvider(store)
 	hits, err := p.Search(context.Background(), Query{
 		EntityURNs: []string{"urn:li:dataset:orders"},
 		Caller:     Caller{Email: "a@example.com", Persona: "analyst"},
@@ -157,24 +149,25 @@ func TestMemoryProvider_EntityLookupScopedToCaller(t *testing.T) {
 	}
 }
 
-func TestMemoryProvider_GraphExpansion(t *testing.T) {
+func TestMemoryProvider_LooksUpEveryEntityURN(t *testing.T) {
+	// The router hands the provider the already lineage-expanded URN set; the
+	// provider looks each up and unions the records.
 	store := &fakeMemoryStore{
 		entity: map[string][]memory.Record{
 			"urn:a": {{ID: "ra", Content: "a", Dimension: memory.DimensionEntity}},
 			"urn:b": {{ID: "rb", Content: "b", Dimension: memory.DimensionEntity}},
 		},
 	}
-	p := NewMemoryProvider(store, fakeLineage{neighbor: "urn:b"})
+	p := NewMemoryProvider(store)
 	hits, err := p.Search(context.Background(), Query{
-		EntityURNs: []string{"urn:a"},
+		EntityURNs: []string{"urn:a", "urn:b"},
 		Caller:     Caller{Email: "a@example.com"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Lineage added urn:b, so both records surface.
 	if len(hits) != 2 {
-		t.Fatalf("expected 2 hits after lineage expansion, got %d: %+v", len(hits), hits)
+		t.Fatalf("expected 2 hits across both URNs, got %d: %+v", len(hits), hits)
 	}
 }
 
@@ -185,7 +178,7 @@ func TestMemoryProvider_EntityAndTextDedup(t *testing.T) {
 		entity:  map[string][]memory.Record{"urn:x": {rec}},
 		lexical: []memory.ScoredRecord{{Record: rec, Score: 0.4}},
 	}
-	p := NewMemoryProvider(store, nil)
+	p := NewMemoryProvider(store)
 	hits, err := p.Search(context.Background(), Query{
 		Intent:     "dup",
 		EntityURNs: []string{"urn:x"},
@@ -201,7 +194,7 @@ func TestMemoryProvider_EntityAndTextDedup(t *testing.T) {
 
 func TestMemoryProvider_SearchError(t *testing.T) {
 	store := &fakeMemoryStore{err: errors.New("db down")}
-	p := NewMemoryProvider(store, nil)
+	p := NewMemoryProvider(store)
 	_, err := p.Search(context.Background(), Query{Intent: "q", Caller: Caller{Email: "a@example.com"}})
 	if err == nil {
 		t.Fatal("expected error to propagate")

--- a/pkg/knowledge/router.go
+++ b/pkg/knowledge/router.go
@@ -42,6 +42,20 @@ type Result struct {
 	Ranking  string
 }
 
+// LineageExpander optionally widens a set of entity URNs along lineage so an
+// entity-keyed lookup also recalls knowledge about upstream and downstream
+// datasets (the old memory_recall "graph" strategy). Implemented by an adapter
+// over the semantic provider; a nil expander disables expansion, leaving a
+// plain entity lookup.
+//
+// It lives on the Router, not on any single provider, so the expansion runs
+// once per search and every entity-keyed provider (memory, insights, the
+// technical catalog) sees the same widened URN set, the same way the query
+// embedding is computed once and shared.
+type LineageExpander interface {
+	Expand(ctx context.Context, urns []string) []string
+}
+
 // Router fans one query across every registered provider, normalizes each
 // provider's local relevance scores onto a common scale, fuses them into one
 // ranked list, and enforces per-user scope. It is the single read path behind
@@ -49,15 +63,17 @@ type Result struct {
 // fusion rules live here once rather than in each surface.
 type Router struct {
 	embedder  embedding.Provider
+	lineage   LineageExpander
 	providers []Provider
 }
 
-// NewRouter builds a router over an embedder and a set of providers. The
-// embedder may be nil or the noop placeholder; the router then ranks
-// lexically. Provider order does not affect ranking (scores are fused), only
+// NewRouter builds a router over an embedder, an optional lineage expander, and
+// a set of providers. The embedder may be nil or the noop placeholder; the
+// router then ranks lexically. lineage may be nil, leaving entity-keyed lookups
+// unexpanded. Provider order does not affect ranking (scores are fused), only
 // the deterministic tie-break.
-func NewRouter(embedder embedding.Provider, providers ...Provider) *Router {
-	return &Router{embedder: embedder, providers: providers}
+func NewRouter(embedder embedding.Provider, lineage LineageExpander, providers ...Provider) *Router {
+	return &Router{embedder: embedder, lineage: lineage, providers: providers}
 }
 
 // Providers returns the registered providers, for introspection and wiring
@@ -121,6 +137,13 @@ func (r *Router) Search(ctx context.Context, q Query) (Result, error) {
 		} else {
 			ranking = rankingLexical
 		}
+	}
+
+	// Widen the entity-keyed lookup along lineage once, so every entity-keyed
+	// provider fans out over the same upstream/downstream neighbors rather than
+	// each re-expanding (which would re-hit the catalog lineage API per source).
+	if len(q.EntityURNs) > 0 && r.lineage != nil {
+		q.EntityURNs = r.lineage.Expand(ctx, q.EntityURNs)
 	}
 
 	perProvider, attempted, errs := r.fanOut(ctx, q)

--- a/pkg/knowledge/router_test.go
+++ b/pkg/knowledge/router_test.go
@@ -56,7 +56,7 @@ func flatHits(res Result) []Hit {
 func TestRouter_PerUserSkippedForAnonymousCaller(t *testing.T) {
 	shared := &fakeProvider{name: "shared", scope: ScopeShared, hits: []Hit{{Source: "shared", Ref: "s1", Score: 1}}}
 	perUser := &fakeProvider{name: "peruser", scope: ScopePerUser, hits: []Hit{{Source: "peruser", Ref: "p1", Score: 1}}}
-	r := NewRouter(nil, shared, perUser)
+	r := NewRouter(nil, nil, shared, perUser)
 
 	res, err := r.Search(context.Background(), Query{Intent: "anything"})
 	if err != nil {
@@ -76,7 +76,7 @@ func TestRouter_PerUserSkippedForAnonymousCaller(t *testing.T) {
 func TestRouter_SourcesNarrowsButNeverWidens(t *testing.T) {
 	datahub := &fakeProvider{name: "datahub", scope: ScopeShared, hits: []Hit{{Source: "datahub", Ref: "d1", Score: 1}}}
 	memory := &fakeProvider{name: "memory", scope: ScopePerUser, hits: []Hit{{Source: "memory", Ref: "m1", Score: 1}}}
-	r := NewRouter(nil, datahub, memory)
+	r := NewRouter(nil, nil, datahub, memory)
 
 	// Narrow to datahub only: memory is skipped even though the caller has identity.
 	caller := Caller{Email: "a@example.com"}
@@ -99,7 +99,7 @@ func TestRouter_SourcesCannotWidenPastScope(t *testing.T) {
 	// An anonymous caller naming a per-user source must still get nothing from
 	// it: sources narrows, it never opts past the scope gate.
 	memory := &fakeProvider{name: "memory", scope: ScopePerUser, hits: []Hit{{Source: "memory", Ref: "m1", Score: 1}}}
-	r := NewRouter(nil, memory)
+	r := NewRouter(nil, nil, memory)
 	res, err := r.Search(context.Background(), Query{Intent: "q", Sources: []string{"memory"}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -115,7 +115,7 @@ func TestRouter_SourcesCannotWidenPastScope(t *testing.T) {
 func TestRouter_BlankSourcesQueriesEverything(t *testing.T) {
 	a := &fakeProvider{name: "a", scope: ScopeShared, hits: []Hit{{Source: "a", Ref: "a1", Score: 1}}}
 	b := &fakeProvider{name: "b", scope: ScopeShared, hits: []Hit{{Source: "b", Ref: "b1", Score: 1}}}
-	r := NewRouter(nil, a, b)
+	r := NewRouter(nil, nil, a, b)
 	// A sources slice of only blanks collapses to "no narrowing".
 	_, err := r.Search(context.Background(), Query{Intent: "q", Sources: []string{"  ", ""}})
 	if err != nil {
@@ -128,7 +128,7 @@ func TestRouter_BlankSourcesQueriesEverything(t *testing.T) {
 
 func TestRouter_PerUserQueriedWithIdentity(t *testing.T) {
 	perUser := &fakeProvider{name: "peruser", scope: ScopePerUser, hits: []Hit{{Source: "peruser", Ref: "p1", Score: 1}}}
-	r := NewRouter(nil, perUser)
+	r := NewRouter(nil, nil, perUser)
 
 	caller := Caller{UserID: "uuid-1", Email: "a@example.com"}
 	_, err := r.Search(context.Background(), Query{Intent: "anything", Caller: caller})
@@ -145,7 +145,7 @@ func TestRouter_PerUserQueriedWithIdentity(t *testing.T) {
 
 func TestRouter_LexicalWhenNoEmbedder(t *testing.T) {
 	p := &fakeProvider{name: "p", scope: ScopeShared}
-	r := NewRouter(nil, p)
+	r := NewRouter(nil, nil, p)
 	res, err := r.Search(context.Background(), Query{Intent: "q"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -158,7 +158,7 @@ func TestRouter_LexicalWhenNoEmbedder(t *testing.T) {
 func TestRouter_HybridWithEmbedder(t *testing.T) {
 	var got Query
 	p := &captureProvider{scope: ScopeShared, sink: &got}
-	r := NewRouter(fakeEmbedder{}, p)
+	r := NewRouter(fakeEmbedder{}, nil, p)
 	res, err := r.Search(context.Background(), Query{Intent: "q"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -184,11 +184,48 @@ func (c captureProvider) Search(_ context.Context, q Query) ([]Hit, error) {
 	return nil, nil
 }
 
+// fakeLineage expands every input urn to itself plus a fixed neighbor.
+type fakeLineage struct{ neighbor string }
+
+func (l fakeLineage) Expand(_ context.Context, urns []string) []string {
+	return append(append([]string{}, urns...), l.neighbor)
+}
+
+func TestRouter_LineageExpandsEntityURNsForAllProviders(t *testing.T) {
+	var got1, got2 Query
+	p1 := &captureProvider{scope: ScopeShared, sink: &got1}
+	p2 := &captureProvider{scope: ScopeShared, sink: &got2}
+	r := NewRouter(nil, fakeLineage{neighbor: "urn:b"}, p1, p2)
+
+	if _, err := r.Search(context.Background(), Query{EntityURNs: []string{"urn:a"}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Expansion runs once on the router and every provider sees the widened set,
+	// so providers never each re-hit the lineage API.
+	for i, got := range []Query{got1, got2} {
+		if len(got.EntityURNs) != 2 {
+			t.Fatalf("provider %d got %d urns, want 2 (expanded): %+v", i, len(got.EntityURNs), got.EntityURNs)
+		}
+	}
+}
+
+func TestRouter_NoLineageLeavesEntityURNsUnchanged(t *testing.T) {
+	var got Query
+	p := &captureProvider{scope: ScopeShared, sink: &got}
+	r := NewRouter(nil, nil, p)
+	if _, err := r.Search(context.Background(), Query{EntityURNs: []string{"urn:a"}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.EntityURNs) != 1 || got.EntityURNs[0] != "urn:a" {
+		t.Errorf("entity urns = %+v, want unchanged [urn:a]", got.EntityURNs)
+	}
+}
+
 func TestRouter_AllProvidersErrorReturnsError(t *testing.T) {
 	boom := errors.New("boom")
 	p1 := &fakeProvider{name: "p1", scope: ScopeShared, err: boom}
 	p2 := &fakeProvider{name: "p2", scope: ScopeShared, err: boom}
-	r := NewRouter(nil, p1, p2)
+	r := NewRouter(nil, nil, p1, p2)
 
 	_, err := r.Search(context.Background(), Query{Intent: "q"})
 	if err == nil {
@@ -199,7 +236,7 @@ func TestRouter_AllProvidersErrorReturnsError(t *testing.T) {
 func TestRouter_PartialErrorTolerated(t *testing.T) {
 	good := &fakeProvider{name: "good", scope: ScopeShared, hits: []Hit{{Source: "good", Ref: "g1", Score: 1}}}
 	bad := &fakeProvider{name: "bad", scope: ScopeShared, err: errors.New("down")}
-	r := NewRouter(nil, good, bad)
+	r := NewRouter(nil, nil, good, bad)
 
 	res, err := r.Search(context.Background(), Query{Intent: "q"})
 	if err != nil {
@@ -216,7 +253,7 @@ func TestRouter_LimitCapsResults(t *testing.T) {
 		hits[i] = Hit{Source: "p", Ref: string(rune('a' + i)), Score: float64(i)}
 	}
 	p := &fakeProvider{name: "p", scope: ScopeShared, hits: hits}
-	r := NewRouter(nil, p)
+	r := NewRouter(nil, nil, p)
 
 	res, err := r.Search(context.Background(), Query{Intent: "q", Limit: 3})
 	if err != nil {
@@ -246,7 +283,7 @@ func TestClampLimit(t *testing.T) {
 
 func TestRouter_Providers(t *testing.T) {
 	p := &fakeProvider{name: "p", scope: ScopeShared}
-	r := NewRouter(nil, p)
+	r := NewRouter(nil, nil, p)
 	if got := r.Providers(); len(got) != 1 || got[0] != p {
 		t.Errorf("Providers() = %+v, want [p]", got)
 	}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1678,7 +1678,16 @@ func (p *Platform) initSearch() error {
 		return nil
 	}
 
-	router := knowledge.NewRouter(p.embeddingProv, providers...)
+	// The lineage expander widens the entity path along DataHub lineage (the old
+	// memory_recall graph strategy) once per search, shared across every
+	// entity-keyed provider; nil when no real catalog is configured, leaving a
+	// plain entity lookup.
+	var lineage knowledge.LineageExpander
+	if p.config.Semantic.Provider == kindDataHub && p.semanticProvider != nil {
+		lineage = &knowledgeLineageExpander{semantic: p.semanticProvider}
+	}
+
+	router := knowledge.NewRouter(p.embeddingProv, lineage, providers...)
 	tk := searchkit.New(instanceDefault, router)
 	if err := p.toolkitRegistry.Register(tk); err != nil {
 		return fmt.Errorf("registering search toolkit: %w", err)
@@ -1695,18 +1704,15 @@ func (p *Platform) storeSearchProviders() []knowledge.Provider {
 	var providers []knowledge.Provider
 
 	if p.memoryStore != nil {
-		// The lineage expander widens the entity path along DataHub lineage
-		// (the old memory_recall graph strategy); nil when no real catalog is
-		// configured, leaving a plain entity lookup.
-		var lineage knowledge.LineageExpander
-		if p.config.Semantic.Provider == kindDataHub && p.semanticProvider != nil {
-			lineage = &knowledgeLineageExpander{semantic: p.semanticProvider}
-		}
-		providers = append(providers, knowledge.NewMemoryProvider(p.memoryStore, lineage))
+		// Lineage expansion of the entity path is the router's job (it runs once
+		// for every entity-keyed provider), so the memory provider takes the URN
+		// set as given.
+		providers = append(providers, knowledge.NewMemoryProvider(p.memoryStore))
 	}
-	// Insights are searchable only through the memory-backed adapter; the
-	// legacy SQL store and the noop store do not implement InsightSearcher.
-	if s, ok := p.knowledgeInsightStore.(knowledgekit.InsightSearcher); ok {
+	// Insights are searchable only through the memory-backed adapter; the legacy
+	// SQL store and the noop store do not implement InsightSearcher (and so are
+	// not SearchableInsightStores).
+	if s, ok := p.knowledgeInsightStore.(knowledgekit.SearchableInsightStore); ok {
 		providers = append(providers, knowledge.NewInsightsProvider(s))
 	}
 	// The technical catalog is a knowledge sink only when a real DataHub

--- a/pkg/toolkits/knowledge/memory_adapter.go
+++ b/pkg/toolkits/knowledge/memory_adapter.go
@@ -125,6 +125,17 @@ type InsightSearcher interface {
 	Search(ctx context.Context, q InsightSearchQuery) ([]ScoredInsight, error)
 }
 
+// SearchableInsightStore is an InsightStore that also supports relevance
+// search. Only the memory-backed adapter satisfies it; the legacy SQL store and
+// the noop store implement InsightStore but not InsightSearcher. The unified
+// search wiring asserts the wired store against this so the insights search
+// provider gets both the entity-keyed lookup (List, filtered by EntityURN) and
+// the relevance search (Search) from one value.
+type SearchableInsightStore interface {
+	InsightStore
+	InsightSearcher
+}
+
 // Search returns the caller's knowledge-dimension insights ranked by
 // relevance to the query. It delegates to the shared memory search
 // primitives (HybridSearch when an embedding is supplied, LexicalSearch

--- a/pkg/toolkits/search/integration_test.go
+++ b/pkg/toolkits/search/integration_test.go
@@ -3,6 +3,7 @@ package search
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -38,10 +39,12 @@ func (s *scopedMemoryStore) LexicalSearch(_ context.Context, q memory.LexicalQue
 	return s.scoped(q.CreatedBy), nil
 }
 
-func (s *scopedMemoryStore) EntityLookup(_ context.Context, _, _, createdBy string) ([]memory.Record, error) {
+func (s *scopedMemoryStore) EntityLookup(_ context.Context, urn, _, createdBy string) ([]memory.Record, error) {
 	var out []memory.Record
 	for _, r := range s.records {
-		if r.CreatedBy == createdBy {
+		// slices.Contains mirrors the entity_urns JSONB containment the real
+		// stores filter on.
+		if r.CreatedBy == createdBy && slices.Contains(r.EntityURNs, urn) {
 			out = append(out, r)
 		}
 	}
@@ -73,6 +76,22 @@ func (s *scopedInsightStore) Search(_ context.Context, q knowledgekit.InsightSea
 	return out, nil
 }
 
+// List is the entity-keyed path: insights owned by the caller and linked to the
+// requested URN, mirroring the real adapter's owner + entity_urns filter.
+func (s *scopedInsightStore) List(_ context.Context, f knowledgekit.InsightFilter) ([]knowledgekit.Insight, int, error) {
+	var out []knowledgekit.Insight
+	for _, in := range s.insights {
+		if in.CapturedBy != f.CapturedBy {
+			continue
+		}
+		if f.EntityURN != "" && !slices.Contains(in.EntityURNs, f.EntityURN) {
+			continue
+		}
+		out = append(out, in)
+	}
+	return out, len(out), nil
+}
+
 // scopedAssetStore returns only assets whose OwnerID matches the query.
 type scopedAssetStore struct {
 	assets []portal.Asset
@@ -94,6 +113,19 @@ type globalCatalog struct{}
 
 func (globalCatalog) SearchTables(_ context.Context, _ semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
 	return []semantic.TableSearchResult{{URN: "g-catalog", Name: "global table"}}, nil
+}
+
+// GetTableContext is the entity-keyed path: it resolves only the known demo
+// dataset, returning an empty (URN-less) context for any other table so a
+// non-existent URN yields no catalog hit.
+func (globalCatalog) GetTableContext(_ context.Context, table semantic.TableIdentifier) (*semantic.TableContext, error) {
+	if table.Table != "os_acme_transactions" {
+		return &semantic.TableContext{}, nil
+	}
+	return &semantic.TableContext{
+		URN:         "urn:li:dataset:(urn:li:dataPlatform:trino," + table.String() + ",PROD)",
+		Description: "acme transactions catalog entry",
+	}, nil
 }
 
 // globalPrompts is a shared prompts fake returning one global prompt for every
@@ -124,8 +156,8 @@ func assembledToolkit() *Toolkit {
 		{ID: "a-alice", OwnerID: userAID, Name: "alice asset"},
 	}}
 
-	router := knowledge.NewRouter(nil,
-		knowledge.NewMemoryProvider(mem, nil),
+	router := knowledge.NewRouter(nil, nil,
+		knowledge.NewMemoryProvider(mem),
 		knowledge.NewInsightsProvider(ins),
 		knowledge.NewDatahubProvider(globalCatalog{}),
 		knowledge.NewPromptsProvider(globalPrompts{}),
@@ -229,7 +261,7 @@ func TestEntityPathScopedToCaller(t *testing.T) {
 	mem := &scopedMemoryStore{records: []memory.Record{
 		{ID: "e-alice", CreatedBy: userAEmail, Content: "alice orders note", Dimension: memory.DimensionEntity, EntityURNs: []string{"urn:li:dataset:orders"}},
 	}}
-	router := knowledge.NewRouter(nil, knowledge.NewMemoryProvider(mem, nil))
+	router := knowledge.NewRouter(nil, nil, knowledge.NewMemoryProvider(mem))
 	tk := New("default", router)
 
 	// Entity-only query (no intent) by user B must not return alice's record.
@@ -247,6 +279,86 @@ func TestEntityPathScopedToCaller(t *testing.T) {
 	}
 	if out.Count != 0 {
 		t.Fatalf("entity lookup leaked across users: %+v", hitsOf(out))
+	}
+}
+
+// callEntitySearch runs an entity-only search (no intent) and decodes the output.
+func callEntitySearch(ctx context.Context, t *testing.T, tk *Toolkit, urns []string) searchOutput {
+	t.Helper()
+	res, _, err := tk.handleSearch(ctx, &mcp.CallToolRequest{}, searchInput{EntityURNs: urns})
+	if err != nil {
+		t.Fatalf("transport error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool reported error: %v", res.Content)
+	}
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("unexpected content type %T", res.Content[0])
+	}
+	var out searchOutput
+	if err := json.Unmarshal([]byte(tc.Text), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out
+}
+
+// TestEntityFanoutUnionsAllSources is the issue #654 acceptance test: an
+// entity-only search over an exact dataset URN must fan out across every
+// entity-keyed source, returning the catalog entity, the URN-linked insights,
+// and the URN-linked memory grouped by source, rather than the old near-empty
+// result.
+func TestEntityFanoutUnionsAllSources(t *testing.T) {
+	const urn = "urn:li:dataset:(urn:li:dataPlatform:trino,opensearch.default.os_acme_transactions,PROD)"
+	mem := &scopedMemoryStore{records: []memory.Record{
+		{ID: "m1", CreatedBy: userAEmail, Content: "alice note", Dimension: memory.DimensionEntity, EntityURNs: []string{urn}},
+	}}
+	ins := &scopedInsightStore{insights: []knowledgekit.Insight{
+		{ID: "i1", CapturedBy: userAEmail, InsightText: "amount is gross margin", Status: knowledgekit.StatusApproved, EntityURNs: []string{urn}},
+	}}
+	router := knowledge.NewRouter(nil, nil,
+		knowledge.NewMemoryProvider(mem),
+		knowledge.NewInsightsProvider(ins),
+		knowledge.NewDatahubProvider(globalCatalog{}),
+	)
+	tk := New("default", router)
+
+	out := callEntitySearch(ctxFor(userAID, userAEmail), t, tk, []string{urn})
+	if out.Ranking != "entity" {
+		t.Errorf("ranking = %q, want entity", out.Ranking)
+	}
+	bySource := map[string]bool{}
+	for _, h := range hitsOf(out) {
+		bySource[h.Source] = true
+	}
+	for _, src := range []string{knowledge.SourceMemory, knowledge.SourceInsights, knowledge.SourceDatahub} {
+		if !bySource[src] {
+			t.Errorf("entity fanout missing %q; sources seen: %v", src, bySource)
+		}
+	}
+}
+
+// TestEntityFanoutNonexistentURNReturnsZero proves a URN that no source has
+// linked content for returns nothing (no false matches), acceptance criterion 4.
+func TestEntityFanoutNonexistentURNReturnsZero(t *testing.T) {
+	const linked = "urn:li:dataset:(urn:li:dataPlatform:trino,opensearch.default.os_acme_transactions,PROD)"
+	const missing = "urn:li:dataset:(urn:li:dataPlatform:trino,opensearch.default.nope,PROD)"
+	mem := &scopedMemoryStore{records: []memory.Record{
+		{ID: "m1", CreatedBy: userAEmail, Content: "alice note", Dimension: memory.DimensionEntity, EntityURNs: []string{linked}},
+	}}
+	ins := &scopedInsightStore{insights: []knowledgekit.Insight{
+		{ID: "i1", CapturedBy: userAEmail, InsightText: "linked", Status: knowledgekit.StatusApproved, EntityURNs: []string{linked}},
+	}}
+	router := knowledge.NewRouter(nil, nil,
+		knowledge.NewMemoryProvider(mem),
+		knowledge.NewInsightsProvider(ins),
+		knowledge.NewDatahubProvider(globalCatalog{}),
+	)
+	tk := New("default", router)
+
+	out := callEntitySearch(ctxFor(userAID, userAEmail), t, tk, []string{missing})
+	if out.Count != 0 {
+		t.Fatalf("non-existent URN produced false matches: %+v", hitsOf(out))
 	}
 }
 
@@ -285,7 +397,7 @@ func (stubConnLister) Connections() []knowledge.ConnectionInfo {
 // matches both the catalog and a connection produces a group and a coverage
 // entry for each, and Count equals the total shown.
 func TestGroupedOutputAndCoverage(t *testing.T) {
-	router := knowledge.NewRouter(nil,
+	router := knowledge.NewRouter(nil, nil,
 		knowledge.NewDatahubProvider(globalCatalog{}),
 		knowledge.NewConnectionsProvider(stubConnLister{}),
 	)
@@ -317,7 +429,7 @@ func TestGroupedOutputAndCoverage(t *testing.T) {
 // TestSourcesNarrowsThroughTool proves the sources filter reaches the router
 // from the tool input.
 func TestSourcesNarrowsThroughTool(t *testing.T) {
-	router := knowledge.NewRouter(nil,
+	router := knowledge.NewRouter(nil, nil,
 		knowledge.NewDatahubProvider(globalCatalog{}),
 		knowledge.NewConnectionsProvider(stubConnLister{}),
 	)

--- a/pkg/toolkits/search/toolkit.go
+++ b/pkg/toolkits/search/toolkit.go
@@ -29,8 +29,9 @@ const toolName = "search"
 // searchInput is the deserialized search input. Intent is the natural-language
 // description of what the caller wants; Context is optional surrounding detail
 // folded into the same query to sharpen ranking. EntityURNs is an exact,
-// entity-keyed lookup (memory linked to those datasets, expanded along
-// lineage). Status optionally filters by review state. Sources optionally
+// entity-keyed lookup that unions every source linked to those datasets (the
+// catalog entity, URN-linked insights, and URN-linked memory), expanded along
+// lineage. Status optionally filters by review state. Sources optionally
 // narrows the federation to named sources (it only narrows; it never opts into
 // a source the persona could not otherwise access). At least one of intent or
 // entity_urns must be set.
@@ -71,7 +72,7 @@ var searchSchema = json.RawMessage(`{
     "entity_urns": {
       "type": "array",
       "items": { "type": "string" },
-      "description": "Exact entity-keyed lookup: return your memory linked to these DataHub URNs, expanded along lineage. Use when you have specific datasets in hand rather than a natural-language question."
+      "description": "Exact entity-keyed lookup: return everything linked to these DataHub URNs (the catalog entity, insights about it, and your memory linked to it), expanded along lineage. Use when you have specific datasets in hand rather than a natural-language question."
     },
     "status": {
       "type": "string",

--- a/pkg/toolkits/search/toolkit_test.go
+++ b/pkg/toolkits/search/toolkit_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestToolkit_TrivialAccessors(t *testing.T) {
-	tk := New("inst", knowledge.NewRouter(nil))
+	tk := New("inst", knowledge.NewRouter(nil, nil))
 	if tk.Name() != "inst" {
 		t.Errorf("Name = %q", tk.Name())
 	}
@@ -37,7 +37,7 @@ func (erroringProvider) Search(context.Context, knowledge.Query) ([]knowledge.Hi
 }
 
 func TestHandleSearch_RouterErrorBecomesToolError(t *testing.T) {
-	tk := New("inst", knowledge.NewRouter(nil, erroringProvider{}))
+	tk := New("inst", knowledge.NewRouter(nil, nil, erroringProvider{}))
 	res, _, err := tk.handleSearch(context.Background(), &mcp.CallToolRequest{}, searchInput{Intent: "q"})
 	if err != nil {
 		t.Fatalf("unexpected transport error: %v", err)


### PR DESCRIPTION
## Summary

Fixes #654. `search` invoked with `entity_urns` and no `intent` returned near-empty results: it consulted only the live-personal memory store, so the DataHub catalog entity, the insights whose `entity_urns` match the requested URN, and reviewed/team knowledge linked to it were all unreachable through the entity-keyed path the parameter advertises ("Exact entity-keyed lookup... pull what you know about specific datasets").

The entity path now unions every entity-keyed source for the requested URNs (expanded along lineage):

- the DataHub catalog entity,
- insights whose `entity_urns` match,
- the caller's memory linked to the URN.

Per-source flooring/capping and per-user scope are preserved on every path.

## Root cause

Only `MemoryProvider` served the entity-keyed path, and it deliberately skips knowledge-dimension records (insights are knowledge-dimension memory rows, owned by `InsightsProvider`). Both `InsightsProvider` and `DatahubProvider` early-returned unless `intent` was set, so an `entity_urns`-only query reached neither. The join already worked in `memory_manage(filter_entity_urn=...)`; the `search` entity path simply did not fan out to the other entity-keyed sources.

## Changes

- **Lineage expansion moved into the Router** (`pkg/knowledge/router.go`). It now runs once per search, before fan-out, and every entity-keyed provider sees the same widened URN set, the same way the query embedding is computed once and shared. Previously it lived only in `MemoryProvider`; replicating it per provider would have re-hit the catalog lineage API once per source (a per-kind fork). `NewRouter` gained a `LineageExpander` parameter; `MemoryProvider` no longer carries its own expander and takes the URN set as given.
- **`InsightsProvider` entity path** (`pkg/knowledge/provider_insights.go`). Added `searchByEntity`, which reuses the owner + `entity_urns` `List` join that `memory_manage(filter_entity_urn=...)` relies on, scoped to the caller's email and the knowledge dimension. When no explicit status is requested, retracted insights (rejected / superseded / rolled_back) are dropped so a "what do we know about this dataset" lookup never surfaces retracted knowledge. An explicit `status` filter is honored verbatim.
- **`DatahubProvider` entity path** (`pkg/knowledge/provider_datahub.go`). Added `searchByEntity`, which parses each URN to a table identifier and fetches the catalog entity via `GetTableContext`. A URN that does not parse, that the catalog cannot resolve, or that returns an empty (URN-less) context is skipped rather than failing the provider, so a non-existent URN returns 0 with no false matches. A catalog error on the entity path is logged and skipped (the URN set is probed across many lineage neighbors, most of which legitimately have no catalog entry).
- **Wiring** (`pkg/platform/platform.go`, `pkg/toolkits/knowledge/memory_adapter.go`). Added `SearchableInsightStore` (an `InsightStore` that also implements `InsightSearcher`) and passed the lineage expander to the router.
- **Docs / tool schema** (`pkg/toolkits/search/toolkit.go`, `docs/server/tools.md`, `docs/llms-full.txt`). Updated the `entity_urns` description to reflect that it now unions catalog + insights + memory, expanded along lineage.

## Acceptance criteria

| Criterion | Covered by |
|---|---|
| `search(entity_urns=[urn])` returns the DataHub entity + URN-linked insights + URN-linked memory, grouped by source | `TestEntityFanoutUnionsAllSources` (integration) |
| Personal scoping preserved: another user's personal memory is never returned; insights/DataHub follow existing access rules | `TestEntityPathScopedToCaller`, `TestAC2_PerUserIsolationBetweenIdentities` |
| `entity_urns` + `intent` continues to return hybrid results; `entity_urns` alone returns the entity-linked union instead of 0 | provider unit tests + `TestEntityFanoutUnionsAllSources` (`ranking: "entity"`) |
| A non-existent URN returns 0 (no false matches) | `TestEntityFanoutNonexistentURNReturnsZero`, `TestDatahubProvider_EntityLookupMissReturnsNothing` |

## Scope boundary

This patches the current path. A durable design (a single polymorphic reference/edge table that this traversal reads from) is tracked separately in #654 and is not part of this PR; the acceptance criteria carry forward unchanged. Backward-compatible: callers could not depend on the previous empty result.

## Testing

- New unit tests for each provider's entity path (entity scoping, retracted-status filtering, status passthrough, entity/text dedup, miss/unparseable/error handling) and router-level lineage expansion.
- Two end-to-end integration tests asserting the union grouped by source, the `entity` ranking mode, per-user isolation, and the non-existent-URN-returns-zero criterion.
- `make verify` passes in full (race tests, coverage, patch-scoped lint, gosec/govulncheck/semgrep, CodeQL, dead-code, mutation, GoReleaser dry-run).