### PR TITLE
fix(knowledge): scope bulk_review stats to requested status (#688); bump gosec to v2.27.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Run Gosec Security Scanner
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@v2.22.0
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
           gosec ./...
 
       - name: Run govulncheck

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ CV_EMBED_DIR := ./internal/contentviewer/dist
 
 # Tool versions — keep in sync with .github/workflows/ci.yml
 GOLANGCI_LINT_VERSION := v2.11.4
-GOSEC_VERSION := v2.22.0
+GOSEC_VERSION := v2.27.1
 
 # Go commands
 GO := go
@@ -103,9 +103,9 @@ migrate-check:
 		-p $(MIGRATE_PG_PORT):5432 $(MIGRATE_PG_IMAGE) >/dev/null
 	@trap 'docker rm -f $(MIGRATE_PG_CONTAINER) >/dev/null 2>&1 || true' EXIT; \
 		echo "  waiting for Postgres on :$(MIGRATE_PG_PORT)..."; \
-		for i in $$(seq 1 30); do \
-			docker exec $(MIGRATE_PG_CONTAINER) pg_isready -U migrate -d migrate_check >/dev/null 2>&1 && break; \
-			if [ "$$i" = "30" ]; then echo "FAIL: Postgres did not become ready" >&2; exit 1; fi; \
+		for i in $$(seq 1 60); do \
+			docker exec $(MIGRATE_PG_CONTAINER) pg_isready -h localhost -p 5432 -U migrate -d migrate_check >/dev/null 2>&1 && break; \
+			if [ "$$i" = "60" ]; then echo "FAIL: Postgres did not become ready" >&2; exit 1; fi; \
 			sleep 1; \
 		done; \
 		MIGRATE_TEST_DSN="postgres://migrate:migrate@localhost:$(MIGRATE_PG_PORT)/migrate_check?sslmode=disable" \

--- a/pkg/admin/catalog_handler.go
+++ b/pkg/admin/catalog_handler.go
@@ -762,6 +762,8 @@ func (*Handler) specErrorStatus(err error) int {
 // caller can early-return without re-checking each step.
 func readSpecUpload(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
 	r.Body = http.MaxBytesReader(w, r.Body, catalogSpecMaxUploadBytes+1024)
+	// #nosec G120 -- r.Body is bounded by http.MaxBytesReader above, so the
+	// multipart parse cannot exhaust memory; gosec's pattern match misses it.
 	if err := r.ParseMultipartForm(multipartMemoryLimit); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid multipart form: "+err.Error())
 		return nil, false

--- a/pkg/audit/postgres/partitions.go
+++ b/pkg/audit/postgres/partitions.go
@@ -70,6 +70,7 @@ func (s *Store) EnsureMonthlyPartitions(ctx context.Context, monthsAhead int) er
 		// two date literals likewise produced by time.Format. None of these
 		// inputs are operator- or model-supplied, so SQL string formatting
 		// is safe here.
+		// #nosec G201 -- inputs are time.Format outputs, not user input
 		stmt := fmt.Sprintf(createPartitionTemplate, //nolint:gosec // G201: inputs are time.Format outputs, not user input
 			name,
 			from.Format(partitionDateSQLLayout),

--- a/pkg/authevents/store_postgres.go
+++ b/pkg/authevents/store_postgres.go
@@ -125,6 +125,7 @@ func (s *PostgresStore) List(ctx context.Context, f Filter) ([]Event, error) {
 	}
 	if !f.Since.IsZero() {
 		args = append(args, f.Since)
+		// #nosec G202 -- only a $N placeholder is formatted; user input goes to args
 		q += fmt.Sprintf(" AND occurred_at >= $%d", len(args)) //nolint:gosec // see G202 note
 	}
 	q += " ORDER BY occurred_at DESC LIMIT $1"

--- a/pkg/browsersession/oidcflow.go
+++ b/pkg/browsersession/oidcflow.go
@@ -247,6 +247,8 @@ func (f *Flow) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	if returnTo != "" {
 		dest = returnTo
 	}
+	// #nosec G710 -- dest is sanitizeReturnTo-validated to a site-relative path
+	// (scheme, host, and scheme-relative prefixes are dropped at write and read).
 	// nosemgrep: go.lang.security.injection.open-redirect.open-redirect
 	http.Redirect(w, r, dest, http.StatusFound)
 }
@@ -379,16 +381,14 @@ func (f *Flow) LogoutHandler(w http.ResponseWriter, r *http.Request) {
 
 	ClearCookie(w, &f.cfg.Cookie)
 
-	// Build the post-logout redirect dynamically from the request so a
-	// session that started on a non-default origin (e.g., Vite dev
-	// server on :5173, an alternate ingress host) returns the operator
-	// to that same origin. The configured PostLogoutRedirect is the
-	// fallback for cases where headers are absent. Each candidate
-	// origin must be registered on the OIDC client's
-	// post.logout.redirect.uris.
-	postLogout := requestPostLogoutRedirect(r, f.cfg.PostLogoutRedirect)
-
 	if f.endpoints.EndSessionEndpoint != "" {
+		// Build the post-logout redirect dynamically from the request so a
+		// session that started on a non-default origin (e.g., Vite dev server
+		// on :5173, an alternate ingress host) returns the operator to that same
+		// origin. Safe here because the OIDC provider validates
+		// post_logout_redirect_uri against the client's registered
+		// post.logout.redirect.uris before honoring it.
+		postLogout := requestPostLogoutRedirect(r, f.cfg.PostLogoutRedirect)
 		params := url.Values{
 			paramClientID:              {f.cfg.ClientID},
 			"post_logout_redirect_uri": {postLogout},
@@ -400,7 +400,11 @@ func (f *Flow) LogoutHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, postLogout, http.StatusFound)
+	// No end_session endpoint: return to the trusted configured post-logout URL.
+	// We deliberately do NOT use the request-derived origin here, because nothing
+	// downstream validates an attacker-supplied X-Forwarded-Host, which would make
+	// this an open redirect (G710).
+	http.Redirect(w, r, f.cfg.PostLogoutRedirect, http.StatusFound)
 }
 
 // requestPostLogoutRedirect derives the absolute post-logout redirect

--- a/pkg/browsersession/oidcflow_test.go
+++ b/pkg/browsersession/oidcflow_test.go
@@ -652,13 +652,13 @@ func TestLogoutHandlerDefaultsPostLogoutToPostLogin(t *testing.T) {
 	}
 }
 
-func TestLogoutHandlerNoEndSessionUsesRequestOrigin(t *testing.T) {
-	// When there's no end_session_endpoint, LogoutHandler derives the
-	// post-logout redirect from the request's scheme + host so a
-	// session started on a non-default origin (e.g., a Vite dev
-	// server, an alternate ingress host) returns to that same origin.
-	// The statically configured PostLogoutRedirect is only the
-	// fallback for header-less requests.
+func TestLogoutHandlerNoEndSessionIgnoresRequestOrigin(t *testing.T) {
+	// When there's no end_session_endpoint, LogoutHandler returns to the
+	// trusted configured PostLogoutRedirect and deliberately ignores the
+	// request-derived origin. Nothing downstream validates the redirect in
+	// this branch (unlike the end_session path, where the OIDC provider checks
+	// post_logout_redirect_uri), so honoring a spoofable X-Forwarded-Host here
+	// would be an open redirect (G710).
 	mux := http.NewServeMux()
 	var serverURL string
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
@@ -681,10 +681,9 @@ func TestLogoutHandlerNoEndSessionUsesRequestOrigin(t *testing.T) {
 		t.Fatalf("NewFlow: %v", err)
 	}
 
-	// X-Forwarded-Host overrides r.Host when set, mirroring the Vite
-	// dev server / ingress reverse-proxy pattern.
+	// A spoofed X-Forwarded-Host must NOT influence the redirect target.
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/portal/auth/logout", http.NoBody)
-	req.Header.Set("X-Forwarded-Host", "vite.local:5173")
+	req.Header.Set("X-Forwarded-Host", "evil.example.com")
 	req.Header.Set("X-Forwarded-Proto", "http")
 	w := httptest.NewRecorder()
 
@@ -696,7 +695,7 @@ func TestLogoutHandlerNoEndSessionUsesRequestOrigin(t *testing.T) {
 	}
 
 	loc := resp.Header.Get("Location")
-	wantLoc := "http://vite.local:5173" + DefaultPortalPath
+	wantLoc := "https://app.example.com/portal/" // the configured value, not the header host
 	if loc != wantLoc {
 		t.Errorf("redirect = %q, want %q", loc, wantLoc)
 	}
@@ -735,11 +734,11 @@ func TestLogoutHandlerNoEndSession(t *testing.T) {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusFound)
 	}
 
-	// LogoutHandler now derives the post-logout target from the request
-	// scheme + host so a session started on a non-default origin
-	// returns to that same origin. httptest's default Host is
-	// "example.com", and no TLS → scheme="http".
-	wantLoc := "http://example.com" + DefaultPortalPath
+	// No end_session_endpoint: LogoutHandler returns to the trusted configured
+	// PostLogoutRedirect, which defaults to PostLoginRedirect ("/portal/") when
+	// unset. The request origin is deliberately not used here (open-redirect
+	// hardening, G710).
+	wantLoc := cfg.PostLoginRedirect
 	if resp.Header.Get("Location") != wantLoc {
 		t.Errorf("redirect = %q, want %q", resp.Header.Get("Location"), wantLoc)
 	}

--- a/pkg/connbackfill/connbackfill_test.go
+++ b/pkg/connbackfill/connbackfill_test.go
@@ -53,6 +53,11 @@ func TestRun_InsertsEveryConnectionInsertOnly(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close() //nolint:errcheck // test cleanup
 
+	// Run iterates registry.All(), which ranges a map, so the insert order is
+	// non-deterministic. The contract is "every connection inserted, insert-only",
+	// not a specific order (ON CONFLICT DO NOTHING is order-independent), so match
+	// the expectations in any order.
+	mock.MatchExpectationsInOrder(false)
 	for _, c := range [][2]string{{"trino", "prod"}, {"api", "stripe"}, {"api", "prometheus"}} {
 		mock.ExpectExec("INSERT INTO connection_instances .*ON CONFLICT .*DO NOTHING").
 			WithArgs(c[0], c[1], "").

--- a/pkg/toolkits/knowledge/memory_adapter.go
+++ b/pkg/toolkits/knowledge/memory_adapter.go
@@ -240,10 +240,22 @@ func (a *memoryInsightAdapter) Stats(ctx context.Context, filter InsightFilter) 
 			return nil, fmt.Errorf("listing records for insight stats: %w", err)
 		}
 		for i := range records {
-			// Report the insight status (pending/approved/applied/...),
-			// not the raw memory status, so the keys match what callers
-			// and the postgres store produce.
-			stats.ByStatus[resolveInsightStatus(records[i])]++
+			// Recover the insight status (pending/approved/applied/...) from the
+			// lossy memory status, so the keys match what callers and the postgres
+			// store produce.
+			st := resolveInsightStatus(records[i])
+			// Scope every tally to the requested status, the way the postgres store
+			// does (its WHERE filters all three group-bys). The memory status filter
+			// is lossy: a Status=pending request maps to memory.StatusActive, which
+			// also returns approved and applied records (mapInsightStatusToMemory).
+			// Without this gate ByStatus/by_category/by_confidence span every active
+			// status while TotalPending counts only pending, so the counts disagree
+			// with each other and with postgres (#688). An empty filter (the portal
+			// "my stats" path, #515) still tallies every status.
+			if filter.Status != "" && st != filter.Status {
+				continue
+			}
+			stats.ByStatus[st]++
 			stats.ByCategory[records[i].Category]++
 			stats.ByConfidence[records[i].Confidence]++
 		}

--- a/pkg/toolkits/knowledge/memory_adapter_test.go
+++ b/pkg/toolkits/knowledge/memory_adapter_test.go
@@ -549,6 +549,50 @@ func TestMemoryInsightAdapter_Stats_Paginates(t *testing.T) {
 	assert.Equal(t, total, stats.TotalPending)
 }
 
+// TestMemoryInsightAdapter_Stats_StatusFiltered is the bulk_review path (#688):
+// a Status=pending filter must scope every tally (ByStatus, by_category,
+// by_confidence) to pending, even though the lossy memory status mapping returns
+// approved and applied records too (they all map to memory.StatusActive). Without
+// scoping, the tallies span every active status while total_pending counts only
+// pending, so the counts disagree with each other and with the postgres store
+// (which filters every group-by by status).
+func TestMemoryInsightAdapter_Stats_StatusFiltered(t *testing.T) {
+	// All three records are memory.StatusActive (what a Status=pending filter
+	// returns from the real store); resolveInsightStatus recovers the true
+	// insight status from metadata.
+	store := &mockMemoryStore{
+		listRecords: []memory.Record{
+			{ID: "p1", Category: "correction", Confidence: "high", Status: memory.StatusActive},
+			{
+				ID: "a1", Category: "business_context", Confidence: "low", Status: memory.StatusActive,
+				Metadata: map[string]any{metaKeyInsightStatus: StatusApproved},
+			},
+			{
+				ID: "x1", Category: "data_quality", Confidence: "medium", Status: memory.StatusActive,
+				Metadata: map[string]any{metaKeyInsightStatus: StatusApplied},
+			},
+		},
+		listTotal: 3,
+	}
+	adapter := NewMemoryInsightAdapter(store)
+
+	stats, err := adapter.Stats(context.Background(), InsightFilter{Status: StatusPending})
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+
+	// The lossy mapping: a pending filter is queried as active, so the store
+	// returns approved and applied records too.
+	assert.Equal(t, memory.StatusActive, store.listFilter.Status)
+
+	// A status filter scopes every tally (postgres parity): only the matching
+	// status survives, so ByStatus, TotalPending, by_category and by_confidence
+	// all agree and exclude the approved/applied records.
+	assert.Equal(t, map[string]int{StatusPending: 1}, stats.ByStatus)
+	assert.Equal(t, 1, stats.TotalPending)
+	assert.Equal(t, map[string]int{"correction": 1}, stats.ByCategory)
+	assert.Equal(t, map[string]int{"high": 1}, stats.ByConfidence)
+}
+
 func TestMemoryInsightAdapter_Stats_Error(t *testing.T) {
 	store := &mockMemoryStore{listErr: fmt.Errorf("db error")}
 	adapter := NewMemoryInsightAdapter(store)


### PR DESCRIPTION
## Summary

Three related changes, in two commits:

1. **fix(knowledge):** correct the `bulk_review` insight-stats counts on the memory-backed store (the core fix for #688).
2. **chore(ci):** bump the pinned `gosec` from `v2.22.0` to `v2.27.1` and resolve the new findings it surfaces, including a real open-redirect fix in the OIDC logout path.
3. **build:** harden the `migrate-check` readiness wait so it stops racing Postgres startup.

Closes #688.

---

## 1. bulk_review insight stats scoped to the requested status (#688)

### The bug

On a memory-backed deployment, `apply_knowledge` action `bulk_review` (default, counts-only) returned `by_category` and `by_confidence` tallies that spanned **every active insight (pending + approved + applied)** while `total_pending` and the response `note` claimed the counts were pending-only. `bulk_review` with `itemize: true` returned the correct pending-only tallies for the same queue, so the two modes disagreed.

### Root cause

`memoryInsightAdapter.Stats` builds its memory query with `Status: mapInsightStatusToMemory(filter.Status)`. That mapping is lossy: `pending`, `approved`, and `applied` all collapse to `memory.StatusActive`, so a `Status=pending` request returns every active record. The loop recovered the true per-record status only for `ByStatus` (so `TotalPending` was right), but tallied `ByCategory`/`ByConfidence` over every returned record.

The PostgreSQL store does not have this problem: `(*postgresStore).Stats` routes the same filter through `countGroupBy` for status, category, and confidence, so all three group-bys are scoped by `WHERE status = ...`. The bug was therefore a store-parity gap: the same MCP call returned different numbers depending on the backing store.

### The fix

Gate every tally (`ByStatus`, `by_category`, `by_confidence`) on the resolved insight status when a status filter is set, so the memory store matches PostgreSQL for all filter values:

```go
for i := range records {
    st := resolveInsightStatus(records[i])
    if filter.Status != "" && st != filter.Status {
        continue
    }
    stats.ByStatus[st]++
    stats.ByCategory[records[i].Category]++
    stats.ByConfidence[records[i].Confidence]++
}
stats.TotalPending = stats.ByStatus[StatusPending]
```

- A `Status=pending` `bulk_review` now reports category/confidence counts that sum to `total_pending`, matching the `itemize` path and the `note`.
- The unfiltered portal "my insight stats" path (`getMyInsightStats`, #515) is unchanged: with no status filter the gate is inert and every status is tallied.
- Adds `TestMemoryInsightAdapter_Stats_StatusFiltered`, which mixes pending + approved + applied active records and asserts the tallies scope to pending. The test fails against the pre-fix code.

---

## 2. gosec v2.22.0 -> v2.27.1 and the findings it surfaces

`v2.27.1` adds detection rules (G120 unbounded form parse, G710 open-redirect taint analysis) that `v2.22.0` did not run, so the bump surfaced five findings. The pin is updated in both the `Makefile` (`GOSEC_VERSION`) and `.github/workflows/ci.yml` to keep local and CI identical.

Each finding was reviewed individually:

| Finding | Location | Resolution |
| --- | --- | --- |
| G201 SQL string formatting | `pkg/audit/postgres/partitions.go` | `#nosec` with justification: the format args are `time.Format` outputs and a generated partition name, no user input |
| G202 SQL string concatenation | `pkg/authevents/store_postgres.go` | `#nosec` with justification: only a `$N` placeholder index is formatted; user values go through `args` (parameterized) |
| G120 unbounded form parse | `pkg/admin/catalog_handler.go` | `#nosec` (false positive): `r.Body` is already bounded by `http.MaxBytesReader` on the preceding line |
| G710 open redirect (dest) | `pkg/browsersession/oidcflow.go` | `#nosec` with justification: `dest` is sanitized to a site-relative path (scheme, host, and scheme-relative prefixes are dropped at write and read) |
| G710 open redirect (logout fallback) | `pkg/browsersession/oidcflow.go` | **fixed in code, see below** |

### Open redirect in the logout fallback (behavior change)

`LogoutHandler` has two branches. When the OIDC provider exposes an `end_session` endpoint, the post-logout redirect URL is derived from the request origin (honoring `X-Forwarded-Proto` / `X-Forwarded-Host`) and handed to the provider, which validates it against the client's registered post-logout URIs. When the provider has **no** `end_session` endpoint, the handler previously redirected the browser directly to that same request-derived URL, with nothing validating the host.

That direct fallback was a genuine open redirect: an attacker-supplied `X-Forwarded-Host` could send the user to an arbitrary origin after logout.

This PR moves the request-origin derivation into the `end_session` branch (where the provider validates it) and makes the fallback redirect to the trusted configured `PostLogoutRedirect` instead.

**Behavior change for reviewers:** a logout on a deployment whose OIDC provider has no `end_session` endpoint now returns the user to the configured `PostLogoutRedirect` (which defaults to `PostLoginRedirect`) rather than the request origin. The originating-origin convenience still applies in the common case (a provider with an `end_session` endpoint), where the provider validates the URI. Two tests that encoded the old fallback behavior are updated; one now asserts that a spoofed `X-Forwarded-Host` is ignored.

---

## 3. migrate-check readiness hardening

The `migrate-check` gate spins up a throwaway Postgres container and waited on `pg_isready` over the container's unix socket. The official Postgres image runs an init phase whose temporary server binds the socket but not TCP, then restarts the real server; the socket check could pass during that window, so the test's TCP connection to the published port hit the restart gap and got reset. This was reproducible locally when the amd64 image runs under emulation, which widens the race.

The wait now polls `pg_isready` over **TCP** (`-h localhost -p 5432`), which only the final server binds, and the retry budget is raised to 60s for slower (emulated) starts.

---

## Testing

- `make verify` passes end to end (unit tests with race, coverage and patch-coverage gates, lint, `gosec v2.27.1`, govulncheck, semgrep, codeql, dead-code, real-Postgres migrate gate, goreleaser dry-run).
- `gosec v2.27.1 ./...` reports 0 issues.
- New and updated unit tests cover the stats scoping and the logout fallback behavior.
