### PR TITLE
fix(knowledge): create page refs on promotion, surface insight lineage, render tags and bare-token chips (#678)

### DIFF
--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -8608,6 +8608,55 @@ const docTemplate = `{
                 }
             }
         },
+        "/portal/knowledge-pages/{id}/lineage": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the insights the page was synthesized from and the promotion changesets that produced it (#678), so a reviewer can trace canonical knowledge back to the captured insights.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "A knowledge page's source-insight lineage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Knowledge page id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.knowledgePageLineageResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/knowledge-pages/{id}/refs": {
             "get": {
                 "security": [
@@ -15248,6 +15297,23 @@ const docTemplate = `{
                 }
             }
         },
+        "portal.knowledgePageLineageResponse": {
+            "type": "object",
+            "properties": {
+                "changesets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/portal.lineageChangeset"
+                    }
+                },
+                "insights": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/portal.lineageInsight"
+                    }
+                }
+            }
+        },
         "portal.knowledgePageRefsResponse": {
             "type": "object",
             "properties": {
@@ -15256,6 +15322,52 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/portal.resolvedRefView"
                     }
+                }
+            }
+        },
+        "portal.lineageChangeset": {
+            "type": "object",
+            "properties": {
+                "change_type": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "rolled_back": {
+                    "type": "boolean"
+                },
+                "source_insight_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "portal.lineageInsight": {
+            "type": "object",
+            "properties": {
+                "captured_by": {
+                    "type": "string"
+                },
+                "category": {
+                    "type": "string"
+                },
+                "confidence": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -8602,6 +8602,55 @@
                 }
             }
         },
+        "/portal/knowledge-pages/{id}/lineage": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the insights the page was synthesized from and the promotion changesets that produced it (#678), so a reviewer can trace canonical knowledge back to the captured insights.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "A knowledge page's source-insight lineage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Knowledge page id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.knowledgePageLineageResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/knowledge-pages/{id}/refs": {
             "get": {
                 "security": [
@@ -15242,6 +15291,23 @@
                 }
             }
         },
