### PR TITLE
feat(knowledge): carry all insight reference types, deep-link chips, broken-ref chip (closes #664)

### DIFF
--- a/pkg/toolkits/knowledge/backfill.go
+++ b/pkg/toolkits/knowledge/backfill.go
@@ -113,7 +113,7 @@ func (t *Toolkit) backfillPage(ctx context.Context, pages knowledgepage.Store, p
 		return
 	}
 	if len(urns) > 0 {
-		if err := pages.AddEntityRefs(ctx, page.ID, dataHubRefs(urns)); err != nil {
+		if err := pages.AddEntityRefs(ctx, page.ID, promotedRefsFromURNs(urns)); err != nil {
 			slog.WarnContext(ctx, "backfill: adding promoted refs failed", "page_id", page.ID, logKeyError, err)
 			return
 		}
@@ -151,16 +151,22 @@ func (t *Toolkit) appendInsightURNs(ctx context.Context, insightIDs []string, se
 		if err != nil || ins == nil {
 			continue // a drained or deleted insight is simply unrecoverable
 		}
-		for _, urn := range ins.EntityURNs {
-			if urn == "" {
-				continue
-			}
-			if _, dup := seen[urn]; dup {
-				continue
-			}
-			seen[urn] = struct{}{}
-			urns = append(urns, urn)
-		}
+		urns = appendUnique(urns, seen, insightReferenceURNs(ins))
 	}
 	return urns
+}
+
+// appendUnique appends each value not already in seen to dst, recording it.
+func appendUnique(dst []string, seen map[string]struct{}, values []string) []string {
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		dst = append(dst, v)
+	}
+	return dst
 }

--- a/pkg/toolkits/knowledge/backfill_test.go
+++ b/pkg/toolkits/knowledge/backfill_test.go
@@ -121,7 +121,8 @@ func TestBackfillPageRefs(t *testing.T) {
 		"kp:fiscal": {{TargetURN: "kp:fiscal", ChangeType: changeCreatePage, SourceInsightIDs: []string{"ins-1"}}},
 	}}
 	insightStore := &fullSpyStore{Insights: []Insight{
-		{ID: "ins-1", EntityURNs: []string{"urn:li:dataset:promoted-x"}},
+		// A duplicate and an empty URN exercise the de-dup/skip path.
+		{ID: "ins-1", EntityURNs: []string{"urn:li:dataset:promoted-x", "urn:li:dataset:promoted-x", ""}},
 	}}
 	tk := newApplyToolkit(t, insightStore, csStore, &spyWriter{})
 

--- a/pkg/toolkits/knowledge/page_sink.go
+++ b/pkg/toolkits/knowledge/page_sink.go
@@ -62,6 +62,7 @@ type pageWriter interface {
 	ListEntityRefs(ctx context.Context, pageID string) ([]knowledgepage.EntityRef, error)
 	AddEntityRefs(ctx context.Context, pageID string, refs []knowledgepage.EntityRef) error
 	ReplaceEntityRefs(ctx context.Context, pageID string, refs []knowledgepage.EntityRef) error
+	ReplaceEntityRefsBySource(ctx context.Context, pageID, source string, refs []knowledgepage.EntityRef) error
 }
 
 // PageReverter is the slice of the knowledge-page store a rollback needs: look up
@@ -73,8 +74,9 @@ type PageReverter interface {
 	GetBySlug(ctx context.Context, slug string) (*knowledgepage.Page, error)
 	Update(ctx context.Context, id string, updates knowledgepage.Update) error
 	SoftDelete(ctx context.Context, id string) error
-	// Entity references (#664): restore the page's references on rollback.
-	ReplaceEntityRefs(ctx context.Context, pageID string, refs []knowledgepage.EntityRef) error
+	// Entity references (#664): restore the page's promoted references on rollback,
+	// scoped to source=promoted so manual and inline references are not clobbered.
+	ReplaceEntityRefsBySource(ctx context.Context, pageID, source string, refs []knowledgepage.EntityRef) error
 }
 
 // PageEditedError is returned when a knowledge-page promotion cannot be rolled
@@ -176,8 +178,8 @@ type pagePromotion struct {
 
 // applyPagePromotion find-or-creates the page by slug, carries the source
 // insights' references onto it (union), and returns the before/after images for
-// the changeset. entityURNs are the DataHub references gathered from the source
-// insights (#664).
+// the changeset. entityURNs are the serialized references (any type) gathered
+// from the source insights (#664).
 //
 // Atomicity: the page write, the reference write, and the changeset record are
 // separate operations (the page and changeset already were before #664; the
@@ -237,8 +239,8 @@ func (t *Toolkit) applyPagePromotion(ctx context.Context, page pagePromotionInpu
 	}
 }
 
