### PR TITLE
feat(knowledge): teach the memory→insight→knowledge loop and expert synthesis in the apply_knowledge contract (#674)

### DIFF
--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -36,6 +36,10 @@ const (
 	// promptName is the MCP prompt name for knowledge capture guidance.
 	promptName = "knowledge_capture_guidance"
 
+	// applyPromptName is the MCP prompt name for the review-and-apply guidance:
+	// how to synthesize insights into durable knowledge (DataHub or knowledge pages).
+	applyPromptName = "knowledge_apply_guidance"
+
 	// userPromptName is the user-facing prompt for capturing knowledge.
 	userPromptName = "capture-this-as-knowledge"
 )
@@ -140,11 +144,23 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 		mcp.AddTool(s, &mcp.Tool{
 			Name:  applyToolName,
 			Title: "Apply Knowledge",
-			Description: "The review gate for captured insights. Holding this tool is the capability that grants " +
-				"insight review and promotion: you review the insights other users capture and promote the good ones into " +
-				"shared, canonical knowledge. Business and domain facts become internal knowledge pages; technical and entity " +
-				"facts are applied to the DataHub catalog. Access is granted per persona by tool visibility, not by an admin role. " +
-				"Reviews, synthesizes, applies, and rolls back captured insights. " +
+			Description: "The review-and-apply gate of the knowledge loop. (The name is historical; read it as 'review and apply knowledge'.) " +
+				"The loop: users and agents capture memories with memory_capture; durable ones become insights pending review " +
+				"(business_knowledge, schema_entity, operational_rule); holding this tool you review those insights and turn the good ones into " +
+				"durable, shared, canonical KNOWLEDGE that every future session recalls via search, so no one re-teaches the same fact. " +
+				"Knowledge has two homes: a DataHub entity when the fact is tied to a catalog dataset or column, or a canonical knowledge page " +
+				"(sink=knowledge_page) when it is business or domain knowledge not tied to one entity (for example seasonal date ranges or company vocabulary). " +
+				"Be an expert reviewer, not a mechanical one: " +
+				"(1) discover existing knowledge first by searching DataHub and knowledge pages for the topic, so every decision is update-vs-create, never blind-create; " +
+				"(2) compare each insight against what exists (new, a refinement, a correction, or already covered); " +
+				"(3) synthesize: merge related insights into one coherent statement and resolve contradictions, rather than writing one artifact per raw insight; " +
+				"(4) route: entity-tied facts update the DataHub entity (description, tags, glossary, curated queries); business or domain knowledge promotes to a knowledge page " +
+				"via sink=knowledge_page with a 'page' object, found-or-created by slug so repeat promotions consolidate and references accumulate; " +
+				"(5) update in place over duplicating, and create only when genuinely new; " +
+				"(6) mark insights applied, rejected, or superseded. " +
+				"Access is granted per persona by tool visibility, not by an admin role. " +
+				"Sinks for the apply action: sink='datahub' (default) applies 'changes' to entity_urn; sink='knowledge_page' promotes a business_knowledge or operational_rule " +
+				"insight to a page using the 'page' object {slug,title,summary,body,tags} and 'insight_ids'. " +
 				"Actions: bulk_review, review, synthesize, apply, approve, reject, rollback, list_changesets. " +
 				"rollback (changeset_id required, confirm required) reverts the aspects a prior apply changed, back to their before-image: " +
 				"it removes tags/glossary terms/documentation links the apply added (leaving any that pre-existed) and restores the prior description. " +
@@ -939,6 +955,20 @@ func (*Toolkit) registerPrompt(s *mcp.Server) {
 	})
 
 	s.AddPrompt(&mcp.Prompt{
+		Name:        applyPromptName,
+		Description: "How to review insights and synthesize them into durable knowledge (DataHub or knowledge pages)",
+	}, func(_ context.Context, _ *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		return &mcp.GetPromptResult{
+			Messages: []*mcp.PromptMessage{
+				{
+					Role:    promptRoleUser,
+					Content: &mcp.TextContent{Text: knowledgeApplyPrompt},
+				},
+			},
+		}, nil
+	})
+
+	s.AddPrompt(&mcp.Prompt{
 		Name:        userPromptName,
 		Description: "Record insights from this conversation for data catalog improvement",
 	}, func(_ context.Context, _ *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
@@ -963,6 +993,12 @@ func (*Toolkit) PromptInfos() []registry.PromptInfo {
 			Content:     knowledgeCapturePrompt,
 		},
 		{
+			Name:        applyPromptName,
+			Description: "How to review insights and synthesize them into durable knowledge (DataHub or knowledge pages)",
+			Category:    "toolkit",
+			Content:     knowledgeApplyPrompt,
+		},
+		{
 			Name:        userPromptName,
 			Description: "Record insights from this conversation for data catalog improvement",
 			Category:    "toolkit",
@@ -977,6 +1013,39 @@ const captureKnowledgePromptContent = `Capture the key insights from this conver
 2. Identify which datasets and columns the insights relate to
 3. Record each insight with appropriate categorization and confidence level
 4. Suggest any catalog improvements (updated descriptions, new tags, glossary terms)`
+
+// knowledgeApplyPrompt teaches the holder of apply_knowledge the memory -> insight
+// -> knowledge loop and how to be an expert reviewer: discover existing knowledge,
+// compare, synthesize, route to DataHub or a knowledge page, update-or-create, and
+// mark insights applied. It is registered as the knowledge_apply_guidance prompt.
+const knowledgeApplyPrompt = `## Reviewing Insights into Durable Knowledge
+
+You hold apply_knowledge, the review-and-apply gate of the platform's knowledge loop. (The tool name is historical; read it as "review and apply knowledge.") Turning raw insights into correct, non-duplicated, durable knowledge is one of the platform's essential functions. Do it as an expert editor, not a mechanical promoter.
+
+### The loop, and why knowledge matters
+
+- **Memory**: transient or personal working context (personal_preference, episodic_event), live immediately and scoped to one user.
+- **Insight**: a durable *candidate* fact captured for review (business_knowledge, schema_entity, operational_rule), pending until you review it.
+- **Knowledge**: reviewed, durable, shared, canonical truth. It lives in DataHub when tied to a catalog entity, or in a knowledge page when it is business or domain knowledge not tied to one entity. Knowledge is what every future session recalls via search, so no user ever has to teach the same fact twice and every answer is grounded in established truth.
+
+Always discover before you apply: search existing memory, insights, and knowledge first.
+
+### The expert review workflow
+
+1. **Discover existing knowledge.** For each pending insight, search DataHub and knowledge pages for the topic. The decision is always update-vs-create, never blind-create.
+2. **Compare.** Is the insight new, a refinement, a correction, or already covered or superseded? Reject or supersede what is redundant or wrong.
+3. **Synthesize.** Merge related insights into one coherent statement and resolve contradictions. Do not produce one page or one description per raw insight.
+4. **Route to the right home.**
+   - Tied to a catalog entity (dataset, column, dashboard): apply to DataHub with sink=datahub, using update_description, add_tag, add_glossary_term, add_curated_query, and so on, against the entity_urn.
+   - Business or domain knowledge not tied to one entity (vocabulary, seasons, policies, cross-cutting context): promote to a knowledge page with sink=knowledge_page and a 'page' object {slug, title, summary, body, tags}. The page is found-or-created by slug, so promoting more insights to the same slug consolidates one living page and accumulates its entity references.
+5. **Update in place over duplicating.** Consolidate onto the existing canonical home; create only when genuinely new.
+6. **Close the loop.** Mark insights applied, rejected, or superseded with review notes, so the queue reflects reality.
+
+### Routing examples
+
+- "The amount column excludes returns" applies to DataHub: update_description on that dataset column.
+- "We run Summer (May-Oct) and Winter (Nov-Apr) seasons for planning" becomes a knowledge page (sink=knowledge_page), for example slug retail-seasons.
+- Three insights all about discount vocabulary become one knowledge page synthesized from all three, not three pages.`
 
 // Helper functions
 

--- a/pkg/toolkits/knowledge/toolkit_test.go
+++ b/pkg/toolkits/knowledge/toolkit_test.go
@@ -449,6 +449,43 @@ func TestToolkit_RegisterTools_WithApply(t *testing.T) {
 	assert.Len(t, tk.Tools(), 1)
 }
 
+// TestApplyKnowledgeDescription_TeachesLoopAndSink asserts the agent-facing
+// apply_knowledge description (#674) teaches the review/synthesis workflow and
+// references the knowledge-page sink, so a fresh agent can discover the capability
+// from the contract rather than only from the JSON schema.
+func TestApplyKnowledgeDescription_TeachesLoopAndSink(t *testing.T) {
+	tk, err := New(testName, nil)
+	require.NoError(t, err)
+	tk.SetApplyConfig(ApplyConfig{Enabled: true}, nil, nil)
+
+	s := mcp.NewServer(&mcp.Implementation{Name: testName, Version: testVersion}, nil)
+	tk.RegisterTools(s)
+
+	ctx := context.Background()
+	t1, t2 := mcp.NewInMemoryTransports()
+	serverSess, err := s.Connect(ctx, t1, nil)
+	require.NoError(t, err)
+	defer func() { _ = serverSess.Close() }()
+	client := mcp.NewClient(&mcp.Implementation{Name: "c", Version: "1.0"}, nil)
+	clientSess, err := client.Connect(ctx, t2, nil)
+	require.NoError(t, err)
+	defer func() { _ = clientSess.Close() }()
+
+	list, err := clientSess.ListTools(ctx, &mcp.ListToolsParams{})
+	require.NoError(t, err)
+	var desc string
+	for _, tool := range list.Tools {
+		if tool.Name == applyToolName {
+			desc = tool.Description
+		}
+	}
+	require.NotEmpty(t, desc, "apply_knowledge tool not advertised")
+	// It must teach the loop, the expert workflow, and the page sink mechanism.
+	for _, want := range []string{"knowledge loop", "synthesize", "sink=knowledge_page", "'page' object", "update-vs-create"} {
+		assert.Contains(t, desc, want, "apply_knowledge description should teach %q", want)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Toolkit interface compliance
 // ---------------------------------------------------------------------------
@@ -2514,15 +2551,22 @@ func TestHandleApply_MixedChangesRejectsBeforeExecution(t *testing.T) {
 func TestPromptInfos(t *testing.T) {
 	tk := &Toolkit{}
 	infos := tk.PromptInfos()
-	require.Len(t, infos, 2)
+	require.Len(t, infos, 3)
 
 	assert.Equal(t, promptName, infos[0].Name)
 	assert.NotEmpty(t, infos[0].Description)
 	assert.Equal(t, "toolkit", infos[0].Category)
 
-	assert.Equal(t, userPromptName, infos[1].Name)
+	assert.Equal(t, applyPromptName, infos[1].Name)
 	assert.NotEmpty(t, infos[1].Description)
 	assert.Equal(t, "toolkit", infos[1].Category)
+	// The apply guidance must teach the loop and the route to a knowledge page.
+	assert.Contains(t, infos[1].Content, "knowledge_page")
+	assert.Contains(t, infos[1].Content, "Synthesize")
+
+	assert.Equal(t, userPromptName, infos[2].Name)
+	assert.NotEmpty(t, infos[2].Description)
+	assert.Equal(t, "toolkit", infos[2].Category)
 }
 
 func TestRegisterPrompts(t *testing.T) {
@@ -2545,17 +2589,18 @@ func TestRegisterPrompts(t *testing.T) {
 	// List prompts
 	listResp, err := clientSess.ListPrompts(ctx, &mcp.ListPromptsParams{})
 	require.NoError(t, err)
-	require.Len(t, listResp.Prompts, 2)
+	require.Len(t, listResp.Prompts, 3)
 
 	names := make(map[string]bool)
 	for _, p := range listResp.Prompts {
 		names[p.Name] = true
 	}
 	assert.True(t, names[promptName])
+	assert.True(t, names[applyPromptName])
 	assert.True(t, names[userPromptName])
 
 	// Get each prompt and verify content
-	for _, name := range []string{promptName, userPromptName} {
+	for _, name := range []string{promptName, applyPromptName, userPromptName} {
 		resp, err := clientSess.GetPrompt(ctx, &mcp.GetPromptParams{Name: name})
 		require.NoError(t, err, "prompt %s", name)
 		require.Len(t, resp.Messages, 1)


### PR DESCRIPTION
Closes #674.

## Problem

The platform's purpose is a learning loop: query data and APIs and, in the process, form memories, classify durable ones as insights, and review those insights into durable knowledge in DataHub or knowledge pages. A fresh agent (Claude Code / Claude Desktop) arrives with **no context** about this loop. The `apply_knowledge` contract stated outcomes ("Business and domain facts become internal knowledge pages") but never taught the agent the loop or how to be an expert reviewer, and it pointed at neither the `sink` nor the `page` mechanism the JSON schema already exposes. So the review/apply half of the platform's essential function was under-explained at exactly the surface an agent reads first.

This PR addresses the agent-understanding half of #674. The operational half (making sure a connected client actually receives an updated contract on each deploy, rather than running on a stale cached schema) is tracked separately in #675.

## What changed

All changes are agent-facing contract text plus tests; no behavior change.

### 1. Reframed the `apply_knowledge` tool description

It now reads as "review and apply knowledge" (the name is historical) and teaches the expert workflow inline rather than just stating outcomes:

1. Discover existing knowledge first by searching DataHub and knowledge pages, so every decision is update-vs-create, never blind-create.
2. Compare each insight against what exists (new, refinement, correction, already covered).
3. Synthesize: merge related insights into one coherent statement, rather than promoting one artifact per raw insight.
4. Route: entity-tied facts update the DataHub entity; business or domain knowledge promotes to a knowledge page via `sink=knowledge_page` with a `page` object, found-or-created by slug so repeat promotions consolidate and references accumulate.
5. Update in place over duplicating; create only when genuinely new.
6. Mark insights applied, rejected, or superseded.

It now documents the `sink`/`page` mechanism in the prose, not only in the JSON schema, so an agent reading the description can discover the knowledge-page path.

### 2. New `knowledge_apply_guidance` MCP prompt

The reviewer-side complement to the existing capture guidance. It teaches:

- What memory vs insight vs knowledge are (transient/personal vs durable candidate vs reviewed canonical truth).
- Why durable knowledge matters: no user re-teaches the same fact, answers are grounded in established truth, the platform compounds what it learns.
- Discover-first, then the six-step expert review workflow, with routing examples (a column-meaning correction goes to DataHub; seasonal date ranges become a knowledge page; three insights about the same vocabulary synthesize into one page, not three).

### 3. Tests

- `TestApplyKnowledgeDescription_TeachesLoopAndSink` does a live `ListTools` round-trip and asserts the advertised description teaches the loop and the page sink (`knowledge loop`, `synthesize`, `sink=knowledge_page`, `'page' object`, `update-vs-create`).
- `TestPromptInfos` and `TestRegisterPrompts` extended for the third prompt, asserting it is advertised and its content teaches synthesis and the page route.

## Verification

- `make verify` green: race + real-Postgres, package budget, lint, gosec/govulncheck, semgrep, CodeQL, mutation, swagger-check, GoReleaser. **Patch coverage 100%.**
- An adversarial review fact-checked every claim in the new contract text against the source: `pageSinkClasses` (business_knowledge + operational_rule promote to a page), the `handleApply` sink dispatch (datahub default vs knowledge_page), `promoteToPage` (find-or-create by slug, references accumulate), the `page` fields matching `pagePromotionInput`, and the memory sink-class semantics. No aspirational claim is stated as a fact; "discover before apply" is phrased as reviewer guidance, not an enforced capability.

## Not covered here

The acceptance criterion "a fresh agent, given only the contract, performs an expert apply against a live deployment" requires the deploy and a client that has the new contract. Per #675, a connected client only sees the updated tools after reconnect, so this is verified post-deploy. The test in this PR proves the contract *teaches* the workflow; it does not exercise a live agent.

## Acceptance criteria

- [x] A guidance prompt teaches the memory -> insight -> knowledge loop, what each layer is, why the agent needs it, and discover-first.
- [x] The `apply_knowledge` description articulates the expert review/synthesis workflow and references the `sink`/`page` mechanism in context.
- [x] The guidance distinguishes update-existing from create-new and instructs synthesis (many insights -> one artifact), not 1:1 promotion.
- [x] The reframing makes the poorly-named `apply_knowledge` tool self-explaining without a rename.
- [ ] Live end-to-end verification against a deployment (post-deploy; depends on #675 for contract delivery).
