### PR TITLE
feat(knowledge): enrich entity tool responses with the pages that document them (#634)

### DIFF
--- a/docs/cross-enrichment/overview.md
+++ b/docs/cross-enrichment/overview.md
@@ -313,6 +313,31 @@ When listing S3 objects, show matching DataHub metadata:
 }
 ```
 
+### Knowledge Pages (entity to knowledge)
+
+When a tool result names entities, the response also carries the canonical
+knowledge pages that document those entities, so an agent sees the business and
+domain knowledge about what it just fetched. The entity URNs are read from the
+result, the reverse lookup finds the pages that reference them, and a bounded
+`knowledge_pages` block is appended (capped so a widely documented entity does not
+balloon the response):
+
+```json
+{
+  "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)",
+  "knowledge_pages": [
+    {"id": "kp_5cdde7bb", "slug": "retail-sales-vocabulary", "title": "Retail Sales Vocabulary"}
+  ]
+}
+```
+
+The same reverse lookup surfaces in two more agent-facing places:
+
+- **`search(entity_urns=[...])`** returns the knowledge pages that reference each
+  entity (datasets and connections), merged with the text-relevance results.
+- **`list_connections`** carries, per connection, a `knowledge_page_count` and a
+  bounded sample of the pages that document it.
+
 ---
 
 ## Configuration

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1137,6 +1137,21 @@ When lineage inheritance is active, responses include column context with proven
 
 **Data lakes**: Parquet files derived from operational databases. Aliases provide explicit mapping when lineage isn't tracked.
 
+### Knowledge Pages (entity to knowledge)
+
+When a tool result names entities, the response also carries the canonical knowledge pages that document those entities, so an agent sees the business and domain knowledge about what it just fetched. Entity URNs are read from the result, the reverse lookup finds the pages that reference them, and a bounded `knowledge_pages` block is appended (capped so a widely documented entity does not balloon the response):
+
+```json
+{
+  "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)",
+  "knowledge_pages": [
+    {"id": "kp_5cdde7bb", "slug": "retail-sales-vocabulary", "title": "Retail Sales Vocabulary"}
+  ]
+}
+```
+
+The same reverse lookup surfaces in two more agent-facing places: `search(entity_urns=[...])` returns the knowledge pages that reference each entity (datasets and connections) merged with the text-relevance results, and `list_connections` carries per connection a `knowledge_page_count` and a bounded sample of the pages that document it.
+
 ## Session Metadata Deduplication
 
 When Trino enrichment is enabled, every tool call targeting a table receives ~2KB of semantic metadata. In a typical session querying the same table multiple times, this wastes LLM context tokens with repeated information.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -28,6 +28,7 @@ mcp-data-platform is the orchestration layer for the txn2 MCP ecosystem. DataHub
 - [Trino to DataHub](https://mcp-data-platform.txn2.com/cross-enrichment/trino-datahub/): Trino results include DataHub metadata
 - [DataHub to Trino](https://mcp-data-platform.txn2.com/cross-enrichment/datahub-trino/): DataHub results show query availability
 - [S3 Enrichment](https://mcp-data-platform.txn2.com/cross-enrichment/s3/): S3 operations include semantic context
+- [Knowledge Pages](https://mcp-data-platform.txn2.com/cross-enrichment/overview/#knowledge-pages-entity-to-knowledge): Entity tool results, search by entity_urns, and list_connections carry the canonical knowledge pages that document the named entities and connections (bounded, reverse lookup)
 - [Lineage Inheritance](https://mcp-data-platform.txn2.com/cross-enrichment/lineage/): Automatic column metadata inheritance from upstream datasets via DataHub lineage
 - [Session Dedup](https://mcp-data-platform.txn2.com/cross-enrichment/overview/#session-metadata-deduplication): Avoids repeating semantic metadata for previously-enriched tables within a session, saving LLM context tokens
 - [Column Context Filtering](https://mcp-data-platform.txn2.com/cross-enrichment/trino-datahub/#column-level-enrichment): Limits column-level enrichment to columns referenced in the SQL query, reducing token usage for wide tables (default: enabled)

--- a/pkg/middleware/knowledge_enrichment.go
+++ b/pkg/middleware/knowledge_enrichment.go
@@ -1,0 +1,69 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// defaultKnowledgePageEnrichmentLimit bounds how many referencing pages are appended
+// per tool result, so the enrichment stays small even for a widely documented entity.
+const defaultKnowledgePageEnrichmentLimit = 5
+
+// maxKnowledgeEnrichmentURNs bounds how many distinct entity URNs are looked up per
+// tool result. Each URN is a reverse-lookup query, so this caps the fan-out for a
+// result that names many entities (e.g. a large search response).
+const maxKnowledgeEnrichmentURNs = 10
+
+// KnowledgePageProvider returns the canonical knowledge pages that reference a set of
+// entity URNs, for cross-enrichment into entity tool responses (#634).
+type KnowledgePageProvider interface {
+	PagesForEntities(ctx context.Context, urns []string, limit int) ([]KnowledgePageSnippet, error)
+}
+
+// KnowledgePageSnippet is a lightweight knowledge-page reference for enrichment.
+type KnowledgePageSnippet struct {
+	ID    string `json:"id"`
+	Slug  string `json:"slug"`
+	Title string `json:"title"`
+}
+
+// enrichWithKnowledgePages appends a knowledge_pages block listing the canonical
+// pages that document the entities named in the result (#634). It is given the
+// entity URNs the tool itself returned (extracted before other enrichment appends
+// blocks), and both the looked-up URN count and the returned page count are bounded,
+// so the appended block and the reverse-lookup fan-out both stay small.
+func enrichWithKnowledgePages(ctx context.Context, kp KnowledgePageProvider, result *mcp.CallToolResult, urns []string) *mcp.CallToolResult {
+	if kp == nil || result == nil || len(urns) == 0 {
+		return result
+	}
+
+	if len(urns) > maxKnowledgeEnrichmentURNs {
+		slog.Debug("knowledge-page enrichment urn set truncated", "have", len(urns), "cap", maxKnowledgeEnrichmentURNs)
+		urns = urns[:maxKnowledgeEnrichmentURNs]
+	}
+
+	pages, err := kp.PagesForEntities(ctx, urns, defaultKnowledgePageEnrichmentLimit)
+	if err != nil {
+		slog.Debug("knowledge-page enrichment failed", "error", err)
+		return result
+	}
+
+	if len(pages) == 0 {
+		return result
+	}
+
+	data, err := json.Marshal(map[string]any{"knowledge_pages": pages})
+	if err != nil {
+		slog.Debug("failed to marshal knowledge pages", "error", err)
+		return result
+	}
+
+	result.Content = append(result.Content, &mcp.TextContent{
+		Text: string(data),
+	})
+
+	return result
+}

--- a/pkg/middleware/knowledge_enrichment_test.go
+++ b/pkg/middleware/knowledge_enrichment_test.go
@@ -1,0 +1,73 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakePageProvider struct {
+	pages   []KnowledgePageSnippet
+	err     error
+	gotURNs []string
+}
+
+func (f *fakePageProvider) PagesForEntities(_ context.Context, urns []string, _ int) ([]KnowledgePageSnippet, error) {
+	f.gotURNs = urns
+	return f.pages, f.err
+}
+
+func resultWithURN() *mcp.CallToolResult {
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{
+		Text: `{"urn":"urn:li:dataset:(urn:li:dataPlatform:trino,a.b.c,PROD)"}`,
+	}}}
+}
+
+func TestEnrichWithKnowledgePages_AppendsBlock(t *testing.T) {
+	kp := &fakePageProvider{pages: []KnowledgePageSnippet{{ID: "kp1", Slug: "vocab", Title: "ACME Vocabulary"}}}
+	urn := "urn:li:dataset:(urn:li:dataPlatform:trino,a.b.c,PROD)"
+	res := enrichWithKnowledgePages(context.Background(), kp, resultWithURN(), []string{urn})
+
+	require.Len(t, res.Content, 2, "a knowledge_pages block is appended")
+	tc, ok := res.Content[1].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, tc.Text, "knowledge_pages")
+	assert.Contains(t, tc.Text, "ACME Vocabulary")
+	assert.Equal(t, []string{urn}, kp.gotURNs)
+}
+
+func TestEnrichWithKnowledgePages_NoopPaths(t *testing.T) {
+	urn := "urn:li:dataset:(urn:li:dataPlatform:trino,a.b.c,PROD)"
+
+	// Nil provider leaves the result untouched.
+	res := resultWithURN()
+	assert.Same(t, res, enrichWithKnowledgePages(context.Background(), nil, res, []string{urn}))
+	assert.Len(t, res.Content, 1)
+
+	// No entity URNs: no enrichment.
+	noURN := resultWithURN()
+	out := enrichWithKnowledgePages(context.Background(), &fakePageProvider{pages: []KnowledgePageSnippet{{ID: "kp1"}}}, noURN, nil)
+	assert.Len(t, out.Content, 1, "no entity urns -> no block")
+
+	// Provider error: result unchanged.
+	out = enrichWithKnowledgePages(context.Background(), &fakePageProvider{err: errors.New("boom")}, resultWithURN(), []string{urn})
+	assert.Len(t, out.Content, 1, "provider error -> result unchanged")
+
+	// No referencing pages: no block.
+	out = enrichWithKnowledgePages(context.Background(), &fakePageProvider{}, resultWithURN(), []string{urn})
+	assert.Len(t, out.Content, 1, "no pages -> no block")
+}
+
+func TestEnrichWithKnowledgePages_CapsURNFanout(t *testing.T) {
+	kp := &fakePageProvider{}
+	urns := make([]string, maxKnowledgeEnrichmentURNs+5)
+	for i := range urns {
+		urns[i] = "urn:li:dataset:(urn:li:dataPlatform:trino,a.b." + string(rune('a'+i)) + ",PROD)"
+	}
+	enrichWithKnowledgePages(context.Background(), kp, resultWithURN(), urns)
+	assert.Len(t, kp.gotURNs, maxKnowledgeEnrichmentURNs, "the looked-up urn set is capped")
+}

--- a/pkg/middleware/mcp_enrichment.go
+++ b/pkg/middleware/mcp_enrichment.go
@@ -29,6 +29,7 @@ func MCPSemanticEnrichmentMiddleware(
 	storageProvider storage.Provider,
 	cfg EnrichmentConfig,
 	memoryProvider MemoryProvider,
+	pageProvider ...KnowledgePageProvider,
 ) mcp.Middleware {
 	enricher := &semanticEnricher{
 		semanticProvider: semanticProvider,
@@ -36,6 +37,9 @@ func MCPSemanticEnrichmentMiddleware(
 		storageProvider:  storageProvider,
 		memoryProvider:   memoryProvider,
 		cfg:              cfg,
+	}
+	if len(pageProvider) > 0 {
+		enricher.pageProvider = pageProvider[0]
 	}
 
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
@@ -114,6 +118,11 @@ func applyEnrichment(
 ) (mcp.Result, error) {
 	callReq := buildCallToolRequest(req)
 
+	// Capture the entities the tool itself returned before any enrichment appends
+	// blocks, so the knowledge-page lookup keys off the tool's own entities rather
+	// than enriched neighbors or memory free-text.
+	entityURNs := extractEntityURNsFromResult(callResult)
+
 	beforeLen := len(callResult.Content)
 	enrichedResult, _ := enricher.enrich(ctx, callResult, callReq, pc)
 	if len(enrichedResult.Content) > beforeLen {
@@ -125,6 +134,9 @@ func applyEnrichment(
 
 	// Attach relevant memories from the memory layer.
 	enrichedResult = enrichWithMemories(ctx, enricher.memoryProvider, enrichedResult, pc)
+
+	// Attach the canonical knowledge pages that document the named entities (#634).
+	enrichedResult = enrichWithKnowledgePages(ctx, enricher.pageProvider, enrichedResult, entityURNs)
 
 	appendDiscoveryNoteIfNeeded(enrichedResult, pc, enricher.cfg.WorkflowTracker)
 

--- a/pkg/middleware/mcp_enrichment_test.go
+++ b/pkg/middleware/mcp_enrichment_test.go
@@ -222,6 +222,38 @@ func TestMCPSemanticEnrichmentMiddleware_DataHubEnrichment(t *testing.T) {
 	assert.Contains(t, tc.Text, "query_context")
 }
 
+// TestMCPSemanticEnrichmentMiddleware_AppendsKnowledgePages proves the #634 wiring
+// end to end: a knowledge-page provider passed to the middleware causes an entity
+// tool result to carry a knowledge_pages block through the real enrichment chain.
+func TestMCPSemanticEnrichmentMiddleware_AppendsKnowledgePages(t *testing.T) {
+	kp := &fakePageProvider{pages: []KnowledgePageSnippet{{ID: "kp1", Slug: "vocab", Title: "ACME Vocabulary"}}}
+	mw := MCPSemanticEnrichmentMiddleware(
+		nil, nil, nil,
+		EnrichmentConfig{EnrichDataHubResults: true},
+		nil,
+		kp,
+	)
+
+	handler := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{
+			Text: `{"urn":"urn:li:dataset:(urn:li:dataPlatform:postgres,test,PROD)"}`,
+		}}}, nil
+	}
+
+	req := createServerRequest(t, "datahub_get_entity", map[string]any{"urn": "x"})
+	result, err := mw(handler)(context.Background(), enrichTestMethodToolsCall, req)
+	require.NoError(t, err)
+	callResult, ok := result.(*mcp.CallToolResult)
+	require.True(t, ok, enrichTestCallToolFmt, result)
+
+	require.Len(t, callResult.Content, 2, "the knowledge_pages block is appended")
+	tc, ok := callResult.Content[1].(*mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, tc.Text, "knowledge_pages")
+	assert.Contains(t, tc.Text, "ACME Vocabulary")
+	assert.Contains(t, kp.gotURNs, "urn:li:dataset:(urn:li:dataPlatform:postgres,test,PROD)")
+}
+
 func TestMCPSemanticEnrichmentMiddleware_UnknownToolPassthrough(t *testing.T) {
 	// Create middleware
 	mw := MCPSemanticEnrichmentMiddleware(nil, nil, nil, EnrichmentConfig{

--- a/pkg/middleware/semantic.go
+++ b/pkg/middleware/semantic.go
@@ -166,6 +166,7 @@ type semanticEnricher struct {
 	queryProvider    query.Provider
 	storageProvider  storage.Provider
 	memoryProvider   MemoryProvider
+	pageProvider     KnowledgePageProvider
 	cfg              EnrichmentConfig
 }
 

--- a/pkg/platform/knowledge_enrichment_bridge_test.go
+++ b/pkg/platform/knowledge_enrichment_bridge_test.go
@@ -1,0 +1,37 @@
+package platform
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
+)
+
+type fakeReverseLookup struct {
+	pages []knowledgepage.PageRef
+}
+
+func (f fakeReverseLookup) ListPagesReferencing(_ context.Context, _ knowledgepage.EntityRef) ([]knowledgepage.PageRef, error) {
+	return f.pages, nil
+}
+
+func TestKnowledgePageEnrichmentBridge_PagesForEntities(t *testing.T) {
+	b := &knowledgePageEnrichmentBridge{store: fakeReverseLookup{pages: []knowledgepage.PageRef{
+		{ID: "kp1", Slug: "vocab", Title: "ACME Vocabulary"},
+	}}}
+	got, err := b.PagesForEntities(context.Background(),
+		[]string{"urn:li:dataset:(urn:li:dataPlatform:trino,a.b.c,PROD)"}, 5)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, middleware.KnowledgePageSnippet{ID: "kp1", Slug: "vocab", Title: "ACME Vocabulary"}, got[0])
+}
+
+func TestKnowledgePageProviders(t *testing.T) {
+	assert.Nil(t, knowledgePageProviders(nil), "no store -> empty variadic")
+	got := knowledgePageProviders(fakeReverseLookup{})
+	require.Len(t, got, 1, "a store yields one provider")
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -2884,8 +2884,37 @@ func (p *Platform) addEnrichmentMiddleware() {
 			p.storageProvider,
 			enrichCfg,
 			mp,
+			knowledgePageProviders(p.portalKnowledgePageStore)...,
 		),
 	)
+}
+
+// knowledgePageProviders returns the page-enrichment provider for the middleware, or
+// nothing when no knowledge-page store is configured (so the variadic stays empty).
+func knowledgePageProviders(store knowledgepage.ReverseLookup) []middleware.KnowledgePageProvider {
+	if store == nil {
+		return nil
+	}
+	return []middleware.KnowledgePageProvider{&knowledgePageEnrichmentBridge{store: store}}
+}
+
+// knowledgePageEnrichmentBridge adapts the knowledge-page reverse lookup to
+// middleware.KnowledgePageProvider for entity tool-response cross-enrichment (#634).
+type knowledgePageEnrichmentBridge struct {
+	store knowledgepage.ReverseLookup
+}
+
+// PagesForEntities returns the bounded set of pages referencing the given entity URNs.
+func (b *knowledgePageEnrichmentBridge) PagesForEntities(ctx context.Context, urns []string, limit int) ([]middleware.KnowledgePageSnippet, error) {
+	pages, err := knowledgepage.PagesForURNs(ctx, b.store, urns, limit)
+	if err != nil {
+		return nil, fmt.Errorf("knowledge-page enrichment lookup: %w", err)
+	}
+	out := make([]middleware.KnowledgePageSnippet, 0, len(pages))
+	for _, pg := range pages {
+		out = append(out, middleware.KnowledgePageSnippet{ID: pg.ID, Slug: pg.Slug, Title: pg.Title})
+	}
+	return out, nil
 }
 
 // buildEnrichmentConfig creates the enrichment middleware config, including

--- a/pkg/portal/knowledgepage/pages_for_urns_test.go
+++ b/pkg/portal/knowledgepage/pages_for_urns_test.go
@@ -1,0 +1,52 @@
+package knowledgepage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeReverseLooker struct {
+	byKey map[string][]PageRef
+	err   error
+}
+
+func (f *fakeReverseLooker) ListPagesReferencing(_ context.Context, ref EntityRef) ([]PageRef, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if ref.TargetType == RefTargetDataHub {
+		return f.byKey[ref.EntityURN], nil
+	}
+	return f.byKey[ref.ConnectionKind+"/"+ref.ConnectionName], nil
+}
+
+func TestPagesForURNs_DedupAcrossURNsAndSkipsUnparseable(t *testing.T) {
+	dataset := "urn:li:dataset:(urn:li:dataPlatform:trino,a.b.c,PROD)"
+	f := &fakeReverseLooker{byKey: map[string][]PageRef{
+		dataset:      {{ID: "kp1", Title: "A"}, {ID: "kp2", Title: "B"}},
+		"trino/acme": {{ID: "kp2", Title: "B"}, {ID: "kp3", Title: "C"}}, // kp2 repeats across URNs
+	}}
+	urns := []string{dataset, "mcp:connection:(trino,acme)", "not-a-ref"}
+
+	pages, err := PagesForURNs(context.Background(), f, urns, 0)
+	require.NoError(t, err)
+	require.Len(t, pages, 3, "kp2 deduped, the unparseable urn skipped")
+	assert.Equal(t, []string{"kp1", "kp2", "kp3"}, []string{pages[0].ID, pages[1].ID, pages[2].ID})
+}
+
+func TestPagesForURNs_CapAndErrorPropagation(t *testing.T) {
+	dataset := "urn:li:dataset:(urn:li:dataPlatform:trino,a.b.c,PROD)"
+	f := &fakeReverseLooker{byKey: map[string][]PageRef{
+		dataset: {{ID: "kp1"}, {ID: "kp2"}, {ID: "kp3"}},
+	}}
+	pages, err := PagesForURNs(context.Background(), f, []string{dataset}, 2)
+	require.NoError(t, err)
+	assert.Len(t, pages, 2, "result is capped at limit")
+
+	_, err = PagesForURNs(context.Background(), &fakeReverseLooker{err: errors.New("boom")}, []string{dataset}, 0)
+	assert.Error(t, err, "a lookup error propagates")
+}

--- a/pkg/portal/knowledgepage/reverse.go
+++ b/pkg/portal/knowledgepage/reverse.go
@@ -15,6 +15,42 @@ type PageRef struct {
 	Title string `json:"title"`
 }
 
+// ReverseLookup is the reverse-lookup capability PagesForURNs needs (the pages that
+// reference a target), satisfied by Store and by lighter adapters in callers.
+type ReverseLookup interface {
+	ListPagesReferencing(ctx context.Context, ref EntityRef) ([]PageRef, error)
+}
+
+// PagesForURNs returns the distinct pages that reference any of the given entity
+// URNs, in first-seen order, capped at limit (limit <= 0 means no cap). A URN that
+// does not parse as a reference is skipped; a lookup error is returned. It backs the
+// cross-enrichment that surfaces the knowledge about the entities a tool returns.
+func PagesForURNs(ctx context.Context, store ReverseLookup, urns []string, limit int) ([]PageRef, error) {
+	seen := make(map[string]bool)
+	out := make([]PageRef, 0, len(urns))
+	for _, urn := range urns {
+		ref, err := ParseEntityRef(urn)
+		if err != nil {
+			continue
+		}
+		pages, err := store.ListPagesReferencing(ctx, ref)
+		if err != nil {
+			return nil, fmt.Errorf("listing pages referencing %q: %w", urn, err)
+		}
+		for _, pg := range pages {
+			if seen[pg.ID] {
+				continue
+			}
+			seen[pg.ID] = true
+			out = append(out, pg)
+			if limit > 0 && len(out) >= limit {
+				return out, nil
+			}
+		}
+	}
+	return out, nil
+}
+
 // reverseLookupFilter returns the WHERE clause and arguments that select the
 // references pointing at the given target, or ("", nil) for an unknown type. The
 // clause is a fixed literal per type; the target values are returned as args and


### PR DESCRIPTION
Adds the third and final agent surface for #634 (the entity/connection cross-enrichment), completing the last open gap of #678. The search and `list_connections` surfaces shipped in #680; this adds enrichment of entity tool responses themselves.

## What this adds

The semantic enrichment middleware (the same one that appends `memory_context`) now appends a bounded `knowledge_pages` block for the entities a tool result names, so an agent fetching an entity (e.g. via `datahub_get_entity`) sees the canonical knowledge pages that document it with no extra call:

```json
{
  "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)",
  "knowledge_pages": [
    {"id": "kp_5cdde7bb", "slug": "retail-sales-vocabulary", "title": "Retail Sales Vocabulary"}
  ]
}
```

The entity URNs are read from the tool's own output once, before any other enrichment appends blocks, so the lookup keys off the entities the tool actually returned rather than enriched neighbors or memory free-text. Two bounds keep the cost small: at most ten distinct URNs are looked up per result (so a large response cannot trigger a query storm), and at most five pages are returned. The reverse lookup is shared with the other surfaces through `knowledgepage.PagesForURNs` (parse, reverse-lookup, dedup by page id, cap). The provider is wired as an optional variadic on the enrichment constructor, so existing call sites are unchanged; it is supplied only when a knowledge-page store is configured.

## Testing

- `make verify` green; patch coverage 93.0%.
- Tests cover `PagesForURNs` (dedup across URNs, the cap, the unparseable-URN skip, error propagation), the middleware enrichment (append, the nil/no-urn/error/empty no-op paths, and the URN-fanout cap), the platform bridge and its nil-store guard, and an integration test driving the real middleware so the `knowledge_pages` block is proven to reach the response through the assembled chain.
- An adversarial review flagged a per-URN fan-out and a re-scan of the appended memory block; both are addressed by extracting URNs once and capping the set.
- Docs updated: cross-enrichment overview, `llms.txt`, `llms-full.txt`.

Closes #634
Closes #678
