### PR TITLE
feat(knowledge): reverse lookup so entity views surface referencing pages (#664 Phase 4)

### DIFF
--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -8505,6 +8505,55 @@ const docTemplate = `{
                 }
             }
         },
+        "/portal/knowledge-pages/backlinks": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Reverse lookup: returns the knowledge pages that reference the given entity (by serialized URN), so an entity view can surface \"N knowledge pages reference this\". Returns empty for an entity the viewer cannot access.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "List knowledge pages that reference an entity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Serialized entity URN (mcp:/urn:li:)",
+                        "name": "urn",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.backlinksResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/knowledge-pages/refs/resolve": {
             "post": {
                 "security": [
@@ -14134,6 +14183,20 @@ const docTemplate = `{
                 }
             }
         },
+        "knowledgepage.PageRef": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
         "persona.AccessSource": {
             "type": "string",
             "enum": [
@@ -14921,6 +14984,17 @@ const docTemplate = `{
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "portal.backlinksResponse": {
+            "type": "object",
+            "properties": {
+                "pages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/knowledgepage.PageRef"
+                    }
                 }
             }
         },

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -8499,6 +8499,55 @@
                 }
             }
         },
+        "/portal/knowledge-pages/backlinks": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Reverse lookup: returns the knowledge pages that reference the given entity (by serialized URN), so an entity view can surface \"N knowledge pages reference this\". Returns empty for an entity the viewer cannot access.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "List knowledge pages that reference an entity",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Serialized entity URN (mcp:/urn:li:)",
+                        "name": "urn",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.backlinksResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/knowledge-pages/refs/resolve": {
             "post": {
                 "security": [
@@ -14128,6 +14177,20 @@
                 }
             }
         },
+        "knowledgepage.PageRef": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
         "persona.AccessSource": {
             "type": "string",
             "enum": [
@@ -14915,6 +14978,17 @@
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "portal.backlinksResponse": {
+            "type": "object",
+            "properties": {
+                "pages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/knowledgepage.PageRef"
+                    }
                 }
             }
         },

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -2237,6 +2237,15 @@ definitions:
         example: amount
         type: string
     type: object
+  knowledgepage.PageRef:
+    properties:
+      id:
+        type: string
+      slug:
+        type: string
+      title:
+        type: string
+    type: object
   persona.AccessSource:
     enum:
     - allow
@@ -2792,6 +2801,13 @@ definitions:
         type: string
       updated_at:
         type: string
+    type: object
+  portal.backlinksResponse:
+    properties:
+      pages:
+        items:
+          $ref: '#/definitions/knowledgepage.PageRef'
+        type: array
     type: object
   portal.captureInsightRequest:
     properties:
@@ -8952,6 +8968,38 @@ paths:
       - ApiKeyAuth: []
       - BearerAuth: []
       summary: Set a knowledge page's manual entity references
+      tags:
+      - Knowledge
+  /portal/knowledge-pages/backlinks:
+    get:
+      description: 'Reverse lookup: returns the knowledge pages that reference the
+        given entity (by serialized URN), so an entity view can surface "N knowledge
+        pages reference this". Returns empty for an entity the viewer cannot access.'
+      parameters:
+      - description: Serialized entity URN (mcp:/urn:li:)
+        in: query
+        name: urn
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/portal.backlinksResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: List knowledge pages that reference an entity
       tags:
       - Knowledge
   /portal/knowledge-pages/refs/resolve:

--- a/pkg/database/migrate/migrate_realpg_test.go
+++ b/pkg/database/migrate/migrate_realpg_test.go
@@ -14,7 +14,7 @@ import (
 
 // expectedFinalVersion is the highest migration the embedded set defines. Bump
 // this when adding a migration so the gate asserts the full set applied.
-const expectedFinalVersion = 73
+const expectedFinalVersion = 74
 
 // TestMigrationsAgainstRealPostgres applies the embedded migrations to a real
 // PostgreSQL (pgvector) instance and exercises the full lifecycle: up, seed,

--- a/pkg/database/migrate/migrate_unit_test.go
+++ b/pkg/database/migrate/migrate_unit_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	migrateTestFileCount    = 146
+	migrateTestFileCount    = 148
 	migrateTestSuccess      = "success"
 	migrateTestFactoryError = "factory error"
 )

--- a/pkg/database/migrate/migrations/000074_kp_entity_refs_reverse_indexes.down.sql
+++ b/pkg/database/migrate/migrations/000074_kp_entity_refs_reverse_indexes.down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS idx_kp_entity_refs_asset_rev;
+DROP INDEX IF EXISTS idx_kp_entity_refs_prompt_rev;
+DROP INDEX IF EXISTS idx_kp_entity_refs_collection_rev;
+DROP INDEX IF EXISTS idx_kp_entity_refs_ref_page_rev;
+DROP INDEX IF EXISTS idx_kp_entity_refs_connection_rev;
+DROP INDEX IF EXISTS idx_kp_entity_refs_urn_rev;

--- a/pkg/database/migrate/migrations/000074_kp_entity_refs_reverse_indexes.up.sql
+++ b/pkg/database/migrate/migrations/000074_kp_entity_refs_reverse_indexes.up.sql
@@ -1,0 +1,16 @@
+-- Reverse-lookup indexes on knowledge_page_entity_refs (#664 Phase 4): the
+-- Phase 0 unique indexes are keyed (page_id, <target>) for the forward lookup
+-- (a page's refs); these target-column indexes make the reverse lookup (the
+-- pages that reference a given entity) indexed for every target type.
+CREATE INDEX IF NOT EXISTS idx_kp_entity_refs_asset_rev
+    ON knowledge_page_entity_refs (asset_id) WHERE asset_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_kp_entity_refs_prompt_rev
+    ON knowledge_page_entity_refs (prompt_id) WHERE prompt_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_kp_entity_refs_collection_rev
+    ON knowledge_page_entity_refs (collection_id) WHERE collection_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_kp_entity_refs_ref_page_rev
+    ON knowledge_page_entity_refs (ref_page_id) WHERE ref_page_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_kp_entity_refs_connection_rev
+    ON knowledge_page_entity_refs (connection_kind, connection_name) WHERE connection_kind IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_kp_entity_refs_urn_rev
+    ON knowledge_page_entity_refs (entity_urn) WHERE entity_urn IS NOT NULL;

--- a/pkg/portal/knowledge_page_handler.go
+++ b/pkg/portal/knowledge_page_handler.go
@@ -48,6 +48,7 @@ func (h *Handler) registerKnowledgePageRoutes() {
 	h.mux.HandleFunc("GET /api/v1/portal/knowledge-pages/{id}/refs", h.listKnowledgePageRefs)
 	h.mux.HandleFunc("PUT /api/v1/portal/knowledge-pages/{id}/refs", h.setKnowledgePageRefs)
 	h.mux.HandleFunc("POST /api/v1/portal/knowledge-pages/refs/resolve", h.resolveKnowledgePageRefs)
+	h.mux.HandleFunc("GET /api/v1/portal/knowledge-pages/backlinks", h.knowledgePageBacklinks)
 }
 
 // knowledgePageRequest is the create/update payload.

--- a/pkg/portal/knowledge_page_handler_test.go
+++ b/pkg/portal/knowledge_page_handler_test.go
@@ -34,6 +34,13 @@ type mockKnowledgePageStore struct {
 
 	refs    []knowledgepage.EntityRef
 	refsErr error
+
+	referencingPages []knowledgepage.PageRef
+	referencingErr   error
+}
+
+func (m *mockKnowledgePageStore) ListPagesReferencing(_ context.Context, _ knowledgepage.EntityRef) ([]knowledgepage.PageRef, error) {
+	return m.referencingPages, m.referencingErr
 }
 
 func (m *mockKnowledgePageStore) Insert(_ context.Context, p knowledgepage.Page) error {

--- a/pkg/portal/knowledge_page_refs_handler.go
+++ b/pkg/portal/knowledge_page_refs_handler.go
@@ -157,6 +157,52 @@ func (h *Handler) setKnowledgePageRefs(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, knowledgePageRefsResponse{Refs: h.resolveAndFilterRefs(r, user, updated)})
 }
 
+// backlinksResponse lists the knowledge pages that reference an entity.
+type backlinksResponse struct {
+	Pages []knowledgepage.PageRef `json:"pages"`
+}
+
+// knowledgePageBacklinks handles GET /api/v1/portal/knowledge-pages/backlinks?urn=.
+//
+// @Summary      List knowledge pages that reference an entity
+// @Description  Reverse lookup: returns the knowledge pages that reference the given entity (by serialized URN), so an entity view can surface "N knowledge pages reference this". Returns empty for an entity the viewer cannot access.
+// @Tags         Knowledge
+// @Produce      json
+// @Param        urn  query  string  true  "Serialized entity URN (mcp:/urn:li:)"
+// @Success      200  {object}  backlinksResponse
+// @Failure      400  {object}  problemDetail
+// @Failure      401  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/knowledge-pages/backlinks [get]
+func (h *Handler) knowledgePageBacklinks(w http.ResponseWriter, r *http.Request) {
+	user := GetUser(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, errAuthRequired)
+		return
+	}
+	ref, err := knowledgepage.ParseEntityRef(r.URL.Query().Get("urn"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// Don't reveal back-references for an entity the viewer cannot access (the
+	// same access model the forward lookup applies).
+	if !h.resolveRef(r, user, ref.URN(), ref).Accessible {
+		writeJSON(w, http.StatusOK, backlinksResponse{Pages: []knowledgepage.PageRef{}})
+		return
+	}
+	pages, err := h.deps.KnowledgePageStore.ListPagesReferencing(r.Context(), ref)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list referencing pages")
+		return
+	}
+	if pages == nil {
+		pages = []knowledgepage.PageRef{}
+	}
+	writeJSON(w, http.StatusOK, backlinksResponse{Pages: pages})
+}
+
 // resolveRefsRequest carries the serialized URNs the renderer wants resolved.
 type resolveRefsRequest struct {
 	URNs []string `json:"urns"`

--- a/pkg/portal/knowledge_page_refs_handler_test.go
+++ b/pkg/portal/knowledge_page_refs_handler_test.go
@@ -189,6 +189,48 @@ func TestResolveKnowledgePageRefs_PageNotFound(t *testing.T) {
 	assert.Equal(t, "gone", resp.Refs[0].Label)
 }
 
+type backlinksResp struct {
+	Pages []knowledgepage.PageRef `json:"pages"`
+}
+
+func TestKnowledgePageBacklinks(t *testing.T) {
+	pages := []knowledgepage.PageRef{{ID: "kp1", Slug: "fiscal", Title: "Fiscal Calendar"}}
+
+	t.Run("returns referencing pages for an accessible entity", func(t *testing.T) {
+		store := &mockKnowledgePageStore{referencingPages: pages}
+		h := newKnowledgePageHandler(store, kpViewer)
+		w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/backlinks?urn=urn:li:dataset:x", "")
+		require.Equal(t, http.StatusOK, w.Code)
+		var resp backlinksResp
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		require.Len(t, resp.Pages, 1)
+		assert.Equal(t, "Fiscal Calendar", resp.Pages[0].Title)
+	})
+
+	t.Run("inaccessible entity returns no backlinks", func(t *testing.T) {
+		// No AssetStore -> the asset is inaccessible, so its back-references are hidden.
+		store := &mockKnowledgePageStore{referencingPages: pages}
+		h := newKnowledgePageHandler(store, kpViewer)
+		w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/backlinks?urn=mcp:asset:secret", "")
+		require.Equal(t, http.StatusOK, w.Code)
+		var resp backlinksResp
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Empty(t, resp.Pages)
+	})
+
+	t.Run("bad urn is 400", func(t *testing.T) {
+		h := newKnowledgePageHandler(&mockKnowledgePageStore{}, kpViewer)
+		w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/backlinks?urn=garbage", "")
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		h := newKnowledgePageHandler(&mockKnowledgePageStore{}, nil)
+		w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/backlinks?urn=urn:li:dataset:x", "")
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}
+
 func TestResolveKnowledgePageRefs_Unauthenticated(t *testing.T) {
 	h := newKnowledgePageHandler(&mockKnowledgePageStore{}, nil)
 	w := doKP(h, "POST", "/api/v1/portal/knowledge-pages/refs/resolve", `{"urns":[]}`)

--- a/pkg/portal/knowledgepage/reverse.go
+++ b/pkg/portal/knowledgepage/reverse.go
@@ -1,0 +1,84 @@
+package knowledgepage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// PageRef identifies a knowledge page that references an entity. It is the result
+// of the reverse lookup (the pages that reference a target), the counterpart of
+// ListEntityRefs (a page's references).
+type PageRef struct {
+	ID    string `json:"id"`
+	Slug  string `json:"slug"`
+	Title string `json:"title"`
+}
+
+// reverseLookupFilter returns the WHERE clause and arguments that select the
+// references pointing at the given target, or ("", nil) for an unknown type. The
+// clause is a fixed literal per type; the target values are returned as args and
+// bound as query parameters, never concatenated into the SQL.
+func reverseLookupFilter(ref EntityRef) (where string, args []any) {
+	switch ref.TargetType {
+	case RefTargetAsset:
+		return "r.asset_id = $1", []any{ref.AssetID}
+	case RefTargetPrompt:
+		return "r.prompt_id = $1", []any{ref.PromptID}
+	case RefTargetCollection:
+		return "r.collection_id = $1", []any{ref.CollectionID}
+	case RefTargetKnowledgePage:
+		return "r.ref_page_id = $1", []any{ref.RefPageID}
+	case RefTargetConnection:
+		return "r.connection_kind = $1 AND r.connection_name = $2", connArgs(ref)
+	case RefTargetDataHub:
+		return "r.entity_urn = $1", []any{ref.EntityURN}
+	default:
+		return "", nil
+	}
+}
+
+// connArgs builds the two bound parameters for a connection reverse lookup. The
+// fixed-capacity make plus append avoids a slice-literal-with-field pattern that
+// the unbounded-make-slice-capacity rule false-positives on.
+func connArgs(ref EntityRef) []any {
+	args := make([]any, 0, 2)
+	return append(args, ref.ConnectionKind, ref.ConnectionName)
+}
+
+// ListPagesReferencing returns the live knowledge pages that reference the given
+// target entity, the reverse of ListEntityRefs. The query is indexed per target
+// type (migration 000074).
+func (s *postgresStore) ListPagesReferencing(ctx context.Context, ref EntityRef) ([]PageRef, error) { //nolint:revive // interface impl
+	where, args := reverseLookupFilter(ref)
+	if where == "" {
+		return nil, nil
+	}
+	// #nosec G202 -- `where` is a fixed literal clause from reverseLookupFilter;
+	// the target values are bound as query parameters via args, not concatenated.
+	query := `SELECT DISTINCT p.id, p.slug, p.title
+		FROM knowledge_page_entity_refs r
+		JOIN portal_knowledge_pages p ON p.id = r.page_id
+		WHERE ` + where + ` AND p.deleted_at IS NULL
+		ORDER BY p.title`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying referencing pages: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // best-effort cleanup after read-only query
+
+	var pages []PageRef
+	for rows.Next() {
+		var p PageRef
+		var slug sql.NullString
+		if err := rows.Scan(&p.ID, &slug, &p.Title); err != nil {
+			return nil, fmt.Errorf("scanning referencing page: %w", err)
+		}
+		p.Slug = slug.String
+		pages = append(pages, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating referencing pages: %w", err)
+	}
+	return pages, nil
+}

--- a/pkg/portal/knowledgepage/reverse_test.go
+++ b/pkg/portal/knowledgepage/reverse_test.go
@@ -1,0 +1,88 @@
+package knowledgepage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore_ListPagesReferencing(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+	store := NewPostgresStore(db)
+
+	mock.ExpectQuery("FROM knowledge_page_entity_refs r.*JOIN portal_knowledge_pages.*r.asset_id = ").
+		WithArgs("asset-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "slug", "title"}).
+			AddRow("kp1", "fiscal", "Fiscal Calendar").
+			AddRow("kp2", nil, "Revenue"))
+
+	pages, err := store.ListPagesReferencing(context.Background(),
+		EntityRef{TargetType: RefTargetAsset, AssetID: "asset-1"})
+	require.NoError(t, err)
+	require.Len(t, pages, 2)
+	assert.Equal(t, "Fiscal Calendar", pages[0].Title)
+	assert.Equal(t, "fiscal", pages[0].Slug)
+	assert.Equal(t, "", pages[1].Slug) // NULL slug
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStore_ListPagesReferencing_Connection(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+	store := NewPostgresStore(db)
+
+	mock.ExpectQuery("connection_kind = .* AND r.connection_name = ").
+		WithArgs("trino", "warehouse").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "slug", "title"}).AddRow("kp1", "p", "P"))
+
+	pages, err := store.ListPagesReferencing(context.Background(),
+		EntityRef{TargetType: RefTargetConnection, ConnectionKind: "trino", ConnectionName: "warehouse"})
+	require.NoError(t, err)
+	require.Len(t, pages, 1)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReverseLookupFilter(t *testing.T) {
+	cases := []struct {
+		ref   EntityRef
+		where string
+		args  []any
+	}{
+		{EntityRef{TargetType: RefTargetAsset, AssetID: "a"}, "r.asset_id = $1", []any{"a"}},
+		{EntityRef{TargetType: RefTargetPrompt, PromptID: "p"}, "r.prompt_id = $1", []any{"p"}},
+		{EntityRef{TargetType: RefTargetCollection, CollectionID: "c"}, "r.collection_id = $1", []any{"c"}},
+		{EntityRef{TargetType: RefTargetKnowledgePage, RefPageID: "kp"}, "r.ref_page_id = $1", []any{"kp"}},
+		{EntityRef{TargetType: RefTargetConnection, ConnectionKind: "k", ConnectionName: "n"}, "r.connection_kind = $1 AND r.connection_name = $2", []any{"k", "n"}},
+		{EntityRef{TargetType: RefTargetDataHub, EntityURN: "u"}, "r.entity_urn = $1", []any{"u"}},
+		{EntityRef{TargetType: "bogus"}, "", nil},
+	}
+	for _, c := range cases {
+		where, args := reverseLookupFilter(c.ref)
+		assert.Equal(t, c.where, where, c.ref.TargetType)
+		assert.Equal(t, c.args, args, c.ref.TargetType)
+	}
+}
+
+func TestStore_ListPagesReferencing_UnknownTypeAndError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+	store := NewPostgresStore(db)
+
+	// Unknown target type makes no query and returns no pages.
+	pages, err := store.ListPagesReferencing(context.Background(), EntityRef{TargetType: "bogus"})
+	require.NoError(t, err)
+	assert.Nil(t, pages)
+
+	// A query error propagates.
+	mock.ExpectQuery("entity_urn = ").WithArgs("urn:li:dataset:x").WillReturnError(errBoom)
+	_, err = store.ListPagesReferencing(context.Background(),
+		EntityRef{TargetType: RefTargetDataHub, EntityURN: "urn:li:dataset:x"})
+	require.Error(t, err)
+}

--- a/pkg/portal/knowledgepage/store.go
+++ b/pkg/portal/knowledgepage/store.go
@@ -95,6 +95,8 @@ type Store interface {
 	AddEntityRefs(ctx context.Context, pageID string, refs []EntityRef) error
 	ReplaceEntityRefs(ctx context.Context, pageID string, refs []EntityRef) error
 	ReplaceEntityRefsBySource(ctx context.Context, pageID, source string, refs []EntityRef) error
+	// ListPagesReferencing is the reverse lookup: the pages that reference a target.
+	ListPagesReferencing(ctx context.Context, ref EntityRef) ([]PageRef, error)
 }
 
 // ErrNotFound is returned when a page id/slug does not resolve to a

--- a/ui/src/api/portal/hooks.ts
+++ b/ui/src/api/portal/hooks.ts
@@ -1318,3 +1318,26 @@ export function useSetKnowledgePageRefs(id: string) {
     },
   });
 }
+
+/** KnowledgeBacklink is a knowledge page that references an entity (reverse lookup). */
+export interface KnowledgeBacklink {
+  id: string;
+  slug: string;
+  title: string;
+}
+
+/**
+ * useKnowledgeBacklinks lists the knowledge pages that reference an entity (#664
+ * Phase 4), so an entity view can surface "N knowledge pages reference this". The
+ * server returns nothing for an entity the viewer cannot access.
+ */
+export function useKnowledgeBacklinks(urn: string | undefined) {
+  return useQuery({
+    queryKey: ["knowledge-backlinks", urn],
+    queryFn: () =>
+      apiFetch<{ pages: KnowledgeBacklink[] }>(
+        `/knowledge-pages/backlinks?urn=${encodeURIComponent(urn ?? "")}`,
+      ),
+    enabled: !!urn,
+  });
+}

--- a/ui/src/components/AssetViewer.tsx
+++ b/ui/src/components/AssetViewer.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Share2, Pencil, Trash2, Download, ChevronRight, ChevronLeft,
 import { useQueryClient } from "@tanstack/react-query";
 import type { Asset, AssetVersion, SharePermission } from "@/api/portal/types";
 import { ContentRenderer } from "@/components/renderers/ContentRenderer";
+import { KnowledgeBacklinks } from "@/components/knowledge/KnowledgeBacklinks";
 import { ProvenancePanel } from "@/components/ProvenancePanel";
 import { VersionHistoryPanel } from "@/components/VersionHistoryPanel";
 import { ShareDialog } from "@/components/ShareDialog";
@@ -288,6 +289,8 @@ export function AssetViewer({
             {sidebarOpen ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
           </button>
         </div>
+
+        <KnowledgeBacklinks urn={`mcp:asset:${asset.id}`} onNavigate={onNavigate} />
 
         {/* View mode toggle + version dropdown + save button */}
         <div className="flex items-center gap-2">

--- a/ui/src/components/knowledge/KnowledgeBacklinks.test.tsx
+++ b/ui/src/components/knowledge/KnowledgeBacklinks.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+
+vi.mock("@/api/portal/hooks", () => ({
+  useKnowledgeBacklinks: (urn: string) => ({
+    data: urn === "mcp:asset:none" ? { pages: [] } : { pages: [{ id: "kp1", slug: "fiscal", title: "Fiscal Calendar" }] },
+  }),
+}));
+
+import { KnowledgeBacklinks } from "./KnowledgeBacklinks";
+
+describe("KnowledgeBacklinks", () => {
+  it("surfaces the referencing pages with a count", () => {
+    const onNavigate = vi.fn();
+    const { container } = render(<KnowledgeBacklinks urn="mcp:asset:a1" onNavigate={onNavigate} />);
+    const text = container.textContent ?? "";
+    expect(text).toContain("1 knowledge page references this");
+    expect(text).toContain("Fiscal Calendar");
+    fireEvent.click(container.querySelector("button")!);
+    expect(onNavigate).toHaveBeenCalledWith("/knowledge#knowledge");
+  });
+
+  it("renders nothing when there are no referencing pages", () => {
+    const { container } = render(<KnowledgeBacklinks urn="mcp:asset:none" />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/ui/src/components/knowledge/KnowledgeBacklinks.tsx
+++ b/ui/src/components/knowledge/KnowledgeBacklinks.tsx
@@ -1,0 +1,43 @@
+import { BookOpen } from "lucide-react";
+import { useKnowledgeBacklinks } from "@/api/portal/hooks";
+
+/**
+ * KnowledgeBacklinks surfaces the knowledge pages that reference an entity (the
+ * reverse lookup, #664 Phase 4) on that entity's view: "N knowledge pages
+ * reference this", with each page title. It renders nothing when there are no
+ * accessible referencing pages. Clicking a title navigates to the Knowledge area
+ * when an onNavigate handler is provided.
+ */
+export function KnowledgeBacklinks({
+  urn,
+  onNavigate,
+}: {
+  urn: string;
+  onNavigate?: (path: string) => void;
+}) {
+  const { data } = useKnowledgeBacklinks(urn);
+  const pages = data?.pages ?? [];
+  if (pages.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-3">
+      <p className="mb-2 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <BookOpen className="h-3.5 w-3.5" />
+        {pages.length} knowledge {pages.length === 1 ? "page references" : "pages reference"} this
+      </p>
+      <div className="flex flex-wrap gap-1.5">
+        {pages.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => onNavigate?.("/knowledge#knowledge")}
+            disabled={!onNavigate}
+            className="rounded-md border border-border px-2 py-1 text-xs text-foreground hover:bg-muted disabled:cursor-default disabled:hover:bg-transparent"
+          >
+            {p.title}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/collections/CollectionViewerPage.tsx
+++ b/ui/src/pages/collections/CollectionViewerPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ArrowLeft, Pencil, Share2, Trash2, AlertTriangle, FileText, Image, Code, File, Table2 } from "lucide-react";
 import { useCollection, useDeleteCollection, useUpdateCollectionConfig } from "@/api/portal/hooks";
+import { KnowledgeBacklinks } from "@/components/knowledge/KnowledgeBacklinks";
 import { AuthImg } from "@/components/AuthImg";
 import { MarkdownRenderer } from "@/components/renderers/MarkdownRenderer";
 import { ShareDialog } from "@/components/ShareDialog";
@@ -145,6 +146,8 @@ export function CollectionViewerPage({ collectionId, onNavigate, onBack }: Props
           </div>
         )}
       </div>
+
+      <KnowledgeBacklinks urn={`mcp:collection:${collectionId}`} onNavigate={onNavigate} />
 
       {/* Sections */}
       {coll.sections.map((section) => (

--- a/ui/src/pages/knowledge-pages/KnowledgePagesPage.tsx
+++ b/ui/src/pages/knowledge-pages/KnowledgePagesPage.tsx
@@ -17,6 +17,7 @@ import { MarkdownRenderer } from "@/components/renderers/MarkdownRenderer";
 import { extractRefUrns } from "@/lib/entityRefs";
 import { RelatedPanel } from "@/components/knowledge/RelatedPanel";
 import { RefPicker } from "@/components/knowledge/RefPicker";
+import { KnowledgeBacklinks } from "@/components/knowledge/KnowledgeBacklinks";
 import { FeedbackButton } from "@/components/feedback/FeedbackButton";
 import { useAuthStore } from "@/stores/auth";
 import { parseTags } from "@/lib/tags";
@@ -346,6 +347,7 @@ function KnowledgePageDetail({
       </article>
 
       <RelatedPanel pageId={id} />
+      <KnowledgeBacklinks urn={`mcp:knowledge_page:${id}`} />
       {canEdit && <RefPicker pageId={id} />}
     </div>
   );

--- a/ui/src/pages/prompts/PromptViewerPage.tsx
+++ b/ui/src/pages/prompts/PromptViewerPage.tsx
@@ -20,6 +20,7 @@ import {
   ArrowUpCircle,
 } from "lucide-react";
 import { useMyPrompts, useUpdateMyPrompt, useDeleteMyPrompt, useCreateAsset, useSharedPrompts } from "@/api/portal/hooks";
+import { KnowledgeBacklinks } from "@/components/knowledge/KnowledgeBacklinks";
 import { useAuthStore } from "@/stores/auth";
 import { ShareDialog } from "@/components/ShareDialog";
 import { FeedbackButton } from "@/components/feedback/FeedbackButton";
@@ -420,6 +421,8 @@ export function PromptViewerPage({ promptId, onNavigate, onBack }: Props) {
           </>
         )}
       </div>
+
+      <KnowledgeBacklinks urn={`mcp:prompt:${promptId}`} onNavigate={onNavigate} />
 
       {/* Notices */}
       {error && (


### PR DESCRIPTION
Phase 4 of #664, building on Phases 0-3 (#666, #667, #669, #670). Does not close the issue: Phase 5 (backfill), the insight reference table, the agent/MCP cross-enrichment surface, and a deep-link UX follow-up remain open.

## Summary

Knowledge pages already show the entities they reference (the Phase 3 "Related" panel). This closes the loop: each entity now surfaces the knowledge pages that reference it, via an indexed reverse lookup, on the asset, prompt, collection, and knowledge-page views.

## Backend

- **Migration 000074** adds per-target-column indexes on `knowledge_page_entity_refs` (asset, prompt, collection, ref_page, the composite `(connection_kind, connection_name)`, and entity_urn), so the reverse lookup is indexed for every target type. The Phase 0 unique indexes lead with `page_id` (the forward lookup, "a page's refs") and cannot serve a target-keyed scan, so these are not redundant.
- **`ListPagesReferencing(ref)`** returns the live pages that reference a target, joined to `portal_knowledge_pages` and excluding soft-deleted pages, ordered by title.
- **`GET /api/v1/portal/knowledge-pages/backlinks?urn=`** resolves the entity from its serialized URN, applies the same access model as the forward lookup, and returns the referencing pages.

## Access model (consistent with Phase 3)

The endpoint returns back-references only for an entity the viewer can access:

- Asset, collection, prompt are gated by the viewer's owner/share access; an inaccessible entity yields no backlinks, so the endpoint never reveals which pages reference a private entity.
- Knowledge pages are org-shared (a missing page is excluded by the soft-delete filter).
- Connection and DataHub entities are platform/catalog context.

## UI

`KnowledgeBacklinks` renders "N knowledge pages reference this" with the page titles, wired into the asset viewer, prompt viewer, collection viewer, and knowledge-page detail. It renders nothing when there are no accessible referencing pages.

## Known follow-ups (called out, not bugs)

- **Deep-link:** the backlink chips navigate to the Knowledge area rather than opening the specific referenced page. The app opens a page via internal React state, not a URL, so cross-area deep-linking needs a separate mechanism.
- **Agent/MCP surface:** the bidirectional thesis also implies the agent should see "there is knowledge about this" on tool responses. That is a distinct middleware concern (with the same access filter) and is not in this phase.

## Testing

- `make verify` green: race + real-Postgres, package budget, lint, gosec/govulncheck, semgrep, CodeQL, mutation, swagger-check, GoReleaser. Patch coverage 87.8%.
- Go: the reverse query (per-type filters, the connection composite, unknown-type and error paths), `reverseLookupFilter` for every type, and the access-gated backlinks endpoint (including that an inaccessible entity yields no backlinks, a bad URN is 400, and unauthenticated is 401).
- TS/React: the `KnowledgeBacklinks` component (count text, navigation, and the empty/no-render case).
- Migration 000074 validated against a throwaway Postgres: the six reverse indexes are created and the down migration is clean.

Not done in this PR: a live light/dark screenshot pass against `make dev`.

## Acceptance (this phase)

- A page that references a connection, an asset, and a prompt: each of those entity views shows the page as a back-reference (for entities the viewer can access).
- A removed page does not appear as a back-reference (soft-delete filtered).
- The backlinks endpoint reveals nothing for an entity the viewer cannot access.

## Follow-up (open on #664)

- Phase 5: backfill existing pages from their source insights.
- The insight reference table, in whichever phase first writes insight references.
- The agent/MCP cross-enrichment surface and the page deep-link UX.
