### PR TITLE
fix(knowledge): batch tag writes into one read-modify-write to stop clobber

### DIFF
--- a/pkg/admin/knowledge_test.go
+++ b/pkg/admin/knowledge_test.go
@@ -209,9 +209,8 @@ func (m *mockDataHubWriter) UpdateDescription(_ context.Context, urn, desc strin
 	return m.updateDescErr
 }
 
-func (*mockDataHubWriter) AddTag(_ context.Context, _, _ string) error { return nil }
-func (m *mockDataHubWriter) RemoveTag(_ context.Context, _, tag string) error {
-	m.removeTagCalls = append(m.removeTagCalls, tag)
+func (m *mockDataHubWriter) ApplyTagChanges(_ context.Context, _ string, _, remove []string) error {
+	m.removeTagCalls = append(m.removeTagCalls, remove...)
 	return nil
 }
 func (*mockDataHubWriter) AddGlossaryTerm(_ context.Context, _, _ string) error { return nil }

--- a/pkg/toolkits/knowledge/datahub_client_writer.go
+++ b/pkg/toolkits/knowledge/datahub_client_writer.go
@@ -275,20 +275,183 @@ func truncateBody(b []byte) string {
 	return string(b[:maxBodyTruncate]) + "..."
 }
 
-// AddTag adds a tag to an entity.
-func (w *DataHubClientWriter) AddTag(ctx context.Context, urn, tag string) error {
-	if err := w.client.AddTag(ctx, urn, tag); err != nil {
-		return fmt.Errorf("adding tag %s to %s: %w", tag, urn, err)
+// globalTagsAspect mirrors the upstream globalTags aspect for REST read-modify-write.
+// globalTagsAspect mirrors the upstream globalTags aspect. Associations are kept as
+// raw JSON so that fields beyond the tag URN (e.g. a tag's propagation context or
+// attribution) survive a read-modify-write instead of being stripped when an
+// unrelated tag is added or removed.
+type globalTagsAspect struct {
+	Tags []json.RawMessage `json:"tags"`
+}
+
+// tagAssociation is the minimal shape used to emit a new tag association and to
+// extract the tag URN from an existing raw association for dedupe/removal.
+type tagAssociation struct {
+	Tag string `json:"tag"`
+}
+
+// tagURNOf extracts the tag URN from a raw globalTags association, returning "" if
+// it cannot be parsed.
+func tagURNOf(raw json.RawMessage) string {
+	var ta tagAssociation
+	if err := json.Unmarshal(raw, &ta); err != nil {
+		return ""
+	}
+	return ta.Tag
+}
+
+// tagSupportedTypes lists entity types DataHub registers the globalTags aspect on.
+// Applying tags to any other type is rejected up front with a clear error, matching
+// the guard the upstream client enforced before this batched path bypassed it.
+// Mirrors the upstream client's globalTagsSupportedTypes set.
+var tagSupportedTypes = map[string]bool{
+	"dataset": true, "dashboard": true, "chart": true, "dataFlow": true,
+	"dataJob": true, "container": true, "dataProduct": true,
+	"domain": true, "glossaryTerm": true, "glossaryNode": true, "document": true,
+}
+
+// tagGraphQLWriteTypes lists entity types whose globalTags aspect is not exposed
+// over the REST aspect API, so the upstream client writes them with the GraphQL
+// addTag/removeTag mutations instead. Those mutations are server-side additive and
+// not subject to the read-modify-write clobber, so for these types ApplyTagChanges
+// delegates per-tag rather than batching a REST read-modify-write. Mirrors the
+// upstream client's graphQLWriteTypes set.
+var tagGraphQLWriteTypes = map[string]bool{
+	"domain": true, "glossaryTerm": true, "glossaryNode": true, "document": true,
+}
+
+// ApplyTagChanges adds and removes tags on an entity in a single read-modify-write
+// of the globalTags aspect. Delegating to the upstream client's per-tag AddTag/
+// RemoveTag issues a read-modify-write per tag; because DataHub aspect writes are
+// eventually consistent, back-to-back calls read stale tag state and the final
+// write overwrites the whole aspect with a single tag, silently dropping the rest
+// (#721). Reading once, merging every add/remove, and writing once is lossless. A
+// tag present in both add and remove is removed.
+func (w *DataHubClientWriter) ApplyTagChanges(ctx context.Context, urn string, add, remove []string) error {
+	if len(add) == 0 && len(remove) == 0 {
+		return nil
+	}
+	parsed, err := dhclient.ParseURN(urn)
+	if err != nil {
+		return fmt.Errorf("apply tag changes: invalid URN: %w", err)
+	}
+	if !tagSupportedTypes[parsed.EntityType] {
+		return fmt.Errorf("apply tag changes: entity type %q does not support tag operations", parsed.EntityType)
+	}
+	if tagGraphQLWriteTypes[parsed.EntityType] {
+		return w.applyTagChangesGraphQL(ctx, urn, add, remove)
+	}
+	return w.applyTagChangesREST(ctx, parsed.EntityType, urn, add, remove)
+}
+
+// applyTagChangesGraphQL applies tag changes for entity types whose globalTags
+// aspect is only writable via GraphQL (domain, glossaryTerm, glossaryNode,
+// document). The upstream AddTag/RemoveTag use the server-side additive GraphQL
+// mutations for these types, which are already lossless, so we delegate per-tag.
+func (w *DataHubClientWriter) applyTagChangesGraphQL(ctx context.Context, urn string, add, remove []string) error {
+	removeSet := make(map[string]bool, len(remove))
+	for _, tag := range remove {
+		removeSet[tag] = true
+	}
+	for _, tag := range remove {
+		if err := w.client.RemoveTag(ctx, urn, tag); err != nil {
+			return fmt.Errorf("removing tag %s from %s: %w", tag, urn, err)
+		}
+	}
+	for _, tag := range add {
+		// A tag in both add and remove is left removed, matching the REST path and
+		// the ApplyTagChanges contract.
+		if removeSet[tag] {
+			continue
+		}
+		if err := w.client.AddTag(ctx, urn, tag); err != nil {
+			return fmt.Errorf("adding tag %s to %s: %w", tag, urn, err)
+		}
 	}
 	return nil
 }
 
-// RemoveTag removes a tag from an entity.
-func (w *DataHubClientWriter) RemoveTag(ctx context.Context, urn, tag string) error {
-	if err := w.client.RemoveTag(ctx, urn, tag); err != nil {
-		return fmt.Errorf("removing tag %s from %s: %w", tag, urn, err)
+// applyTagChangesREST reads the current globalTags aspect once, applies all
+// removes and adds, and writes the merged aspect once.
+func (w *DataHubClientWriter) applyTagChangesREST(ctx context.Context, entityType, urn string, add, remove []string) error {
+	current, err := w.readGlobalTags(ctx, entityType, urn)
+	if err != nil {
+		return fmt.Errorf("apply tag changes: read globalTags: %w", err)
 	}
-	return nil
+	merged, err := mergeGlobalTags(current.Tags, add, remove)
+	if err != nil {
+		return fmt.Errorf("apply tag changes: %w", err)
+	}
+	current.Tags = merged
+	return w.postIngestProposal(ctx, entityType, urn, "globalTags", current)
+}
+
+// mergeGlobalTags returns the globalTags associations after removing every tag in
+// remove and appending every tag in add that is not already present, deduped. Each
+// surviving existing association's full JSON is preserved (context/attribution),
+// and a tag present in both add and remove is removed.
+func mergeGlobalTags(current []json.RawMessage, add, remove []string) ([]json.RawMessage, error) {
+	removeSet := make(map[string]bool, len(remove))
+	for _, t := range remove {
+		removeSet[t] = true
+	}
+
+	merged := make([]json.RawMessage, 0, len(current)+len(add))
+	have := make(map[string]bool, len(current)+len(add))
+	for _, raw := range current {
+		u := tagURNOf(raw)
+		if u == "" || removeSet[u] || have[u] {
+			continue
+		}
+		have[u] = true
+		merged = append(merged, raw)
+	}
+	for _, t := range add {
+		if removeSet[t] || have[t] {
+			continue
+		}
+		have[t] = true
+		assoc, err := json.Marshal(tagAssociation{Tag: t})
+		if err != nil {
+			return nil, fmt.Errorf("marshal tag %s: %w", t, err)
+		}
+		merged = append(merged, assoc)
+	}
+	return merged, nil
+}
+
+// readGlobalTags reads the current globalTags aspect via the REST aspect API,
+// returning an empty aspect when none exists.
+func (w *DataHubClientWriter) readGlobalTags(ctx context.Context, entityType, urn string) (*globalTagsAspect, error) {
+	body, statusCode, err := w.doRESTGet(ctx, w.aspectGetURL(entityType, urn, "globalTags"))
+	if err != nil {
+		return nil, fmt.Errorf("rest get aspect: %w", err)
+	}
+	if statusCode == http.StatusNotFound {
+		return &globalTagsAspect{}, nil
+	}
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("rest get status %d: %s", statusCode, truncateBody(body))
+	}
+	return parseGlobalTags(body)
+}
+
+// parseGlobalTags unmarshals the REST response body into a globalTagsAspect.
+func parseGlobalTags(body []byte) (*globalTagsAspect, error) {
+	var aspectResp struct {
+		Value json.RawMessage `json:"value"`
+	}
+	if err := json.Unmarshal(body, &aspectResp); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+	if len(aspectResp.Value) == 0 || string(bytes.TrimSpace(aspectResp.Value)) == "null" {
+		return &globalTagsAspect{}, nil
+	}
+	var aspect globalTagsAspect
+	if err := json.Unmarshal(aspectResp.Value, &aspect); err != nil {
+		return nil, fmt.Errorf("unmarshal globalTags: %w", err)
+	}
+	return &aspect, nil
 }
 
 // AddGlossaryTerm adds a glossary term to an entity.

--- a/pkg/toolkits/knowledge/datahub_client_writer_test.go
+++ b/pkg/toolkits/knowledge/datahub_client_writer_test.go
@@ -181,56 +181,327 @@ func TestDataHubClientWriter_UpdateDescription_Error(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestDataHubClientWriter_AddTag(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// globalTagsServer returns a test server that serves the given existing tags on
+// GET (as the globalTags aspect) and captures the POSTed aspect body. A nil
+// existing slice responds 404 (no aspect yet). It records the number of GET and
+// POST requests so tests can assert a single read-modify-write.
+func globalTagsServer(t *testing.T, existing []string, posted *[]byte, gets, posts *int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			// Return empty tags (not found)
-			w.WriteHeader(http.StatusNotFound)
+			*gets++
+			if existing == nil {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			assocs := make([]string, 0, len(existing))
+			for _, tag := range existing {
+				assocs = append(assocs, `{"tag":"`+tag+`"}`)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":{"tags":[` + strings.Join(assocs, ",") + `]}}`))
 		case http.MethodPost:
+			*posts++
+			*posted, _ = io.ReadAll(r.Body)
 			w.WriteHeader(http.StatusOK)
 		}
 	}))
+}
+
+func TestDataHubClientWriter_ApplyTagChanges_AddMergesExisting(t *testing.T) {
+	var posted []byte
+	var gets, posts int
+	server := globalTagsServer(t, []string{"urn:li:tag:Existing"}, &posted, &gets, &posts)
 	defer server.Close()
 
 	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
-	err := writer.AddTag(context.Background(), testURN, "urn:li:tag:NewTag")
-
+	err := writer.ApplyTagChanges(context.Background(), testURN, []string{"urn:li:tag:NewTag"}, nil)
 	require.NoError(t, err)
+
+	body := string(posted)
+	assert.Contains(t, body, "urn:li:tag:Existing", "existing tag must be preserved")
+	assert.Contains(t, body, "urn:li:tag:NewTag", "new tag must be added")
+	assert.Equal(t, 1, gets, "exactly one read")
+	assert.Equal(t, 1, posts, "exactly one write")
 }
 
-func TestDataHubClientWriter_AddTag_Error(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`server error`))
+// TestDataHubClientWriter_ApplyTagChanges_NoClobber is the #721 regression: adding
+// several tags in one call must read once and write all of them, not clobber down
+// to a single tag the way back-to-back per-tag read-modify-writes did.
+func TestDataHubClientWriter_ApplyTagChanges_NoClobber(t *testing.T) {
+	var posted []byte
+	var gets, posts int
+	server := globalTagsServer(t, nil, &posted, &gets, &posts)
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	tags := []string{"urn:li:tag:a", "urn:li:tag:b", "urn:li:tag:c", "urn:li:tag:d"}
+	err := writer.ApplyTagChanges(context.Background(), testURN, tags, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, gets, "a batched apply reads once")
+	assert.Equal(t, 1, posts, "a batched apply writes once")
+	body := string(posted)
+	for _, tag := range tags {
+		assert.Contains(t, body, tag, "all tags must survive the single write")
+	}
+}
+
+func TestDataHubClientWriter_ApplyTagChanges_Remove(t *testing.T) {
+	var posted []byte
+	var gets, posts int
+	server := globalTagsServer(t, []string{"urn:li:tag:Keep", "urn:li:tag:Remove"}, &posted, &gets, &posts)
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyTagChanges(context.Background(), testURN, nil, []string{"urn:li:tag:Remove"})
+	require.NoError(t, err)
+
+	body := string(posted)
+	assert.Contains(t, body, "urn:li:tag:Keep")
+	assert.NotContains(t, body, "urn:li:tag:Remove")
+}
+
+// TestDataHubClientWriter_ApplyTagChanges_AddAndRemove verifies a mixed delta (as
+// produced by a rollback containing both add_tag and remove_tag) is applied in a
+// single read-modify-write.
+func TestDataHubClientWriter_ApplyTagChanges_AddAndRemove(t *testing.T) {
+	var posted []byte
+	var gets, posts int
+	server := globalTagsServer(t, []string{"urn:li:tag:Old"}, &posted, &gets, &posts)
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyTagChanges(context.Background(), testURN, []string{"urn:li:tag:New"}, []string{"urn:li:tag:Old"})
+	require.NoError(t, err)
+
+	body := string(posted)
+	assert.Contains(t, body, "urn:li:tag:New")
+	assert.NotContains(t, body, "urn:li:tag:Old")
+	assert.Equal(t, 1, gets)
+	assert.Equal(t, 1, posts)
+}
+
+// TestDataHubClientWriter_ApplyTagChanges_Dedup ensures adding a tag that already
+// exists does not duplicate it, and a tag in both add and remove is removed.
+func TestDataHubClientWriter_ApplyTagChanges_Dedup(t *testing.T) {
+	var posted []byte
+	var gets, posts int
+	server := globalTagsServer(t, []string{"urn:li:tag:Dup"}, &posted, &gets, &posts)
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyTagChanges(context.Background(), testURN,
+		[]string{"urn:li:tag:Dup", "urn:li:tag:Conflict"}, []string{"urn:li:tag:Conflict"})
+	require.NoError(t, err)
+
+	body := string(posted)
+	assert.Equal(t, 1, strings.Count(body, "urn:li:tag:Dup"), "existing tag must not be duplicated")
+	assert.NotContains(t, body, "urn:li:tag:Conflict", "a tag in both add and remove is removed")
+}
+
+func TestDataHubClientWriter_ApplyTagChanges_NoChanges(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("ApplyTagChanges with no add/remove must not hit DataHub")
 	}))
 	defer server.Close()
 
 	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
-	err := writer.AddTag(context.Background(), testURN, "urn:li:tag:NewTag")
+	require.NoError(t, writer.ApplyTagChanges(context.Background(), testURN, nil, nil))
+}
 
