### PR TITLE
feat(knowledge): one-time startup backfill of references for existing pages (#664 Phase 5)

### DIFF
--- a/pkg/database/migrate/migrate_realpg_test.go
+++ b/pkg/database/migrate/migrate_realpg_test.go
@@ -14,7 +14,7 @@ import (
 
 // expectedFinalVersion is the highest migration the embedded set defines. Bump
 // this when adding a migration so the gate asserts the full set applied.
-const expectedFinalVersion = 74
+const expectedFinalVersion = 75
 
 // TestMigrationsAgainstRealPostgres applies the embedded migrations to a real
 // PostgreSQL (pgvector) instance and exercises the full lifecycle: up, seed,

--- a/pkg/database/migrate/migrate_unit_test.go
+++ b/pkg/database/migrate/migrate_unit_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	migrateTestFileCount    = 148
+	migrateTestFileCount    = 150
 	migrateTestSuccess      = "success"
 	migrateTestFactoryError = "factory error"
 )

--- a/pkg/database/migrate/migrations/000075_platform_backfills.down.sql
+++ b/pkg/database/migrate/migrations/000075_platform_backfills.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS platform_backfills;

--- a/pkg/database/migrate/migrations/000075_platform_backfills.up.sql
+++ b/pkg/database/migrate/migrations/000075_platform_backfills.up.sql
@@ -1,0 +1,9 @@
+-- platform_backfills records one-time Go-level data backfills that have run, so a
+-- guarded startup task (for example the #664 Phase 5 knowledge-page reference
+-- backfill) executes once rather than on every boot. A SQL migration cannot run
+-- the Go reconcile logic itself, so the sentinel lives here and the application
+-- checks/sets it.
+CREATE TABLE IF NOT EXISTS platform_backfills (
+    name         TEXT PRIMARY KEY,
+    completed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -3286,6 +3286,12 @@ func (p *Platform) Start(ctx context.Context) error {
 	// Validate agent_instructions references against registered tools
 	p.validateAgentInstructions()
 
+	// One-time knowledge-page reference backfill (#664 Phase 5), guarded by a
+	// sentinel and run in the background so it never delays startup.
+	if p.db != nil && p.knowledgeToolkit != nil {
+		go p.knowledgeToolkit.RunGuardedBackfill(ctx, p.db, knowledgepage.NewPostgresStore(p.db))
+	}
+
 	// Start lifecycle
 	return p.lifecycle.Start(ctx)
 }

--- a/pkg/toolkits/knowledge/backfill.go
+++ b/pkg/toolkits/knowledge/backfill.go
@@ -1,0 +1,166 @@
+package knowledge
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+
+	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
+)
+
+// backfillPageBatch is the page-list batch size. It is the store's maximum list
+// limit (clampSearchLimit caps anything above 100 back down to the default), so
+// the backfill must page through with Offset rather than request all at once.
+var backfillPageBatch = 100
+
+// backfillChangesetLimit caps changesets read per page when re-deriving promoted
+// refs. A page accrues one changeset per promotion, so this is far above any real
+// count; it is the changeset store's maximum (EffectiveLimit caps above 100).
+const backfillChangesetLimit = 100
+
+// logKeyError is the structured-log key for an error value.
+const logKeyError = "error"
+
+// backfillSentinelName keys this backfill's row in platform_backfills.
+const backfillSentinelName = "kp_entity_refs_v1"
+
+// RunGuardedBackfill runs BackfillPageRefs once, guarded by the platform_backfills
+// sentinel: if the sentinel is absent it runs the backfill and records it. It is
+// idempotent and leaves the sentinel unset on failure so it retries on the next
+// start. Failures are logged, never fatal. Intended to be called in a goroutine at
+// startup.
+func (t *Toolkit) RunGuardedBackfill(ctx context.Context, db *sql.DB, pages knowledgepage.Store) {
+	if db == nil {
+		return
+	}
+	var exists bool
+	if err := db.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM platform_backfills WHERE name = $1)`, backfillSentinelName).Scan(&exists); err != nil {
+		slog.WarnContext(ctx, "knowledge-page ref backfill: sentinel check failed", logKeyError, err)
+		return
+	}
+	if exists {
+		return
+	}
+	stats, err := t.BackfillPageRefs(ctx, pages)
+	if err != nil {
+		slog.WarnContext(ctx, "knowledge-page ref backfill failed", logKeyError, err)
+		return
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO platform_backfills (name) VALUES ($1) ON CONFLICT (name) DO NOTHING`, backfillSentinelName); err != nil {
+		slog.WarnContext(ctx, "knowledge-page ref backfill: marking sentinel failed", logKeyError, err)
+		return
+	}
+	slog.InfoContext(ctx, "knowledge-page ref backfill complete",
+		"pages_scanned", stats.PagesScanned, "inline_refs", stats.InlineRefs, "promoted_refs", stats.PromotedRefs)
+}
+
+// BackfillStats reports what a reference backfill touched.
+type BackfillStats struct {
+	PagesScanned int `json:"pages_scanned"`
+	InlineRefs   int `json:"inline_refs"`
+	PromotedRefs int `json:"promoted_refs"`
+}
+
+// BackfillPageRefs re-derives entity references for existing knowledge pages, so
+// pages that predate the reference feature get their references without a manual
+// re-save (#664 Phase 5). For each live page it:
+//
+//  1. re-scans the body for inline references and reconciles them as source=inline
+//     (the same reconcile a page save performs); and
+//  2. re-derives the references the page's source insights carried, via the
+//     page's changesets, and adds them as source=promoted.
+//
+// It is idempotent (the inline reconcile is a source-scoped replace, the promoted
+// add unions) and best-effort per page: a page whose reference cannot be written
+// (for example an inline mention of a since-deleted entity, the same case the live
+// save path swallows) is logged and skipped, so one bad page never aborts the
+// pass. Only a failure to list pages is returned. Pages are processed in batches
+// because the store caps a single list at backfillPageBatch.
+func (t *Toolkit) BackfillPageRefs(ctx context.Context, pages knowledgepage.Store) (BackfillStats, error) {
+	var stats BackfillStats
+	for offset := 0; ; offset += backfillPageBatch {
+		batch, _, err := pages.List(ctx, knowledgepage.Filter{Limit: backfillPageBatch, Offset: offset})
+		if err != nil {
+			return stats, fmt.Errorf("listing pages for backfill: %w", err)
+		}
+		for i := range batch {
+			t.backfillPage(ctx, pages, batch[i], &stats)
+		}
+		if len(batch) < backfillPageBatch {
+			return stats, nil
+		}
+	}
+}
+
+// backfillPage reconciles one page's inline and promoted references, best-effort:
+// a per-page write failure is logged and skipped rather than aborting the pass.
+func (t *Toolkit) backfillPage(ctx context.Context, pages knowledgepage.Store, page knowledgepage.Page, stats *BackfillStats) {
+	stats.PagesScanned++
+
+	inline := knowledgepage.ScanBodyRefs(page.Body)
+	if err := pages.ReplaceEntityRefsBySource(ctx, page.ID, knowledgepage.RefSourceInline, inline); err != nil {
+		slog.WarnContext(ctx, "backfill: reconciling inline refs failed", "page_id", page.ID, logKeyError, err)
+	} else {
+		stats.InlineRefs += len(inline)
+	}
+
+	urns, err := t.pageSourceURNs(ctx, page.Slug)
+	if err != nil {
+		slog.WarnContext(ctx, "backfill: gathering source URNs failed", "page_id", page.ID, logKeyError, err)
+		return
+	}
+	if len(urns) > 0 {
+		if err := pages.AddEntityRefs(ctx, page.ID, dataHubRefs(urns)); err != nil {
+			slog.WarnContext(ctx, "backfill: adding promoted refs failed", "page_id", page.ID, logKeyError, err)
+			return
+		}
+		stats.PromotedRefs += len(urns)
+	}
+}
+
+// pageSourceURNs gathers the de-duplicated entity URNs the page's source insights
+// carried, found via the page's changesets (target_urn = "kp:<slug>"). A page with
+// no slug or no recoverable changeset/insight yields none.
+func (t *Toolkit) pageSourceURNs(ctx context.Context, slug string) ([]string, error) {
+	if t.changesetStore == nil || slug == "" {
+		return nil, nil
+	}
+	css, _, err := t.changesetStore.ListChangesets(ctx, ChangesetFilter{
+		EntityURN: pageTargetPrefix + slug,
+		Limit:     backfillChangesetLimit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing changesets for page %q: %w", slug, err)
+	}
+	seen := map[string]struct{}{}
+	var urns []string
+	for _, cs := range css {
+		urns = t.appendInsightURNs(ctx, cs.SourceInsightIDs, seen, urns)
+	}
+	return urns, nil
+}
+
+// appendInsightURNs appends the de-duplicated entity URNs carried by the given
+// insights (skipping drained/deleted ones) to urns, recording each in seen.
+func (t *Toolkit) appendInsightURNs(ctx context.Context, insightIDs []string, seen map[string]struct{}, urns []string) []string {
+	for _, insightID := range insightIDs {
+		ins, err := t.store.Get(ctx, insightID)
+		if err != nil || ins == nil {
+			continue // a drained or deleted insight is simply unrecoverable
+		}
+		for _, urn := range ins.EntityURNs {
+			if urn == "" {
+				continue
+			}
+			if _, dup := seen[urn]; dup {
+				continue
+			}
+			seen[urn] = struct{}{}
+			urns = append(urns, urn)
+		}
+	}
+	return urns
+}

--- a/pkg/toolkits/knowledge/backfill_test.go
+++ b/pkg/toolkits/knowledge/backfill_test.go
@@ -1,0 +1,298 @@
+package knowledge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
+)
+
+// fakeBackfillStore is a knowledgepage.Store that records the inline and promoted
+// references the backfill writes; the unused methods are stubs.
+type fakeBackfillStore struct {
+	pages       []knowledgepage.Page
+	inline      map[string][]knowledgepage.EntityRef
+	promoted    map[string][]knowledgepage.EntityRef
+	listErr     error
+	inlineErr   error // ReplaceEntityRefsBySource error (best-effort path)
+	promotedErr error // AddEntityRefs error (best-effort path)
+	listCalls   int
+}
+
+func newFakeBackfillStore(pages ...knowledgepage.Page) *fakeBackfillStore {
+	return &fakeBackfillStore{
+		pages:    pages,
+		inline:   map[string][]knowledgepage.EntityRef{},
+		promoted: map[string][]knowledgepage.EntityRef{},
+	}
+}
+
+// List honors Offset and Limit so the backfill's pagination is exercised (and
+// terminates), mirroring the real store rather than masking it.
+func (f *fakeBackfillStore) List(_ context.Context, filter knowledgepage.Filter) ([]knowledgepage.Page, int, error) {
+	f.listCalls++
+	if f.listErr != nil {
+		return nil, 0, f.listErr
+	}
+	start := min(filter.Offset, len(f.pages))
+	end := start + filter.Limit
+	if filter.Limit <= 0 || end > len(f.pages) {
+		end = len(f.pages)
+	}
+	return f.pages[start:end], len(f.pages), nil
+}
+
+func (f *fakeBackfillStore) ReplaceEntityRefsBySource(_ context.Context, pageID, _ string, refs []knowledgepage.EntityRef) error {
+	if f.inlineErr != nil {
+		return f.inlineErr
+	}
+	f.inline[pageID] = refs
+	return nil
+}
+
+func (f *fakeBackfillStore) AddEntityRefs(_ context.Context, pageID string, refs []knowledgepage.EntityRef) error {
+	if f.promotedErr != nil {
+		return f.promotedErr
+	}
+	f.promoted[pageID] = append(f.promoted[pageID], refs...)
+	return nil
+}
+
+// --- unused Store methods (stubs).
+func (*fakeBackfillStore) Insert(context.Context, knowledgepage.Page) error { return nil }
+
+func (*fakeBackfillStore) Get(context.Context, string) (*knowledgepage.Page, error) {
+	return nil, knowledgepage.ErrNotFound
+}
+
+func (*fakeBackfillStore) GetBySlug(context.Context, string) (*knowledgepage.Page, error) {
+	return nil, knowledgepage.ErrNotFound
+}
+func (*fakeBackfillStore) Update(context.Context, string, knowledgepage.Update) error { return nil }
+func (*fakeBackfillStore) SoftDelete(context.Context, string) error                   { return nil }
+func (*fakeBackfillStore) ListVersions(context.Context, string, int, int) ([]knowledgepage.Version, int, error) {
+	return nil, 0, nil
+}
+
+func (*fakeBackfillStore) GetVersion(context.Context, string, int) (*knowledgepage.Version, error) {
+	return nil, knowledgepage.ErrNotFound
+}
+
+func (*fakeBackfillStore) ListEntityRefs(context.Context, string) ([]knowledgepage.EntityRef, error) {
+	return nil, nil
+}
+
+func (*fakeBackfillStore) ReplaceEntityRefs(context.Context, string, []knowledgepage.EntityRef) error {
+	return nil
+}
+
+func (*fakeBackfillStore) ListPagesReferencing(context.Context, knowledgepage.EntityRef) ([]knowledgepage.PageRef, error) {
+	return nil, nil
+}
+
+// filterCSStore is a ChangesetStore that respects the EntityURN (target) filter,
+// so the backfill's per-page changeset query is exercised correctly.
+type filterCSStore struct{ byTarget map[string][]Changeset }
+
+func (s *filterCSStore) ListChangesets(_ context.Context, f ChangesetFilter) ([]Changeset, int, error) {
+	cs := s.byTarget[f.EntityURN]
+	return cs, len(cs), nil
+}
+func (*filterCSStore) InsertChangeset(context.Context, Changeset) error { return nil }
+func (*filterCSStore) GetChangeset(context.Context, string) (*Changeset, error) {
+	return nil, nil //nolint:nilnil // unused stub
+}
+func (*filterCSStore) RollbackChangeset(context.Context, string, string) error { return nil }
+
+func TestBackfillPageRefs(t *testing.T) {
+	store := newFakeBackfillStore(
+		// kp1 has an inline body ref AND a changeset source insight (promoted).
+		knowledgepage.Page{ID: "kp1", Slug: "fiscal", Body: "see [a](mcp:asset:asset-1) and urn:li:glossaryTerm:revenue"},
+		// kp2 has neither -> no refs.
+		knowledgepage.Page{ID: "kp2", Slug: "empty", Body: "just prose"},
+	)
+	csStore := &filterCSStore{byTarget: map[string][]Changeset{
+		"kp:fiscal": {{TargetURN: "kp:fiscal", ChangeType: changeCreatePage, SourceInsightIDs: []string{"ins-1"}}},
+	}}
+	insightStore := &fullSpyStore{Insights: []Insight{
+		{ID: "ins-1", EntityURNs: []string{"urn:li:dataset:promoted-x"}},
+	}}
+	tk := newApplyToolkit(t, insightStore, csStore, &spyWriter{})
+
+	stats, err := tk.BackfillPageRefs(context.Background(), store)
+	require.NoError(t, err)
+	assert.Equal(t, 2, stats.PagesScanned)
+
+	// kp1 inline: the two body references reconciled as inline.
+	inline := refURNset(store.inline["kp1"])
+	assert.Contains(t, inline, "mcp:asset:asset-1")
+	assert.Contains(t, inline, "urn:li:glossaryTerm:revenue")
+	// kp1 promoted: the insight's entity URN, source=promoted.
+	require.Len(t, store.promoted["kp1"], 1)
+	assert.Equal(t, "urn:li:dataset:promoted-x", store.promoted["kp1"][0].EntityURN)
+	assert.Equal(t, knowledgepage.RefSourcePromoted, store.promoted["kp1"][0].Source)
+
+	// kp2: inline reconciled to empty (no refs), no promoted.
+	assert.Empty(t, store.inline["kp2"])
+	assert.Empty(t, store.promoted["kp2"])
+}
+
+func TestBackfillPageRefs_EdgesAndError(t *testing.T) {
+	// A List error aborts the backfill.
+	errStore := newFakeBackfillStore()
+	errStore.listErr = errors.New("list boom")
+	tk := newApplyToolkit(t, &fullSpyStore{}, &filterCSStore{byTarget: map[string][]Changeset{}}, &spyWriter{})
+	_, err := tk.BackfillPageRefs(context.Background(), errStore)
+	require.Error(t, err)
+
+	// An empty-slug page gets no promoted refs (no changeset link), and a
+	// changeset whose source insight is gone is skipped, not fatal.
+	store := newFakeBackfillStore(
+		knowledgepage.Page{ID: "kp3", Slug: "", Body: "no refs"},
+		knowledgepage.Page{ID: "kp4", Slug: "has-cs", Body: ""},
+	)
+	cs := &filterCSStore{byTarget: map[string][]Changeset{
+		"kp:has-cs": {{SourceInsightIDs: []string{"missing-insight"}}},
+	}}
+	tk2 := newApplyToolkit(t, &fullSpyStore{}, cs, &spyWriter{}) // no insights -> Get not found
+	stats, err := tk2.BackfillPageRefs(context.Background(), store)
+	require.NoError(t, err)
+	assert.Equal(t, 2, stats.PagesScanned)
+	assert.Empty(t, store.promoted["kp3"])
+	assert.Empty(t, store.promoted["kp4"])
+}
+
+func TestBackfillPageRefs_Paginates(t *testing.T) {
+	orig := backfillPageBatch
+	backfillPageBatch = 2
+	defer func() { backfillPageBatch = orig }()
+
+	pages := make([]knowledgepage.Page, 5)
+	for i := range pages {
+		pages[i] = knowledgepage.Page{ID: fmt.Sprintf("kp%d", i), Slug: fmt.Sprintf("s%d", i)}
+	}
+	store := newFakeBackfillStore(pages...)
+	tk := newApplyToolkit(t, &fullSpyStore{}, &filterCSStore{byTarget: map[string][]Changeset{}}, &spyWriter{})
+
+	stats, err := tk.BackfillPageRefs(context.Background(), store)
+	require.NoError(t, err)
+	assert.Equal(t, 5, stats.PagesScanned, "every page across all batches is processed")
+	assert.GreaterOrEqual(t, store.listCalls, 3, "should page through (2 + 2 + 1)")
+}
+
+func TestBackfillPageRefs_BestEffortOnInlineError(t *testing.T) {
+	store := newFakeBackfillStore(knowledgepage.Page{ID: "kp1", Slug: "s", Body: "[a](mcp:asset:x)"})
+	store.inlineErr = errors.New("FK violation: asset gone")
+	tk := newApplyToolkit(t, &fullSpyStore{}, &filterCSStore{byTarget: map[string][]Changeset{}}, &spyWriter{})
+
+	stats, err := tk.BackfillPageRefs(context.Background(), store)
+	require.NoError(t, err, "a per-page inline error must not abort the pass")
+	assert.Equal(t, 1, stats.PagesScanned)
+	assert.Zero(t, stats.InlineRefs, "a failed inline reconcile is not counted")
+}
+
+func TestBackfillPageRefs_BestEffortOnPromotedError(t *testing.T) {
+	store := newFakeBackfillStore(knowledgepage.Page{ID: "kp1", Slug: "fiscal", Body: ""})
+	store.promotedErr = errors.New("FK violation")
+	cs := &filterCSStore{byTarget: map[string][]Changeset{
+		"kp:fiscal": {{SourceInsightIDs: []string{"ins-1"}}},
+	}}
+	insights := &fullSpyStore{Insights: []Insight{{ID: "ins-1", EntityURNs: []string{"urn:li:dataset:x"}}}}
+	tk := newApplyToolkit(t, insights, cs, &spyWriter{})
+
+	stats, err := tk.BackfillPageRefs(context.Background(), store)
+	require.NoError(t, err, "a per-page promoted-add error must not abort the pass")
+	assert.Equal(t, 1, stats.PagesScanned)
+	assert.Zero(t, stats.PromotedRefs)
+}
+
+func TestRunGuardedBackfill(t *testing.T) {
+	emptyCS := func() *filterCSStore { return &filterCSStore{byTarget: map[string][]Changeset{}} }
+
+	t.Run("runs the backfill and marks the sentinel when not yet done", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close() //nolint:errcheck // test cleanup
+		mock.ExpectQuery("SELECT EXISTS").WithArgs("kp_entity_refs_v1").
+			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+		mock.ExpectExec("INSERT INTO platform_backfills").WithArgs("kp_entity_refs_v1").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		store := newFakeBackfillStore(knowledgepage.Page{ID: "kp1", Slug: "s", Body: "[a](mcp:asset:x)"})
+		tk := newApplyToolkit(t, &fullSpyStore{}, emptyCS(), &spyWriter{})
+		tk.RunGuardedBackfill(context.Background(), db, store)
+
+		assert.Len(t, store.inline["kp1"], 1, "backfill should have reconciled the inline ref")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("skips when the sentinel already exists", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close() //nolint:errcheck // test cleanup
+		mock.ExpectQuery("SELECT EXISTS").
+			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+		store := newFakeBackfillStore(knowledgepage.Page{ID: "kp1", Body: "[a](mcp:asset:x)"})
+		tk := newApplyToolkit(t, &fullSpyStore{}, emptyCS(), &spyWriter{})
+		tk.RunGuardedBackfill(context.Background(), db, store)
+
+		assert.Empty(t, store.inline["kp1"], "backfill must be skipped when already done")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("sentinel-check error is logged, not fatal", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close() //nolint:errcheck // test cleanup
+		mock.ExpectQuery("SELECT EXISTS").WillReturnError(errors.New("db down"))
+		tk := newApplyToolkit(t, &fullSpyStore{}, emptyCS(), &spyWriter{})
+		tk.RunGuardedBackfill(context.Background(), db, newFakeBackfillStore())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("backfill error leaves the sentinel unset", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close() //nolint:errcheck // test cleanup
+		mock.ExpectQuery("SELECT EXISTS").
+			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+		// No ExpectExec: the backfill fails before the sentinel is marked.
+		errStore := newFakeBackfillStore()
+		errStore.listErr = errors.New("list boom")
+		tk := newApplyToolkit(t, &fullSpyStore{}, emptyCS(), &spyWriter{})
+		tk.RunGuardedBackfill(context.Background(), db, errStore)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("mark error is logged, not fatal", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close() //nolint:errcheck // test cleanup
+		mock.ExpectQuery("SELECT EXISTS").
+			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+		mock.ExpectExec("INSERT INTO platform_backfills").WillReturnError(errors.New("insert boom"))
+		tk := newApplyToolkit(t, &fullSpyStore{}, emptyCS(), &spyWriter{})
+		tk.RunGuardedBackfill(context.Background(), db, newFakeBackfillStore())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("nil db is a no-op", func(t *testing.T) {
+		tk := newApplyToolkit(t, &fullSpyStore{}, emptyCS(), &spyWriter{})
+		tk.RunGuardedBackfill(context.Background(), nil, newFakeBackfillStore())
+	})
+}
+
+func refURNset(refs []knowledgepage.EntityRef) []string {
+	urns := make([]string, 0, len(refs))
+	for _, r := range refs {
+		urns = append(urns, r.URN())
+	}
+	return urns
+}


### PR DESCRIPTION
Phase 5 (final) of #664, building on Phases 0-4 (#666, #667, #669, #670, #671). Does not close the issue: the standalone follow-ups (insight reference table, agent/MCP cross-enrichment, page deep-link UX) remain open.

## Summary

Knowledge pages created before the reference feature have no entity references, so the Related panel, the inline chips, and the reverse lookup are empty for them. This backfills existing pages once at startup, so they get their references without a manual re-save.

## What it does

`BackfillPageRefs`, for each live page:

1. re-scans the body for `mcp:`/`urn:li:` references and reconciles them as `source=inline` (the same reconcile a page save performs); and
2. re-derives the references the page's source insights carried, via the page's changesets (`changeset.source_insight_ids` -> insight `entity_urns`), adding them as `source=promoted`.

Both steps are idempotent: the inline reconcile is a source-scoped replace (it never touches `manual`/`promoted` rows) and the promoted add unions (`ON CONFLICT DO NOTHING`), so re-running changes nothing.

## How it runs

`RunGuardedBackfill` runs the backfill once, guarded by a `platform_backfills` sentinel (migration `000075`). On any failure it leaves the sentinel unset so it retries on the next start. It is wired as a background goroutine at startup so it never delays boot. A SQL migration can't run the Go reconcile logic, so the sentinel lives in a table and the application checks/sets it.

The orchestration and guard live in the knowledge package (not `pkg/platform`), which keeps `pkg/platform` under its size budget and makes the guard unit-testable with sqlmock.

## Correctness properties the adversarial review caught and this fixes

The `/code-review` found two feature-breaking bugs, both initially masked by test fakes that ignored the store's `Filter`:

1. **Pagination.** The page store caps a single list at 100 (and `clampSearchLimit` silently clamps anything larger back to the default 20). A naive `List(Limit: 10000)` would have processed only ~20 pages and then marked the backfill done, permanently skipping the rest. The backfill now pages through with `Offset` in batches of 100. The fake store was updated to honor limit/offset (rather than mask it), and a pagination test proves all pages across batches are processed.
2. **Best-effort per page.** A single page whose reference cannot be written (for example an inline mention of a since-deleted entity, which has a real FK) must not abort the whole pass and leave the sentinel unset forever. The backfill now logs and skips such a page, matching the live save path (`reconcileInlineRefs`), and only a failure to list pages is fatal.

## Testing

- `make verify` green: race + real-Postgres, package budget, lint, gosec/govulncheck, semgrep, CodeQL, mutation, swagger-check, GoReleaser. Patch coverage 90.3%.
- Tests cover: the inline + promoted backfill of a page; pagination across batches (with a lowered batch size); the best-effort inline-error and promoted-error paths; the per-page changeset -> insight URN derivation (including empty-slug and missing-insight skips); and the sentinel guard (runs/marks, skips when present, sentinel-check error, mark error, nil db) via sqlmock.
- Migration `000075` validated against a throwaway Postgres (table created, sentinel select/insert work, down migration clean).

## Acceptance (this phase)

- One-time: existing pages have their references re-derived from their source insights via the changeset record; pages with no recoverable source are left with whatever the body scan finds.
- The backfill is idempotent (safe to re-run) and never clobbers manual or promoted references with the inline reconcile.
- A page with a since-deleted referenced entity does not abort the backfill.

## Follow-up (open on #664)

- The insight reference table (when something writes insight references).
- The agent/MCP cross-enrichment surface (the same "there is knowledge about this", on tool responses, with the same access filter).
- The page deep-link UX for back-reference chips.