+        "portal.knowledgePageLineageResponse": {
+            "type": "object",
+            "properties": {
+                "changesets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/portal.lineageChangeset"
+                    }
+                },
+                "insights": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/portal.lineageInsight"
+                    }
+                }
+            }
+        },
         "portal.knowledgePageRefsResponse": {
             "type": "object",
             "properties": {
@@ -15250,6 +15316,52 @@
                     "items": {
                         "$ref": "#/definitions/portal.resolvedRefView"
                     }
+                }
+            }
+        },
+        "portal.lineageChangeset": {
+            "type": "object",
+            "properties": {
+                "change_type": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "rolled_back": {
+                    "type": "boolean"
+                },
+                "source_insight_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "portal.lineageInsight": {
+            "type": "object",
+            "properties": {
+                "captured_by": {
+                    "type": "string"
+                },
+                "category": {
+                    "type": "string"
+                },
+                "confidence": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "text": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -2980,12 +2980,53 @@ definitions:
       updated_at:
         type: string
     type: object
+  portal.knowledgePageLineageResponse:
+    properties:
+      changesets:
+        items:
+          $ref: '#/definitions/portal.lineageChangeset'
+        type: array
+      insights:
+        items:
+          $ref: '#/definitions/portal.lineageInsight'
+        type: array
+    type: object
   portal.knowledgePageRefsResponse:
     properties:
       refs:
         items:
           $ref: '#/definitions/portal.resolvedRefView'
         type: array
+    type: object
+  portal.lineageChangeset:
+    properties:
+      change_type:
+        type: string
+      created_at:
+        type: string
+      id:
+        type: string
+      rolled_back:
+        type: boolean
+      source_insight_ids:
+        items:
+          type: string
+        type: array
+    type: object
+  portal.lineageInsight:
+    properties:
+      captured_by:
+        type: string
+      category:
+        type: string
+      confidence:
+        type: string
+      id:
+        type: string
+      status:
+        type: string
+      text:
+        type: string
     type: object
   portal.listCollectionsResponse:
     properties:
@@ -8888,6 +8929,38 @@ paths:
       summary: Feedback activity feed
       tags:
       - Feedback
+  /portal/knowledge-pages/{id}/lineage:
+    get:
+      description: Returns the insights the page was synthesized from and the promotion
+        changesets that produced it (#678), so a reviewer can trace canonical knowledge
+        back to the captured insights.
+      parameters:
+      - description: Knowledge page id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/portal.knowledgePageLineageResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: A knowledge page's source-insight lineage
+      tags:
+      - Knowledge
   /portal/knowledge-pages/{id}/refs:
     get:
       description: Returns the entities the page references (assets, prompts, collections,

--- a/pkg/portal/handler.go
+++ b/pkg/portal/handler.go
@@ -58,6 +58,9 @@ type AuditMetrics interface {
 type InsightReader interface {
 	List(ctx context.Context, filter knowledge.InsightFilter) ([]knowledge.Insight, int, error)
 	Stats(ctx context.Context, filter knowledge.InsightFilter) (*knowledge.InsightStats, error)
+	// Get returns a single insight by id, used to surface a knowledge page's
+	// source-insight lineage (#678). A drained or deleted insight returns an error.
+	Get(ctx context.Context, id string) (*knowledge.Insight, error)
 }
 
 // ChangesetReader provides read access to knowledge changesets, used to surface

--- a/pkg/portal/handler_test.go
+++ b/pkg/portal/handler_test.go
@@ -3,6 +3,7 @@ package portal
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -2237,11 +2238,23 @@ type mockInsightStore struct {
 	statsResult *knowledge.InsightStats
 	statsErr    error
 	lastFilter  knowledge.InsightFilter
+	getResult   map[string]*knowledge.Insight
+	getErr      error
 }
 
 func (m *mockInsightStore) List(_ context.Context, f knowledge.InsightFilter) ([]knowledge.Insight, int, error) {
 	m.lastFilter = f
 	return m.listResult, m.listTotal, m.listErr
+}
+
+func (m *mockInsightStore) Get(_ context.Context, id string) (*knowledge.Insight, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	if ins, ok := m.getResult[id]; ok {
+		return ins, nil
+	}
+	return nil, errors.New("insight not found")
 }
 
 func (m *mockInsightStore) Stats(_ context.Context, f knowledge.InsightFilter) (*knowledge.InsightStats, error) {

--- a/pkg/portal/knowledge_page_handler.go
+++ b/pkg/portal/knowledge_page_handler.go
@@ -44,6 +44,8 @@ func (h *Handler) registerKnowledgePageRoutes() {
 	h.mux.HandleFunc("PUT /api/v1/portal/knowledge-pages/{id}", h.updateKnowledgePage)
 	h.mux.HandleFunc("DELETE /api/v1/portal/knowledge-pages/{id}", h.deleteKnowledgePage)
 	h.mux.HandleFunc("GET /api/v1/portal/knowledge-pages/{id}/versions", h.listKnowledgePageVersions)
+	// Source-insight lineage (#678): the insights a page was synthesized from.
+	h.mux.HandleFunc("GET /api/v1/portal/knowledge-pages/{id}/lineage", h.knowledgePageLineage)
 	// Entity references (#664): the entities a page provides knowledge about.
 	h.mux.HandleFunc("GET /api/v1/portal/knowledge-pages/{id}/refs", h.listKnowledgePageRefs)
 	h.mux.HandleFunc("PUT /api/v1/portal/knowledge-pages/{id}/refs", h.setKnowledgePageRefs)

--- a/pkg/portal/knowledge_page_refs_handler.go
+++ b/pkg/portal/knowledge_page_refs_handler.go
@@ -9,9 +9,15 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
+	"github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
 )
+
+// maxLineageChangesets caps how many promotion changesets a page's lineage query
+// reads. A page accrues one changeset per promotion, far below this bound.
+const maxLineageChangesets = 200
 
 // maxEntityRefsPerPage caps how many references a single set request may carry,
 // so a malformed or hostile payload cannot fan out unbounded inserts.
@@ -89,6 +95,133 @@ func (h *Handler) listKnowledgePageRefs(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	writeJSON(w, http.StatusOK, knowledgePageRefsResponse{Refs: h.resolveAndFilterRefs(r, user, refs)})
+}
+
+// lineageInsight is a source insight that contributed to a knowledge page.
+type lineageInsight struct {
+	ID         string `json:"id"`
+	Text       string `json:"text"`
+	Category   string `json:"category"`
+	Status     string `json:"status"`
+	Confidence string `json:"confidence"`
+	CapturedBy string `json:"captured_by"`
+}
+
+// lineageChangeset is one promotion (apply_knowledge) that produced the page.
+type lineageChangeset struct {
+	ID               string    `json:"id"`
+	ChangeType       string    `json:"change_type"`
+	CreatedAt        time.Time `json:"created_at"`
+	RolledBack       bool      `json:"rolled_back"`
+	SourceInsightIDs []string  `json:"source_insight_ids"`
+}
+
+// knowledgePageLineageResponse is the lineage envelope: the insights a page was
+// synthesized from, and the promotion changesets that produced it.
+type knowledgePageLineageResponse struct {
+	Insights   []lineageInsight   `json:"insights"`
+	Changesets []lineageChangeset `json:"changesets"`
+}
+
+// knowledgePageLineage handles GET /api/v1/portal/knowledge-pages/{id}/lineage.
+//
+// @Summary      A knowledge page's source-insight lineage
+// @Description  Returns the insights the page was synthesized from and the promotion changesets that produced it (#678), so a reviewer can trace canonical knowledge back to the captured insights.
+// @Tags         Knowledge
+// @Produce      json
+// @Param        id  path  string  true  "Knowledge page id"
+// @Success      200  {object}  knowledgePageLineageResponse
+// @Failure      401  {object}  problemDetail
+// @Failure      404  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/knowledge-pages/{id}/lineage [get]
+func (h *Handler) knowledgePageLineage(w http.ResponseWriter, r *http.Request) {
+	user := GetUser(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, errAuthRequired)
+		return
+	}
+	// Lineage exposes the raw source-insight text and the capturer's identity, which
+	// are reviewer-facing source material, not org-shared page content. Gate it to
+	// apply_knowledge holders (the same gate as editing a page), not every viewer.
+	if !h.userHasApplyKnowledge(user) {
+		writeError(w, http.StatusForbidden, errKnowledgePageForbidden)
+		return
+	}
+	if h.deps.KnowledgePageStore == nil {
+		writeError(w, http.StatusNotFound, "knowledge pages are not enabled")
+		return
+	}
+	id := r.PathValue(kpIDParam)
+	page, err := h.deps.KnowledgePageStore.Get(r.Context(), id)
+	if errors.Is(err, knowledgepage.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "knowledge page not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load knowledge page")
+		return
+	}
+
+	resp := knowledgePageLineageResponse{Insights: []lineageInsight{}, Changesets: []lineageChangeset{}}
+	if h.deps.ChangesetReader == nil {
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+	changesets, _, err := h.deps.ChangesetReader.ListChangesets(r.Context(),
+		knowledge.ChangesetFilter{EntityURN: knowledge.PageTargetURN(page.Slug), Limit: maxLineageChangesets})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load page lineage")
+		return
+	}
+
+	var insightIDs []string
+	resp.Changesets, insightIDs = lineageFromChangesets(changesets)
+	resp.Insights = h.loadLineageInsights(r.Context(), insightIDs)
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// lineageFromChangesets maps changesets to lineage entries and returns the
+// de-duplicated source-insight ids across them (first-seen order).
+func lineageFromChangesets(changesets []knowledge.Changeset) (entries []lineageChangeset, insightIDs []string) {
+	entries = make([]lineageChangeset, 0, len(changesets))
+	seen := make(map[string]struct{})
+	insightIDs = make([]string, 0)
+	for _, cs := range changesets {
+		entries = append(entries, lineageChangeset{
+			ID: cs.ID, ChangeType: cs.ChangeType, CreatedAt: cs.CreatedAt,
+			RolledBack: cs.RolledBack, SourceInsightIDs: cs.SourceInsightIDs,
+		})
+		for _, iid := range cs.SourceInsightIDs {
+			if _, dup := seen[iid]; dup {
+				continue
+			}
+			seen[iid] = struct{}{}
+			insightIDs = append(insightIDs, iid)
+		}
+	}
+	return entries, insightIDs
+}
+
+// loadLineageInsights fetches each source insight; drained or deleted ones are
+// skipped rather than failing the request.
+func (h *Handler) loadLineageInsights(ctx context.Context, ids []string) []lineageInsight {
+	out := make([]lineageInsight, 0, len(ids))
+	if h.deps.InsightStore == nil {
+		return out
+	}
+	for _, iid := range ids {
+		ins, err := h.deps.InsightStore.Get(ctx, iid)
+		if err != nil || ins == nil {
+			continue
+		}
+		out = append(out, lineageInsight{
+			ID: ins.ID, Text: ins.InsightText, Category: ins.Category,
+			Status: ins.Status, Confidence: ins.Confidence, CapturedBy: ins.CapturedBy,
+		})
+	}
+	return out
 }
 
 // setKnowledgePageRefs handles PUT /api/v1/portal/knowledge-pages/{id}/refs.

--- a/pkg/portal/knowledge_page_refs_handler_test.go
+++ b/pkg/portal/knowledge_page_refs_handler_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
 	"github.com/txn2/mcp-data-platform/pkg/prompt"
+	"github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
 )
 
 type refsResp struct {
@@ -235,6 +236,92 @@ func TestResolveKnowledgePageRefs_Unauthenticated(t *testing.T) {
 	h := newKnowledgePageHandler(&mockKnowledgePageStore{}, nil)
 	w := doKP(h, "POST", "/api/v1/portal/knowledge-pages/refs/resolve", `{"urns":[]}`)
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestKnowledgePageLineage(t *testing.T) {
+	kp := &mockKnowledgePageStore{page: &knowledgepage.Page{ID: "kp1", Slug: "seasons"}}
+	cr := &mockChangesetReader{changesets: []knowledge.Changeset{
+		// i3 is referenced but missing from the insight store (drained); it is skipped.
+		{ID: "cs1", TargetURN: "kp:seasons", ChangeType: "create_knowledge_page", SourceInsightIDs: []string{"i1", "i2", "i3"}},
+		{ID: "cs2", TargetURN: "kp:seasons", ChangeType: "update_knowledge_page", SourceInsightIDs: []string{"i2"}},
+	}}
+	is := &mockInsightStore{getResult: map[string]*knowledge.Insight{
+		"i1": {ID: "i1", InsightText: "Summer is May to Oct", Status: "applied", Category: "business_context"},
+		"i2": {ID: "i2", InsightText: "Winter is Nov to Apr", Status: "applied"},
+	}}
+	deps := Deps{
+		KnowledgePageStore: kp, ChangesetReader: cr, InsightStore: is,
+		AdminRoles: []string{"admin"}, RateLimit: RateLimitConfig{RequestsPerMinute: 600, BurstSize: 100},
+	}
+	h := NewHandler(deps, testAuthMiddleware(kpAdmin))
+	w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/kp1/lineage", "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp knowledgePageLineageResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Len(t, resp.Changesets, 2, "both promotions appear in lineage")
+	require.Len(t, resp.Insights, 2, "i2 deduped across changesets; the drained i3 is skipped")
+	gotIDs := []string{resp.Insights[0].ID, resp.Insights[1].ID}
+	assert.ElementsMatch(t, []string{"i1", "i2"}, gotIDs)
+	// The changeset query must target this page (kp:<slug>), or lineage silently empties.
+	assert.Equal(t, "kp:seasons", cr.gotFilter.EntityURN)
+}
+
+func TestKnowledgePageLineage_RequiresApplyKnowledge(t *testing.T) {
+	deps := Deps{
+		KnowledgePageStore: &mockKnowledgePageStore{page: &knowledgepage.Page{ID: "kp1", Slug: "s"}},
+		ChangesetReader:    &mockChangesetReader{},
+		AdminRoles:         []string{"admin"},
+		RateLimit:          RateLimitConfig{RequestsPerMinute: 600, BurstSize: 100},
+	}
+	// kpViewer holds no apply_knowledge, so the raw insight lineage is forbidden.
+	h := NewHandler(deps, testAuthMiddleware(kpViewer))
+	w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/kp1/lineage", "")
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestKnowledgePageLineage_NoChangesetReader(t *testing.T) {
+	deps := Deps{
+		KnowledgePageStore: &mockKnowledgePageStore{page: &knowledgepage.Page{ID: "kp1", Slug: "s"}},
+		AdminRoles:         []string{"admin"},
+		RateLimit:          RateLimitConfig{RequestsPerMinute: 600, BurstSize: 100},
+	}
+	h := NewHandler(deps, testAuthMiddleware(kpAdmin))
+	w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/kp1/lineage", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp knowledgePageLineageResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Insights)
+	assert.Empty(t, resp.Changesets)
+}
+
+func TestKnowledgePageLineage_NotFound(t *testing.T) {
+	deps := Deps{
+		KnowledgePageStore: &mockKnowledgePageStore{}, // nil page -> ErrNotFound
+		AdminRoles:         []string{"admin"},
+		RateLimit:          RateLimitConfig{RequestsPerMinute: 600, BurstSize: 100},
+	}
+	h := NewHandler(deps, testAuthMiddleware(kpAdmin))
+	w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/missing/lineage", "")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestKnowledgePageLineage_Unauthenticated(t *testing.T) {
+	h := newKnowledgePageHandler(&mockKnowledgePageStore{page: &knowledgepage.Page{ID: "kp1", Slug: "s"}}, nil)
+	w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/kp1/lineage", "")
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestKnowledgePageLineage_ChangesetError(t *testing.T) {
+	deps := Deps{
+		KnowledgePageStore: &mockKnowledgePageStore{page: &knowledgepage.Page{ID: "kp1", Slug: "s"}},
+		ChangesetReader:    &mockChangesetReader{err: errors.New("boom")},
+		AdminRoles:         []string{"admin"},
+		RateLimit:          RateLimitConfig{RequestsPerMinute: 600, BurstSize: 100},
+	}
+	h := NewHandler(deps, testAuthMiddleware(kpAdmin))
+	w := doKP(h, "GET", "/api/v1/portal/knowledge-pages/kp1/lineage", "")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 func TestResolveKnowledgePageRefs_WithStores(t *testing.T) {

--- a/pkg/toolkits/knowledge/page_sink.go
+++ b/pkg/toolkits/knowledge/page_sink.go
@@ -26,6 +26,11 @@ const (
 // Page changeset markers. The changeset target_urn is free-form text (migration
 // 000008), so a page promotion records "kp:<slug>" and shares the same changeset
 // store / list / rollback surface as DataHub changesets.
+// PageTargetURN is the changeset target_urn for a knowledge page, keyed by slug.
+// Exported so other packages (the portal lineage endpoint) reference the same
+// format instead of duplicating the "kp:" prefix.
+func PageTargetURN(slug string) string { return pageTargetPrefix + slug }
+
 const (
 	pageTargetPrefix    = "kp:"
 	changeCreatePage    = "create_page"
@@ -212,6 +217,12 @@ func (t *Toolkit) applyPagePromotion(ctx context.Context, page pagePromotionInpu
 		if err != nil {
 			return nil, err
 		}
+		// Reconcile the body's inline references (#678): a page promoted through
+		// apply_knowledge gets the same source=inline refs the portal save path
+		// derives, so inline mcp:/urn: links in the body become references.
+		if err := t.reconcileInlineRefs(ctx, existing.ID, page.Body); err != nil {
+			return nil, err
+		}
 		return &pagePromotion{
 			pageID: existing.ID, slug: page.Slug, changeType: changeUpdatePage,
 			prev: prev,
@@ -227,6 +238,9 @@ func (t *Toolkit) applyPagePromotion(ctx context.Context, page pagePromotionInpu
 		}
 		nextURNs, err := t.addPageEntityRefs(ctx, id, entityURNs, appliedBy)
 		if err != nil {
+			return nil, err
+		}
+		if err := t.reconcileInlineRefs(ctx, id, page.Body); err != nil {
 			return nil, err
 		}
 		return &pagePromotion{
@@ -269,6 +283,19 @@ func (t *Toolkit) addPageEntityRefs(ctx context.Context, pageID string, entityUR
 		}
 	}
 	return t.pageEntityURNs(ctx, pageID)
+}
+
+// reconcileInlineRefs scans a page body for inline mcp:/urn: references and
+// replaces the page's source=inline references to match, identical to the portal
+// save path (#678). Promoted and manual references are untouched. This makes a page
+// authored or promoted through apply_knowledge capture the references in its body,
+// not just the ones carried from the source insight.
+func (t *Toolkit) reconcileInlineRefs(ctx context.Context, pageID, body string) error {
+	inline := knowledgepage.ScanBodyRefs(body)
+	if err := t.pageWriter.ReplaceEntityRefsBySource(ctx, pageID, knowledgepage.RefSourceInline, inline); err != nil {
+		return fmt.Errorf("reconciling inline page references: %w", err)
+	}
+	return nil
 }
 
 // promotedRefsFromURNs parses serialized reference URNs (any type: a urn:li:

--- a/pkg/toolkits/knowledge/page_sink_test.go
+++ b/pkg/toolkits/knowledge/page_sink_test.go
@@ -19,14 +19,16 @@ var errKP = errors.New("kp boom")
 
 // fakePageWriter is an in-memory pageWriter for sink-router tests.
 type fakePageWriter struct {
-	pages     map[string]*knowledgepage.Page       // slug -> page
-	refs      map[string][]knowledgepage.EntityRef // pageID -> refs
-	inserted  []string
-	updated   []string
-	deleted   []string
-	insertErr error
-	updateErr error
-	getErr    error
+	pages            map[string]*knowledgepage.Page       // slug -> page
+	refs             map[string][]knowledgepage.EntityRef // pageID -> refs
+	inserted         []string
+	updated          []string
+	deleted          []string
+	insertErr        error
+	updateErr        error
+	getErr           error
+	replaceBySrcErr  error // errors any ReplaceEntityRefsBySource call
+	replaceInlineErr error // errors only the source=inline replace
 }
 
 func newFakePageWriter() *fakePageWriter {
@@ -64,6 +66,12 @@ func (f *fakePageWriter) ReplaceEntityRefs(_ context.Context, pageID string, ref
 }
 
 func (f *fakePageWriter) ReplaceEntityRefsBySource(_ context.Context, pageID, source string, refs []knowledgepage.EntityRef) error {
+	if f.replaceBySrcErr != nil {
+		return f.replaceBySrcErr
+	}
+	if source == knowledgepage.RefSourceInline && f.replaceInlineErr != nil {
+		return f.replaceInlineErr
+	}
 	kept := f.refs[pageID][:0:0]
 	for _, r := range f.refs[pageID] {
 		if r.Source != source {
@@ -205,6 +213,93 @@ func TestPromoteToPage_CarriesMixedInsightRefTypes(t *testing.T) {
 		"mcp:asset:asset-1",
 		dataset,
 	}, urns, "the insight's connection, asset, and dataset references all carry onto the page")
+}
+
+// TestPromoteToPage_ReconcilesInlineBodyRefs proves #678: a page promoted via
+// apply_knowledge gets the inline references in its own body reconciled as
+// source=inline, not only the references carried from the source insight.
+func TestPromoteToPage_ReconcilesInlineBodyRefs(t *testing.T) {
+	// The source insight carries no references of its own.
+	store := &fullSpyStore{Insights: []Insight{{ID: "i1", SinkClass: memory.SinkBusinessKnowledge}}}
+	pw := newFakePageWriter()
+	tk := newApplyToolkit(t, store, &spyChangesetStore{}, &spyWriter{})
+	tk.SetPageWriter(pw)
+
+	input := applyKnowledgeInput{
+		Action: actionApply, Sink: sinkKnowledgePage, InsightIDs: []string{"i1"},
+		Page: &pagePromotionInput{
+			Slug:  "guide",
+			Title: "Guide",
+			Body:  "See [the warehouse](mcp:connection:(trino,acme)) and the [dashboard](mcp:asset:asset-1).",
+		},
+	}
+	res, _, err := tk.handleApplyKnowledge(pageCtx(), &mcp.CallToolRequest{}, input)
+	require.NoError(t, err)
+	require.False(t, res.IsError, "unexpected error result")
+	page := pw.pages["guide"]
+	require.NotNil(t, page)
+
+	urns := make([]string, 0, len(pw.refs[page.ID]))
+	for _, r := range pw.refs[page.ID] {
+		assert.Equal(t, knowledgepage.RefSourceInline, r.Source, "body references are source=inline")
+		urns = append(urns, r.URN())
+	}
+	assert.ElementsMatch(t, []string{"mcp:connection:(trino,acme)", "mcp:asset:asset-1"}, urns,
+		"inline references in the promoted page body must be reconciled onto the page")
+}
+
+// TestPromoteToPage_InlineReconcileError surfaces a failure in the inline-ref
+// reconcile during promotion as an error result rather than silently dropping refs.
+func TestPromoteToPage_InlineReconcileError(t *testing.T) {
+	store := &fullSpyStore{Insights: []Insight{{ID: "i1", SinkClass: memory.SinkBusinessKnowledge}}}
+	pw := newFakePageWriter()
+	pw.replaceBySrcErr = errors.New("inline reconcile boom")
+	tk := newApplyToolkit(t, store, &spyChangesetStore{}, &spyWriter{})
+	tk.SetPageWriter(pw)
+
+	input := applyKnowledgeInput{
+		Action: actionApply, Sink: sinkKnowledgePage, InsightIDs: []string{"i1"},
+		Page: &pagePromotionInput{Slug: "guide", Title: "Guide", Body: "[a](mcp:asset:asset-1)"},
+	}
+	res, _, err := tk.handleApplyKnowledge(pageCtx(), &mcp.CallToolRequest{}, input)
+	require.NoError(t, err)
+	assert.True(t, res.IsError, "an inline reconcile failure should surface as an error result")
+}
+
+// TestPromoteToPage_InlineReconcileError_Update covers the inline-reconcile error
+// on the update branch (an existing page promoted to the same slug).
+func TestPromoteToPage_InlineReconcileError_Update(t *testing.T) {
+	store := &fullSpyStore{Insights: []Insight{{ID: "i1", SinkClass: memory.SinkBusinessKnowledge}}}
+	pw := newFakePageWriter()
+	pw.pages["seasons"] = &knowledgepage.Page{ID: "kp1", Slug: "seasons", CurrentVersion: 1}
+	pw.replaceBySrcErr = errKP
+	tk := newApplyToolkit(t, store, &spyChangesetStore{}, &spyWriter{})
+	tk.SetPageWriter(pw)
+
+	res, _, err := tk.handleApplyKnowledge(pageCtx(), &mcp.CallToolRequest{}, applyPageInput([]string{"i1"}))
+	require.NoError(t, err)
+	assert.True(t, res.IsError, "an inline reconcile failure on update should surface as an error result")
+}
+
+// TestRevertPageChangeset_InlineReconcileError covers the inline-reconcile error on
+// the rollback path (the promoted restore succeeds, the inline restore fails).
+func TestRevertPageChangeset_InlineReconcileError(t *testing.T) {
+	prev := map[string]any{
+		pageFieldTitle: "Old", pageFieldBody: "old body", pageFieldSummary: "", pageFieldTags: []any{},
+		pageFieldEntityURNs: []any{},
+	}
+	cs := pageChangeset("seasons", changeUpdatePage, 4, prev)
+	pw := newFakePageWriter()
+	pw.pages["seasons"] = &knowledgepage.Page{ID: "kp1", Slug: "seasons", CurrentVersion: 4}
+	pw.replaceInlineErr = errKP // promoted restore succeeds, inline restore fails
+	csStore := &spyChangesetStore{Changesets: []Changeset{cs}}
+	tk := newApplyToolkit(t, &fullSpyStore{}, csStore, &spyWriter{})
+	tk.SetPageWriter(pw)
+
+	res, _, err := tk.handleApplyKnowledge(pageCtx(), &mcp.CallToolRequest{},
+		applyKnowledgeInput{Action: actionRollback, ChangesetID: "cs1", Confirm: true})
+	require.NoError(t, err)
+	assert.True(t, res.IsError, "an inline reconcile failure on rollback should surface as an error result")
 }
 
 func applyPageInput(insightIDs []string) applyKnowledgeInput {

--- a/pkg/toolkits/knowledge/rollback.go
+++ b/pkg/toolkits/knowledge/rollback.go
@@ -397,6 +397,12 @@ func applyPageRevert(ctx context.Context, pages PageReverter, cs *Changeset, pag
 			promotedRefsFromURNs(strsFromMap(cs.PreviousValue, pageFieldEntityURNs))); err != nil {
 			return "", fmt.Errorf("restoring knowledge page references: %w", err)
 		}
+		// Re-derive the inline references from the restored body (#678) so they stay
+		// consistent with the body after a rollback; manual refs are untouched.
+		if err := pages.ReplaceEntityRefsBySource(ctx, page.ID, knowledgepage.RefSourceInline,
+			knowledgepage.ScanBodyRefs(body)); err != nil {
+			return "", fmt.Errorf("restoring inline knowledge page references: %w", err)
+		}
 		return "restored page " + page.Slug, nil
 	default:
 		return "", fmt.Errorf("unknown page change type: %s", cs.ChangeType)

--- a/ui/src/api/portal/hooks.ts
+++ b/ui/src/api/portal/hooks.ts
@@ -1299,6 +1299,37 @@ export function useKnowledgePageRefs(id: string) {
   });
 }
 
+export interface LineageInsight {
+  id: string;
+  text: string;
+  category: string;
+  status: string;
+  confidence: string;
+  captured_by: string;
+}
+
+export interface LineageChangeset {
+  id: string;
+  change_type: string;
+  created_at: string;
+  rolled_back: boolean;
+  source_insight_ids: string[];
+}
+
+export interface KnowledgePageLineage {
+  insights: LineageInsight[];
+  changesets: LineageChangeset[];
+}
+
+/** useKnowledgePageLineage returns the insights a page was synthesized from (#678). */
+export function useKnowledgePageLineage(id: string) {
+  return useQuery({
+    queryKey: ["knowledge-page-lineage", id],
+    queryFn: () => apiFetch<KnowledgePageLineage>(`/knowledge-pages/${id}/lineage`),
+    enabled: !!id,
+  });
+}
+
 /**
  * useSetKnowledgePageRefs replaces a page's manual references with the given URNs
  * (promoted/inline refs are preserved server-side). Requires apply_knowledge.

--- a/ui/src/components/knowledge/LineagePanel.tsx
+++ b/ui/src/components/knowledge/LineagePanel.tsx
@@ -1,0 +1,47 @@
+import { useKnowledgePageLineage } from "@/api/portal/hooks";
+
+const STATUS_TONE: Record<string, string> = {
+  applied: "border-primary/20 bg-primary/10 text-primary",
+  approved: "border-primary/20 bg-primary/10 text-primary",
+  pending: "border-border bg-muted text-muted-foreground",
+  rejected: "border-border bg-muted text-muted-foreground line-through",
+  superseded: "border-border bg-muted text-muted-foreground",
+};
+
+/**
+ * LineagePanel shows the insights a knowledge page was synthesized from (#678),
+ * tracing canonical knowledge back to the captured insights that produced it. It is
+ * the reviewer-facing provenance view, so the raw insight text is shown here rather
+ * than as agent context.
+ */
+export function LineagePanel({ pageId }: { pageId: string }) {
+  const { data } = useKnowledgePageLineage(pageId);
+  const insights = data?.insights ?? [];
+  if (insights.length === 0) return null;
+
+  return (
+    <aside className="rounded-lg border border-border bg-card p-4">
+      <h2 className="mb-1 text-sm font-semibold text-foreground">Synthesized from</h2>
+      <p className="mb-3 text-xs text-muted-foreground">
+        The captured insights this page was promoted from.
+      </p>
+      <ul className="space-y-2">
+        {insights.map((ins) => (
+          <li key={ins.id} className="rounded-md border border-border bg-background p-2.5">
+            <div className="mb-1 flex items-center gap-2">
+              <span
+                className={`inline-flex items-center rounded-full border px-1.5 py-0.5 text-xs ${
+                  STATUS_TONE[ins.status] ?? STATUS_TONE.pending
+                }`}
+              >
+                {ins.status}
+              </span>
+              {ins.category && <span className="text-xs text-muted-foreground">{ins.category}</span>}
+            </div>
+            <p className="text-sm text-foreground">{ins.text}</p>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/ui/src/components/renderers/MarkdownRenderer.test.tsx
+++ b/ui/src/components/renderers/MarkdownRenderer.test.tsx
@@ -96,6 +96,30 @@ describe("MarkdownRenderer entity chips", () => {
     expect(container.querySelector('a[href^="mcp:"]')).toBeNull();
   });
 
+  it("chips a BARE mcp: token in body text (not just markdown links) (#678)", () => {
+    const { container } = render(
+      <MarkdownRenderer content="Configured in mcp:connection:(trino,acme) for promotions." />,
+    );
+    // The bare token becomes a chip showing the derived label, not raw text.
+    expect(container.textContent).toContain("acme (trino)");
+    expect(container.textContent).not.toContain("mcp:connection:(trino,acme)");
+  });
+
+  it("chips a BARE urn:li: dataset token in body text (#678)", () => {
+    const { container } = render(
+      <MarkdownRenderer content="Query urn:li:dataset:(urn:li:dataPlatform:trino,opensearch.default.os_acme_transactions,PROD) carefully." />,
+    );
+    expect(container.textContent).toContain("os_acme_transactions");
+  });
+
+  it("does not chip a ref token inside an inline code span", () => {
+    const { container } = render(
+      <MarkdownRenderer content="Use the literal `mcp:asset:asset-001` token." />,
+    );
+    // Inside code it stays literal text, not a chip.
+    expect(container.querySelector("code")?.textContent).toContain("mcp:asset:asset-001");
+  });
+
   it("renders the server-resolved label when provided", () => {
     const refs = new Map<string, ResolvedRef>([
       ["mcp:asset:asset-001", { urn: "mcp:asset:asset-001", type: "asset", label: "Q4 Dashboard", exists: true, accessible: true }],

--- a/ui/src/components/renderers/MarkdownRenderer.tsx
+++ b/ui/src/components/renderers/MarkdownRenderer.tsx
@@ -5,7 +5,49 @@ import type { Components } from "react-markdown";
 import mermaid from "mermaid";
 import DOMPurify from "dompurify";
 import { EntityChip } from "@/components/knowledge/EntityChip";
-import { isRefUrn, type ResolvedRef } from "@/lib/entityRefs";
+import { isRefUrn, REF_TOKEN_SOURCE, type ResolvedRef } from "@/lib/entityRefs";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MdNode = { type?: string; value?: string; url?: string; children?: any[] };
+
+function splitRefTokens(value: string): MdNode[] {
+  const re = new RegExp(REF_TOKEN_SOURCE, "g");
+  const out: MdNode[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(value)) !== null) {
+    if (m.index > last) out.push({ type: "text", value: value.slice(last, m.index) });
+    out.push({ type: "link", url: m[0], children: [{ type: "text", value: m[0] }] });
+    last = m.index + m[0].length;
+  }
+  if (last === 0) return [{ type: "text", value }];
+  if (last < value.length) out.push({ type: "text", value: value.slice(last) });
+  return out;
+}
+
+function walkRefs(node: MdNode): void {
+  if (!Array.isArray(node.children)) return;
+  const next: MdNode[] = [];
+  for (const child of node.children) {
+    if (child.type === "text" && typeof child.value === "string") {
+      next.push(...splitRefTokens(child.value));
+    } else {
+      // Do not descend into links (already a chip) or code (literal).
+      if (child.type !== "link" && child.type !== "code" && child.type !== "inlineCode") {
+        walkRefs(child);
+      }
+      next.push(child);
+    }
+  }
+  node.children = next;
+}
+
+// remarkEntityRefs converts bare mcp:/urn: tokens in text into link nodes so they
+// render as entity chips via the `a` override, even when the author wrote a bare
+// token rather than a markdown link (#678).
+function remarkEntityRefs() {
+  return (tree: MdNode) => walkRefs(tree);
+}
 
 // DOMPurify's default FORBID_CONTENTS strips the children of `foreignObject`
 // (among others). We reuse that default list but drop `foreignobject` so the
@@ -236,7 +278,7 @@ export function MarkdownRenderer({
       className={`prose prose-sm max-w-none dark:prose-invert [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 ${bare ? "" : "rounded-lg border bg-card p-6"}`}
     >
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={[remarkGfm, remarkEntityRefs]}
         components={components}
         // Preserve entity-reference URNs (mcp:/urn:) so the `a` override can chip
         // them; everything else keeps react-markdown's default URL sanitization.

--- a/ui/src/lib/entityRefs.ts
+++ b/ui/src/lib/entityRefs.ts
@@ -56,8 +56,11 @@ export interface ResolvedRef {
 // Mirrors the backend refTokenRe: at most one level of parentheses, which covers
 // every reference form. Parenthesized alternatives come first so a connection or
 // DataHub token is matched whole rather than truncated at an enclosing paren.
-const REF_TOKEN_RE =
-  /mcp:[a-z_]+:\([^)]*\)|mcp:[a-z_]+:[A-Za-z0-9_.-]+|urn:[a-z]+:[A-Za-z0-9]+:\([^)]*\)|urn:[a-z]+:[^\s)\]>]+/g;
+// Exported as a source string so other modules (the markdown renderer) build a
+// fresh RegExp from the same pattern rather than copying it.
+export const REF_TOKEN_SOURCE =
+  "mcp:[a-z_]+:\\([^)]*\\)|mcp:[a-z_]+:[A-Za-z0-9_.-]+|urn:[a-z]+:[A-Za-z0-9]+:\\([^)]*\\)|urn:[a-z]+:[^\\s)\\]>]+";
+const REF_TOKEN_RE = new RegExp(REF_TOKEN_SOURCE, "g");
 
 // Fenced code blocks and inline code spans are stripped before scanning so a URN
 // shown as a documentation example is not treated as a reference (mirrors the

--- a/ui/src/pages/knowledge-pages/KnowledgePagesPage.tsx
+++ b/ui/src/pages/knowledge-pages/KnowledgePagesPage.tsx
@@ -16,6 +16,7 @@ import { MarkdownEditor } from "@/components/MarkdownEditor";
 import { MarkdownRenderer } from "@/components/renderers/MarkdownRenderer";
 import { extractRefUrns } from "@/lib/entityRefs";
 import { RelatedPanel } from "@/components/knowledge/RelatedPanel";
+import { LineagePanel } from "@/components/knowledge/LineagePanel";
 import { RefPicker } from "@/components/knowledge/RefPicker";
 import { KnowledgeBacklinks } from "@/components/knowledge/KnowledgeBacklinks";
 import { FeedbackButton } from "@/components/feedback/FeedbackButton";
@@ -341,6 +342,18 @@ function KnowledgePageDetail({
           v{page.current_version}
           {page.updated_by ? ` · last edited by ${page.updated_by}` : ""}
         </p>
+        {page.tags && page.tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {page.tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
 
       {showHistory && <KnowledgePageHistory id={id} onClose={() => setShowHistory(false)} />}
@@ -354,6 +367,7 @@ function KnowledgePageDetail({
 
       <RelatedPanel pageId={id} onNavigate={onNavigate} />
       <KnowledgeBacklinks urn={`mcp:knowledge_page:${id}`} onNavigate={onNavigate} />
+      {canEdit && <LineagePanel pageId={id} />}
       {canEdit && <RefPicker pageId={id} onNavigate={onNavigate} />}
     </div>
   );


### PR DESCRIPTION
Addresses #678 (four of six gaps). A data-population pass on a live v1.88.1 deployment (capturing memories, promoting them to knowledge pages via `apply_knowledge`, then checking enrichment) surfaced that knowledge-page entity references were broken end to end: pages got **no references at all**, there was **no lineage** back to the source insights, the **view omitted tags**, and inline reference tokens rendered as **raw text**. Root causes were verified against the source.

## What this fixes

### 1. References are created on promotion (the root cause)

`applyPagePromotion` carried only the source insight's references; it never scanned the page **body** it was given. The inline body-scan that turns `mcp:`/`urn:` mentions into `source=inline` references lived only in the portal save handler and the one-time startup backfill. So a page created or updated through `apply_knowledge` with inline links in its markdown captured none of them.

Now promotion (create and update) runs the same inline reconcile (`ScanBodyRefs` + `ReplaceEntityRefsBySource(inline)`), and rollback re-derives inline refs from the restored body. Promoted and manual references are untouched.

### 2. Source-insight lineage

New `GET /api/v1/portal/knowledge-pages/{id}/lineage` returns the insights a page was synthesized from (deduped across promotion changesets, drained/deleted insights skipped) plus the promotions that produced it. A reviewer-facing **"Synthesized from"** panel on the page detail renders them, so canonical knowledge can be traced back to the captured insights.

Access: the endpoint exposes raw insight text and the capturer's identity, which is reviewer-facing source material, not org-shared page content, so it is gated to `apply_knowledge` holders (the same gate as editing a page), not every authenticated viewer. The `"kp:"` page changeset target prefix is now an exported `PageTargetURN` helper so the portal query and the toolkit writer cannot drift.

### 3. Tags on the view page

The page view now renders the page's tags (previously only the edit form did).

### 4. Bare reference tokens render as chips

A remark transform converts bare `mcp:`/`urn:` tokens in body text into entity chips (the existing `a` override path), so a page authored with a bare token is not left with raw URN noise. Code spans and existing markdown links are left alone. The reference token regex is now shared between the client and the renderer (one source string) so they cannot diverge.

## Not in this change

- **Gap 5** (references visible on the page) follows directly from #1: the Related panel renders once a page has references.
- **Gap 6** (surfacing knowledge-page backrefs in agent tools such as `list_connections`, `datahub_get_entity`, and `search(entity_urns)`) is the separate **#634** agent cross-enrichment epic. This pass is concrete evidence for it; it is referenced in #678, not built here.

## Testing

- `make verify` green: race + real-Postgres, package budget, lint, gosec/govulncheck, semgrep, CodeQL, mutation, swagger-check, GoReleaser. **Patch coverage 89.7%.**
- Go tests cover the inline reconcile on create/update and on rollback (including the `ReplaceEntityRefsBySource` error paths), and the lineage endpoint: dedup across changesets, drained-insight skip, the `kp:`+slug filter is asserted, and the `apply_knowledge` gate (403 for a non-holder, 401 unauthenticated, 404 missing page).
- UI tests cover bare-token chipping (both `mcp:` and `urn:li:` forms), code-span literals (not chipped), and the existing markdown-link path (no double-chip).
- Two adversarial review passes. The second caught an access-control leak in an earlier draft of the lineage endpoint (raw insight text and emails returned to any authenticated user); this PR gates it to `apply_knowledge` and adds the test.

## Follow-up

Once this ships, the demo pages that currently show no references (they were authored with bare URN tokens through the old promotion path) can be re-promoted with proper `[label](urn:...)` links to populate their references and lineage.
