### PR TITLE
fix(apigateway): make every served admin route discoverable in api_list_endpoints (#697)

### DIFF
--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -2974,6 +2974,43 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/connection-instances/effective": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the merged view of file-configured (live) and database-managed connection instances, with secrets redacted.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "List effective connections",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/admin.effectiveConnection"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/connection-instances/{kind}/{name}": {
             "get": {
                 "security": [
@@ -8505,6 +8542,136 @@ const docTemplate = `{
                 }
             }
         },
+        "/portal/knowledge-pages": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns canonical, org-shared knowledge pages. Open to every authenticated user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "List knowledge pages",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by tag",
+                        "name": "tag",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by title/summary text",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Results per page (default: 20)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Pagination offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.knowledgePageListResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Creates a canonical, org-shared knowledge page. Requires apply_knowledge access (the same authorization that applies captured insights).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Create a knowledge page",
+                "parameters": [
+                    {
+                        "description": "Knowledge page content",
+                        "name": "page",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/portal.knowledgePageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/knowledgepage.Page"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/knowledge-pages/backlinks": {
             "get": {
                 "security": [
@@ -8601,6 +8768,261 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/knowledge-pages/search": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Ranks knowledge-page content by relevance to the query. Uses semantic ranking when an embedding provider is configured, else degrades to lexical-only. Open to every authenticated user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Search knowledge pages",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum results (default: 20)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/knowledgepage.ScoredPage"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/knowledge-pages/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a single canonical knowledge page by id. Open to every authenticated user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Get a knowledge page",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Knowledge page id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/knowledgepage.Page"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Replaces a knowledge page's content and records a new version. Requires apply_knowledge access.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Update a knowledge page",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Knowledge page id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Knowledge page content",
+                        "name": "page",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/portal.knowledgePageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/knowledgepage.Page"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft-deletes a knowledge page. Requires apply_knowledge access.",
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Delete a knowledge page",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Knowledge page id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/portal.problemDetail"
                         }
@@ -8776,6 +9198,67 @@ const docTemplate = `{
                     },
                     "422": {
                         "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/knowledge-pages/{id}/versions": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the saved versions of a knowledge page, newest first. Open to every authenticated user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "List a knowledge page's version history",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Knowledge page id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Results per page (default: 20)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Pagination offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.knowledgePageVersionsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/portal.problemDetail"
                         }
@@ -12030,6 +12513,56 @@ const docTemplate = `{
                 }
             }
         },
+        "admin.effectiveConnection": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "connection": {
+                    "type": "string",
+                    "example": "acme-warehouse"
+                },
+                "created_by": {
+                    "type": "string",
+                    "example": "admin@example.com"
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Production data warehouse"
+                },
+                "health": {
+                    "$ref": "#/definitions/toolkit.ConnectionHealthWire"
+                },
+                "kind": {
+                    "type": "string",
+                    "example": "trino"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "acme-warehouse"
+                },
+                "source": {
+                    "description": "\"file\", \"database\", or \"both\"",
+                    "type": "string",
+                    "example": "file"
+                },
+                "tools": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "trino_query",
+                        "trino_describe_table"
+                    ]
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "admin.embeddingHealthResponse": {
             "type": "object",
             "properties": {
@@ -14232,6 +14765,62 @@ const docTemplate = `{
                 }
             }
         },
+        "knowledgepage.Page": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string",
+                    "example": "# Fiscal Calendar\n\nQ1 begins..."
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string",
+                    "example": "alice@example.com"
+                },
+                "created_email": {
+                    "type": "string",
+                    "example": "alice@example.com"
+                },
+                "current_version": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "deleted_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "kp_01HK7R8Z8M0Y6A5G1R6FQ2VQNK"
+                },
+                "slug": {
+                    "type": "string",
+                    "example": "fiscal-calendar"
+                },
+                "summary": {
+                    "type": "string",
+                    "example": "How the company defines fiscal quarters."
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Fiscal Calendar"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string",
+                    "example": "bob@example.com"
+                }
+            }
+        },
         "knowledgepage.PageRef": {
             "type": "object",
             "properties": {
@@ -14243,6 +14832,61 @@ const docTemplate = `{
                 },
                 "title": {
                     "type": "string"
+                }
+            }
+        },
+        "knowledgepage.ScoredPage": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "$ref": "#/definitions/knowledgepage.Page"
+                },
+                "score": {
+                    "type": "number"
+                }
+            }
+        },
+        "knowledgepage.Version": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "change_summary": {
+                    "type": "string",
+                    "example": "Clarified Q1 start"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string",
+                    "example": "bob@example.com"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "kpv_01HK7R9A"
+                },
+                "page_id": {
+                    "type": "string",
+                    "example": "kp_01HK7R8Z8M0Y6A5G1R6FQ2VQNK"
+                },
+                "summary": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Fiscal Calendar"
+                },
+                "version": {
+                    "type": "integer",
+                    "example": 2
                 }
             }
         },
@@ -15314,6 +15958,20 @@ const docTemplate = `{
                 }
             }
         },
