### PR TITLE
feat(knowledge): knowledge pages reference the entities they describe (#664 Phase 0)

### DIFF
--- a/pkg/database/migrate/migrate_realpg_test.go
+++ b/pkg/database/migrate/migrate_realpg_test.go
@@ -14,7 +14,7 @@ import (
 
 // expectedFinalVersion is the highest migration the embedded set defines. Bump
 // this when adding a migration so the gate asserts the full set applied.
-const expectedFinalVersion = 72
+const expectedFinalVersion = 73
 
 // TestMigrationsAgainstRealPostgres applies the embedded migrations to a real
 // PostgreSQL (pgvector) instance and exercises the full lifecycle: up, seed,

--- a/pkg/database/migrate/migrate_unit_test.go
+++ b/pkg/database/migrate/migrate_unit_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	migrateTestFileCount    = 144
+	migrateTestFileCount    = 146
 	migrateTestSuccess      = "success"
 	migrateTestFactoryError = "factory error"
 )

--- a/pkg/database/migrate/migrations/000073_knowledge_page_entity_refs.down.sql
+++ b/pkg/database/migrate/migrations/000073_knowledge_page_entity_refs.down.sql
@@ -1,0 +1,2 @@
+-- Revert 000073: drop the knowledge-page entity reference table.
+DROP TABLE IF EXISTS knowledge_page_entity_refs;

--- a/pkg/database/migrate/migrations/000073_knowledge_page_entity_refs.up.sql
+++ b/pkg/database/migrate/migrations/000073_knowledge_page_entity_refs.up.sql
@@ -1,0 +1,52 @@
+-- 000073: knowledge_page_entity_refs (#664 Phase 0)
+--
+-- A knowledge page references 0..N entities it provides knowledge about. Internal
+-- entities are real foreign keys (referential integrity and cascade cleanup);
+-- only the external DataHub case is a text URN, because there is no local row to
+-- reference. This mirrors the portal_threads / portal_shares 1-of-N target
+-- polymorphism: exactly one target is set per row, enforced by a CHECK.
+--
+-- Phase 0 populates the DataHub (entity_urn) references that apply_knowledge was
+-- silently dropping when it promoted a business_knowledge insight to a page. The
+-- foreign-key target columns are part of the same designed table and are written
+-- by later phases (the authoring picker and inline body references); the source
+-- column records each reference's origin so the body-scan reconciliation can
+-- touch only inline references without clobbering picked or promoted ones.
+CREATE TABLE IF NOT EXISTS knowledge_page_entity_refs (
+    id              TEXT PRIMARY KEY,
+    page_id         TEXT NOT NULL REFERENCES portal_knowledge_pages(id) ON DELETE CASCADE,
+    target_type     TEXT NOT NULL,                       -- asset|prompt|collection|knowledge_page|connection|datahub
+    asset_id        TEXT REFERENCES portal_assets(id) ON DELETE CASCADE,
+    prompt_id       UUID REFERENCES prompts(id) ON DELETE CASCADE,
+    collection_id   TEXT REFERENCES portal_collections(id) ON DELETE CASCADE,
+    ref_page_id     TEXT REFERENCES portal_knowledge_pages(id) ON DELETE CASCADE,
+    connection_kind TEXT,
+    connection_name TEXT,
+    entity_urn      TEXT,                                -- DataHub or other external; no FK
+    source          TEXT NOT NULL DEFAULT 'promoted',    -- promoted|manual|inline
+    created_by      TEXT NOT NULL DEFAULT '',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    FOREIGN KEY (connection_kind, connection_name)
+        REFERENCES connection_instances(kind, name) ON DELETE CASCADE,
+    CONSTRAINT chk_kp_entity_ref_target CHECK (
+        (target_type = 'asset'          AND asset_id IS NOT NULL AND prompt_id IS NULL AND collection_id IS NULL AND ref_page_id IS NULL AND connection_kind IS NULL AND connection_name IS NULL AND entity_urn IS NULL) OR
+        (target_type = 'prompt'         AND prompt_id IS NOT NULL AND asset_id IS NULL AND collection_id IS NULL AND ref_page_id IS NULL AND connection_kind IS NULL AND connection_name IS NULL AND entity_urn IS NULL) OR
+        (target_type = 'collection'     AND collection_id IS NOT NULL AND asset_id IS NULL AND prompt_id IS NULL AND ref_page_id IS NULL AND connection_kind IS NULL AND connection_name IS NULL AND entity_urn IS NULL) OR
+        (target_type = 'knowledge_page' AND ref_page_id IS NOT NULL AND asset_id IS NULL AND prompt_id IS NULL AND collection_id IS NULL AND connection_kind IS NULL AND connection_name IS NULL AND entity_urn IS NULL) OR
+        (target_type = 'connection'     AND connection_kind IS NOT NULL AND connection_name IS NOT NULL AND asset_id IS NULL AND prompt_id IS NULL AND collection_id IS NULL AND ref_page_id IS NULL AND entity_urn IS NULL) OR
+        (target_type = 'datahub'        AND entity_urn IS NOT NULL AND asset_id IS NULL AND prompt_id IS NULL AND collection_id IS NULL AND ref_page_id IS NULL AND connection_kind IS NULL AND connection_name IS NULL)
+    ),
+    CONSTRAINT chk_kp_entity_ref_source CHECK (source IN ('promoted', 'manual', 'inline'))
+);
+
+-- Forward lookup: all references of a page (ListEntityRefs).
+CREATE INDEX IF NOT EXISTS idx_kp_entity_refs_page ON knowledge_page_entity_refs(page_id);
+
+-- Per-target-type uniqueness so a reference is recorded once per page (union on
+-- promotion). One partial unique index per target, since exactly one column is set.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_kp_entity_refs_asset ON knowledge_page_entity_refs(page_id, asset_id) WHERE asset_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_kp_entity_refs_prompt ON knowledge_page_entity_refs(page_id, prompt_id) WHERE prompt_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_kp_entity_refs_collection ON knowledge_page_entity_refs(page_id, collection_id) WHERE collection_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_kp_entity_refs_page_ref ON knowledge_page_entity_refs(page_id, ref_page_id) WHERE ref_page_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_kp_entity_refs_connection ON knowledge_page_entity_refs(page_id, connection_kind, connection_name) WHERE connection_kind IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_kp_entity_refs_urn ON knowledge_page_entity_refs(page_id, entity_urn) WHERE entity_urn IS NOT NULL;

--- a/pkg/portal/knowledge_page_handler_test.go
+++ b/pkg/portal/knowledge_page_handler_test.go
@@ -84,6 +84,18 @@ func (m *mockKnowledgePageStore) Search(_ context.Context, _ knowledgepage.Searc
 	return m.scored, nil
 }
 
+func (*mockKnowledgePageStore) ListEntityRefs(_ context.Context, _ string) ([]knowledgepage.EntityRef, error) {
+	return nil, nil
+}
+
+func (*mockKnowledgePageStore) AddEntityRefs(_ context.Context, _ string, _ []knowledgepage.EntityRef) error {
+	return nil
+}
+
+func (*mockKnowledgePageStore) ReplaceEntityRefs(_ context.Context, _ string, _ []knowledgepage.EntityRef) error {
+	return nil
+}
+
 var (
 	kpAdmin  = &User{UserID: "admin-1", Email: "admin@example.com", Roles: []string{"admin"}}
 	kpViewer = &User{UserID: "viewer-1", Email: "viewer@example.com", Roles: []string{"analyst"}}

--- a/pkg/portal/knowledgepage/entity_refs.go
+++ b/pkg/portal/knowledgepage/entity_refs.go
@@ -1,0 +1,241 @@
+package knowledgepage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Entity-reference target types. Exactly one target is set on a reference row:
+// an internal entity by foreign key, or an external DataHub URN.
+const (
+	RefTargetAsset         = "asset"
+	RefTargetPrompt        = "prompt"
+	RefTargetCollection    = "collection"
+	RefTargetKnowledgePage = "knowledge_page"
+	RefTargetConnection    = "connection"
+	RefTargetDataHub       = "datahub"
+)
+
+// Entity-reference sources, recording how a reference came to be so the inline
+// body-scan (a later phase) can reconcile only its own rows without clobbering
+// picked or promoted references.
+const (
+	RefSourcePromoted = "promoted" // carried from a source insight by apply_knowledge
+	RefSourceManual   = "manual"   // added explicitly through the authoring picker
+	RefSourceInline   = "inline"   // derived from a mention in the page body
+)
+
+// EntityRef is a typed reference from a knowledge page to an entity it provides
+// knowledge about. Exactly one target is populated, matching TargetType.
+type EntityRef struct {
+	ID             string    `json:"id,omitempty"`
+	PageID         string    `json:"page_id,omitempty"`
+	TargetType     string    `json:"target_type"`
+	AssetID        string    `json:"asset_id,omitempty"`
+	PromptID       string    `json:"prompt_id,omitempty"`
+	CollectionID   string    `json:"collection_id,omitempty"`
+	RefPageID      string    `json:"ref_page_id,omitempty"`
+	ConnectionKind string    `json:"connection_kind,omitempty"`
+	ConnectionName string    `json:"connection_name,omitempty"`
+	EntityURN      string    `json:"entity_urn,omitempty"`
+	Source         string    `json:"source,omitempty"`
+	CreatedBy      string    `json:"created_by,omitempty"`
+	CreatedAt      time.Time `json:"created_at"`
+}
+
+// refKeySep separates the target type from its id in a reference identity key.
+const refKeySep = ":"
+
+// DataHubRef builds a reference to an external DataHub entity (a urn:li: URN).
+// This is the only reference type Phase 0 writes: the references apply_knowledge
+// carries from a promoted insight.
+func DataHubRef(urn, source string) EntityRef {
+	return EntityRef{TargetType: RefTargetDataHub, EntityURN: urn, Source: source}
+}
+
+// identity returns a stable key for a reference's target, used to de-duplicate
+// within a page (the union on promotion) and mirrors each per-type unique index.
+func (r EntityRef) identity() string {
+	switch r.TargetType {
+	case RefTargetAsset:
+		return RefTargetAsset + refKeySep + r.AssetID
+	case RefTargetPrompt:
+		return RefTargetPrompt + refKeySep + r.PromptID
+	case RefTargetCollection:
+		return RefTargetCollection + refKeySep + r.CollectionID
+	case RefTargetKnowledgePage:
+		return RefTargetKnowledgePage + refKeySep + r.RefPageID
+	case RefTargetConnection:
+		return RefTargetConnection + refKeySep + r.ConnectionKind + "/" + r.ConnectionName
+	case RefTargetDataHub:
+		return RefTargetDataHub + refKeySep + r.EntityURN
+	default:
+		return r.TargetType + refKeySep
+	}
+}
+
+// NewRefID returns a unique id for an entity-reference row ("kpr_<uuid>").
+func NewRefID() string { return "kpr_" + uuid.New().String() }
+
+const entityRefColumns = `id, page_id, target_type, asset_id, prompt_id, collection_id, ref_page_id, ` +
+	`connection_kind, connection_name, entity_urn, source, created_by, created_at`
+
+// ListEntityRefs returns all references of a page, oldest first.
+func (s *postgresStore) ListEntityRefs(ctx context.Context, pageID string) ([]EntityRef, error) { //nolint:revive // interface impl
+	query := `SELECT ` + entityRefColumns + ` FROM knowledge_page_entity_refs WHERE page_id = $1 ORDER BY created_at, id`
+	rows, err := s.db.QueryContext(ctx, query, pageID)
+	if err != nil {
+		return nil, fmt.Errorf("querying entity refs: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // best-effort cleanup after read-only query
+
+	var refs []EntityRef
+	for rows.Next() {
+		ref, scanErr := scanEntityRef(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		refs = append(refs, ref)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating entity ref rows: %w", err)
+	}
+	return refs, nil
+}
+
+// AddEntityRefs inserts the given references for a page (union semantics): a
+// reference whose target already exists on the page is skipped. Each insert uses
+// ON CONFLICT DO NOTHING against the per-type unique index, so the union is
+// idempotent and race-safe (a concurrent duplicate is a no-op, not an error) and
+// re-running a failed promotion is safe.
+func (s *postgresStore) AddEntityRefs(ctx context.Context, pageID string, refs []EntityRef) error { //nolint:revive // interface impl
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		if _, dup := seen[ref.identity()]; dup { // collapse duplicates within the batch
+			continue
+		}
+		seen[ref.identity()] = struct{}{}
+		if err := insertEntityRef(ctx, s.db, pageID, ref); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// refConflictTarget returns the ON CONFLICT arbiter (matching the per-type
+// partial unique index) so an insert of an already-present reference is a no-op.
+func refConflictTarget(targetType string) string {
+	switch targetType {
+	case RefTargetAsset:
+		return "(page_id, asset_id) WHERE asset_id IS NOT NULL"
+	case RefTargetPrompt:
+		return "(page_id, prompt_id) WHERE prompt_id IS NOT NULL"
+	case RefTargetCollection:
+		return "(page_id, collection_id) WHERE collection_id IS NOT NULL"
+	case RefTargetKnowledgePage:
+		return "(page_id, ref_page_id) WHERE ref_page_id IS NOT NULL"
+	case RefTargetConnection:
+		return "(page_id, connection_kind, connection_name) WHERE connection_kind IS NOT NULL"
+	case RefTargetDataHub:
+		return "(page_id, entity_urn) WHERE entity_urn IS NOT NULL"
+	default:
+		return ""
+	}
+}
+
+// ReplaceEntityRefs sets a page's references to exactly the given set (clearing
+// the rest), used to restore the prior references when a promotion is rolled back.
+func (s *postgresStore) ReplaceEntityRefs(ctx context.Context, pageID string, refs []EntityRef) error { //nolint:revive // interface impl
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // commit below on success
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM knowledge_page_entity_refs WHERE page_id = $1`, pageID); err != nil {
+		return fmt.Errorf("clearing entity refs: %w", err)
+	}
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		if _, dup := seen[ref.identity()]; dup {
+			continue
+		}
+		if err := insertEntityRef(ctx, tx, pageID, ref); err != nil {
+			return err
+		}
+		seen[ref.identity()] = struct{}{}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+
+// execer is satisfied by both *sql.DB and *sql.Tx so insertEntityRef serves the
+// union (DB) and replace (Tx) paths.
+type execer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+func insertEntityRef(ctx context.Context, e execer, pageID string, ref EntityRef) error {
+	id := ref.ID
+	if id == "" {
+		id = NewRefID()
+	}
+	source := ref.Source
+	if source == "" {
+		source = RefSourcePromoted
+	}
+	query := `
+		INSERT INTO knowledge_page_entity_refs
+		(id, page_id, target_type, asset_id, prompt_id, collection_id, ref_page_id,
+		 connection_kind, connection_name, entity_urn, source, created_by)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+	`
+	if target := refConflictTarget(ref.TargetType); target != "" {
+		query += " ON CONFLICT " + target + " DO NOTHING"
+	}
+	_, err := e.ExecContext(ctx, query,
+		id, pageID, ref.TargetType,
+		nullRefString(ref.AssetID), nullRefString(ref.PromptID), nullRefString(ref.CollectionID), nullRefString(ref.RefPageID),
+		nullRefString(ref.ConnectionKind), nullRefString(ref.ConnectionName), nullRefString(ref.EntityURN),
+		source, ref.CreatedBy,
+	)
+	if err != nil {
+		return fmt.Errorf("inserting entity ref: %w", err)
+	}
+	return nil
+}
+
+func scanEntityRef(rows *sql.Rows) (EntityRef, error) {
+	var r EntityRef
+	var assetID, promptID, collectionID, refPageID, connKind, connName, urn sql.NullString
+	if err := rows.Scan(
+		&r.ID, &r.PageID, &r.TargetType, &assetID, &promptID, &collectionID, &refPageID,
+		&connKind, &connName, &urn, &r.Source, &r.CreatedBy, &r.CreatedAt,
+	); err != nil {
+		return r, fmt.Errorf("scanning entity ref row: %w", err)
+	}
+	r.AssetID = assetID.String
+	r.PromptID = promptID.String
+	r.CollectionID = collectionID.String
+	r.RefPageID = refPageID.String
+	r.ConnectionKind = connKind.String
+	r.ConnectionName = connName.String
+	r.EntityURN = urn.String
+	return r, nil
+}
+
+// nullRefString maps an empty string to a SQL NULL so an unset 1-of-N target
+// column is NULL (which the exactly-one CHECK and the partial unique indexes
+// require), not an empty string.
+func nullRefString(s string) sql.NullString {
+	if s == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: s, Valid: true}
+}

--- a/pkg/portal/knowledgepage/entity_refs_test.go
+++ b/pkg/portal/knowledgepage/entity_refs_test.go
@@ -1,0 +1,187 @@
+package knowledgepage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func refRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id", "page_id", "target_type", "asset_id", "prompt_id", "collection_id", "ref_page_id",
+		"connection_kind", "connection_name", "entity_urn", "source", "created_by", "created_at",
+	})
+}
+
+func TestStore_ListEntityRefs(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+	store := NewPostgresStore(db)
+	now := time.Now()
+
+	mock.ExpectQuery("FROM knowledge_page_entity_refs WHERE page_id").
+		WithArgs("kp1").
+		WillReturnRows(refRows().
+			AddRow("r1", "kp1", "datahub", nil, nil, nil, nil, nil, nil, "urn:li:dataset:x", "promoted", "alice", now).
+			AddRow("r2", "kp1", "connection", nil, nil, nil, nil, "trino", "warehouse", nil, "manual", "bob", now))
+
+	refs, err := store.ListEntityRefs(context.Background(), "kp1")
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+	assert.Equal(t, RefTargetDataHub, refs[0].TargetType)
+	assert.Equal(t, "urn:li:dataset:x", refs[0].EntityURN)
+	assert.Equal(t, RefTargetConnection, refs[1].TargetType)
+	assert.Equal(t, "trino", refs[1].ConnectionKind)
+	assert.Equal(t, "warehouse", refs[1].ConnectionName)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStore_AddEntityRefs_InsertsWithConflictTarget(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+	store := NewPostgresStore(db)
+
+	// Each distinct batch ref is inserted with ON CONFLICT DO NOTHING (the union
+	// is enforced at the DB by the per-type unique index, race-safe).
+	mock.ExpectExec("INSERT INTO knowledge_page_entity_refs.*ON CONFLICT .page_id, entity_urn. WHERE entity_urn IS NOT NULL DO NOTHING").
+		WithArgs(sqlmock.AnyArg(), "kp1", "datahub", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), "urnA", "promoted", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO knowledge_page_entity_refs.*ON CONFLICT").
+		WithArgs(sqlmock.AnyArg(), "kp1", "datahub", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), "urnB", "promoted", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// urnA is repeated in the batch and must be collapsed to a single insert.
+	err = store.AddEntityRefs(context.Background(), "kp1", []EntityRef{
+		DataHubRef("urnA", RefSourcePromoted),
+		DataHubRef("urnB", RefSourcePromoted),
+		DataHubRef("urnA", RefSourcePromoted),
+	})
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStore_AddEntityRefs_InternalTargets(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+	store := NewPostgresStore(db)
+
+	// An asset reference uses its own conflict target and FK column.
+	mock.ExpectExec("INSERT INTO knowledge_page_entity_refs.*ON CONFLICT .page_id, asset_id. WHERE asset_id IS NOT NULL DO NOTHING").
+		WithArgs(sqlmock.AnyArg(), "kp1", "asset", "asset-001", sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), "manual", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	// A connection reference uses the composite conflict target.
+	mock.ExpectExec("INSERT INTO knowledge_page_entity_refs.*ON CONFLICT .page_id, connection_kind, connection_name. WHERE connection_kind IS NOT NULL DO NOTHING").
+		WithArgs(sqlmock.AnyArg(), "kp1", "connection", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), "trino", "warehouse", sqlmock.AnyArg(), "manual", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = store.AddEntityRefs(context.Background(), "kp1", []EntityRef{
+		{TargetType: RefTargetAsset, AssetID: "asset-001", Source: RefSourceManual},
+		{TargetType: RefTargetConnection, ConnectionKind: "trino", ConnectionName: "warehouse", Source: RefSourceManual},
+	})
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStore_ReplaceEntityRefs(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+	store := NewPostgresStore(db)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM knowledge_page_entity_refs WHERE page_id").
+		WithArgs("kp1").
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec("INSERT INTO knowledge_page_entity_refs").
+		WithArgs(sqlmock.AnyArg(), "kp1", "datahub", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), "urnA", "promoted", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err = store.ReplaceEntityRefs(context.Background(), "kp1", []EntityRef{DataHubRef("urnA", RefSourcePromoted)})
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestEntityRefIdentity covers the per-target de-dup key used by the union.
+func TestEntityRefIdentity(t *testing.T) {
+	assert.Equal(t, "datahub:u", EntityRef{TargetType: RefTargetDataHub, EntityURN: "u"}.identity())
+	assert.Equal(t, "asset:a", EntityRef{TargetType: RefTargetAsset, AssetID: "a"}.identity())
+	assert.Equal(t, "prompt:p", EntityRef{TargetType: RefTargetPrompt, PromptID: "p"}.identity())
+	assert.Equal(t, "collection:c", EntityRef{TargetType: RefTargetCollection, CollectionID: "c"}.identity())
+	assert.Equal(t, "knowledge_page:kp", EntityRef{TargetType: RefTargetKnowledgePage, RefPageID: "kp"}.identity())
+	assert.Equal(t, "connection:trino/warehouse",
+		EntityRef{TargetType: RefTargetConnection, ConnectionKind: "trino", ConnectionName: "warehouse"}.identity())
+	assert.Equal(t, "bogus:", EntityRef{TargetType: "bogus"}.identity())
+	assert.NotEqual(t,
+		EntityRef{TargetType: RefTargetAsset, AssetID: "a"}.identity(),
+		EntityRef{TargetType: RefTargetPrompt, PromptID: "a"}.identity())
+}
+
+func TestRefConflictTarget(t *testing.T) {
+	cases := map[string]string{
+		RefTargetAsset:         "(page_id, asset_id) WHERE asset_id IS NOT NULL",
+		RefTargetPrompt:        "(page_id, prompt_id) WHERE prompt_id IS NOT NULL",
+		RefTargetCollection:    "(page_id, collection_id) WHERE collection_id IS NOT NULL",
+		RefTargetKnowledgePage: "(page_id, ref_page_id) WHERE ref_page_id IS NOT NULL",
+		RefTargetConnection:    "(page_id, connection_kind, connection_name) WHERE connection_kind IS NOT NULL",
+		RefTargetDataHub:       "(page_id, entity_urn) WHERE entity_urn IS NOT NULL",
+		"bogus":                "",
+	}
+	for targetType, want := range cases {
+		assert.Equal(t, want, refConflictTarget(targetType), targetType)
+	}
+}
+
+func TestStore_EntityRefs_ErrorPaths(t *testing.T) {
+	t.Run("list query error", func(t *testing.T) {
+		db, mock, _ := sqlmock.New()
+		defer db.Close() //nolint:errcheck // test cleanup
+		mock.ExpectQuery("FROM knowledge_page_entity_refs WHERE page_id").WithArgs("kp1").WillReturnError(errBoom)
+		_, err := NewPostgresStore(db).ListEntityRefs(context.Background(), "kp1")
+		require.Error(t, err)
+	})
+
+	t.Run("add insert error", func(t *testing.T) {
+		db, mock, _ := sqlmock.New()
+		defer db.Close() //nolint:errcheck // test cleanup
+		mock.ExpectExec("INSERT INTO knowledge_page_entity_refs").WillReturnError(errBoom)
+		err := NewPostgresStore(db).AddEntityRefs(context.Background(), "kp1", []EntityRef{DataHubRef("u", RefSourcePromoted)})
+		require.Error(t, err)
+	})
+
+	t.Run("replace delete error rolls back", func(t *testing.T) {
+		db, mock, _ := sqlmock.New()
+		defer db.Close() //nolint:errcheck // test cleanup
+		mock.ExpectBegin()
+		mock.ExpectExec("DELETE FROM knowledge_page_entity_refs WHERE page_id").WithArgs("kp1").WillReturnError(errBoom)
+		mock.ExpectRollback()
+		err := NewPostgresStore(db).ReplaceEntityRefs(context.Background(), "kp1", []EntityRef{DataHubRef("u", RefSourcePromoted)})
+		require.Error(t, err)
+	})
+
+	t.Run("replace begin error", func(t *testing.T) {
+		db, mock, _ := sqlmock.New()
+		defer db.Close() //nolint:errcheck // test cleanup
+		mock.ExpectBegin().WillReturnError(errBoom)
+		err := NewPostgresStore(db).ReplaceEntityRefs(context.Background(), "kp1", []EntityRef{DataHubRef("u", RefSourcePromoted)})
+		require.Error(t, err)
+	})
+
+	t.Run("add with no refs is a no-op", func(t *testing.T) {
+		db, _, _ := sqlmock.New()
+		defer db.Close() //nolint:errcheck // test cleanup
+		require.NoError(t, NewPostgresStore(db).AddEntityRefs(context.Background(), "kp1", nil))
+	})
+}

--- a/pkg/portal/knowledgepage/store.go
+++ b/pkg/portal/knowledgepage/store.go
@@ -90,6 +90,10 @@ type Store interface {
 	SoftDelete(ctx context.Context, id string) error
 	ListVersions(ctx context.Context, pageID string, limit, offset int) ([]Version, int, error)
 	GetVersion(ctx context.Context, pageID string, version int) (*Version, error)
+	// Entity references (#664): the entities a page provides knowledge about.
+	ListEntityRefs(ctx context.Context, pageID string) ([]EntityRef, error)
+	AddEntityRefs(ctx context.Context, pageID string, refs []EntityRef) error
+	ReplaceEntityRefs(ctx context.Context, pageID string, refs []EntityRef) error
 }
 
 // ErrNotFound is returned when a page id/slug does not resolve to a

--- a/pkg/toolkits/knowledge/page_sink.go
+++ b/pkg/toolkits/knowledge/page_sink.go
@@ -27,14 +27,15 @@ const (
 // 000008), so a page promotion records "kp:<slug>" and shares the same changeset
 // store / list / rollback surface as DataHub changesets.
 const (
-	pageTargetPrefix = "kp:"
-	changeCreatePage = "create_page"
-	changeUpdatePage = "update_page"
-	pageFieldTitle   = "title"
-	pageFieldSummary = "summary"
-	pageFieldBody    = "body"
-	pageFieldTags    = "tags"
-	pageFieldVersion = "version"
+	pageTargetPrefix    = "kp:"
+	changeCreatePage    = "create_page"
+	changeUpdatePage    = "update_page"
+	pageFieldTitle      = "title"
+	pageFieldSummary    = "summary"
+	pageFieldBody       = "body"
+	pageFieldTags       = "tags"
+	pageFieldVersion    = "version"
+	pageFieldEntityURNs = "entity_urns"
 )
 
 // Knowledge-page promotion validation bounds. These MUST match the portal REST
@@ -57,6 +58,10 @@ type pageWriter interface {
 	Insert(ctx context.Context, page knowledgepage.Page) error
 	Update(ctx context.Context, id string, updates knowledgepage.Update) error
 	SoftDelete(ctx context.Context, id string) error
+	// Entity references (#664): carry a promoted insight's references onto the page.
+	ListEntityRefs(ctx context.Context, pageID string) ([]knowledgepage.EntityRef, error)
+	AddEntityRefs(ctx context.Context, pageID string, refs []knowledgepage.EntityRef) error
+	ReplaceEntityRefs(ctx context.Context, pageID string, refs []knowledgepage.EntityRef) error
 }
 
 // PageReverter is the slice of the knowledge-page store a rollback needs: look up
@@ -68,6 +73,8 @@ type PageReverter interface {
 	GetBySlug(ctx context.Context, slug string) (*knowledgepage.Page, error)
 	Update(ctx context.Context, id string, updates knowledgepage.Update) error
 	SoftDelete(ctx context.Context, id string) error
+	// Entity references (#664): restore the page's references on rollback.
+	ReplaceEntityRefs(ctx context.Context, pageID string, refs []knowledgepage.EntityRef) error
 }
 
 // PageEditedError is returned when a knowledge-page promotion cannot be rolled
@@ -132,8 +139,10 @@ func (t *Toolkit) promoteToPage(ctx context.Context, input applyKnowledgeInput) 
 		return errorResult(msg), nil, nil
 	}
 
-	// Mis-routing guard: every source insight must be page-class.
-	originClass, err := t.validatePageInsightClasses(ctx, input.InsightIDs)
+	// Mis-routing guard: every source insight must be page-class. This also
+	// collects the references the source insights carried, so they survive
+	// promotion onto the page instead of being dropped (#664).
+	originClass, entityURNs, err := t.validatePageInsightClasses(ctx, input.InsightIDs)
 	if err != nil {
 		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol
 	}
@@ -148,7 +157,7 @@ func (t *Toolkit) promoteToPage(ctx context.Context, input applyKnowledgeInput) 
 
 	appliedBy := userIDFromContext(ctx)
 	tags := tagsWithOrigin(page.Tags, originClass)
-	prom, err := t.applyPagePromotion(ctx, *page, tags, appliedBy)
+	prom, err := t.applyPagePromotion(ctx, *page, tags, appliedBy, entityURNs)
 	if err != nil {
 		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol
 	}
@@ -165,9 +174,19 @@ type pagePromotion struct {
 	next       map[string]any
 }
 
-// applyPagePromotion find-or-creates the page by slug and returns the before/after
-// images for the changeset.
-func (t *Toolkit) applyPagePromotion(ctx context.Context, page pagePromotionInput, tags []string, appliedBy string) (*pagePromotion, error) {
+// applyPagePromotion find-or-creates the page by slug, carries the source
+// insights' references onto it (union), and returns the before/after images for
+// the changeset. entityURNs are the DataHub references gathered from the source
+// insights (#664).
+//
+// Atomicity: the page write, the reference write, and the changeset record are
+// separate operations (the page and changeset already were before #664; the
+// reference write joins that sequence). A failure between them can leave the
+// page written while the promotion reports failure. The reference write uses
+// ON CONFLICT DO NOTHING, so it is idempotent and a retry is safe; a single
+// cross-store transaction spanning the page, references, and changeset is a
+// broader change tracked separately.
+func (t *Toolkit) applyPagePromotion(ctx context.Context, page pagePromotionInput, tags []string, appliedBy string, entityURNs []string) (*pagePromotion, error) {
 	existing, err := t.pageWriter.GetBySlug(ctx, page.Slug)
 	switch {
 	case err == nil:
@@ -175,7 +194,11 @@ func (t *Toolkit) applyPagePromotion(ctx context.Context, page pagePromotionInpu
 		// changeset records the prior content regardless of whether the store
 		// returns a shared row pointer.
 		producedVersion := existing.CurrentVersion + 1
-		prev := pageImage(existing.Title, existing.Summary, existing.Body, existing.Tags, existing.CurrentVersion)
+		prevURNs, err := t.pageEntityURNs(ctx, existing.ID)
+		if err != nil {
+			return nil, err
+		}
+		prev := pageImageWithRefs(pageSnapshot{existing.Title, existing.Summary, existing.Body, existing.Tags, existing.CurrentVersion, prevURNs})
 		// Update the existing page (consolidation): a new version is produced.
 		if uErr := t.pageWriter.Update(ctx, existing.ID, knowledgepage.Update{
 			Title: &page.Title, Summary: &page.Summary, Body: &page.Body, Tags: &tags,
@@ -183,10 +206,14 @@ func (t *Toolkit) applyPagePromotion(ctx context.Context, page pagePromotionInpu
 		}); uErr != nil {
 			return nil, fmt.Errorf("updating knowledge page: %w", uErr)
 		}
+		nextURNs, err := t.addPageEntityRefs(ctx, existing.ID, entityURNs, appliedBy)
+		if err != nil {
+			return nil, err
+		}
 		return &pagePromotion{
 			pageID: existing.ID, slug: page.Slug, changeType: changeUpdatePage,
 			prev: prev,
-			next: pageImage(page.Title, page.Summary, page.Body, tags, producedVersion),
+			next: pageImageWithRefs(pageSnapshot{page.Title, page.Summary, page.Body, tags, producedVersion, nextURNs}),
 		}, nil
 	case errors.Is(err, knowledgepage.ErrNotFound):
 		id := knowledgepage.NewID()
@@ -196,14 +223,62 @@ func (t *Toolkit) applyPagePromotion(ctx context.Context, page pagePromotionInpu
 		}); iErr != nil {
 			return nil, fmt.Errorf("creating knowledge page: %w", iErr)
 		}
+		nextURNs, err := t.addPageEntityRefs(ctx, id, entityURNs, appliedBy)
+		if err != nil {
+			return nil, err
+		}
 		return &pagePromotion{
 			pageID: id, slug: page.Slug, changeType: changeCreatePage,
-			prev: map[string]any{},
-			next: pageImage(page.Title, page.Summary, page.Body, tags, 1),
+			prev: pageImageWithRefs(pageSnapshot{}),
+			next: pageImageWithRefs(pageSnapshot{title: page.Title, summary: page.Summary, body: page.Body, tags: tags, version: 1, entityURNs: nextURNs}),
 		}, nil
 	default:
 		return nil, fmt.Errorf("looking up knowledge page by slug: %w", err)
 	}
+}
+
+// pageEntityURNs returns the page's current DataHub reference URNs (Phase 0 only
+// writes DataHub references, so the changeset snapshot tracks those).
+func (t *Toolkit) pageEntityURNs(ctx context.Context, pageID string) ([]string, error) {
+	refs, err := t.pageWriter.ListEntityRefs(ctx, pageID)
+	if err != nil {
+		return nil, fmt.Errorf("listing page references: %w", err)
+	}
+	var urns []string
+	for _, r := range refs {
+		if r.TargetType == knowledgepage.RefTargetDataHub && r.EntityURN != "" {
+			urns = append(urns, r.EntityURN)
+		}
+	}
+	return urns, nil
+}
+
+// addPageEntityRefs unions the given DataHub URNs onto the page as promoted
+// references and returns the page's full DataHub URN set afterward (for the
+// changeset after-image).
+func (t *Toolkit) addPageEntityRefs(ctx context.Context, pageID string, entityURNs []string, appliedBy string) ([]string, error) {
+	if len(entityURNs) > 0 {
+		refs := dataHubRefs(entityURNs)
+		for i := range refs {
+			refs[i].CreatedBy = appliedBy
+		}
+		if err := t.pageWriter.AddEntityRefs(ctx, pageID, refs); err != nil {
+			return nil, fmt.Errorf("adding page references: %w", err)
+		}
+	}
+	return t.pageEntityURNs(ctx, pageID)
+}
+
+// dataHubRefs builds promoted DataHub references from a list of URNs.
+func dataHubRefs(urns []string) []knowledgepage.EntityRef {
+	refs := make([]knowledgepage.EntityRef, 0, len(urns))
+	for _, urn := range urns {
+		if urn == "" {
+			continue
+		}
+		refs = append(refs, knowledgepage.DataHubRef(urn, knowledgepage.RefSourcePromoted))
+	}
+	return refs
 }
 
 // recordPageChangesetAndMarkApplied records the promotion changeset (target
@@ -255,19 +330,31 @@ func (t *Toolkit) recordPageChangesetAndMarkApplied(ctx context.Context, input a
 // validatePageInsightClasses fetches each insight and rejects any whose sink-class
 // does not belong to the knowledge-page sink, returning the common origin class
 // for tagging. Empty insight_ids is allowed (a curator authoring a page directly).
-func (t *Toolkit) validatePageInsightClasses(ctx context.Context, insightIDs []string) (string, error) {
-	origin := ""
+func (t *Toolkit) validatePageInsightClasses(ctx context.Context, insightIDs []string) (origin string, entityURNs []string, err error) {
+	seen := map[string]struct{}{}
 	for _, id := range insightIDs {
-		ins, err := t.store.Get(ctx, id)
-		if err != nil {
-			return "", fmt.Errorf("insight %s not found", id)
+		ins, gErr := t.store.Get(ctx, id)
+		if gErr != nil {
+			return "", nil, fmt.Errorf("insight %s not found", id)
 		}
 		if !pageSinkClasses[ins.SinkClass] {
-			return "", fmt.Errorf("insight %s is sink-class %q, which is not promoted to a knowledge page (schema_entity goes to DataHub)", id, ins.SinkClass)
+			return "", nil, fmt.Errorf("insight %s is sink-class %q, which is not promoted to a knowledge page (schema_entity goes to DataHub)", id, ins.SinkClass)
 		}
 		origin = ins.SinkClass
+		// Collect the references the insight carried so they survive promotion
+		// onto the page (#664). De-duped across all source insights.
+		for _, urn := range ins.EntityURNs {
+			if urn == "" {
+				continue
+			}
+			if _, dup := seen[urn]; dup {
+				continue
+			}
+			seen[urn] = struct{}{}
+			entityURNs = append(entityURNs, urn)
+		}
 	}
-	return origin, nil
+	return origin, entityURNs, nil
 }
 
 // validatePagePromotion checks the caller-supplied page payload.
@@ -348,13 +435,25 @@ func strsFromMap(m map[string]any, key string) []string {
 	return out
 }
 
-// pageImage renders a page before/after snapshot for a changeset value.
-func pageImage(title, summary, body string, tags []string, version int) map[string]any {
+// pageSnapshot is the page state captured in a changeset before/after image.
+type pageSnapshot struct {
+	title, summary, body string
+	tags                 []string
+	version              int
+	entityURNs           []string
+}
+
+// pageImageWithRefs renders a page before/after snapshot for a changeset value,
+// including the page's DataHub reference URNs so a rollback can restore them
+// (#664). Phase 0 only writes DataHub references; when the picker and inline
+// references land, this snapshot will need to carry the full typed ref set.
+func pageImageWithRefs(s pageSnapshot) map[string]any {
 	return map[string]any{
-		pageFieldTitle:   title,
-		pageFieldSummary: summary,
-		pageFieldBody:    body,
-		pageFieldTags:    tags,
-		pageFieldVersion: version,
+		pageFieldTitle:      s.title,
+		pageFieldSummary:    s.summary,
+		pageFieldBody:       s.body,
+		pageFieldTags:       s.tags,
+		pageFieldVersion:    s.version,
+		pageFieldEntityURNs: s.entityURNs,
 	}
 }

--- a/pkg/toolkits/knowledge/page_sink_realdb_integration_test.go
+++ b/pkg/toolkits/knowledge/page_sink_realdb_integration_test.go
@@ -33,13 +33,16 @@ func TestPageSink_RealDB_PromoteAndRollback(t *testing.T) {
 
 	ctx := ctxWithUser("admin@example.com", "sess", "admin")
 
-	// Capture a business_knowledge insight (the provisional inbox draft).
+	// Capture a business_knowledge insight (the provisional inbox draft). It
+	// carries a DataHub reference that must survive promotion onto the page (#664).
+	const refURN = "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)"
 	require.NoError(t, insightStore.Insert(ctx, Insight{
 		ID:          "ins-bk-1",
 		CapturedBy:  "alice@example.com",
 		InsightText: "Our fiscal year starts in February.",
 		SinkClass:   memory.SinkBusinessKnowledge,
 		Status:      StatusPending,
+		EntityURNs:  []string{refURN},
 	}))
 
 	// Promote it to a canonical knowledge page.
@@ -64,6 +67,15 @@ func TestPageSink_RealDB_PromoteAndRollback(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Fiscal Calendar", page.Title)
 	assert.Contains(t, page.Tags, memory.SinkBusinessKnowledge)
+
+	// The insight's DataHub reference was carried onto the page (#664), against
+	// the real table with its CHECK, FK, and unique-index constraints.
+	refs, err := pageStore.ListEntityRefs(ctx, page.ID)
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+	assert.Equal(t, knowledgepage.RefTargetDataHub, refs[0].TargetType)
+	assert.Equal(t, refURN, refs[0].EntityURN)
+	assert.Equal(t, knowledgepage.RefSourcePromoted, refs[0].Source)
 
 	// Changeset recorded with the kp: target.
 	cs, err := csStore.GetChangeset(ctx, changesetID)

--- a/pkg/toolkits/knowledge/page_sink_test.go
+++ b/pkg/toolkits/knowledge/page_sink_test.go
@@ -19,7 +19,8 @@ var errKP = errors.New("kp boom")
 
 // fakePageWriter is an in-memory pageWriter for sink-router tests.
 type fakePageWriter struct {
-	pages     map[string]*knowledgepage.Page // slug -> page
+	pages     map[string]*knowledgepage.Page       // slug -> page
+	refs      map[string][]knowledgepage.EntityRef // pageID -> refs
 	inserted  []string
 	updated   []string
 	deleted   []string
@@ -29,7 +30,37 @@ type fakePageWriter struct {
 }
 
 func newFakePageWriter() *fakePageWriter {
-	return &fakePageWriter{pages: map[string]*knowledgepage.Page{}}
+	return &fakePageWriter{pages: map[string]*knowledgepage.Page{}, refs: map[string][]knowledgepage.EntityRef{}}
+}
+
+// fakeRefKey mirrors the store's per-target uniqueness for the in-memory union.
+func fakeRefKey(r knowledgepage.EntityRef) string {
+	return r.TargetType + "|" + r.AssetID + "|" + r.PromptID + "|" + r.CollectionID + "|" +
+		r.RefPageID + "|" + r.ConnectionKind + "/" + r.ConnectionName + "|" + r.EntityURN
+}
+
+func (f *fakePageWriter) ListEntityRefs(_ context.Context, pageID string) ([]knowledgepage.EntityRef, error) {
+	return f.refs[pageID], nil
+}
+
+func (f *fakePageWriter) AddEntityRefs(_ context.Context, pageID string, refs []knowledgepage.EntityRef) error {
+	seen := map[string]bool{}
+	for _, e := range f.refs[pageID] {
+		seen[fakeRefKey(e)] = true
+	}
+	for _, r := range refs {
+		if seen[fakeRefKey(r)] {
+			continue
+		}
+		f.refs[pageID] = append(f.refs[pageID], r)
+		seen[fakeRefKey(r)] = true
+	}
+	return nil
+}
+
+func (f *fakePageWriter) ReplaceEntityRefs(_ context.Context, pageID string, refs []knowledgepage.EntityRef) error {
+	f.refs[pageID] = append([]knowledgepage.EntityRef{}, refs...)
+	return nil
 }
 
 func (f *fakePageWriter) GetBySlug(_ context.Context, slug string) (*knowledgepage.Page, error) {
@@ -78,6 +109,53 @@ func (f *fakePageWriter) Update(_ context.Context, id string, u knowledgepage.Up
 func (f *fakePageWriter) SoftDelete(_ context.Context, id string) error {
 	f.deleted = append(f.deleted, id)
 	return nil
+}
+
+func refURNs(refs []knowledgepage.EntityRef) []string {
+	urns := make([]string, 0, len(refs))
+	for _, r := range refs {
+		urns = append(urns, r.EntityURN)
+	}
+	return urns
+}
+
+// TestPromoteToPage_CarriesAndUnionsInsightRefs proves #664's core: a promoted
+// insight's entity_urns land on the page as promoted DataHub references, survive
+// into the changeset after-image, and union (no duplicates) across promotions.
+func TestPromoteToPage_CarriesAndUnionsInsightRefs(t *testing.T) {
+	urnA := "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.a,PROD)"
+	urnB := "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.b,PROD)"
+	store := &fullSpyStore{Insights: []Insight{
+		{ID: "i1", SinkClass: memory.SinkBusinessKnowledge, EntityURNs: []string{urnA}},
+		{ID: "i2", SinkClass: memory.SinkBusinessKnowledge, EntityURNs: []string{urnA, urnB}},
+	}}
+	cs := &spyChangesetStore{}
+	pw := newFakePageWriter()
+	tk := newApplyToolkit(t, store, cs, &spyWriter{})
+	tk.SetPageWriter(pw)
+
+	// First promotion creates the page carrying urnA.
+	res, _, err := tk.handleApplyKnowledge(pageCtx(), &mcp.CallToolRequest{}, applyPageInput([]string{"i1"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError, "unexpected error result")
+	page := pw.pages["seasons"]
+	require.NotNil(t, page)
+	require.Len(t, pw.refs[page.ID], 1)
+	assert.Equal(t, urnA, pw.refs[page.ID][0].EntityURN)
+	assert.Equal(t, knowledgepage.RefTargetDataHub, pw.refs[page.ID][0].TargetType)
+	assert.Equal(t, knowledgepage.RefSourcePromoted, pw.refs[page.ID][0].Source)
+
+	// Second promotion to the same slug unions urnB; urnA is not duplicated.
+	res2, _, err := tk.handleApplyKnowledge(pageCtx(), &mcp.CallToolRequest{}, applyPageInput([]string{"i2"}))
+	require.NoError(t, err)
+	require.False(t, res2.IsError, "unexpected error result")
+	assert.ElementsMatch(t, []string{urnA, urnB}, refURNs(pw.refs[page.ID]))
+
+	// The changeset after-image carries the page's full URN set.
+	require.Len(t, cs.Changesets, 2)
+	gotURNs, ok := cs.Changesets[1].NewValue[pageFieldEntityURNs].([]string)
+	require.True(t, ok, "after-image should carry entity_urns as []string")
+	assert.ElementsMatch(t, []string{urnA, urnB}, gotURNs)
 }
 
 func applyPageInput(insightIDs []string) applyKnowledgeInput {
@@ -242,6 +320,34 @@ func TestRevertPageChangeset_UpdateRestores(t *testing.T) {
 	assert.Contains(t, pw.updated, "kp1")
 	assert.Equal(t, "Old", pw.pages["seasons"].Title)
 	assert.True(t, csStore.Changesets[0].RolledBack)
+}
+
+// TestRevertPageChangeset_RestoresRefs proves a page rollback restores the prior
+// reference set from the changeset previous-value (#664).
+func TestRevertPageChangeset_RestoresRefs(t *testing.T) {
+	urnA := "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.a,PROD)"
+	urnB := "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.b,PROD)"
+	prev := map[string]any{
+		pageFieldTitle: "Old", pageFieldBody: "old body", pageFieldSummary: "", pageFieldTags: []any{},
+		pageFieldEntityURNs: []any{urnA}, // []any mirrors a JSONB-decoded changeset value
+	}
+	cs := pageChangeset("seasons", changeUpdatePage, 4, prev)
+	pw := newFakePageWriter()
+	pw.pages["seasons"] = &knowledgepage.Page{ID: "kp1", Slug: "seasons", Title: "New", CurrentVersion: 4}
+	// The page currently has both URNs (urnB was added by the promotion being reverted).
+	pw.refs["kp1"] = []knowledgepage.EntityRef{
+		knowledgepage.DataHubRef(urnA, knowledgepage.RefSourcePromoted),
+		knowledgepage.DataHubRef(urnB, knowledgepage.RefSourcePromoted),
+	}
+	csStore := &spyChangesetStore{Changesets: []Changeset{cs}}
+	tk := newApplyToolkit(t, &fullSpyStore{}, csStore, &spyWriter{})
+	tk.SetPageWriter(pw)
+
+	res, _, err := tk.handleApplyKnowledge(pageCtx(), &mcp.CallToolRequest{},
+		applyKnowledgeInput{Action: actionRollback, ChangesetID: "cs1", Confirm: true})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	assert.ElementsMatch(t, []string{urnA}, refURNs(pw.refs["kp1"]), "rollback should restore the prior ref set")
 }
 
 func TestRevertPageChangeset_ConflictRefused(t *testing.T) {

--- a/pkg/toolkits/knowledge/rollback.go
+++ b/pkg/toolkits/knowledge/rollback.go
@@ -390,6 +390,11 @@ func applyPageRevert(ctx context.Context, pages PageReverter, cs *Changeset, pag
 		}); err != nil {
 			return "", fmt.Errorf("restoring knowledge page: %w", err)
 		}
+		// Restore the page's references to the prior set (#664). Phase 0 snapshots
+		// DataHub references; rebuild them from the previous-value URNs.
+		if err := pages.ReplaceEntityRefs(ctx, page.ID, dataHubRefs(strsFromMap(cs.PreviousValue, pageFieldEntityURNs))); err != nil {
+			return "", fmt.Errorf("restoring knowledge page references: %w", err)
+		}
 		return "restored page " + page.Slug, nil
 	default:
 		return "", fmt.Errorf("unknown page change type: %s", cs.ChangeType)


### PR DESCRIPTION
Phase 0 of #664. Does not close it: the later phases (connection URN scheme, authoring picker, inline body references, cross-enrichment, backfill) remain open on the issue.

## Summary

`apply_knowledge` could promote a `business_knowledge` insight into a knowledge page but discarded the references the insight carried, because pages had no place to store them. The page sink wrote only `title/summary/body/tags`; the source insight's `entity_urns` were dropped. A page could not reference the entities it provided knowledge about, and connections (which DataHub does not model at all) had no knowledge home.

This PR stops that loss and lays the relational foundation: a real lookup table with foreign keys for internal entities, a text URN for the one external case (DataHub), and the `apply_knowledge` wiring that carries the references onto the page and preserves them through rollback.

## Scope of this PR (read before reviewing)

- **Backend only.** The references are now captured correctly and survive promotion, but they are not surfaced anywhere yet: no "Related" panel, no authoring picker, no cross-enrichment. The first user-visible surface is a later phase. This is deliberate per the issue's phasing.
- **Only DataHub references are written here**, because those are the ones `apply_knowledge` was dropping. The foreign-key target columns (asset, prompt, collection, page-to-page, connection) are part of the designed table and are written by the later phases.

## Data model

References are real relational rows, not strings. Migration `000073` adds `knowledge_page_entity_refs`:

- `page_id` FK to `portal_knowledge_pages` (`ON DELETE CASCADE`), the owning page.
- Exactly one target per row: `asset_id`, `prompt_id`, `collection_id`, `ref_page_id` (page-to-page) foreign keys, the composite `(connection_kind, connection_name)` foreign key to `connection_instances`, or an `entity_urn` text column for DataHub or other external systems that have no local row to reference.
- A CHECK enforcing exactly-one-target, mirroring the `portal_threads` / `portal_shares` 1-of-N polymorphism.
- `ON DELETE CASCADE` on every internal FK, so deleting an asset (or connection, prompt, collection, page) removes its references rather than leaving an orphaned string.
- A `source` flag (`promoted` | `manual` | `inline`) so a later phase's body-scan can reconcile inline references without clobbering picked or promoted ones.
- Per-type partial unique indexes giving idempotent, race-safe union semantics.

The `mcp:` / `urn:li:` text forms are the serialized projection of these rows (for the agent, API, search, and display), not the storage.

## Changes

- **`pkg/portal/knowledgepage/entity_refs.go`**: `EntityRef` plus store CRUD: `ListEntityRefs`, `AddEntityRefs` (union), `ReplaceEntityRefs`. `AddEntityRefs` inserts with `ON CONFLICT DO NOTHING` against the per-type unique index, so the union is idempotent and race-safe and a failed promotion is safe to retry.
- **`pkg/toolkits/knowledge/page_sink.go`**: on promotion, collect the source insights' `entity_urns` and write them onto the page; union with the page's existing references on a find-or-create-by-slug update; carry them into the changeset before/after snapshot.
- **`pkg/toolkits/knowledge/rollback.go`**: a page rollback restores the prior reference set from the changeset previous-value.
- **Migration count test constants** bumped (file count and final-version gate).

## Atomicity (documented, not papered over)

The page write, the reference write, and the changeset record are separate operations. The page and changeset already were before this change; the reference write joins that sequence. A failure between them can leave the page written while the promotion reports failure. The reference write is idempotent (ON CONFLICT DO NOTHING), so a retry is safe. A single cross-store transaction spanning the page, references, and changeset is a broader change tracked separately; the comment on `applyPagePromotion` says so.

## Testing

- `make verify` green: race + real-Postgres migration roundtrip, the package-size budget, lint (`--new-from-rev` clean), gosec/govulncheck, semgrep, CodeQL, mutation testing, swagger-check, and GoReleaser. Patch coverage 86.7%; new functions are at or above 80%.
- Validated against a throwaway `pgvector/pgvector:pg16` instance: the CHECK rejects multi-target rows, `ON CONFLICT` no-ops a duplicate (DataHub and asset references each stay one row), and deleting a referenced entity cascades its references away.
- The real-DB integration test (`page_sink_realdb_integration_test.go`) was extended to assert a promoted insight's reference lands on the page, against the real table with its CHECK, FK, and unique constraints.
- Unit tests cover the carry, the union, the rollback restore, the store CRUD, and every per-type conflict target.
- An adversarial `/code-review` ran before `make verify`. It surfaced four findings: the race-unsafe union (fixed with `ON CONFLICT`, validated on real Postgres), an untested generic insert path (now covered), and two atomicity observations (the pre-existing page/changeset sequence, documented above).

## Acceptance (this phase)

- Promoting a `business_knowledge` insight that carries `entity_urns` to a page records the matching DataHub references; promoting a second insight to the same slug unions them with no duplicates.
- Rolling back a page promotion restores the page's prior references.
- Deleting a referenced entity removes its reference rows by cascade.

## Follow-up (open on #664)

- Connection URN scheme and the typed resolver/serializer.
- The authoring picker and the inline `mcp:` / `urn:li:` renderer plus body-scan reconciliation (the `source` flag is already in the schema for this).
- Bidirectional cross-enrichment across the asset, prompt, collection, connection, and DataHub surfaces.
- Backfill of existing pages from their source insights.

