### PR TITLE
fix(portal): carry deep-link target through OIDC login via return_to (#710)

### DIFF
--- a/ui/src/api/admin/client.ts
+++ b/ui/src/api/admin/client.ts
@@ -1,4 +1,5 @@
 import { useAuthStore } from "@/stores/auth";
+import { buildLoginURL } from "@/lib/loginUrl";
 
 const BASE_URL = "/api/v1/admin";
 
@@ -29,9 +30,7 @@ function handleUnauthorized(): void {
     return;
   }
 
-  const returnTo = window.location.pathname + window.location.search + window.location.hash;
-  const loginURL = `/portal/auth/login?return_to=${encodeURIComponent(returnTo)}`;
-  window.location.replace(loginURL);
+  window.location.replace(buildLoginURL());
 }
 
 // apiFetchAt is the shared authenticated JSON fetch. It attaches the

--- a/ui/src/lib/loginUrl.test.ts
+++ b/ui/src/lib/loginUrl.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { buildLoginURL } from "./loginUrl";
+
+describe("buildLoginURL (#710)", () => {
+  const originalLocation = window.location;
+
+  function mockLocation(pathname: string, search = "", hash = ""): void {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { pathname, search, hash },
+    });
+  }
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("captures the current path as return_to", () => {
+    mockLocation("/assets/asset-001");
+    expect(buildLoginURL()).toBe(
+      "/portal/auth/login?return_to=" + encodeURIComponent("/assets/asset-001"),
+    );
+  });
+
+  it("captures path, query, and hash together", () => {
+    mockLocation("/knowledge", "?tab=pages", "#section-2");
+    expect(buildLoginURL()).toBe(
+      "/portal/auth/login?return_to=" +
+        encodeURIComponent("/knowledge?tab=pages#section-2"),
+    );
+  });
+
+  it("encodes the return_to so a query string does not split into a second top-level param", () => {
+    mockLocation("/collections/c1/items", "?q=a&b=c");
+    const url = buildLoginURL();
+    // Exactly one "?" (the login endpoint's); the captured "&" is escaped.
+    expect(url.indexOf("?")).toBe(url.lastIndexOf("?"));
+    expect(url).not.toContain("&b=c");
+    const encoded = url.split("return_to=")[1] ?? "";
+    expect(decodeURIComponent(encoded)).toBe("/collections/c1/items?q=a&b=c");
+  });
+
+  it("falls back to a bare login URL when the path is pathologically long", () => {
+    // A return_to long enough to risk overflowing the signed state cookie is
+    // dropped so the server lands the user on the default page rather than
+    // setting a cookie the browser would silently discard.
+    mockLocation("/x" + "a".repeat(2000));
+    expect(buildLoginURL()).toBe("/portal/auth/login");
+  });
+
+  it("keeps a return_to that is just under the cap", () => {
+    mockLocation("/" + "a".repeat(1000));
+    expect(buildLoginURL()).toContain("?return_to=");
+  });
+});

--- a/ui/src/lib/loginUrl.ts
+++ b/ui/src/lib/loginUrl.ts
@@ -1,0 +1,33 @@
+// Shared construction of the OIDC login redirect. Two entry points send a user
+// through login and both want to return them to where they were: a fresh
+// "Sign in with OIDC" click (stores/auth.ts loginOIDC) and a 401 session-expiry
+// recovery (api/admin/client.ts handleUnauthorized). Keeping the URL building in
+// one place means the return_to contract stays identical across both, so a
+// future change to the login path or capture rule cannot drift one entry point
+// out of sync with the other.
+
+// The captured return_to is folded into the signed OIDC state cookie at the
+// server's LoginHandler. A pathological deep link long enough to push that
+// cookie past the browser's ~4KB per-cookie limit would be silently dropped,
+// failing login with a misleading "session expired". Cap the captured path well
+// under that budget and fall back to a bare login URL (the server then lands the
+// user on the default page, the documented safe fallback) rather than risk a
+// dropped cookie. Real in-app routes are far shorter than this.
+const MAX_RETURN_TO = 1024;
+
+/**
+ * buildLoginURL returns the OIDC login endpoint with the current in-app location
+ * captured as a return_to, so a user sent through login is brought back to the
+ * page they were on instead of the default landing page (#710). The server
+ * sanitizes return_to against open redirects (sanitizeReturnTo in
+ * pkg/browsersession/oidcflow.go), so a cross-origin or scheme-relative value is
+ * dropped server-side; this only captures a same-origin in-app path.
+ */
+export function buildLoginURL(): string {
+  const returnTo =
+    window.location.pathname + window.location.search + window.location.hash;
+  if (returnTo.length > MAX_RETURN_TO) {
+    return "/portal/auth/login";
+  }
+  return "/portal/auth/login?return_to=" + encodeURIComponent(returnTo);
+}

