### PR TITLE
feat(knowledge): inline entity references render as live chips (#664 Phase 2)

### DIFF
--- a/dev/seed.sql
+++ b/dev/seed.sql
@@ -889,6 +889,13 @@ Our fiscal year starts in **February**.
 - Q2: May - July
 - Q3: August - October
 - Q4: November - January
+
+## Related
+
+The fiscal calendar underpins the [revenue definition](mcp:knowledge_page:kp-seed-2)
+and is applied in the [sales warehouse](mcp:connection:(trino,warehouse)), where
+urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD) records
+quarter-tagged sales.
 $md$,
    '["finance","calendar"]'::jsonb, 'sarah.chen@example.com', 'sarah.chen@example.com', 'sarah.chen@example.com', 2, '2026-06-01T10:00:00Z', '2026-06-10T12:00:00Z'),
 

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -8505,6 +8505,60 @@ const docTemplate = `{
                 }
             }
         },
+        "/portal/knowledge-pages/refs/resolve": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Resolves a batch of serialized reference URNs (mcp:/urn:li:) to a display label, type, and whether the target still exists, so the renderer can show named chips.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Resolve entity references to display labels",
+                "parameters": [
+                    {
+                        "description": "URNs to resolve",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/portal.resolveRefsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.resolveRefsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/knowledge-pages/{id}/refs": {
             "get": {
                 "security": [
@@ -15407,6 +15461,45 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "portal.resolveRefsRequest": {
+            "type": "object",
+            "properties": {
+                "urns": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "portal.resolveRefsResponse": {
+            "type": "object",
+            "properties": {
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/portal.resolvedRef"
+                    }
+                }
+            }
+        },
+        "portal.resolvedRef": {
+            "type": "object",
+            "properties": {
+                "exists": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "urn": {
                     "type": "string"
                 }
             }

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -8499,6 +8499,60 @@
                 }
             }
         },
+        "/portal/knowledge-pages/refs/resolve": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Resolves a batch of serialized reference URNs (mcp:/urn:li:) to a display label, type, and whether the target still exists, so the renderer can show named chips.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Resolve entity references to display labels",
+                "parameters": [
+                    {
+                        "description": "URNs to resolve",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/portal.resolveRefsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.resolveRefsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/knowledge-pages/{id}/refs": {
             "get": {
                 "security": [
@@ -15401,6 +15455,45 @@
                     "type": "string"
                 },
                 "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "portal.resolveRefsRequest": {
+            "type": "object",
+            "properties": {
+                "urns": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "portal.resolveRefsResponse": {
+            "type": "object",
+            "properties": {
+                "refs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/portal.resolvedRef"
+                    }
+                }
+            }
+        },
+        "portal.resolvedRef": {
+            "type": "object",
+            "properties": {
+                "exists": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "urn": {
                     "type": "string"
                 }
             }

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -3165,6 +3165,31 @@ definitions:
       type:
         type: string
     type: object
+  portal.resolveRefsRequest:
+    properties:
+      urns:
+        items:
+          type: string
+        type: array
+    type: object
+  portal.resolveRefsResponse:
+    properties:
+      refs:
+        items:
+          $ref: '#/definitions/portal.resolvedRef'
+        type: array
+    type: object
+  portal.resolvedRef:
+    properties:
+      exists:
+        type: boolean
+      label:
+        type: string
+      type:
+        type: string
+      urn:
+        type: string
+    type: object
   portal.respondValidationRequest:
     properties:
       reason:
@@ -8939,6 +8964,41 @@ paths:
       - ApiKeyAuth: []
       - BearerAuth: []
       summary: Set a knowledge page's manual entity references
+      tags:
+      - Knowledge
+  /portal/knowledge-pages/refs/resolve:
+    post:
+      consumes:
+      - application/json
+      description: Resolves a batch of serialized reference URNs (mcp:/urn:li:) to
+        a display label, type, and whether the target still exists, so the renderer
+        can show named chips.
+      parameters:
+      - description: URNs to resolve
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/portal.resolveRefsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/portal.resolveRefsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Resolve entity references to display labels
       tags:
       - Knowledge
   /portal/knowledge/insights:

--- a/pkg/portal/knowledge_page_handler.go
+++ b/pkg/portal/knowledge_page_handler.go
@@ -47,6 +47,7 @@ func (h *Handler) registerKnowledgePageRoutes() {
 	// Entity references (#664): the entities a page provides knowledge about.
 	h.mux.HandleFunc("GET /api/v1/portal/knowledge-pages/{id}/refs", h.listKnowledgePageRefs)
 	h.mux.HandleFunc("PUT /api/v1/portal/knowledge-pages/{id}/refs", h.setKnowledgePageRefs)
+	h.mux.HandleFunc("POST /api/v1/portal/knowledge-pages/refs/resolve", h.resolveKnowledgePageRefs)
 }
 
 // knowledgePageRequest is the create/update payload.
@@ -101,6 +102,7 @@ func (h *Handler) createKnowledgePage(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to create knowledge page")
 		return
 	}
+	h.reconcileInlineRefs(r.Context(), page.ID, page.Body)
 	created, err := h.deps.KnowledgePageStore.Get(r.Context(), page.ID)
 	if err != nil {
 		writeJSON(w, http.StatusCreated, page)
@@ -234,6 +236,7 @@ func (h *Handler) updateKnowledgePage(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to update knowledge page")
 		return
 	}
+	h.reconcileInlineRefs(r.Context(), id, req.Body)
 	updated, err := h.deps.KnowledgePageStore.Get(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to read updated knowledge page")

--- a/pkg/portal/knowledge_page_refs_handler.go
+++ b/pkg/portal/knowledge_page_refs_handler.go
@@ -1,11 +1,14 @@
 package portal
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
 )
@@ -133,6 +136,140 @@ func (h *Handler) setKnowledgePageRefs(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, knowledgePageRefsResponse{Refs: entityRefViews(updated)})
 }
 
+// resolveRefsRequest carries the serialized URNs the renderer wants resolved.
+type resolveRefsRequest struct {
+	URNs []string `json:"urns"`
+}
+
+// resolvedRef is a reference enriched with a display label and existence, so the
+// renderer can show a named chip (greyed when the target is gone) instead of a
+// bare URN. The frontend builds its own link from type + the URN.
+type resolvedRef struct {
+	URN    string `json:"urn"`
+	Type   string `json:"type"`
+	Label  string `json:"label"`
+	Exists bool   `json:"exists"`
+}
+
+// resolveRefsResponse is the resolve envelope.
+type resolveRefsResponse struct {
+	Refs []resolvedRef `json:"refs"`
+}
+
+// resolveKnowledgePageRefs handles POST /api/v1/portal/knowledge-pages/refs/resolve.
+//
+// @Summary      Resolve entity references to display labels
+// @Description  Resolves a batch of serialized reference URNs (mcp:/urn:li:) to a display label, type, and whether the target still exists, so the renderer can show named chips.
+// @Tags         Knowledge
+// @Accept       json
+// @Produce      json
+// @Param        body  body  resolveRefsRequest  true  "URNs to resolve"
+// @Success      200  {object}  resolveRefsResponse
+// @Failure      400  {object}  problemDetail
+// @Failure      401  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/knowledge-pages/refs/resolve [post]
+func (h *Handler) resolveKnowledgePageRefs(w http.ResponseWriter, r *http.Request) {
+	user := GetUser(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, errAuthRequired)
+		return
+	}
+	var req resolveRefsRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxEntityRefsBodyBytes)).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, errInvalidRequestBody)
+		return
+	}
+	if len(req.URNs) > maxEntityRefsPerPage {
+		writeError(w, http.StatusBadRequest, "too many references")
+		return
+	}
+	out := make([]resolvedRef, 0, len(req.URNs))
+	for _, s := range req.URNs {
+		ref, err := knowledgepage.ParseEntityRef(s)
+		if err != nil {
+			out = append(out, resolvedRef{URN: s, Label: s, Exists: false})
+			continue
+		}
+		out = append(out, h.resolveRef(r.Context(), user, s, ref))
+	}
+	writeJSON(w, http.StatusOK, resolveRefsResponse{Refs: out})
+}
+
+// resolveRef resolves a single reference to a display label. Knowledge pages are
+// org-shared so their title and existence are resolved for any reader. Asset and
+// collection names are only revealed to their owner, and their existence is never
+// revealed, so the endpoint cannot enumerate names or existence across the share
+// boundary (share-aware, page-scoped resolution is a later phase). Connection,
+// prompt, and DataHub labels derive from the URN itself.
+func (h *Handler) resolveRef(ctx context.Context, user *User, urn string, ref knowledgepage.EntityRef) resolvedRef {
+	out := resolvedRef{URN: urn, Type: ref.TargetType, Label: urn, Exists: true}
+	switch ref.TargetType {
+	case knowledgepage.RefTargetAsset:
+		out.Label = h.resolveOwnedAssetLabel(ctx, user, ref.AssetID)
+	case knowledgepage.RefTargetCollection:
+		out.Label = h.resolveOwnedCollectionLabel(ctx, user, ref.CollectionID)
+	case knowledgepage.RefTargetKnowledgePage:
+		out.Label, out.Exists = h.resolvePageLabel(ctx, ref.RefPageID)
+	case knowledgepage.RefTargetConnection:
+		out.Label = ref.ConnectionName + " (" + ref.ConnectionKind + ")"
+	case knowledgepage.RefTargetPrompt:
+		out.Label = ref.PromptID
+	case knowledgepage.RefTargetDataHub:
+		out.Label = datahubLabel(ref.EntityURN)
+	}
+	return out
+}
+
+// resolveOwnedAssetLabel returns the asset's name only when the requesting user
+// owns it; otherwise the id is returned and existence is not signaled, so the
+// endpoint cannot leak names or confirm existence of assets the user cannot view.
+func (h *Handler) resolveOwnedAssetLabel(ctx context.Context, user *User, id string) string {
+	if h.deps.AssetStore == nil {
+		return id
+	}
+	if a, err := h.deps.AssetStore.Get(ctx, id); err == nil && a.OwnerID == user.UserID {
+		return a.Name
+	}
+	return id
+}
+
+// resolveOwnedCollectionLabel returns the collection's name only when the user owns it.
+func (h *Handler) resolveOwnedCollectionLabel(ctx context.Context, user *User, id string) string {
+	if h.deps.CollectionStore == nil {
+		return id
+	}
+	if c, err := h.deps.CollectionStore.Get(ctx, id); err == nil && c.OwnerID == user.UserID {
+		return c.Name
+	}
+	return id
+}
+
+// resolvePageLabel returns a knowledge page's title and existence.
+func (h *Handler) resolvePageLabel(ctx context.Context, id string) (string, bool) {
+	if p, err := h.deps.KnowledgePageStore.Get(ctx, id); err == nil {
+		return p.Title, true
+	}
+	return id, false
+}
+
+// datahubLabel extracts a readable name from a DataHub URN: the dataset name from
+// urn:li:dataset:(<platform>,<name>,<env>), or the last colon-segment otherwise.
+func datahubLabel(urn string) string {
+	if rest, ok := strings.CutPrefix(urn, "urn:li:dataset:("); ok {
+		inner := strings.TrimSuffix(rest, ")")
+		parts := strings.Split(inner, ",")
+		if len(parts) >= 2 {
+			return parts[1]
+		}
+	}
+	if i := strings.LastIndex(urn, ":"); i >= 0 && i < len(urn)-1 {
+		return urn[i+1:]
+	}
+	return urn
+}
+
 // knowledgePageExists verifies the page is live, writing a 404 (or 500) on
 // failure. It returns true only when the page exists and is not deleted.
 func (h *Handler) knowledgePageExists(w http.ResponseWriter, r *http.Request, id string) bool {
@@ -161,6 +298,19 @@ func parseEntityRefs(urns []string, createdBy string) ([]knowledgepage.EntityRef
 		refs = append(refs, ref)
 	}
 	return refs, nil
+}
+
+// reconcileInlineRefs replaces a page's source=inline references with those
+// mentioned in its body, leaving promoted and manual references untouched. It is
+// best-effort: a failure (for example an inline reference to an entity that no
+// longer exists) is logged but does not fail the page write, since the body
+// itself is valid. Called after every create/update that writes the body.
+func (h *Handler) reconcileInlineRefs(ctx context.Context, pageID, body string) {
+	refs := knowledgepage.ScanBodyRefs(body)
+	if err := h.deps.KnowledgePageStore.ReplaceEntityRefsBySource(ctx, pageID, knowledgepage.RefSourceInline, refs); err != nil {
+		slog.WarnContext(ctx, "reconcile inline knowledge-page references failed",
+			"page_id", pageID, "error", err)
+	}
 }
 
 func entityRefViews(refs []knowledgepage.EntityRef) []entityRefView {

--- a/pkg/portal/knowledge_page_refs_handler_test.go
+++ b/pkg/portal/knowledge_page_refs_handler_test.go
@@ -131,3 +131,178 @@ func TestSetKnowledgePageRefs(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, w.Code)
 	})
 }
+
+type resolveResp struct {
+	Refs []resolvedRef `json:"refs"`
+}
+
+func TestResolveKnowledgePageRefs(t *testing.T) {
+	store := &mockKnowledgePageStore{page: &knowledgepage.Page{ID: "kp-2", Title: "Fiscal Calendar"}}
+	h := newKnowledgePageHandler(store, kpViewer)
+	body := `{"urns":[
+		"mcp:knowledge_page:kp-2",
+		"mcp:connection:(trino,warehouse)",
+		"urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)",
+		"mcp:asset:asset-9",
+		"garbage"
+	]}`
+	w := doKP(h, "POST", "/api/v1/portal/knowledge-pages/refs/resolve", body)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp resolveResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Refs, 5)
+
+	byURN := map[string]resolvedRef{}
+	for _, r := range resp.Refs {
+		byURN[r.URN] = r
+	}
+	assert.Equal(t, "Fiscal Calendar", byURN["mcp:knowledge_page:kp-2"].Label)
+	assert.True(t, byURN["mcp:knowledge_page:kp-2"].Exists)
+	assert.Equal(t, "warehouse (trino)", byURN["mcp:connection:(trino,warehouse)"].Label)
+	assert.Equal(t, "iceberg.retail.daily_sales", byURN["urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)"].Label)
+	// AssetStore not configured in this harness: keep the id, do not grey out.
+	assert.Equal(t, "asset-9", byURN["mcp:asset:asset-9"].Label)
+	assert.True(t, byURN["mcp:asset:asset-9"].Exists)
+	// Unparseable URN is returned as non-existent.
+	assert.False(t, byURN["garbage"].Exists)
+}
+
+func TestResolveKnowledgePageRefs_PageNotFound(t *testing.T) {
+	// A reference to a deleted page resolves as non-existent.
+	h := newKnowledgePageHandler(&mockKnowledgePageStore{}, kpViewer) // nil page -> ErrNotFound
+	w := doKP(h, "POST", "/api/v1/portal/knowledge-pages/refs/resolve", `{"urns":["mcp:knowledge_page:gone"]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp resolveResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Refs, 1)
+	assert.False(t, resp.Refs[0].Exists)
+	assert.Equal(t, "gone", resp.Refs[0].Label)
+}
+
+func TestResolveKnowledgePageRefs_Unauthenticated(t *testing.T) {
+	h := newKnowledgePageHandler(&mockKnowledgePageStore{}, nil)
+	w := doKP(h, "POST", "/api/v1/portal/knowledge-pages/refs/resolve", `{"urns":[]}`)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestResolveKnowledgePageRefs_WithStores(t *testing.T) {
+	// The viewer owns these, so names resolve (non-owners get the bare id).
+	deps := Deps{
+		KnowledgePageStore: &mockKnowledgePageStore{},
+		AssetStore:         &mockAssetStore{getAsset: &Asset{ID: "asset-9", OwnerID: kpViewer.UserID, Name: "Revenue Dashboard"}},
+		CollectionStore:    &mockCollectionStore{getResult: &Collection{ID: "coll-1", OwnerID: kpViewer.UserID, Name: "Q4 Review"}},
+		AdminRoles:         []string{"admin"},
+		RateLimit:          RateLimitConfig{RequestsPerMinute: 600, BurstSize: 100},
+	}
+	h := NewHandler(deps, testAuthMiddleware(kpViewer))
+	body := `{"urns":["mcp:asset:asset-9","mcp:collection:coll-1","mcp:prompt:11111111-1111-1111-1111-111111111111","urn:li:glossaryTerm:revenue"]}`
+	w := doKP(h, "POST", "/api/v1/portal/knowledge-pages/refs/resolve", body)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp resolveResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	byURN := map[string]resolvedRef{}
+	for _, r := range resp.Refs {
+		byURN[r.URN] = r
+	}
+	assert.Equal(t, "Revenue Dashboard", byURN["mcp:asset:asset-9"].Label)
+	assert.Equal(t, "Q4 Review", byURN["mcp:collection:coll-1"].Label)
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", byURN["mcp:prompt:11111111-1111-1111-1111-111111111111"].Label)
+	assert.Equal(t, "revenue", byURN["urn:li:glossaryTerm:revenue"].Label)
+}
+
+func TestResolveKnowledgePageRefs_AssetNotOwnedIsNotLeaked(t *testing.T) {
+	// An asset the user does not own (or that is missing) yields only the id, with
+	// no name and no existence signal, so the endpoint cannot enumerate them.
+	deps := Deps{
+		KnowledgePageStore: &mockKnowledgePageStore{},
+		AssetStore:         &mockAssetStore{getAsset: &Asset{ID: "secret", OwnerID: "someone-else", Name: "Confidential Q4 Layoffs"}},
+		CollectionStore:    &mockCollectionStore{getResult: &Collection{ID: "secret-c", OwnerID: "someone-else", Name: "Confidential Board Deck"}},
+		AdminRoles:         []string{"admin"},
+		RateLimit:          RateLimitConfig{RequestsPerMinute: 600, BurstSize: 100},
+	}
+	h := NewHandler(deps, testAuthMiddleware(kpViewer))
+	w := doKP(h, "POST", "/api/v1/portal/knowledge-pages/refs/resolve",
+		`{"urns":["mcp:asset:secret","mcp:collection:secret-c"]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp resolveResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	byURN := map[string]resolvedRef{}
+	for _, r := range resp.Refs {
+		byURN[r.URN] = r
+	}
+	assert.Equal(t, "secret", byURN["mcp:asset:secret"].Label, "must not leak a non-owned asset's name")
+	assert.Equal(t, "secret-c", byURN["mcp:collection:secret-c"].Label, "must not leak a non-owned collection's name")
+}
+
+func TestResolveKnowledgePageRefs_BadInput(t *testing.T) {
+	h := newKnowledgePageHandler(&mockKnowledgePageStore{}, kpViewer)
+	t.Run("malformed body", func(t *testing.T) {
+		w := doKP(h, "POST", "/api/v1/portal/knowledge-pages/refs/resolve", `{nope`)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+	t.Run("too many", func(t *testing.T) {
+		urns := make([]string, maxEntityRefsPerPage+1)
+		for i := range urns {
+			urns[i] = "mcp:asset:a"
+		}
+		body, _ := json.Marshal(resolveRefsRequest{URNs: urns})
+		w := doKP(h, "POST", "/api/v1/portal/knowledge-pages/refs/resolve", string(body))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+func TestDatahubLabel(t *testing.T) {
+	assert.Equal(t, "iceberg.retail.daily_sales",
+		datahubLabel("urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)"))
+	assert.Equal(t, "revenue", datahubLabel("urn:li:glossaryTerm:revenue"))
+	assert.Equal(t, "nocolon", datahubLabel("nocolon"))
+}
+
+func TestCreateKnowledgePage_InlineReconcileErrorDoesNotFail(t *testing.T) {
+	// A reconcile failure is logged but must not fail the page create.
+	store := &mockKnowledgePageStore{refsErr: errors.New("boom")}
+	h := newKnowledgePageHandler(store, kpAdmin)
+	w := doKP(h, "POST", "/api/v1/portal/knowledge-pages",
+		`{"title":"T","body":"see [a](mcp:asset:x)"}`)
+	assert.Equal(t, http.StatusCreated, w.Code)
+}
+
+func TestCreateKnowledgePage_ReconcilesInlineRefs(t *testing.T) {
+	store := &mockKnowledgePageStore{}
+	h := newKnowledgePageHandler(store, kpAdmin)
+	body := `{"title":"Sales","body":"see [a](mcp:asset:asset-001) and urn:li:glossaryTerm:revenue"}`
+	w := doKP(h, "POST", "/api/v1/portal/knowledge-pages", body)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	urns := make([]string, 0, len(store.refs))
+	for _, rf := range store.refs {
+		assert.Equal(t, knowledgepage.RefSourceInline, rf.Source)
+		urns = append(urns, rf.URN())
+	}
+	assert.Contains(t, urns, "mcp:asset:asset-001")
+	assert.Contains(t, urns, "urn:li:glossaryTerm:revenue")
+}
+
+func TestUpdateKnowledgePage_InlineReconcilePreservesPromoted(t *testing.T) {
+	store := &mockKnowledgePageStore{
+		page: livePage(),
+		refs: []knowledgepage.EntityRef{
+			{TargetType: knowledgepage.RefTargetDataHub, EntityURN: "urn:li:dataset:x", Source: knowledgepage.RefSourcePromoted},
+			{TargetType: knowledgepage.RefTargetAsset, AssetID: "stale-inline", Source: knowledgepage.RefSourceInline},
+		},
+	}
+	h := newKnowledgePageHandler(store, kpAdmin)
+	w := doKP(h, "PUT", "/api/v1/portal/knowledge-pages/kp1",
+		`{"title":"T","body":"now references [coll](mcp:collection:coll-1)"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	urns := make([]string, 0, len(store.refs))
+	for _, rf := range store.refs {
+		urns = append(urns, rf.URN())
+	}
+	assert.Contains(t, urns, "urn:li:dataset:x", "promoted ref preserved")
+	assert.Contains(t, urns, "mcp:collection:coll-1", "new inline ref from body")
+	assert.NotContains(t, urns, "mcp:asset:stale-inline", "old inline ref replaced")
+}

--- a/pkg/portal/knowledgepage/entity_ref_scan.go
+++ b/pkg/portal/knowledgepage/entity_ref_scan.go
@@ -1,0 +1,47 @@
+package knowledgepage
+
+import "regexp"
+
+// refTokenRe matches a serialized reference token in page-body text: an mcp:
+// internal reference (a simple id, or a (kind,name) connection) or a urn:
+// external reference (with or without a single parenthesized id group, the form
+// DataHub uses). At most one level of parentheses is supported, which covers
+// every current reference form. The parenthesized alternatives come first so a
+// connection or DataHub token is matched whole rather than truncated at the
+// closing paren of an enclosing markdown link.
+var refTokenRe = regexp.MustCompile(
+	`mcp:[a-z_]+:\([^)]*\)|mcp:[a-z_]+:[A-Za-z0-9_.\-]+|urn:[a-z]+:[A-Za-z0-9]+:\([^)]*\)|urn:[a-z]+:[^\s)\]>]+`)
+
+// codeSpanRe matches fenced code blocks and inline code spans, which are stripped
+// before scanning so a URN shown as a documentation example does not become a
+// stored reference (the renderer never chips code, so scanning it would diverge).
+var codeSpanRe = regexp.MustCompile("(?s)```.*?```|`[^`]*`")
+
+// ScanBodyRefs extracts the entity references mentioned in a page's markdown body.
+// It is content-agnostic: a reference is found whether it appears as a markdown
+// link href, an autolink, or inline text. Unparseable matches are skipped, the
+// result is de-duplicated by target, and every ref is marked source=inline so a
+// reconcile can replace only the inline set without touching promoted or manual
+// references.
+func ScanBodyRefs(body string) []EntityRef {
+	body = codeSpanRe.ReplaceAllString(body, " ")
+	matches := refTokenRe.FindAllString(body, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(matches))
+	refs := make([]EntityRef, 0, len(matches))
+	for _, m := range matches {
+		ref, err := ParseEntityRef(m)
+		if err != nil {
+			continue
+		}
+		if _, dup := seen[ref.identity()]; dup {
+			continue
+		}
+		seen[ref.identity()] = struct{}{}
+		ref.Source = RefSourceInline
+		refs = append(refs, ref)
+	}
+	return refs
+}

--- a/pkg/portal/knowledgepage/entity_ref_scan_test.go
+++ b/pkg/portal/knowledgepage/entity_ref_scan_test.go
@@ -1,0 +1,58 @@
+package knowledgepage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func scannedURNs(refs []EntityRef) []string {
+	urns := make([]string, 0, len(refs))
+	for _, r := range refs {
+		urns = append(urns, r.URN())
+	}
+	return urns
+}
+
+func TestScanBodyRefs(t *testing.T) {
+	body := `# Daily Sales
+
+The [daily sales asset](mcp:asset:asset-001) is built from the
+[warehouse connection](mcp:connection:(trino,warehouse)) and the
+underlying dataset urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD).
+
+See also the glossary term <urn:li:glossaryTerm:revenue> and the
+related page [calendar](mcp:knowledge_page:kp-2). A duplicate
+[asset link](mcp:asset:asset-001) should collapse.
+
+This is just prose mentioning mcp but no real reference.`
+
+	refs := ScanBodyRefs(body)
+	got := scannedURNs(refs)
+
+	assert.ElementsMatch(t, []string{
+		"mcp:asset:asset-001",
+		"mcp:connection:(trino,warehouse)",
+		"urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)",
+		"urn:li:glossaryTerm:revenue",
+		"mcp:knowledge_page:kp-2",
+	}, got, "should extract each distinct reference exactly once")
+
+	for _, r := range refs {
+		assert.Equal(t, RefSourceInline, r.Source, "scanned refs are inline")
+	}
+}
+
+func TestScanBodyRefs_IgnoresCode(t *testing.T) {
+	body := "A real ref [a](mcp:asset:real-1).\n\n" +
+		"```\nmcp:asset:in-fence\nurn:li:dataset:(urn:li:dataPlatform:trino,in.fence.t,PROD)\n```\n\n" +
+		"Inline `mcp:asset:in-code` example."
+	got := scannedURNs(ScanBodyRefs(body))
+	assert.Equal(t, []string{"mcp:asset:real-1"}, got, "refs inside code must be ignored")
+}
+
+func TestScanBodyRefs_NoneAndUnparseable(t *testing.T) {
+	assert.Nil(t, ScanBodyRefs("just regular prose, no refs here"))
+	// A malformed prompt id is skipped rather than producing a bad ref.
+	assert.Empty(t, ScanBodyRefs("see [bad](mcp:prompt:not-a-uuid) and [also](mcp:bogus:x)"))
+}

--- a/ui/src/api/portal/hooks.ts
+++ b/ui/src/api/portal/hooks.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiFetch, apiFetchRaw } from "./client";
+import type { ResolvedRef } from "@/lib/entityRefs";
 import type {
   Asset,
   AssetVersion,
@@ -1247,6 +1248,31 @@ export function useDeleteKnowledgePage() {
     },
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ["knowledge-pages"] });
+    },
+  });
+}
+
+/**
+ * useResolveRefs resolves a batch of entity-reference URNs (mcp:/urn:li:) to
+ * display labels and existence for inline knowledge-page chips (#664). Returns a
+ * Map keyed by URN. Disabled when there are no references.
+ */
+export function useResolveRefs(urns: string[]) {
+  // Stable key independent of order/duplication so identical ref sets share a cache entry.
+  const key = Array.from(new Set(urns)).sort().join("\n");
+  return useQuery({
+    queryKey: ["knowledge-page-refs-resolve", key],
+    queryFn: () =>
+      apiFetch<{ refs: ResolvedRef[] }>("/knowledge-pages/refs/resolve", {
+        method: "POST",
+        body: JSON.stringify({ urns }),
+      }),
+    enabled: urns.length > 0,
+    staleTime: 60_000,
+    select: (data): Map<string, ResolvedRef> => {
+      const map = new Map<string, ResolvedRef>();
+      for (const r of data.refs) map.set(r.urn, r);
+      return map;
     },
   });
 }