+        "portal.knowledgePageListResponse": {
+            "type": "object",
+            "properties": {
+                "pages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/knowledgepage.Page"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
         "portal.knowledgePageRefsResponse": {
             "type": "object",
             "properties": {
@@ -15321,6 +15979,46 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/portal.resolvedRefView"
+                    }
+                }
+            }
+        },
+        "portal.knowledgePageRequest": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "change_summary": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "summary": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "portal.knowledgePageVersionsResponse": {
+            "type": "object",
+            "properties": {
+                "total": {
+                    "type": "integer"
+                },
+                "versions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/knowledgepage.Version"
                     }
                 }
             }

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -2968,6 +2968,43 @@
                 }
             }
         },
+        "/admin/connection-instances/effective": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the merged view of file-configured (live) and database-managed connection instances, with secrets redacted.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Connections"
+                ],
+                "summary": "List effective connections",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/admin.effectiveConnection"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/admin.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/connection-instances/{kind}/{name}": {
             "get": {
                 "security": [
@@ -8499,6 +8536,136 @@
                 }
             }
         },
+        "/portal/knowledge-pages": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns canonical, org-shared knowledge pages. Open to every authenticated user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "List knowledge pages",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter by tag",
+                        "name": "tag",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by title/summary text",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Results per page (default: 20)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Pagination offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.knowledgePageListResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Creates a canonical, org-shared knowledge page. Requires apply_knowledge access (the same authorization that applies captured insights).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Create a knowledge page",
+                "parameters": [
+                    {
+                        "description": "Knowledge page content",
+                        "name": "page",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/portal.knowledgePageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/knowledgepage.Page"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
         "/portal/knowledge-pages/backlinks": {
             "get": {
                 "security": [
@@ -8595,6 +8762,261 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/knowledge-pages/search": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Ranks knowledge-page content by relevance to the query. Uses semantic ranking when an embedding provider is configured, else degrades to lexical-only. Open to every authenticated user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Search knowledge pages",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum results (default: 20)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/knowledgepage.ScoredPage"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/knowledge-pages/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a single canonical knowledge page by id. Open to every authenticated user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Get a knowledge page",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Knowledge page id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/knowledgepage.Page"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Replaces a knowledge page's content and records a new version. Requires apply_knowledge access.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Update a knowledge page",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Knowledge page id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Knowledge page content",
+                        "name": "page",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/portal.knowledgePageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/knowledgepage.Page"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Soft-deletes a knowledge page. Requires apply_knowledge access.",
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "Delete a knowledge page",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Knowledge page id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/portal.problemDetail"
                         }
@@ -8770,6 +9192,67 @@
                     },
                     "422": {
                         "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    }
+                }
+            }
+        },
+        "/portal/knowledge-pages/{id}/versions": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the saved versions of a knowledge page, newest first. Open to every authenticated user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Knowledge"
+                ],
+                "summary": "List a knowledge page's version history",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Knowledge page id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Results per page (default: 20)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Pagination offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/portal.knowledgePageVersionsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/portal.problemDetail"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/portal.problemDetail"
                         }
@@ -12024,6 +12507,56 @@
                 }
             }
         },
+        "admin.effectiveConnection": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "connection": {
+                    "type": "string",
+                    "example": "acme-warehouse"
+                },
+                "created_by": {
+                    "type": "string",
+                    "example": "admin@example.com"
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Production data warehouse"
+                },
+                "health": {
+                    "$ref": "#/definitions/toolkit.ConnectionHealthWire"
+                },
+                "kind": {
+                    "type": "string",
+                    "example": "trino"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "acme-warehouse"
+                },
+                "source": {
+                    "description": "\"file\", \"database\", or \"both\"",
+                    "type": "string",
+                    "example": "file"
+                },
+                "tools": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "trino_query",
+                        "trino_describe_table"
+                    ]
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "admin.embeddingHealthResponse": {
             "type": "object",
             "properties": {
@@ -14226,6 +14759,62 @@
                 }
             }
         },
+        "knowledgepage.Page": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string",
+                    "example": "# Fiscal Calendar\n\nQ1 begins..."
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string",
+                    "example": "alice@example.com"
+                },
+                "created_email": {
+                    "type": "string",
+                    "example": "alice@example.com"
+                },
+                "current_version": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "deleted_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "kp_01HK7R8Z8M0Y6A5G1R6FQ2VQNK"
+                },
+                "slug": {
+                    "type": "string",
+                    "example": "fiscal-calendar"
+                },
+                "summary": {
+                    "type": "string",
+                    "example": "How the company defines fiscal quarters."
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Fiscal Calendar"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string",
+                    "example": "bob@example.com"
+                }
+            }
+        },
         "knowledgepage.PageRef": {
             "type": "object",
             "properties": {
@@ -14237,6 +14826,61 @@
                 },
                 "title": {
                     "type": "string"
+                }
+            }
+        },
+        "knowledgepage.ScoredPage": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "$ref": "#/definitions/knowledgepage.Page"
+                },
+                "score": {
+                    "type": "number"
+                }
+            }
+        },
+        "knowledgepage.Version": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "change_summary": {
+                    "type": "string",
+                    "example": "Clarified Q1 start"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string",
+                    "example": "bob@example.com"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "kpv_01HK7R9A"
+                },
+                "page_id": {
+                    "type": "string",
+                    "example": "kp_01HK7R8Z8M0Y6A5G1R6FQ2VQNK"
+                },
+                "summary": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Fiscal Calendar"
+                },
+                "version": {
+                    "type": "integer",
+                    "example": 2
                 }
             }
         },
