### PR TITLE
fix(knowledge): batch glossary-term writes into one read-modify-write to stop clobber

### DIFF
--- a/pkg/admin/knowledge_test.go
+++ b/pkg/admin/knowledge_test.go
@@ -213,9 +213,8 @@ func (m *mockDataHubWriter) ApplyTagChanges(_ context.Context, _ string, _, remo
 	m.removeTagCalls = append(m.removeTagCalls, remove...)
 	return nil
 }
-func (*mockDataHubWriter) AddGlossaryTerm(_ context.Context, _, _ string) error { return nil }
-func (m *mockDataHubWriter) RemoveGlossaryTerm(_ context.Context, _, termURN string) error {
-	m.removeTermCalls = append(m.removeTermCalls, termURN)
+func (m *mockDataHubWriter) ApplyGlossaryTermChanges(_ context.Context, _ string, _, remove []string) error {
+	m.removeTermCalls = append(m.removeTermCalls, remove...)
 	return nil
 }
 

--- a/pkg/toolkits/knowledge/datahub_client_writer.go
+++ b/pkg/toolkits/knowledge/datahub_client_writer.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	dhclient "github.com/txn2/mcp-datahub/pkg/client"
 	"github.com/txn2/mcp-datahub/pkg/types"
@@ -126,37 +127,50 @@ type editableFieldInfo struct {
 	GlossaryTerms json.RawMessage `json:"glossaryTerms,omitempty"`
 }
 
-// readEditableSchema reads the current editableSchemaMetadata aspect via REST.
-func (w *DataHubClientWriter) readEditableSchema(ctx context.Context, entityType, urn string) (*editableSchemaAspect, error) {
-	body, statusCode, err := w.doRESTGet(ctx, w.aspectGetURL(entityType, urn, "editableSchemaMetadata"))
+// readAspect performs a REST aspect GET and parses the response into *T, returning a
+// zero-valued *T when the aspect does not exist (404 or an empty/null value). Shared
+// by the editableSchemaMetadata, globalTags, and glossaryTerms read paths.
+func readAspect[T any](ctx context.Context, w *DataHubClientWriter, entityType, urn, aspectName string) (*T, error) {
+	body, statusCode, err := w.doRESTGet(ctx, w.aspectGetURL(entityType, urn, aspectName))
 	if err != nil {
 		return nil, fmt.Errorf("rest get aspect: %w", err)
 	}
 	if statusCode == http.StatusNotFound {
-		return &editableSchemaAspect{}, nil
+		return new(T), nil
 	}
 	if statusCode != http.StatusOK {
 		return nil, fmt.Errorf("rest get status %d: %s", statusCode, truncateBody(body))
 	}
-	return parseEditableSchema(body)
+	return parseAspect[T](body)
 }
 
-// parseEditableSchema unmarshals the REST response body into an editableSchemaAspect.
-func parseEditableSchema(body []byte) (*editableSchemaAspect, error) {
+// parseAspect unmarshals a REST aspect GET response (a {"value": <aspect>} envelope)
+// into *T, returning a zero-valued *T when the aspect is absent (empty or null value).
+func parseAspect[T any](body []byte) (*T, error) {
 	var aspectResp struct {
 		Value json.RawMessage `json:"value"`
 	}
 	if err := json.Unmarshal(body, &aspectResp); err != nil {
 		return nil, fmt.Errorf("unmarshal response: %w", err)
 	}
+	out := new(T)
 	if len(aspectResp.Value) == 0 || string(bytes.TrimSpace(aspectResp.Value)) == "null" {
-		return &editableSchemaAspect{}, nil
+		return out, nil
 	}
-	var schema editableSchemaAspect
-	if err := json.Unmarshal(aspectResp.Value, &schema); err != nil {
-		return nil, fmt.Errorf("unmarshal schema: %w", err)
+	if err := json.Unmarshal(aspectResp.Value, out); err != nil {
+		return nil, fmt.Errorf("unmarshal aspect: %w", err)
 	}
-	return &schema, nil
+	return out, nil
+}
+
+// readEditableSchema reads the current editableSchemaMetadata aspect via REST.
+func (w *DataHubClientWriter) readEditableSchema(ctx context.Context, entityType, urn string) (*editableSchemaAspect, error) {
+	return readAspect[editableSchemaAspect](ctx, w, entityType, urn, "editableSchemaMetadata")
+}
+
+// parseEditableSchema unmarshals the REST response body into an editableSchemaAspect.
+func parseEditableSchema(body []byte) (*editableSchemaAspect, error) {
+	return parseAspect[editableSchemaAspect](body)
 }
 
 // aspectGetURL builds the REST URL for reading an aspect.
@@ -310,13 +324,13 @@ var tagSupportedTypes = map[string]bool{
 	"domain": true, "glossaryTerm": true, "glossaryNode": true, "document": true,
 }
 
-// tagGraphQLWriteTypes lists entity types whose globalTags aspect is not exposed
-// over the REST aspect API, so the upstream client writes them with the GraphQL
-// addTag/removeTag mutations instead. Those mutations are server-side additive and
-// not subject to the read-modify-write clobber, so for these types ApplyTagChanges
-// delegates per-tag rather than batching a REST read-modify-write. Mirrors the
-// upstream client's graphQLWriteTypes set.
-var tagGraphQLWriteTypes = map[string]bool{
+// graphQLWriteTypes lists entity types whose globalTags/glossaryTerms aspects are
+// not exposed over the REST aspect API, so the upstream client writes them with
+// GraphQL mutations instead. Those mutations are server-side additive and not
+// subject to the read-modify-write clobber, so for these types ApplyTagChanges and
+// ApplyGlossaryTermChanges delegate per-item rather than batching a REST
+// read-modify-write. Mirrors the upstream client's graphQLWriteTypes set.
+var graphQLWriteTypes = map[string]bool{
 	"domain": true, "glossaryTerm": true, "glossaryNode": true, "document": true,
 }
 
@@ -338,10 +352,35 @@ func (w *DataHubClientWriter) ApplyTagChanges(ctx context.Context, urn string, a
 	if !tagSupportedTypes[parsed.EntityType] {
 		return fmt.Errorf("apply tag changes: entity type %q does not support tag operations", parsed.EntityType)
 	}
-	if tagGraphQLWriteTypes[parsed.EntityType] {
+	if graphQLWriteTypes[parsed.EntityType] {
 		return w.applyTagChangesGraphQL(ctx, urn, add, remove)
 	}
 	return w.applyTagChangesREST(ctx, parsed.EntityType, urn, add, remove)
+}
+
+// applyAssociationChangesGraphQL removes then adds items via per-item GraphQL
+// mutations, skipping an add that is also a remove (so an item present in both is
+// left removed, matching the REST merge semantics and the Apply*Changes contracts).
+// removeFn/addFn perform and wrap each per-item call.
+func applyAssociationChangesGraphQL(add, remove []string, removeFn, addFn func(string) error) error {
+	removeSet := make(map[string]bool, len(remove))
+	for _, x := range remove {
+		removeSet[x] = true
+	}
+	for _, x := range remove {
+		if err := removeFn(x); err != nil {
+			return err
+		}
+	}
+	for _, x := range add {
+		if removeSet[x] {
+			continue
+		}
+		if err := addFn(x); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // applyTagChangesGraphQL applies tag changes for entity types whose globalTags
@@ -349,26 +388,19 @@ func (w *DataHubClientWriter) ApplyTagChanges(ctx context.Context, urn string, a
 // document). The upstream AddTag/RemoveTag use the server-side additive GraphQL
 // mutations for these types, which are already lossless, so we delegate per-tag.
 func (w *DataHubClientWriter) applyTagChangesGraphQL(ctx context.Context, urn string, add, remove []string) error {
-	removeSet := make(map[string]bool, len(remove))
-	for _, tag := range remove {
-		removeSet[tag] = true
-	}
-	for _, tag := range remove {
-		if err := w.client.RemoveTag(ctx, urn, tag); err != nil {
-			return fmt.Errorf("removing tag %s from %s: %w", tag, urn, err)
-		}
-	}
-	for _, tag := range add {
-		// A tag in both add and remove is left removed, matching the REST path and
-		// the ApplyTagChanges contract.
-		if removeSet[tag] {
-			continue
-		}
-		if err := w.client.AddTag(ctx, urn, tag); err != nil {
-			return fmt.Errorf("adding tag %s to %s: %w", tag, urn, err)
-		}
-	}
-	return nil
+	return applyAssociationChangesGraphQL(add, remove,
+		func(tag string) error {
+			if err := w.client.RemoveTag(ctx, urn, tag); err != nil {
+				return fmt.Errorf("removing tag %s from %s: %w", tag, urn, err)
+			}
+			return nil
+		},
+		func(tag string) error {
+			if err := w.client.AddTag(ctx, urn, tag); err != nil {
+				return fmt.Errorf("adding tag %s to %s: %w", tag, urn, err)
+			}
+			return nil
+		})
 }
 
 // applyTagChangesREST reads the current globalTags aspect once, applies all
@@ -386,11 +418,18 @@ func (w *DataHubClientWriter) applyTagChangesREST(ctx context.Context, entityTyp
 	return w.postIngestProposal(ctx, entityType, urn, "globalTags", current)
 }
 
-// mergeGlobalTags returns the globalTags associations after removing every tag in
-// remove and appending every tag in add that is not already present, deduped. Each
-// surviving existing association's full JSON is preserved (context/attribution),
-// and a tag present in both add and remove is removed.
-func mergeGlobalTags(current []json.RawMessage, add, remove []string) ([]json.RawMessage, error) {
+// mergeRawAssociations returns the aspect associations after removing every URN in
+// remove and appending every URN in add that is not already present, deduped. Each
+// surviving existing association's full JSON is preserved, and a URN present in both
+// add and remove is removed. urnOf extracts the URN from a raw association; newAssoc
+// marshals a new association for an added URN. Shared by the globalTags and
+// glossaryTerms read-modify-write paths.
+func mergeRawAssociations(
+	current []json.RawMessage,
+	add, remove []string,
+	urnOf func(json.RawMessage) string,
+	newAssoc func(string) ([]byte, error),
+) ([]json.RawMessage, error) {
 	removeSet := make(map[string]bool, len(remove))
 	for _, t := range remove {
 		removeSet[t] = true
@@ -399,8 +438,15 @@ func mergeGlobalTags(current []json.RawMessage, add, remove []string) ([]json.Ra
 	merged := make([]json.RawMessage, 0, len(current)+len(add))
 	have := make(map[string]bool, len(current)+len(add))
 	for _, raw := range current {
-		u := tagURNOf(raw)
-		if u == "" || removeSet[u] || have[u] {
+		u := urnOf(raw)
+		// An association whose URN cannot be extracted is preserved as-is rather than
+		// dropped: it cannot be deduped or matched for removal, but discarding it would
+		// silently lose a tag/term on an unrelated change.
+		if u == "" {
+			merged = append(merged, raw)
+			continue
+		}
+		if removeSet[u] || have[u] {
 			continue
 		}
 		have[u] = true
@@ -411,63 +457,165 @@ func mergeGlobalTags(current []json.RawMessage, add, remove []string) ([]json.Ra
 			continue
 		}
 		have[t] = true
-		assoc, err := json.Marshal(tagAssociation{Tag: t})
+		assoc, err := newAssoc(t)
 		if err != nil {
-			return nil, fmt.Errorf("marshal tag %s: %w", t, err)
+			return nil, err
 		}
 		merged = append(merged, assoc)
 	}
 	return merged, nil
 }
 
+// mergeGlobalTags merges tag adds/removes into the current globalTags associations,
+// preserving each surviving association's full JSON (context/attribution).
+func mergeGlobalTags(current []json.RawMessage, add, remove []string) ([]json.RawMessage, error) {
+	return mergeRawAssociations(current, add, remove, tagURNOf, func(t string) ([]byte, error) {
+		assoc, err := json.Marshal(tagAssociation{Tag: t})
+		if err != nil {
+			return nil, fmt.Errorf("marshal tag %s: %w", t, err)
+		}
+		return assoc, nil
+	})
+}
+
 // readGlobalTags reads the current globalTags aspect via the REST aspect API,
 // returning an empty aspect when none exists.
 func (w *DataHubClientWriter) readGlobalTags(ctx context.Context, entityType, urn string) (*globalTagsAspect, error) {
-	body, statusCode, err := w.doRESTGet(ctx, w.aspectGetURL(entityType, urn, "globalTags"))
-	if err != nil {
-		return nil, fmt.Errorf("rest get aspect: %w", err)
-	}
-	if statusCode == http.StatusNotFound {
-		return &globalTagsAspect{}, nil
-	}
-	if statusCode != http.StatusOK {
-		return nil, fmt.Errorf("rest get status %d: %s", statusCode, truncateBody(body))
-	}
-	return parseGlobalTags(body)
+	return readAspect[globalTagsAspect](ctx, w, entityType, urn, "globalTags")
 }
 
 // parseGlobalTags unmarshals the REST response body into a globalTagsAspect.
 func parseGlobalTags(body []byte) (*globalTagsAspect, error) {
-	var aspectResp struct {
-		Value json.RawMessage `json:"value"`
-	}
-	if err := json.Unmarshal(body, &aspectResp); err != nil {
-		return nil, fmt.Errorf("unmarshal response: %w", err)
-	}
-	if len(aspectResp.Value) == 0 || string(bytes.TrimSpace(aspectResp.Value)) == "null" {
-		return &globalTagsAspect{}, nil
-	}
-	var aspect globalTagsAspect
-	if err := json.Unmarshal(aspectResp.Value, &aspect); err != nil {
-		return nil, fmt.Errorf("unmarshal globalTags: %w", err)
-	}
-	return &aspect, nil
+	return parseAspect[globalTagsAspect](body)
 }
 
-// AddGlossaryTerm adds a glossary term to an entity.
-func (w *DataHubClientWriter) AddGlossaryTerm(ctx context.Context, urn, termURN string) error {
-	if err := w.client.AddGlossaryTerm(ctx, urn, termURN); err != nil {
-		return fmt.Errorf("adding glossary term %s to %s: %w", termURN, urn, err)
-	}
-	return nil
+// glossaryTermsAspect mirrors the upstream glossaryTerms aspect. Associations are
+// kept as raw JSON so fields beyond the term URN survive a read-modify-write. Per
+// the GlossaryTerms PDL, auditStamp is required and is set on every write.
+type glossaryTermsAspect struct {
+	Terms      []json.RawMessage  `json:"terms"`
+	AuditStamp glossaryAuditStamp `json:"auditStamp"`
 }
 
-// RemoveGlossaryTerm removes a glossary term association from an entity.
-func (w *DataHubClientWriter) RemoveGlossaryTerm(ctx context.Context, urn, termURN string) error {
-	if err := w.client.RemoveGlossaryTerm(ctx, urn, termURN); err != nil {
-		return fmt.Errorf("removing glossary term %s from %s: %w", termURN, urn, err)
+// termAssociation is the minimal shape used to emit a new term association and to
+// extract the term URN from an existing raw association for dedupe/removal.
+type termAssociation struct {
+	URN string `json:"urn"`
+}
+
+// glossaryAuditStamp is the required audit metadata on the glossaryTerms aspect.
+type glossaryAuditStamp struct {
+	Time  int64  `json:"time"`
+	Actor string `json:"actor"`
+}
+
+// glossaryAuditActor mirrors the system actor the upstream client stamps writes with.
+const glossaryAuditActor = "urn:li:corpuser:datahub"
+
+// newGlossaryAuditStamp builds the required auditStamp for a glossaryTerms write.
+func newGlossaryAuditStamp() glossaryAuditStamp {
+	return glossaryAuditStamp{Time: time.Now().UnixMilli(), Actor: glossaryAuditActor}
+}
+
+// glossaryTermURNOf extracts the term URN from a raw glossaryTerms association,
+// returning "" if it cannot be parsed.
+func glossaryTermURNOf(raw json.RawMessage) string {
+	var ta termAssociation
+	if err := json.Unmarshal(raw, &ta); err != nil {
+		return ""
 	}
-	return nil
+	return ta.URN
+}
+
+// glossaryTermSupportedTypes lists entity types DataHub registers the glossaryTerms
+// aspect on. Mirrors the upstream client's glossaryTermsSupportedTypes set (kept
+// separate from the tag set because DataHub may add support to each independently).
+var glossaryTermSupportedTypes = map[string]bool{
+	"dataset": true, "dashboard": true, "chart": true, "dataFlow": true,
+	"dataJob": true, "container": true, "dataProduct": true,
+	"domain": true, "glossaryTerm": true, "glossaryNode": true, "document": true,
+}
+
+// ApplyGlossaryTermChanges adds and removes glossary terms on an entity in a single
+// read-modify-write of the glossaryTerms aspect. Delegating to the upstream client's
+// per-term AddGlossaryTerm/RemoveGlossaryTerm issues a read-modify-write per term;
+// because DataHub aspect writes are eventually consistent, back-to-back calls read
+// stale state and the final write overwrites the whole aspect with a single term,
+// silently dropping the rest (#729). Reading once, merging every add/remove, and
+// writing once is lossless. A term present in both add and remove is removed.
+func (w *DataHubClientWriter) ApplyGlossaryTermChanges(ctx context.Context, urn string, add, remove []string) error {
+	if len(add) == 0 && len(remove) == 0 {
+		return nil
+	}
+	parsed, err := dhclient.ParseURN(urn)
+	if err != nil {
+		return fmt.Errorf("apply glossary term changes: invalid URN: %w", err)
+	}
+	if !glossaryTermSupportedTypes[parsed.EntityType] {
+		return fmt.Errorf("apply glossary term changes: entity type %q does not support glossary term operations", parsed.EntityType)
+	}
+	if graphQLWriteTypes[parsed.EntityType] {
+		return w.applyGlossaryTermChangesGraphQL(ctx, urn, add, remove)
+	}
+	return w.applyGlossaryTermChangesREST(ctx, parsed.EntityType, urn, add, remove)
+}
+
+// applyGlossaryTermChangesGraphQL applies term changes for entity types whose
+// glossaryTerms aspect is only writable via GraphQL (domain, glossaryTerm,
+// glossaryNode, document), delegating per-term to the upstream lossless mutations.
+func (w *DataHubClientWriter) applyGlossaryTermChangesGraphQL(ctx context.Context, urn string, add, remove []string) error {
+	return applyAssociationChangesGraphQL(add, remove,
+		func(term string) error {
+			if err := w.client.RemoveGlossaryTerm(ctx, urn, term); err != nil {
+				return fmt.Errorf("removing glossary term %s from %s: %w", term, urn, err)
+			}
+			return nil
+		},
+		func(term string) error {
+			if err := w.client.AddGlossaryTerm(ctx, urn, term); err != nil {
+				return fmt.Errorf("adding glossary term %s to %s: %w", term, urn, err)
+			}
+			return nil
+		})
+}
+
+// applyGlossaryTermChangesREST reads the current glossaryTerms aspect once, applies
+// all removes and adds, refreshes the required auditStamp, and writes once.
+func (w *DataHubClientWriter) applyGlossaryTermChangesREST(ctx context.Context, entityType, urn string, add, remove []string) error {
+	current, err := w.readGlossaryTerms(ctx, entityType, urn)
+	if err != nil {
+		return fmt.Errorf("apply glossary term changes: read glossaryTerms: %w", err)
+	}
+	merged, err := mergeGlossaryTerms(current.Terms, add, remove)
+	if err != nil {
+		return fmt.Errorf("apply glossary term changes: %w", err)
+	}
+	current.Terms = merged
+	current.AuditStamp = newGlossaryAuditStamp()
+	return w.postIngestProposal(ctx, entityType, urn, "glossaryTerms", current)
+}
+
+// mergeGlossaryTerms merges term adds/removes into the current glossaryTerms
+// associations, preserving each surviving association's full JSON.
+func mergeGlossaryTerms(current []json.RawMessage, add, remove []string) ([]json.RawMessage, error) {
+	return mergeRawAssociations(current, add, remove, glossaryTermURNOf, func(t string) ([]byte, error) {
+		assoc, err := json.Marshal(termAssociation{URN: t})
+		if err != nil {
+			return nil, fmt.Errorf("marshal glossary term %s: %w", t, err)
+		}
+		return assoc, nil
+	})
+}
+
+// readGlossaryTerms reads the current glossaryTerms aspect via the REST aspect API,
+// returning an empty aspect when none exists.
+func (w *DataHubClientWriter) readGlossaryTerms(ctx context.Context, entityType, urn string) (*glossaryTermsAspect, error) {
+	return readAspect[glossaryTermsAspect](ctx, w, entityType, urn, "glossaryTerms")
+}
+
+// parseGlossaryTerms unmarshals the REST response body into a glossaryTermsAspect.
+func parseGlossaryTerms(body []byte) (*glossaryTermsAspect, error) {
+	return parseAspect[glossaryTermsAspect](body)
 }
 
 // AddDocumentationLink adds a documentation link to an entity.

--- a/pkg/toolkits/knowledge/datahub_client_writer_test.go
+++ b/pkg/toolkits/knowledge/datahub_client_writer_test.go
@@ -439,6 +439,33 @@ func TestDataHubClientWriter_ApplyTagChanges_PreservesAssociationFields(t *testi
 	assert.Contains(t, body, "urn:li:tag:New")
 }
 
+// TestDataHubClientWriter_ApplyTagChanges_PreservesUnparseableAssociation verifies
+// that an existing association whose URN cannot be extracted is preserved on the
+// merged write rather than silently dropped.
+func TestDataHubClientWriter_ApplyTagChanges_PreservesUnparseableAssociation(t *testing.T) {
+	var posted []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			// One well-formed association and one without a parseable tag URN.
+			_, _ = w.Write([]byte(`{"value":{"tags":[{"tag":"urn:li:tag:Keep"},{"weird":true}]}}`))
+			return
+		}
+		posted, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyTagChanges(context.Background(), testURN, []string{"urn:li:tag:New"}, nil)
+	require.NoError(t, err)
+
+	body := string(posted)
+	assert.Contains(t, body, "urn:li:tag:Keep")
+	assert.Contains(t, body, "weird", "an association without a parseable URN must be preserved, not dropped")
+	assert.Contains(t, body, "urn:li:tag:New")
+}
+
 func TestDataHubClientWriter_ApplyTagChanges_UnsupportedType(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		t.Error("unsupported entity types must be rejected before any DataHub call")
@@ -504,33 +531,214 @@ func TestParseGlobalTags_InvalidJSON(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestDataHubClientWriter_AddGlossaryTerm(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// glossaryTermsServer mirrors globalTagsServer for the glossaryTerms aspect: it
+// serves the given existing terms on GET and captures the POSTed aspect body,
+// counting reads and writes.
+func glossaryTermsServer(t *testing.T, existing []string, posted *[]byte, gets, posts *int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			w.WriteHeader(http.StatusNotFound)
+			*gets++
+			if existing == nil {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			assocs := make([]string, 0, len(existing))
+			for _, term := range existing {
+				assocs = append(assocs, `{"urn":"`+term+`"}`)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"value":{"terms":[` + strings.Join(assocs, ",") + `]}}`))
 		case http.MethodPost:
+			*posts++
+			*posted, _ = io.ReadAll(r.Body)
 			w.WriteHeader(http.StatusOK)
 		}
 	}))
+}
+
+// TestDataHubClientWriter_ApplyGlossaryTermChanges_NoClobber is the #729 regression:
+// adding several terms in one call must read once and write all of them, with the
+// required auditStamp, not clobber down to a single term.
+func TestDataHubClientWriter_ApplyGlossaryTermChanges_NoClobber(t *testing.T) {
+	var posted []byte
+	var gets, posts int
+	server := glossaryTermsServer(t, nil, &posted, &gets, &posts)
 	defer server.Close()
 
 	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
-	err := writer.AddGlossaryTerm(context.Background(), testURN, "urn:li:glossaryTerm:Revenue")
-
+	terms := []string{"urn:li:glossaryTerm:a", "urn:li:glossaryTerm:b", "urn:li:glossaryTerm:c"}
+	err := writer.ApplyGlossaryTermChanges(context.Background(), testURN, terms, nil)
 	require.NoError(t, err)
+
+	assert.Equal(t, 1, gets, "a batched apply reads once")
+	assert.Equal(t, 1, posts, "a batched apply writes once")
+	body := string(posted)
+	for _, term := range terms {
+		assert.Contains(t, body, term, "all terms must survive the single write")
+	}
+	assert.Contains(t, body, "auditStamp", "the required auditStamp must be written")
+	assert.Contains(t, body, glossaryAuditActor)
 }
 
-func TestDataHubClientWriter_AddGlossaryTerm_Error(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`server error`))
+func TestDataHubClientWriter_ApplyGlossaryTermChanges_AddMergesExisting(t *testing.T) {
+	var posted []byte
+	var gets, posts int
+	server := glossaryTermsServer(t, []string{"urn:li:glossaryTerm:Existing"}, &posted, &gets, &posts)
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyGlossaryTermChanges(context.Background(), testURN, []string{"urn:li:glossaryTerm:New"}, nil)
+	require.NoError(t, err)
+
+	body := string(posted)
+	assert.Contains(t, body, "urn:li:glossaryTerm:Existing", "existing term must be preserved")
+	assert.Contains(t, body, "urn:li:glossaryTerm:New")
+	assert.Equal(t, 1, gets)
+	assert.Equal(t, 1, posts)
+}
+
+func TestDataHubClientWriter_ApplyGlossaryTermChanges_Remove(t *testing.T) {
+	var posted []byte
+	var gets, posts int
+	server := glossaryTermsServer(t, []string{"urn:li:glossaryTerm:Keep", "urn:li:glossaryTerm:Drop"}, &posted, &gets, &posts)
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyGlossaryTermChanges(context.Background(), testURN, nil, []string{"urn:li:glossaryTerm:Drop"})
+	require.NoError(t, err)
+
+	body := string(posted)
+	assert.Contains(t, body, "urn:li:glossaryTerm:Keep")
+	assert.NotContains(t, body, "urn:li:glossaryTerm:Drop")
+}
+
+func TestDataHubClientWriter_ApplyGlossaryTermChanges_NoChanges(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("ApplyGlossaryTermChanges with no add/remove must not hit DataHub")
 	}))
 	defer server.Close()
 
 	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
-	err := writer.AddGlossaryTerm(context.Background(), testURN, "urn:li:glossaryTerm:Revenue")
+	require.NoError(t, writer.ApplyGlossaryTermChanges(context.Background(), testURN, nil, nil))
+}
 
+func TestDataHubClientWriter_ApplyGlossaryTermChanges_UnsupportedType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("unsupported entity types must be rejected before any DataHub call")
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyGlossaryTermChanges(context.Background(),
+		"urn:li:mlModel:(urn:li:dataPlatform:science,model,PROD)", []string{"urn:li:glossaryTerm:x"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support glossary term operations")
+}
+
+func TestDataHubClientWriter_ApplyGlossaryTermChanges_InvalidURN(t *testing.T) {
+	writer := NewDataHubClientWriter(newTestClient(t, "http://unused"))
+	err := writer.ApplyGlossaryTermChanges(context.Background(), "not-a-urn", []string{"urn:li:glossaryTerm:x"}, nil)
+	assert.Error(t, err)
+}
+
+func TestDataHubClientWriter_ApplyGlossaryTermChanges_ReadError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`boom`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyGlossaryTermChanges(context.Background(), testURN, []string{"urn:li:glossaryTerm:x"}, nil)
+	assert.Error(t, err)
+}
+
+func TestDataHubClientWriter_ApplyGlossaryTermChanges_WriteError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`boom`))
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyGlossaryTermChanges(context.Background(), testURN, []string{"urn:li:glossaryTerm:x"}, nil)
+	assert.Error(t, err)
+}
+
+// TestDataHubClientWriter_ApplyGlossaryTermChanges_GraphQLType verifies that for
+// entity types whose glossaryTerms aspect is GraphQL-only, term changes go through
+// the upstream per-term GraphQL mutation rather than a REST aspect write, and a term
+// in both add and remove is left removed.
+func TestDataHubClientWriter_ApplyGlossaryTermChanges_GraphQLType(t *testing.T) {
+	var addedTerms []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "GraphQL types must not issue REST aspect GETs")
+		body, _ := io.ReadAll(r.Body)
+		s := string(body)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(s, "removeTerm") {
+			_ = json.NewEncoder(w).Encode(graphQLResponse{Data: json.RawMessage(`{"removeTerm":true}`)})
+			return
+		}
+		if strings.Contains(s, "urn:li:glossaryTerm:Both") {
+			addedTerms = append(addedTerms, "urn:li:glossaryTerm:Both")
+		}
+		_ = json.NewEncoder(w).Encode(graphQLResponse{Data: json.RawMessage(`{"addTerm":true}`)})
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	err := writer.ApplyGlossaryTermChanges(context.Background(),
+		"urn:li:domain:sales", []string{"urn:li:glossaryTerm:Both"}, []string{"urn:li:glossaryTerm:Both"})
+	require.NoError(t, err)
+	assert.Empty(t, addedTerms, "a term in both add and remove must not be re-added")
+}
+
+func TestDataHubClientWriter_ApplyGlossaryTermChanges_GraphQLTypeError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`boom`))
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	addErr := writer.ApplyGlossaryTermChanges(context.Background(), "urn:li:domain:sales", []string{"urn:li:glossaryTerm:x"}, nil)
+	assert.Error(t, addErr)
+	removeErr := writer.ApplyGlossaryTermChanges(context.Background(), "urn:li:domain:sales", nil, []string{"urn:li:glossaryTerm:x"})
+	assert.Error(t, removeErr)
+}
+
+func TestGlossaryTermURNOf(t *testing.T) {
+	assert.Equal(t, "urn:li:glossaryTerm:a", glossaryTermURNOf([]byte(`{"urn":"urn:li:glossaryTerm:a"}`)))
+	assert.Empty(t, glossaryTermURNOf([]byte(`{"nourn":1}`)))
+	assert.Empty(t, glossaryTermURNOf([]byte(`not json`)))
+}
+
+func TestParseGlossaryTerms(t *testing.T) {
+	aspect, err := parseGlossaryTerms([]byte(`{"value":{"terms":[{"urn":"urn:li:glossaryTerm:a"}]}}`))
+	require.NoError(t, err)
+	require.Len(t, aspect.Terms, 1)
+	assert.Equal(t, "urn:li:glossaryTerm:a", glossaryTermURNOf(aspect.Terms[0]))
+}
+
+func TestParseGlossaryTerms_NullValue(t *testing.T) {
+	aspect, err := parseGlossaryTerms([]byte(`{"value":null}`))
+	require.NoError(t, err)
+	assert.Empty(t, aspect.Terms)
+}
+
+func TestParseGlossaryTerms_InvalidJSON(t *testing.T) {
+	_, err := parseGlossaryTerms([]byte(`not json`))
 	assert.Error(t, err)
 }
 

--- a/pkg/toolkits/knowledge/datahub_writer.go
+++ b/pkg/toolkits/knowledge/datahub_writer.go
@@ -22,9 +22,13 @@ type DataHubWriter interface {
 	// Batching every add/remove for an entity into one read-modify-write is lossless.
 	// add and remove hold full TagUrns; a tag in both add and remove is removed.
 	ApplyTagChanges(ctx context.Context, urn string, add, remove []string) error
-	AddGlossaryTerm(ctx context.Context, urn string, termURN string) error
-	// RemoveGlossaryTerm removes a glossary term association. Used to revert add_glossary_term.
-	RemoveGlossaryTerm(ctx context.Context, urn string, termURN string) error
+	// ApplyGlossaryTermChanges adds and removes the given glossary terms in a single
+	// read-modify-write of the glossaryTerms aspect. Per-term writes are
+	// read-modify-write against DataHub's eventually consistent store, so back-to-back
+	// single calls read stale state and the last write clobbers the rest, silently
+	// dropping terms (#729, same class of bug as #721). add and remove hold full
+	// glossaryTerm URNs; a term in both add and remove is removed.
+	ApplyGlossaryTermChanges(ctx context.Context, urn string, add, remove []string) error
 	AddDocumentationLink(ctx context.Context, urn string, url string, description string) error
 	// RemoveDocumentationLink removes a documentation link by URL. Used to revert add_documentation.
 	RemoveDocumentationLink(ctx context.Context, urn string, url string) error
@@ -73,11 +77,10 @@ func (*NoopDataHubWriter) ApplyTagChanges(_ context.Context, _ string, _, _ []st
 	return nil
 }
 
-// AddGlossaryTerm is a no-op.
-func (*NoopDataHubWriter) AddGlossaryTerm(_ context.Context, _, _ string) error { return nil }
-
-// RemoveGlossaryTerm is a no-op.
-func (*NoopDataHubWriter) RemoveGlossaryTerm(_ context.Context, _, _ string) error { return nil }
+// ApplyGlossaryTermChanges is a no-op.
+func (*NoopDataHubWriter) ApplyGlossaryTermChanges(_ context.Context, _ string, _, _ []string) error {
+	return nil
+}
 
 // AddDocumentationLink is a no-op.
 func (*NoopDataHubWriter) AddDocumentationLink(_ context.Context, _, _, _ string) error { return nil }

--- a/pkg/toolkits/knowledge/datahub_writer_test.go
+++ b/pkg/toolkits/knowledge/datahub_writer_test.go
@@ -45,9 +45,10 @@ func TestNoopDataHubWriter_ApplyTagChanges(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestNoopDataHubWriter_AddGlossaryTerm(t *testing.T) {
+func TestNoopDataHubWriter_ApplyGlossaryTermChanges(t *testing.T) {
 	writer := &NoopDataHubWriter{}
-	err := writer.AddGlossaryTerm(context.Background(), testDatasetURN, "urn:li:glossaryTerm:revenue")
+	err := writer.ApplyGlossaryTermChanges(context.Background(), testDatasetURN,
+		[]string{"urn:li:glossaryTerm:revenue"}, []string{"urn:li:glossaryTerm:old"})
 	assert.NoError(t, err)
 }
 

--- a/pkg/toolkits/knowledge/rollback.go
+++ b/pkg/toolkits/knowledge/rollback.go
@@ -181,20 +181,31 @@ func applyInverseChanges(
 	changes []recordedChange,
 	prior priorState,
 ) (reverted, skipped []string, err error) {
-	// Tag inverses are reverted in a single read-modify-write. Reverting each tag
-	// with its own write reads DataHub's eventually consistent state back-to-back,
-	// so the last write clobbers the rest and a multi-tag rollback could leave the
-	// entity with zero tags instead of its prior set (#721). Non-tag inverses
-	// (description, glossary term, documentation) are reverted individually.
+	// Tag and glossary-term inverses are each reverted in a single read-modify-write.
+	// Reverting each one with its own write reads DataHub's eventually consistent
+	// state back-to-back, so the last write clobbers the rest and a multi-item
+	// rollback could leave the entity with zero tags/terms instead of its prior set
+	// (#721, #729). The remaining inverses (description, documentation) are reverted
+	// individually.
+	// On a write error, return what was reverted so far (honoring the documented
+	// contract) rather than discarding it: an earlier batch may have already
+	// persisted its revert to DataHub.
 	tagReverted, tagSkipped, err := revertTagChanges(ctx, writer, urn, changes, prior)
-	if err != nil {
-		return nil, nil, err
-	}
 	reverted = append(reverted, tagReverted...)
 	skipped = append(skipped, tagSkipped...)
+	if err != nil {
+		return reverted, skipped, err
+	}
+
+	termReverted, termSkipped, err := revertGlossaryTermChanges(ctx, writer, urn, changes, prior)
+	reverted = append(reverted, termReverted...)
+	skipped = append(skipped, termSkipped...)
+	if err != nil {
+		return reverted, skipped, err
+	}
 
 	for _, c := range changes {
-		if isTagChange(c.ChangeType) {
+		if isBatchedInverse(c.ChangeType) {
 			continue
 		}
 		desc, didRevert, applyErr := applyInverse(ctx, writer, urn, c, prior)
@@ -210,10 +221,12 @@ func applyInverseChanges(
 	return reverted, skipped, nil
 }
 
-// isTagChange reports whether a change type is reverted by the batched tag path.
-func isTagChange(changeType string) bool {
+// isBatchedInverse reports whether a change type is reverted by a batched
+// read-modify-write path (tags or glossary terms) rather than individually.
+func isBatchedInverse(changeType string) bool {
 	switch changeType {
-	case string(actionAddTag), string(actionRemoveTag), string(actionFlagQualityIssue):
+	case string(actionAddTag), string(actionRemoveTag), string(actionFlagQualityIssue),
+		string(actionAddGlossaryTerm):
 		return true
 	default:
 		return false
@@ -268,17 +281,50 @@ func classifyAddedTagRevert(tagURN string, prior priorState, reverted, skipped, 
 	return append(reverted, fmt.Sprintf("removed tag %s", tagURN)), skipped, append(remove, tagURN)
 }
 
+// revertGlossaryTermChanges computes the glossary-term removals that invert the
+// changeset's add_glossary_term changes and applies them in a single
+// read-modify-write. A term that already existed before the changeset (per the
+// before-image) is left untouched. Descriptions are only committed after the single
+// write succeeds, so a failed write reports nothing as reverted. There is no
+// remove_glossary_term apply action, so reverts are always removals.
+func revertGlossaryTermChanges(
+	ctx context.Context,
+	writer DataHubWriter,
+	urn string,
+	changes []recordedChange,
+	prior priorState,
+) (reverted, skipped []string, err error) {
+	var remove []string
+	for _, c := range changes {
+		if c.ChangeType != string(actionAddGlossaryTerm) {
+			continue
+		}
+		termURN := normalizeGlossaryTermURN(c.Detail)
+		if prior.GlossaryTerms[termURN] {
+			skipped = append(skipped, fmt.Sprintf("kept pre-existing glossary term %s", termURN))
+			continue
+		}
+		remove = append(remove, termURN)
+		reverted = append(reverted, fmt.Sprintf("removed glossary term %s", termURN))
+	}
+	if len(remove) == 0 {
+		return reverted, skipped, nil
+	}
+	if err := writer.ApplyGlossaryTermChanges(ctx, urn, nil, remove); err != nil {
+		return nil, nil, fmt.Errorf("reverting glossary terms: %w", err)
+	}
+	return reverted, skipped, nil
+}
+
 // applyInverse reverts a single change. didRevert is false when the change was a
 // no-op at apply time (the value already existed in the before-image), so the
 // rollback intentionally leaves the pre-existing value in place.
 func applyInverse(ctx context.Context, writer DataHubWriter, urn string, c recordedChange, prior priorState) (desc string, didRevert bool, err error) {
-	// Tag inverses (add_tag, remove_tag, flag_quality_issue) are not handled here:
-	// applyInverseChanges reverts them in a single batched read-modify-write (#721).
+	// Tag and glossary-term inverses are not handled here: applyInverseChanges reverts
+	// them in batched read-modify-writes (#721, #729).
 	switch c.ChangeType {
 	case string(actionUpdateDescription):
 		return revertDescription(ctx, writer, urn, prior)
-	case string(actionAddGlossaryTerm):
-		return revertAddedTerm(ctx, writer, urn, normalizeGlossaryTermURN(c.Detail), prior)
 	case string(actionAddDocumentation):
 		return revertAddedDocumentation(ctx, writer, urn, c.Target)
 	default:
@@ -291,16 +337,6 @@ func revertDescription(ctx context.Context, writer DataHubWriter, urn string, pr
 		return "", false, fmt.Errorf("restoring description: %w", err)
 	}
 	return "restored description", true, nil
-}
-
-func revertAddedTerm(ctx context.Context, writer DataHubWriter, urn, termURN string, prior priorState) (desc string, reverted bool, err error) {
-	if prior.GlossaryTerms[termURN] {
-		return fmt.Sprintf("kept pre-existing glossary term %s", termURN), false, nil
-	}
-	if err := writer.RemoveGlossaryTerm(ctx, urn, termURN); err != nil {
-		return "", false, fmt.Errorf("removing glossary term %s: %w", termURN, err)
-	}
-	return fmt.Sprintf("removed glossary term %s", termURN), true, nil
 }
 
 func revertAddedDocumentation(ctx context.Context, writer DataHubWriter, urn, linkURL string) (desc string, reverted bool, err error) {

--- a/pkg/toolkits/knowledge/rollback_handlers_test.go
+++ b/pkg/toolkits/knowledge/rollback_handlers_test.go
@@ -75,7 +75,7 @@ func TestHandleRollback_Success(t *testing.T) {
 	m := parseJSONResult(t, result)
 	assert.Equal(t, "cs1", m["changeset_id"])
 	require.Len(t, writer.WriteCalls, 1)
-	assert.Equal(t, "RemoveGlossaryTerm", writer.WriteCalls[0].Method)
+	assert.Equal(t, "ApplyGlossaryTermChanges", writer.WriteCalls[0].Method)
 	assert.True(t, csStore.Changesets[0].RolledBack)
 	assert.Equal(t, StatusRolledBack, store.Insights[0].Status)
 }
@@ -241,9 +241,11 @@ func TestApplyRollbackEndToEnd(t *testing.T) {
 	})
 	assert.Equal(t, changesetID, rbResp["changeset_id"])
 
-	require.Len(t, writer.WriteCalls, 2, "one AddGlossaryTerm on apply, one RemoveGlossaryTerm on rollback")
-	assert.Equal(t, "AddGlossaryTerm", writer.WriteCalls[0].Method)
-	assert.Equal(t, "RemoveGlossaryTerm", writer.WriteCalls[1].Method)
+	require.Len(t, writer.WriteCalls, 2, "one ApplyGlossaryTermChanges add on apply, one remove on rollback")
+	assert.Equal(t, "ApplyGlossaryTermChanges", writer.WriteCalls[0].Method)
+	assert.Equal(t, "urn:li:glossaryTerm:e2e", writer.WriteCalls[0].Arg1, "apply adds the term")
+	assert.Equal(t, "ApplyGlossaryTermChanges", writer.WriteCalls[1].Method)
+	assert.Equal(t, "urn:li:glossaryTerm:e2e", writer.WriteCalls[1].Arg2, "rollback removes the term")
 	require.Len(t, csStore.Changesets, 1)
 	assert.True(t, csStore.Changesets[0].RolledBack)
 }

--- a/pkg/toolkits/knowledge/rollback_test.go
+++ b/pkg/toolkits/knowledge/rollback_test.go
@@ -47,8 +47,9 @@ func TestRevertChangeset_RemovesAddedTerm(t *testing.T) {
 	res, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: insights}, cs, "admin")
 	require.NoError(t, err)
 	require.Len(t, writer.WriteCalls, 1)
-	assert.Equal(t, "RemoveGlossaryTerm", writer.WriteCalls[0].Method)
-	assert.Equal(t, "urn:li:glossaryTerm:new", writer.WriteCalls[0].Arg1)
+	assert.Equal(t, "ApplyGlossaryTermChanges", writer.WriteCalls[0].Method)
+	assert.Empty(t, writer.WriteCalls[0].Arg1, "no adds")
+	assert.Equal(t, "urn:li:glossaryTerm:new", writer.WriteCalls[0].Arg2)
 	assert.True(t, store.Changesets[0].RolledBack)
 	assert.Equal(t, []string{"ins-1"}, res.InsightsRolledBack)
 	assert.Equal(t, StatusRolledBack, insights.Insights[0].Status)
@@ -116,6 +117,60 @@ func TestRevertChangeset_MultiTagBatch(t *testing.T) {
 	// The pre-existing tag "a" is kept (skipped), b and c are reverted.
 	assert.Len(t, res.RevertedChanges, 2)
 	assert.Len(t, res.SkippedChanges, 1)
+}
+
+// TestRevertChangeset_MultiGlossaryTermBatch is the #729 regression for rollback:
+// reverting a changeset that added several glossary terms must remove them in a
+// single batched ApplyGlossaryTermChanges, keeping any pre-existing term.
+func TestRevertChangeset_MultiGlossaryTermBatch(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{
+			"change_0": changeEntry("add_glossary_term", "", "urn:li:glossaryTerm:a"),
+			"change_1": changeEntry("add_glossary_term", "", "urn:li:glossaryTerm:b"),
+			"change_2": changeEntry("add_glossary_term", "", "urn:li:glossaryTerm:c"),
+		},
+		// Term "a" pre-existed, so it must be kept; b and c were added by the changeset.
+		map[string]any{"glossary_terms": []any{"urn:li:glossaryTerm:a"}},
+	)
+	store := seededStore(cs)
+	writer := &spyWriter{}
+
+	res, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	require.NoError(t, err)
+
+	// Exactly one batched write removing only the newly-added terms.
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "ApplyGlossaryTermChanges", writer.WriteCalls[0].Method)
+	assert.Empty(t, writer.WriteCalls[0].Arg1, "no adds")
+	assert.Equal(t, "urn:li:glossaryTerm:b,urn:li:glossaryTerm:c", writer.WriteCalls[0].Arg2)
+
+	// The pre-existing term "a" is kept (skipped), b and c are reverted.
+	assert.Len(t, res.RevertedChanges, 2)
+	assert.Len(t, res.SkippedChanges, 1)
+}
+
+// TestRevertChangeset_PartialRevertReportsProgress verifies that when an earlier
+// batched revert (tags) succeeds but a later one (glossary terms) fails, the error
+// reports what was already reverted rather than discarding it (and claiming zero).
+func TestRevertChangeset_PartialRevertReportsProgress(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{
+			"change_0": changeEntry("add_tag", "", "pii"),
+			"change_1": changeEntry("add_glossary_term", "", "urn:li:glossaryTerm:revenue"),
+		},
+		map[string]any{"tags": []any{}, "glossary_terms": []any{}},
+	)
+	store := seededStore(cs)
+	// Tag revert is call 1 (succeeds); glossary-term revert is call 2 (fails).
+	writer := &spyWriter{FailAtCall: 2}
+
+	res, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	require.Error(t, err)
+	assert.Nil(t, res)
+	// The tag was actually removed from DataHub, so the error must not claim zero
+	// changes were reverted.
+	assert.Contains(t, err.Error(), "reverting 1 change")
+	assert.NotContains(t, err.Error(), "reverting 0 change")
 }
 
 func TestRevertChangeset_ReAddsRemovedTag(t *testing.T) {

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -679,27 +679,62 @@ func (t *Toolkit) executeChanges(ctx context.Context, urn string, changes []Appl
 
 	columnDescs, nonColumnChanges := partitionColumnChanges(changes)
 
-	// Track whether any batched write (column descriptions, tags) has already been
-	// persisted, so a later per-change failure does not falsely report that nothing
-	// was applied. These batched writes run before the per-change dispatch loop.
+	// Track whether any batched write (column descriptions, tags, glossary terms) has
+	// already been persisted, so a later batch or per-change failure does not falsely
+	// report that nothing was applied. These batched writes run before the per-change
+	// dispatch loop.
 	priorWrites := false
 
 	if len(columnDescs) > 0 {
 		if err := t.datahubWriter.UpdateColumnDescriptionBatch(ctx, urn, columnDescs); err != nil {
-			return nil, fmt.Errorf("datahub write failed for column descriptions: %w", err)
+			return nil, batchWriteError("column descriptions", priorWrites, err)
 		}
 		priorWrites = true
 	}
 
-	addTags, removeTags, otherChanges := partitionTagChanges(nonColumnChanges)
+	addTags, removeTags, nonTagChanges := partitionTagChanges(nonColumnChanges)
 	if len(addTags) > 0 || len(removeTags) > 0 {
 		if err := t.datahubWriter.ApplyTagChanges(ctx, urn, addTags, removeTags); err != nil {
-			return nil, fmt.Errorf("datahub write failed for tag changes: %w", err)
+			return nil, batchWriteError("tag changes", priorWrites, err)
+		}
+		priorWrites = true
+	}
+
+	addTerms, otherChanges := partitionGlossaryTermChanges(nonTagChanges)
+	if len(addTerms) > 0 {
+		if err := t.datahubWriter.ApplyGlossaryTermChanges(ctx, urn, addTerms, nil); err != nil {
+			return nil, batchWriteError("glossary term changes", priorWrites, err)
 		}
 		priorWrites = true
 	}
 
 	return t.dispatchNonColumnChanges(ctx, urn, otherChanges, priorWrites)
+}
+
+// batchWriteError wraps a batched-write failure, appending the "earlier changes
+// already applied" warning when a prior batch in the same changeset has already
+// persisted to DataHub (those writes are not transactional and are not rolled back).
+func batchWriteError(stage string, priorWrites bool, err error) error {
+	if priorWrites {
+		return fmt.Errorf("datahub write failed for %s: %w (earlier changes in this changeset were already applied and were NOT rolled back)", stage, err)
+	}
+	return fmt.Errorf("datahub write failed for %s: %w", stage, err)
+}
+
+// partitionGlossaryTermChanges separates add_glossary_term changes from other
+// changes so they can be applied in a single read-modify-write. Batching avoids the
+// stale-read clobber where back-to-back per-term writes drop all but the last term
+// (#729). There is no remove_glossary_term apply action; removal happens only on
+// rollback.
+func partitionGlossaryTermChanges(changes []ApplyChange) (add []string, other []ApplyChange) {
+	for _, c := range changes {
+		if c.ChangeType == string(actionAddGlossaryTerm) {
+			add = append(add, normalizeGlossaryTermURN(c.Detail))
+			continue
+		}
+		other = append(other, c)
+	}
+	return add, other
 }
 
 // partitionTagChanges separates tag-setting changes (add_tag, remove_tag, and
@@ -789,14 +824,13 @@ func (t *Toolkit) dispatchChange(ctx context.Context, urn string, c ApplyChange)
 // dispatchCoreOrV14Change handles core DataHub changes and delegates to V14 for newer types.
 func (t *Toolkit) dispatchCoreOrV14Change(ctx context.Context, urn string, c ApplyChange) (string, error) {
 	var err error
-	// Tag changes (add_tag, remove_tag, flag_quality_issue) are not handled here:
-	// executeChanges batches them through ApplyTagChanges so a multi-tag apply is a
-	// single read-modify-write rather than a clobbering sequence of per-tag writes (#721).
+	// Tag changes (add_tag, remove_tag, flag_quality_issue) and glossary-term changes
+	// (add_glossary_term) are not handled here: executeChanges batches them through
+	// ApplyTagChanges / ApplyGlossaryTermChanges so a multi-item apply is a single
+	// read-modify-write rather than a clobbering sequence of per-item writes (#721, #729).
 	switch c.ChangeType {
 	case string(actionUpdateDescription):
 		err = t.executeUpdateDescription(ctx, urn, c)
-	case string(actionAddGlossaryTerm):
-		err = t.datahubWriter.AddGlossaryTerm(ctx, urn, normalizeGlossaryTermURN(c.Detail))
 	case string(actionAddDocumentation):
 		err = t.datahubWriter.AddDocumentationLink(ctx, urn, c.Target, c.Detail)
 	default:

--- a/pkg/toolkits/knowledge/toolkit_test.go
+++ b/pkg/toolkits/knowledge/toolkit_test.go
@@ -299,6 +299,10 @@ type spyWriter struct {
 	// TagState simulates the persisted globalTags per URN, applied additively by
 	// ApplyTagChanges so tests can assert the batched write does not clobber tags.
 	TagState map[string]map[string]bool
+	// TermState simulates the persisted glossaryTerms per URN, applied additively by
+	// ApplyGlossaryTermChanges so tests can assert the batched write does not clobber
+	// terms.
+	TermState map[string]map[string]bool
 }
 
 type writerCall struct {
@@ -371,12 +375,25 @@ func (w *spyWriter) ApplyTagChanges(_ context.Context, urn string, add, remove [
 	return nil
 }
 
-func (w *spyWriter) AddGlossaryTerm(_ context.Context, urn, termURN string) error {
-	return w.recordAndCheck("AddGlossaryTerm", urn, termURN, "")
-}
-
-func (w *spyWriter) RemoveGlossaryTerm(_ context.Context, urn, termURN string) error {
-	return w.recordAndCheck("RemoveGlossaryTerm", urn, termURN, "")
+func (w *spyWriter) ApplyGlossaryTermChanges(_ context.Context, urn string, add, remove []string) error {
+	if err := w.recordAndCheck("ApplyGlossaryTermChanges", urn, strings.Join(add, ","), strings.Join(remove, ",")); err != nil {
+		return err
+	}
+	// Model additive/subtractive semantics so regression tests can assert that a
+	// batched apply/rollback does not clobber pre-existing glossary terms (#729).
+	if w.TermState == nil {
+		w.TermState = map[string]map[string]bool{}
+	}
+	if w.TermState[urn] == nil {
+		w.TermState[urn] = map[string]bool{}
+	}
+	for _, t := range remove {
+		delete(w.TermState[urn], t)
+	}
+	for _, t := range add {
+		w.TermState[urn][t] = true
+	}
+	return nil
 }
 
 func (w *spyWriter) AddDocumentationLink(_ context.Context, urn, url, desc string) error {
@@ -1338,17 +1355,18 @@ func TestHandleApply_WritesToDataHub(t *testing.T) {
 	require.Nil(t, callErr)
 	require.False(t, result.IsError, "expected success but got error: %v", result.Content)
 
-	// The three tag changes (add_tag, remove_tag, flag_quality_issue) are batched
-	// into a single ApplyTagChanges that runs before the other dispatched writes
-	// (#721). Remaining writes: update_description, add_glossary_term, add_documentation.
+	// Tag changes batch into one ApplyTagChanges and add_glossary_term into one
+	// ApplyGlossaryTermChanges, both before the dispatched writes (#721, #729).
+	// Remaining dispatched writes: update_description, add_documentation.
 	assert.Len(t, writer.WriteCalls, 4)
 	assert.Equal(t, "ApplyTagChanges", writer.WriteCalls[0].Method)
 	// Arg1 is the comma-joined adds (add_tag then flag_quality_issue's QualityIssue),
 	// Arg2 the comma-joined removes.
 	assert.Equal(t, "urn:li:tag:important,urn:li:tag:QualityIssue", writer.WriteCalls[0].Arg1)
 	assert.Equal(t, "urn:li:tag:deprecated", writer.WriteCalls[0].Arg2)
-	assert.Equal(t, "UpdateDescription", writer.WriteCalls[1].Method)
-	assert.Equal(t, "AddGlossaryTerm", writer.WriteCalls[2].Method)
+	assert.Equal(t, "ApplyGlossaryTermChanges", writer.WriteCalls[1].Method)
+	assert.Equal(t, "urn:li:glossaryTerm:revenue", writer.WriteCalls[1].Arg1)
+	assert.Equal(t, "UpdateDescription", writer.WriteCalls[2].Method)
 	assert.Equal(t, "AddDocumentationLink", writer.WriteCalls[3].Method)
 	assert.Equal(t, "https://docs.example.com", writer.WriteCalls[3].Arg1)
 	assert.Equal(t, "Revenue docs", writer.WriteCalls[3].Arg2)
@@ -2285,9 +2303,9 @@ func TestExecuteChanges_AllTypes(t *testing.T) {
 
 	_, err := tk.executeChanges(context.Background(), testEntityURN, changes)
 	require.NoError(t, err)
-	// add_tag, remove_tag, and flag_quality_issue collapse into one batched
-	// ApplyTagChanges (run first), leaving update_description, add_glossary_term,
-	// and add_documentation as individual dispatched writes (#721).
+	// add_tag/remove_tag/flag_quality_issue collapse into one ApplyTagChanges and
+	// add_glossary_term into one ApplyGlossaryTermChanges (both run first), leaving
+	// update_description and add_documentation as dispatched writes (#721, #729).
 	assert.Len(t, writer.WriteCalls, 4)
 
 	// Batched tag write: adds (add_tag then flag_quality_issue) and removes, with
@@ -2296,11 +2314,12 @@ func TestExecuteChanges_AllTypes(t *testing.T) {
 	assert.Equal(t, "urn:li:tag:tag1,urn:li:tag:QualityIssue", writer.WriteCalls[0].Arg1)
 	assert.Equal(t, "urn:li:tag:old_tag", writer.WriteCalls[0].Arg2)
 
-	assert.Equal(t, "UpdateDescription", writer.WriteCalls[1].Method)
-	assert.Equal(t, "new desc", writer.WriteCalls[1].Arg1)
+	// Batched glossary-term write.
+	assert.Equal(t, "ApplyGlossaryTermChanges", writer.WriteCalls[1].Method)
+	assert.Equal(t, "urn:li:glossaryTerm:t1", writer.WriteCalls[1].Arg1)
 
-	assert.Equal(t, "AddGlossaryTerm", writer.WriteCalls[2].Method)
-	assert.Equal(t, "urn:li:glossaryTerm:t1", writer.WriteCalls[2].Arg1)
+	assert.Equal(t, "UpdateDescription", writer.WriteCalls[2].Method)
+	assert.Equal(t, "new desc", writer.WriteCalls[2].Arg1)
 
 	// add_documentation: detail=description, target=URL
 	assert.Equal(t, "AddDocumentationLink", writer.WriteCalls[3].Method)
@@ -2365,7 +2384,25 @@ func TestExecuteChanges_FailsOnError(t *testing.T) {
 // not claim "no changes were applied" (which would mislead the operator into not
 // cleaning up the already-applied tags).
 func TestExecuteChanges_DispatchFailAfterTagBatch(t *testing.T) {
-	writer := &spyWriter{FailAtCall: 2} // tag batch (call 1) succeeds, glossary (call 2) fails
+	writer := &spyWriter{FailAtCall: 2} // tag batch (call 1) succeeds, dispatched doc (call 2) fails
+	tk := &Toolkit{datahubWriter: writer}
+
+	changes := []ApplyChange{
+		{ChangeType: "add_tag", Detail: "important"},
+		{ChangeType: "add_documentation", Detail: "docs", Target: "https://docs.example.com"},
+	}
+
+	_, err := tk.executeChanges(context.Background(), testEntityURN, changes)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "no changes were applied")
+	assert.Contains(t, err.Error(), "earlier changes in this changeset were already applied")
+}
+
+// TestExecuteChanges_BatchFailAfterPriorBatch verifies that when an earlier batch
+// (tags) persisted and a later batch (glossary terms) fails, the error warns that
+// earlier changes were already applied rather than reading as a clean failure.
+func TestExecuteChanges_BatchFailAfterPriorBatch(t *testing.T) {
+	writer := &spyWriter{FailAtCall: 2} // tag batch (call 1) succeeds, glossary batch (call 2) fails
 	tk := &Toolkit{datahubWriter: writer}
 
 	changes := []ApplyChange{
@@ -2375,7 +2412,7 @@ func TestExecuteChanges_DispatchFailAfterTagBatch(t *testing.T) {
 
 	_, err := tk.executeChanges(context.Background(), testEntityURN, changes)
 	require.Error(t, err)
-	assert.NotContains(t, err.Error(), "no changes were applied")
+	assert.Contains(t, err.Error(), "glossary term changes")
 	assert.Contains(t, err.Error(), "earlier changes in this changeset were already applied")
 }
 
@@ -2619,12 +2656,11 @@ func TestExecuteChanges_GlossaryTermNormalization(t *testing.T) {
 
 	_, err := tk.executeChanges(context.Background(), testEntityURN, changes)
 	require.NoError(t, err)
-	require.Len(t, writer.WriteCalls, 2)
-
-	// Short name gets normalized
-	assert.Equal(t, "urn:li:glossaryTerm:Revenue", writer.WriteCalls[0].Arg1)
-	// Full URN passes through unchanged
-	assert.Equal(t, "urn:li:glossaryTerm:Revenue", writer.WriteCalls[1].Arg1)
+	// Both add_glossary_term changes batch into a single ApplyGlossaryTermChanges;
+	// each short name is normalized to its full URN.
+	require.Len(t, writer.WriteCalls, 1)
+	assert.Equal(t, "ApplyGlossaryTermChanges", writer.WriteCalls[0].Method)
+	assert.Equal(t, "urn:li:glossaryTerm:Revenue,urn:li:glossaryTerm:Revenue", writer.WriteCalls[0].Arg1)
 }
 
 func TestExecuteChanges_DocumentationParamMapping(t *testing.T) {

--- a/test/e2e/knowledge_datahub_writer_test.go
+++ b/test/e2e/knowledge_datahub_writer_test.go
@@ -216,8 +216,8 @@ func TestDataHubWriterAddGlossaryTerm(t *testing.T) {
 	})
 
 	// Add glossary term
-	if err := writer.AddGlossaryTerm(ctx, urn, termURN); err != nil {
-		t.Fatalf("AddGlossaryTerm: %v", err)
+	if err := writer.ApplyGlossaryTermChanges(ctx, urn, []string{termURN}, nil); err != nil {
+		t.Fatalf("ApplyGlossaryTermChanges: %v", err)
 	}
 
 	// Verify via GetCurrentMetadata


### PR DESCRIPTION
Closes #729

## Problem

`apply_knowledge` `change_type: add_glossary_term` (sink=datahub) silently dropped terms by the **same mechanism** as the `add_tag` clobber fixed in #721. Each term was written through the upstream `mcp-datahub` client's per-term read-modify-write of the `glossaryTerms` aspect: read current terms, append one, overwrite the whole aspect. Because DataHub aspect reads are eventually consistent, back-to-back per-term writes read stale state and the last write overwrites `glossaryTerms` with just that term.

- Applying `[A, B, C]` to one entity in a changeset ended with only `C`.
- Rolling back a multi-term changeset could leave the entity with **zero** terms.

Found during the review of #721 and filed as a follow-up.

## Fix

Replace the per-term `AddGlossaryTerm`/`RemoveGlossaryTerm` methods on the `DataHubWriter` interface with a single `ApplyGlossaryTermChanges(ctx, urn, add, remove)` that reads `glossaryTerms` once, merges every add and remove, refreshes the required `auditStamp`, and writes once.

- **Apply** (`pkg/toolkits/knowledge/toolkit.go`): `partitionGlossaryTermChanges` pulls `add_glossary_term` out of the per-change dispatch and applies it in one `ApplyGlossaryTermChanges` call (there is no `remove_glossary_term` apply action; removal happens only on rollback).
- **Rollback** (`pkg/toolkits/knowledge/rollback.go`): `revertGlossaryTermChanges` aggregates every term inverse for a changeset into one atomic `ApplyGlossaryTermChanges` call. This is what fixes the zero-after-rollback case.

The `glossaryTerms` aspect carries a required `auditStamp` (per the GlossaryTerms PDL), which is set on every write. As in #721, the REST read-modify-write is kept (rather than DataHub's server-side GraphQL mutation, which requires the term entity to pre-exist), surviving associations are preserved as raw JSON, the entity-type guard is restored, and the GraphQL-only entity path skips an add that is also a remove.

## Additional fixes (from review of this change)

- **Rollback progress no longer discarded:** `applyInverseChanges` previously returned `nil, nil, err` when a later batched revert failed, throwing away the reverts already applied to DataHub (e.g. a tag removed before the glossary-term revert failed) and reporting "0 change(s)". It now returns the reverts applied so far, honoring the documented contract.
- **Honest batched-failure message:** a tag or glossary-term batch failure that follows an already-persisted batch now warns that earlier changes were applied and were NOT rolled back, instead of reading as a clean failure (matching the dispatch loop's behavior).
- **No silent association loss:** an existing association whose URN cannot be parsed is preserved on the merged write rather than dropped.

## Cleanup (shared helpers across the tag + term paths)

- Generic `readAspect[T]` / `parseAspect[T]` collapse the previously triplicated REST read + envelope-parse bodies (editableSchemaMetadata, globalTags, glossaryTerms) into one each, behind thin wrappers.
- `mergeRawAssociations` (introduced for tags) is now shared by both merges.
- `applyAssociationChangesGraphQL` is a single source for the GraphQL dedup/ordering used by both tags and terms.

## Tests

- Client-writer unit tests for: multi-term no-clobber (single read/write, `auditStamp` present), add merges existing, remove, unsupported entity type, GraphQL-type path and its add/remove dedup, unparseable-association preservation, and the parse helpers.
- Apply-path tests asserting `add_glossary_term` collapses into one `ApplyGlossaryTermChanges`, plus the honest batched-failure message.
- Rollback tests including a multi-term changeset reverting in one batched call (keeping a pre-existing term) and partial-revert progress reporting.
- `test/e2e` integration test updated to the new method.

`make verify` passes locally (race tests, coverage >=80%, lint, gosec/govulncheck, semgrep, mutation, GoReleaser dry-run).

## Out of scope

Orphaned partial writes (a batch persists, a later change fails, no changeset is recorded so it cannot be rolled back via the tool) are a pre-existing, non-transactional-apply property that also affects tags and column descriptions under #721. This PR continues rather than introduces the class; the honest-failure message above mitigates operator blindness. A transactional-apply (or record-changeset-on-partial-failure) change would be a separate issue.