--- a/ui/src/components/knowledge/EntityChip.tsx
+++ b/ui/src/components/knowledge/EntityChip.tsx
@@ -1,0 +1,42 @@
+import { FileText, MessageSquareText, FolderOpen, BookOpen, Plug, Database, Link2 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { parseRef, type ResolvedRef, type RefType } from "@/lib/entityRefs";
+
+const TYPE_ICONS: Record<RefType, LucideIcon> = {
+  asset: FileText,
+  prompt: MessageSquareText,
+  collection: FolderOpen,
+  knowledge_page: BookOpen,
+  connection: Plug,
+  datahub: Database,
+  unknown: Link2,
+};
+
+/**
+ * EntityChip renders an inline reference (mcp:/urn:li:) from a knowledge-page body
+ * as a typed chip: a type icon plus the entity's display name. When the server has
+ * resolved the reference, the real name is shown and a missing target is greyed out
+ * and struck through; before resolution (or app-wide, without a resolver) it falls
+ * back to the name derived from the URN itself.
+ */
+export function EntityChip({ urn, resolved }: { urn: string; resolved?: ResolvedRef }) {
+  const parsed = parseRef(urn);
+  const type = (resolved?.type ?? parsed?.type ?? "unknown") as RefType;
+  const Icon = TYPE_ICONS[type] ?? Link2;
+  const label = resolved?.label ?? parsed?.fallbackLabel ?? urn;
+  const missing = resolved ? !resolved.exists : false;
+
+  return (
+    <span
+      title={urn}
+      className={`not-prose mx-0.5 inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 align-baseline text-xs font-medium no-underline ${
+        missing
+          ? "border-border bg-muted text-muted-foreground line-through"
+          : "border-primary/20 bg-primary/10 text-primary"
+      }`}
+    >
+      <Icon className="h-3 w-3 shrink-0" aria-hidden />
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/ui/src/components/renderers/MarkdownRenderer.test.tsx
+++ b/ui/src/components/renderers/MarkdownRenderer.test.tsx
@@ -81,3 +81,35 @@ describe("sanitizeMermaidSvg", () => {
     expect(out).toContain("safe");
   });
 });
+
+import { render } from "@testing-library/react";
+import { MarkdownRenderer } from "./MarkdownRenderer";
+import type { ResolvedRef } from "@/lib/entityRefs";
+
+describe("MarkdownRenderer entity chips", () => {
+  it("renders an mcp: link as a chip (urlTransform must preserve the ref href)", () => {
+    const { container } = render(
+      <MarkdownRenderer content="See [Sales](mcp:asset:asset-001) here." />,
+    );
+    // The fallback label (the id) appears, and it is NOT a raw mcp: anchor.
+    expect(container.textContent).toContain("asset-001");
+    expect(container.querySelector('a[href^="mcp:"]')).toBeNull();
+  });
+
+  it("renders the server-resolved label when provided", () => {
+    const refs = new Map<string, ResolvedRef>([
+      ["mcp:asset:asset-001", { urn: "mcp:asset:asset-001", type: "asset", label: "Q4 Dashboard", exists: true }],
+    ]);
+    const { container } = render(
+      <MarkdownRenderer content="[x](mcp:asset:asset-001)" refs={refs} />,
+    );
+    expect(container.textContent).toContain("Q4 Dashboard");
+  });
+
+  it("leaves ordinary links untouched", () => {
+    const { container } = render(
+      <MarkdownRenderer content="[home](https://example.com)" />,
+    );
+    expect(container.querySelector('a[href="https://example.com"]')).not.toBeNull();
+  });
+});

--- a/ui/src/components/renderers/MarkdownRenderer.tsx
+++ b/ui/src/components/renderers/MarkdownRenderer.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useId, useCallback, useState } from "react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Components } from "react-markdown";
 import mermaid from "mermaid";
 import DOMPurify from "dompurify";