@@ -15308,6 +15952,20 @@
                 }
             }
         },
+        "portal.knowledgePageListResponse": {
+            "type": "object",
+            "properties": {
+                "pages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/knowledgepage.Page"
+                    }
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
         "portal.knowledgePageRefsResponse": {
             "type": "object",
             "properties": {
@@ -15315,6 +15973,46 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/portal.resolvedRefView"
+                    }
+                }
+            }
+        },
+        "portal.knowledgePageRequest": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "change_summary": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "summary": {
+                    "type": "string"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "portal.knowledgePageVersionsResponse": {
+            "type": "object",
+            "properties": {
+                "total": {
+                    "type": "integer"
+                },
+                "versions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/knowledgepage.Version"
                     }
                 }
             }

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -540,6 +540,42 @@ definitions:
         example: ACME Corp analytics platform
         type: string
     type: object
+  admin.effectiveConnection:
+    properties:
+      config:
+        additionalProperties: {}
+        type: object
+      connection:
+        example: acme-warehouse
+        type: string
+      created_by:
+        example: admin@example.com
+        type: string
+      description:
+        example: Production data warehouse
+        type: string
+      health:
+        $ref: '#/definitions/toolkit.ConnectionHealthWire'
+      kind:
+        example: trino
+        type: string
+      name:
+        example: acme-warehouse
+        type: string
+      source:
+        description: '"file", "database", or "both"'
+        example: file
+        type: string
+      tools:
+        example:
+        - trino_query
+        - trino_describe_table
+        items:
+          type: string
+        type: array
+      updated_at:
+        type: string
+    type: object
   admin.embeddingHealthResponse:
     properties:
       catalog_id:
@@ -2237,6 +2273,49 @@ definitions:
         example: amount
         type: string
     type: object
+  knowledgepage.Page:
+    properties:
+      body:
+        example: |-
+          # Fiscal Calendar
+
+          Q1 begins...
+        type: string
+      created_at:
+        type: string
+      created_by:
+        example: alice@example.com
+        type: string
+      created_email:
+        example: alice@example.com
+        type: string
+      current_version:
+        example: 3
+        type: integer
+      deleted_at:
+        type: string
+      id:
+        example: kp_01HK7R8Z8M0Y6A5G1R6FQ2VQNK
+        type: string
+      slug:
+        example: fiscal-calendar
+        type: string
+      summary:
+        example: How the company defines fiscal quarters.
+        type: string
+      tags:
+        items:
+          type: string
+        type: array
+      title:
+        example: Fiscal Calendar
+        type: string
+      updated_at:
+        type: string
+      updated_by:
+        example: bob@example.com
+        type: string
+    type: object
   knowledgepage.PageRef:
     properties:
       id:
@@ -2245,6 +2324,44 @@ definitions:
         type: string
       title:
         type: string
+    type: object
+  knowledgepage.ScoredPage:
+    properties:
+      page:
+        $ref: '#/definitions/knowledgepage.Page'
+      score:
+        type: number
+    type: object
+  knowledgepage.Version:
+    properties:
+      body:
+        type: string
+      change_summary:
+        example: Clarified Q1 start
+        type: string
+      created_at:
+        type: string
+      created_by:
+        example: bob@example.com
+        type: string
+      id:
+        example: kpv_01HK7R9A
+        type: string
+      page_id:
+        example: kp_01HK7R8Z8M0Y6A5G1R6FQ2VQNK
+        type: string
+      summary:
+        type: string
+      tags:
+        items:
+          type: string
+        type: array
+      title:
+        example: Fiscal Calendar
+        type: string
+      version:
+        example: 2
+        type: integer
     type: object
   persona.AccessSource:
     enum:
@@ -2991,11 +3108,46 @@ definitions:
           $ref: '#/definitions/portal.lineageInsight'
         type: array
     type: object
+  portal.knowledgePageListResponse:
+    properties:
+      pages:
+        items:
+          $ref: '#/definitions/knowledgepage.Page'
+        type: array
+      total:
+        type: integer
+    type: object
   portal.knowledgePageRefsResponse:
     properties:
       refs:
         items:
           $ref: '#/definitions/portal.resolvedRefView'
+        type: array
+    type: object
+  portal.knowledgePageRequest:
+    properties:
+      body:
+        type: string
+      change_summary:
+        type: string
+      slug:
+        type: string
+      summary:
+        type: string
+      tags:
+        items:
+          type: string
+        type: array
+      title:
+        type: string
+    type: object
+  portal.knowledgePageVersionsResponse:
+    properties:
+      total:
+        type: integer
+      versions:
+        items:
+          $ref: '#/definitions/knowledgepage.Version'
         type: array
     type: object
   portal.lineageChangeset:
@@ -5493,6 +5645,29 @@ paths:
       - ApiKeyAuth: []
       - BearerAuth: []
       summary: Create or update connection instance
+      tags:
+      - Connections
+  /admin/connection-instances/effective:
+    get:
+      description: Returns the merged view of file-configured (live) and database-managed
+        connection instances, with secrets redacted.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/admin.effectiveConnection'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/admin.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: List effective connections
       tags:
       - Connections
   /admin/connections:
