### PR TITLE
feat(knowledge): mcp:/urn:li: reference serializer + page references API (#664 Phase 1)

### DIFF
--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -8505,6 +8505,132 @@ const docTemplate = `{
                 }
             }
         },
+        "/portal/knowledge-pages/{id}/refs": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the entities the page references (assets, prompts, collections, connections, DataHub URNs, and other pages), each with its serialized URN.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "List a knowledge page's entity references",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Knowledge page id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.knowledgePageRefsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Replaces the page's manually-authored references with the given set (parsed from serialized URNs). References carried from promotion (source=promoted) are preserved. Requires apply_knowledge access.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Set a knowledge page's manual entity references",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Knowledge page id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "References to set",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/portal.setEntityRefsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.knowledgePageRefsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/knowledge/insights": {
             "get": {
                 "security": [
@@ -14930,6 +15056,53 @@ const docTemplate = `{
                 }
             }
         },
+        "portal.entityRefView": {
+            "type": "object",
+            "properties": {
+                "asset_id": {
+                    "type": "string"
+                },
+                "collection_id": {
+                    "type": "string"
+                },
+                "connection_kind": {
+                    "type": "string"
+                },
+                "connection_name": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "entity_urn": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "page_id": {
+                    "type": "string"
+                },
+                "prompt_id": {
+                    "type": "string"
+                },
+                "ref_page_id": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "target_type": {
+                    "type": "string"
+                },
+                "urn": {
+                    "type": "string"
+                }
+            }
+        },
         "portal.getCollectionResponse": {
             "type": "object",
             "properties": {
@@ -14991,6 +15164,17 @@ const docTemplate = `{
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "portal.knowledgePageRefsResponse": {
+            "type": "object",
+            "properties": {
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/portal.entityRefView"
+                    }
                 }
             }
         },
@@ -15259,6 +15443,17 @@ const docTemplate = `{
                 },
                 "ranking": {
                     "type": "string"
+                }
+            }
+        },
+        "portal.setEntityRefsRequest": {
+            "type": "object",
+            "properties": {
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -8499,6 +8499,132 @@
                 }
             }
         },
+        "/portal/knowledge-pages/{id}/refs": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the entities the page references (assets, prompts, collections, connections, DataHub URNs, and other pages), each with its serialized URN.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "List a knowledge page's entity references",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Knowledge page id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.knowledgePageRefsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Replaces the page's manually-authored references with the given set (parsed from serialized URNs). References carried from promotion (source=promoted) are preserved. Requires apply_knowledge access.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Set a knowledge page's manual entity references",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Knowledge page id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "References to set",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/portal.setEntityRefsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.knowledgePageRefsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/knowledge/insights": {
             "get": {
                 "security": [
@@ -14924,6 +15050,53 @@
                 }
             }
         },
+        "portal.entityRefView": {
+            "type": "object",
+            "properties": {
+                "asset_id": {
+                    "type": "string"
+                },
+                "collection_id": {
+                    "type": "string"
+                },
+                "connection_kind": {
+                    "type": "string"
+                },
+                "connection_name": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "entity_urn": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "page_id": {
+                    "type": "string"
+                },
+                "prompt_id": {
+                    "type": "string"
+                },
+                "ref_page_id": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "target_type": {
+                    "type": "string"
+                },
+                "urn": {
+                    "type": "string"
+                }
+            }
+        },
         "portal.getCollectionResponse": {
             "type": "object",
             "properties": {
@@ -14985,6 +15158,17 @@
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "portal.knowledgePageRefsResponse": {
+            "type": "object",
+            "properties": {
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/portal.entityRefView"
+                    }
                 }
             }
         },