--- a/ui/src/stores/auth.test.ts
+++ b/ui/src/stores/auth.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { useAuthStore } from "./auth";
+
+describe("loginOIDC return_to capture (#710)", () => {
+  const originalLocation = window.location;
+
+  // jsdom's window.location is mostly read-only; replace it with a
+  // controllable stand-in so we can capture the assigned href without an
+  // actual navigation tearing down the test.
+  function mockLocation(pathname: string, search = "", hash = ""): { get href(): string } {
+    let href = "";
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        pathname,
+        search,
+        hash,
+        set href(v: string) {
+          href = v;
+        },
+      },
+    });
+    return {
+      get href() {
+        return href;
+      },
+    };
+  }
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("redirects to the login endpoint carrying the current path as return_to", () => {
+    const loc = mockLocation("/assets/asset-001");
+    useAuthStore.getState().loginOIDC();
+    expect(loc.href).toBe(
+      "/portal/auth/login?return_to=" + encodeURIComponent("/assets/asset-001"),
+    );
+  });
+
+  it("includes query and hash in the captured return_to", () => {
+    const loc = mockLocation("/knowledge", "?tab=pages", "#section-2");
+    useAuthStore.getState().loginOIDC();
+    expect(loc.href).toBe(
+      "/portal/auth/login?return_to=" +
+        encodeURIComponent("/knowledge?tab=pages#section-2"),
+    );
+  });
+});

--- a/ui/src/stores/auth.ts
+++ b/ui/src/stores/auth.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { buildLoginURL } from "@/lib/loginUrl";
 
 /** User profile returned by GET /api/v1/portal/me. */
 export interface UserProfile {
@@ -110,7 +111,11 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   },
 
   loginOIDC: () => {
-    window.location.href = "/portal/auth/login";
+    // Carry the current in-app location through the OIDC round-trip so an
+    // unauthenticated user who opened a deep link lands back on it after login
+    // instead of the default page. When the SPA renders the login form at a
+    // protected deep link, window.location is that deep link (#710).
+    window.location.href = buildLoginURL();
   },
 
   loginApiKey: async (key: string) => {


### PR DESCRIPTION
## Summary

Fixes #710. An unauthenticated user who opened a deep link (e.g. a specific asset URL) and signed in with OIDC landed on the default post-login page instead of the page they originally requested. The intended destination was lost across the login round-trip.

The server already supports returning to the original path; the SPA just never sent it:

- `pkg/browsersession/oidcflow.go` `LoginHandler` reads `return_to` from the query, sanitizes it, and stores it in the signed OIDC state cookie so it survives the provider round-trip.
- The callback re-sanitizes the captured `return_to` and redirects back to it after login.
- `pkg/portal/public.go` already constructs `/portal/auth/login?return_to=<path>` for server-rendered protected routes.

The client's `loginOIDC` did a full-page redirect to a bare `/portal/auth/login` with no `return_to`, so the server had nothing to return to and fell back to the default landing page.

## Changes

### The fix
`ui/src/stores/auth.ts` `loginOIDC` now captures the current in-app location (`pathname + search + hash`) and passes it as `return_to`. When the SPA renders the login form at a protected deep link, `window.location` at that moment is the deep link, so capturing it is sufficient. Open-redirect safety is already enforced server-side by `sanitizeReturnTo`, which restricts `return_to` to a same-origin relative path; a cross-origin or scheme-relative value is dropped and the server falls back to the default page.

### Shared helper (review finding)
An adversarial review flagged that this construction was about to become a byte-identical copy of the `return_to` login-URL building already in `handleUnauthorized` (the 401 session-expiry recovery in `ui/src/api/admin/client.ts`). Per the single-shared-abstraction rule, the logic is extracted into `ui/src/lib/loginUrl.ts` `buildLoginURL()` and both entry points (fresh OIDC sign-in and 401 recovery) call it, so the `return_to` contract cannot drift between them.

### Cookie-overflow guard (review finding)
The captured `return_to` is folded into the signed OIDC state cookie at `LoginHandler`. A pathological deep link long enough to push that cookie past the browser's ~4KB per-cookie limit would be silently dropped, failing login with a misleading "session expired". `buildLoginURL` caps the captured path (1024 chars, far above any real in-app route) and falls back to a bare login URL when exceeded, so the server lands the user on the default page (the issue's documented safe fallback) rather than setting a cookie the browser would discard. This also hardens the pre-existing 401-recovery path.

## Tests

- `ui/src/lib/loginUrl.test.ts`: path capture, path+query+hash, encoding (a captured query string does not split into a second top-level param), the length-cap fallback, and a just-under-cap case.
- `ui/src/stores/auth.test.ts`: `loginOIDC` delegates and assigns `window.location.href`.
- The existing `ui/src/api/admin/client.test.ts` 401-recovery tests now exercise `buildLoginURL` from the client side, unchanged.

## Verification

`tsc --noEmit` and `eslint` clean on the changed files; full `make verify` is green (CI-equivalent suite, including the GoReleaser dry-run that rebuilds the UI).

## Acceptance criteria (#710)

- [x] An unauthenticated user who opens a deep link and signs in with OIDC lands on that exact deep link after login, not the default page.
- [x] `return_to` is the originally requested in-app path (including query/hash where applicable).
- [x] A malformed or cross-origin `return_to` still falls back safely to the default (existing server-side `sanitizeReturnTo`, unchanged).
- [x] The API-key login path continues to preserve the current URL (it does not full-page redirect; unchanged).