@@ -8933,6 +9108,207 @@ paths:
       summary: Feedback activity feed
       tags:
       - Feedback
+  /portal/knowledge-pages:
+    get:
+      description: Returns canonical, org-shared knowledge pages. Open to every authenticated
+        user.
+      parameters:
+      - description: Filter by tag
+        in: query
+        name: tag
+        type: string
+      - description: Filter by title/summary text
+        in: query
+        name: q
+        type: string
+      - description: 'Results per page (default: 20)'
+        in: query
+        name: limit
+        type: integer
+      - description: Pagination offset
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/portal.knowledgePageListResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: List knowledge pages
+      tags:
+      - Knowledge
+    post:
+      consumes:
+      - application/json
+      description: Creates a canonical, org-shared knowledge page. Requires apply_knowledge
+        access (the same authorization that applies captured insights).
+      parameters:
+      - description: Knowledge page content
+        in: body
+        name: page
+        required: true
+        schema:
+          $ref: '#/definitions/portal.knowledgePageRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/knowledgepage.Page'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Create a knowledge page
+      tags:
+      - Knowledge
+  /portal/knowledge-pages/{id}:
+    delete:
+      description: Soft-deletes a knowledge page. Requires apply_knowledge access.
+      parameters:
+      - description: Knowledge page id
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Delete a knowledge page
+      tags:
+      - Knowledge
+    get:
+      description: Returns a single canonical knowledge page by id. Open to every
+        authenticated user.
+      parameters:
+      - description: Knowledge page id
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/knowledgepage.Page'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Get a knowledge page
+      tags:
+      - Knowledge
+    put:
+      consumes:
+      - application/json
+      description: Replaces a knowledge page's content and records a new version.
+        Requires apply_knowledge access.
+      parameters:
+      - description: Knowledge page id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Knowledge page content
+        in: body
+        name: page
+        required: true
+        schema:
+          $ref: '#/definitions/portal.knowledgePageRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/knowledgepage.Page'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Update a knowledge page
+      tags:
+      - Knowledge
   /portal/knowledge-pages/{id}/lineage:
     get:
       description: Returns the insights the page was synthesized from and the promotion
@@ -9047,6 +9423,45 @@ paths:
       summary: Set a knowledge page's manual entity references
       tags:
       - Knowledge
+  /portal/knowledge-pages/{id}/versions:
+    get:
+      description: Returns the saved versions of a knowledge page, newest first. Open
+        to every authenticated user.
+      parameters:
+      - description: Knowledge page id
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: 'Results per page (default: 20)'
+        in: query
+        name: limit
+        type: integer
+      - description: Pagination offset
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/portal.knowledgePageVersionsResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: List a knowledge page's version history
+      tags:
+      - Knowledge
   /portal/knowledge-pages/backlinks:
     get:
       description: 'Reverse lookup: returns the knowledge pages that reference the
@@ -9112,6 +9527,52 @@ paths:
       - ApiKeyAuth: []
       - BearerAuth: []
       summary: Resolve entity references to display labels
+      tags:
+      - Knowledge
+  /portal/knowledge-pages/search:
+    get:
+      description: Ranks knowledge-page content by relevance to the query. Uses semantic
+        ranking when an embedding provider is configured, else degrades to lexical-only.
+        Open to every authenticated user.
+      parameters:
+      - description: Search query
+        in: query
+        name: q
+        required: true
+        type: string
+      - description: 'Maximum results (default: 20)'
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/knowledgepage.ScoredPage'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/portal.problemDetail'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Search knowledge pages
       tags:
       - Knowledge
   /portal/knowledge/insights:

--- a/pkg/admin/connection_handler.go
+++ b/pkg/admin/connection_handler.go
@@ -304,6 +304,16 @@ type effectiveConnection struct {
 }
 
 // listEffectiveConnections returns the merged view of file-configured and DB-managed connections.
