### PR TITLE
fix(search): retract non-live insights from the intent/text discovery path (#684)

### DIFF
--- a/pkg/knowledge/provider_insights.go
+++ b/pkg/knowledge/provider_insights.go
@@ -138,6 +138,12 @@ func (p *InsightsProvider) searchByText(ctx context.Context, q Query, seen map[s
 		if seen[scored[i].Insight.ID] {
 			continue
 		}
+		// Same retraction as the entity path: with no explicit status requested, a
+		// rejected/superseded/rolled-back insight is no longer in force and must not
+		// surface in a "what do we know" lookup (#684).
+		if q.Status == "" && !isLiveInsightStatus(scored[i].Insight.Status) {
+			continue
+		}
 		seen[scored[i].Insight.ID] = true
 		hits = append(hits, insightHit(scored[i].Insight, scored[i].Score))
 	}
@@ -159,7 +165,7 @@ func insightHit(in knowledgekit.Insight, score float64) Hit {
 
 // isLiveInsightStatus reports whether an insight status represents knowledge
 // still in force. Rejected, superseded, and rolled-back insights are retracted
-// and must not surface on the unfiltered entity path.
+// and must not surface on either unfiltered discovery path (entity or text).
 func isLiveInsightStatus(status string) bool {
 	switch status {
 	case knowledgekit.StatusRejected, knowledgekit.StatusSuperseded, knowledgekit.StatusRolledBack:

--- a/pkg/knowledge/provider_insights_realdb_integration_test.go
+++ b/pkg/knowledge/provider_insights_realdb_integration_test.go
@@ -1,0 +1,87 @@
+//go:build integration
+
+package knowledge
+
+// End-to-end #684 guard against real Postgres: through the assembled chain
+// (memory store -> insight adapter -> InsightsProvider), a recall-first superseded
+// insight must not surface in EITHER unfiltered discovery path (intent/text or
+// entity-keyed), while its live successor does, and an explicit status filter still
+// returns it. This is the single test that fails if any one read arm forgets the
+// retraction; its absence is why the #684 leak shipped (the entity arm was tested,
+// the text arm was assumed to match).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/internal/testdb"
+	"github.com/txn2/mcp-data-platform/pkg/memory"
+	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
+)
+
+func TestInsightsProvider_RealDB_RetractsSupersededAcrossBothPaths(t *testing.T) {
+	store := memory.NewPostgresStore(testdb.New(t))
+	adapter, ok := knowledgekit.NewMemoryInsightAdapter(store).(knowledgekit.SearchableInsightStore)
+	require.True(t, ok, "the memory insight adapter must be searchable")
+	provider := NewInsightsProvider(adapter)
+	ctx := context.Background()
+
+	const (
+		alice = "alice@example.com"
+		urn   = "urn:li:dataset:(urn:li:dataPlatform:trino,retail.public.returns,PROD)"
+		token = "zqreturnpolicy" // distinctive lexical token shared by both records
+	)
+	mk := func(id string) memory.Record {
+		return memory.Record{
+			ID:         id,
+			CreatedBy:  alice,
+			Dimension:  memory.DimensionKnowledge,
+			Category:   "business_context",
+			Source:     "user",
+			Status:     memory.StatusActive,
+			Content:    token + " standard return policy window is thirty days",
+			EntityURNs: []string{urn},
+			Metadata:   map[string]any{memory.MetaKeyInsightStatus: memory.InsightStatusPending},
+		}
+	}
+	require.NoError(t, store.Insert(ctx, mk("ins-live")))
+	require.NoError(t, store.Insert(ctx, mk("ins-old")))
+
+	// Recall-first supersede: ins-old is superseded by ins-live. This advances both
+	// the lifecycle status and insight_status to superseded (#682).
+	require.NoError(t, store.Supersede(ctx, "ins-old", "ins-live"))
+
+	caller := Caller{Email: alice}
+
+	// Text/intent discovery: only the live insight (the #684 fix; the store still
+	// returns the superseded record, the provider must drop it).
+	textHits, err := provider.Search(ctx, Query{Intent: token, Caller: caller, Limit: 20})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ins-live"}, refIDs(textHits),
+		"text path must surface only the live insight, not the superseded one")
+
+	// Entity-keyed discovery: same retraction.
+	entHits, err := provider.Search(ctx, Query{EntityURNs: []string{urn}, Caller: caller, Limit: 20})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ins-live"}, refIDs(entHits),
+		"entity path must surface only the live insight")
+
+	// An explicit status filter still returns the superseded record.
+	supHits, err := provider.Search(ctx, Query{
+		Intent: token, Status: knowledgekit.StatusSuperseded, Caller: caller, Limit: 20,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ins-old"}, refIDs(supHits),
+		"status=superseded must still return the superseded record")
+}
+
+func refIDs(hits []Hit) []string {
+	out := make([]string, 0, len(hits))
+	for _, h := range hits {
+		out = append(out, h.Ref)
+	}
+	return out
+}

--- a/pkg/knowledge/provider_insights_test.go
+++ b/pkg/knowledge/provider_insights_test.go
@@ -38,6 +38,58 @@ func (f *fakeInsightStore) List(_ context.Context, filter knowledgekit.InsightFi
 	return recs, len(recs), nil
 }
 
+// TestInsightsProvider_TextPathRetractsNonLive is the #684 regression: an
+// unfiltered text/intent search must drop rejected/superseded/rolled-back insights,
+// exactly as the entity path does, so a "what do we know" lookup never surfaces
+// retracted knowledge.
+func TestInsightsProvider_TextPathRetractsNonLive(t *testing.T) {
+	s := &fakeInsightStore{scored: []knowledgekit.ScoredInsight{
+		{Insight: knowledgekit.Insight{ID: "live-pending", Status: knowledgekit.StatusPending}, Score: 0.9},
+		{Insight: knowledgekit.Insight{ID: "live-applied", Status: knowledgekit.StatusApplied}, Score: 0.8},
+		{Insight: knowledgekit.Insight{ID: "dead-superseded", Status: knowledgekit.StatusSuperseded}, Score: 0.95},
+		{Insight: knowledgekit.Insight{ID: "dead-rejected", Status: knowledgekit.StatusRejected}, Score: 0.7},
+		{Insight: knowledgekit.Insight{ID: "dead-rolledback", Status: knowledgekit.StatusRolledBack}, Score: 0.6},
+	}}
+	p := NewInsightsProvider(s)
+	hits, err := p.Search(context.Background(), Query{Intent: "q", Caller: Caller{Email: "a@example.com"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := map[string]bool{}
+	for _, h := range hits {
+		got[h.Ref] = true
+	}
+	for _, live := range []string{"live-pending", "live-applied"} {
+		if !got[live] {
+			t.Errorf("live insight %q was dropped from text search", live)
+		}
+	}
+	for _, dead := range []string{"dead-superseded", "dead-rejected", "dead-rolledback"} {
+		if got[dead] {
+			t.Errorf("retracted insight %q surfaced in unfiltered text search (#684)", dead)
+		}
+	}
+}
+
+// TestInsightsProvider_TextPathHonorsExplicitStatus confirms the retraction only
+// applies when no status was requested: an explicit status=superseded still returns
+// superseded insights (the store does that filtering; the provider must not re-drop).
+func TestInsightsProvider_TextPathHonorsExplicitStatus(t *testing.T) {
+	s := &fakeInsightStore{scored: []knowledgekit.ScoredInsight{
+		{Insight: knowledgekit.Insight{ID: "sup", Status: knowledgekit.StatusSuperseded}, Score: 0.9},
+	}}
+	p := NewInsightsProvider(s)
+	hits, err := p.Search(context.Background(), Query{
+		Intent: "q", Status: knowledgekit.StatusSuperseded, Caller: Caller{Email: "a@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hits) != 1 || hits[0].Ref != "sup" {
+		t.Errorf("explicit status=superseded must return the superseded insight, got %+v", hits)
+	}
+}
+
 func TestInsightsProvider_Metadata(t *testing.T) {
 	p := NewInsightsProvider(&fakeInsightStore{})
 	if p.Name() != SourceInsights {


### PR DESCRIPTION
Fixes #684: the unified `search` intent/text discovery path surfaced retracted insights (superseded, rejected, rolled_back), while the entity-keyed path correctly hid them. Found while verifying #682 against the live instance.

## The inconsistency

`pkg/knowledge/provider_insights.go` has two discovery arms:

- `searchByEntity` (entity-keyed) dropped non-live insights when no explicit status was requested: `if q.Status == "" && !isLiveInsightStatus(insights[i].Status) { continue }`.
- `searchByText` (intent) had no such guard. It appended every scored insight regardless of review status.

So the same retracted insight was hidden by `search(entity_urns=...)` yet still listed by `search(intent=...)`. The `isLiveInsightStatus` doc comment even scoped the rule to "the unfiltered entity path"; the text arm was simply never guarded.

This is the residual from #682. That fix correctly advances a superseded insight's review status and removes it from the pending review queue, but on the live instance the text discovery search still listed the superseded record (labeled, but present), alongside rejected insights.

## The fix

`searchByText` now applies the same retraction as `searchByEntity`: with no explicit status, a `rejected`/`superseded`/`rolled_back` insight is dropped. With an explicit `status`, the store does the filtering and the provider does not second-guess it, so `status=superseded` still returns superseded records. The `isLiveInsightStatus` comment is generalized to cover both paths.

## Audit: no other surface has this gap

I checked every path that surfaces insights to agents, because the whole point is that this class of bug should not recur:

- **`memory_context` enrichment** (`datahub_get_entity`, the highest-stakes path since it injects context as if live): `RecallForEntities` -> `EntityLookup`, which hard-filters `WHERE status = active` unconditionally. Superseded (lifecycle `superseded`) and rejected (lifecycle `archived`) records are excluded.
- **`MemoryProvider`** (the `memory` search source): filters `Status: StatusActive`.
- **Review queue** (`apply_knowledge`): filters by explicit status.

The text discovery arm was the only place a retracted insight could leak.

## Testing

- `make verify` green: race plus real-Postgres, package budget, lint, gosec/govulncheck, semgrep, CodeQL, mutation, swagger-check, GoReleaser. Patch coverage 100%.
- Unit coverage of both arms: the text path drops superseded/rejected/rolled-back with no status; it honors an explicit `status=superseded`.
- An end-to-end real-Postgres test (`TestInsightsProvider_RealDB_RetractsSupersededAcrossBothPaths`) that exercises the assembled chain (memory store -> insight adapter -> `InsightsProvider`): a recall-first superseded insight is retracted from BOTH the text and entity paths, the live successor surfaces, and `status=superseded` still returns it. This is the gate whose absence let the leak ship: the entity arm was tested, the text arm was assumed to match. It runs in the `test-realdb` gate against a real pgvector container.

## Process note

This was a logic gap, not a production anomaly, observable only by exercising both read arms against real data. The durable fix is the assembled-path test above, which covers every read surface at once so a single arm missing the guard fails locally rather than against a tagged release.

Closes #684
