### PR TITLE
feat(knowledge): surface knowledge pages about entities and connections to agents (#634)

### DIFF
--- a/pkg/connview/connview.go
+++ b/pkg/connview/connview.go
@@ -1,0 +1,139 @@
+// Package connview builds the list_connections view: the configured connections
+// across toolkits, each enriched with the canonical knowledge pages that reference
+// it (#634). It lives outside pkg/platform so that package stays within its size
+// budget, and depends only on narrow capabilities (a source resolver and a
+// knowledge-page reverse lookup) rather than on the platform itself.
+package connview
+
+import (
+	"context"
+
+	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
+)
+
+// maxKnowledgePages bounds how many referencing pages are listed per connection, so
+// list_connections output stays small even when a connection is widely documented.
+// The full total is still reported via Entry.KnowledgePageCount.
+const maxKnowledgePages = 5
+
+// dataKinds are the toolkit kinds that represent a data connection in the fallback
+// (non-ConnectionLister) path.
+var dataKinds = map[string]bool{"trino": true, "datahub": true, "s3": true}
+
+// KnowledgePage is a brief reference to a knowledge page documenting a connection.
+type KnowledgePage struct {
+	ID    string `json:"id"`
+	Slug  string `json:"slug"`
+	Title string `json:"title"`
+}
+
+// Entry describes a single toolkit connection. CatalogID and OperationCount are
+// populated only for kinds where they have meaning (today: api).
+type Entry struct {
+	Kind              string                        `json:"kind"`
+	Name              string                        `json:"name"`
+	Connection        string                        `json:"connection"`
+	Description       string                        `json:"description,omitempty"`
+	IsDefault         bool                          `json:"is_default,omitempty"`
+	DataHubSourceName string                        `json:"datahub_source_name,omitempty"`
+	CatalogID         string                        `json:"catalog_id,omitempty"`
+	OperationCount    int                           `json:"operation_count,omitempty"`
+	Health            *toolkit.ConnectionHealthWire `json:"health,omitempty"`
+	// KnowledgePageCount is the total number of knowledge pages that reference this
+	// connection; KnowledgePages carries a bounded sample of them (#634).
+	KnowledgePageCount int             `json:"knowledge_page_count,omitempty"`
+	KnowledgePages     []KnowledgePage `json:"knowledge_pages,omitempty"`
+}
+
+// Output is the JSON response for the list_connections tool.
+type Output struct {
+	Connections []Entry `json:"connections"`
+	Count       int     `json:"count"`
+}
+
+// SourceResolver resolves a connection's DataHub source name (empty when none).
+type SourceResolver interface {
+	DataHubSourceName(kind, name string) string
+}
+
+// PageLookup is the knowledge-page reverse lookup: the pages referencing a target.
+type PageLookup interface {
+	ListPagesReferencing(ctx context.Context, ref knowledgepage.EntityRef) ([]knowledgepage.PageRef, error)
+}
+
+// Build enumerates connections across the toolkits and enriches each with the
+// knowledge pages that reference it (bounded by maxKnowledgePages). src and pages
+// may be nil; a nil page lookup simply skips the knowledge enrichment.
+func Build(ctx context.Context, toolkits []registry.Toolkit, src SourceResolver, pages PageLookup) Output {
+	entries := make([]Entry, 0, len(toolkits))
+	for _, tk := range toolkits {
+		if lister, ok := tk.(toolkit.ConnectionLister); ok {
+			entries = appendFromLister(entries, tk, lister, src)
+		} else {
+			entries = appendFallback(entries, tk, src)
+		}
+	}
+	enrichWithKnowledge(ctx, pages, entries)
+	return Output{Connections: entries, Count: len(entries)}
+}
+
+func appendFromLister(entries []Entry, tk registry.Toolkit, lister toolkit.ConnectionLister, src SourceResolver) []Entry {
+	for _, conn := range lister.ListConnections() {
+		e := Entry{
+			Kind:           tk.Kind(),
+			Name:           conn.Name,
+			Connection:     conn.Name,
+			Description:    conn.Description,
+			IsDefault:      conn.IsDefault,
+			CatalogID:      conn.CatalogID,
+			OperationCount: conn.OperationCount,
+			Health:         conn.Health.Wire(),
+		}
+		if src != nil {
+			e.DataHubSourceName = src.DataHubSourceName(tk.Kind(), conn.Name)
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}
+
+func appendFallback(entries []Entry, tk registry.Toolkit, src SourceResolver) []Entry {
+	kind := tk.Kind()
+	if !dataKinds[kind] {
+		return entries
+	}
+	e := Entry{Kind: kind, Name: tk.Name(), Connection: tk.Connection()}
+	if src != nil {
+		e.DataHubSourceName = src.DataHubSourceName(kind, tk.Name())
+	}
+	return append(entries, e)
+}
+
+// enrichWithKnowledge fills each entry's KnowledgePageCount and a bounded sample of
+// referencing pages. A nil lookup or per-connection failure is skipped, never fatal.
+// Knowledge pages are org-shared, so their titles are safe to surface here.
+func enrichWithKnowledge(ctx context.Context, pages PageLookup, entries []Entry) {
+	if pages == nil {
+		return
+	}
+	for i := range entries {
+		e := &entries[i]
+		refs, err := pages.ListPagesReferencing(ctx, knowledgepage.EntityRef{
+			TargetType:     knowledgepage.RefTargetConnection,
+			ConnectionKind: e.Kind,
+			ConnectionName: e.Name,
+		})
+		if err != nil || len(refs) == 0 {
+			continue
+		}
+		e.KnowledgePageCount = len(refs)
+		for _, pg := range refs {
+			if len(e.KnowledgePages) >= maxKnowledgePages {
+				break
+			}
+			e.KnowledgePages = append(e.KnowledgePages, KnowledgePage{ID: pg.ID, Slug: pg.Slug, Title: pg.Title})
+		}
+	}
+}

--- a/pkg/connview/connview_test.go
+++ b/pkg/connview/connview_test.go
@@ -1,0 +1,120 @@
+package connview
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
+	"github.com/txn2/mcp-data-platform/pkg/query"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/semantic"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
+)
+
+// mockTK implements registry.Toolkit without ConnectionLister (the fallback path).
+type mockTK struct {
+	kind, name, conn string
+}
+
+func (m *mockTK) Kind() string                          { return m.kind }
+func (m *mockTK) Name() string                          { return m.name }
+func (m *mockTK) Connection() string                    { return m.conn }
+func (*mockTK) RegisterTools(_ *mcp.Server)             {}
+func (*mockTK) Tools() []string                         { return nil }
+func (*mockTK) SetSemanticProvider(_ semantic.Provider) {}
+func (*mockTK) SetQueryProvider(_ query.Provider)       {}
+func (*mockTK) Close() error                            { return nil }
+
+// listerTK additionally implements toolkit.ConnectionLister.
+type listerTK struct {
+	mockTK
+	conns []toolkit.ConnectionDetail
+}
+
+func (m *listerTK) ListConnections() []toolkit.ConnectionDetail { return m.conns }
+
+type fakeSource struct{ names map[string]string }
+
+func (f fakeSource) DataHubSourceName(kind, name string) string { return f.names[kind+"/"+name] }
+
+type fakePages struct {
+	byConn map[string][]knowledgepage.PageRef
+	err    error
+}
+
+func (f fakePages) ListPagesReferencing(_ context.Context, ref knowledgepage.EntityRef) ([]knowledgepage.PageRef, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.byConn[ref.ConnectionKind+"/"+ref.ConnectionName], nil
+}
+
+func pageRefs(n int) []knowledgepage.PageRef {
+	out := make([]knowledgepage.PageRef, 0, n)
+	for i := range n {
+		id := string(rune('a' + i))
+		out = append(out, knowledgepage.PageRef{ID: "kp" + id, Slug: "s" + id, Title: "Page " + id})
+	}
+	return out
+}
+
+// TestBuild_KnowledgeBoundedByCap proves the token guard: a connection referenced by
+// many pages reports the full count but lists only maxKnowledgePages of them.
+func TestBuild_KnowledgeBoundedByCap(t *testing.T) {
+	tk := &listerTK{
+		mockTK: mockTK{kind: "trino"},
+		conns:  []toolkit.ConnectionDetail{{Name: "acme", IsDefault: true}},
+	}
+	pages := fakePages{byConn: map[string][]knowledgepage.PageRef{
+		"trino/acme": pageRefs(7), // more than the cap
+	}}
+	src := fakeSource{names: map[string]string{"trino/acme": "trino_src"}}
+	out := Build(context.Background(), []registry.Toolkit{tk}, src, pages)
+
+	require.Len(t, out.Connections, 1)
+	e := out.Connections[0]
+	assert.Equal(t, "trino_src", e.DataHubSourceName, "the lister path resolves the source")
+	assert.Equal(t, 7, e.KnowledgePageCount, "the full total is reported")
+	assert.Len(t, e.KnowledgePages, maxKnowledgePages, "the listed sample is capped")
+	assert.Equal(t, "Page a", e.KnowledgePages[0].Title)
+}
+
+func TestBuild_FallbackKindFilterAndSource(t *testing.T) {
+	toolkits := []registry.Toolkit{
+		&mockTK{kind: "trino", name: "warehouse", conn: "warehouse-conn"}, // data kind -> entry
+		&mockTK{kind: "api", name: "gw", conn: "gw-conn"},                 // not a data kind -> skipped
+	}
+	src := fakeSource{names: map[string]string{"trino/warehouse": "trino_src"}}
+	out := Build(context.Background(), toolkits, src, nil)
+
+	require.Len(t, out.Connections, 1, "non-data kinds are dropped in the fallback path")
+	assert.Equal(t, "trino", out.Connections[0].Kind)
+	assert.Equal(t, "trino_src", out.Connections[0].DataHubSourceName)
+	assert.Equal(t, 1, out.Count)
+}
+
+func TestBuild_NoEnrichmentWhenLookupNilOrEmpty(t *testing.T) {
+	tk := &listerTK{mockTK: mockTK{kind: "trino"}, conns: []toolkit.ConnectionDetail{{Name: "acme"}}}
+
+	// Nil lookup: no enrichment fields.
+	out := Build(context.Background(), []registry.Toolkit{tk}, nil, nil)
+	require.Len(t, out.Connections, 1)
+	assert.Zero(t, out.Connections[0].KnowledgePageCount)
+	assert.Empty(t, out.Connections[0].KnowledgePages)
+
+	// Lookup with no referencing pages for this connection.
+	out = Build(context.Background(), []registry.Toolkit{tk}, nil, fakePages{})
+	assert.Zero(t, out.Connections[0].KnowledgePageCount)
+}
+
+func TestBuild_LookupErrorSkipped(t *testing.T) {
+	tk := &listerTK{mockTK: mockTK{kind: "trino"}, conns: []toolkit.ConnectionDetail{{Name: "acme"}}}
+	out := Build(context.Background(), []registry.Toolkit{tk}, nil, fakePages{err: errors.New("boom")})
+	require.Len(t, out.Connections, 1)
+	assert.Zero(t, out.Connections[0].KnowledgePageCount, "a lookup error leaves the connection unenriched, not failed")
+}

--- a/pkg/knowledge/provider_knowledge_pages.go
+++ b/pkg/knowledge/provider_knowledge_pages.go
@@ -3,6 +3,7 @@ package knowledge
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
@@ -11,11 +12,13 @@ import (
 // SourceKnowledgePages is the provenance label for knowledge-page hits.
 const SourceKnowledgePages = "knowledge_pages"
 
-// knowledgePageSearcher is the relevance-search capability of the knowledge-page
-// store. It matches knowledgepage.Searcher; declared locally so the
+// PageSearcher is what the provider needs from the knowledge-page store:
+// relevance search over page content (the text path) and the reverse lookup of the
+// pages that reference an entity (the entity path, #634). Declared locally so the
 // provider depends on the capability and tests can supply a fake.
-type knowledgePageSearcher interface {
+type PageSearcher interface {
 	Search(ctx context.Context, q knowledgepage.SearchQuery) ([]knowledgepage.ScoredPage, error)
+	ListPagesReferencing(ctx context.Context, ref knowledgepage.EntityRef) ([]knowledgepage.PageRef, error)
 }
 
 // PagesProvider exposes the platform's canonical knowledge pages (the
@@ -23,11 +26,11 @@ type knowledgePageSearcher interface {
 // org-shared, so this provider is shared: it is queried for every request and
 // needs no caller identity, and it never holds per-user records.
 type PagesProvider struct {
-	searcher knowledgePageSearcher
+	searcher PageSearcher
 }
 
 // NewKnowledgePagesProvider builds the knowledge-pages provider over a searcher.
-func NewKnowledgePagesProvider(searcher knowledgePageSearcher) *PagesProvider {
+func NewKnowledgePagesProvider(searcher PageSearcher) *PagesProvider {
 	return &PagesProvider{searcher: searcher}
 }
 
@@ -37,10 +40,59 @@ func (*PagesProvider) Name() string { return SourceKnowledgePages }
 // Scope marks knowledge pages shared (global canonical knowledge, always queried).
 func (*PagesProvider) Scope() Scope { return ScopeShared }
 
-// Search returns knowledge pages relevant to the intent, ranked over page
-// CONTENT (title + body + tags are indexed). It responds to the text path only;
-// a query with no intent yields nothing.
+// Search returns knowledge pages matching the query: the pages that REFERENCE each
+// requested entity (the entity path, via the reverse lookup) plus the pages relevant
+// to the intent (the text path, ranked over title/body/tags), merged and de-duplicated
+// by page id. So an entity-keyed search surfaces "the knowledge about this entity",
+// not just text matches (#634).
 func (p *PagesProvider) Search(ctx context.Context, q Query) ([]Hit, error) {
+	seen := make(map[string]bool)
+	entityHits := p.searchByEntity(ctx, q, seen)
+	textHits, err := p.searchByText(ctx, q, seen)
+	if err != nil {
+		return nil, err
+	}
+	if len(entityHits) == 0 && len(textHits) == 0 {
+		return nil, nil
+	}
+	return append(entityHits, textHits...), nil
+}
+
+// searchByEntity returns the knowledge pages that reference each requested entity
+// URN (the reverse lookup). A URN that does not parse as a reference, or that no
+// page references, is skipped rather than failing the search.
+func (p *PagesProvider) searchByEntity(ctx context.Context, q Query, seen map[string]bool) []Hit {
+	var hits []Hit
+	for _, urn := range q.EntityURNs {
+		ref, err := knowledgepage.ParseEntityRef(urn)
+		if err != nil {
+			continue
+		}
+		pages, err := p.searcher.ListPagesReferencing(ctx, ref)
+		if err != nil {
+			slog.Debug("knowledge-page reverse lookup skipped", "urn", urn, "error", err)
+			continue
+		}
+		for _, pg := range pages {
+			if seen[pg.ID] {
+				continue
+			}
+			seen[pg.ID] = true
+			hits = append(hits, Hit{
+				Text:       knowledgePageRefHitText(pg),
+				Source:     SourceKnowledgePages,
+				Ref:        pg.ID,
+				Score:      entityMatchScore,
+				EntityURNs: []string{urn},
+			})
+		}
+	}
+	return hits
+}
+
+// searchByText returns knowledge pages relevant to the intent, ranked over page
+// content. A query with no intent yields nothing.
+func (p *PagesProvider) searchByText(ctx context.Context, q Query, seen map[string]bool) ([]Hit, error) {
 	if q.Intent == "" {
 		return nil, nil
 	}
@@ -56,6 +108,10 @@ func (p *PagesProvider) Search(ctx context.Context, q Query) ([]Hit, error) {
 
 	hits := make([]Hit, 0, len(scored))
 	for i := range scored {
+		if seen[scored[i].Page.ID] {
+			continue
+		}
+		seen[scored[i].Page.ID] = true
 		hits = append(hits, Hit{
 			Text:   knowledgePageHitText(scored[i].Page),
 			Source: SourceKnowledgePages,
@@ -64,6 +120,12 @@ func (p *PagesProvider) Search(ctx context.Context, q Query) ([]Hit, error) {
 		})
 	}
 	return hits, nil
+}
+
+// knowledgePageRefHitText renders a reverse-lookup page hit: its title, noting it
+// is knowledge about the queried entity.
+func knowledgePageRefHitText(pg knowledgepage.PageRef) string {
+	return pg.Title
 }
 
 // knowledgePageHitText renders a page as a knowledge snippet: its title and its

--- a/pkg/knowledge/provider_knowledge_pages_test.go
+++ b/pkg/knowledge/provider_knowledge_pages_test.go
@@ -8,21 +8,29 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
 )
 
-type fakeKnowledgePageSearcher struct {
-	scored []knowledgepage.ScoredPage
-	err    error
-	got    knowledgepage.SearchQuery
-	called bool
+type fakePageSearcher struct {
+	scored     []knowledgepage.ScoredPage
+	err        error
+	got        knowledgepage.SearchQuery
+	called     bool
+	pages      []knowledgepage.PageRef // reverse-lookup result
+	reverseErr error
+	gotRef     knowledgepage.EntityRef
 }
 
-func (f *fakeKnowledgePageSearcher) Search(_ context.Context, q knowledgepage.SearchQuery) ([]knowledgepage.ScoredPage, error) {
+func (f *fakePageSearcher) Search(_ context.Context, q knowledgepage.SearchQuery) ([]knowledgepage.ScoredPage, error) {
 	f.called = true
 	f.got = q
 	return f.scored, f.err
 }
 
+func (f *fakePageSearcher) ListPagesReferencing(_ context.Context, ref knowledgepage.EntityRef) ([]knowledgepage.PageRef, error) {
+	f.gotRef = ref
+	return f.pages, f.reverseErr
+}
+
 func TestKnowledgePagesProvider_Metadata(t *testing.T) {
-	p := NewKnowledgePagesProvider(&fakeKnowledgePageSearcher{})
+	p := NewKnowledgePagesProvider(&fakePageSearcher{})
 	if p.Name() != SourceKnowledgePages {
 		t.Errorf("Name = %q", p.Name())
 	}
@@ -32,7 +40,7 @@ func TestKnowledgePagesProvider_Metadata(t *testing.T) {
 }
 
 func TestKnowledgePagesProvider_NoIntentSkips(t *testing.T) {
-	s := &fakeKnowledgePageSearcher{}
+	s := &fakePageSearcher{}
 	p := NewKnowledgePagesProvider(s)
 	hits, err := p.Search(context.Background(), Query{EntityURNs: []string{"urn:x"}})
 	if err != nil {
@@ -44,7 +52,7 @@ func TestKnowledgePagesProvider_NoIntentSkips(t *testing.T) {
 }
 
 func TestKnowledgePagesProvider_MapsAndForwards(t *testing.T) {
-	s := &fakeKnowledgePageSearcher{
+	s := &fakePageSearcher{
 		scored: []knowledgepage.ScoredPage{
 			{Page: knowledgepage.Page{ID: "kp1", Title: "Fiscal Calendar", Summary: "How quarters are defined"}, Score: 0.8},
 			{Page: knowledgepage.Page{ID: "kp2", Title: "Seasons"}, Score: 0.4},
@@ -71,9 +79,99 @@ func TestKnowledgePagesProvider_MapsAndForwards(t *testing.T) {
 }
 
 func TestKnowledgePagesProvider_SearchError(t *testing.T) {
-	p := NewKnowledgePagesProvider(&fakeKnowledgePageSearcher{err: errors.New("boom")})
+	p := NewKnowledgePagesProvider(&fakePageSearcher{err: errors.New("boom")})
 	_, err := p.Search(context.Background(), Query{Intent: "q"})
 	if err == nil {
 		t.Fatal("expected error to propagate")
+	}
+}
+
+// TestKnowledgePagesProvider_ReverseLookupByEntity proves #634: an entity-keyed
+// search returns the pages that REFERENCE the entity, attributed to that URN.
+func TestKnowledgePagesProvider_ReverseLookupByEntity(t *testing.T) {
+	s := &fakePageSearcher{pages: []knowledgepage.PageRef{
+		{ID: "kp1", Slug: "vocab", Title: "ACME Vocabulary"},
+		{ID: "kp2", Slug: "guide", Title: "Query Guide"},
+	}}
+	p := NewKnowledgePagesProvider(s)
+	urn := "mcp:connection:(trino,acme)"
+	hits, err := p.Search(context.Background(), Query{EntityURNs: []string{urn}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hits) != 2 {
+		t.Fatalf("len = %d, want 2", len(hits))
+	}
+	if hits[0].Source != SourceKnowledgePages || hits[0].Ref != "kp1" || hits[0].Text != "ACME Vocabulary" {
+		t.Errorf("unexpected hit[0]: %+v", hits[0])
+	}
+	if len(hits[0].EntityURNs) != 1 || hits[0].EntityURNs[0] != urn {
+		t.Errorf("hit must be attributed to the queried entity: %+v", hits[0].EntityURNs)
+	}
+	if s.gotRef.TargetType != knowledgepage.RefTargetConnection || s.gotRef.ConnectionName != "acme" {
+		t.Errorf("URN should parse to a connection ref: %+v", s.gotRef)
+	}
+}
+
+// TestKnowledgePagesProvider_EntityAndTextMergeDedup proves a page returned by both
+// the reverse lookup and the text search appears once.
+func TestKnowledgePagesProvider_EntityAndTextMergeDedup(t *testing.T) {
+	s := &fakePageSearcher{
+		pages: []knowledgepage.PageRef{{ID: "kp1", Title: "Seasons"}},
+		scored: []knowledgepage.ScoredPage{
+			{Page: knowledgepage.Page{ID: "kp1", Title: "Seasons"}, Score: 0.9},
+			{Page: knowledgepage.Page{ID: "kp2", Title: "Other"}, Score: 0.5},
+		},
+	}
+	p := NewKnowledgePagesProvider(s)
+	hits, err := p.Search(context.Background(), Query{
+		Intent:     "seasons",
+		EntityURNs: []string{"urn:li:dataset:(urn:li:dataPlatform:trino,x.y.z,PROD)"},
+		Limit:      5,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hits) != 2 {
+		t.Fatalf("len = %d, want 2 (kp1 deduped across entity+text)", len(hits))
+	}
+	// Entity hit (kp1) comes first, then the text-only hit (kp2).
+	if hits[0].Ref != "kp1" || hits[1].Ref != "kp2" {
+		t.Errorf("unexpected refs/order: %s, %s", hits[0].Ref, hits[1].Ref)
+	}
+}
+
+// TestKnowledgePagesProvider_ReverseLookupError covers a reverse-lookup failure being
+// skipped (not fatal) while the text path still runs; and an unparseable URN skipped.
+func TestKnowledgePagesProvider_ReverseLookupError(t *testing.T) {
+	s := &fakePageSearcher{
+		reverseErr: errors.New("boom"),
+		scored:     []knowledgepage.ScoredPage{{Page: knowledgepage.Page{ID: "kp1", Title: "T"}, Score: 0.5}},
+	}
+	p := NewKnowledgePagesProvider(s)
+	hits, err := p.Search(context.Background(), Query{
+		Intent:     "q",
+		EntityURNs: []string{"urn:li:dataset:(urn:li:dataPlatform:trino,x.y.z,PROD)"},
+	})
+	if err != nil {
+		t.Fatalf("a reverse-lookup error must not fail the search: %v", err)
+	}
+	if len(hits) != 1 || hits[0].Ref != "kp1" {
+		t.Fatalf("the text path should still produce a hit: %+v", hits)
+	}
+}
+
+func TestKnowledgePagesProvider_UnparseableURNSkipped(t *testing.T) {
+	s := &fakePageSearcher{pages: []knowledgepage.PageRef{{ID: "kp1", Title: "T"}}}
+	p := NewKnowledgePagesProvider(s)
+	hits, err := p.Search(context.Background(), Query{EntityURNs: []string{"garbage"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hits != nil {
+		t.Errorf("an unparseable URN should yield no hits, got %+v", hits)
+	}
+	if (s.gotRef != knowledgepage.EntityRef{}) {
+		t.Errorf("reverse lookup should be skipped for an unparseable URN, got %+v", s.gotRef)
 	}
 }

--- a/pkg/platform/connection_source.go
+++ b/pkg/platform/connection_source.go
@@ -91,6 +91,15 @@ func (m *ConnectionSourceMap) ForConnection(kind, name string) *ConnectionSource
 	return m.byConnection[kind+"/"+name]
 }
 
+// DataHubSourceName returns the DataHub source name mapped to a connection, or ""
+// when none; it adapts the map to the connview.SourceResolver capability.
+func (m *ConnectionSourceMap) DataHubSourceName(kind, name string) string {
+	if s := m.ForConnection(kind, name); s != nil {
+		return s.DataHubSourceName
+	}
+	return ""
+}
+
 // ForConnectionName returns the DataHub source info by connection name only.
 // Searches all kinds. Returns nil if not found.
 func (m *ConnectionSourceMap) ForConnectionName(name string) *ConnectionSource {

--- a/pkg/platform/connections_tool.go
+++ b/pkg/platform/connections_tool.go
@@ -6,35 +6,15 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	"github.com/txn2/mcp-data-platform/pkg/registry"
-	"github.com/txn2/mcp-data-platform/pkg/toolkit"
+	"github.com/txn2/mcp-data-platform/pkg/connview"
 )
 
-// connectionEntry describes a single toolkit connection.
-//
-// CatalogID and OperationCount are populated only for kinds where they
-// have meaning (today: api). They make the runtime view of a
-// connection visible to MCP clients so a stale in-memory binding
-// (DB updated, toolkit not reloaded) is observable from list_connections
-// rather than only via a downstream tool failing with "no catalog
-// configured".
-type connectionEntry struct {
-	Kind              string                        `json:"kind"`
-	Name              string                        `json:"name"`
-	Connection        string                        `json:"connection"`
-	Description       string                        `json:"description,omitempty"`
-	IsDefault         bool                          `json:"is_default,omitempty"`
-	DataHubSourceName string                        `json:"datahub_source_name,omitempty"`
-	CatalogID         string                        `json:"catalog_id,omitempty"`
-	OperationCount    int                           `json:"operation_count,omitempty"`
-	Health            *toolkit.ConnectionHealthWire `json:"health,omitempty"`
-}
+// connectionEntry and listConnectionsOutput are the list_connections view types,
+// owned by pkg/connview (kept out of pkg/platform for the size budget). The aliases
+// preserve the existing platform-internal names and JSON shape.
+type connectionEntry = connview.Entry
 
-// listConnectionsOutput is the JSON response for the list_connections tool.
-type listConnectionsOutput struct {
-	Connections []connectionEntry `json:"connections"`
-	Count       int               `json:"count"`
-}
+type listConnectionsOutput = connview.Output
 
 // listConnectionsInput is empty since this tool has no parameters.
 type listConnectionsInput struct{}
@@ -42,32 +22,29 @@ type listConnectionsInput struct{}
 // registerConnectionsTool registers the list_connections tool with the MCP server.
 func (p *Platform) registerConnectionsTool() {
 	mcp.AddTool(p.mcpServer, &mcp.Tool{
-		Name:        toolListConns,
-		Title:       "List Connections",
-		Description: "List all configured data connections across toolkits (Trino, DataHub, S3, etc.).",
+		Name:  toolListConns,
+		Title: "List Connections",
+		Description: "List all configured data connections across toolkits (Trino, DataHub, S3, etc.). " +
+			"Each connection includes a count and a bounded sample of the canonical knowledge pages that document it.",
 		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ listConnectionsInput) (*mcp.CallToolResult, any, error) {
 		return p.handleListConnections(ctx, req)
 	})
 }
 
-// handleListConnections handles the list_connections tool call.
-func (p *Platform) handleListConnections(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, any, error) {
-	toolkits := p.toolkitRegistry.All()
-
-	entries := make([]connectionEntry, 0, len(toolkits))
-	for _, tk := range toolkits {
-		if lister, ok := tk.(toolkit.ConnectionLister); ok {
-			entries = p.entriesFromLister(entries, tk, lister)
-		} else {
-			entries = p.entryFromFallback(entries, tk)
-		}
+// handleListConnections handles the list_connections tool call, delegating the view
+// build (and the knowledge-page reverse-lookup enrichment) to pkg/connview.
+func (p *Platform) handleListConnections(ctx context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, any, error) {
+	var src connview.SourceResolver
+	if p.connectionSources != nil {
+		src = p.connectionSources
+	}
+	var pages connview.PageLookup
+	if p.portalKnowledgePageStore != nil {
+		pages = p.portalKnowledgePageStore
 	}
 
-	out := listConnectionsOutput{
-		Connections: entries,
-		Count:       len(entries),
-	}
+	out := connview.Build(ctx, p.toolkitRegistry.All(), src, pages)
 
 	data, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
@@ -84,43 +61,4 @@ func (p *Platform) handleListConnections(_ context.Context, _ *mcp.CallToolReque
 			&mcp.TextContent{Text: string(data)},
 		},
 	}, nil, nil
-}
-
-// entriesFromLister builds connection entries from a toolkit that implements ConnectionLister.
-func (p *Platform) entriesFromLister(entries []connectionEntry, tk registry.Toolkit, lister toolkit.ConnectionLister) []connectionEntry {
-	for _, conn := range lister.ListConnections() {
-		entry := connectionEntry{
-			Kind:           tk.Kind(),
-			Name:           conn.Name,
-			Connection:     conn.Name,
-			Description:    conn.Description,
-			IsDefault:      conn.IsDefault,
-			CatalogID:      conn.CatalogID,
-			OperationCount: conn.OperationCount,
-		}
-		if src := p.connectionSources.ForConnection(tk.Kind(), conn.Name); src != nil {
-			entry.DataHubSourceName = src.DataHubSourceName
-		}
-		entry.Health = conn.Health.Wire()
-		entries = append(entries, entry)
-	}
-	return entries
-}
-
-// entryFromFallback builds a single connection entry for toolkits that do not
-// implement ConnectionLister. Non-data toolkits are skipped.
-func (p *Platform) entryFromFallback(entries []connectionEntry, tk registry.Toolkit) []connectionEntry {
-	kind := tk.Kind()
-	if kind != kindTrino && kind != kindDataHub && kind != kindS3 {
-		return entries
-	}
-	entry := connectionEntry{
-		Kind:       kind,
-		Name:       tk.Name(),
-		Connection: tk.Connection(),
-	}
-	if src := p.connectionSources.ForConnection(kind, tk.Name()); src != nil {
-		entry.DataHubSourceName = src.DataHubSourceName
-	}
-	return append(entries, entry)
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1730,7 +1730,7 @@ func (p *Platform) storeSearchProviders() []knowledge.Provider {
 	}
 	// Canonical knowledge pages (the internal-knowledge home for business
 	// ontology) are shared and searchable over their full content.
-	if s, ok := p.portalKnowledgePageStore.(knowledgepage.Searcher); ok {
+	if s, ok := p.portalKnowledgePageStore.(knowledge.PageSearcher); ok {
 		providers = append(providers, knowledge.NewKnowledgePagesProvider(s))
 	}
 	// Prompts are searchable through the postgres prompt store.

--- a/pkg/toolkits/search/integration_test.go
+++ b/pkg/toolkits/search/integration_test.go
@@ -145,6 +145,10 @@ func (globalKnowledgePages) Search(_ context.Context, _ knowledgepage.SearchQuer
 	return []knowledgepage.ScoredPage{{Page: knowledgepage.Page{ID: "g-page", Title: "global page"}, Score: 0.5}}, nil
 }
 
+func (globalKnowledgePages) ListPagesReferencing(_ context.Context, _ knowledgepage.EntityRef) ([]knowledgepage.PageRef, error) {
+	return nil, nil
+}
+
 const (
 	userAEmail = "alice@example.com"
 	userAID    = "uuid-alice"


### PR DESCRIPTION
Completes #634 (agent cross-enrichment) and the last open gap of #678. Knowledge pages document the entities and connections an agent works with, but that knowledge was only reachable by opening a page in the portal. This wires the existing reverse lookup (`ListPagesReferencing`, the pages that reference a target) into the three agent-facing surfaces where the knowledge belongs, so it appears where the agent already looks.

## The three surfaces

### 1. `search(entity_urns=[X])` returns the pages that reference X

`PagesProvider.Search` previously answered the text path only. It now also answers the entity path: for each requested URN it parses an entity reference and runs the reverse lookup, returning the knowledge pages that reference that entity, merged and de-duplicated with the text-relevance results. It covers datasets (`urn:li:dataset:(...)`) and connections (`mcp:connection:(trino,acme)`) alike. An unparseable URN or a lookup error is skipped, never fatal. The capability interface is exported as `knowledge.PageSearcher`.

### 2. `list_connections` shows the pages that document each connection

Each connection entry now carries `knowledge_page_count` (the full total) and `knowledge_pages`, a bounded sample (id, slug, title) capped at five. The cap keeps the tool output small even when a connection is widely documented; the count still conveys the true scale.

### 3. Entity tool responses carry the knowledge about what they return

The semantic enrichment middleware (the same one that appends `memory_context`) now appends a bounded `knowledge_pages` block for the entities a tool result names, so an agent fetching an entity (e.g. via `datahub_get_entity`) sees the canonical knowledge about it with no extra call:

```json
{
  "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)",
  "knowledge_pages": [
    {"id": "kp_5cdde7bb", "slug": "retail-sales-vocabulary", "title": "Retail Sales Vocabulary"}
  ]
}
```

The entity URNs are read from the tool's own output once, before any other enrichment appends blocks, so the lookup keys off the entities the tool actually returned rather than enriched neighbors or memory free-text. Two bounds keep the cost small: at most ten distinct URNs are looked up per result (so a large search response cannot trigger a query storm), and at most five pages are returned. The shared reverse lookup lives in `knowledgepage.PagesForURNs` (parse, reverse-lookup, dedup by page id, cap).

## Decomposition: `pkg/connview`

`pkg/platform` was at its hard package-size budget (the `TestPackageSizeBudget` gate, which forbids raising the ceiling). The `list_connections` connection-view build (toolkit enumeration plus the knowledge enrichment) moves into a new `pkg/connview` package behind two narrow capabilities (`SourceResolver`, `PageLookup`). `pkg/platform` keeps a thin handler that delegates to `connview.Build`, with `connectionEntry`/`listConnectionsOutput` as type aliases so the internal names and JSON shape are unchanged. Both new fields are `omitempty`, so the no-knowledge output is byte-identical to before.

## Testing

- `make verify` green: race plus real-Postgres, package-size budget, lint, gosec/govulncheck, semgrep, CodeQL, mutation, swagger-check, GoReleaser. Patch coverage 93.0%.
- Tests cover the search reverse-lookup entity path and entity+text dedup; the connection enrichment including the sample cap; `PagesForURNs` (dedup across URNs, the cap, the unparseable-URN skip, error propagation); the middleware enrichment (append, the nil/no-urn/error/empty no-op paths, and the URN-fanout cap); the platform bridge and its nil-store guard; and an integration test driving the real middleware so the `knowledge_pages` block is proven to reach the response through the assembled chain.
- Adversarial reviews across the three surfaces confirmed the runtime `PageSearcher` assertion still succeeds, the moved `connview` logic preserves the prior behavior exactly, the nil-interface guards hold, and the token bounds are enforced; the review of the middleware surface flagged a per-URN fan-out and a re-scan of the appended memory block, both addressed by extracting URNs once and capping the set.
- Docs updated: cross-enrichment overview, `llms.txt`, `llms-full.txt`.

## Follow-up

The surfaces are wired correctly but read empty against the current demo data, whose pages were authored with bare URN tokens through the old promotion path and so have no stored references. After this and #679 ship, re-promoting or re-authoring those pages with `[label](urn:...)` links will populate the connection counts, the `search(entity_urns)` results, and the entity-response blocks.

Closes #634
Closes #678
