### PR TITLE
fix(knowledge): trim trailing sentence punctuation from inline references (#704)

### DIFF
--- a/pkg/portal/knowledgepage/entity_ref_scan.go
+++ b/pkg/portal/knowledgepage/entity_ref_scan.go
@@ -1,6 +1,19 @@
 package knowledgepage
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
+
+// trailingPunct is the set of sentence punctuation trimmed from the tail of an
+// undelimited reference token. The id class of an mcp: reference includes ".",
+// and the bare-urn class stops only at whitespace or a closing bracket, so a
+// reference written in prose immediately before sentence punctuation absorbs
+// that punctuation into the token (#704). No real reference id or URN ends in
+// these characters, and the parenthesized/dataset forms already terminate at
+// ")", so trimming a trailing run is safe and never touches punctuation inside
+// a token.
+const trailingPunct = ".,;:!?"
 
 // refTokenRe matches a serialized reference token in page-body text: an mcp:
 // internal reference (a simple id, or a (kind,name) connection) or a urn:
@@ -34,6 +47,7 @@ func ScanBodyRefs(body string) []EntityRef {
 	seen := make(map[string]struct{}, len(matches))
 	refs := make([]EntityRef, 0, len(matches))
 	for _, m := range matches {
+		m = strings.TrimRight(m, trailingPunct)
 		ref, err := ParseCitableRef(m)
 		if err != nil {
 			continue

--- a/pkg/portal/knowledgepage/entity_ref_scan_test.go
+++ b/pkg/portal/knowledgepage/entity_ref_scan_test.go
@@ -56,3 +56,57 @@ func TestScanBodyRefs_NoneAndUnparseable(t *testing.T) {
 	// A malformed prompt id is skipped rather than producing a bad ref.
 	assert.Empty(t, ScanBodyRefs("see [bad](mcp:prompt:not-a-uuid) and [also](mcp:bogus:x)"))
 }
+
+// TestScanBodyRefs_TrimsTrailingSentencePunctuation proves that an inline
+// reference written in prose immediately before sentence punctuation scans to
+// the intended target rather than absorbing that punctuation into the id (#704).
+func TestScanBodyRefs_TrimsTrailingSentencePunctuation(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{"period", "The fact lives in mcp:asset:asset-001.", []string{"mcp:asset:asset-001"}},
+		{"comma", "See mcp:asset:asset-001, which is built nightly.", []string{"mcp:asset:asset-001"}},
+		{"semicolon", "Use mcp:asset:asset-001; it is current.", []string{"mcp:asset:asset-001"}},
+		{"colon", "Source: mcp:asset:asset-001: nightly load.", []string{"mcp:asset:asset-001"}},
+		{"exclamation", "Check mcp:asset:asset-001!", []string{"mcp:asset:asset-001"}},
+		{"question", "Did you read mcp:asset:asset-001?", []string{"mcp:asset:asset-001"}},
+		{"bare urn tag", "Tagged urn:li:tag:revenue.", []string{"urn:li:tag:revenue"}},
+		{"run of punctuation", "Really, mcp:asset:asset-001?!", []string{"mcp:asset:asset-001"}},
+		{
+			"parenthesized connection unaffected",
+			"Connect via mcp:connection:(trino,acme).",
+			[]string{"mcp:connection:(trino,acme)"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, scannedURNs(ScanBodyRefs(tt.body)))
+		})
+	}
+}
+
+// TestScanBodyRefs_PreservesInternalDot proves the trim only removes a trailing
+// run of punctuation and never touches a "." inside the token. The bare
+// mcp:asset: form is undelimited, so its id class includes "." and the whole
+// dotted id reaches TrimRight: this is the case that actually exercises the trim
+// (the parenthesized dataset form below terminates at ")" in the regex and never
+// reaches TrimRight, so it is a control that proves the regex path is untouched).
+func TestScanBodyRefs_PreservesInternalDot(t *testing.T) {
+	// Undelimited token with both internal and trailing dots: only the trailing
+	// dot is trimmed, the internal dots survive.
+	assert.Equal(t,
+		[]string{"mcp:asset:a.b.c"},
+		scannedURNs(ScanBodyRefs("The rollup lives in mcp:asset:a.b.c.")),
+		"internal dots in a bare id are preserved; only the trailing period is trimmed",
+	)
+
+	// Parenthesized dataset form: terminates at ")" in the regex, so the trailing
+	// period is never part of the token (control for the regex, not the trim).
+	assert.Equal(t,
+		[]string{"urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD)"},
+		scannedURNs(ScanBodyRefs("Dataset urn:li:dataset:(urn:li:dataPlatform:trino,iceberg.retail.daily_sales,PROD).")),
+		"parenthesized dataset path is matched whole and unaffected by the trim",
+	)
+}

--- a/ui/src/components/renderers/MarkdownRenderer.test.tsx
+++ b/ui/src/components/renderers/MarkdownRenderer.test.tsx
@@ -112,6 +112,23 @@ describe("MarkdownRenderer entity chips", () => {
     expect(container.textContent).toContain("os_acme_transactions");
   });
 
+  it("splits trailing sentence punctuation out of a bare-token chip (#704)", () => {
+    // The token abuts a period in prose; the chip must resolve against the
+    // trimmed ref (so the server-resolved label shows) and the period must
+    // remain as ordinary text, not be swallowed into the chip's id.
+    const refs = new Map<string, ResolvedRef>([
+      ["mcp:asset:asset-001", { urn: "mcp:asset:asset-001", type: "asset", label: "Q4 Dashboard", exists: true, accessible: true }],
+    ]);
+    const { container } = render(
+      <MarkdownRenderer content="The fact lives in mcp:asset:asset-001. Done." refs={refs} />,
+    );
+    // Resolved label appears (proves the chip url was trimmed to match the key).
+    expect(container.textContent).toContain("Q4 Dashboard");
+    // The punctuated id never renders, and the sentence period survives as prose.
+    expect(container.textContent).not.toContain("asset-001.");
+    expect(container.textContent).toContain(". Done.");
+  });
+
   it("does not chip a ref token inside an inline code span", () => {
     const { container } = render(
       <MarkdownRenderer content="Use the literal `mcp:asset:asset-001` token." />,

--- a/ui/src/components/renderers/MarkdownRenderer.tsx
+++ b/ui/src/components/renderers/MarkdownRenderer.tsx
@@ -5,7 +5,7 @@ import type { Components } from "react-markdown";
 import mermaid from "mermaid";
 import DOMPurify from "dompurify";
 import { EntityChip } from "@/components/knowledge/EntityChip";
-import { isRefUrn, REF_TOKEN_SOURCE, type ResolvedRef } from "@/lib/entityRefs";
+import { isRefUrn, REF_TOKEN_SOURCE, trimRefToken, type ResolvedRef } from "@/lib/entityRefs";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type MdNode = { type?: string; value?: string; url?: string; children?: any[] };
@@ -17,7 +17,13 @@ function splitRefTokens(value: string): MdNode[] {
   let m: RegExpExecArray | null;
   while ((m = re.exec(value)) !== null) {
     if (m.index > last) out.push({ type: "text", value: value.slice(last, m.index) });
-    out.push({ type: "link", url: m[0], children: [{ type: "text", value: m[0] }] });
+    // Trailing sentence punctuation absorbed by the token's char class is split
+    // back out so the chip url matches the (trimmed) resolved ref and the
+    // punctuation renders as ordinary prose after the chip (#704).
+    const token = trimRefToken(m[0]);
+    out.push({ type: "link", url: token, children: [{ type: "text", value: token }] });
+    const trailing = m[0].slice(token.length);
+    if (trailing) out.push({ type: "text", value: trailing });
     last = m.index + m[0].length;
   }
   if (last === 0) return [{ type: "text", value }];

--- a/ui/src/lib/entityRefs.test.ts
+++ b/ui/src/lib/entityRefs.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { extractRefUrns, parseRef, isRefUrn, buildRefUrn, entityHref } from "./entityRefs";
+import {
+  extractRefUrns,
+  parseRef,
+  isRefUrn,
+  buildRefUrn,
+  entityHref,
+  trimRefToken,
+} from "./entityRefs";
 
 describe("entityHref", () => {
   it("routes asset/collection/prompt to their viewers and nothing else", () => {
@@ -88,5 +95,24 @@ and <urn:li:glossaryTerm:revenue> and a duplicate [a2](mcp:asset:asset-001).`;
     const body =
       "Real [a](mcp:asset:real-1).\n\n```\nmcp:asset:in-fence\n```\n\nInline `mcp:asset:in-code`.";
     expect(extractRefUrns(body)).toEqual(["mcp:asset:real-1"]);
+  });
+
+  it("trims trailing sentence punctuation from inline prose tokens (#704)", () => {
+    // Mirrors the server-side trim so the resolved-ref map keys match what the
+    // chip url will be; a bare token before a period must not absorb it.
+    const body =
+      "The fact is in mcp:asset:asset-001. Also tagged urn:li:tag:revenue, plus mcp:asset:a.b.c!";
+    expect(extractRefUrns(body).sort()).toEqual(
+      ["mcp:asset:a.b.c", "mcp:asset:asset-001", "urn:li:tag:revenue"].sort(),
+    );
+  });
+});
+
+describe("trimRefToken", () => {
+  it("strips a trailing run of sentence punctuation only", () => {
+    expect(trimRefToken("mcp:asset:asset-001.")).toBe("mcp:asset:asset-001");
+    expect(trimRefToken("urn:li:tag:revenue?!")).toBe("urn:li:tag:revenue");
+    expect(trimRefToken("mcp:asset:a.b.c.")).toBe("mcp:asset:a.b.c"); // internal dots kept
+    expect(trimRefToken("mcp:connection:(trino,acme)")).toBe("mcp:connection:(trino,acme)"); // no-op
   });
 });

--- a/ui/src/lib/entityRefs.ts
+++ b/ui/src/lib/entityRefs.ts
@@ -67,6 +67,21 @@ const REF_TOKEN_RE = new RegExp(REF_TOKEN_SOURCE, "g");
 // server's codeSpanRe).
 const CODE_SPAN_RE = /```[\s\S]*?```|`[^`]*`/g;
 
+// TRAILING_PUNCT_RE mirrors the server's trailingPunct trim (entity_ref_scan.go,
+// #704). An undelimited mcp:/urn: token written in prose immediately before
+// sentence punctuation absorbs that punctuation into the match (the mcp id class
+// includes "." and the bare-urn class stops only at whitespace or a closing
+// bracket), so it is trimmed before the token is parsed or resolved. The
+// parenthesized forms already terminate at ")", so this never touches
+// punctuation inside a token. Keeping this in lockstep with the server is what
+// prevents the rendered chip and the stored reference from diverging.
+const TRAILING_PUNCT_RE = /[.,;:!?]+$/;
+
+/** trimRefToken strips a trailing run of sentence punctuation from a scanned token. */
+export function trimRefToken(token: string): string {
+  return token.replace(TRAILING_PUNCT_RE, "");
+}
+
 /** PickableRefType is an entity type the manual-reference picker can search. */
 export type PickableRefType = "asset" | "collection" | "knowledge_page" | "prompt";
 
@@ -84,7 +99,9 @@ export function isRefUrn(href: string | undefined): boolean {
 /** extractRefUrns returns the distinct reference URNs mentioned in a body. */
 export function extractRefUrns(body: string): string[] {
   const matches = body.replace(CODE_SPAN_RE, " ").match(REF_TOKEN_RE) ?? [];
-  return Array.from(new Set(matches.filter((m) => parseRef(m) !== null)));
+  return Array.from(
+    new Set(matches.map(trimRefToken).filter((m) => parseRef(m) !== null)),
+  );
 }
 
 /** datahubLabel pulls a readable name out of a DataHub URN. */


### PR DESCRIPTION
## Summary

Fixes #704. An undelimited inline reference written in prose immediately before sentence punctuation absorbed that punctuation into the matched token, so a valid citation parsed to the wrong target id and silently failed to attach.

- The `mcp:` id class (`[A-Za-z0-9_.\-]+`) includes `.`, so `mcp:asset:abc.` matched as id `abc.`.
- The bare-urn class (`[^\s)\]>]+`) stops only at whitespace or a closing bracket, so a trailing `.`/`,`/`;`/`:`/`!`/`?` on `urn:li:tag:revenue.` was captured too.
- The existence check then failed on the punctuated id and the reference did not attach (since #696 it surfaces in `references_dropped`, but the intended citation was still lost).

Parenthesized forms (`mcp:connection:(kind,name)`, dataset URNs) terminate at `)` and were never affected.

## Changes

### Backend
`pkg/portal/knowledgepage/entity_ref_scan.go`: trim a trailing run of sentence punctuation (`.,;:!?`) from each scanned token before `ParseCitableRef`. No real reference id or URN ends in those characters, and the parenthesized forms already end at `)`, so the trim is safe and never touches punctuation inside a token.

### Frontend
The UI carries two tokenizers that mirror the backend regex by design, both with the identical defect, so a backend-only fix would have left the rendered chip broken (it would show the punctuated id, fail to resolve, and render the raw label):

- `ui/src/lib/entityRefs.ts`: add a shared `trimRefToken` helper (mirrors the Go-side trim) and apply it in `extractRefUrns`, so the resolve request and the resolved-ref map key use the trimmed URN.
- `ui/src/components/renderers/MarkdownRenderer.tsx`: in `splitRefTokens`, split the trailing punctuation back out of the chip token. The chip url now matches the trimmed resolved ref, and the punctuation renders as ordinary prose after the chip.

## Tests

- Backend: table-driven cases per punctuation mark, the bare `urn:li:tag:` form, and a run of punctuation. The internal-dot test uses a bare `mcp:asset:a.b.c.` token that actually reaches the trim (the original test used the parenthesized dataset form, which terminates at `)` in the regex and never exercised `TrimRight`), proving internal dots survive while only the trailing run is removed. A parenthesized control confirms the regex path is untouched.
- Frontend: `trimRefToken` unit cases, an `extractRefUrns` prose case, and a `MarkdownRenderer` case asserting the chip resolves against the trimmed ref while the sentence period stays as prose.

## Verification

`make verify` is green (full CI-equivalent suite, including the GoReleaser dry-run that rebuilds the UI). UI `tsc --noEmit` and `eslint` clean on the changed files.

## Acceptance criteria (#704)

- [x] An inline `mcp:asset:<id>.` at the end of a sentence scans to `mcp:asset:<id>`.
- [x] Same for `,`, `;`, `:`, `!`, `?` and for the bare `urn:li:tag:<name>.` form.
- [x] Parenthesized forms (`mcp:connection:(kind,name)`, dataset URNs) and markdown-link hrefs are unchanged.
- [x] Table-driven tests cover each punctuation case plus a token with an internal `.` to prove only trailing punctuation is trimmed.

## Out of scope (follow-up)

An adversarial review of this change surfaced a separate, pre-existing defect not covered by #704: two bare URNs written with no intervening space (`urn:li:tag:a,urn:li:tag:b`) merge into one malformed token, because the bare-urn class includes `,`. This is distinct from trailing punctuation (it is an internal separator, not a trailing run) and present in both the Go and TS regexes. It is left out of this PR to keep the change scoped; it is worth its own ticket (the fix is to exclude `,` from the bare-urn class in both regexes, which is safe because bare URNs never legitimately contain commas).