+func TestDataHubClientWriter_ApplyTagChanges_InvalidURN(t *testing.T) {
+	writer := NewDataHubClientWriter(newTestClient(t, "http://unused"))
+	err := writer.ApplyTagChanges(context.Background(), "not-a-urn", []string{"urn:li:tag:x"}, nil)
 	assert.Error(t, err)
 }
 
-func TestDataHubClientWriter_RemoveTag(t *testing.T) {
+func TestDataHubClientWriter_ApplyTagChanges_ReadError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodGet:
-			w.Header().Set("Content-Type", "application/json")
-			resp := map[string]json.RawMessage{
-				"value": json.RawMessage(`{"tags":[{"tag":"urn:li:tag:Keep"},{"tag":"urn:li:tag:Remove"}]}`),
-			}
-			_ = json.NewEncoder(w).Encode(resp)
-		case http.MethodPost:
-			w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`boom`))
+			return
 		}
+		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
 	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
-	err := writer.RemoveTag(context.Background(), testURN, "urn:li:tag:Remove")
+	err := writer.ApplyTagChanges(context.Background(), testURN, []string{"urn:li:tag:x"}, nil)
+	assert.Error(t, err)
+}
 
+func TestDataHubClientWriter_ApplyTagChanges_WriteError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`boom`))
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyTagChanges(context.Background(), testURN, []string{"urn:li:tag:x"}, nil)
+	assert.Error(t, err)
+}
+
+// TestDataHubClientWriter_ApplyTagChanges_GraphQLType verifies that for entity
+// types whose globalTags aspect is GraphQL-only (e.g. glossaryTerm), tag changes
+// go through the upstream per-tag GraphQL mutation rather than a REST aspect write.
+func TestDataHubClientWriter_ApplyTagChanges_GraphQLType(t *testing.T) {
+	var graphqlCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "GraphQL types must not issue REST aspect GETs")
+		graphqlCalls++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(graphQLResponse{Data: json.RawMessage(`{"addTag":true}`)})
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyTagChanges(context.Background(),
+		"urn:li:glossaryTerm:revenue", []string{"urn:li:tag:Curated"}, nil)
 	require.NoError(t, err)
