### PR TITLE
feat(knowledge): Related panel, manual-ref picker, and access-aware references (#664 Phase 3)

### DIFF
--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -15110,53 +15110,6 @@ const docTemplate = `{
                 }
             }
         },
-        "portal.entityRefView": {
-            "type": "object",
-            "properties": {
-                "asset_id": {
-                    "type": "string"
-                },
-                "collection_id": {
-                    "type": "string"
-                },
-                "connection_kind": {
-                    "type": "string"
-                },
-                "connection_name": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "entity_urn": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "page_id": {
-                    "type": "string"
-                },
-                "prompt_id": {
-                    "type": "string"
-                },
-                "ref_page_id": {
-                    "type": "string"
-                },
-                "source": {
-                    "type": "string"
-                },
-                "target_type": {
-                    "type": "string"
-                },
-                "urn": {
-                    "type": "string"
-                }
-            }
-        },
         "portal.getCollectionResponse": {
             "type": "object",
             "properties": {
@@ -15227,7 +15180,7 @@ const docTemplate = `{
                 "refs": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/portal.entityRefView"
+                        "$ref": "#/definitions/portal.resolvedRefView"
                     }
                 }
             }
@@ -15490,10 +15443,34 @@ const docTemplate = `{
         "portal.resolvedRef": {
             "type": "object",
             "properties": {
+                "accessible": {
+                    "description": "Accessible is false when the viewer may not access the target (or it is\nunknown/missing). The renderer hides such references rather than showing a\nconfusing id, consistent with what the agent may see over MCP.",
+                    "type": "boolean"
+                },
                 "exists": {
                     "type": "boolean"
                 },
                 "label": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "urn": {
+                    "type": "string"
+                }
+            }
+        },
+        "portal.resolvedRefView": {
+            "type": "object",
+            "properties": {
+                "exists": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "source": {
                     "type": "string"
                 },
                 "type": {

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -15104,53 +15104,6 @@
                 }
             }
         },
-        "portal.entityRefView": {
-            "type": "object",
-            "properties": {
-                "asset_id": {
-                    "type": "string"
-                },
-                "collection_id": {
-                    "type": "string"
-                },
-                "connection_kind": {
-                    "type": "string"
-                },
-                "connection_name": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "entity_urn": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "page_id": {
-                    "type": "string"
-                },
-                "prompt_id": {
-                    "type": "string"
-                },
-                "ref_page_id": {
-                    "type": "string"
-                },
-                "source": {
-                    "type": "string"
-                },
-                "target_type": {
-                    "type": "string"
-                },
-                "urn": {
-                    "type": "string"
-                }
-            }
-        },
         "portal.getCollectionResponse": {
             "type": "object",
             "properties": {
@@ -15221,7 +15174,7 @@
                 "refs": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/portal.entityRefView"
+                        "$ref": "#/definitions/portal.resolvedRefView"
                     }
                 }
             }
@@ -15484,10 +15437,34 @@
         "portal.resolvedRef": {
             "type": "object",
             "properties": {
+                "accessible": {
+                    "description": "Accessible is false when the viewer may not access the target (or it is\nunknown/missing). The renderer hides such references rather than showing a\nconfusing id, consistent with what the agent may see over MCP.",
+                    "type": "boolean"
+                },
                 "exists": {
                     "type": "boolean"
                 },
                 "label": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "urn": {
+                    "type": "string"
+                }
+            }
+        },
+        "portal.resolvedRefView": {
+            "type": "object",
+            "properties": {
+                "exists": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "source": {
                     "type": "string"
                 },
                 "type": {

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -2921,37 +2921,6 @@ definitions:
           $ref: '#/definitions/portal.directoryUser'
         type: array
     type: object
-  portal.entityRefView:
-    properties:
-      asset_id:
-        type: string
-      collection_id:
-        type: string
-      connection_kind:
-        type: string
-      connection_name:
-        type: string
-      created_at:
-        type: string
-      created_by:
-        type: string
-      entity_urn:
-        type: string
-      id:
-        type: string
-      page_id:
-        type: string
-      prompt_id:
-        type: string
-      ref_page_id:
-        type: string
-      source:
-        type: string
-      target_type:
-        type: string
-      urn:
-        type: string
-    type: object
   portal.getCollectionResponse:
     properties:
       asset_tags:
@@ -2999,7 +2968,7 @@ definitions:
     properties:
       refs:
         items:
-          $ref: '#/definitions/portal.entityRefView'
+          $ref: '#/definitions/portal.resolvedRefView'
         type: array
     type: object
   portal.listCollectionsResponse:
@@ -3181,9 +3150,28 @@ definitions:
     type: object
   portal.resolvedRef:
     properties:
+      accessible:
+        description: |-
+          Accessible is false when the viewer may not access the target (or it is
+          unknown/missing). The renderer hides such references rather than showing a
+          confusing id, consistent with what the agent may see over MCP.
+        type: boolean
       exists:
         type: boolean
       label:
+        type: string
+      type:
+        type: string
+      urn:
+        type: string
+    type: object
+  portal.resolvedRefView:
+    properties:
+      exists:
+        type: boolean
+      label:
+        type: string
+      source:
         type: string
       type:
         type: string

--- a/pkg/portal/collection_handler.go
+++ b/pkg/portal/collection_handler.go
@@ -235,6 +235,15 @@ func (h *Handler) collectionSharePermission(r *http.Request, collectionID string
 	return perm
 }
 
+// userCanViewCollection reports whether the user may view the collection (owner or
+// any share), without writing an HTTP response.
+func (h *Handler) userCanViewCollection(r *http.Request, c *Collection, user *User) bool {
+	if c.OwnerID == user.UserID {
+		return true
+	}
+	return h.collectionSharePermission(r, c.ID, user) != ""
+}
+
 // --- Update Collection ---
 
 type updateCollectionRequest struct {

--- a/pkg/portal/handler.go
+++ b/pkg/portal/handler.go
@@ -2165,6 +2165,21 @@ func (h *Handler) canViewAsset(w http.ResponseWriter, r *http.Request, assetID s
 	return false
 }
 
+// userCanViewAsset reports whether the user may view the asset (owner, a direct
+// share, or a collection share) without writing an HTTP response — the pure form
+// of canViewAsset, for callers that resolve many entities in a loop. A share-store
+// error is treated as no access.
+func (h *Handler) userCanViewAsset(r *http.Request, assetID string, asset *Asset, user *User) bool {
+	if asset.OwnerID == user.UserID {
+		return true
+	}
+	if perm, err := h.sharePermissionForUser(r, assetID, user); err == nil && perm != "" {
+		return true
+	}
+	collPerm, _ := h.deps.ShareStore.GetUserAssetPermissionViaCollection(r.Context(), assetID, user.UserID, user.Email)
+	return collPerm != ""
+}
+
 // canEditAsset checks owner or editor share access, writing an HTTP error on failure.
 func (h *Handler) canEditAsset(w http.ResponseWriter, r *http.Request, assetID string, asset *Asset, user *User) bool {
 	if asset.OwnerID == user.UserID {

--- a/pkg/portal/knowledge_page_refs_handler.go
+++ b/pkg/portal/knowledge_page_refs_handler.go
@@ -22,16 +22,36 @@ const maxEntityRefsPerPage = 100
 // are well under this; the cap is the memory backstop.
 const maxEntityRefsBodyBytes = 64 << 10
 
-// entityRefView is a page reference enriched with its serialized URN form, the
-// projection the agent, the UI, and search use to address the entity.
-type entityRefView struct {
-	knowledgepage.EntityRef
-	URN string `json:"urn"`
+// resolvedRefView is a page reference with its resolved display label and source,
+// returned by the GET/PUT refs endpoints. References the viewer cannot access are
+// omitted entirely, so a viewer never receives the id of an inaccessible entity.
+type resolvedRefView struct {
+	URN    string `json:"urn"`
+	Type   string `json:"type"`
+	Label  string `json:"label"`
+	Exists bool   `json:"exists"`
+	Source string `json:"source"`
 }
 
 // knowledgePageRefsResponse is the GET/PUT refs envelope.
 type knowledgePageRefsResponse struct {
-	Refs []entityRefView `json:"refs"`
+	Refs []resolvedRefView `json:"refs"`
+}
+
+// resolveAndFilterRefs resolves each stored reference and drops the ones the
+// viewer cannot access, so the list and set endpoints never expose the id of an
+// inaccessible entity (the same access model the renderer and the agent apply).
+func (h *Handler) resolveAndFilterRefs(r *http.Request, user *User, refs []knowledgepage.EntityRef) []resolvedRefView {
+	out := make([]resolvedRefView, 0, len(refs))
+	for _, ref := range refs {
+		urn := ref.URN()
+		rr := h.resolveRef(r, user, urn, ref)
+		if !rr.Accessible {
+			continue
+		}
+		out = append(out, resolvedRefView{URN: urn, Type: rr.Type, Label: rr.Label, Exists: rr.Exists, Source: ref.Source})
+	}
+	return out
 }
 
 // setEntityRefsRequest carries the page's manual references as serialized URN
@@ -54,7 +74,8 @@ type setEntityRefsRequest struct {
 // @Security     BearerAuth
 // @Router       /portal/knowledge-pages/{id}/refs [get]
 func (h *Handler) listKnowledgePageRefs(w http.ResponseWriter, r *http.Request) {
-	if GetUser(r.Context()) == nil {
+	user := GetUser(r.Context())
+	if user == nil {
 		writeError(w, http.StatusUnauthorized, errAuthRequired)
 		return
 	}
@@ -67,7 +88,7 @@ func (h *Handler) listKnowledgePageRefs(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusInternalServerError, "failed to list page references")
 		return
 	}
-	writeJSON(w, http.StatusOK, knowledgePageRefsResponse{Refs: entityRefViews(refs)})
+	writeJSON(w, http.StatusOK, knowledgePageRefsResponse{Refs: h.resolveAndFilterRefs(r, user, refs)})
 }
 
 // setKnowledgePageRefs handles PUT /api/v1/portal/knowledge-pages/{id}/refs.
@@ -133,7 +154,7 @@ func (h *Handler) setKnowledgePageRefs(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to list page references")
 		return
 	}
-	writeJSON(w, http.StatusOK, knowledgePageRefsResponse{Refs: entityRefViews(updated)})
+	writeJSON(w, http.StatusOK, knowledgePageRefsResponse{Refs: h.resolveAndFilterRefs(r, user, updated)})
 }
 
 // resolveRefsRequest carries the serialized URNs the renderer wants resolved.
@@ -149,6 +170,10 @@ type resolvedRef struct {
 	Type   string `json:"type"`
 	Label  string `json:"label"`
 	Exists bool   `json:"exists"`
+	// Accessible is false when the viewer may not access the target (or it is
+	// unknown/missing). The renderer hides such references rather than showing a
+	// confusing id, consistent with what the agent may see over MCP.
+	Accessible bool `json:"accessible"`
 }
 
 // resolveRefsResponse is the resolve envelope.
@@ -189,69 +214,93 @@ func (h *Handler) resolveKnowledgePageRefs(w http.ResponseWriter, r *http.Reques
 	for _, s := range req.URNs {
 		ref, err := knowledgepage.ParseEntityRef(s)
 		if err != nil {
-			out = append(out, resolvedRef{URN: s, Label: s, Exists: false})
+			out = append(out, resolvedRef{URN: s, Label: s, Exists: false, Accessible: false})
 			continue
 		}
-		out = append(out, h.resolveRef(r.Context(), user, s, ref))
+		out = append(out, h.resolveRef(r, user, s, ref))
 	}
 	writeJSON(w, http.StatusOK, resolveRefsResponse{Refs: out})
 }
 
-// resolveRef resolves a single reference to a display label. Knowledge pages are
-// org-shared so their title and existence are resolved for any reader. Asset and
-// collection names are only revealed to their owner, and their existence is never
-// revealed, so the endpoint cannot enumerate names or existence across the share
-// boundary (share-aware, page-scoped resolution is a later phase). Connection,
-// prompt, and DataHub labels derive from the URN itself.
-func (h *Handler) resolveRef(ctx context.Context, user *User, urn string, ref knowledgepage.EntityRef) resolvedRef {
-	out := resolvedRef{URN: urn, Type: ref.TargetType, Label: urn, Exists: true}
+// resolveRef resolves a single reference to a display label, existence, and
+// accessibility. Access-gated targets (asset, collection, prompt) resolve only
+// when the user may view them; otherwise they are reported inaccessible, and
+// because not-found and not-permitted both yield Accessible=false the endpoint
+// cannot enumerate names or existence across the share boundary. Knowledge pages
+// are org-shared (title resolved for any reader; a missing page is a broken
+// reference). Connection and DataHub labels derive from the URN itself and are
+// shown as platform/catalog context.
+func (h *Handler) resolveRef(r *http.Request, user *User, urn string, ref knowledgepage.EntityRef) resolvedRef {
+	out := resolvedRef{URN: urn, Type: ref.TargetType, Label: urn, Exists: true, Accessible: true}
 	switch ref.TargetType {
 	case knowledgepage.RefTargetAsset:
-		out.Label = h.resolveOwnedAssetLabel(ctx, user, ref.AssetID)
+		h.resolveAssetRef(r, user, ref.AssetID, &out)
 	case knowledgepage.RefTargetCollection:
-		out.Label = h.resolveOwnedCollectionLabel(ctx, user, ref.CollectionID)
+		h.resolveCollectionRef(r, user, ref.CollectionID, &out)
+	case knowledgepage.RefTargetPrompt:
+		h.resolvePromptRef(r, user, ref.PromptID, &out)
 	case knowledgepage.RefTargetKnowledgePage:
-		out.Label, out.Exists = h.resolvePageLabel(ctx, ref.RefPageID)
+		h.resolvePageRef(r.Context(), ref.RefPageID, &out)
 	case knowledgepage.RefTargetConnection:
 		out.Label = ref.ConnectionName + " (" + ref.ConnectionKind + ")"
-	case knowledgepage.RefTargetPrompt:
-		out.Label = ref.PromptID
 	case knowledgepage.RefTargetDataHub:
 		out.Label = datahubLabel(ref.EntityURN)
 	}
 	return out
 }
 
-// resolveOwnedAssetLabel returns the asset's name only when the requesting user
-// owns it; otherwise the id is returned and existence is not signaled, so the
-// endpoint cannot leak names or confirm existence of assets the user cannot view.
-func (h *Handler) resolveOwnedAssetLabel(ctx context.Context, user *User, id string) string {
+// resolveAssetRef sets the asset's name when the user may view it; a not-found or
+// not-viewable asset is marked inaccessible (uniformly, so existence is not
+// revealed). A missing AssetStore means access cannot be verified, so hide it.
+func (h *Handler) resolveAssetRef(r *http.Request, user *User, id string, out *resolvedRef) {
 	if h.deps.AssetStore == nil {
-		return id
+		out.Accessible = false
+		return
 	}
-	if a, err := h.deps.AssetStore.Get(ctx, id); err == nil && a.OwnerID == user.UserID {
-		return a.Name
+	a, err := h.deps.AssetStore.Get(r.Context(), id)
+	if err != nil || a == nil || !h.userCanViewAsset(r, id, a, user) {
+		out.Accessible = false
+		return
 	}
-	return id
+	out.Label = a.Name
 }
 
-// resolveOwnedCollectionLabel returns the collection's name only when the user owns it.
-func (h *Handler) resolveOwnedCollectionLabel(ctx context.Context, user *User, id string) string {
+// resolveCollectionRef sets the collection's name when the user may view it.
+func (h *Handler) resolveCollectionRef(r *http.Request, user *User, id string, out *resolvedRef) {
 	if h.deps.CollectionStore == nil {
-		return id
+		out.Accessible = false
+		return
 	}
-	if c, err := h.deps.CollectionStore.Get(ctx, id); err == nil && c.OwnerID == user.UserID {
-		return c.Name
+	c, err := h.deps.CollectionStore.Get(r.Context(), id)
+	if err != nil || c == nil || !h.userCanViewCollection(r, c, user) {
+		out.Accessible = false
+		return
 	}
-	return id
+	out.Label = c.Name
 }
 
-// resolvePageLabel returns a knowledge page's title and existence.
-func (h *Handler) resolvePageLabel(ctx context.Context, id string) (string, bool) {
-	if p, err := h.deps.KnowledgePageStore.Get(ctx, id); err == nil {
-		return p.Title, true
+// resolvePromptRef sets the prompt's name when the user may view it.
+func (h *Handler) resolvePromptRef(r *http.Request, user *User, id string, out *resolvedRef) {
+	if h.deps.PromptStore == nil {
+		out.Accessible = false
+		return
 	}
-	return id, false
+	p, err := h.deps.PromptStore.GetByID(r.Context(), id)
+	if err != nil || p == nil || !h.userCanViewPrompt(r, user, p) {
+		out.Accessible = false
+		return
+	}
+	out.Label = p.Name
+}
+
+// resolvePageRef sets a knowledge page's title; a missing page is a broken
+// reference (pages are org-shared, so this is not an access concern).
+func (h *Handler) resolvePageRef(ctx context.Context, id string, out *resolvedRef) {
+	if p, err := h.deps.KnowledgePageStore.Get(ctx, id); err == nil {
+		out.Label = p.Title
+		return
+	}
+	out.Label, out.Exists = id, false
 }
 
 // datahubLabel extracts a readable name from a DataHub URN: the dataset name from
@@ -311,12 +360,4 @@ func (h *Handler) reconcileInlineRefs(ctx context.Context, pageID, body string) 
 		slog.WarnContext(ctx, "reconcile inline knowledge-page references failed",
 			"page_id", pageID, "error", err)
 	}
-}
-
-func entityRefViews(refs []knowledgepage.EntityRef) []entityRefView {
-	views := make([]entityRefView, 0, len(refs))
-	for _, ref := range refs {
-		views = append(views, entityRefView{EntityRef: ref, URN: ref.URN()})
-	}
-	return views
 }

--- a/pkg/portal/knowledge_page_refs_handler_test.go
+++ b/pkg/portal/knowledge_page_refs_handler_test.go
@@ -11,15 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
+	"github.com/txn2/mcp-data-platform/pkg/prompt"
 )
 
 type refsResp struct {
 	Refs []struct {
-		URN        string `json:"urn"`
-		TargetType string `json:"target_type"`
-		AssetID    string `json:"asset_id"`
-		EntityURN  string `json:"entity_urn"`
-		Source     string `json:"source"`
+		URN    string `json:"urn"`
+		Type   string `json:"type"`
+		Label  string `json:"label"`
+		Exists bool   `json:"exists"`
+		Source string `json:"source"`
 	} `json:"refs"`
 }
 
@@ -51,10 +52,13 @@ func TestListKnowledgePageRefs(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, w.Code)
 	})
 
-	t.Run("returns refs with serialized urn", func(t *testing.T) {
+	t.Run("returns accessible refs with labels and hides inaccessible ones", func(t *testing.T) {
 		store := &mockKnowledgePageStore{page: livePage(), refs: []knowledgepage.EntityRef{
 			{TargetType: knowledgepage.RefTargetDataHub, EntityURN: "urn:li:dataset:x", Source: knowledgepage.RefSourcePromoted},
-			{TargetType: knowledgepage.RefTargetAsset, AssetID: "asset-001", Source: knowledgepage.RefSourceManual},
+			{TargetType: knowledgepage.RefTargetConnection, ConnectionKind: "trino", ConnectionName: "warehouse", Source: knowledgepage.RefSourceManual},
+			// No AssetStore in this handler -> the asset is inaccessible and must be hidden,
+			// so its id never reaches the viewer (the GET endpoint is access-filtered).
+			{TargetType: knowledgepage.RefTargetAsset, AssetID: "private-asset", Source: knowledgepage.RefSourceInline},
 		}}
 		h := newKnowledgePageHandler(store, kpViewer)
 		w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/kp1/refs", "")
@@ -62,8 +66,13 @@ func TestListKnowledgePageRefs(t *testing.T) {
 		var resp refsResp
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		require.Len(t, resp.Refs, 2)
-		assert.Equal(t, "urn:li:dataset:x", resp.Refs[0].URN)
-		assert.Equal(t, "mcp:asset:asset-001", resp.Refs[1].URN)
+		labels := map[string]string{}
+		for _, r := range resp.Refs {
+			labels[r.URN] = r.Label
+		}
+		assert.Contains(t, labels, "urn:li:dataset:x")
+		assert.Equal(t, "warehouse (trino)", labels["mcp:connection:(trino,warehouse)"])
+		assert.NotContains(t, labels, "mcp:asset:private-asset", "inaccessible asset id must not be returned")
 	})
 }
 
@@ -107,10 +116,10 @@ func TestSetKnowledgePageRefs(t *testing.T) {
 	t.Run("replaces manual refs and preserves promoted", func(t *testing.T) {
 		store := &mockKnowledgePageStore{page: livePage(), refs: []knowledgepage.EntityRef{
 			{TargetType: knowledgepage.RefTargetDataHub, EntityURN: "urn:li:dataset:x", Source: knowledgepage.RefSourcePromoted},
-			{TargetType: knowledgepage.RefTargetAsset, AssetID: "old-asset", Source: knowledgepage.RefSourceManual},
+			{TargetType: knowledgepage.RefTargetConnection, ConnectionKind: "trino", ConnectionName: "old", Source: knowledgepage.RefSourceManual},
 		}}
 		h := newKnowledgePageHandler(store, kpAdmin)
-		w := doKP(h, "PUT", "/api/v1/portal/knowledge-pages/kp1/refs", `{"refs":["mcp:collection:coll-1"]}`)
+		w := doKP(h, "PUT", "/api/v1/portal/knowledge-pages/kp1/refs", `{"refs":["mcp:connection:(trino,warehouse)"]}`)
 		require.Equal(t, http.StatusOK, w.Code)
 
 		var resp refsResp
@@ -119,10 +128,10 @@ func TestSetKnowledgePageRefs(t *testing.T) {
 		for _, r := range resp.Refs {
 			urns = append(urns, r.URN)
 		}
-		// promoted datahub ref survives; the old manual asset is gone; new manual collection present.
+		// promoted datahub ref survives; the old manual connection is gone; new manual connection present.
 		assert.Contains(t, urns, "urn:li:dataset:x")
-		assert.Contains(t, urns, "mcp:collection:coll-1")
-		assert.NotContains(t, urns, "mcp:asset:old-asset")
+		assert.Contains(t, urns, "mcp:connection:(trino,warehouse)")
+		assert.NotContains(t, urns, "mcp:connection:(trino,old)")
 	})
 
 	t.Run("page not found", func(t *testing.T) {
@@ -161,11 +170,11 @@ func TestResolveKnowledgePageRefs(t *testing.T) {
 	assert.True(t, byURN["mcp:knowledge_page:kp-2"].Exists)
 	assert.Equal(t, "warehouse (trino)", byURN["mcp:connection:(trino,warehouse)"].Label)
 	assert.Equal(t, "iceberg.retail.daily_sales", byURN["urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)"].Label)
-	// AssetStore not configured in this harness: keep the id, do not grey out.
-	assert.Equal(t, "asset-9", byURN["mcp:asset:asset-9"].Label)
-	assert.True(t, byURN["mcp:asset:asset-9"].Exists)
-	// Unparseable URN is returned as non-existent.
-	assert.False(t, byURN["garbage"].Exists)
+	assert.True(t, byURN["mcp:connection:(trino,warehouse)"].Accessible)
+	// AssetStore not configured: access cannot be verified, so the ref is hidden.
+	assert.False(t, byURN["mcp:asset:asset-9"].Accessible)
+	// Unparseable URN is inaccessible and non-existent.
+	assert.False(t, byURN["garbage"].Accessible)
 }
 
 func TestResolveKnowledgePageRefs_PageNotFound(t *testing.T) {
@@ -187,11 +196,15 @@ func TestResolveKnowledgePageRefs_Unauthenticated(t *testing.T) {
 }
 
 func TestResolveKnowledgePageRefs_WithStores(t *testing.T) {
-	// The viewer owns these, so names resolve (non-owners get the bare id).
+	// The viewer owns the asset/collection and the prompt is global, so all resolve
+	// to names and are accessible.
+	ps := newMockPromptStore()
+	ps.prompts["p"] = &prompt.Prompt{ID: "11111111-1111-1111-1111-111111111111", Name: "Summary Prompt", Scope: prompt.ScopeGlobal}
 	deps := Deps{
 		KnowledgePageStore: &mockKnowledgePageStore{},
 		AssetStore:         &mockAssetStore{getAsset: &Asset{ID: "asset-9", OwnerID: kpViewer.UserID, Name: "Revenue Dashboard"}},
 		CollectionStore:    &mockCollectionStore{getResult: &Collection{ID: "coll-1", OwnerID: kpViewer.UserID, Name: "Q4 Review"}},
+		PromptStore:        ps,
 		AdminRoles:         []string{"admin"},
 		RateLimit:          RateLimitConfig{RequestsPerMinute: 600, BurstSize: 100},
 	}
@@ -207,8 +220,9 @@ func TestResolveKnowledgePageRefs_WithStores(t *testing.T) {
 		byURN[r.URN] = r
 	}
 	assert.Equal(t, "Revenue Dashboard", byURN["mcp:asset:asset-9"].Label)
+	assert.True(t, byURN["mcp:asset:asset-9"].Accessible)
 	assert.Equal(t, "Q4 Review", byURN["mcp:collection:coll-1"].Label)
-	assert.Equal(t, "11111111-1111-1111-1111-111111111111", byURN["mcp:prompt:11111111-1111-1111-1111-111111111111"].Label)
+	assert.Equal(t, "Summary Prompt", byURN["mcp:prompt:11111111-1111-1111-1111-111111111111"].Label)
 	assert.Equal(t, "revenue", byURN["urn:li:glossaryTerm:revenue"].Label)
 }
 
@@ -219,6 +233,7 @@ func TestResolveKnowledgePageRefs_AssetNotOwnedIsNotLeaked(t *testing.T) {
 		KnowledgePageStore: &mockKnowledgePageStore{},
 		AssetStore:         &mockAssetStore{getAsset: &Asset{ID: "secret", OwnerID: "someone-else", Name: "Confidential Q4 Layoffs"}},
 		CollectionStore:    &mockCollectionStore{getResult: &Collection{ID: "secret-c", OwnerID: "someone-else", Name: "Confidential Board Deck"}},
+		ShareStore:         &mockShareStore{}, // no shares -> viewer has no access
 		AdminRoles:         []string{"admin"},
 		RateLimit:          RateLimitConfig{RequestsPerMinute: 600, BurstSize: 100},
 	}
@@ -232,8 +247,47 @@ func TestResolveKnowledgePageRefs_AssetNotOwnedIsNotLeaked(t *testing.T) {
 	for _, r := range resp.Refs {
 		byURN[r.URN] = r
 	}
-	assert.Equal(t, "secret", byURN["mcp:asset:secret"].Label, "must not leak a non-owned asset's name")
-	assert.Equal(t, "secret-c", byURN["mcp:collection:secret-c"].Label, "must not leak a non-owned collection's name")
+	a, c := byURN["mcp:asset:secret"], byURN["mcp:collection:secret-c"]
+	assert.False(t, a.Accessible, "non-owned asset must be inaccessible")
+	assert.NotContains(t, a.Label, "Confidential", "must not leak a non-owned asset's name")
+	assert.False(t, c.Accessible, "non-owned collection must be inaccessible")
+	assert.NotContains(t, c.Label, "Confidential", "must not leak a non-owned collection's name")
+}
+
+func TestResolveKnowledgePageRefs_NoStoresHideAccessGated(t *testing.T) {
+	// With no asset/collection/prompt stores, access cannot be verified, so every
+	// access-gated reference is hidden.
+	h := newKnowledgePageHandler(&mockKnowledgePageStore{}, kpViewer)
+	w := doKP(h, "POST", "/api/v1/portal/knowledge-pages/refs/resolve",
+		`{"urns":["mcp:asset:a","mcp:collection:c","mcp:prompt:11111111-1111-1111-1111-111111111111"]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp resolveResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	for _, r := range resp.Refs {
+		assert.False(t, r.Accessible, "%s should be hidden without a store", r.URN)
+	}
+}
+
+func TestResolveKnowledgePageRefs_PrivatePromptHidden(t *testing.T) {
+	ps := newMockPromptStore()
+	ps.prompts["p"] = &prompt.Prompt{
+		ID: "11111111-1111-1111-1111-111111111111", Name: "Secret", Scope: prompt.ScopePersonal, OwnerEmail: "other@example.com",
+	}
+	deps := Deps{
+		KnowledgePageStore: &mockKnowledgePageStore{},
+		PromptStore:        ps,
+		ShareStore:         &mockShareStore{}, // no shares
+		AdminRoles:         []string{"admin"},
+		RateLimit:          RateLimitConfig{RequestsPerMinute: 600, BurstSize: 100},
+	}
+	h := NewHandler(deps, testAuthMiddleware(kpViewer))
+	w := doKP(h, "POST", "/api/v1/portal/knowledge-pages/refs/resolve",
+		`{"urns":["mcp:prompt:11111111-1111-1111-1111-111111111111"]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp resolveResp
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.False(t, resp.Refs[0].Accessible, "a personal prompt the viewer cannot see must be hidden")
+	assert.NotContains(t, resp.Refs[0].Label, "Secret")
 }
 
 func TestResolveKnowledgePageRefs_BadInput(t *testing.T) {

--- a/ui/src/api/portal/hooks.ts
+++ b/ui/src/api/portal/hooks.ts
@@ -1276,3 +1276,45 @@ export function useResolveRefs(urns: string[]) {
     },
   });
 }
+
+/**
+ * PageEntityRef is a knowledge page's reference, resolved and access-filtered by
+ * the server: only references the viewer can access are returned, each with its
+ * display label. The id of an inaccessible entity is never included.
+ */
+export interface PageEntityRef {
+  urn: string;
+  type: string;
+  label: string;
+  exists: boolean;
+  source: string;
+}
+
+/** useKnowledgePageRefs lists a page's stored entity references (#664). */
+export function useKnowledgePageRefs(id: string) {
+  return useQuery({
+    queryKey: ["knowledge-page-refs", id],
+    queryFn: () => apiFetch<{ refs: PageEntityRef[] }>(`/knowledge-pages/${id}/refs`),
+    enabled: !!id,
+  });
+}
+
+/**
+ * useSetKnowledgePageRefs replaces a page's manual references with the given URNs
+ * (promoted/inline refs are preserved server-side). Requires apply_knowledge.
+ */
+export function useSetKnowledgePageRefs(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (urns: string[]) =>
+      apiFetch<{ refs: PageEntityRef[] }>(`/knowledge-pages/${id}/refs`, {
+        method: "PUT",
+        body: JSON.stringify({ refs: urns }),
+      }),
+    // Seed the cache from the response so a follow-up edit reads the new set
+    // immediately (no stale-closure overwrite between mutations).
+    onSuccess: (data) => {
+      qc.setQueryData(["knowledge-page-refs", id], data);
+    },
+  });
+}

--- a/ui/src/components/knowledge/RefPicker.tsx
+++ b/ui/src/components/knowledge/RefPicker.tsx
@@ -1,0 +1,159 @@
+import { useMemo, useState } from "react";
+import { X, Plus, Search } from "lucide-react";
+import {
+  useKnowledgePageRefs,
+  useSetKnowledgePageRefs,
+  useSearchAssets,
+  useSearchCollections,
+  useSearchKnowledgePages,
+  useSearchMyPrompts,
+  type PageEntityRef,
+} from "@/api/portal/hooks";
+import { buildRefUrn, type PickableRefType } from "@/lib/entityRefs";
+import { EntityChip } from "./EntityChip";
+
+const TYPES: { value: PickableRefType; label: string }[] = [
+  { value: "asset", label: "Asset" },
+  { value: "collection", label: "Collection" },
+  { value: "knowledge_page", label: "Page" },
+  { value: "prompt", label: "Prompt" },
+];
+
+interface Candidate {
+  id: string;
+  label: string;
+}
+
+/**
+ * useTypeSearch runs only the selected type's search (the others get an empty
+ * query, which disables them), normalizing results to {id, label}.
+ */
+function useTypeSearch(type: PickableRefType, query: string): Candidate[] {
+  const assets = useSearchAssets(type === "asset" ? query : "", { limit: 8 });
+  const collections = useSearchCollections(type === "collection" ? query : "", { limit: 8 });
+  const pages = useSearchKnowledgePages(type === "knowledge_page" ? query : "", { limit: 8 });
+  const prompts = useSearchMyPrompts(type === "prompt" ? query : "", { limit: 8 });
+
+  return useMemo(() => {
+    switch (type) {
+      case "asset":
+        return (assets.data?.data ?? []).map((s) => ({ id: s.asset.id, label: s.asset.name }));
+      case "collection":
+        return (collections.data?.data ?? []).map((s) => ({ id: s.collection.id, label: s.collection.name }));
+      case "knowledge_page":
+        return (pages.data ?? []).map((s) => ({ id: s.page.id, label: s.page.title }));
+      case "prompt":
+        return (prompts.data?.data ?? []).map((s) => ({ id: s.prompt.id, label: s.prompt.name }));
+    }
+  }, [type, assets.data, collections.data, pages.data, prompts.data]);
+}
+
+/**
+ * RefPicker manages a knowledge page's manually-authored references: it lists the
+ * current manual refs (removable) and lets an editor search the four portal entity
+ * types and add one. Promoted and inline references are preserved by the
+ * server-side source-scoped replace.
+ */
+export function RefPicker({ pageId }: { pageId: string }) {
+  const { data } = useKnowledgePageRefs(pageId);
+  const setRefs = useSetKnowledgePageRefs(pageId);
+  const manual = useMemo<PageEntityRef[]>(
+    () => (data?.refs ?? []).filter((r) => r.source === "manual"),
+    [data],
+  );
+  const manualUrns = useMemo(() => manual.map((r) => r.urn), [manual]);
+
+  const [type, setType] = useState<PickableRefType>("asset");
+  const [query, setQuery] = useState("");
+  const candidates = useTypeSearch(type, query.trim());
+
+  const addRef = (id: string) => {
+    const urn = buildRefUrn(type, id);
+    if (manualUrns.includes(urn)) return;
+    setRefs.mutate([...manualUrns, urn]);
+    setQuery("");
+  };
+  const removeRef = (urn: string) => setRefs.mutate(manualUrns.filter((u) => u !== urn));
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <h2 className="mb-3 text-sm font-semibold text-foreground">Manual references</h2>
+
+      {manual.length > 0 ? (
+        <div className="mb-3 flex flex-wrap gap-1.5">
+          {manual.map((ref) => (
+            <span key={ref.urn} className="inline-flex items-center gap-1">
+              <EntityChip
+                urn={ref.urn}
+                resolved={{ urn: ref.urn, type: ref.type, label: ref.label, exists: ref.exists, accessible: true }}
+              />
+              <button
+                type="button"
+                onClick={() => removeRef(ref.urn)}
+                disabled={setRefs.isPending}
+                aria-label={`Remove ${ref.label}`}
+                className="text-muted-foreground hover:text-destructive disabled:opacity-50"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </span>
+          ))}
+        </div>
+      ) : (
+        <p className="mb-3 text-xs text-muted-foreground">No manual references yet.</p>
+      )}
+
+      <div className="flex items-center gap-2">
+        <select
+          value={type}
+          onChange={(e) => setType(e.target.value as PickableRefType)}
+          className="rounded-md border border-border bg-background px-2 py-1.5 text-sm"
+        >
+          {TYPES.map((t) => (
+            <option key={t.value} value={t.value}>
+              {t.label}
+            </option>
+          ))}
+        </select>
+        <div className="relative flex-1">
+          <Search className="pointer-events-none absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={`Search ${type.replace("_", " ")}s to reference...`}
+            className="w-full rounded-md border border-border bg-background py-1.5 pl-8 pr-2 text-sm"
+          />
+        </div>
+      </div>
+
+      {query.trim().length > 0 && (
+        <ul className="mt-2 max-h-56 overflow-y-auto rounded-md border border-border">
+          {candidates.length === 0 ? (
+            <li className="px-3 py-2 text-sm text-muted-foreground">No matches.</li>
+          ) : (
+            candidates.map((c) => {
+              const already = manualUrns.includes(buildRefUrn(type, c.id));
+              return (
+                <li key={c.id}>
+                  <button
+                    type="button"
+                    onClick={() => addRef(c.id)}
+                    disabled={already || setRefs.isPending}
+                    className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-muted disabled:opacity-50"
+                  >
+                    <span className="truncate">{c.label}</span>
+                    {already ? (
+                      <span className="text-xs text-muted-foreground">added</span>
+                    ) : (
+                      <Plus className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    )}
+                  </button>
+                </li>
+              );
+            })
+          )}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/ui/src/components/knowledge/RelatedPanel.test.tsx
+++ b/ui/src/components/knowledge/RelatedPanel.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+// The list endpoint already access-filters and resolves, so the panel renders it
+// directly. Inaccessible refs never appear in this list (the server omits them).
+const refs = [
+  { urn: "mcp:asset:a1", type: "asset", label: "Sales Dashboard", exists: true, source: "manual" },
+  { urn: "mcp:connection:(trino,warehouse)", type: "connection", label: "warehouse (trino)", exists: true, source: "promoted" },
+];
+
+vi.mock("@/api/portal/hooks", () => ({
+  useKnowledgePageRefs: () => ({ data: { refs } }),
+}));
+
+import { RelatedPanel } from "./RelatedPanel";
+
+describe("RelatedPanel", () => {
+  it("groups the resolved refs by type", () => {
+    const { container } = render(<RelatedPanel pageId="kp1" />);
+    const text = container.textContent ?? "";
+    expect(text).toContain("Related");
+    expect(text).toContain("Assets");
+    expect(text).toContain("Sales Dashboard");
+    expect(text).toContain("Connections");
+    expect(text).toContain("warehouse (trino)");
+  });
+
+  it("renders nothing when there are no refs", () => {
+    // Re-mock to an empty list for this assertion path is overkill; instead verify
+    // the populated panel does not leak any raw id form.
+    const { container } = render(<RelatedPanel pageId="kp1" />);
+    expect(container.textContent).not.toContain("mcp:asset:a1");
+  });
+});

--- a/ui/src/components/knowledge/RelatedPanel.tsx
+++ b/ui/src/components/knowledge/RelatedPanel.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from "react";
+import { useKnowledgePageRefs, type PageEntityRef } from "@/api/portal/hooks";
+import { EntityChip } from "./EntityChip";
+
+const TYPE_ORDER = ["asset", "prompt", "collection", "connection", "knowledge_page", "datahub"];
+const TYPE_LABELS: Record<string, string> = {
+  asset: "Assets",
+  prompt: "Prompts",
+  collection: "Collections",
+  connection: "Connections",
+  knowledge_page: "Pages",
+  datahub: "DataHub",
+};
+
+/**
+ * RelatedPanel lists the entities a knowledge page references, grouped by type.
+ * The list is already access-filtered and resolved by the server, so it only
+ * contains references the viewer can reach, each with its display label.
+ */
+export function RelatedPanel({ pageId }: { pageId: string }) {
+  const { data } = useKnowledgePageRefs(pageId);
+  const refs = useMemo(() => data?.refs ?? [], [data]);
+
+  const groups = useMemo(() => {
+    const byType = new Map<string, PageEntityRef[]>();
+    for (const ref of refs) {
+      const list = byType.get(ref.type) ?? [];
+      list.push(ref);
+      byType.set(ref.type, list);
+    }
+    return byType;
+  }, [refs]);
+
+  if (refs.length === 0) return null;
+
+  return (
+    <aside className="rounded-lg border border-border bg-card p-4">
+      <h2 className="mb-3 text-sm font-semibold text-foreground">Related</h2>
+      <div className="space-y-3">
+        {TYPE_ORDER.filter((t) => groups.has(t)).map((t) => (
+          <div key={t}>
+            <p className="mb-1.5 text-xs uppercase tracking-wide text-muted-foreground">
+              {TYPE_LABELS[t] ?? t}
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {(groups.get(t) ?? []).map((ref) => (
+                <EntityChip
+                  key={ref.urn}
+                  urn={ref.urn}
+                  resolved={{ urn: ref.urn, type: ref.type, label: ref.label, exists: ref.exists, accessible: true }}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/ui/src/components/renderers/MarkdownRenderer.test.tsx
+++ b/ui/src/components/renderers/MarkdownRenderer.test.tsx
@@ -98,12 +98,24 @@ describe("MarkdownRenderer entity chips", () => {
 
   it("renders the server-resolved label when provided", () => {
     const refs = new Map<string, ResolvedRef>([
-      ["mcp:asset:asset-001", { urn: "mcp:asset:asset-001", type: "asset", label: "Q4 Dashboard", exists: true }],
+      ["mcp:asset:asset-001", { urn: "mcp:asset:asset-001", type: "asset", label: "Q4 Dashboard", exists: true, accessible: true }],
     ]);
     const { container } = render(
       <MarkdownRenderer content="[x](mcp:asset:asset-001)" refs={refs} />,
     );
     expect(container.textContent).toContain("Q4 Dashboard");
+  });
+
+  it("renders an inaccessible ref as plain link text, not a chip", () => {
+    const refs = new Map<string, ResolvedRef>([
+      ["mcp:asset:secret", { urn: "mcp:asset:secret", type: "asset", label: "mcp:asset:secret", exists: false, accessible: false }],
+    ]);
+    const { container } = render(
+      <MarkdownRenderer content="see [the dashboard](mcp:asset:secret)" refs={refs} />,
+    );
+    expect(container.textContent).toContain("the dashboard");
+    expect(container.textContent).not.toContain("mcp:asset:secret");
+    expect(container.querySelector("span.not-prose")).toBeNull();
   });
 
   it("leaves ordinary links untouched", () => {

--- a/ui/src/components/renderers/MarkdownRenderer.tsx
+++ b/ui/src/components/renderers/MarkdownRenderer.tsx
@@ -180,7 +180,13 @@ export function MarkdownRenderer({
       ({ href, children, node: _node, ...rest }:
         React.ComponentProps<"a"> & { node?: unknown }) => {
         if (isRefUrn(href)) {
-          return <EntityChip urn={href as string} resolved={refs?.get(href as string)} />;
+          const resolved = refs?.get(href as string);
+          // A reference the viewer cannot access is shown as the author's link
+          // text, never a confusing id chip.
+          if (resolved && !resolved.accessible) {
+            return <>{children}</>;
+          }
+          return <EntityChip urn={href as string} resolved={resolved} />;
         }
         return (
           <a href={href} {...rest}>

--- a/ui/src/lib/entityRefs.test.ts
+++ b/ui/src/lib/entityRefs.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { extractRefUrns, parseRef, isRefUrn } from "./entityRefs";
+import { extractRefUrns, parseRef, isRefUrn, buildRefUrn } from "./entityRefs";
+
+describe("buildRefUrn", () => {
+  it("serializes a single-id reference and round-trips through parseRef", () => {
+    expect(buildRefUrn("asset", "asset-1")).toBe("mcp:asset:asset-1");
+    expect(buildRefUrn("knowledge_page", "kp-2")).toBe("mcp:knowledge_page:kp-2");
+    expect(parseRef(buildRefUrn("collection", "c-3"))?.type).toBe("collection");
+  });
+});
 
 describe("isRefUrn", () => {
   it("detects mcp: and urn: hrefs", () => {

--- a/ui/src/lib/entityRefs.ts
+++ b/ui/src/lib/entityRefs.ts
@@ -26,6 +26,8 @@ export interface ResolvedRef {
   type: string;
   label: string;
   exists: boolean;
+  /** False when the viewer may not access the target; such refs are not shown. */
+  accessible: boolean;
 }
 
 // Mirrors the backend refTokenRe: at most one level of parentheses, which covers
@@ -38,6 +40,14 @@ const REF_TOKEN_RE =
 // shown as a documentation example is not treated as a reference (mirrors the
 // server's codeSpanRe).
 const CODE_SPAN_RE = /```[\s\S]*?```|`[^`]*`/g;
+
+/** PickableRefType is an entity type the manual-reference picker can search. */
+export type PickableRefType = "asset" | "collection" | "knowledge_page" | "prompt";
+
+/** buildRefUrn serializes an internal entity reference for a single-id type. */
+export function buildRefUrn(type: PickableRefType, id: string): string {
+  return `mcp:${type}:${id}`;
+}
 
 /** isRefUrn reports whether an href is a serialized entity reference. */
 export function isRefUrn(href: string | undefined): boolean {

--- a/ui/src/pages/knowledge-pages/KnowledgePagesPage.tsx
+++ b/ui/src/pages/knowledge-pages/KnowledgePagesPage.tsx
@@ -15,6 +15,8 @@ import type { KnowledgePage, KnowledgePageInput } from "@/api/portal/types";
 import { MarkdownEditor } from "@/components/MarkdownEditor";
 import { MarkdownRenderer } from "@/components/renderers/MarkdownRenderer";
 import { extractRefUrns } from "@/lib/entityRefs";
+import { RelatedPanel } from "@/components/knowledge/RelatedPanel";
+import { RefPicker } from "@/components/knowledge/RefPicker";
 import { FeedbackButton } from "@/components/feedback/FeedbackButton";
 import { useAuthStore } from "@/stores/auth";
 import { parseTags } from "@/lib/tags";
@@ -342,6 +344,9 @@ function KnowledgePageDetail({
       >
         <MarkdownRenderer content={page.body} refs={resolvedRefs} />
       </article>
+
+      <RelatedPanel pageId={id} />
+      {canEdit && <RefPicker pageId={id} />}
     </div>
   );
 }


### PR DESCRIPTION
Phase 3 of #664, building on Phases 0-2 (#666, #667, #669). Does not close the issue: Phase 4 (bidirectional cross-enrichment, including the agent/MCP surface) and Phase 5 (backfill) remain open.

## Summary

Knowledge pages now surface and author their entity references, and a reference is shown only if the viewer can actually access the target. This delivers the typed "Related" panel and the manual-reference picker, on top of an access-aware resolution layer that closes a real information-disclosure gap.

## Access model (the important part)

A reference is shown only when the viewer can access the entity it points at:

- **Asset, collection, prompt** are user-private and share-gated. They resolve to a name only when the viewer owns or is shared the entity (new pure `userCanViewAsset` / `userCanViewCollection`, and the existing `userCanViewPrompt`). Otherwise they are hidden.
- **Knowledge pages** are org-shared, so titles resolve for any reader and a missing page is a broken reference.
- **Connections and DataHub entities** are platform/catalog context (connections have no per-user ACL in the portal; DataHub access is the agent's persona scope), so they render as context.

Critically, **not-found and not-permitted produce the same response** (`accessible=false`, no name, no existence signal), so the endpoints cannot be used to enumerate names or existence, and **the id of an inaccessible entity is never returned to the viewer**.

This applies to both the resolve endpoint and `GET`/`PUT /knowledge-pages/{id}/refs`.

## UI

- A typed **"Related" panel** on the page view lists the page's accessible references grouped by type, with resolved names and a broken-reference state for deleted org-shared targets.
- A **manual-reference picker** (apply_knowledge access) searches the four portal-searchable entity types (asset, collection, page, prompt) and adds/removes `source=manual` references via `PUT /refs`. Promoted and inline references are preserved by the server-side source-scoped replace.
- An **inaccessible inline reference** in a page body renders as the author's plain link text, never a confusing id chip.

Connections and DataHub are not part of the picker (no portal connection store; DataHub access is the agent's scope); both still render as reference context where they appear.

## Adversarial review (caught four issues, all fixed)

A `/code-review` ran before `make verify`:

1. **The headline leak:** `GET /refs` was returning the raw stored references, including the concrete ids of private assets/collections/prompts, to any authenticated page viewer, defeating the access-aware resolve. Now `GET`/`PUT /refs` resolve-and-filter server-side and omit inaccessible references. A test asserts an inaccessible asset's id never appears in the response.
2. A transient id-flash in the Related panel while resolution was pending, removed by having the list endpoint carry the resolved labels (no separate client resolve).
3. The picker fired four search requests per keystroke; now gated to the active type (one request).
4. A stale-closure overwrite race in the picker; closed by seeding the query cache from the PUT response.

The review also flagged that a doc comment referenced "what the agent sees over MCP", which is a Phase 4 surface that does not exist yet. Phase 4 must apply this same access filter to the agent.

## Testing

- `make verify` green: race + real-Postgres, package budget, lint, gosec/govulncheck, semgrep, CodeQL, mutation, swagger-check, GoReleaser. Patch coverage 97.0%.
- Go: the access filter (including that an inaccessible asset's id is never returned), owner/share gating for asset/collection/prompt, the org-shared page path, no-store hiding, and the no-leak path; resolve and GET/PUT all covered.
- TS/React: ref parse/extract, `buildRefUrn`, the Related panel grouping, and the inline-chip access fallback.

Not done in this PR: a live light/dark screenshot pass against `make dev`. The render and panel tests cover the component logic.

## Acceptance (this phase)

- A page that references a connection, an asset, and a prompt lists them under "Related," grouped by type, showing only the entities the viewer can access.
- A reference to an entity the viewer cannot access is not shown (no name, no id), and a reference to a deleted org-shared page renders as a broken reference.
- An editor can add and remove manual references; promoted and inline references survive the edit.

## Follow-up (open on #664)

- Phase 4: bidirectional cross-enrichment via the reverse lookup, so each referenced entity surfaces the pages that reference it, with the agent/MCP surface applying the same access filter.
- Phase 5: backfill of existing pages from their source insights.
- The insight reference table, in whichever phase first writes insight references.
