### PR TITLE
fix(knowledge): count and paginate the insight review queue on exact status (#706)

### DIFF
--- a/pkg/toolkits/knowledge/memory_adapter.go
+++ b/pkg/toolkits/knowledge/memory_adapter.go
@@ -59,47 +59,97 @@ func (a *memoryInsightAdapter) Get(ctx context.Context, id string) (*Insight, er
 	return &insight, nil
 }
 
-// List returns insights matching the given filter.
+// insightWalkOrder is the stable total ordering used for the active-set walk
+// that List and Stats share. The OFFSET-paged walk pages at memory.MaxLimit, so
+// the sort must be a total order: created_at alone is not unique (bulk-imported
+// rows can share a timestamp), and a non-unique sort lets Postgres OFFSET skip
+// or duplicate a row straddling a page boundary, which would silently drop or
+// double-count a pending insight and re-open #706 under tie conditions. The id
+// column is the primary key, so created_at DESC, id DESC is deterministic.
+const insightWalkOrder = "created_at DESC, id DESC"
+
+// eachActiveInsightRecord pages the entire result of mf and invokes fn for every
+// record. mf must carry the coarse memory status (the store cannot filter on the
+// exact insight status, which lives in metadata and is recovered per record by
+// the caller's fn). List and Stats share this so the multi-page walk, its page
+// size, and its stable ordering have a single definition: a future paging fix
+// applied here cannot drift the two out of agreement, the disagreement #706 was
+// filed for.
+//
+// Cost note: this walks the whole matching set (one store page per memory.MaxLimit
+// records), so it is O(matching active records), the same shape as Stats. Callers
+// that pass EntityURN are store-filtered to one entity (a small set); the
+// unscoped review-queue walk is bounded by the active insight count. Pushing the
+// exact-status predicate into the store (so it can LIMIT/OFFSET/COUNT directly)
+// is the larger future optimization noted in #706.
+func (a *memoryInsightAdapter) eachActiveInsightRecord(ctx context.Context, mf memory.Filter, fn func(memory.Record)) error {
+	mf.Dimension = a.dimension
+	mf.Limit = memory.MaxLimit
+	mf.Offset = 0
+	if mf.OrderBy == "" {
+		mf.OrderBy = insightWalkOrder
+	}
+	for {
+		records, _, err := a.store.List(ctx, mf)
+		if err != nil {
+			return fmt.Errorf("listing insight records: %w", err)
+		}
+		for i := range records {
+			fn(records[i])
+		}
+		if len(records) < memory.MaxLimit {
+			return nil
+		}
+		mf.Offset += memory.MaxLimit
+	}
+}
+
+// List returns insights matching the given filter, with total being the exact
+// count of matching insights (not the coarse active-record count).
+//
+// The status/confidence filter cannot be delegated to a single store page.
+// memory.Filter's status enum is coarser than the insight status (pending,
+// approved and applied all collapse to memory StatusActive, see
+// mapInsightStatusToMemory) and it has no confidence field. A store-side
+// LIMIT/OFFSET over the coarse status would therefore (a) report total as the
+// count of all active records rather than the requested status, and (b) drop
+// matching records that sit behind non-matching ones in the active set, so a
+// pending insight past the first page becomes invisible and un-reviewable
+// (#706). So walk the whole matching active set (eachActiveInsightRecord),
+// recover and filter on the exact insight status and confidence, then count and
+// paginate the survivors in Go.
 func (a *memoryInsightAdapter) List(ctx context.Context, filter InsightFilter) ([]Insight, int, error) {
 	mf := memory.Filter{
-		Dimension: a.dimension,
 		Category:  filter.Category,
 		EntityURN: filter.EntityURN,
 		CreatedBy: filter.CapturedBy,
 		Source:    filter.Source,
 		Since:     filter.Since,
 		Until:     filter.Until,
-		Limit:     filter.Limit,
-		Offset:    filter.Offset,
+		// Lossy map; the exact status is recovered per record below.
+		Status: mapInsightStatusToMemory(filter.Status),
 	}
 
-	// Map the insight status onto its memory status. This mapping is lossy:
-	// pending, approved and applied all collapse to memory StatusActive, so
-	// the store fetch alone cannot distinguish them. The exact insight status
-	// is recovered per record below and post-filtered.
-	mf.Status = mapInsightStatusToMemory(filter.Status)
-
-	records, total, err := a.store.List(ctx, mf)
-	if err != nil {
-		return nil, 0, fmt.Errorf("listing insight records: %w", err)
-	}
-
-	insights := make([]Insight, 0, len(records))
-	for _, r := range records {
+	matched := make([]Insight, 0)
+	err := a.eachActiveInsightRecord(ctx, mf, func(r memory.Record) {
 		insight := recordToInsight(r)
-		// Confidence and the exact insight status are filtered post-fetch:
-		// memory.Filter has no confidence field, and its status enum is
-		// coarser than the insight status (see the lossy mapping above).
 		if filter.Confidence != "" && insight.Confidence != filter.Confidence {
-			continue
+			return
 		}
 		if filter.Status != "" && insight.Status != filter.Status {
-			continue
+			return
 		}
-		insights = append(insights, insight)
+		matched = append(matched, insight)
+	})
+	if err != nil {
+		return nil, 0, err
 	}
 
-	return insights, total, nil
+	// total is the exact matching count so the caller's pagination footer agrees
+	// with the stat card; pageInsights returns the requested window in the same
+	// created_at DESC order the walk preserved.
+	page, _, _ := pageInsights(matched, filter.Offset, filter.Limit)
+	return page, len(matched), nil
 }
 
 // InsightSearchQuery parameterizes a relevance-ranked insight search. It
@@ -223,17 +273,15 @@ func (a *memoryInsightAdapter) Update(ctx context.Context, id string, updates In
 }
 
 // Stats returns aggregate counts of insights by category, confidence, and
-// status. The memory.Store has no Stats method, so we page through the
-// matching records and tally them. The filter must be scoped the same way
-// List scopes (owner + knowledge dimension); otherwise the totals would
-// count other users' records and non-knowledge memory dimensions, leaving
-// the stat card and the list disagreeing.
+// status. The memory.Store has no Stats method, so it walks the matching records
+// (eachActiveInsightRecord) and tallies them. The filter must be scoped the same
+// way List scopes (owner + knowledge dimension); otherwise the totals would count
+// other users' records and non-knowledge memory dimensions, leaving the stat card
+// and the list disagreeing.
 func (a *memoryInsightAdapter) Stats(ctx context.Context, filter InsightFilter) (*InsightStats, error) {
 	mf := memory.Filter{
-		Dimension: a.dimension,
 		CreatedBy: filter.CapturedBy,
 		Status:    mapInsightStatusToMemory(filter.Status),
-		Limit:     memory.MaxLimit,
 	}
 
 	stats := &InsightStats{
@@ -242,35 +290,28 @@ func (a *memoryInsightAdapter) Stats(ctx context.Context, filter InsightFilter) 
 		ByStatus:     make(map[string]int),
 	}
 
-	for {
-		records, _, err := a.store.List(ctx, mf)
-		if err != nil {
-			return nil, fmt.Errorf("listing records for insight stats: %w", err)
+	err := a.eachActiveInsightRecord(ctx, mf, func(r memory.Record) {
+		// Recover the insight status (pending/approved/applied/...) from the lossy
+		// memory status, so the keys match what callers and the postgres store
+		// produce.
+		st := resolveInsightStatus(r)
+		// Scope every tally to the requested status, the way the postgres store
+		// does (its WHERE filters all three group-bys). The memory status filter
+		// is lossy: a Status=pending request maps to memory.StatusActive, which
+		// also returns approved and applied records (mapInsightStatusToMemory).
+		// Without this gate ByStatus/by_category/by_confidence span every active
+		// status while TotalPending counts only pending, so the counts disagree
+		// with each other and with postgres (#688). An empty filter (the portal
+		// "my stats" path, #515) still tallies every status.
+		if filter.Status != "" && st != filter.Status {
+			return
 		}
-		for i := range records {
-			// Recover the insight status (pending/approved/applied/...) from the
-			// lossy memory status, so the keys match what callers and the postgres
-			// store produce.
-			st := resolveInsightStatus(records[i])
-			// Scope every tally to the requested status, the way the postgres store
-			// does (its WHERE filters all three group-bys). The memory status filter
-			// is lossy: a Status=pending request maps to memory.StatusActive, which
-			// also returns approved and applied records (mapInsightStatusToMemory).
-			// Without this gate ByStatus/by_category/by_confidence span every active
-			// status while TotalPending counts only pending, so the counts disagree
-			// with each other and with postgres (#688). An empty filter (the portal
-			// "my stats" path, #515) still tallies every status.
-			if filter.Status != "" && st != filter.Status {
-				continue
-			}
-			stats.ByStatus[st]++
-			stats.ByCategory[records[i].Category]++
-			stats.ByConfidence[records[i].Confidence]++
-		}
-		if len(records) < memory.MaxLimit {
-			break
-		}
-		mf.Offset += memory.MaxLimit
+		stats.ByStatus[st]++
+		stats.ByCategory[r.Category]++
+		stats.ByConfidence[r.Confidence]++
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing records for insight stats: %w", err)
 	}
 	stats.TotalPending = stats.ByStatus[StatusPending]
 

--- a/pkg/toolkits/knowledge/memory_adapter_test.go
+++ b/pkg/toolkits/knowledge/memory_adapter_test.go
@@ -352,7 +352,7 @@ func TestMemoryInsightAdapter_List_FilterMapping(t *testing.T) {
 		Since:      &since,
 		Until:      &until,
 		Limit:      10,
-		Offset:     5,
+		Offset:     0,
 	}
 
 	insights, total, err := adapter.List(context.Background(), filter)
@@ -369,9 +369,15 @@ func TestMemoryInsightAdapter_List_FilterMapping(t *testing.T) {
 	assert.Equal(t, "user", mf.Source)
 	assert.Equal(t, &since, mf.Since)
 	assert.Equal(t, &until, mf.Until)
-	assert.Equal(t, 10, mf.Limit)
-	assert.Equal(t, 5, mf.Offset)
+	// The caller's Limit/Offset are applied in Go, not delegated to the store:
+	// the store is walked a full page at a time so the adapter sees every active
+	// record and can filter/count on the exact insight status (#706).
+	assert.Equal(t, memory.MaxLimit, mf.Limit)
+	assert.Equal(t, 0, mf.Offset)
 	assert.Equal(t, memory.StatusActive, mf.Status) // pending -> active
+	// The walk uses a stable total order so OFFSET paging cannot skip or
+	// duplicate a record on a page boundary with a tied created_at (#706).
+	assert.Equal(t, insightWalkOrder, mf.OrderBy)
 }
 
 func TestMemoryInsightAdapter_List_ConfidencePostFiltering(t *testing.T) {
@@ -387,7 +393,7 @@ func TestMemoryInsightAdapter_List_ConfidencePostFiltering(t *testing.T) {
 
 	insights, total, err := adapter.List(context.Background(), InsightFilter{Confidence: "high"})
 	require.NoError(t, err)
-	assert.Equal(t, 3, total) // total from store (pre-filter)
+	assert.Equal(t, 2, total) // exact count of matching insights, not the coarse store total
 	assert.Len(t, insights, 2)
 	for _, ins := range insights {
 		assert.Equal(t, "high", ins.Confidence)
@@ -426,6 +432,94 @@ func TestMemoryInsightAdapter_List_Error(t *testing.T) {
 	_, _, err := adapter.List(context.Background(), InsightFilter{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "listing insight records")
+}
+
+// pagingMemoryStore is a memory.Store whose List honors the coarse status filter
+// and Offset/Limit over a backing slice, so a test can exercise the adapter's
+// multi-page walk. The base mockMemoryStore returns its whole slice on every
+// call regardless of offset, which both cannot reproduce paging and would loop
+// forever once the slice reaches memory.MaxLimit.
+type pagingMemoryStore struct {
+	mockMemoryStore
+	all []memory.Record
+}
+
+func (p *pagingMemoryStore) List(_ context.Context, filter memory.Filter) ([]memory.Record, int, error) {
+	matched := make([]memory.Record, 0, len(p.all))
+	for _, r := range p.all {
+		if filter.Status != "" && r.Status != filter.Status {
+			continue
+		}
+		matched = append(matched, r)
+	}
+	start := min(filter.Offset, len(matched))
+	end := min(start+filter.EffectiveLimit(), len(matched))
+	return matched[start:end], len(matched), nil
+}
+
+// TestMemoryInsightAdapter_List_AgreesWithStatsAcrossPages is the #706
+// regression: List must filter, paginate, and count on the EXACT insight status,
+// not post-filter a single coarse page. With pending/approved/applied all
+// collapsed to memory StatusActive and the pending records scattered past the
+// first store page, the old List returned the coarse active total and dropped
+// pending records beyond the first window, so the review-queue footer and the
+// Pending stat card disagreed and a pending insight was hidden and un-reviewable.
+func TestMemoryInsightAdapter_List_AgreesWithStatsAcrossPages(t *testing.T) {
+	// 150 active records, round-robin pending/approved/applied so 50 of each and
+	// pending records land at indices up to 147 (well past the first 100-record
+	// store page). All three are memory.StatusActive, so only the exact insight
+	// status distinguishes them.
+	const total = 150
+	all := make([]memory.Record, 0, total)
+	wantPending := 0
+	for i := range total {
+		rec := memory.Record{
+			ID:       fmt.Sprintf("r%03d", i),
+			Status:   memory.StatusActive,
+			Metadata: map[string]any{},
+		}
+		switch i % 3 {
+		case 0:
+			wantPending++ // no insight_status metadata -> resolves to pending
+		case 1:
+			rec.Metadata[metaKeyInsightStatus] = StatusApproved
+		case 2:
+			rec.Metadata[metaKeyInsightStatus] = StatusApplied
+		}
+		all = append(all, rec)
+	}
+	require.Equal(t, 50, wantPending)
+
+	adapter := NewMemoryInsightAdapter(&pagingMemoryStore{all: all})
+	ctx := context.Background()
+
+	// Stats already counts the exact pending status across the whole active set.
+	stats, err := adapter.Stats(ctx, InsightFilter{Status: StatusPending})
+	require.NoError(t, err)
+	assert.Equal(t, wantPending, stats.TotalPending)
+
+	// List's total must equal that exact pending count (the footer "of N"), not
+	// the coarse active total of 150.
+	page, listTotal, err := adapter.List(ctx, InsightFilter{Status: StatusPending, Limit: 20, Offset: 0})
+	require.NoError(t, err)
+	assert.Equal(t, wantPending, listTotal, "List total must match the Pending stat card")
+	assert.Equal(t, stats.TotalPending, listTotal, "List and Stats must agree")
+	assert.Len(t, page, 20, "first page is one full window")
+
+	// A pending insight past the first window is reachable: paging to offset 40
+	// returns the last 10 pending records, every one of them pending.
+	tail, tailTotal, err := adapter.List(ctx, InsightFilter{Status: StatusPending, Limit: 20, Offset: 40})
+	require.NoError(t, err)
+	assert.Equal(t, wantPending, tailTotal)
+	assert.Len(t, tail, 10)
+	for _, ins := range tail {
+		assert.Equal(t, StatusPending, ins.Status)
+	}
+
+	// The other statuses that collapse to active are likewise exact, not coarse.
+	_, approvedTotal, err := adapter.List(ctx, InsightFilter{Status: StatusApproved})
+	require.NoError(t, err)
+	assert.Equal(t, 50, approvedTotal)
 }
 
 func TestMemoryInsightAdapter_UpdateStatus(t *testing.T) {

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -344,14 +344,13 @@ func (t *Toolkit) bulkReviewItemized(ctx context.Context, input applyKnowledgeIn
 	return jsonResult(result)
 }
 
-// collectPending returns every pending insight in the global review queue.
-// The memory-backed store maps pending, approved and applied onto a single
-// "active" memory status and recovers the exact insight status per record, so a
-// single status-filtered page is not guaranteed to be complete: pending
-// insights can sit behind applied ones. We walk the whole active set by the
-// underlying total and keep the pending records.
+// collectPending returns every pending insight in the global review queue by
+// paging List until its reported total is covered. Since #706, List filters and
+// counts on the exact insight status and returns the exact pending total, so this
+// loop pages the pending set directly rather than walking the coarse active set;
+// for the common case (pending count <= one page) it is a single List call.
 //
-// The stride is MaxLimit, which is also the per-page count the store returns when
+// The stride is MaxLimit, which is also the per-page window List returns when
 // more records remain. That holds only while MaxLimit does not exceed the backing
 // store's own page cap (memory.MaxLimit); if it did, pages would be short and the
 // fixed stride would skip records. TestCollectPendingStrideInvariant guards that.

--- a/ui/src/pages/knowledge/KnowledgePage.tsx
+++ b/ui/src/pages/knowledge/KnowledgePage.tsx
@@ -254,7 +254,7 @@ export function KnowledgeCaptureTab() {
       {totalPages > 1 && (
         <div className="flex items-center justify-between text-sm">
           <span className="text-muted-foreground">
-            Showing {(page - 1) * PER_PAGE + 1}--
+            Showing {(page - 1) * PER_PAGE + 1}-
             {Math.min(page * PER_PAGE, data?.total ?? 0)} of{" "}
             {data?.total ?? 0}
           </span>
@@ -696,7 +696,7 @@ export function ChangesetsTab() {
       {totalPages > 1 && (
         <div className="flex items-center justify-between text-sm">
           <span className="text-muted-foreground">
-            Showing {(page - 1) * PER_PAGE + 1}--
+            Showing {(page - 1) * PER_PAGE + 1}-
             {Math.min(page * PER_PAGE, data?.total ?? 0)} of{" "}
             {data?.total ?? 0}
           </span>


### PR DESCRIPTION
## Summary

Fixes #706. In the admin Insights review queue, the **Pending Review** stat and the list disagreed, and a pending insight could be hidden from the queue entirely (invisible and un-reviewable). With the Pending filter selected: the stat card read **Pending Review: 4**, the list rendered only **3 rows**, and the footer read **"Showing 1-20 of 112"**.

## Root cause

`memoryInsightAdapter.List` (`pkg/toolkits/knowledge/memory_adapter.go`) filtered on the wrong granularity:

1. It mapped the requested `status=pending` onto the coarse memory status. `pending`, `approved`, and `applied` all collapse to `memory.StatusActive` (`mapInsightStatusToMemory`), so the store fetch cannot distinguish them.
2. It fetched one `LIMIT/OFFSET` page and got back `total` = count of **all active** records (pending + approved + applied).
3. It post-filtered that single page in Go down to the exact status.
4. It returned the survivors plus the **coarse** `total`.

Consequences:
- `total` was the count of all active records (112), not pending, so the footer said "of 112" under the Pending filter.
- Because the page was post-filtered, only the pending records that happened to fall in the first window appeared. Pending insights past the first page never surfaced, so the 4th pending insight was invisible and could not be approved or rejected.

`Stats` was already fixed for this exact lossy-mapping trap (#688) and walks the whole active set recovering each record's exact status; `List` never got the equivalent fix, so `Stats` and `List` permanently disagreed. The postgres `knowledge_insights` store path filters status correctly in SQL, so only the memory-backed (live) path was affected.

## Fix

`List` now walks the whole matching active set, recovers and filters on the **exact** insight status and confidence, and counts + paginates the survivors in Go. `total` is the exact matching count, and every matching record is reachable regardless of how status values interleave. One adapter fix covers both REST handlers (`pkg/portal/handler.go` `getMyInsights` and `pkg/admin/knowledge.go`), since both call `List` directly and trust its `total`.

### Review-driven hardening
An adversarial review of the change surfaced two issues that are addressed here:

- **List/Stats walk duplication.** The active-set paging walk now lives in one shared iterator, `eachActiveInsightRecord`, used by both `List` and `Stats`. The doc note that they "must do the same or the two permanently disagree" is now structural rather than a convention, so a future paging fix cannot drift them apart (the disagreement this PR exists to close).
- **Pagination stability.** The walk pages at `memory.MaxLimit` with `OFFSET`, so the sort must be a total order. `created_at` alone is not unique (bulk-imported rows can share a timestamp), and a non-unique sort lets `OFFSET` skip or duplicate a row straddling a page boundary, which would silently drop or double-count a pending insight and re-open this bug under tie conditions. The walk now orders by `created_at DESC, id DESC` (`id` is the primary key), making paging deterministic. This also hardens the existing `Stats` walk.

### Performance note
The walk is O(matching active records) per call, the same shape as `Stats`. The per-entity callers (`searchByEntity`, `handleReview`, `handleSynthesize`) pass `EntityURN` and are store-filtered to one entity, so their walk stays small. The unscoped review-queue walk is bounded by the active insight count, the same walk the admin stat card already runs via `Stats`. Pushing the exact-status predicate into the shared memory store so it can `LIMIT/OFFSET/COUNT` directly is the larger future optimization noted in the issue; it is intentionally out of scope here.

### Cosmetic
Fixed the literal double hyphen in the pagination footer (`ui/src/pages/knowledge/KnowledgePage.tsx`): `Showing 1--20` is now `Showing 1-20` (both paginated sections).

## Tests

- A multi-page regression with 150 active records (round-robin pending/approved/applied, pending scattered past the first 100-record store page) asserts that `List` total equals the `Stats` pending count, that a pending insight past the first window is reachable, and that the `approved` count is exact.
- Existing `List` tests updated for the exact-total contract (the confidence-filter total is now the exact matching count; the filter-mapping test asserts the walk uses the full page size, offset 0, and the stable `created_at DESC, id DESC` order).
- `List`, `Stats`, and `eachActiveInsightRecord` are each 100% covered.

## Verification

Full `make verify` is green (CI-equivalent suite, including the GoReleaser dry-run that rebuilds the UI).

## Acceptance criteria (#706)

- [x] With the Pending filter, the list returns all pending insights and `total` equals the pending count (matches the Pending Review stat card).
- [x] The same holds for `approved` and `applied` (the other statuses that collapse to memory `active`) and for the confidence filter.
- [x] A regression test asserts `List` and `Stats` agree on the pending count when the active set contains a mix of pending/approved/applied records spanning more than one page.
- [x] Cosmetic: the `1--20` double hyphen is fixed.