+	assert.Positive(t, graphqlCalls)
+}
+
+// TestDataHubClientWriter_ApplyTagChanges_GraphQLTypeRemove covers the remove path
+// for GraphQL-only entity types.
+func TestDataHubClientWriter_ApplyTagChanges_GraphQLTypeRemove(t *testing.T) {
+	var ops []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		// The mutation name distinguishes add from remove.
+		if strings.Contains(string(body), "removeTag") {
+			ops = append(ops, "remove")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(graphQLResponse{Data: json.RawMessage(`{"removeTag":true}`)})
+			return
+		}
+		ops = append(ops, "add")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(graphQLResponse{Data: json.RawMessage(`{"addTag":true}`)})
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyTagChanges(context.Background(),
+		"urn:li:domain:sales", []string{"urn:li:tag:Add"}, []string{"urn:li:tag:Drop"})
+	require.NoError(t, err)
+	// Removes are applied before adds.
+	assert.Equal(t, []string{"remove", "add"}, ops)
+}
+
+func TestDataHubClientWriter_ApplyTagChanges_GraphQLTypeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`boom`))
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	addErr := writer.ApplyTagChanges(context.Background(), "urn:li:domain:sales", []string{"urn:li:tag:x"}, nil)
+	assert.Error(t, addErr)
+	removeErr := writer.ApplyTagChanges(context.Background(), "urn:li:domain:sales", nil, []string{"urn:li:tag:x"})
+	assert.Error(t, removeErr)
+}
+
+// TestDataHubClientWriter_ApplyTagChanges_PreservesAssociationFields verifies that
+// a read-modify-write preserves fields beyond the tag URN (e.g. propagation
+// context/attribution) on existing associations, rather than stripping them.
+func TestDataHubClientWriter_ApplyTagChanges_PreservesAssociationFields(t *testing.T) {
+	var posted []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			// An existing association carrying a propagation context field.
+			_, _ = w.Write([]byte(`{"value":{"tags":[{"tag":"urn:li:tag:Propagated","context":"lineage"}]}}`))
+			return
+		}
+		posted, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyTagChanges(context.Background(), testURN, []string{"urn:li:tag:New"}, nil)
+	require.NoError(t, err)
+
+	// The aspect is embedded as an escaped JSON string in the v2 ingest body, so
+	// match the unescaped substrings rather than exact quoting.
+	body := string(posted)
+	assert.Contains(t, body, "lineage", "existing association context must be preserved")
+	assert.Contains(t, body, "urn:li:tag:Propagated")
+	assert.Contains(t, body, "urn:li:tag:New")
+}
+
+func TestDataHubClientWriter_ApplyTagChanges_UnsupportedType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("unsupported entity types must be rejected before any DataHub call")
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyTagChanges(context.Background(),
+		"urn:li:mlModel:(urn:li:dataPlatform:science,model,PROD)", []string{"urn:li:tag:x"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support tag operations")
+}
+
+// TestDataHubClientWriter_ApplyTagChanges_GraphQLDedup verifies that on a GraphQL
+// entity type, a tag in both add and remove ends up removed (matching the REST path
+// and the documented contract): it is never re-added.
+func TestDataHubClientWriter_ApplyTagChanges_GraphQLDedup(t *testing.T) {
+	var addedTags []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s := string(body)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(s, "removeTag") {
+			_ = json.NewEncoder(w).Encode(graphQLResponse{Data: json.RawMessage(`{"removeTag":true}`)})
+			return
+		}
+		// Capture which tag was added.
+		if strings.Contains(s, "urn:li:tag:Both") {
+			addedTags = append(addedTags, "urn:li:tag:Both")
+		}
+		_ = json.NewEncoder(w).Encode(graphQLResponse{Data: json.RawMessage(`{"addTag":true}`)})
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyTagChanges(context.Background(),
+		"urn:li:domain:sales", []string{"urn:li:tag:Both"}, []string{"urn:li:tag:Both"})
+	require.NoError(t, err)
+	assert.Empty(t, addedTags, "a tag in both add and remove must not be re-added")
+}
+
+func TestTagURNOf(t *testing.T) {
+	assert.Equal(t, "urn:li:tag:a", tagURNOf([]byte(`{"tag":"urn:li:tag:a"}`)))
+	assert.Empty(t, tagURNOf([]byte(`{"notag":1}`)), "missing tag field yields empty")
+	assert.Empty(t, tagURNOf([]byte(`not json`)), "unparseable association yields empty")
+}
+
+func TestParseGlobalTags(t *testing.T) {
+	aspect, err := parseGlobalTags([]byte(`{"value":{"tags":[{"tag":"urn:li:tag:a"}]}}`))
+	require.NoError(t, err)
+	require.Len(t, aspect.Tags, 1)
+	assert.Equal(t, "urn:li:tag:a", tagURNOf(aspect.Tags[0]))
+}
+
+func TestParseGlobalTags_NullValue(t *testing.T) {
+	aspect, err := parseGlobalTags([]byte(`{"value":null}`))
+	require.NoError(t, err)
+	assert.Empty(t, aspect.Tags)
+}
+
+func TestParseGlobalTags_InvalidJSON(t *testing.T) {
+	_, err := parseGlobalTags([]byte(`not json`))
+	assert.Error(t, err)
 }
 
 func TestDataHubClientWriter_AddGlossaryTerm(t *testing.T) {

--- a/pkg/toolkits/knowledge/datahub_writer.go
+++ b/pkg/toolkits/knowledge/datahub_writer.go
@@ -15,8 +15,13 @@ type DataHubWriter interface {
 	// read-modify-write cycle, avoiding the stale-read bug where back-to-back single
 	// calls lose all but the last column.
 	UpdateColumnDescriptionBatch(ctx context.Context, urn string, columns map[string]string) error
-	AddTag(ctx context.Context, urn string, tag string) error
-	RemoveTag(ctx context.Context, urn string, tag string) error
+	// ApplyTagChanges adds and removes the given tags in a single read-modify-write
+	// of the globalTags aspect. Per-tag writes are read-modify-write against
+	// DataHub's eventually consistent store, so back-to-back single calls read stale
+	// tag state and the last write clobbers the rest, silently dropping tags (#721).
+	// Batching every add/remove for an entity into one read-modify-write is lossless.
+	// add and remove hold full TagUrns; a tag in both add and remove is removed.
+	ApplyTagChanges(ctx context.Context, urn string, add, remove []string) error
 	AddGlossaryTerm(ctx context.Context, urn string, termURN string) error
 	// RemoveGlossaryTerm removes a glossary term association. Used to revert add_glossary_term.
 	RemoveGlossaryTerm(ctx context.Context, urn string, termURN string) error
@@ -63,11 +68,10 @@ func (*NoopDataHubWriter) UpdateColumnDescriptionBatch(_ context.Context, _ stri
 	return nil
 }
 
-// AddTag is a no-op.
-func (*NoopDataHubWriter) AddTag(_ context.Context, _, _ string) error { return nil }
-
-// RemoveTag is a no-op.
-func (*NoopDataHubWriter) RemoveTag(_ context.Context, _, _ string) error { return nil }
+// ApplyTagChanges is a no-op.
+func (*NoopDataHubWriter) ApplyTagChanges(_ context.Context, _ string, _, _ []string) error {
+	return nil
+}
 
 // AddGlossaryTerm is a no-op.
 func (*NoopDataHubWriter) AddGlossaryTerm(_ context.Context, _, _ string) error { return nil }

--- a/pkg/toolkits/knowledge/datahub_writer_test.go
+++ b/pkg/toolkits/knowledge/datahub_writer_test.go
@@ -39,15 +39,9 @@ func TestNoopDataHubWriter_UpdateDescription(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestNoopDataHubWriter_AddTag(t *testing.T) {
+func TestNoopDataHubWriter_ApplyTagChanges(t *testing.T) {
 	writer := &NoopDataHubWriter{}
-	err := writer.AddTag(context.Background(), testDatasetURN, "important")
-	assert.NoError(t, err)
-}
-
-func TestNoopDataHubWriter_RemoveTag(t *testing.T) {
-	writer := &NoopDataHubWriter{}
-	err := writer.RemoveTag(context.Background(), testDatasetURN, "deprecated")
+	err := writer.ApplyTagChanges(context.Background(), testDatasetURN, []string{"important"}, []string{"deprecated"})
 	assert.NoError(t, err)
 }
 

--- a/pkg/toolkits/knowledge/rollback.go
+++ b/pkg/toolkits/knowledge/rollback.go
@@ -181,7 +181,22 @@ func applyInverseChanges(
 	changes []recordedChange,
 	prior priorState,
 ) (reverted, skipped []string, err error) {
+	// Tag inverses are reverted in a single read-modify-write. Reverting each tag
+	// with its own write reads DataHub's eventually consistent state back-to-back,
+	// so the last write clobbers the rest and a multi-tag rollback could leave the
+	// entity with zero tags instead of its prior set (#721). Non-tag inverses
+	// (description, glossary term, documentation) are reverted individually.
+	tagReverted, tagSkipped, err := revertTagChanges(ctx, writer, urn, changes, prior)
+	if err != nil {
+		return nil, nil, err
+	}
+	reverted = append(reverted, tagReverted...)
+	skipped = append(skipped, tagSkipped...)
+
 	for _, c := range changes {
+		if isTagChange(c.ChangeType) {
+			continue
+		}
 		desc, didRevert, applyErr := applyInverse(ctx, writer, urn, c, prior)
 		if applyErr != nil {
 			return reverted, skipped, applyErr
@@ -195,19 +210,73 @@ func applyInverseChanges(
 	return reverted, skipped, nil
 }
 
+// isTagChange reports whether a change type is reverted by the batched tag path.
+func isTagChange(changeType string) bool {
+	switch changeType {
+	case string(actionAddTag), string(actionRemoveTag), string(actionFlagQualityIssue):
+		return true
+	default:
+		return false
+	}
+}
+
+// revertTagChanges computes the tag adds and removes that invert the changeset's
+// tag changes and applies them in a single read-modify-write. A tag whose value
+// already existed before the changeset (per the before-image) is left untouched.
+// The returned descriptions are only committed after the single write succeeds, so
+// a failed write reports nothing as reverted (the write is all-or-nothing).
+func revertTagChanges(
+	ctx context.Context,
+	writer DataHubWriter,
+	urn string,
+	changes []recordedChange,
+	prior priorState,
+) (reverted, skipped []string, err error) {
+	var add, remove []string
+	for _, c := range changes {
+		switch c.ChangeType {
+		case string(actionAddTag):
+			tagURN := normalizeTagURN(c.Detail)
+			reverted, skipped, remove = classifyAddedTagRevert(tagURN, prior, reverted, skipped, remove)
+		case string(actionFlagQualityIssue):
+			reverted, skipped, remove = classifyAddedTagRevert(qualityIssueTagURN, prior, reverted, skipped, remove)
+		case string(actionRemoveTag):
+			tagURN := normalizeTagURN(c.Detail)
+			if !prior.Tags[tagURN] {
+				skipped = append(skipped, fmt.Sprintf("tag %s was not present before; nothing to restore", tagURN))
+				continue
+			}
+			add = append(add, tagURN)
+			reverted = append(reverted, fmt.Sprintf("restored tag %s", tagURN))
+		}
+	}
+	if len(add) == 0 && len(remove) == 0 {
+		return reverted, skipped, nil
+	}
+	if err := writer.ApplyTagChanges(ctx, urn, add, remove); err != nil {
+		return nil, nil, fmt.Errorf("reverting tags: %w", err)
+	}
+	return reverted, skipped, nil
+}
+
+// classifyAddedTagRevert decides how to revert an added tag: a tag that existed
+// before the changeset is kept (skipped); otherwise it is queued for removal.
+func classifyAddedTagRevert(tagURN string, prior priorState, reverted, skipped, remove []string) (rev, skip, rem []string) {
+	if prior.Tags[tagURN] {
+		return reverted, append(skipped, fmt.Sprintf("kept pre-existing tag %s", tagURN)), remove
+	}
+	return append(reverted, fmt.Sprintf("removed tag %s", tagURN)), skipped, append(remove, tagURN)
+}
+
 // applyInverse reverts a single change. didRevert is false when the change was a
 // no-op at apply time (the value already existed in the before-image), so the
 // rollback intentionally leaves the pre-existing value in place.
 func applyInverse(ctx context.Context, writer DataHubWriter, urn string, c recordedChange, prior priorState) (desc string, didRevert bool, err error) {
+	// Tag inverses (add_tag, remove_tag, flag_quality_issue) are not handled here:
+	// applyInverseChanges reverts them in a single batched read-modify-write (#721).
 	switch c.ChangeType {
 	case string(actionUpdateDescription):
 		return revertDescription(ctx, writer, urn, prior)
-	case string(actionAddTag):
-		return revertAddedTag(ctx, writer, urn, normalizeTagURN(c.Detail), prior)
-	case string(actionFlagQualityIssue):
-		return revertAddedTag(ctx, writer, urn, qualityIssueTagURN, prior)
-	case string(actionRemoveTag):
-		return revertRemovedTag(ctx, writer, urn, normalizeTagURN(c.Detail), prior)
 	case string(actionAddGlossaryTerm):
 		return revertAddedTerm(ctx, writer, urn, normalizeGlossaryTermURN(c.Detail), prior)
 	case string(actionAddDocumentation):
@@ -222,26 +291,6 @@ func revertDescription(ctx context.Context, writer DataHubWriter, urn string, pr
 		return "", false, fmt.Errorf("restoring description: %w", err)
 	}
 	return "restored description", true, nil
-}
-
-func revertAddedTag(ctx context.Context, writer DataHubWriter, urn, tagURN string, prior priorState) (desc string, reverted bool, err error) {
-	if prior.Tags[tagURN] {
-		return fmt.Sprintf("kept pre-existing tag %s", tagURN), false, nil
-	}
-	if err := writer.RemoveTag(ctx, urn, tagURN); err != nil {
-		return "", false, fmt.Errorf("removing tag %s: %w", tagURN, err)
-	}
-	return fmt.Sprintf("removed tag %s", tagURN), true, nil
-}
-
-func revertRemovedTag(ctx context.Context, writer DataHubWriter, urn, tagURN string, prior priorState) (desc string, reverted bool, err error) {
-	if !prior.Tags[tagURN] {
-		return fmt.Sprintf("tag %s was not present before; nothing to restore", tagURN), false, nil
-	}
-	if err := writer.AddTag(ctx, urn, tagURN); err != nil {
-		return "", false, fmt.Errorf("restoring tag %s: %w", tagURN, err)
-	}
-	return fmt.Sprintf("restored tag %s", tagURN), true, nil
 }
 
 func revertAddedTerm(ctx context.Context, writer DataHubWriter, urn, termURN string, prior priorState) (desc string, reverted bool, err error) {

--- a/pkg/toolkits/knowledge/rollback_test.go
+++ b/pkg/toolkits/knowledge/rollback_test.go
@@ -80,9 +80,42 @@ func TestRevertChangeset_RemovesAddedTag(t *testing.T) {
 
 	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
 	require.NoError(t, err)
+	// The added tag is reverted via a single batched ApplyTagChanges removing it.
 	require.Len(t, writer.WriteCalls, 1)
-	assert.Equal(t, "RemoveTag", writer.WriteCalls[0].Method)
-	assert.Equal(t, normalizeTagURN("pii"), writer.WriteCalls[0].Arg1)
+	assert.Equal(t, "ApplyTagChanges", writer.WriteCalls[0].Method)
+	assert.Empty(t, writer.WriteCalls[0].Arg1, "no adds")
+	assert.Equal(t, normalizeTagURN("pii"), writer.WriteCalls[0].Arg2)
+}
+
+// TestRevertChangeset_MultiTagBatch is the #721 regression for rollback: reverting
+// a changeset that added several tags must remove them in a single batched
+// ApplyTagChanges, not a sequence of per-tag writes that read stale state and
+// could leave the entity with zero (or the wrong set of) tags.
+func TestRevertChangeset_MultiTagBatch(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{
+			"change_0": changeEntry("add_tag", "", "a"),
+			"change_1": changeEntry("add_tag", "", "b"),
+			"change_2": changeEntry("add_tag", "", "c"),
+		},
+		// Tag "a" pre-existed, so it must be kept; b and c were added by the changeset.
+		map[string]any{"tags": []any{normalizeTagURN("a")}},
+	)
+	store := seededStore(cs)
+	writer := &spyWriter{}
+
+	res, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	require.NoError(t, err)
+
+	// Exactly one batched write removing only the newly-added tags.
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "ApplyTagChanges", writer.WriteCalls[0].Method)
+	assert.Empty(t, writer.WriteCalls[0].Arg1, "no adds")
+	assert.Equal(t, normalizeTagURN("b")+","+normalizeTagURN("c"), writer.WriteCalls[0].Arg2)
+
+	// The pre-existing tag "a" is kept (skipped), b and c are reverted.
+	assert.Len(t, res.RevertedChanges, 2)
+	assert.Len(t, res.SkippedChanges, 1)
 }
 
 func TestRevertChangeset_ReAddsRemovedTag(t *testing.T) {
@@ -96,9 +129,11 @@ func TestRevertChangeset_ReAddsRemovedTag(t *testing.T) {
 
 	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
 	require.NoError(t, err)
+	// The removed tag is restored via a single batched ApplyTagChanges adding it.
 	require.Len(t, writer.WriteCalls, 1)
-	assert.Equal(t, "AddTag", writer.WriteCalls[0].Method)
+	assert.Equal(t, "ApplyTagChanges", writer.WriteCalls[0].Method)
 	assert.Equal(t, tagURN, writer.WriteCalls[0].Arg1)
+	assert.Empty(t, writer.WriteCalls[0].Arg2, "no removes")
 }
 
 func TestRevertChangeset_RemovedTagNotPreviouslyPresentIsNoop(t *testing.T) {
@@ -125,9 +160,11 @@ func TestRevertChangeset_FlagQualityIssueRemovesTag(t *testing.T) {
 
 	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
 	require.NoError(t, err)
+	// The QualityIssue tag is reverted via a single batched ApplyTagChanges removing it.
 	require.Len(t, writer.WriteCalls, 1)
-	assert.Equal(t, "RemoveTag", writer.WriteCalls[0].Method)
-	assert.Equal(t, qualityIssueTagURN, writer.WriteCalls[0].Arg1)
+	assert.Equal(t, "ApplyTagChanges", writer.WriteCalls[0].Method)
+	assert.Empty(t, writer.WriteCalls[0].Arg1, "no adds")
+	assert.Equal(t, qualityIssueTagURN, writer.WriteCalls[0].Arg2)
 }
 
 func TestRevertChangeset_RestoresDescription(t *testing.T) {

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -679,13 +679,47 @@ func (t *Toolkit) executeChanges(ctx context.Context, urn string, changes []Appl
 
 	columnDescs, nonColumnChanges := partitionColumnChanges(changes)
 
+	// Track whether any batched write (column descriptions, tags) has already been
+	// persisted, so a later per-change failure does not falsely report that nothing
+	// was applied. These batched writes run before the per-change dispatch loop.
+	priorWrites := false
+
 	if len(columnDescs) > 0 {
 		if err := t.datahubWriter.UpdateColumnDescriptionBatch(ctx, urn, columnDescs); err != nil {
 			return nil, fmt.Errorf("datahub write failed for column descriptions: %w", err)
 		}
+		priorWrites = true
 	}
 
-	return t.dispatchNonColumnChanges(ctx, urn, nonColumnChanges)
+	addTags, removeTags, otherChanges := partitionTagChanges(nonColumnChanges)
+	if len(addTags) > 0 || len(removeTags) > 0 {
+		if err := t.datahubWriter.ApplyTagChanges(ctx, urn, addTags, removeTags); err != nil {
+			return nil, fmt.Errorf("datahub write failed for tag changes: %w", err)
+		}
+		priorWrites = true
+	}
+
+	return t.dispatchNonColumnChanges(ctx, urn, otherChanges, priorWrites)
+}
+
+// partitionTagChanges separates tag-setting changes (add_tag, remove_tag, and
+// flag_quality_issue, which sets the QualityIssue tag) from other changes so they
+// can be applied in a single read-modify-write. Batching avoids the stale-read
+// clobber where back-to-back per-tag writes drop all but the last tag (#721).
+func partitionTagChanges(changes []ApplyChange) (add, remove []string, other []ApplyChange) {
+	for _, c := range changes {
+		switch c.ChangeType {
+		case string(actionAddTag):
+			add = append(add, normalizeTagURN(c.Detail))
+		case string(actionRemoveTag):
+			remove = append(remove, normalizeTagURN(c.Detail))
+		case string(actionFlagQualityIssue):
+			add = append(add, qualityIssueTagURN)
+		default:
+			other = append(other, c)
+		}
+	}
+	return add, remove, other
 }
 
 // validateAllChanges pre-checks entity type compatibility for all changes.
@@ -714,19 +748,23 @@ func partitionColumnChanges(changes []ApplyChange) (map[string]string, []ApplyCh
 	return columnDescs, other
 }
 
-// dispatchNonColumnChanges applies non-column changes individually.
-func (t *Toolkit) dispatchNonColumnChanges(ctx context.Context, urn string, changes []ApplyChange) ([]string, error) {
+// dispatchNonColumnChanges applies non-column changes individually. priorWrites
+// reports whether batched writes (column descriptions, tags) were already persisted
+// before this loop, so a failure on the first dispatched change is not mislabeled as
+// "no changes were applied".
+func (t *Toolkit) dispatchNonColumnChanges(ctx context.Context, urn string, changes []ApplyChange, priorWrites bool) ([]string, error) {
 	var createdURNs []string
 	for i, c := range changes {
 		queryURN, err := t.dispatchChange(ctx, urn, c)
 		if err != nil {
-			// Writes are not transactional: changes 1..i already persisted and are
-			// NOT automatically undone. Report this honestly so the caller can use
-			// rollback (or re-apply) rather than assuming a clean failure.
-			if i == 0 {
+			// Writes are not transactional: any batched writes plus dispatched changes
+			// 1..i already persisted and are NOT automatically undone. Report this
+			// honestly so the caller can re-apply (or roll back) rather than assuming a
+			// clean failure.
+			if i == 0 && !priorWrites {
 				return nil, fmt.Errorf("datahub write failed for change 1 of %d: %w (no changes were applied)", len(changes), err)
 			}
-			return nil, fmt.Errorf("datahub write failed for change %d of %d: %w (changes 1-%d were already applied and were NOT rolled back)", i+1, len(changes), err, i)
+			return nil, fmt.Errorf("datahub write failed for change %d of %d: %w (earlier changes in this changeset were already applied and were NOT rolled back)", i+1, len(changes), err)
 		}
 		if queryURN != "" {
 			createdURNs = append(createdURNs, queryURN)
@@ -751,19 +789,16 @@ func (t *Toolkit) dispatchChange(ctx context.Context, urn string, c ApplyChange)
 // dispatchCoreOrV14Change handles core DataHub changes and delegates to V14 for newer types.
 func (t *Toolkit) dispatchCoreOrV14Change(ctx context.Context, urn string, c ApplyChange) (string, error) {
 	var err error
+	// Tag changes (add_tag, remove_tag, flag_quality_issue) are not handled here:
+	// executeChanges batches them through ApplyTagChanges so a multi-tag apply is a
+	// single read-modify-write rather than a clobbering sequence of per-tag writes (#721).
 	switch c.ChangeType {
 	case string(actionUpdateDescription):
 		err = t.executeUpdateDescription(ctx, urn, c)
-	case string(actionAddTag):
-		err = t.datahubWriter.AddTag(ctx, urn, normalizeTagURN(c.Detail))
-	case string(actionRemoveTag):
-		err = t.datahubWriter.RemoveTag(ctx, urn, normalizeTagURN(c.Detail))
 	case string(actionAddGlossaryTerm):
 		err = t.datahubWriter.AddGlossaryTerm(ctx, urn, normalizeGlossaryTermURN(c.Detail))
 	case string(actionAddDocumentation):
 		err = t.datahubWriter.AddDocumentationLink(ctx, urn, c.Target, c.Detail)
-	case string(actionFlagQualityIssue):
-		err = t.datahubWriter.AddTag(ctx, urn, qualityIssueTagURN)
 	default:
 		return t.dispatchV14Change(ctx, urn, c)
 	}

--- a/pkg/toolkits/knowledge/toolkit_test.go
+++ b/pkg/toolkits/knowledge/toolkit_test.go
@@ -296,6 +296,9 @@ type spyWriter struct {
 	FailAtCall  int // If > 0, fail on the Nth write call
 	currentCall int
 	QueryURN    string // URN returned by CreateCuratedQuery
+	// TagState simulates the persisted globalTags per URN, applied additively by
+	// ApplyTagChanges so tests can assert the batched write does not clobber tags.
+	TagState map[string]map[string]bool
 }
 
 type writerCall struct {
@@ -347,12 +350,25 @@ func (w *spyWriter) UpdateColumnDescriptionBatch(_ context.Context, urn string, 
 	return nil
 }
 
-func (w *spyWriter) AddTag(_ context.Context, urn, tag string) error {
-	return w.recordAndCheck("AddTag", urn, tag, "")
-}
-
-func (w *spyWriter) RemoveTag(_ context.Context, urn, tag string) error {
-	return w.recordAndCheck("RemoveTag", urn, tag, "")
+func (w *spyWriter) ApplyTagChanges(_ context.Context, urn string, add, remove []string) error {
+	if err := w.recordAndCheck("ApplyTagChanges", urn, strings.Join(add, ","), strings.Join(remove, ",")); err != nil {
+		return err
+	}
+	// Model the server-side additive/subtractive semantics so regression tests can
+	// assert that a batched apply/rollback does not clobber pre-existing tags (#721).
+	if w.TagState == nil {
+		w.TagState = map[string]map[string]bool{}
+	}
+	if w.TagState[urn] == nil {
+		w.TagState[urn] = map[string]bool{}
+	}
+	for _, t := range remove {
+		delete(w.TagState[urn], t)
+	}
+	for _, t := range add {
+		w.TagState[urn][t] = true
+	}
+	return nil
 }
 
 func (w *spyWriter) AddGlossaryTerm(_ context.Context, urn, termURN string) error {
@@ -1322,21 +1338,25 @@ func TestHandleApply_WritesToDataHub(t *testing.T) {
 	require.Nil(t, callErr)
 	require.False(t, result.IsError, "expected success but got error: %v", result.Content)
 
-	// Verify all 6 write calls were made
-	assert.Len(t, writer.WriteCalls, 6)
-	assert.Equal(t, "UpdateDescription", writer.WriteCalls[0].Method)
-	assert.Equal(t, "AddTag", writer.WriteCalls[1].Method)
-	assert.Equal(t, "urn:li:tag:important", writer.WriteCalls[1].Arg1)
-	assert.Equal(t, "RemoveTag", writer.WriteCalls[2].Method)
-	assert.Equal(t, "urn:li:tag:deprecated", writer.WriteCalls[2].Arg1)
-	assert.Equal(t, "AddGlossaryTerm", writer.WriteCalls[3].Method)
-	assert.Equal(t, "AddDocumentationLink", writer.WriteCalls[4].Method)
-	assert.Equal(t, "https://docs.example.com", writer.WriteCalls[4].Arg1)
-	assert.Equal(t, "Revenue docs", writer.WriteCalls[4].Arg2)
-	assert.Equal(t, "AddTag", writer.WriteCalls[5].Method)
+	// The three tag changes (add_tag, remove_tag, flag_quality_issue) are batched
+	// into a single ApplyTagChanges that runs before the other dispatched writes
+	// (#721). Remaining writes: update_description, add_glossary_term, add_documentation.
+	assert.Len(t, writer.WriteCalls, 4)
+	assert.Equal(t, "ApplyTagChanges", writer.WriteCalls[0].Method)
+	// Arg1 is the comma-joined adds (add_tag then flag_quality_issue's QualityIssue),
+	// Arg2 the comma-joined removes.
+	assert.Equal(t, "urn:li:tag:important,urn:li:tag:QualityIssue", writer.WriteCalls[0].Arg1)
+	assert.Equal(t, "urn:li:tag:deprecated", writer.WriteCalls[0].Arg2)
+	assert.Equal(t, "UpdateDescription", writer.WriteCalls[1].Method)
+	assert.Equal(t, "AddGlossaryTerm", writer.WriteCalls[2].Method)
+	assert.Equal(t, "AddDocumentationLink", writer.WriteCalls[3].Method)
+	assert.Equal(t, "https://docs.example.com", writer.WriteCalls[3].Arg1)
+	assert.Equal(t, "Revenue docs", writer.WriteCalls[3].Arg2)
 
-	// Verify flag_quality_issue uses fixed QualityIssue tag (not dynamic slugified tag)
-	assert.Equal(t, "urn:li:tag:QualityIssue", writer.WriteCalls[5].Arg1)
+	// The QualityIssue tag survives in the same batched write as the other tags,
+	// rather than being clobbered by a separate per-tag write.
+	assert.Contains(t, writer.TagState[testEntityURN], "urn:li:tag:important")
+	assert.Contains(t, writer.TagState[testEntityURN], "urn:li:tag:QualityIssue")
 
 	// Verify all writes target the correct URN
 	for _, wc := range writer.WriteCalls {
@@ -1527,7 +1547,6 @@ func TestHandleApply_WriterFailsMidBatch(t *testing.T) {
 	m := parseJSONResult(t, result)
 	errMsg, _ := m["error"].(string)
 	assert.Contains(t, errMsg, "datahub write failed")
-	assert.Contains(t, errMsg, "2 of 3")
 
 	// No changeset should be recorded on failure
 	assert.Empty(t, csStore.Changesets)
@@ -2266,30 +2285,27 @@ func TestExecuteChanges_AllTypes(t *testing.T) {
 
 	_, err := tk.executeChanges(context.Background(), testEntityURN, changes)
 	require.NoError(t, err)
-	assert.Len(t, writer.WriteCalls, 6)
+	// add_tag, remove_tag, and flag_quality_issue collapse into one batched
+	// ApplyTagChanges (run first), leaving update_description, add_glossary_term,
+	// and add_documentation as individual dispatched writes (#721).
+	assert.Len(t, writer.WriteCalls, 4)
 
-	assert.Equal(t, "UpdateDescription", writer.WriteCalls[0].Method)
-	assert.Equal(t, "new desc", writer.WriteCalls[0].Arg1)
+	// Batched tag write: adds (add_tag then flag_quality_issue) and removes, with
+	// short names normalized to full URNs.
+	assert.Equal(t, "ApplyTagChanges", writer.WriteCalls[0].Method)
+	assert.Equal(t, "urn:li:tag:tag1,urn:li:tag:QualityIssue", writer.WriteCalls[0].Arg1)
+	assert.Equal(t, "urn:li:tag:old_tag", writer.WriteCalls[0].Arg2)
 
-	// add_tag: short name normalized to full URN
-	assert.Equal(t, "AddTag", writer.WriteCalls[1].Method)
-	assert.Equal(t, "urn:li:tag:tag1", writer.WriteCalls[1].Arg1)
+	assert.Equal(t, "UpdateDescription", writer.WriteCalls[1].Method)
+	assert.Equal(t, "new desc", writer.WriteCalls[1].Arg1)
 
-	// remove_tag: short name normalized to full URN
-	assert.Equal(t, "RemoveTag", writer.WriteCalls[2].Method)
-	assert.Equal(t, "urn:li:tag:old_tag", writer.WriteCalls[2].Arg1)
-
-	assert.Equal(t, "AddGlossaryTerm", writer.WriteCalls[3].Method)
-	assert.Equal(t, "urn:li:glossaryTerm:t1", writer.WriteCalls[3].Arg1)
+	assert.Equal(t, "AddGlossaryTerm", writer.WriteCalls[2].Method)
+	assert.Equal(t, "urn:li:glossaryTerm:t1", writer.WriteCalls[2].Arg1)
 
 	// add_documentation: detail=description, target=URL
-	assert.Equal(t, "AddDocumentationLink", writer.WriteCalls[4].Method)
-	assert.Equal(t, "https://docs.example.com", writer.WriteCalls[4].Arg1)
-	assert.Equal(t, "API Docs", writer.WriteCalls[4].Arg2)
-
-	// flag_quality_issue: fixed QualityIssue tag (detail is stored as context, not in tag name)
-	assert.Equal(t, "AddTag", writer.WriteCalls[5].Method)
-	assert.Equal(t, "urn:li:tag:QualityIssue", writer.WriteCalls[5].Arg1)
+	assert.Equal(t, "AddDocumentationLink", writer.WriteCalls[3].Method)
+	assert.Equal(t, "https://docs.example.com", writer.WriteCalls[3].Arg1)
+	assert.Equal(t, "API Docs", writer.WriteCalls[3].Arg2)
 }
 
 func TestExecuteChanges_AddCuratedQuery(t *testing.T) {
@@ -2339,7 +2355,28 @@ func TestExecuteChanges_FailsOnError(t *testing.T) {
 
 	_, err := tk.executeChanges(context.Background(), testEntityURN, changes)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "datahub write failed for change 1 of 2")
+	// Both tags are written in one batched call, so a writer failure surfaces as a
+	// single tag-changes error rather than a per-change failure.
+	assert.Contains(t, err.Error(), "datahub write failed for tag changes")
+}
+
+// TestExecuteChanges_DispatchFailAfterTagBatch verifies that when the batched tag
+// write has already persisted and a later dispatched change fails, the error does
+// not claim "no changes were applied" (which would mislead the operator into not
+// cleaning up the already-applied tags).
+func TestExecuteChanges_DispatchFailAfterTagBatch(t *testing.T) {
+	writer := &spyWriter{FailAtCall: 2} // tag batch (call 1) succeeds, glossary (call 2) fails
+	tk := &Toolkit{datahubWriter: writer}
+
+	changes := []ApplyChange{
+		{ChangeType: "add_tag", Detail: "important"},
+		{ChangeType: "add_glossary_term", Detail: "Revenue"},
+	}
+
+	_, err := tk.executeChanges(context.Background(), testEntityURN, changes)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "no changes were applied")
+	assert.Contains(t, err.Error(), "earlier changes in this changeset were already applied")
 }
 
 func TestExecuteChanges_UnknownType(t *testing.T) {
@@ -2433,14 +2470,14 @@ func TestExecuteChanges_MixedColumnAndDataset(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, writer.WriteCalls, 3)
 
-	// Column descriptions are batched and applied first.
+	// Column descriptions are batched and applied first, then the batched tag
+	// changes, then the remaining non-column changes.
 	assert.Equal(t, "UpdateColumnDescriptionBatch", writer.WriteCalls[0].Method)
 	assert.Equal(t, "email", writer.WriteCalls[0].Arg1)
-	// Then non-column changes in order.
-	assert.Equal(t, "UpdateDescription", writer.WriteCalls[1].Method)
-	assert.Equal(t, "AddTag", writer.WriteCalls[2].Method)
+	assert.Equal(t, "ApplyTagChanges", writer.WriteCalls[1].Method)
 	// Full URN should pass through unchanged (no double-prepend)
-	assert.Equal(t, "urn:li:tag:PII", writer.WriteCalls[2].Arg1)
+	assert.Equal(t, "urn:li:tag:PII", writer.WriteCalls[1].Arg1)
+	assert.Equal(t, "UpdateDescription", writer.WriteCalls[2].Method)
 }
 
 func TestExecuteChanges_ColumnTargetError(t *testing.T) {
@@ -2524,12 +2561,11 @@ func TestExecuteChanges_TagNormalization(t *testing.T) {
 
 	_, err := tk.executeChanges(context.Background(), testEntityURN, changes)
 	require.NoError(t, err)
-	require.Len(t, writer.WriteCalls, 2)
-
-	// Short name gets normalized
-	assert.Equal(t, "urn:li:tag:pii", writer.WriteCalls[0].Arg1)
-	// Full URN passes through unchanged
-	assert.Equal(t, "urn:li:tag:pii", writer.WriteCalls[1].Arg1)
+	// Both add_tag changes batch into a single ApplyTagChanges; each short name is
+	// normalized to its full URN.
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "ApplyTagChanges", writer.WriteCalls[0].Method)
+	assert.Equal(t, "urn:li:tag:pii,urn:li:tag:pii", writer.WriteCalls[0].Arg1)
 }
 
 func TestExecuteChanges_RemoveTag(t *testing.T) {
@@ -2543,14 +2579,12 @@ func TestExecuteChanges_RemoveTag(t *testing.T) {
 
 	_, err := tk.executeChanges(context.Background(), testEntityURN, changes)
 	require.NoError(t, err)
-	require.Len(t, writer.WriteCalls, 2)
-
-	// Short name gets normalized
-	assert.Equal(t, "RemoveTag", writer.WriteCalls[0].Method)
-	assert.Equal(t, "urn:li:tag:deprecated", writer.WriteCalls[0].Arg1)
-	// Full URN passes through unchanged
-	assert.Equal(t, "RemoveTag", writer.WriteCalls[1].Method)
-	assert.Equal(t, "urn:li:tag:QualityIssue", writer.WriteCalls[1].Arg1)
+	// Both remove_tag changes batch into a single ApplyTagChanges; the removes are
+	// the comma-joined Arg2, with short names normalized to full URNs.
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "ApplyTagChanges", writer.WriteCalls[0].Method)
+	assert.Empty(t, writer.WriteCalls[0].Arg1, "no adds")
+	assert.Equal(t, "urn:li:tag:deprecated,urn:li:tag:QualityIssue", writer.WriteCalls[0].Arg2)
 }
 
 func TestExecuteChanges_FlagQualityIssue_FixedTag(t *testing.T) {
@@ -2566,13 +2600,12 @@ func TestExecuteChanges_FlagQualityIssue_FixedTag(t *testing.T) {
 
 	_, err := tk.executeChanges(context.Background(), testEntityURN, changes)
 	require.NoError(t, err)
-	require.Len(t, writer.WriteCalls, 3)
-
-	// All calls should use the same fixed tag
-	for i, call := range writer.WriteCalls {
-		assert.Equal(t, "AddTag", call.Method, "call %d", i)
-		assert.Equal(t, "urn:li:tag:QualityIssue", call.Arg1, "call %d", i)
-	}
+	// All flag_quality_issue changes batch into a single ApplyTagChanges adding the
+	// fixed QualityIssue tag, regardless of detail text.
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "ApplyTagChanges", writer.WriteCalls[0].Method)
+	assert.Equal(t, "urn:li:tag:QualityIssue,urn:li:tag:QualityIssue,urn:li:tag:QualityIssue", writer.WriteCalls[0].Arg1)
+	assert.Contains(t, writer.TagState[testEntityURN], "urn:li:tag:QualityIssue")
 }
 
 func TestExecuteChanges_GlossaryTermNormalization(t *testing.T) {
@@ -2754,7 +2787,10 @@ func TestHandleApply_AddTagOnNonDatasetSucceeds(t *testing.T) {
 	require.Nil(t, callErr)
 	require.False(t, result.IsError, "tag/glossary/doc/quality ops should work on domains: %v", result.Content)
 
-	assert.Len(t, writer.WriteCalls, 5)
+	// add_tag, remove_tag, and flag_quality_issue batch into one ApplyTagChanges,
+	// leaving add_glossary_term and add_documentation as individual writes.
+	assert.Len(t, writer.WriteCalls, 3)
+	assert.Equal(t, "ApplyTagChanges", writer.WriteCalls[0].Method)
 }
 
 func TestHandleApply_MixedChangesRejectsBeforeExecution(t *testing.T) {

--- a/test/e2e/knowledge_datahub_writer_test.go
+++ b/test/e2e/knowledge_datahub_writer_test.go
@@ -137,13 +137,13 @@ func TestDataHubWriterAddTag(t *testing.T) {
 		cleanCtx, cleanCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cleanCancel()
 
-		if err := writer.RemoveTag(cleanCtx, urn, tagURN); err != nil {
+		if err := writer.ApplyTagChanges(cleanCtx, urn, nil, []string{tagURN}); err != nil {
 			t.Logf("cleanup: failed to remove tag: %v", err)
 		}
 	})
 
 	// Add tag
-	if err := writer.AddTag(ctx, urn, tagURN); err != nil {
+	if err := writer.ApplyTagChanges(ctx, urn, []string{tagURN}, nil); err != nil {
 		t.Fatalf("AddTag: %v", err)
 	}
 
@@ -167,7 +167,7 @@ func TestDataHubWriterRemoveTag(t *testing.T) {
 	tagURN := fmt.Sprintf("urn:li:tag:e2e_writer_%s", nanos())
 
 	// Setup: add tag first
-	if err := writer.AddTag(ctx, urn, tagURN); err != nil {
+	if err := writer.ApplyTagChanges(ctx, urn, []string{tagURN}, nil); err != nil {
 		t.Fatalf("setup AddTag: %v", err)
 	}
 
@@ -176,13 +176,13 @@ func TestDataHubWriterRemoveTag(t *testing.T) {
 		cleanCtx, cleanCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cleanCancel()
 
-		if err := writer.RemoveTag(cleanCtx, urn, tagURN); err != nil {
+		if err := writer.ApplyTagChanges(cleanCtx, urn, nil, []string{tagURN}); err != nil {
 			t.Logf("cleanup: failed to remove tag: %v", err)
 		}
 	})
 
 	// Remove tag
-	if err := writer.RemoveTag(ctx, urn, tagURN); err != nil {
+	if err := writer.ApplyTagChanges(ctx, urn, nil, []string{tagURN}); err != nil {
 		t.Fatalf("RemoveTag: %v", err)
 	}
 


### PR DESCRIPTION
Closes #721

## Problem

`apply_knowledge` `change_type: add_tag` (sink=datahub) silently dropped tags. Each tag was written through the upstream `mcp-datahub` client's per-tag read-modify-write of the `globalTags` aspect: read the current tags, append one, overwrite the whole aspect. Because DataHub aspect reads are eventually consistent, back-to-back per-tag writes read stale (pre-write) state, append a single tag, and overwrite `globalTags` with just that tag. Last write wins, so tags are silently lost.

Observed (v1.94.0):
- A 4-tag apply `[a, b, c, d]` ended with only `d`.
- A later single `add_tag a` on an entity that already had `b` left only `a`.
- Rolling back an `add_tag` changeset left the entity with **zero** tags.
- `flag_quality_issue` (which sets a `QualityIssue` tag) co-applied with an `add_tag` was clobbered.

## Fix

Replace the per-tag `AddTag`/`RemoveTag` methods on the `DataHubWriter` interface with a single `ApplyTagChanges(ctx, urn, add, remove)` that reads `globalTags` once, merges every add and remove, and writes once. A single read-modify-write per entity removes the back-to-back race entirely.

- **Apply** (`pkg/toolkits/knowledge/toolkit.go`): `partitionTagChanges` pulls `add_tag`, `remove_tag`, and `flag_quality_issue` out of the per-change dispatch and applies them in one `ApplyTagChanges` call.
- **Rollback** (`pkg/toolkits/knowledge/rollback.go`): `revertTagChanges` aggregates every tag inverse for a changeset (a rollback can mix added and removed tags) into one atomic `ApplyTagChanges` call. This is what fixes the zero-after-rollback case: the previous per-term inverse writes raced the same way.

### Why REST read-modify-write and not the server-side GraphQL `addTag` mutation

DataHub exposes an additive `addTag` GraphQL mutation, but its resolver requires the referenced tag entity to already exist, and this platform has no create-tag step. Routing through GraphQL would regress applying a brand-new tag. The REST read-modify-write preserves the lenient URN-reference write the deployed path relied on, and mirrors the existing `UpdateColumnDescriptionBatch` precedent in the same file.

## Additional correctness fixes (from review of this change)

- **Preserve association metadata:** the merged write keeps each surviving tag association as raw JSON, so a tag's propagation `context`/`attribution` is not stripped when an unrelated tag is added or removed.
- **Restore the entity-type guard:** `ApplyTagChanges` rejects entity types that do not support the `globalTags` aspect with a clear error, matching the guard the upstream per-tag path enforced before this batched path bypassed it.
- **GraphQL dedup parity:** for entity types whose `globalTags` aspect is GraphQL-only (domain, glossaryTerm, glossaryNode, document), a tag present in both add and remove is left removed, matching the REST path and the documented contract.
- **Honest partial-failure message:** `dispatchNonColumnChanges` no longer reports "no changes were applied" when a batched tag or column-description write already persisted before a later per-change failure.

## Tests

- Client-writer unit tests for: multi-tag no-clobber (single read, single write), add merges existing, remove, mixed add+remove, dedup, unsupported entity type, association-metadata preservation, GraphQL-type path and its add/remove dedup, and the parse helpers.
- Apply-path tests asserting the three tag change types collapse into one batched `ApplyTagChanges`, plus the honest-error path when a dispatch fails after a tag batch.
- Rollback tests including a multi-tag changeset reverting in a single batched call while keeping a pre-existing tag.
- `test/e2e` integration test updated to the new method.

`make verify` passes locally (race tests, coverage >=80%, lint, gosec/govulncheck, semgrep, mutation, GoReleaser dry-run).

## Out of scope

`add_glossary_term` has the identical read-modify-write clobber in a separate code path (the `glossaryTerms` aspect, which additionally carries a required `auditStamp`). Tracked in #729.