+//
+// @Summary      List effective connections
+// @Description  Returns the merged view of file-configured (live) and database-managed connection instances, with secrets redacted.
+// @Tags         Connections
+// @Produce      json
+// @Success      200  {array}   effectiveConnection
+// @Failure      500  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /admin/connection-instances/effective [get]
 func (h *Handler) listEffectiveConnections(w http.ResponseWriter, r *http.Request) {
 	live := h.collectLiveConnections()
 

--- a/pkg/platform/admin_catalog_parity_test.go
+++ b/pkg/platform/admin_catalog_parity_test.go
@@ -1,0 +1,233 @@
+package platform
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	apigatewaycatalog "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway/catalog"
+)
+
+// TestAdminCatalogRouteParity guards issue #697: every authenticated admin /
+// portal REST route registered on the running server must be discoverable
+// through the OpenAPI catalog that the platform-admin self-connection seeds and
+// that api_list_endpoints serves. A served-but-undocumented endpoint makes an
+// agent conclude a capability does not exist when it is present and authorized.
+//
+// The test enumerates the real route table by parsing every
+// `*.Handle`/`*.HandleFunc("METHOD /api/v1/...")` registration in the source
+// tree, then asserts each appears in the catalog content produced by
+// adminSelfSpecContent (the exact OpenAPI document the self-connection upserts),
+// enumerated through the same production parser api_list_endpoints uses. The two
+// directions of drift it cannot tolerate:
+//
+//   - A new authenticated route added without swaggo annotations: it is
+//     registered, served, and authorized, yet invisible to discovery.
+//   - A stale entry in catalogParityExclusions: a route that was removed or
+//     later documented but whose exclusion lingers.
+func TestAdminCatalogRouteParity(t *testing.T) {
+	catalog := catalogOperationSet(t)
+	registered := registeredAPIRoutes(t)
+
+	// Every registered route, minus the documented exclusions, must be in the
+	// catalog.
+	var undocumented []string
+	for route := range registered {
+		if _, excluded := catalogParityExclusions[route]; excluded {
+			continue
+		}
+		if !catalog[normalizeRouteParams(route)] {
+			undocumented = append(undocumented, route.method+" "+route.path)
+		}
+	}
+	if len(undocumented) > 0 {
+		sort.Strings(undocumented)
+		t.Errorf("served-but-undocumented admin routes (#697): %d endpoint(s) are registered "+
+			"but absent from the OpenAPI catalog api_list_endpoints serves. Add swaggo "+
+			"annotations and run `make swagger`, or, if the route is genuinely not part of "+
+			"the operable admin surface, add it to catalogParityExclusions with a rationale:\n  %s",
+			len(undocumented), strings.Join(undocumented, "\n  "))
+	}
+
+	// Keep the exclusion list honest: an exclusion that no longer matches a
+	// registered route is stale and must be removed so the gate cannot silently
+	// rot into hiding a real route behind a dead entry.
+	for route := range catalogParityExclusions {
+		if !registered[route] {
+			t.Errorf("stale catalogParityExclusions entry %q %q: no such route is registered; "+
+				"remove the exclusion", route.method, route.path)
+		}
+	}
+}
+
+// routeKey is a (METHOD, path) pair with the /api/v1 base path stripped, matching
+// how catalog operations are keyed (basePath becomes a server URL on the v2->v3
+// conversion, leaving paths like /portal/knowledge-pages).
+type routeKey struct {
+	method string
+	path   string
+}
+
+// catalogParityExclusions lists routes that are registered on an HTTP mux but
+// deliberately absent from the admin OpenAPI catalog, each with the reason it is
+// not part of the operable, authenticated admin surface api_list_endpoints
+// exposes. Keep this set as small as the truth allows.
+var catalogParityExclusions = map[routeKey]string{
+	{method: "GET", path: "/admin/public/branding"}: "served on the unauthenticated publicMux to brand " +
+		"the login screen before sign-in; not part of the authenticated, identity-passthrough admin surface.",
+	{method: "GET", path: "/observability/query"}: "raw Prometheus PromQL proxy passthrough; its request/response " +
+		"contract is defined by upstream Prometheus and it backs the observability dashboards, not a first-class admin REST operation.",
+	{method: "GET", path: "/observability/query_range"}: "raw Prometheus PromQL range-query proxy passthrough; " +
+		"contract defined by upstream Prometheus, backs the observability dashboards, not a first-class admin REST operation.",
+	{method: "POST", path: "/gateway/{connection}/invoke"}: "generic API-gateway data-plane proxy: forwards an " +
+		"arbitrary request to a configured upstream connection. Its contract is the upstream's OpenAPI spec (surfaced " +
+		"per connection via api_list_endpoints), not the platform's own admin control-plane catalog.",
+	{method: "POST", path: "/gateway/{connection}/invoke-raw"}: "generic API-gateway data-plane proxy that streams " +
+		"the upstream body unbuffered (#535); same rationale as /gateway/{connection}/invoke.",
+}
+
+// catalogOperationSet parses the catalog content the self-connection seeds and
+// returns the set of (METHOD, path) operations with path parameters normalized.
+// It enumerates through the production parser (apigatewaycatalog.ParseSpec +
+// PathItem.Operations) so the test measures exactly the operation surface
+// api_list_endpoints walks, not a parallel hand-rolled reading of the JSON.
+func catalogOperationSet(t *testing.T) map[routeKey]bool {
+	t.Helper()
+	content, err := adminSelfSpecContent()
+	if err != nil {
+		t.Fatalf("building admin spec content: %v", err)
+	}
+	doc, err := apigatewaycatalog.ParseSpec(content)
+	if err != nil {
+		t.Fatalf("parsing catalog content: %v", err)
+	}
+	if doc.Paths == nil {
+		t.Fatal("catalog produced no paths; the embedded OpenAPI document is empty or unparsable")
+	}
+	ops := make(map[routeKey]bool)
+	for path, item := range doc.Paths.Map() {
+		for method := range item.Operations() {
+			ops[routeKey{method: strings.ToUpper(method), path: normalizePath(path)}] = true
+		}
+	}
+	if len(ops) == 0 {
+		t.Fatal("catalog produced zero operations; the embedded OpenAPI document is empty or unparsable")
+	}
+	return ops
+}
+
+// registeredAPIRoutes walks the source tree and returns every
+// `*.Handle`/`*.HandleFunc("METHOD /api/v1/...")` registration as a routeKey
+// with the /api/v1 base path stripped. Both registration styles are scanned
+// because per-route middleware (e.g. the gateway's withMetrics wrapper) is wired
+// with mux.Handle, and such a route is just as served and authorized as a
+// HandleFunc one. Using the AST (not a text scan) means commented-out or
+// string-fragment matches cannot leak in.
+func registeredAPIRoutes(t *testing.T) map[routeKey]bool {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed; cannot locate repo root")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+
+	routes := make(map[routeKey]bool)
+	fset := token.NewFileSet()
+	// Scan every directory that can register HTTP routes, not just pkg/, so a
+	// route added under internal/ cannot escape the gate by location.
+	for _, dir := range []string{"pkg", "internal"} {
+		scanRoutesUnder(t, fset, filepath.Join(repoRoot, dir), routes)
+	}
+	if len(routes) == 0 {
+		t.Fatal("found zero registered /api/v1 routes; the source scan is broken")
+	}
+	return routes
+}
+
+// scanRoutesUnder parses every non-test .go file under root and records each
+// Handle/HandleFunc route pattern into routes.
+func scanRoutesUnder(t *testing.T, fset *token.FileSet, root string, routes map[routeKey]bool) {
+	t.Helper()
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			t.Fatalf("parsing %s: %v", path, perr)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			if key, ok := routeFromCall(n); ok {
+				routes[key] = true
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+}
+
+// routeFromCall extracts a routeKey from an AST node when it is a
+// Handle/HandleFunc call whose first argument is a "METHOD /api/v1/..." string
+// literal; ok=false otherwise.
+func routeFromCall(n ast.Node) (routeKey, bool) {
+	call, ok := n.(*ast.CallExpr)
+	if !ok {
+		return routeKey{}, false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || (sel.Sel.Name != "HandleFunc" && sel.Sel.Name != "Handle") || len(call.Args) == 0 {
+		return routeKey{}, false
+	}
+	lit, ok := call.Args[0].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return routeKey{}, false
+	}
+	return parseRoutePattern(strings.Trim(lit.Value, "`\""))
+}
+
+// parseRoutePattern splits a Go 1.22 ServeMux pattern ("METHOD /path") into a
+// routeKey, returning ok=false unless it is a method-prefixed pattern under the
+// /api/v1 base path. Patterns without a method, or outside /api/v1, are not part
+// of the catalog surface.
+func parseRoutePattern(pattern string) (routeKey, bool) {
+	method, path, found := strings.Cut(pattern, " ")
+	if !found {
+		return routeKey{}, false
+	}
+	method = strings.TrimSpace(method)
+	path = strings.TrimSpace(path)
+	if method == "" || !strings.HasPrefix(path, "/api/v1/") {
+		return routeKey{}, false
+	}
+	return routeKey{method: strings.ToUpper(method), path: strings.TrimPrefix(path, "/api/v1")}, true
+}
+
+// normalizeRouteParams returns a routeKey with path parameters normalized so a
+// registered {id} matches the catalog's {id} regardless of the parameter name.
+func normalizeRouteParams(r routeKey) routeKey {
+	return routeKey{method: r.method, path: normalizePath(r.path)}
+}
+
+// normalizePath replaces every {param} segment with a placeholder so paths
+// compare on shape, not on the (arbitrary) parameter name.
+func normalizePath(path string) string {
+	segments := strings.Split(path, "/")
+	for i, seg := range segments {
+		if strings.HasPrefix(seg, "{") && strings.HasSuffix(seg, "}") {
+			segments[i] = "{}"
+		}
+	}
+	return strings.Join(segments, "/")
+}

--- a/pkg/portal/knowledge_page_handler.go
+++ b/pkg/portal/knowledge_page_handler.go
@@ -69,7 +69,28 @@ type knowledgePageListResponse struct {
 	Total int                  `json:"total"`
 }
 
+// knowledgePageVersionsResponse is the paginated version-history envelope.
+type knowledgePageVersionsResponse struct {
+	Versions []knowledgepage.Version `json:"versions"`
+	Total    int                     `json:"total"`
+}
+
 // createKnowledgePage handles POST /api/v1/portal/knowledge-pages (apply_knowledge access).
+//
+// @Summary      Create a knowledge page
+// @Description  Creates a canonical, org-shared knowledge page. Requires apply_knowledge access (the same authorization that applies captured insights).
+// @Tags         Knowledge
+// @Accept       json
+// @Produce      json
+// @Param        page  body  knowledgePageRequest  true  "Knowledge page content"
+// @Success      201  {object}  knowledgepage.Page
+// @Failure      400  {object}  problemDetail
+// @Failure      401  {object}  problemDetail
+// @Failure      403  {object}  problemDetail
+// @Failure      500  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/knowledge-pages [post]
 func (h *Handler) createKnowledgePage(w http.ResponseWriter, r *http.Request) {
 	user := GetUser(r.Context())
 	if user == nil {
@@ -115,6 +136,21 @@ func (h *Handler) createKnowledgePage(w http.ResponseWriter, r *http.Request) {
 }
 
 // listKnowledgePages handles GET /api/v1/portal/knowledge-pages (any user).
+//
+// @Summary      List knowledge pages
+// @Description  Returns canonical, org-shared knowledge pages. Open to every authenticated user.
+// @Tags         Knowledge
+// @Produce      json
+// @Param        tag     query  string   false  "Filter by tag"
+// @Param        q       query  string   false  "Filter by title/summary text"
+// @Param        limit   query  integer  false  "Results per page (default: 20)"
+// @Param        offset  query  integer  false  "Pagination offset"
+// @Success      200  {object}  knowledgePageListResponse
+// @Failure      401  {object}  problemDetail
+// @Failure      500  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/knowledge-pages [get]
 func (h *Handler) listKnowledgePages(w http.ResponseWriter, r *http.Request) {
 	if GetUser(r.Context()) == nil {
 		writeError(w, http.StatusUnauthorized, errAuthRequired)
@@ -140,6 +176,21 @@ func (h *Handler) listKnowledgePages(w http.ResponseWriter, r *http.Request) {
 // searchKnowledgePages handles GET /api/v1/portal/knowledge-pages/search?q= (any
 // user). It ranks page CONTENT; the embedding is computed server-side when a
 // provider is configured, else it degrades to lexical-only.
+//
+// @Summary      Search knowledge pages
+// @Description  Ranks knowledge-page content by relevance to the query. Uses semantic ranking when an embedding provider is configured, else degrades to lexical-only. Open to every authenticated user.
+// @Tags         Knowledge
+// @Produce      json
+// @Param        q      query  string   true   "Search query"
+// @Param        limit  query  integer  false  "Maximum results (default: 20)"
+// @Success      200  {array}   knowledgepage.ScoredPage
+// @Failure      400  {object}  problemDetail
+// @Failure      401  {object}  problemDetail
+// @Failure      500  {object}  problemDetail
+// @Failure      501  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/knowledge-pages/search [get]
 func (h *Handler) searchKnowledgePages(w http.ResponseWriter, r *http.Request) {
 	if GetUser(r.Context()) == nil {
 		writeError(w, http.StatusUnauthorized, errAuthRequired)
@@ -173,6 +224,19 @@ func (h *Handler) searchKnowledgePages(w http.ResponseWriter, r *http.Request) {
 }
 
 // getKnowledgePage handles GET /api/v1/portal/knowledge-pages/{id} (any user).
+//
+// @Summary      Get a knowledge page
+// @Description  Returns a single canonical knowledge page by id. Open to every authenticated user.
+// @Tags         Knowledge
+// @Produce      json
+// @Param        id  path  string  true  "Knowledge page id"
+// @Success      200  {object}  knowledgepage.Page
+// @Failure      401  {object}  problemDetail
+// @Failure      404  {object}  problemDetail
+// @Failure      500  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/knowledge-pages/{id} [get]
 func (h *Handler) getKnowledgePage(w http.ResponseWriter, r *http.Request) {
 	if GetUser(r.Context()) == nil {
 		writeError(w, http.StatusUnauthorized, errAuthRequired)
@@ -195,6 +259,23 @@ func (h *Handler) getKnowledgePage(w http.ResponseWriter, r *http.Request) {
 }
 
 // updateKnowledgePage handles PUT /api/v1/portal/knowledge-pages/{id} (apply_knowledge access).
+//
+// @Summary      Update a knowledge page
+// @Description  Replaces a knowledge page's content and records a new version. Requires apply_knowledge access.
+// @Tags         Knowledge
+// @Accept       json
+// @Produce      json
+// @Param        id    path  string                true  "Knowledge page id"
+// @Param        page  body  knowledgePageRequest  true  "Knowledge page content"
+// @Success      200  {object}  knowledgepage.Page
+// @Failure      400  {object}  problemDetail
+// @Failure      401  {object}  problemDetail
+// @Failure      403  {object}  problemDetail
+// @Failure      404  {object}  problemDetail
+// @Failure      500  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/knowledge-pages/{id} [put]
 func (h *Handler) updateKnowledgePage(w http.ResponseWriter, r *http.Request) {
 	user := GetUser(r.Context())
 	if user == nil {
@@ -249,6 +330,19 @@ func (h *Handler) updateKnowledgePage(w http.ResponseWriter, r *http.Request) {
 }
 
 // deleteKnowledgePage handles DELETE /api/v1/portal/knowledge-pages/{id} (apply_knowledge access).
+//
+// @Summary      Delete a knowledge page
+// @Description  Soft-deletes a knowledge page. Requires apply_knowledge access.
+// @Tags         Knowledge
+// @Param        id  path  string  true  "Knowledge page id"
+// @Success      204  "No Content"
+// @Failure      401  {object}  problemDetail
+// @Failure      403  {object}  problemDetail
+// @Failure      404  {object}  problemDetail
+// @Failure      500  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/knowledge-pages/{id} [delete]
 func (h *Handler) deleteKnowledgePage(w http.ResponseWriter, r *http.Request) {
 	user := GetUser(r.Context())
 	if user == nil {
@@ -271,6 +365,20 @@ func (h *Handler) deleteKnowledgePage(w http.ResponseWriter, r *http.Request) {
 }
 
 // listKnowledgePageVersions handles GET /api/v1/portal/knowledge-pages/{id}/versions (any user).
+//
+// @Summary      List a knowledge page's version history
+// @Description  Returns the saved versions of a knowledge page, newest first. Open to every authenticated user.
+// @Tags         Knowledge
+// @Produce      json
+// @Param        id      path   string   true   "Knowledge page id"
+// @Param        limit   query  integer  false  "Results per page (default: 20)"
+// @Param        offset  query  integer  false  "Pagination offset"
+// @Success      200  {object}  knowledgePageVersionsResponse
+// @Failure      401  {object}  problemDetail
+// @Failure      500  {object}  problemDetail
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /portal/knowledge-pages/{id}/versions [get]
 func (h *Handler) listKnowledgePageVersions(w http.ResponseWriter, r *http.Request) {
 	if GetUser(r.Context()) == nil {
 		writeError(w, http.StatusUnauthorized, errAuthRequired)
@@ -285,7 +393,7 @@ func (h *Handler) listKnowledgePageVersions(w http.ResponseWriter, r *http.Reque
 	if versions == nil {
 		versions = []knowledgepage.Version{}
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"versions": versions, "total": total})
+	writeJSON(w, http.StatusOK, knowledgePageVersionsResponse{Versions: versions, Total: total})
 }
 
 // validateKnowledgePage checks the create/update payload, returning an empty


### PR DESCRIPTION
## Summary

Fixes #697. `api_list_endpoints` reads the admin OpenAPI catalog that the platform-admin self-connection seeds from the binary's embedded swagger document (`internal/apidocs`). Any route registered without swaggo annotations never reaches that document, so working, authorized endpoints were absent from the catalog. An agent relying on `api_list_endpoints` for discovery concluded those capabilities did not exist and was pushed toward wrong workarounds.

The concrete gap from the issue: `GET /api/v1/portal/knowledge-pages/{id}` and `GET /api/v1/portal/knowledge-pages` are served and return `200`, but did not appear in `api_list_endpoints`.

A source scan found **11 registered, authenticated `/api/v1` routes missing from the catalog**: the 7 knowledge-page CRUD/search/versions handlers plus `GET /api/v1/admin/connection-instances/effective` (and the 3 routes intentionally excluded below).

## Root cause

The catalog is generated, not hand-maintained: `make swagger` runs `swag init` over the codebase, and only handlers carrying `// @Router` annotations land in `swagger.json`. `pkg/portal/knowledge_page_handler.go` had zero annotations, so its routes were silently dropped from the document the self-connection embeds (`pkg/platform/admin_self_connection.go` → `adminSelfSpecContent()` → catalog → `api_list_endpoints`).

## Changes

**Document the missing routes**
- `pkg/portal/knowledge_page_handler.go` — added swaggo annotations to all 7 knowledge-page handlers (create/list/search/get/update/delete/versions). The versions handler now returns a named `knowledgePageVersionsResponse` (byte-identical JSON to the previous inline `map[string]any`) so its response shape is documentable rather than opaque.
- `pkg/admin/connection_handler.go` — annotated `listEffectiveConnections`.
- The knowledge-page write handlers (create/update/delete) document `@Failure 500`, matching both the reads and the handlers' actual `http.StatusInternalServerError` paths.
- `internal/apidocs/{swagger.json,swagger.yaml,docs.go}` — regenerated via `make swagger`.

**Parity test (acceptance criterion)**
- `pkg/platform/admin_catalog_parity_test.go` (new) — `TestAdminCatalogRouteParity` AST-scans every `Handle`/`HandleFunc("METHOD /api/v1/...")` registration under `pkg/` and `internal/`, then asserts each route appears in the catalog enumerated through the **same production parser** `api_list_endpoints` uses (`catalog.ParseSpec` + `PathItem.Operations()`). It fails on any served-but-undocumented route, and a second guard fails on any stale exclusion entry, so the list cannot rot into silently hiding a real route.

### Intentional exclusions (documented in the test)

Routes that are registered but deliberately not part of the operable admin catalog:

| Route | Reason |
| --- | --- |
| `GET /admin/public/branding` | Served on the unauthenticated `publicMux` to brand the login screen before sign-in; not part of the authenticated, identity-passthrough admin surface. |
| `GET /observability/query`, `GET /observability/query_range` | Raw Prometheus PromQL proxy passthroughs; the request/response contract is upstream Prometheus's, backing the observability dashboards rather than being first-class admin REST operations. |
| `POST /gateway/{connection}/invoke`, `.../invoke-raw` | Generic API-gateway data-plane proxy. Its contract is each configured upstream's OpenAPI spec (surfaced per connection via `api_list_endpoints`), not the platform's own admin control-plane catalog. |

## Acceptance criteria

> A test asserts every registered admin route appears in the catalog that `api_list_endpoints` serves (no served-but-undocumented endpoints).

Met by `TestAdminCatalogRouteParity`.

## Testing

- `make verify` — full CI-equivalent suite green (tools-check, gofmt, race tests, total + patch coverage, golangci-lint, gosec, govulncheck, semgrep, CodeQL, dead-code, mutation, GoReleaser dry-run).
- Verified the parity test has real discriminating power: with the exclusion list emptied it flags all 3 excluded routes; dropping the two gateway entries flags the `mux.Handle`-registered gateway routes (confirming the scan covers both registration styles).

## Review

A multi-agent adversarial code review ran before `make verify`; all four findings were fixed in this branch (missing `@Failure 500`; `HandleFunc`-only scan missing `mux.Handle` routes; hand-rolled JSON parse vs. the production enumerator; `pkg/`-only scan missing `internal/`).