+import { EntityChip } from "@/components/knowledge/EntityChip";
+import { isRefUrn, type ResolvedRef } from "@/lib/entityRefs";
 
 // DOMPurify's default FORBID_CONTENTS strips the children of `foreignObject`
 // (among others). We reuse that default list but drop `foreignobject` so the
@@ -163,8 +165,31 @@ function MermaidBlock({ content }: { content: string }) {
   );
 }
 
-export function MarkdownRenderer({ content, bare }: { content: string | null | undefined; bare?: boolean }) {
+export function MarkdownRenderer({
+  content,
+  bare,
+  refs,
+}: {
+  content: string | null | undefined;
+  bare?: boolean;
+  refs?: Map<string, ResolvedRef>;
+}) {
   const components: Components = {
+    // Render mcp:/urn: links as entity chips; ordinary links are unchanged.
+    a: useCallback(
+      ({ href, children, node: _node, ...rest }:
+        React.ComponentProps<"a"> & { node?: unknown }) => {
+        if (isRefUrn(href)) {
+          return <EntityChip urn={href as string} resolved={refs?.get(href as string)} />;
+        }
+        return (
+          <a href={href} {...rest}>
+            {children}
+          </a>
+        );
+      },
+      [refs],
+    ),
     code: useCallback(
       // react-markdown passes `node` (hast AST) — destructure it out so it
       // doesn't leak into the DOM as an invalid attribute.
@@ -202,7 +227,13 @@ export function MarkdownRenderer({ content, bare }: { content: string | null | u
       data-feedback-anchorable
       className={`prose prose-sm max-w-none dark:prose-invert [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 ${bare ? "" : "rounded-lg border bg-card p-6"}`}
     >
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={components}
+        // Preserve entity-reference URNs (mcp:/urn:) so the `a` override can chip
+        // them; everything else keeps react-markdown's default URL sanitization.
+        urlTransform={(url) => (isRefUrn(url) ? url : defaultUrlTransform(url))}
+      >
         {content}
       </ReactMarkdown>
     </div>

--- a/ui/src/lib/entityRefs.test.ts
+++ b/ui/src/lib/entityRefs.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { extractRefUrns, parseRef, isRefUrn } from "./entityRefs";
+
+describe("isRefUrn", () => {
+  it("detects mcp: and urn: hrefs", () => {
+    expect(isRefUrn("mcp:asset:a")).toBe(true);
+    expect(isRefUrn("urn:li:dataset:(x)")).toBe(true);
+    expect(isRefUrn("https://example.com")).toBe(false);
+    expect(isRefUrn(undefined)).toBe(false);
+  });
+});
+
+describe("parseRef", () => {
+  it("parses each reference type with a fallback label", () => {
+    expect(parseRef("mcp:asset:asset-001")).toEqual({
+      urn: "mcp:asset:asset-001",
+      type: "asset",
+      fallbackLabel: "asset-001",
+    });
+    expect(parseRef("mcp:connection:(trino,warehouse)")).toEqual({
+      urn: "mcp:connection:(trino,warehouse)",
+      type: "connection",
+      fallbackLabel: "warehouse (trino)",
+    });
+    expect(
+      parseRef("urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)")?.fallbackLabel,
+    ).toBe("iceberg.retail.daily_sales");
+    expect(parseRef("urn:li:glossaryTerm:revenue")?.fallbackLabel).toBe("revenue");
+  });
+
+  it("rejects malformed references", () => {
+    expect(parseRef("mcp:")).toBeNull();
+    expect(parseRef("mcp:asset:")).toBeNull();
+    expect(parseRef("mcp:connection:trino,warehouse")).toBeNull();
+    expect(parseRef("not-a-ref")).toBeNull();
+  });
+});
+
+describe("extractRefUrns", () => {
+  it("extracts distinct references from a markdown body", () => {
+    const body = `See [a](mcp:asset:asset-001) and
+[warehouse](mcp:connection:(trino,warehouse)) plus the dataset
+urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)
+and <urn:li:glossaryTerm:revenue> and a duplicate [a2](mcp:asset:asset-001).`;
+    expect(extractRefUrns(body).sort()).toEqual(
+      [
+        "mcp:asset:asset-001",
+        "mcp:connection:(trino,warehouse)",
+        "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)",
+        "urn:li:glossaryTerm:revenue",
+      ].sort(),
+    );
+  });
+
+  it("returns nothing for plain prose", () => {
+    expect(extractRefUrns("just words, no references")).toEqual([]);
+  });
+
+  it("ignores references inside code blocks and spans", () => {
+    const body =
+      "Real [a](mcp:asset:real-1).\n\n```\nmcp:asset:in-fence\n```\n\nInline `mcp:asset:in-code`.";
+    expect(extractRefUrns(body)).toEqual(["mcp:asset:real-1"]);
+  });
+});

--- a/ui/src/lib/entityRefs.ts
+++ b/ui/src/lib/entityRefs.ts
@@ -1,0 +1,95 @@
+// Client-side helpers for the inline entity references that knowledge-page
+// bodies carry (#664). The serialized forms mirror the Go projection: mcp:<type>:<id>
+// for internal entities (mcp:connection:(kind,name) for connections) and a urn:
+// URN for DataHub. These helpers extract the references from a body and derive a
+// type + fallback label for rendering before the server resolve completes.
+
+export type RefType =
+  | "asset"
+  | "prompt"
+  | "collection"
+  | "knowledge_page"
+  | "connection"
+  | "datahub"
+  | "unknown";
+
+export interface ParsedRef {
+  urn: string;
+  type: RefType;
+  /** A label to show before (or instead of) a server-resolved name. */
+  fallbackLabel: string;
+}
+
+/** ResolvedRef is the server's resolution of a reference URN to a display label. */
+export interface ResolvedRef {
+  urn: string;
+  type: string;
+  label: string;
+  exists: boolean;
+}
+
+// Mirrors the backend refTokenRe: at most one level of parentheses, which covers
+// every reference form. Parenthesized alternatives come first so a connection or
+// DataHub token is matched whole rather than truncated at an enclosing paren.
+const REF_TOKEN_RE =
+  /mcp:[a-z_]+:\([^)]*\)|mcp:[a-z_]+:[A-Za-z0-9_.-]+|urn:[a-z]+:[A-Za-z0-9]+:\([^)]*\)|urn:[a-z]+:[^\s)\]>]+/g;
+
+// Fenced code blocks and inline code spans are stripped before scanning so a URN
+// shown as a documentation example is not treated as a reference (mirrors the
+// server's codeSpanRe).
+const CODE_SPAN_RE = /```[\s\S]*?```|`[^`]*`/g;
+
+/** isRefUrn reports whether an href is a serialized entity reference. */
+export function isRefUrn(href: string | undefined): boolean {
+  if (!href) return false;
+  return href.startsWith("mcp:") || href.startsWith("urn:");
+}
+
+/** extractRefUrns returns the distinct reference URNs mentioned in a body. */
+export function extractRefUrns(body: string): string[] {
+  const matches = body.replace(CODE_SPAN_RE, " ").match(REF_TOKEN_RE) ?? [];
+  return Array.from(new Set(matches.filter((m) => parseRef(m) !== null)));
+}
+
+/** datahubLabel pulls a readable name out of a DataHub URN. */
+function datahubLabel(urn: string): string {
+  const prefix = "urn:li:dataset:(";
+  if (urn.startsWith(prefix)) {
+    const inner = urn.slice(prefix.length).replace(/\)$/, "");
+    const name = inner.split(",")[1];
+    if (name) return name;
+  }
+  const i = urn.lastIndexOf(":");
+  return i >= 0 && i < urn.length - 1 ? urn.slice(i + 1) : urn;
+}
+
+/** parseRef parses a serialized reference into its type and a fallback label. */
+export function parseRef(urn: string): ParsedRef | null {
+  const trimmed = urn.trim();
+  if (trimmed.startsWith("urn:")) {
+    return { urn: trimmed, type: "datahub", fallbackLabel: datahubLabel(trimmed) };
+  }
+  if (!trimmed.startsWith("mcp:")) return null;
+
+  const rest = trimmed.slice("mcp:".length);
+  const sep = rest.indexOf(":");
+  if (sep < 0) return null;
+  const type = rest.slice(0, sep);
+  const id = rest.slice(sep + 1);
+  if (!id) return null;
+
+  switch (type) {
+    case "asset":
+    case "prompt":
+    case "collection":
+    case "knowledge_page":
+      return { urn: trimmed, type, fallbackLabel: id };
+    case "connection": {
+      const m = id.match(/^\(([^,]+),([^)]+)\)$/);
+      if (!m) return null;
+      return { urn: trimmed, type: "connection", fallbackLabel: `${m[2]} (${m[1]})` as string };
+    }
+    default:
+      return null;
+  }
+}

--- a/ui/src/pages/knowledge-pages/KnowledgePagesPage.tsx
+++ b/ui/src/pages/knowledge-pages/KnowledgePagesPage.tsx
@@ -4,6 +4,7 @@ import {
   useKnowledgePages,
   useSearchKnowledgePages,
   useKnowledgePage,
+  useResolveRefs,
   useKnowledgePageVersions,
   useCreateKnowledgePage,
   useUpdateKnowledgePage,
@@ -13,6 +14,7 @@ import {
 import type { KnowledgePage, KnowledgePageInput } from "@/api/portal/types";
 import { MarkdownEditor } from "@/components/MarkdownEditor";
 import { MarkdownRenderer } from "@/components/renderers/MarkdownRenderer";
+import { extractRefUrns } from "@/lib/entityRefs";
 import { FeedbackButton } from "@/components/feedback/FeedbackButton";
 import { useAuthStore } from "@/stores/auth";
 import { parseTags } from "@/lib/tags";
@@ -275,6 +277,9 @@ function KnowledgePageDetail({
   const { data: page, isLoading, isError } = useKnowledgePage(id);
   const del = useDeleteKnowledgePage();
   const [showHistory, setShowHistory] = useState(false);
+  // Resolve the body's inline entity references to display names for the chips (#664).
+  const refUrns = useMemo(() => extractRefUrns(page?.body ?? ""), [page?.body]);
+  const { data: resolvedRefs } = useResolveRefs(refUrns);
 
   if (isLoading) return <p className="text-sm text-muted-foreground">Loading...</p>;
   if (isError || !page) return <p className="text-sm text-destructive">Knowledge page not found.</p>;
@@ -335,7 +340,7 @@ function KnowledgePageDetail({
         className="prose prose-sm max-w-none rounded-lg border border-border bg-card p-6 dark:prose-invert"
         data-feedback-anchorable
       >
-        <MarkdownRenderer content={page.body} />
+        <MarkdownRenderer content={page.body} refs={resolvedRefs} />
       </article>
     </div>
   );


### PR DESCRIPTION
Phase 2 of #664, building on Phase 0 (#666) and Phase 1 (#667). Does not close the issue: Phase 3 (authoring picker + Related panel), Phase 4 (bidirectional cross-enrichment), Phase 5 (backfill), and the insight reference table remain open.

## Summary

Phase 1 added the serializer and the page-references API. Phase 2 makes a reference written **inline in a page body** first-class: it is reconciled into a stored reference on save, resolved to a display name, and rendered as a typed chip. This is the first phase with UI.

## Backend

### Body-scan reconciliation

`ScanBodyRefs` extracts the references mentioned in a page body, whether they appear as a markdown link href (`[t](mcp:asset:x)`), an autolink (`<urn:li:..>`), or a bare token. It strips fenced code blocks and inline code spans first, so a URN shown as a documentation example does not become a stored reference (the renderer never chips code, so scanning it would diverge). `createKnowledgePage` and `updateKnowledgePage` reconcile the result into `source=inline` references via `ReplaceEntityRefsBySource`, leaving `promoted` and `manual` references untouched. The reconcile is best-effort: a bad inline reference (for example to a deleted entity) is logged, not fatal to the page write, since the body itself is valid.

### Resolve endpoint

`POST /api/v1/portal/knowledge-pages/refs/resolve` resolves a batch of reference URNs to `{urn, type, label, exists}` so the renderer can show named chips. Resolution is permission-aware:

- Knowledge-page titles resolve for any reader (pages are org-shared canonical knowledge).
- **Asset and collection names resolve only for their owner, and their existence is never revealed otherwise**, so the endpoint cannot be used to enumerate names or confirm existence of entities the user cannot see. Share-aware, page-scoped resolution is a later phase.
- Connection, prompt, and DataHub labels derive from the URN itself (no store lookup).

## Frontend

- `ui/src/lib/entityRefs.ts` parses and extracts references client-side, mirroring the server token regex and the code-stripping so the client and server see the same set.
- `useResolveRefs` batches a page's references to the resolve endpoint.
- `EntityChip` renders a reference as a typed, named, existence-aware chip (icon per type, dark-mode aware, greyed and struck through when the target is gone).
- `MarkdownRenderer` renders `mcp:`/`urn:` links as chips via an `a` override, and passes a `urlTransform` that allows the reference schemes through react-markdown's URL sanitization (which strips unknown schemes to empty by default) while keeping the default sanitization for ordinary links.
- A dev seed page carries an inline-reference example for screenshot work.

## Adversarial review (caught three real bugs, all fixed here)

A `/code-review` ran before `make verify`. It found:

1. **The feature was dead.** react-markdown v10 strips `mcp:`/`urn:` hrefs to empty before the `a` override runs, so no chip ever rendered. Fixed with the `urlTransform` above; a render test now asserts an `mcp:` link mounts as a chip, not a stripped anchor.
2. **A cross-share leak.** The resolve endpoint originally looked up asset/collection names for any id, letting any authenticated user enumerate names and existence across the share boundary. Now owner-gated as described; a "must not leak" test covers it.
3. **Code-block over-match.** URNs inside code fences were stored as references. Now stripped on both the Go and TS sides.

## Testing

- `make verify` green: race + real-Postgres, package budget, lint, gosec/govulncheck, semgrep, CodeQL, mutation, swagger-check, GoReleaser. Patch coverage 98.0%.
- Go unit tests: the scan (including code exclusion and dedup), the reconcile wiring (inline replace preserves promoted), the owner-gated resolve (including the no-leak path), datahub label parsing.
- TS unit tests: client-side parse/extract parity with the server, including code exclusion.
- React render tests: `mcp:` links render as chips (not stripped anchors), resolved labels are used, ordinary links are untouched.

Not done in this PR: a live visual screenshot pass (light/dark) against `make dev`. The render tests prove the chips mount and resolve.

## Acceptance (this phase)

- Saving a page whose body links `mcp:`/`urn:li:` references records matching `source=inline` references; removing them on a later save clears the inline set without touching promoted/manual.
- Viewing a page renders those links as typed chips with resolved names where permitted.
- The resolve endpoint never reveals a non-owned asset/collection's name or existence.

## Follow-up (open on #664)

- Phase 3: the cross-entity reference picker (`source=manual`) and the typed "Related" panel, with share-aware, page-scoped name resolution.
- Phase 4: bidirectional cross-enrichment via the reverse lookup.
- Phase 5: backfill of existing pages from their source insights.
- The insight reference table, in whichever phase first writes insight references.
