### PR TITLE
fix(knowledge): reflect supersede at read time and use email for authorship (#682)

### DIFF
--- a/pkg/memory/postgres.go
+++ b/pkg/memory/postgres.go
@@ -702,16 +702,41 @@ func (s *postgresStore) MarkVerified(ctx context.Context, ids []string) error {
 
 // Supersede marks an old record as superseded by a new one.
 // Uses an atomic UPDATE with jsonb || merge to avoid read-modify-write races.
+//
+// It advances both status axes: the lifecycle status column and, when the record
+// carries an insight review status (metadata.insight_status, i.e. it is a reviewable
+// insight), that review status too. Without the second half the insights read path,
+// which filters on insight_status, keeps surfacing a record the write path already
+// superseded (#682). Non-insight records have no insight_status and are left alone.
 func (s *postgresStore) Supersede(ctx context.Context, oldID, newID string) error {
 	patch, err := json.Marshal(map[string]any{"superseded_by": newID})
 	if err != nil {
 		return fmt.Errorf("marshaling supersede metadata: %w", err)
 	}
 
+	// Build the new metadata:
+	//   1. Base: the existing metadata, but coerced to '{}' when it is not a JSON
+	//      object. A record captured with no extra metadata is stored as JSON null
+	//      (captureMetadata returns nil for the empty case), and `null || obj` yields
+	//      a JSON ARRAY in Postgres, which then fails to read back as a map. Coercing
+	//      to '{}' keeps the merge an object regardless of the prior shape.
+	//   2. The superseded_by patch.
+	//   3. insight_status -> superseded, but only when the record already carries one
+	//      (a reviewable insight); a null/non-object base has no keys so jsonb_exists
+	//      is false and no insight_status is invented.
+	// jsonb_exists (the function form of the `?` operator) avoids the `?` being read
+	// as a bind placeholder by the dollar-placeholder rewriter.
+	metaExpr := sq.Expr(
+		"(CASE WHEN jsonb_typeof(metadata) = 'object' THEN metadata ELSE '{}'::jsonb END) "+
+			"|| ?::jsonb "+
+			"|| (CASE WHEN jsonb_exists(metadata, ?::text) THEN jsonb_build_object(?::text, ?::text) ELSE '{}'::jsonb END)",
+		patch, MetaKeyInsightStatus, MetaKeyInsightStatus, InsightStatusSuperseded,
+	)
+
 	now := time.Now()
 	query, args, err := psq.Update(tableName).
 		Set(colStatus, StatusSuperseded).
-		Set(colMetadata, sq.Expr("metadata || ?::jsonb", patch)).
+		Set(colMetadata, metaExpr).
 		Set("updated_at", now).
 		Where(sq.Eq{"id": oldID}).
 		ToSql()

--- a/pkg/memory/postgres_test.go
+++ b/pkg/memory/postgres_test.go
@@ -556,12 +556,18 @@ func TestPostgresStore_Supersede_Success(t *testing.T) {
 
 	store := NewPostgresStore(db)
 
+	// The metadata merge conditionally advances insight_status to superseded, so the
+	// SQL binds the insight_status key (twice: jsonb_exists + jsonb_build_object) and
+	// the superseded value alongside the lifecycle status and the superseded_by patch.
 	mock.ExpectExec("UPDATE memory_records SET").
 		WithArgs(
-			sqlmock.AnyArg(), // status
-			sqlmock.AnyArg(), // metadata
-			sqlmock.AnyArg(), // updated_at
-			sqlmock.AnyArg(), // old id
+			StatusSuperseded,        // lifecycle status column
+			sqlmock.AnyArg(),        // metadata superseded_by patch (jsonb)
+			MetaKeyInsightStatus,    // jsonb_exists key
+			MetaKeyInsightStatus,    // jsonb_build_object key
+			InsightStatusSuperseded, // jsonb_build_object value
+			sqlmock.AnyArg(),        // updated_at
+			"old-id",                // where id
 		).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -579,6 +585,9 @@ func TestPostgresStore_Supersede_NotFound(t *testing.T) {
 
 	mock.ExpectExec("UPDATE memory_records SET").
 		WithArgs(
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
 			sqlmock.AnyArg(),
 			sqlmock.AnyArg(),
 			sqlmock.AnyArg(),

--- a/pkg/memory/store_realdb_integration_test.go
+++ b/pkg/memory/store_realdb_integration_test.go
@@ -130,3 +130,54 @@ func TestMemoryStore_LexicalSearch_RealDB_Differentiates(t *testing.T) {
 		assert.Less(t, s, 1.0, "score for %s must be < 1", id)
 	}
 }
+
+// TestMemoryStore_Supersede_RealDB_AdvancesInsightStatus is the #682 fix at the
+// store level: superseding a reviewable insight must advance BOTH the lifecycle
+// status column AND metadata.insight_status, so the insights read path (which
+// filters on insight_status) stops surfacing the stale record. A non-insight
+// record, which carries no insight_status, must be superseded without one being
+// invented. Validates the jsonb_exists CASE that sqlmock cannot exercise.
+func TestMemoryStore_Supersede_RealDB_AdvancesInsightStatus(t *testing.T) {
+	store := NewPostgresStore(testdb.New(t))
+	ctx := context.Background()
+
+	insight := Record{
+		ID:        "mem_realdb_supersede_insight",
+		Content:   "Original business-knowledge insight to be superseded.",
+		Dimension: "knowledge",
+		Category:  "business_context",
+		Source:    "user",
+		Status:    StatusActive,
+		Metadata:  map[string]any{MetaKeyInsightStatus: InsightStatusPending},
+	}
+	require.NoError(t, store.Insert(ctx, insight))
+
+	pref := Record{
+		ID:        "mem_realdb_supersede_pref",
+		Content:   "A personal preference to be superseded (no insight_status).",
+		Dimension: "preference",
+		Category:  "general",
+		Source:    "user",
+		Status:    StatusActive,
+	}
+	require.NoError(t, store.Insert(ctx, pref))
+
+	require.NoError(t, store.Supersede(ctx, insight.ID, "mem_successor"))
+	require.NoError(t, store.Supersede(ctx, pref.ID, "mem_successor"))
+
+	gotInsight, err := store.Get(ctx, insight.ID)
+	require.NoError(t, err)
+	require.NotNil(t, gotInsight)
+	assert.Equal(t, StatusSuperseded, gotInsight.Status, "lifecycle status advanced")
+	assert.Equal(t, InsightStatusSuperseded, gotInsight.Metadata[MetaKeyInsightStatus],
+		"insight review status follows to superseded so the insights read path retracts it (#682)")
+	assert.Equal(t, "mem_successor", gotInsight.Metadata["superseded_by"])
+
+	gotPref, err := store.Get(ctx, pref.ID)
+	require.NoError(t, err)
+	require.NotNil(t, gotPref)
+	assert.Equal(t, StatusSuperseded, gotPref.Status, "non-insight lifecycle status advanced")
+	_, hasInsightStatus := gotPref.Metadata[MetaKeyInsightStatus]
+	assert.False(t, hasInsightStatus, "a non-insight record must not be given an insight_status")
+	assert.Equal(t, "mem_successor", gotPref.Metadata["superseded_by"])
+}

--- a/pkg/memory/types.go
+++ b/pkg/memory/types.go
@@ -110,6 +110,11 @@ const (
 	MetaKeySuggestedActions = "suggested_actions"
 	MetaKeySessionID        = "session_id"
 	InsightStatusPending    = "pending"
+	// InsightStatusSuperseded mirrors knowledgekit.StatusSuperseded. It is the
+	// review-status counterpart of the StatusSuperseded lifecycle column: when a
+	// record is superseded, its insight review status must follow, or the insights
+	// read path (which filters on insight_status) keeps surfacing the stale record.
+	InsightStatusSuperseded = "superseded"
 )
 
 // Status values for memory records.

--- a/pkg/toolkits/knowledge/page_sink.go
+++ b/pkg/toolkits/knowledge/page_sink.go
@@ -162,7 +162,7 @@ func (t *Toolkit) promoteToPage(ctx context.Context, input applyKnowledgeInput) 
 		})
 	}
 
-	appliedBy := userIDFromContext(ctx)
+	appliedBy := authorFromContext(ctx)
 	tags := tagsWithOrigin(page.Tags, originClass)
 	prom, err := t.applyPagePromotion(ctx, *page, tags, appliedBy, entityURNs)
 	if err != nil {

--- a/pkg/toolkits/knowledge/page_sink_realdb_integration_test.go
+++ b/pkg/toolkits/knowledge/page_sink_realdb_integration_test.go
@@ -67,6 +67,9 @@ func TestPageSink_RealDB_PromoteAndRollback(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Fiscal Calendar", page.Title)
 	assert.Contains(t, page.Tags, memory.SinkBusinessKnowledge)
+	// Authorship is the acting user's email, not the opaque user id (#682).
+	assert.Equal(t, "admin@example.com", page.CreatedEmail)
+	assert.Equal(t, "admin@example.com", page.CreatedBy)
 
 	// The insight's DataHub reference was carried onto the page (#664), against
 	// the real table with its CHECK, FK, and unique-index constraints.

--- a/pkg/toolkits/knowledge/rollback_handlers.go
+++ b/pkg/toolkits/knowledge/rollback_handlers.go
@@ -45,7 +45,7 @@ func (t *Toolkit) handleRollback(ctx context.Context, input applyKnowledgeInput)
 	}
 
 	deps := RollbackDeps{Writer: t.datahubWriter, Changesets: t.changesetStore, Insights: t.store, Pages: t.pageWriter}
-	result, err := RevertChangeset(ctx, deps, cs, userIDFromContext(ctx))
+	result, err := RevertChangeset(ctx, deps, cs, authorFromContext(ctx))
 	if err != nil {
 		return rollbackErrorResult(err), nil, nil
 	}

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -438,7 +438,7 @@ func (t *Toolkit) handleApply(ctx context.Context, input applyKnowledgeInput) (*
 		})
 	}
 
-	appliedBy := userIDFromContext(ctx)
+	appliedBy := authorFromContext(ctx)
 
 	// Get current metadata for recording previous values
 	prevMeta, err := t.datahubWriter.GetCurrentMetadata(ctx, input.EntityURN)
@@ -512,13 +512,21 @@ func (t *Toolkit) recordChangesetAndMarkApplied(ctx context.Context, input apply
 	return jsonResult(result)
 }
 
-// userIDFromContext extracts the user ID from the platform context, or returns empty.
-func userIDFromContext(ctx context.Context) string {
+// authorFromContext returns the acting user's identity for authorship fields
+// (page created_by/created_email, changeset author, rollback author). It prefers the
+// email, matching the portal page handler, captured-insight authorship, and how these
+// fields are displayed; it falls back to the user id only when no email is present
+// (e.g. an API-key identity), so authorship is never the opaque id when an email
+// exists (#682).
+func authorFromContext(ctx context.Context) string {
 	pc := middleware.GetPlatformContext(ctx)
-	if pc != nil {
-		return pc.UserID
+	if pc == nil {
+		return ""
 	}
-	return ""
+	if pc.UserEmail != "" {
+		return pc.UserEmail
+	}
+	return pc.UserID
 }
 
 // columnTargetPrefix is the prefix for column-level targets in the target field.

--- a/pkg/toolkits/knowledge/toolkit_test.go
+++ b/pkg/toolkits/knowledge/toolkit_test.go
@@ -408,6 +408,31 @@ func ctxWithUser(userID, sessionID, persona string) context.Context {
 	return middleware.WithPlatformContext(context.Background(), pc)
 }
 
+// TestAuthorFromContext covers #682 finding 2: authorship fields (page
+// created_by/created_email, changeset author) must prefer the email, falling back
+// to the user id only when no email is present, never the opaque id when an email
+// exists.
+func TestAuthorFromContext(t *testing.T) {
+	t.Run("prefers email over id", func(t *testing.T) {
+		ctx := middleware.WithPlatformContext(context.Background(), &middleware.PlatformContext{
+			UserID:    "00f10812-22a1-4549-8a6b-8116b1f3cd06",
+			UserEmail: "alice@example.com",
+		})
+		assert.Equal(t, "alice@example.com", authorFromContext(ctx))
+	})
+
+	t.Run("falls back to id when no email", func(t *testing.T) {
+		ctx := middleware.WithPlatformContext(context.Background(), &middleware.PlatformContext{
+			UserID: "svc-api-key-1",
+		})
+		assert.Equal(t, "svc-api-key-1", authorFromContext(ctx))
+	})
+
+	t.Run("empty when no platform context", func(t *testing.T) {
+		assert.Equal(t, "", authorFromContext(context.Background()))
+	})
+}
+
 // ---------------------------------------------------------------------------
 // AC-1: Tool registration
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the two "works but not well" defects found in the v1.89.0 end-to-end live test of the memory/insight/knowledge loop (#682). Both are read-time/display correctness; the loop logic itself was already sound.

## Finding 1: a superseded insight kept surfacing in search and the review queue

A memory record carries two status axes:

- the lifecycle `status` column (active, superseded, archived), and
- the insight review status (`metadata.insight_status`: pending, applied, superseded).

Recall-first supersede advanced only the lifecycle column, while the insights read path keys off the review status (`resolveInsightStatus` prefers `metadata.insight_status`, and `isLiveInsightStatus` retracts `rejected`/`superseded`/`rolled_back`). So a superseded record still read as live: it kept appearing in `search` and stayed `pending` in the review queue, even after its successor was promoted. That defeats recall-first at read time and leaves an orphaned pending insight.

`Supersede` now advances `insight_status` to `superseded` as well, but only when the record already carries one (a reviewable insight). A non-insight record (a preference, an event) is not given an `insight_status` it never had.

### A pre-existing bug the fix uncovered

While reworking the metadata update, the real-Postgres test surfaced a latent corruption: a record captured with no extra metadata is stored as JSON `null` (`captureMetadata` returns `nil` for the empty case), and `null || patch` yields a JSON **array** in Postgres, which then fails to read back as a `map`. Superseding such a record (a recall-first restatement of a plain preference) would corrupt it. The base metadata is now coerced to `'{}'` when it is not a JSON object, so the merge stays an object regardless of the prior shape.

This is exactly the class of jsonb semantics that sqlmock cannot validate (it also caught a Postgres bind type-inference error on the way in). The new `*RealDB*` test exercises both `CASE` branches against a real pgvector container.

## Finding 2: page and changeset authorship was the user UUID, not the email

`userIDFromContext` returned `pc.UserID` (a UUID) and it was assigned to a knowledge page's `created_by`/`created_email`, the DataHub changeset author, and the rollback author. The page view then displayed an opaque UUID rather than an email, against the convention used everywhere else.

It is renamed `authorFromContext` and now prefers `pc.UserEmail`, falling back to the id only when no email is present (e.g. an API-key identity). This matches the portal page handler (which sets both fields to `user.Email`), captured-insight authorship, and the `created_by` ownership convention used for the "my pages" filter.

## Why this was not caught earlier

Both defects are observable only at read/display time against real data: the supersede gap needs the two status axes to diverge and the insights read path to be queried; the authorship gap needs the rendered field inspected. The unit suite (sqlmock + fakes) is green for both. The fix adds real-Postgres coverage so the regression cannot return silently.

## Testing

- `make verify` green: race plus real-Postgres, package budget, lint, gosec/govulncheck, semgrep, CodeQL, mutation, swagger-check, GoReleaser. **Patch coverage 100%.**
- `TestMemoryStore_Supersede_RealDB_AdvancesInsightStatus` (real Postgres): an insight's `insight_status` advances to `superseded`; a non-insight is superseded without one being invented; a null-metadata record reads back cleanly. Runs in the `test-realdb` gate.
- `TestAuthorFromContext`: email preferred over id, id fallback when no email, empty when no context.
- The page-sink RealDB test now asserts `created_by`/`created_email` are the email.
- Updated the `Supersede` sqlmock test to assert the new bind arguments (the conditional `insight_status` update).
- An adversarial review confirmed the SQL placeholder ordering and dual-`CASE` semantics (both `CASE`s read the pre-update metadata), that advancing `insight_status` is required because the read path prefers it (and lineage stays display-accurate), and that no join or foreign key keys on the user id, so the authorship change is safe.

Closes #682