-// pageEntityURNs returns the page's current DataHub reference URNs (Phase 0 only
-// writes DataHub references, so the changeset snapshot tracks those).
+// pageEntityURNs returns the serialized URNs of the page's promoted references
+// (every type, not just DataHub), for the changeset before/after image.
 func (t *Toolkit) pageEntityURNs(ctx context.Context, pageID string) ([]string, error) {
 	refs, err := t.pageWriter.ListEntityRefs(ctx, pageID)
 	if err != nil {
@@ -246,19 +248,19 @@ func (t *Toolkit) pageEntityURNs(ctx context.Context, pageID string) ([]string, 
 	}
 	var urns []string
 	for _, r := range refs {
-		if r.TargetType == knowledgepage.RefTargetDataHub && r.EntityURN != "" {
-			urns = append(urns, r.EntityURN)
+		if r.Source == knowledgepage.RefSourcePromoted {
+			urns = append(urns, r.URN())
 		}
 	}
 	return urns, nil
 }
 
-// addPageEntityRefs unions the given DataHub URNs onto the page as promoted
-// references and returns the page's full DataHub URN set afterward (for the
-// changeset after-image).
+// addPageEntityRefs unions the given references (serialized as URNs of any type)
+// onto the page as promoted references and returns the page's full promoted URN
+// set afterward (for the changeset after-image).
 func (t *Toolkit) addPageEntityRefs(ctx context.Context, pageID string, entityURNs []string, appliedBy string) ([]string, error) {
 	if len(entityURNs) > 0 {
-		refs := dataHubRefs(entityURNs)
+		refs := promotedRefsFromURNs(entityURNs)
 		for i := range refs {
 			refs[i].CreatedBy = appliedBy
 		}
@@ -269,14 +271,19 @@ func (t *Toolkit) addPageEntityRefs(ctx context.Context, pageID string, entityUR
 	return t.pageEntityURNs(ctx, pageID)
 }
 
-// dataHubRefs builds promoted DataHub references from a list of URNs.
-func dataHubRefs(urns []string) []knowledgepage.EntityRef {
+// promotedRefsFromURNs parses serialized reference URNs (any type: a urn:li:
+// DataHub URN or an mcp: internal reference) into promoted EntityRefs. An
+// unparseable URN is skipped. This carries every reference type an insight holds
+// onto the page, not just DataHub URNs (#664).
+func promotedRefsFromURNs(urns []string) []knowledgepage.EntityRef {
 	refs := make([]knowledgepage.EntityRef, 0, len(urns))
 	for _, urn := range urns {
-		if urn == "" {
+		ref, err := knowledgepage.ParseEntityRef(urn)
+		if err != nil {
 			continue
 		}
-		refs = append(refs, knowledgepage.DataHubRef(urn, knowledgepage.RefSourcePromoted))
+		ref.Source = knowledgepage.RefSourcePromoted
+		refs = append(refs, ref)
 	}
 	return refs
 }
@@ -343,7 +350,7 @@ func (t *Toolkit) validatePageInsightClasses(ctx context.Context, insightIDs []s
 		origin = ins.SinkClass
 		// Collect the references the insight carried so they survive promotion
 		// onto the page (#664). De-duped across all source insights.
-		for _, urn := range ins.EntityURNs {
+		for _, urn := range insightReferenceURNs(ins) {
 			if urn == "" {
 				continue
 			}
@@ -355,6 +362,19 @@ func (t *Toolkit) validatePageInsightClasses(ctx context.Context, insightIDs []s
 		}
 	}
 	return origin, entityURNs, nil
+}
+
+// insightReferenceURNs returns the serialized reference URNs an insight carries:
+// its DataHub entity_urns plus the mcp:/urn:li: references mentioned inline in its
+// text. These are carried onto the page on promotion (and by the backfill), so an
+// insight's references of every type survive synthesis into a knowledge page.
+func insightReferenceURNs(ins *Insight) []string {
+	urns := make([]string, 0, len(ins.EntityURNs))
+	urns = append(urns, ins.EntityURNs...)
+	for _, ref := range knowledgepage.ScanBodyRefs(ins.InsightText) {
+		urns = append(urns, ref.URN())
+	}
+	return urns
 }
 
 // validatePagePromotion checks the caller-supplied page payload.

--- a/pkg/toolkits/knowledge/page_sink_test.go
+++ b/pkg/toolkits/knowledge/page_sink_test.go
@@ -63,6 +63,21 @@ func (f *fakePageWriter) ReplaceEntityRefs(_ context.Context, pageID string, ref
 	return nil
 }
 
+func (f *fakePageWriter) ReplaceEntityRefsBySource(_ context.Context, pageID, source string, refs []knowledgepage.EntityRef) error {
+	kept := f.refs[pageID][:0:0]
+	for _, r := range f.refs[pageID] {
+		if r.Source != source {
+			kept = append(kept, r)
+		}
+	}
+	for _, r := range refs {
+		r.Source = source
+		kept = append(kept, r)
+	}
+	f.refs[pageID] = kept
+	return nil
+}
+
 func (f *fakePageWriter) GetBySlug(_ context.Context, slug string) (*knowledgepage.Page, error) {
 	if f.getErr != nil {
 		return nil, f.getErr
@@ -156,6 +171,40 @@ func TestPromoteToPage_CarriesAndUnionsInsightRefs(t *testing.T) {
 	gotURNs, ok := cs.Changesets[1].NewValue[pageFieldEntityURNs].([]string)
 	require.True(t, ok, "after-image should carry entity_urns as []string")
 	assert.ElementsMatch(t, []string{urnA, urnB}, gotURNs)
+}
+
+// TestPromoteToPage_CarriesMixedInsightRefTypes proves acceptance criterion 1:
+// an insight whose references mix types (a dataset via entity_urns, a connection
+// and an asset mentioned inline in its text) carries all of them onto the page as
+// promoted references — not just the DataHub URN.
+func TestPromoteToPage_CarriesMixedInsightRefTypes(t *testing.T) {
+	dataset := "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.x,PROD)"
+	store := &fullSpyStore{Insights: []Insight{{
+		ID:          "i1",
+		SinkClass:   memory.SinkBusinessKnowledge,
+		InsightText: "Quarterly sales live in [warehouse](mcp:connection:(trino,warehouse)) and the [dashboard](mcp:asset:asset-1).",
+		EntityURNs:  []string{dataset},
+	}}}
+	pw := newFakePageWriter()
+	tk := newApplyToolkit(t, store, &spyChangesetStore{}, &spyWriter{})
+	tk.SetPageWriter(pw)
+
+	res, _, err := tk.handleApplyKnowledge(pageCtx(), &mcp.CallToolRequest{}, applyPageInput([]string{"i1"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError, "unexpected error result")
+	page := pw.pages["seasons"]
+	require.NotNil(t, page)
+
+	urns := make([]string, 0, len(pw.refs[page.ID]))
+	for _, r := range pw.refs[page.ID] {
+		assert.Equal(t, knowledgepage.RefSourcePromoted, r.Source)
+		urns = append(urns, r.URN())
+	}
+	assert.ElementsMatch(t, []string{
+		"mcp:connection:(trino,warehouse)",
+		"mcp:asset:asset-1",
+		dataset,
+	}, urns, "the insight's connection, asset, and dataset references all carry onto the page")
 }
 
 func applyPageInput(insightIDs []string) applyKnowledgeInput {
@@ -334,10 +383,12 @@ func TestRevertPageChangeset_RestoresRefs(t *testing.T) {
 	cs := pageChangeset("seasons", changeUpdatePage, 4, prev)
 	pw := newFakePageWriter()
 	pw.pages["seasons"] = &knowledgepage.Page{ID: "kp1", Slug: "seasons", Title: "New", CurrentVersion: 4}
-	// The page currently has both URNs (urnB was added by the promotion being reverted).
+	// The page has both promoted URNs (urnB was added by the promotion being
+	// reverted) AND a manually-picked asset ref that must survive the rollback.
 	pw.refs["kp1"] = []knowledgepage.EntityRef{
 		knowledgepage.DataHubRef(urnA, knowledgepage.RefSourcePromoted),
 		knowledgepage.DataHubRef(urnB, knowledgepage.RefSourcePromoted),
+		{TargetType: knowledgepage.RefTargetAsset, AssetID: "kept-asset", Source: knowledgepage.RefSourceManual},
 	}
 	csStore := &spyChangesetStore{Changesets: []Changeset{cs}}
 	tk := newApplyToolkit(t, &fullSpyStore{}, csStore, &spyWriter{})
@@ -347,7 +398,13 @@ func TestRevertPageChangeset_RestoresRefs(t *testing.T) {
 		applyKnowledgeInput{Action: actionRollback, ChangesetID: "cs1", Confirm: true})
 	require.NoError(t, err)
 	require.False(t, res.IsError)
-	assert.ElementsMatch(t, []string{urnA}, refURNs(pw.refs["kp1"]), "rollback should restore the prior ref set")
+	// Promoted refs revert to the prior set (urnB dropped); the manual ref survives.
+	got := make([]string, 0, len(pw.refs["kp1"]))
+	for _, r := range pw.refs["kp1"] {
+		got = append(got, r.URN())
+	}
+	assert.ElementsMatch(t, []string{urnA, "mcp:asset:kept-asset"}, got,
+		"rollback restores promoted refs to the prior set and leaves manual refs intact")
 }
 
 func TestRevertPageChangeset_ConflictRefused(t *testing.T) {

--- a/pkg/toolkits/knowledge/rollback.go
+++ b/pkg/toolkits/knowledge/rollback.go
@@ -390,9 +390,11 @@ func applyPageRevert(ctx context.Context, pages PageReverter, cs *Changeset, pag
 		}); err != nil {
 			return "", fmt.Errorf("restoring knowledge page: %w", err)
 		}
-		// Restore the page's references to the prior set (#664). Phase 0 snapshots
-		// DataHub references; rebuild them from the previous-value URNs.
-		if err := pages.ReplaceEntityRefs(ctx, page.ID, dataHubRefs(strsFromMap(cs.PreviousValue, pageFieldEntityURNs))); err != nil {
+		// Restore the page's promoted references to the prior set (#664), scoped to
+		// source=promoted so manual and inline references survive the rollback. The
+		// previous-value URNs are serialized references of any type.
+		if err := pages.ReplaceEntityRefsBySource(ctx, page.ID, knowledgepage.RefSourcePromoted,
+			promotedRefsFromURNs(strsFromMap(cs.PreviousValue, pageFieldEntityURNs))); err != nil {
 			return "", fmt.Errorf("restoring knowledge page references: %w", err)
 		}
 		return "restored page " + page.Slug, nil

--- a/ui/src/components/knowledge/EntityChip.test.tsx
+++ b/ui/src/components/knowledge/EntityChip.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { EntityChip } from "./EntityChip";
+import type { ResolvedRef } from "@/lib/entityRefs";
+
+const resolved = (over: Partial<ResolvedRef>): ResolvedRef => ({
+  urn: "mcp:asset:a1",
+  type: "asset",
+  label: "Sales Dashboard",
+  exists: true,
+  accessible: true,
+  ...over,
+});
+
+describe("EntityChip", () => {
+  it("deep-links an asset chip via onNavigate (criterion 5)", () => {
+    const onNavigate = vi.fn();
+    const { container } = render(
+      <EntityChip urn="mcp:asset:a1" resolved={resolved({})} onNavigate={onNavigate} />,
+    );
+    const a = container.querySelector("a");
+    expect(a).not.toBeNull();
+    fireEvent.click(a!);
+    expect(onNavigate).toHaveBeenCalledWith("/assets/a1");
+  });
+
+  it("renders a deleted reference as a broken, non-link chip (criterion 7)", () => {
+    const onNavigate = vi.fn();
+    const { container } = render(
+      <EntityChip
+        urn="mcp:knowledge_page:kp-9"
+        resolved={resolved({ urn: "mcp:knowledge_page:kp-9", type: "knowledge_page", label: "Old Page", exists: false })}
+        onNavigate={onNavigate}
+      />,
+    );
+    expect(container.querySelector("a")).toBeNull(); // a broken ref is never a link
+    expect(container.textContent).toContain("Old Page");
+    expect(container.querySelector(".line-through")).not.toBeNull();
+  });
+
+  it("does not link a type without an in-app route (connection)", () => {
+    const onNavigate = vi.fn();
+    const { container } = render(
+      <EntityChip urn="mcp:connection:(trino,warehouse)" onNavigate={onNavigate} />,
+    );
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toContain("warehouse (trino)");
+  });
+});

--- a/ui/src/components/knowledge/EntityChip.tsx
+++ b/ui/src/components/knowledge/EntityChip.tsx
@@ -1,6 +1,6 @@
-import { FileText, MessageSquareText, FolderOpen, BookOpen, Plug, Database, Link2 } from "lucide-react";
+import { FileText, MessageSquareText, FolderOpen, BookOpen, Plug, Database, Link2, Unlink } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { parseRef, type ResolvedRef, type RefType } from "@/lib/entityRefs";
+import { parseRef, entityHref, type ResolvedRef, type RefType } from "@/lib/entityRefs";
 
 const TYPE_ICONS: Record<RefType, LucideIcon> = {
   asset: FileText,
@@ -13,30 +13,65 @@ const TYPE_ICONS: Record<RefType, LucideIcon> = {
 };
 
 /**
- * EntityChip renders an inline reference (mcp:/urn:li:) from a knowledge-page body
- * as a typed chip: a type icon plus the entity's display name. When the server has
- * resolved the reference, the real name is shown and a missing target is greyed out
- * and struck through; before resolution (or app-wide, without a resolver) it falls
- * back to the name derived from the URN itself.
+ * EntityChip renders an entity reference (mcp:/urn:li:) as a typed chip: a type
+ * icon plus the entity's display name. When the server has resolved the reference
+ * it shows the real name; before resolution (or without a resolver) it falls back
+ * to the name derived from the URN.
+ *
+ * - A reference to a deleted entity (resolved.exists === false) renders as a
+ *   broken-reference chip (struck through, broken-link icon) and is never a link.
+ * - Otherwise, if the entity has an in-app route and an onNavigate handler is
+ *   provided, the chip deep-links to it; else it is a plain styled chip.
  */
-export function EntityChip({ urn, resolved }: { urn: string; resolved?: ResolvedRef }) {
+export function EntityChip({
+  urn,
+  resolved,
+  onNavigate,
+}: {
+  urn: string;
+  resolved?: ResolvedRef;
+  onNavigate?: (path: string) => void;
+}) {
   const parsed = parseRef(urn);
   const type = (resolved?.type ?? parsed?.type ?? "unknown") as RefType;
-  const Icon = TYPE_ICONS[type] ?? Link2;
   const label = resolved?.label ?? parsed?.fallbackLabel ?? urn;
-  const missing = resolved ? !resolved.exists : false;
+  const broken = resolved ? !resolved.exists : false;
+  const Icon = broken ? Unlink : (TYPE_ICONS[type] ?? Link2);
 
-  return (
-    <span
-      title={urn}
-      className={`not-prose mx-0.5 inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 align-baseline text-xs font-medium no-underline ${
-        missing
-          ? "border-border bg-muted text-muted-foreground line-through"
-          : "border-primary/20 bg-primary/10 text-primary"
-      }`}
-    >
+  const base =
+    "not-prose mx-0.5 inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 align-baseline text-xs font-medium no-underline";
+  const tone = broken
+    ? "border-border bg-muted text-muted-foreground line-through"
+    : "border-primary/20 bg-primary/10 text-primary";
+
+  const inner = (
+    <>
       <Icon className="h-3 w-3 shrink-0" aria-hidden />
       <span>{label}</span>
+    </>
+  );
+
+  // A live (non-broken) reference deep-links when it has a route and a navigator.
+  const href = broken ? null : parsed && onNavigate ? entityHref(parsed.type, parsed.id) : null;
+  if (href && onNavigate) {
+    return (
+      <a
+        href={href}
+        title={urn}
+        onClick={(e) => {
+          e.preventDefault();
+          onNavigate(href);
+        }}
+        className={`${base} ${tone} cursor-pointer hover:bg-primary/20`}
+      >
+        {inner}
+      </a>
+    );
+  }
+
+  return (
+    <span title={broken ? `${urn} (no longer exists)` : urn} className={`${base} ${tone}`}>
+      {inner}
     </span>
   );
 }

--- a/ui/src/components/knowledge/RefPicker.tsx
+++ b/ui/src/components/knowledge/RefPicker.tsx
@@ -54,7 +54,7 @@ function useTypeSearch(type: PickableRefType, query: string): Candidate[] {
  * types and add one. Promoted and inline references are preserved by the
  * server-side source-scoped replace.
  */
-export function RefPicker({ pageId }: { pageId: string }) {
+export function RefPicker({ pageId, onNavigate }: { pageId: string; onNavigate?: (path: string) => void }) {
   const { data } = useKnowledgePageRefs(pageId);
   const setRefs = useSetKnowledgePageRefs(pageId);
   const manual = useMemo<PageEntityRef[]>(
@@ -86,6 +86,7 @@ export function RefPicker({ pageId }: { pageId: string }) {
               <EntityChip
                 urn={ref.urn}
                 resolved={{ urn: ref.urn, type: ref.type, label: ref.label, exists: ref.exists, accessible: true }}
+                onNavigate={onNavigate}
               />
               <button
                 type="button"

--- a/ui/src/components/knowledge/RelatedPanel.tsx
+++ b/ui/src/components/knowledge/RelatedPanel.tsx
@@ -17,7 +17,7 @@ const TYPE_LABELS: Record<string, string> = {
  * The list is already access-filtered and resolved by the server, so it only
  * contains references the viewer can reach, each with its display label.
  */
-export function RelatedPanel({ pageId }: { pageId: string }) {
+export function RelatedPanel({ pageId, onNavigate }: { pageId: string; onNavigate?: (path: string) => void }) {
   const { data } = useKnowledgePageRefs(pageId);
   const refs = useMemo(() => data?.refs ?? [], [data]);
 
@@ -48,6 +48,7 @@ export function RelatedPanel({ pageId }: { pageId: string }) {
                   key={ref.urn}
                   urn={ref.urn}
                   resolved={{ urn: ref.urn, type: ref.type, label: ref.label, exists: ref.exists, accessible: true }}
+                  onNavigate={onNavigate}
                 />
               ))}
             </div>

--- a/ui/src/components/renderers/MarkdownRenderer.tsx
+++ b/ui/src/components/renderers/MarkdownRenderer.tsx
@@ -169,10 +169,12 @@ export function MarkdownRenderer({
   content,
   bare,
   refs,
+  onNavigate,
 }: {
   content: string | null | undefined;
   bare?: boolean;
   refs?: Map<string, ResolvedRef>;
+  onNavigate?: (path: string) => void;
 }) {
   const components: Components = {
     // Render mcp:/urn: links as entity chips; ordinary links are unchanged.
@@ -186,7 +188,7 @@ export function MarkdownRenderer({
           if (resolved && !resolved.accessible) {
             return <>{children}</>;
           }
-          return <EntityChip urn={href as string} resolved={resolved} />;
+          return <EntityChip urn={href as string} resolved={resolved} onNavigate={onNavigate} />;
         }
         return (
           <a href={href} {...rest}>
@@ -194,7 +196,7 @@ export function MarkdownRenderer({
           </a>
         );
       },
-      [refs],
+      [refs, onNavigate],
     ),
     code: useCallback(
       // react-markdown passes `node` (hast AST) — destructure it out so it

--- a/ui/src/lib/entityRefs.test.ts
+++ b/ui/src/lib/entityRefs.test.ts
@@ -1,5 +1,23 @@
 import { describe, it, expect } from "vitest";
-import { extractRefUrns, parseRef, isRefUrn, buildRefUrn } from "./entityRefs";
+import { extractRefUrns, parseRef, isRefUrn, buildRefUrn, entityHref } from "./entityRefs";
+
+describe("entityHref", () => {
+  it("routes asset/collection/prompt to their viewers and nothing else", () => {
+    expect(entityHref("asset", "a1")).toBe("/assets/a1");
+    expect(entityHref("collection", "c1")).toBe("/collections/c1");
+    expect(entityHref("prompt", "p1")).toBe("/prompts/p1");
+    expect(entityHref("knowledge_page", "kp1")).toBeNull(); // no URL route
+    expect(entityHref("connection", "")).toBeNull();
+    expect(entityHref("datahub", "")).toBeNull();
+    expect(entityHref("asset", "")).toBeNull(); // no id
+  });
+
+  it("refuses an unsafe id so a crafted href cannot path-traverse", () => {
+    expect(entityHref("asset", "../../admin")).toBeNull();
+    expect(entityHref("asset", "a/b")).toBeNull();
+    expect(entityHref("collection", "x?y")).toBeNull();
+  });
+});
 
 describe("buildRefUrn", () => {
   it("serializes a single-id reference and round-trips through parseRef", () => {
@@ -23,11 +41,13 @@ describe("parseRef", () => {
     expect(parseRef("mcp:asset:asset-001")).toEqual({
       urn: "mcp:asset:asset-001",
       type: "asset",
+      id: "asset-001",
       fallbackLabel: "asset-001",
     });
     expect(parseRef("mcp:connection:(trino,warehouse)")).toEqual({
       urn: "mcp:connection:(trino,warehouse)",
       type: "connection",
+      id: "",
       fallbackLabel: "warehouse (trino)",
     });
     expect(

--- a/ui/src/lib/entityRefs.ts
+++ b/ui/src/lib/entityRefs.ts
@@ -16,8 +16,31 @@ export type RefType =
 export interface ParsedRef {
   urn: string;
   type: RefType;
+  /** The raw id for single-id internal types (asset/prompt/collection/page); "" otherwise. */
+  id: string;
   /** A label to show before (or instead of) a server-resolved name. */
   fallbackLabel: string;
+}
+
+// SAFE_ID matches the server's mcp: simple-id charset. A reference id that
+// contains anything else (for example a crafted `../../admin` path-traversal in a
+// markdown link href) is treated as non-navigable rather than interpolated into a
+// route.
+const SAFE_ID = /^[A-Za-z0-9_.-]+$/;
+
+/** entityHref returns the in-app path to an entity, or null if it has no route. */
+export function entityHref(type: string, id: string): string | null {
+  if (!id || !SAFE_ID.test(id)) return null;
+  switch (type) {
+    case "asset":
+      return `/assets/${id}`;
+    case "collection":
+      return `/collections/${id}`;
+    case "prompt":
+      return `/prompts/${id}`;
+    default:
+      return null; // knowledge_page (no URL route), connection, datahub
+  }
 }
 
 /** ResolvedRef is the server's resolution of a reference URN to a display label. */
@@ -77,7 +100,7 @@ function datahubLabel(urn: string): string {
 export function parseRef(urn: string): ParsedRef | null {
   const trimmed = urn.trim();
   if (trimmed.startsWith("urn:")) {
-    return { urn: trimmed, type: "datahub", fallbackLabel: datahubLabel(trimmed) };
+    return { urn: trimmed, type: "datahub", id: "", fallbackLabel: datahubLabel(trimmed) };
   }
   if (!trimmed.startsWith("mcp:")) return null;
 
@@ -93,11 +116,11 @@ export function parseRef(urn: string): ParsedRef | null {
     case "prompt":
     case "collection":
     case "knowledge_page":
-      return { urn: trimmed, type, fallbackLabel: id };
+      return { urn: trimmed, type, id, fallbackLabel: id };
     case "connection": {
       const m = id.match(/^\(([^,]+),([^)]+)\)$/);
       if (!m) return null;
-      return { urn: trimmed, type: "connection", fallbackLabel: `${m[2]} (${m[1]})` as string };
+      return { urn: trimmed, type: "connection", id: "", fallbackLabel: `${m[2]} (${m[1]})` as string };
     }
     default:
       return null;

--- a/ui/src/pages/knowledge-pages/KnowledgePagesPage.tsx
+++ b/ui/src/pages/knowledge-pages/KnowledgePagesPage.tsx
@@ -36,6 +36,7 @@ type Mode = { view: "list" } | { view: "page"; id: string } | { view: "edit"; id
 export function KnowledgePagesPage({
   openPage,
   onPageOpened,
+  onNavigate,
 }: {
   // A request from the Knowledge hub's search to open a specific page in detail
   // view. The bump counter makes re-opening the same page re-fire the effect.
@@ -43,6 +44,8 @@ export function KnowledgePagesPage({
   // Called once the request has been consumed so the parent can clear it,
   // preventing a stale request from re-opening the page on the next remount.
   onPageOpened?: () => void;
+  // Navigate to an in-app path (for entity-reference chip deep-links).
+  onNavigate?: (path: string) => void;
 } = {}) {
   const [mode, setMode] = useState<Mode>({ view: "list" });
 
@@ -74,6 +77,7 @@ export function KnowledgePagesPage({
       <KnowledgePageDetail
         id={mode.id}
         canEdit={canEdit}
+        onNavigate={onNavigate}
         onBack={() => setMode({ view: "list" })}
         onEdit={() => setMode({ view: "edit", id: mode.id })}
         onDeleted={() => setMode({ view: "list" })}
@@ -267,12 +271,14 @@ function KnowledgePageList({ canEdit, onOpen, onCreate }: { canEdit: boolean; on
 function KnowledgePageDetail({
   id,
   canEdit,
+  onNavigate,
   onBack,
   onEdit,
   onDeleted,
 }: {
   id: string;
   canEdit: boolean;
+  onNavigate?: (path: string) => void;
   onBack: () => void;
   onEdit: () => void;
   onDeleted: () => void;
@@ -343,12 +349,12 @@ function KnowledgePageDetail({
         className="prose prose-sm max-w-none rounded-lg border border-border bg-card p-6 dark:prose-invert"
         data-feedback-anchorable
       >
-        <MarkdownRenderer content={page.body} refs={resolvedRefs} />
+        <MarkdownRenderer content={page.body} refs={resolvedRefs} onNavigate={onNavigate} />
       </article>
 
-      <RelatedPanel pageId={id} />
-      <KnowledgeBacklinks urn={`mcp:knowledge_page:${id}`} />
-      {canEdit && <RefPicker pageId={id} />}
+      <RelatedPanel pageId={id} onNavigate={onNavigate} />
+      <KnowledgeBacklinks urn={`mcp:knowledge_page:${id}`} onNavigate={onNavigate} />
+      {canEdit && <RefPicker pageId={id} onNavigate={onNavigate} />}
     </div>
   );
 }

--- a/ui/src/pages/knowledge/KnowledgeHub.tsx
+++ b/ui/src/pages/knowledge/KnowledgeHub.tsx
@@ -695,6 +695,7 @@ export function KnowledgeHub({
             <KnowledgePagesPage
               openPage={pageRequest ?? undefined}
               onPageOpened={clearPageRequest}
+              onNavigate={onNavigate}
             />
           )}
           {/* Changesets live under Knowledge (the promoted layer), not Insights:


### PR DESCRIPTION
Closes #664. This is the final piece: with Phases 0-5 already merged (#666, #667, #669, #670, #671, #672), this completes the three remaining acceptance criteria so knowledge-page entity references work end to end through apply_knowledge.

See the [#664 clarification comment](https://github.com/txn2/mcp-data-platform/issues/664#issuecomment-4791831795) for the insight-side scope decision this builds on: insights carry their references **inline in their prose** (mirroring how pages work), those references survive promotion onto the page, and insights are deliberately **not** richly surfaced (no insight picker / "Related" panel / reverse lookup) because a raw insight must not surface as agent context.

## 1. Promotion carries every reference type an insight holds (criterion 1)

Previously only an insight's DataHub `entity_urns` survived promotion; a connection or asset reference was dropped. Now:

- `insightReferenceURNs(ins)` unions `ins.EntityURNs` with the `mcp:`/`urn:li:` references scanned from the insight's prose (`ScanBodyRefs(ins.InsightText)`), re-serialized as URNs.
- `promotedRefsFromURNs(urns)` parses each URN to its real target type via `ParseEntityRef` (a `urn:li:` DataHub URN and an `mcp:asset:<id>` both round-trip) and marks it `source=promoted`. An unparseable token is skipped.

So promoting an insight that references a dataset, a connection, and an asset produces all three `knowledge_page_entity_refs` rows. The Phase 5 backfill uses the same path, so pre-existing pages get the same treatment.

This is a focused change rather than a new `insight_entity_refs` table: the insight's text is the carrier (the inline form the issue clarification settled on), the only consumer is promotion, and insights stay unsurfaced.

### Rollback correctness (bonus)

Rollback now scopes to `source=promoted` (`ReplaceEntityRefsBySource`) instead of replacing *all* references. So a manual reference added after a promotion **survives** a rollback while the promoted set reverts; the Phase 0 path would have wiped it. `pageEntityURNs` snapshots the promoted references of every type (serialized URNs) into the changeset image; rollback re-parses them. Covered by an extended `TestRevertPageChangeset_RestoresRefs` that asserts a manual ref is intact and the promoted set reverts.

## 2. Chip deep-linking (criterion 5)

Inline body chips and the Related / backlink / picker chips now deep-link to the entity: `/assets/<id>`, `/collections/<id>`, `/prompts/<id>`, via the app navigator threaded down from the Knowledge hub. Types with no in-app route (pages, connections, DataHub) stay non-links. `onNavigate` is optional throughout, so the renderer used elsewhere (asset descriptions, etc.) is unaffected.

**Security:** `entityHref` refuses any id outside the server's safe id charset (`[A-Za-z0-9_.-]+`), so a crafted markdown link like `[x](mcp:asset:../../admin)` cannot path-traverse into another in-app route; it renders as a non-navigable chip. (The client parses raw markdown hrefs, not the server-scanned token, so this guard belongs on the client too.)

## 3. Broken-reference chip (criterion 7)

A reference to a deleted entity renders as a struck-through, broken-link chip and is never a link. The access model is preserved: a broken chip appears only for a reference the viewer can access (org-shared pages whose target was deleted); an inaccessible reference still renders as the author's plain link text and never reveals whether the entity exists.

## Testing

- `make verify` green: race + real-Postgres, package budget, lint, gosec/govulncheck, semgrep, CodeQL, mutation, swagger-check, GoReleaser. **Patch coverage 100%.**
- UI: `tsc --noEmit` and eslint clean, `npm run build` passes, 36 vitest tests pass.
- New/updated tests: `TestPromoteToPage_CarriesMixedInsightRefTypes` (dataset + connection + asset all carry); the rollback manual-survives behavior; the de-dup/skip path; `entityHref` routing and the unsafe-id refusal; the chip deep-link / broken / non-route states.

## Adversarial review

A pre-PR review caught three issues, all fixed here: the path-traversal/spoofing gap in the deep-link (now charset-guarded); the rollback behavior change being untested (now covered); and stale doc comments contradicting the new all-type behavior.

## Acceptance criteria (all met)

- [x] An insight whose references mix a dataset, a connection, and an asset produces the matching page rows; a second promotion to the same slug unions with no duplicates.
- [x] A page lists references under "Related" grouped by type; each surface shows the page as a back-reference.
- [x] Deleting a referenced entity cascades its ref rows.
- [x] Rolling back a promotion restores the page's prior references (and leaves manual refs intact).
- [x] A `[label](mcp:asset:<id>)` link renders as a live chip with the current name and deep-links to it.
- [x] Adding/removing an inline link reconciles `source=inline` rows; a `source=manual` ref survives the edit.
- [x] A reference to a deleted entity renders as a broken-reference chip rather than a dead link.

This closes the #664 series: #666, #667, #669, #670, #671, #672, and this PR.