@@ -15253,6 +15437,17 @@
                 },
                 "ranking": {
                     "type": "string"
+                }
+            }
+        },
+        "portal.setEntityRefsRequest": {
+            "type": "object",
+            "properties": {
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -2921,6 +2921,37 @@ definitions:
           $ref: '#/definitions/portal.directoryUser'
         type: array
     type: object
+  portal.entityRefView:
+    properties:
+      asset_id:
+        type: string
+      collection_id:
+        type: string
+      connection_kind:
+        type: string
+      connection_name:
+        type: string
+      created_at:
+        type: string
+      created_by:
+        type: string
+      entity_urn:
+        type: string
+      id:
+        type: string
+      page_id:
+        type: string
+      prompt_id:
+        type: string
+      ref_page_id:
+        type: string
+      source:
+        type: string
+      target_type:
+        type: string
+      urn:
+        type: string
+    type: object
   portal.getCollectionResponse:
     properties:
       asset_tags:
@@ -2963,6 +2994,13 @@ definitions:
         type: string
       updated_at:
         type: string
+    type: object
+  portal.knowledgePageRefsResponse:
+    properties:
+      refs:
+        items:
+          $ref: '#/definitions/portal.entityRefView'
+        type: array
     type: object
   portal.listCollectionsResponse:
     properties:
@@ -3149,6 +3187,13 @@ definitions:
         type: array
       ranking:
         type: string
+    type: object
+  portal.setEntityRefsRequest:
+    properties:
+      refs:
+        items:
+          type: string
+        type: array
     type: object
   portal.setSectionsRequest:
     properties:
@@ -8814,6 +8859,88 @@ paths:
       summary: Feedback activity feed
       tags:
       - Feedback
+  /portal/knowledge-pages/{id}/refs:
+    get:
+      description: Returns the entities the page references (assets, prompts, collections,
+        connections, DataHub URNs, and other pages), each with its serialized URN.
+      parameters:
+      - description: Knowledge page id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/portal.knowledgePageRefsResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: List a knowledge page's entity references
+      tags:
+      - Knowledge
+    put:
+      consumes:
+      - application/json
+      description: Replaces the page's manually-authored references with the given
+        set (parsed from serialized URNs). References carried from promotion (source=promoted)
+        are preserved. Requires apply_knowledge access.
+      parameters:
+      - description: Knowledge page id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: References to set
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/portal.setEntityRefsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/portal.knowledgePageRefsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Set a knowledge page's manual entity references
+      tags:
+      - Knowledge
   /portal/knowledge/insights:
     get:
       description: Returns paginated insights captured by the current user.

--- a/pkg/portal/knowledge_page_handler.go
+++ b/pkg/portal/knowledge_page_handler.go
@@ -44,6 +44,9 @@ func (h *Handler) registerKnowledgePageRoutes() {
 	h.mux.HandleFunc("PUT /api/v1/portal/knowledge-pages/{id}", h.updateKnowledgePage)
 	h.mux.HandleFunc("DELETE /api/v1/portal/knowledge-pages/{id}", h.deleteKnowledgePage)
 	h.mux.HandleFunc("GET /api/v1/portal/knowledge-pages/{id}/versions", h.listKnowledgePageVersions)
+	// Entity references (#664): the entities a page provides knowledge about.
+	h.mux.HandleFunc("GET /api/v1/portal/knowledge-pages/{id}/refs", h.listKnowledgePageRefs)
+	h.mux.HandleFunc("PUT /api/v1/portal/knowledge-pages/{id}/refs", h.setKnowledgePageRefs)
 }
 
 // knowledgePageRequest is the create/update payload.

--- a/pkg/portal/knowledge_page_handler_test.go
+++ b/pkg/portal/knowledge_page_handler_test.go
@@ -31,6 +31,9 @@ type mockKnowledgePageStore struct {
 	inserted *knowledgepage.Page
 	updated  *knowledgepage.Update
 	deleted  string
+
+	refs    []knowledgepage.EntityRef
+	refsErr error
 }
 
 func (m *mockKnowledgePageStore) Insert(_ context.Context, p knowledgepage.Page) error {
@@ -84,15 +87,41 @@ func (m *mockKnowledgePageStore) Search(_ context.Context, _ knowledgepage.Searc
 	return m.scored, nil
 }
 
-func (*mockKnowledgePageStore) ListEntityRefs(_ context.Context, _ string) ([]knowledgepage.EntityRef, error) {
-	return nil, nil
+func (m *mockKnowledgePageStore) ListEntityRefs(_ context.Context, _ string) ([]knowledgepage.EntityRef, error) {
+	return m.refs, m.refsErr
 }
 
-func (*mockKnowledgePageStore) AddEntityRefs(_ context.Context, _ string, _ []knowledgepage.EntityRef) error {
+func (m *mockKnowledgePageStore) AddEntityRefs(_ context.Context, _ string, refs []knowledgepage.EntityRef) error {
+	if m.refsErr != nil {
+		return m.refsErr
+	}
+	m.refs = append(m.refs, refs...)
 	return nil
 }
 
-func (*mockKnowledgePageStore) ReplaceEntityRefs(_ context.Context, _ string, _ []knowledgepage.EntityRef) error {
+func (m *mockKnowledgePageStore) ReplaceEntityRefs(_ context.Context, _ string, refs []knowledgepage.EntityRef) error {
+	if m.refsErr != nil {
+		return m.refsErr
+	}
+	m.refs = append([]knowledgepage.EntityRef{}, refs...)
+	return nil
+}
+
+func (m *mockKnowledgePageStore) ReplaceEntityRefsBySource(_ context.Context, _, source string, refs []knowledgepage.EntityRef) error {
+	if m.refsErr != nil {
+		return m.refsErr
+	}
+	kept := m.refs[:0:0]
+	for _, r := range m.refs {
+		if r.Source != source {
+			kept = append(kept, r)
+		}
+	}
+	for _, r := range refs {
+		r.Source = source
+		kept = append(kept, r)
+	}
+	m.refs = kept
 	return nil
 }
 

--- a/pkg/portal/knowledge_page_refs_handler.go
+++ b/pkg/portal/knowledge_page_refs_handler.go
@@ -1,0 +1,172 @@
+package portal
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
+)
+
+// maxEntityRefsPerPage caps how many references a single set request may carry,
+// so a malformed or hostile payload cannot fan out unbounded inserts.
+const maxEntityRefsPerPage = 100
+
+// maxEntityRefsBodyBytes bounds the refs request body so the count cap is not
+// reached only after buffering an arbitrarily large payload. 100 serialized URNs
+// are well under this; the cap is the memory backstop.
+const maxEntityRefsBodyBytes = 64 << 10
+
+// entityRefView is a page reference enriched with its serialized URN form, the
+// projection the agent, the UI, and search use to address the entity.
+type entityRefView struct {
+	knowledgepage.EntityRef
+	URN string `json:"urn"`
+}
+
+// knowledgePageRefsResponse is the GET/PUT refs envelope.
+type knowledgePageRefsResponse struct {
+	Refs []entityRefView `json:"refs"`
+}
+
+// setEntityRefsRequest carries the page's manual references as serialized URN
+// strings (mcp:asset:<id>, urn:li:dataset:..., mcp:connection:(kind,name)).
+type setEntityRefsRequest struct {
+	Refs []string `json:"refs"`
+}
+
+// listKnowledgePageRefs handles GET /api/v1/portal/knowledge-pages/{id}/refs.
+//
+// @Summary      List a knowledge page's entity references
+// @Description  Returns the entities the page references (assets, prompts, collections, connections, DataHub URNs, and other pages), each with its serialized URN.
+// @Tags         Knowledge
+// @Produce      json
+// @Param        id  path  string  true  "Knowledge page id"
+// @Success      200  {object}  knowledgePageRefsResponse
+// @Failure      401  {object}  problemDetail
+// @Failure      404  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/knowledge-pages/{id}/refs [get]
+func (h *Handler) listKnowledgePageRefs(w http.ResponseWriter, r *http.Request) {
+	if GetUser(r.Context()) == nil {
+		writeError(w, http.StatusUnauthorized, errAuthRequired)
+		return
+	}
+	id := r.PathValue(kpIDParam)
+	if !h.knowledgePageExists(w, r, id) {
+		return
+	}
+	refs, err := h.deps.KnowledgePageStore.ListEntityRefs(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list page references")
+		return
+	}
+	writeJSON(w, http.StatusOK, knowledgePageRefsResponse{Refs: entityRefViews(refs)})
+}
+
+// setKnowledgePageRefs handles PUT /api/v1/portal/knowledge-pages/{id}/refs.
+//
+// @Summary      Set a knowledge page's manual entity references
+// @Description  Replaces the page's manually-authored references with the given set (parsed from serialized URNs). References carried from promotion (source=promoted) are preserved. Requires apply_knowledge access.
+// @Tags         Knowledge
+// @Accept       json
+// @Produce      json
+// @Param        id    path  string                true  "Knowledge page id"
+// @Param        body  body  setEntityRefsRequest  true  "References to set"
+// @Success      200  {object}  knowledgePageRefsResponse
+// @Failure      400  {object}  problemDetail
+// @Failure      401  {object}  problemDetail
+// @Failure      403  {object}  problemDetail
+// @Failure      404  {object}  problemDetail
+// @Failure      422  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/knowledge-pages/{id}/refs [put]
+func (h *Handler) setKnowledgePageRefs(w http.ResponseWriter, r *http.Request) {
+	user := GetUser(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, errAuthRequired)
+		return
+	}
+	if !h.userHasApplyKnowledge(user) {
+		writeError(w, http.StatusForbidden, errKnowledgePageForbidden)
+		return
+	}
+	id := r.PathValue(kpIDParam)
+	if !h.knowledgePageExists(w, r, id) {
+		return
+	}
+
+	var req setEntityRefsRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxEntityRefsBodyBytes)).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errInvalidRequestBody)
+		return
+	}
+	if len(req.Refs) > maxEntityRefsPerPage {
+		writeError(w, http.StatusBadRequest, "too many references")
+		return
+	}
+
+	refs, err := parseEntityRefs(req.Refs, user.Email)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := h.deps.KnowledgePageStore.ReplaceEntityRefsBySource(r.Context(), id, knowledgepage.RefSourceManual, refs); err != nil {
+		if errors.Is(err, knowledgepage.ErrRefTargetNotFound) {
+			writeError(w, http.StatusUnprocessableEntity, err.Error())
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to set page references")
+		return
+	}
+
+	updated, err := h.deps.KnowledgePageStore.ListEntityRefs(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list page references")
+		return
+	}
+	writeJSON(w, http.StatusOK, knowledgePageRefsResponse{Refs: entityRefViews(updated)})
+}
+
+// knowledgePageExists verifies the page is live, writing a 404 (or 500) on
+// failure. It returns true only when the page exists and is not deleted.
+func (h *Handler) knowledgePageExists(w http.ResponseWriter, r *http.Request, id string) bool {
+	page, err := h.deps.KnowledgePageStore.Get(r.Context(), id)
+	if errors.Is(err, knowledgepage.ErrNotFound) || (err == nil && page.DeletedAt != nil) {
+		writeError(w, http.StatusNotFound, errKnowledgePageNotFoundMsg)
+		return false
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get knowledge page")
+		return false
+	}
+	return true
+}
+
+// parseEntityRefs parses serialized URN strings into typed references, stamping
+// each with the authoring user. A parse failure aborts with the offending error.
+func parseEntityRefs(urns []string, createdBy string) ([]knowledgepage.EntityRef, error) {
+	refs := make([]knowledgepage.EntityRef, 0, len(urns))
+	for _, s := range urns {
+		ref, err := knowledgepage.ParseEntityRef(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid reference: %w", err)
+		}
+		ref.CreatedBy = createdBy
+		refs = append(refs, ref)
+	}
+	return refs, nil
+}
+
+func entityRefViews(refs []knowledgepage.EntityRef) []entityRefView {
+	views := make([]entityRefView, 0, len(refs))
+	for _, ref := range refs {
+		views = append(views, entityRefView{EntityRef: ref, URN: ref.URN()})
+	}
+	return views
+}

--- a/pkg/portal/knowledge_page_refs_handler_test.go
+++ b/pkg/portal/knowledge_page_refs_handler_test.go
@@ -1,0 +1,133 @@
+package portal
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
+)
+
+type refsResp struct {
+	Refs []struct {
+		URN        string `json:"urn"`
+		TargetType string `json:"target_type"`
+		AssetID    string `json:"asset_id"`
+		EntityURN  string `json:"entity_urn"`
+		Source     string `json:"source"`
+	} `json:"refs"`
+}
+
+func livePage() *knowledgepage.Page { return &knowledgepage.Page{ID: "kp1", Slug: "p", Title: "P"} }
+
+func TestListKnowledgePageRefs(t *testing.T) {
+	t.Run("unauthenticated", func(t *testing.T) {
+		h := newKnowledgePageHandler(&mockKnowledgePageStore{page: livePage()}, nil)
+		w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/kp1/refs", "")
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("page not found", func(t *testing.T) {
+		h := newKnowledgePageHandler(&mockKnowledgePageStore{}, kpViewer) // nil page -> ErrNotFound
+		w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/missing/refs", "")
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("store error is 500", func(t *testing.T) {
+		h := newKnowledgePageHandler(&mockKnowledgePageStore{getErr: errors.New("boom")}, kpViewer)
+		w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/kp1/refs", "")
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("deleted page is 404", func(t *testing.T) {
+		now := time.Now()
+		h := newKnowledgePageHandler(&mockKnowledgePageStore{page: &knowledgepage.Page{ID: "kp1", DeletedAt: &now}}, kpViewer)
+		w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/kp1/refs", "")
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("returns refs with serialized urn", func(t *testing.T) {
+		store := &mockKnowledgePageStore{page: livePage(), refs: []knowledgepage.EntityRef{
+			{TargetType: knowledgepage.RefTargetDataHub, EntityURN: "urn:li:dataset:x", Source: knowledgepage.RefSourcePromoted},
+			{TargetType: knowledgepage.RefTargetAsset, AssetID: "asset-001", Source: knowledgepage.RefSourceManual},
+		}}
+		h := newKnowledgePageHandler(store, kpViewer)
+		w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/kp1/refs", "")
+		require.Equal(t, http.StatusOK, w.Code)
+		var resp refsResp
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Len(t, resp.Refs, 2)
+		assert.Equal(t, "urn:li:dataset:x", resp.Refs[0].URN)
+		assert.Equal(t, "mcp:asset:asset-001", resp.Refs[1].URN)
+	})
+}
+
+func TestSetKnowledgePageRefs(t *testing.T) {
+	t.Run("requires apply_knowledge", func(t *testing.T) {
+		h := newKnowledgePageHandler(&mockKnowledgePageStore{page: livePage()}, kpViewer)
+		w := doKP(h, "PUT", "/api/v1/portal/knowledge-pages/kp1/refs", `{"refs":["mcp:asset:a"]}`)
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("invalid urn is 400", func(t *testing.T) {
+		h := newKnowledgePageHandler(&mockKnowledgePageStore{page: livePage()}, kpAdmin)
+		w := doKP(h, "PUT", "/api/v1/portal/knowledge-pages/kp1/refs", `{"refs":["not-a-ref"]}`)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("malformed body is 400", func(t *testing.T) {
+		h := newKnowledgePageHandler(&mockKnowledgePageStore{page: livePage()}, kpAdmin)
+		w := doKP(h, "PUT", "/api/v1/portal/knowledge-pages/kp1/refs", `{not json`)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("too many refs is 400", func(t *testing.T) {
+		refs := make([]string, maxEntityRefsPerPage+1)
+		for i := range refs {
+			refs[i] = "mcp:asset:a"
+		}
+		body, _ := json.Marshal(setEntityRefsRequest{Refs: refs})
+		h := newKnowledgePageHandler(&mockKnowledgePageStore{page: livePage()}, kpAdmin)
+		w := doKP(h, "PUT", "/api/v1/portal/knowledge-pages/kp1/refs", string(body))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("missing target is 422", func(t *testing.T) {
+		store := &mockKnowledgePageStore{page: livePage(), refsErr: knowledgepage.ErrRefTargetNotFound}
+		h := newKnowledgePageHandler(store, kpAdmin)
+		w := doKP(h, "PUT", "/api/v1/portal/knowledge-pages/kp1/refs", `{"refs":["mcp:asset:ghost"]}`)
+		assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	})
+
+	t.Run("replaces manual refs and preserves promoted", func(t *testing.T) {
+		store := &mockKnowledgePageStore{page: livePage(), refs: []knowledgepage.EntityRef{
+			{TargetType: knowledgepage.RefTargetDataHub, EntityURN: "urn:li:dataset:x", Source: knowledgepage.RefSourcePromoted},
+			{TargetType: knowledgepage.RefTargetAsset, AssetID: "old-asset", Source: knowledgepage.RefSourceManual},
+		}}
+		h := newKnowledgePageHandler(store, kpAdmin)
+		w := doKP(h, "PUT", "/api/v1/portal/knowledge-pages/kp1/refs", `{"refs":["mcp:collection:coll-1"]}`)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var resp refsResp
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		urns := make([]string, 0, len(resp.Refs))
+		for _, r := range resp.Refs {
+			urns = append(urns, r.URN)
+		}
+		// promoted datahub ref survives; the old manual asset is gone; new manual collection present.
+		assert.Contains(t, urns, "urn:li:dataset:x")
+		assert.Contains(t, urns, "mcp:collection:coll-1")
+		assert.NotContains(t, urns, "mcp:asset:old-asset")
+	})
+
+	t.Run("page not found", func(t *testing.T) {
+		h := newKnowledgePageHandler(&mockKnowledgePageStore{}, kpAdmin)
+		w := doKP(h, "PUT", "/api/v1/portal/knowledge-pages/missing/refs", `{"refs":[]}`)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+}

--- a/pkg/portal/knowledgepage/entity_ref_urn.go
+++ b/pkg/portal/knowledgepage/entity_ref_urn.go
@@ -1,0 +1,111 @@
+package knowledgepage
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// mcpScheme prefixes the serialized form of an internal-entity reference, for
+// example "mcp:asset:<id>" or "mcp:connection:(trino,warehouse)". It is the
+// platform's existing internal scheme (pkg/resource uses "mcp" as well). The
+// external DataHub case keeps its native "urn:li:" URN.
+const mcpScheme = "mcp:"
+
+// externalURNPrefix marks an external (DataHub or other catalog) reference. A
+// reference string with this prefix is stored verbatim in entity_urn.
+const externalURNPrefix = "urn:"
+
+// URN returns the serialized projection of a reference: the mcp: form for an
+// internal entity (resolved by id, so a rename does not change it), or the
+// external URN as-is for a DataHub reference. The empty string is returned for an
+// unrecognized target type.
+func (r EntityRef) URN() string {
+	switch r.TargetType {
+	case RefTargetAsset:
+		return mcpScheme + RefTargetAsset + refKeySep + r.AssetID
+	case RefTargetPrompt:
+		return mcpScheme + RefTargetPrompt + refKeySep + r.PromptID
+	case RefTargetCollection:
+		return mcpScheme + RefTargetCollection + refKeySep + r.CollectionID
+	case RefTargetKnowledgePage:
+		return mcpScheme + RefTargetKnowledgePage + refKeySep + r.RefPageID
+	case RefTargetConnection:
+		return mcpScheme + RefTargetConnection + refKeySep + "(" + r.ConnectionKind + "," + r.ConnectionName + ")"
+	case RefTargetDataHub:
+		return r.EntityURN
+	default:
+		return ""
+	}
+}
+
+// ParseEntityRef parses a serialized reference (the inverse of URN) into a typed
+// EntityRef. A "urn:" reference is an external (DataHub) URN, stored verbatim; an
+// "mcp:" reference resolves to the matching internal target. Source and the
+// owning page id are not part of the serialized form and are left to the caller.
+func ParseEntityRef(s string) (EntityRef, error) {
+	s = strings.TrimSpace(s)
+	switch {
+	case s == "":
+		return EntityRef{}, fmt.Errorf("empty entity reference")
+	case strings.HasPrefix(s, externalURNPrefix):
+		return EntityRef{TargetType: RefTargetDataHub, EntityURN: s}, nil
+	case strings.HasPrefix(s, mcpScheme):
+		return parseMCPRef(s)
+	default:
+		return EntityRef{}, fmt.Errorf("unrecognized entity reference %q (want mcp: or urn:)", s)
+	}
+}
+
+// parseMCPRef parses the "mcp:<type>:<id>" internal form.
+func parseMCPRef(s string) (EntityRef, error) {
+	rest := s[len(mcpScheme):]
+	typ, id, ok := strings.Cut(rest, refKeySep)
+	if !ok || id == "" {
+		return EntityRef{}, fmt.Errorf("malformed internal reference %q (want mcp:<type>:<id>)", s)
+	}
+	if typ == RefTargetConnection {
+		kind, name, cErr := parseConnectionTuple(id)
+		if cErr != nil {
+			return EntityRef{}, fmt.Errorf("invalid connection reference %q: %w", s, cErr)
+		}
+		return EntityRef{TargetType: RefTargetConnection, ConnectionKind: kind, ConnectionName: name}, nil
+	}
+	return parseSimpleMCPRef(typ, id, s)
+}
+
+// parseSimpleMCPRef parses the single-id internal reference types (everything
+// except connection, which carries a (kind,name) pair).
+func parseSimpleMCPRef(typ, id, s string) (EntityRef, error) {
+	switch typ {
+	case RefTargetAsset:
+		return EntityRef{TargetType: RefTargetAsset, AssetID: id}, nil
+	case RefTargetPrompt:
+		// prompt_id is a UUID column; reject a malformed id here so it is a clean
+		// client error rather than a database type error surfaced as a 500.
+		if _, uErr := uuid.Parse(id); uErr != nil {
+			return EntityRef{}, fmt.Errorf("prompt reference id must be a uuid: %q", id)
+		}
+		return EntityRef{TargetType: RefTargetPrompt, PromptID: id}, nil
+	case RefTargetCollection:
+		return EntityRef{TargetType: RefTargetCollection, CollectionID: id}, nil
+	case RefTargetKnowledgePage:
+		return EntityRef{TargetType: RefTargetKnowledgePage, RefPageID: id}, nil
+	default:
+		return EntityRef{}, fmt.Errorf("unknown internal reference type %q in %q", typ, s)
+	}
+}
+
+// parseConnectionTuple parses the "(kind,name)" body of a connection reference.
+func parseConnectionTuple(body string) (kind, name string, err error) {
+	if !strings.HasPrefix(body, "(") || !strings.HasSuffix(body, ")") {
+		return "", "", fmt.Errorf("connection reference must be (kind,name)")
+	}
+	inner := body[1 : len(body)-1]
+	kind, name, ok := strings.Cut(inner, ",")
+	if !ok || kind == "" || name == "" {
+		return "", "", fmt.Errorf("connection reference must be (kind,name)")
+	}
+	return kind, name, nil
+}

--- a/pkg/portal/knowledgepage/entity_ref_urn_test.go
+++ b/pkg/portal/knowledgepage/entity_ref_urn_test.go
@@ -1,0 +1,62 @@
+package knowledgepage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntityRef_URNRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		ref  EntityRef
+		urn  string
+	}{
+		{"asset", EntityRef{TargetType: RefTargetAsset, AssetID: "asset-001"}, "mcp:asset:asset-001"},
+		{"prompt", EntityRef{TargetType: RefTargetPrompt, PromptID: "11111111-1111-1111-1111-111111111111"}, "mcp:prompt:11111111-1111-1111-1111-111111111111"},
+		{"collection", EntityRef{TargetType: RefTargetCollection, CollectionID: "coll-001"}, "mcp:collection:coll-001"},
+		{"page", EntityRef{TargetType: RefTargetKnowledgePage, RefPageID: "kp-2"}, "mcp:knowledge_page:kp-2"},
+		{"connection", EntityRef{TargetType: RefTargetConnection, ConnectionKind: "trino", ConnectionName: "warehouse"}, "mcp:connection:(trino,warehouse)"},
+		{"datahub", EntityRef{TargetType: RefTargetDataHub, EntityURN: "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)"}, "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.urn, c.ref.URN(), "serialize")
+			got, err := ParseEntityRef(c.urn)
+			require.NoError(t, err, "parse")
+			assert.Equal(t, c.ref, got, "round-trip")
+		})
+	}
+}
+
+func TestEntityRef_URN_UnknownType(t *testing.T) {
+	assert.Empty(t, EntityRef{TargetType: "bogus"}.URN())
+}
+
+func TestParseEntityRef_Errors(t *testing.T) {
+	for _, s := range []string{
+		"",
+		"asset-001",                   // no scheme
+		"mcp:",                        // no type/id
+		"mcp:asset",                   // no id
+		"mcp:asset:",                  // empty id
+		"mcp:bogus:x",                 // unknown type
+		"mcp:prompt:not-a-uuid",       // prompt id must be a UUID
+		"mcp:connection:trino,wh",     // missing parens
+		"mcp:connection:(trino)",      // missing name
+		"mcp:connection:(,warehouse)", // empty kind
+	} {
+		_, err := ParseEntityRef(s)
+		assert.Error(t, err, "want error for %q", s)
+	}
+}
+
+// TestParseEntityRef_ExternalPassthrough checks any urn: prefix is treated as an
+// external (DataHub) reference and stored verbatim.
+func TestParseEntityRef_ExternalPassthrough(t *testing.T) {
+	ref, err := ParseEntityRef("  urn:li:glossaryTerm:revenue  ")
+	require.NoError(t, err)
+	assert.Equal(t, RefTargetDataHub, ref.TargetType)
+	assert.Equal(t, "urn:li:glossaryTerm:revenue", ref.EntityURN)
+}

--- a/pkg/portal/knowledgepage/entity_refs.go
+++ b/pkg/portal/knowledgepage/entity_refs.go
@@ -3,11 +3,21 @@ package knowledgepage
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 )
+
+// ErrRefTargetNotFound is returned when a reference points at an internal entity
+// (asset, prompt, collection, page, connection) that does not exist, so the
+// foreign key rejects it. Callers map it to a client error rather than a 500.
+var ErrRefTargetNotFound = errors.New("entity reference target does not exist")
+
+// pgForeignKeyViolation is the PostgreSQL SQLSTATE for a foreign-key violation.
+const pgForeignKeyViolation = "23503"
 
 // Entity-reference target types. Exactly one target is set on a reference row:
 // an internal entity by foreign key, or an external DataHub URN.
@@ -150,19 +160,42 @@ func refConflictTarget(targetType string) string {
 // ReplaceEntityRefs sets a page's references to exactly the given set (clearing
 // the rest), used to restore the prior references when a promotion is rolled back.
 func (s *postgresStore) ReplaceEntityRefs(ctx context.Context, pageID string, refs []EntityRef) error { //nolint:revive // interface impl
+	return s.replaceRefs(ctx, pageID, "", refs)
+}
+
+// ReplaceEntityRefsBySource sets the page's references of one source (for example
+// the "manual" ones authored through the picker) to exactly the given set, while
+// references of other sources (promoted, inline) are left untouched.
+func (s *postgresStore) ReplaceEntityRefsBySource(ctx context.Context, pageID, source string, refs []EntityRef) error { //nolint:revive // interface impl
+	return s.replaceRefs(ctx, pageID, source, refs)
+}
+
+// replaceRefs clears the page's references (all, or only the given source when
+// non-empty) and inserts refs, in one transaction. The inserted rows are stamped
+// with source when provided.
+func (s *postgresStore) replaceRefs(ctx context.Context, pageID, source string, refs []EntityRef) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback() //nolint:errcheck // commit below on success
 
-	if _, err := tx.ExecContext(ctx, `DELETE FROM knowledge_page_entity_refs WHERE page_id = $1`, pageID); err != nil {
+	del := `DELETE FROM knowledge_page_entity_refs WHERE page_id = $1`
+	args := []any{pageID}
+	if source != "" {
+		del += ` AND source = $2`
+		args = append(args, source)
+	}
+	if _, err := tx.ExecContext(ctx, del, args...); err != nil {
 		return fmt.Errorf("clearing entity refs: %w", err)
 	}
 	seen := make(map[string]struct{}, len(refs))
 	for _, ref := range refs {
 		if _, dup := seen[ref.identity()]; dup {
 			continue
+		}
+		if source != "" {
+			ref.Source = source
 		}
 		if err := insertEntityRef(ctx, tx, pageID, ref); err != nil {
 			return err
@@ -206,6 +239,10 @@ func insertEntityRef(ctx context.Context, e execer, pageID string, ref EntityRef
 		source, ref.CreatedBy,
 	)
 	if err != nil {
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) && string(pqErr.Code) == pgForeignKeyViolation {
+			return fmt.Errorf("reference %q: %w", ref.identity(), ErrRefTargetNotFound)
+		}
 		return fmt.Errorf("inserting entity ref: %w", err)
 	}
 	return nil

--- a/pkg/portal/knowledgepage/entity_refs_test.go
+++ b/pkg/portal/knowledgepage/entity_refs_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -127,6 +128,40 @@ func TestEntityRefIdentity(t *testing.T) {
 	assert.NotEqual(t,
 		EntityRef{TargetType: RefTargetAsset, AssetID: "a"}.identity(),
 		EntityRef{TargetType: RefTargetPrompt, PromptID: "a"}.identity())
+}
+
+func TestStore_ReplaceEntityRefsBySource(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+	store := NewPostgresStore(db)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM knowledge_page_entity_refs WHERE page_id = .* AND source = ").
+		WithArgs("kp1", "manual").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	// The ref is stamped with the given source on insert.
+	mock.ExpectExec("INSERT INTO knowledge_page_entity_refs").
+		WithArgs(sqlmock.AnyArg(), "kp1", "asset", "asset-001", sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), "manual", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err = store.ReplaceEntityRefsBySource(context.Background(), "kp1", RefSourceManual,
+		[]EntityRef{{TargetType: RefTargetAsset, AssetID: "asset-001"}})
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStore_AddEntityRefs_ForeignKeyViolation(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+	mock.ExpectExec("INSERT INTO knowledge_page_entity_refs").
+		WillReturnError(&pq.Error{Code: "23503"})
+	err = NewPostgresStore(db).AddEntityRefs(context.Background(), "kp1",
+		[]EntityRef{{TargetType: RefTargetAsset, AssetID: "ghost"}})
+	require.ErrorIs(t, err, ErrRefTargetNotFound)
 }
 
 func TestRefConflictTarget(t *testing.T) {

--- a/pkg/portal/knowledgepage/store.go
+++ b/pkg/portal/knowledgepage/store.go
@@ -94,6 +94,7 @@ type Store interface {
 	ListEntityRefs(ctx context.Context, pageID string) ([]EntityRef, error)
 	AddEntityRefs(ctx context.Context, pageID string, refs []EntityRef) error
 	ReplaceEntityRefs(ctx context.Context, pageID string, refs []EntityRef) error
+	ReplaceEntityRefsBySource(ctx context.Context, pageID, source string, refs []EntityRef) error
 }
 
 // ErrNotFound is returned when a page id/slug does not resolve to a


### PR DESCRIPTION
Phase 1 of #664, building on Phase 0 (#666, merged). Does not close the issue: the renderer/body-scan (Phase 2), authoring picker UI (Phase 3), cross-enrichment (Phase 4), and backfill (Phase 5) remain open.

## Summary

Phase 0 added the `knowledge_page_entity_refs` table and carried a promoted insight's references onto the page, but those references were unreachable: nothing projected them to the addressable string form, and the page API did not return them. Phase 1 adds the projection layer and the read/write REST surface.

## Scope of this PR (read before reviewing)

- **Backend only.** This adds serialization and two REST endpoints. There is no UI yet; the authoring picker and the "Related" panel are a later phase. The GET endpoint is the read foundation those will build on.
- **The insight reference table is intentionally not here.** The issue's Phase 1 lists it, but nothing writes internal-entity references onto an insight yet (capture writes `entity_urns`; the picker and inline body-scan that would populate a join table are Phases 2-3). The repo's `TestMigrationTablesHaveConsumers` gate fails a table with no DML, so adding it now would be vaporware. It lands in the phase that writes it.

## Changes

### Serializer / parser (`pkg/portal/knowledgepage/entity_ref_urn.go`)

`EntityRef.URN()` and `ParseEntityRef()` are the projection both directions:

- Internal entities take the `mcp:` form, resolved by id so a rename does not change the reference:
  - `mcp:asset:<id>`
  - `mcp:prompt:<uuid>`
  - `mcp:collection:<id>`
  - `mcp:knowledge_page:<id>`
  - `mcp:connection:(kind,name)`
- A DataHub entity keeps its native `urn:li:` URN verbatim (external, no local row).

The `mcp` scheme is the platform's existing internal scheme (`pkg/resource` uses it too), not an invented one. Round-trip is tested for every type, plus malformed-input cases.

### Page references API (`pkg/portal/knowledge_page_refs_handler.go`)

- `GET /api/v1/portal/knowledge-pages/{id}/refs` (any authenticated user): returns a page's references, each as the structured `EntityRef` plus its serialized `urn`. Pages are org-shared canonical knowledge, so reads are open, matching the existing page GET.
- `PUT /api/v1/portal/knowledge-pages/{id}/refs` (apply_knowledge access): replaces the page's **manual** references from a list of serialized URNs. References carried from promotion (`source=promoted`) are preserved, via a new source-scoped `ReplaceEntityRefsBySource`. This is the authoring backend the Phase 3 picker will call.

### Validation and safety

- A reference to a non-existent internal entity is rejected by the foreign key and surfaces as **422** (`ErrRefTargetNotFound`, translated from the Postgres FK SQLSTATE), not a 500.
- A `mcp:prompt:<id>` whose id is not a UUID is rejected at parse time as a **400**, rather than reaching the UUID column and erroring as a 500.
- The PUT body is bounded with `io.LimitReader` (matching the rest of the portal) and capped at 100 references.

## Testing

- `make verify` green: race + real-Postgres, package-size budget, lint (`--new-from-rev` clean), gosec/govulncheck, semgrep, CodeQL, mutation, swagger-check, GoReleaser. Patch coverage 93.6%; new functions at or above 80%.
- Unit tests cover the serializer/parser round-trip for all six target types and the error cases; the GET/PUT handlers (auth, page-not-found, malformed body, invalid URN, the 422 FK path, and that a manual replace preserves promoted references); and the store's source-scoped replace and FK-violation translation (via sqlmock).
- An adversarial `/code-review` ran before `make verify`. It found two real bugs, both fixed in this PR: the malformed-prompt-UUID 500 and the unbounded request body. It also confirmed several non-bugs (the manual/promoted union is a no-op via `ON CONFLICT`, connection names with commas round-trip, the FK detection works through the error wrap).

## Acceptance (this phase)

- `EntityRef.URN()` then `ParseEntityRef()` reproduces the same reference for every target type.
- `GET .../refs` returns a page's references with their serialized URNs.
- `PUT .../refs` sets the manual references and leaves promoted references intact; an unknown internal target returns 422; a malformed URN returns 400.

## Follow-up (open on #664)

- Inline references: the renderer resolving `mcp:`/`urn:li:` links to live chips, and the body-scan reconciliation into `source=inline` rows (Phase 2, the first UI surface).
- The cross-entity reference picker and the typed "Related" panel (Phase 3).
- Bidirectional cross-enrichment via the reverse lookup (Phase 4).
- Backfill of existing pages from their source insights (Phase 5).
- The insight reference table, in whichever phase first writes insight references.

