### PR TITLE
feat(knowledge): surface flag_quality_issue detail as a verifiable DataHub incident

### DIFF
--- a/docs/knowledge/governance.md
+++ b/docs/knowledge/governance.md
@@ -206,7 +206,7 @@ When `require_confirmation` is enabled in configuration and `confirm` is not `tr
 | `add_tag` | Add a tag to the entity | (ignored) | Tag name or URN (e.g., `pii` or `urn:li:tag:pii`) |
 | `remove_tag` | Remove a tag from the entity | (ignored) | Tag name or URN to remove |
 | `add_glossary_term` | Associate a glossary term | (ignored) | Glossary term name or URN |
-| `flag_quality_issue` | Add fixed `QualityIssue` tag to the entity | (ignored) | Issue description (stored as context in the knowledge store) |
+| `flag_quality_issue` | Add fixed `QualityIssue` tag and, on incident-supporting entity types with a detail, raise a deduped DataHub incident ("Data quality issue") carrying the detail | (ignored) | Issue description (raised as the incident description; empty, or an unsupported entity type, means tag only) |
 | `add_documentation` | Add a documentation link | URL of the documentation | Link description |
 | `add_curated_query` | Create a reusable Query entity linked to the dataset | (ignored) | Query name. Also requires `query_sql` (SQL statement) and optionally `query_description` |
 
@@ -291,6 +291,7 @@ Rollback reverts each change the apply made, back to its before-image:
 - A tag, glossary term, or documentation link the apply **added** is removed, **unless** it was already present in the before-image (in which case the add was a no-op and the pre-existing value is kept). This is what preserves an entity's canonical glossary term when an apply added another term alongside it.
 - A tag the apply **removed** is restored.
 - A description the apply changed is reset to the prior description.
+- An incident the apply **created** (the `flag_quality_issue` detail incident) is resolved. Its URN is recorded in the changeset's `new_value` (`created_urns`) so the rollback can find it.
 
 The rollback also transitions the changeset's source insights from `applied` to `rolled_back` and records the rollback as its own auditable tool call referencing the original `changeset_id`.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1716,7 +1716,7 @@ Records domain knowledge shared during a session (memory toolkit).
 
 **Detail field:** Description text, tag name or URN (e.g., `pii` or `urn:li:tag:pii`), glossary term name or URN, quality issue description, link description, or query name (for `add_curated_query`). Short tag/term names are auto-normalized to full URNs.
 
-`flag_quality_issue` adds a fixed `QualityIssue` tag; the detail text is stored as context in the knowledge store, not encoded in the tag name.
+`flag_quality_issue` adds a fixed `QualityIssue` tag and, on entity types DataHub supports incidents for (datasets, dashboards, charts, data flows/jobs, containers, data products) with a detail, raises a "Data quality issue" incident whose description is the detail, so the issue is verifiable on the entity (the detail is not encoded in the tag name). Re-applying the same detail reuses the existing open incident rather than creating a duplicate. The created incident URN is recorded in the changeset's `new_value.created_urns`, and rolling the changeset back removes the tag and resolves any incident it created. On entity types that do not support incidents, only the tag is set.
 
 `add_curated_query` creates a reusable Query entity in DataHub linked to the target dataset. Requires `query_sql` (the SQL statement) and optionally `query_description`. The `detail` field serves as the query name.
 

--- a/docs/reference/tools-api.md
+++ b/docs/reference/tools-api.md
@@ -1063,7 +1063,7 @@ Review, synthesize, and apply captured insights to the data catalog. Admin-only.
 | `update_description` | `column:<fieldPath>` for column-level, empty for entity-level | Description text |
 | `add_tag` / `remove_tag` | Ignored | Tag name or URN |
 | `add_glossary_term` | Ignored | Term name or URN |
-| `flag_quality_issue` | Ignored | Quality issue description |
+| `flag_quality_issue` | Ignored | Quality issue description (sets the `QualityIssue` tag; with a detail, also raises a DataHub incident carrying it) |
 | `add_documentation` | URL | Link description |
 | `add_curated_query` | Ignored | Query name |
 | `set_structured_property` | Property qualified name or URN | Value or JSON array |

--- a/pkg/admin/knowledge_test.go
+++ b/pkg/admin/knowledge_test.go
@@ -253,6 +253,10 @@ func (*mockDataHubWriter) RaiseIncident(_ context.Context, _, _, _ string) (stri
 
 func (*mockDataHubWriter) ResolveIncident(_ context.Context, _, _ string) error { return nil }
 
+func (*mockDataHubWriter) GetIncidents(_ context.Context, _ string) ([]types.Incident, error) {
+	return nil, nil
+}
+
 func (*mockDataHubWriter) UpsertContextDocument(_ context.Context, _ string, _ types.ContextDocumentInput) (*types.ContextDocument, error) {
 	return &types.ContextDocument{}, nil
 }

--- a/pkg/toolkits/knowledge/datahub_client_writer.go
+++ b/pkg/toolkits/knowledge/datahub_client_writer.go
@@ -858,6 +858,15 @@ func (w *DataHubClientWriter) RaiseIncident(ctx context.Context, entityURN, titl
 	return incidentURN, nil
 }
 
+// GetIncidents returns the incidents currently on an entity.
+func (w *DataHubClientWriter) GetIncidents(ctx context.Context, entityURN string) ([]types.Incident, error) {
+	result, err := w.client.GetIncidents(ctx, entityURN)
+	if err != nil {
+		return nil, fmt.Errorf("getting incidents for %s: %w", entityURN, err)
+	}
+	return result.Incidents, nil
+}
+
 // ResolveIncident marks an incident as resolved.
 func (w *DataHubClientWriter) ResolveIncident(ctx context.Context, incidentURN, message string) error {
 	if err := w.client.ResolveIncident(ctx, incidentURN, message); err != nil {

--- a/pkg/toolkits/knowledge/datahub_client_writer_test.go
+++ b/pkg/toolkits/knowledge/datahub_client_writer_test.go
@@ -1448,6 +1448,27 @@ func TestDataHubClientWriter_RaiseIncident(t *testing.T) {
 	assert.Equal(t, "urn:li:incident:new123", urn)
 }
 
+func TestDataHubClientWriter_GetIncidents(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(graphQLResponse{
+			Data: json.RawMessage(`{"entity":{"incidents":{"total":1,"incidents":[` +
+				`{"urn":"urn:li:incident:abc","type":"OPERATIONAL","title":"Data quality issue",` +
+				`"description":"nulls","status":{"state":"ACTIVE"}}` +
+				`]}}}`),
+		})
+	}))
+	defer server.Close()
+
+	writer := NewDataHubClientWriter(newTestClient(t, server.URL))
+	incidents, err := writer.GetIncidents(context.Background(), testURN)
+	require.NoError(t, err)
+	require.Len(t, incidents, 1)
+	assert.Equal(t, "urn:li:incident:abc", incidents[0].URN)
+	assert.Equal(t, "Data quality issue", incidents[0].Title)
+	assert.Equal(t, "ACTIVE", incidents[0].State)
+}
+
 func TestDataHubClientWriter_RaiseIncident_Error(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/toolkits/knowledge/datahub_writer.go
+++ b/pkg/toolkits/knowledge/datahub_writer.go
@@ -41,6 +41,9 @@ type DataHubWriter interface {
 	// Incidents (DataHub 1.4.x)
 	RaiseIncident(ctx context.Context, entityURN, title, description string) (string, error)
 	ResolveIncident(ctx context.Context, incidentURN, message string) error
+	// GetIncidents returns the incidents currently on an entity, used to avoid raising
+	// a duplicate quality-issue incident.
+	GetIncidents(ctx context.Context, entityURN string) ([]types.Incident, error)
 
 	// Context documents (DataHub 1.4.x with document support)
 	UpsertContextDocument(ctx context.Context, entityURN string, doc types.ContextDocumentInput) (*types.ContextDocument, error)
@@ -106,6 +109,11 @@ func (*NoopDataHubWriter) RemoveStructuredProperty(_ context.Context, _, _ strin
 // RaiseIncident is a no-op.
 func (*NoopDataHubWriter) RaiseIncident(_ context.Context, _, _, _ string) (string, error) {
 	return "", nil
+}
+
+// GetIncidents returns no incidents.
+func (*NoopDataHubWriter) GetIncidents(_ context.Context, _ string) ([]types.Incident, error) {
+	return nil, nil
 }
 
 // ResolveIncident is a no-op.

--- a/pkg/toolkits/knowledge/datahub_writer_test.go
+++ b/pkg/toolkits/knowledge/datahub_writer_test.go
@@ -153,6 +153,13 @@ func TestNoopDataHubWriter_ResolveIncident(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestNoopDataHubWriter_GetIncidents(t *testing.T) {
+	writer := &NoopDataHubWriter{}
+	incidents, err := writer.GetIncidents(context.Background(), testDatasetURN)
+	require.NoError(t, err)
+	assert.Empty(t, incidents)
+}
+
 // --- Context document noop methods ---
 
 func TestNoopDataHubWriter_UpsertContextDocument(t *testing.T) {

--- a/pkg/toolkits/knowledge/entity_type.go
+++ b/pkg/toolkits/knowledge/entity_type.go
@@ -35,6 +35,23 @@ const (
 	opsSeparator = ", "
 )
 
+// incidentSupportedTypes are the entity types DataHub raises incidents on.
+// flag_quality_issue raises its detail incident only for these; on any other type
+// (glossary terms, glossary nodes, domains, documents, etc.) it sets the QualityIssue
+// tag alone, so it never fails an apply on an unsupported type and never orphans an
+// incident a rollback cannot resolve. Being conservative here can only skip an
+// incident on a type that would have supported one, which is not a regression
+// (flag_quality_issue was tag-only before #722).
+var incidentSupportedTypes = map[string]bool{
+	entityTypeDataset:     true,
+	entityTypeDashboard:   true,
+	"chart":               true,
+	"dataFlow":            true,
+	"dataJob":             true,
+	entityTypeContainer:   true,
+	entityTypeDataProduct: true,
+}
+
 // descriptionReadableTypes are entity types whose description GetCurrentMetadata can
 // read back, and therefore capture in a changeset before-image: dataset and
 // dashboard via the entity query, glossaryTerm and dataProduct via dedicated getters.

--- a/pkg/toolkits/knowledge/rollback.go
+++ b/pkg/toolkits/knowledge/rollback.go
@@ -120,6 +120,14 @@ func RevertChangeset(ctx context.Context, deps RollbackDeps, cs *Changeset, roll
 		return nil, fmt.Errorf("rollback aborted after reverting %d change(s): %w", len(reverted), err)
 	}
 
+	// Resolve any DataHub incident this changeset created (e.g. the incident raised
+	// by flag_quality_issue to carry its detail), recorded in created_urns (#722).
+	incidentReverted, err := resolveCreatedIncidents(ctx, deps.Writer, cs.NewValue, rolledBackBy)
+	if err != nil {
+		return nil, fmt.Errorf("rollback reverted %d change(s) but resolving the incident failed: %w", len(reverted), err)
+	}
+	reverted = append(reverted, incidentReverted...)
+
 	rolledBackInsights := rollbackInsights(ctx, deps.Insights, cs.SourceInsightIDs, rolledBackBy)
 
 	if err := deps.Changesets.RollbackChangeset(ctx, cs.ID, rolledBackBy); err != nil {
@@ -134,6 +142,28 @@ func RevertChangeset(ctx context.Context, deps RollbackDeps, cs *Changeset, roll
 		InsightsRolledBack: rolledBackInsights,
 		RolledBackBy:       rolledBackBy,
 	}, nil
+}
+
+// incidentURNPrefix identifies DataHub incident URNs among a changeset's created URNs.
+const incidentURNPrefix = "urn:li:incident:"
+
+// resolveCreatedIncidents resolves the DataHub incidents a changeset created
+// (recorded in created_urns), e.g. the incident raised by flag_quality_issue to make
+// its detail verifiable. Only incident URNs are resolved; other created URNs (queries,
+// documents) are left untouched. It returns a description per resolved incident.
+func resolveCreatedIncidents(ctx context.Context, writer DataHubWriter, newValue map[string]any, rolledBackBy string) ([]string, error) {
+	var reverted []string
+	for _, urn := range strsFromMap(newValue, fieldCreatedURNs) {
+		if !strings.HasPrefix(urn, incidentURNPrefix) {
+			continue
+		}
+		msg := fmt.Sprintf("Resolved by knowledge changeset rollback (%s)", rolledBackBy)
+		if err := writer.ResolveIncident(ctx, urn, msg); err != nil {
+			return reverted, fmt.Errorf("resolving incident %s: %w", urn, err)
+		}
+		reverted = append(reverted, fmt.Sprintf("resolved incident %s", urn))
+	}
+	return reverted, nil
 }
 
 // revertibleChangeTypes is the set of change types whose inverse operation can be

--- a/pkg/toolkits/knowledge/rollback_test.go
+++ b/pkg/toolkits/knowledge/rollback_test.go
@@ -3,6 +3,7 @@ package knowledge
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -117,6 +118,55 @@ func TestRevertChangeset_MultiTagBatch(t *testing.T) {
 	// The pre-existing tag "a" is kept (skipped), b and c are reverted.
 	assert.Len(t, res.RevertedChanges, 2)
 	assert.Len(t, res.SkippedChanges, 1)
+}
+
+// TestRevertChangeset_ResolvesQualityIncident is the #722 rollback regression:
+// rolling back a flag_quality_issue removes the QualityIssue tag AND resolves the
+// DataHub incident it raised (recorded in created_urns).
+func TestRevertChangeset_ResolvesQualityIncident(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{
+			"change_0": changeEntry("flag_quality_issue", "", "nulls"),
+			// A non-incident created URN must be left untouched (only incidents resolve).
+			"created_urns": []any{"urn:li:incident:abc", "urn:li:query:q1"},
+		},
+		map[string]any{"tags": []any{}},
+	)
+	store := seededStore(cs)
+	writer := &spyWriter{}
+
+	res, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	require.NoError(t, err)
+
+	var resolveCalls int
+	for _, wc := range writer.WriteCalls {
+		if wc.Method == "ResolveIncident" {
+			resolveCalls++
+			assert.Equal(t, "urn:li:incident:abc", wc.URN)
+		}
+	}
+	assert.Equal(t, 1, resolveCalls, "only the incident URN is resolved, not the query URN")
+	assert.Contains(t, strings.Join(res.RevertedChanges, " "), "resolved incident urn:li:incident:abc")
+	assert.True(t, store.Changesets[0].RolledBack)
+}
+
+// TestRevertChangeset_ResolveIncidentErrorReported verifies a failed incident
+// resolve surfaces an error rather than silently succeeding.
+func TestRevertChangeset_ResolveIncidentErrorReported(t *testing.T) {
+	cs := baseChangeset("cs1",
+		map[string]any{
+			"change_0":     changeEntry("flag_quality_issue", "", "nulls"),
+			"created_urns": []any{"urn:li:incident:abc"},
+		},
+		map[string]any{"tags": []any{}},
+	)
+	store := seededStore(cs)
+	// Tag revert is call 1 (succeeds); ResolveIncident is call 2 (fails).
+	writer := &spyWriter{FailAtCall: 2}
+
+	_, err := RevertChangeset(context.Background(), RollbackDeps{Writer: writer, Changesets: store, Insights: &fullSpyStore{}}, cs, "admin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolving the incident failed")
 }
 
 // TestRevertChangeset_RefusesDescriptionOnUnreadableType verifies that rolling back

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -205,7 +205,7 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 				"add_tag, remove_tag, add_glossary_term, add_documentation, and flag_quality_issue work on all entity types. " +
 				"add_curated_query is dataset-only. " +
 				"For add_tag/remove_tag, detail is the tag name or URN (e.g., 'pii' or 'urn:li:tag:pii'). " +
-				"flag_quality_issue adds a fixed 'QualityIssue' tag; the detail text is stored as context in the knowledge store. " +
+				"flag_quality_issue adds a fixed 'QualityIssue' tag and, for entity types DataHub supports incidents on (datasets, dashboards, charts, data flows/jobs, containers, data products) with a detail, raises a 'Data quality issue' incident whose description is the detail, so the issue is verifiable on the entity (re-applying the same detail reuses the existing open incident instead of duplicating it); rolling back the changeset resolves an incident it created. On other entity types it sets only the tag. " +
 				"For add_documentation, target is the URL, detail is the link description. " +
 				"For add_curated_query, detail is the query name, query_sql is the SQL statement (required), and query_description is optional. " +
 				"For set_structured_property, target is the property qualified name or URN, detail is the value or JSON array. " +
@@ -603,12 +603,20 @@ func (t *Toolkit) recordChangesetAndMarkApplied(ctx context.Context, input apply
 		insightIDs = []string{}
 	}
 
+	newValue := changesToMap(input.Changes)
+	// Record the URNs created by this apply (incidents, queries, documents) so
+	// rollback can act on them, e.g. resolve the incident raised by
+	// flag_quality_issue (#722).
+	if len(createdURNs) > 0 {
+		newValue[fieldCreatedURNs] = createdURNs
+	}
+
 	cs := Changeset{
 		ID:               csID,
 		TargetURN:        input.EntityURN,
 		ChangeType:       summarizeChangeTypes(input.Changes),
 		PreviousValue:    metadataToMap(prevMeta),
-		NewValue:         changesToMap(input.Changes),
+		NewValue:         newValue,
 		SourceInsightIDs: insightIDs,
 		AppliedBy:        appliedBy,
 	}
@@ -741,6 +749,11 @@ func partitionGlossaryTermChanges(changes []ApplyChange) (add []string, other []
 // flag_quality_issue, which sets the QualityIssue tag) from other changes so they
 // can be applied in a single read-modify-write. Batching avoids the stale-read
 // clobber where back-to-back per-tag writes drop all but the last tag (#721).
+//
+// flag_quality_issue also keeps its change in the dispatched set when it carries a
+// detail, so dispatchCoreOrV14Change raises a DataHub incident describing the issue:
+// the QualityIssue tag is the at-a-glance signal and the incident makes the detail
+// verifiable on the entity (#722). With no detail, only the tag is set.
 func partitionTagChanges(changes []ApplyChange) (add, remove []string, other []ApplyChange) {
 	for _, c := range changes {
 		switch c.ChangeType {
@@ -750,6 +763,9 @@ func partitionTagChanges(changes []ApplyChange) (add, remove []string, other []A
 			remove = append(remove, normalizeTagURN(c.Detail))
 		case string(actionFlagQualityIssue):
 			add = append(add, qualityIssueTagURN)
+			if strings.TrimSpace(c.Detail) != "" {
+				other = append(other, c)
+			}
 		default:
 			other = append(other, c)
 		}
@@ -824,15 +840,19 @@ func (t *Toolkit) dispatchChange(ctx context.Context, urn string, c ApplyChange)
 // dispatchCoreOrV14Change handles core DataHub changes and delegates to V14 for newer types.
 func (t *Toolkit) dispatchCoreOrV14Change(ctx context.Context, urn string, c ApplyChange) (string, error) {
 	var err error
-	// Tag changes (add_tag, remove_tag, flag_quality_issue) and glossary-term changes
-	// (add_glossary_term) are not handled here: executeChanges batches them through
-	// ApplyTagChanges / ApplyGlossaryTermChanges so a multi-item apply is a single
-	// read-modify-write rather than a clobbering sequence of per-item writes (#721, #729).
+	// The tag side of add_tag/remove_tag/flag_quality_issue and the glossary-term
+	// changes (add_glossary_term) are not handled here: executeChanges batches them
+	// through ApplyTagChanges / ApplyGlossaryTermChanges so a multi-item apply is a
+	// single read-modify-write rather than a clobbering sequence of per-item writes
+	// (#721, #729). flag_quality_issue with a detail still reaches this dispatch to
+	// raise the incident that makes the detail verifiable (#722).
 	switch c.ChangeType {
 	case string(actionUpdateDescription):
 		err = t.executeUpdateDescription(ctx, urn, c)
 	case string(actionAddDocumentation):
 		err = t.datahubWriter.AddDocumentationLink(ctx, urn, c.Target, c.Detail)
+	case string(actionFlagQualityIssue):
+		return t.dispatchQualityIncident(ctx, urn, c)
 	default:
 		return t.dispatchV14Change(ctx, urn, c)
 	}
@@ -840,6 +860,54 @@ func (t *Toolkit) dispatchCoreOrV14Change(ctx context.Context, urn string, c App
 		return "", fmt.Errorf(errFmtExecuting, c.ChangeType, err)
 	}
 	return "", nil
+}
+
+// dispatchQualityIncident raises a DataHub incident carrying a flag_quality_issue's
+// detail so the issue is verifiable on the entity. It returns the created incident
+// URN (recorded in the changeset so rollback can resolve it), or "" when no incident
+// was created: the entity type does not support incidents, or an identical active
+// quality incident already exists (deduped). A deduped incident is intentionally not
+// recorded, so rollback only resolves incidents this changeset actually created.
+func (t *Toolkit) dispatchQualityIncident(ctx context.Context, urn string, c ApplyChange) (string, error) {
+	// An unparseable URN yields entityType "", which is not incident-supported, so it
+	// falls through to the tag-only path below (the change's URN was already validated
+	// before dispatch).
+	entityType, _ := entityTypeFromURN(urn)
+	if !incidentSupportedTypes[entityType] {
+		// Unsupported entity type: the QualityIssue tag is the signal; the detail
+		// stays in the changeset record. No incident, no apply failure.
+		return "", nil
+	}
+	if t.activeQualityIncidentExists(ctx, urn, c.Detail) {
+		return "", nil
+	}
+	return t.raiseIncident(ctx, urn, qualityIssueIncidentTitle, c.Detail, c.ChangeType)
+}
+
+// activeQualityIncidentExists reports whether the entity already has an active
+// quality-issue incident with the same detail, so a re-apply or retry does not pile
+// up duplicates. A read failure is treated as "no duplicate" (best-effort dedup).
+func (t *Toolkit) activeQualityIncidentExists(ctx context.Context, urn, detail string) bool {
+	incidents, err := t.datahubWriter.GetIncidents(ctx, urn)
+	if err != nil {
+		return false
+	}
+	for _, inc := range incidents {
+		if inc.State == "ACTIVE" && inc.Title == qualityIssueIncidentTitle && inc.Description == detail {
+			return true
+		}
+	}
+	return false
+}
+
+// raiseIncident raises a DataHub incident and returns its URN, wrapping a failure
+// with the change type. Shared by flag_quality_issue and the raise_incident action.
+func (t *Toolkit) raiseIncident(ctx context.Context, urn, title, description, changeType string) (string, error) {
+	incidentURN, err := t.datahubWriter.RaiseIncident(ctx, urn, title, description)
+	if err != nil {
+		return "", fmt.Errorf(errFmtExecuting, changeType, err)
+	}
+	return incidentURN, nil
 }
 
 // dispatchCuratedQuery handles add_curated_query changes.
@@ -891,11 +959,7 @@ func (t *Toolkit) dispatchV14Change(ctx context.Context, urn string, c ApplyChan
 	case string(actionRemoveStructuredProperty):
 		err = t.datahubWriter.RemoveStructuredProperty(ctx, urn, normalizeStructuredPropertyURN(c.Target))
 	case string(actionRaiseIncident):
-		incidentURN, iErr := t.datahubWriter.RaiseIncident(ctx, urn, c.Target, c.Detail)
-		if iErr != nil {
-			return "", fmt.Errorf(errFmtExecuting, c.ChangeType, iErr)
-		}
-		return incidentURN, nil
+		return t.raiseIncident(ctx, urn, c.Target, c.Detail, c.ChangeType)
 	case string(actionResolveIncident):
 		err = t.datahubWriter.ResolveIncident(ctx, c.Target, c.Detail)
 	default:
@@ -978,6 +1042,9 @@ const (
 	fieldDescription = "description"
 	fieldTarget      = "target"
 	fieldDetail      = "detail"
+	// fieldCreatedURNs is the changeset NewValue key holding the URNs created by an
+	// apply (incidents, queries, documents), used by rollback.
+	fieldCreatedURNs = "created_urns"
 )
 
 // promptRoleUser is the MCP message Role value for user-authored
@@ -989,8 +1056,14 @@ const promptRoleUser = "user"
 
 // qualityIssueTagURN is the single fixed DataHub tag applied by flag_quality_issue.
 // Instead of encoding quality issue details into dynamic tag names (which pollutes
-// the tag namespace), the detail text is stored as a knowledge insight for admin review.
+// the tag namespace), the QualityIssue tag is the at-a-glance signal and the detail
+// text is raised as a DataHub incident (titled qualityIssueIncidentTitle) so it is
+// verifiable on the entity (#722).
 const qualityIssueTagURN = "urn:li:tag:QualityIssue"
+
+// qualityIssueIncidentTitle is the fixed title of the DataHub incident raised to
+// carry a flag_quality_issue's detail.
+const qualityIssueIncidentTitle = "Data quality issue"
 
 // normalizeStructuredPropertyURN ensures a property name is a full DataHub URN.
 func normalizeStructuredPropertyURN(name string) string {

--- a/pkg/toolkits/knowledge/toolkit_test.go
+++ b/pkg/toolkits/knowledge/toolkit_test.go
@@ -303,6 +303,10 @@ type spyWriter struct {
 	// ApplyGlossaryTermChanges so tests can assert the batched write does not clobber
 	// terms.
 	TermState map[string]map[string]bool
+	// Incidents is returned by GetIncidents (for dedup tests); IncidentsErr forces an
+	// error.
+	Incidents    []types.Incident
+	IncidentsErr error
 }
 
 type writerCall struct {
@@ -427,6 +431,13 @@ func (w *spyWriter) RaiseIncident(_ context.Context, entityURN, title, desc stri
 		return "", err
 	}
 	return "urn:li:incident:generated-id", nil
+}
+
+func (w *spyWriter) GetIncidents(_ context.Context, _ string) ([]types.Incident, error) {
+	if w.IncidentsErr != nil {
+		return nil, w.IncidentsErr
+	}
+	return w.Incidents, nil
 }
 
 func (w *spyWriter) ResolveIncident(_ context.Context, incidentURN, message string) error {
@@ -1357,8 +1368,9 @@ func TestHandleApply_WritesToDataHub(t *testing.T) {
 
 	// Tag changes batch into one ApplyTagChanges and add_glossary_term into one
 	// ApplyGlossaryTermChanges, both before the dispatched writes (#721, #729).
-	// Remaining dispatched writes: update_description, add_documentation.
-	assert.Len(t, writer.WriteCalls, 4)
+	// Remaining dispatched writes: update_description, add_documentation, and the
+	// flag_quality_issue incident carrying its detail (#722).
+	assert.Len(t, writer.WriteCalls, 5)
 	assert.Equal(t, "ApplyTagChanges", writer.WriteCalls[0].Method)
 	// Arg1 is the comma-joined adds (add_tag then flag_quality_issue's QualityIssue),
 	// Arg2 the comma-joined removes.
@@ -1370,6 +1382,11 @@ func TestHandleApply_WritesToDataHub(t *testing.T) {
 	assert.Equal(t, "AddDocumentationLink", writer.WriteCalls[3].Method)
 	assert.Equal(t, "https://docs.example.com", writer.WriteCalls[3].Arg1)
 	assert.Equal(t, "Revenue docs", writer.WriteCalls[3].Arg2)
+	// flag_quality_issue raises an incident titled "Data quality issue" with the
+	// detail as the description.
+	assert.Equal(t, "RaiseIncident", writer.WriteCalls[4].Method)
+	assert.Equal(t, "Data quality issue", writer.WriteCalls[4].Arg1)
+	assert.Equal(t, "missing_values", writer.WriteCalls[4].Arg2)
 
 	// The QualityIssue tag survives in the same batched write as the other tags,
 	// rather than being clobbered by a separate per-tag write.
@@ -2305,8 +2322,9 @@ func TestExecuteChanges_AllTypes(t *testing.T) {
 	require.NoError(t, err)
 	// add_tag/remove_tag/flag_quality_issue collapse into one ApplyTagChanges and
 	// add_glossary_term into one ApplyGlossaryTermChanges (both run first), leaving
-	// update_description and add_documentation as dispatched writes (#721, #729).
-	assert.Len(t, writer.WriteCalls, 4)
+	// update_description, add_documentation, and the flag_quality_issue incident as
+	// dispatched writes (#721, #729, #722).
+	assert.Len(t, writer.WriteCalls, 5)
 
 	// Batched tag write: adds (add_tag then flag_quality_issue) and removes, with
 	// short names normalized to full URNs.
@@ -2325,6 +2343,10 @@ func TestExecuteChanges_AllTypes(t *testing.T) {
 	assert.Equal(t, "AddDocumentationLink", writer.WriteCalls[3].Method)
 	assert.Equal(t, "https://docs.example.com", writer.WriteCalls[3].Arg1)
 	assert.Equal(t, "API Docs", writer.WriteCalls[3].Arg2)
+
+	// flag_quality_issue raises an incident carrying its detail (#722).
+	assert.Equal(t, "RaiseIncident", writer.WriteCalls[4].Method)
+	assert.Equal(t, "nulls", writer.WriteCalls[4].Arg2)
 }
 
 func TestExecuteChanges_AddCuratedQuery(t *testing.T) {
@@ -2638,11 +2660,123 @@ func TestExecuteChanges_FlagQualityIssue_FixedTag(t *testing.T) {
 	_, err := tk.executeChanges(context.Background(), testEntityURN, changes)
 	require.NoError(t, err)
 	// All flag_quality_issue changes batch into a single ApplyTagChanges adding the
-	// fixed QualityIssue tag, regardless of detail text.
-	require.Len(t, writer.WriteCalls, 1)
+	// fixed QualityIssue tag, regardless of detail text. Each one with a non-empty
+	// detail also raises an incident carrying that detail (#722); the empty-detail
+	// one raises no incident.
+	require.Len(t, writer.WriteCalls, 3)
 	assert.Equal(t, "ApplyTagChanges", writer.WriteCalls[0].Method)
 	assert.Equal(t, "urn:li:tag:QualityIssue,urn:li:tag:QualityIssue,urn:li:tag:QualityIssue", writer.WriteCalls[0].Arg1)
 	assert.Contains(t, writer.TagState[testEntityURN], "urn:li:tag:QualityIssue")
+	assert.Equal(t, "RaiseIncident", writer.WriteCalls[1].Method)
+	assert.Equal(t, "Missing column descriptions", writer.WriteCalls[1].Arg2)
+	assert.Equal(t, "RaiseIncident", writer.WriteCalls[2].Method)
+	assert.Equal(t, "nulls", writer.WriteCalls[2].Arg2)
+}
+
+// TestHandleApply_FlagQualityIssueRaisesIncident is the #722 regression: a
+// flag_quality_issue with a detail sets the QualityIssue tag AND raises a DataHub
+// incident carrying the detail, and the created incident URN is recorded on the
+// changeset so rollback can resolve it.
+func TestHandleApply_FlagQualityIssueRaisesIncident(t *testing.T) {
+	store := &fullSpyStore{}
+	csStore := &spyChangesetStore{}
+	writer := &spyWriter{}
+	tk := newApplyToolkit(t, store, csStore, writer)
+
+	input := applyKnowledgeInput{
+		Action:    "apply",
+		EntityURN: testEntityURN,
+		Changes:   []ApplyChange{{ChangeType: "flag_quality_issue", Detail: "amount column has nulls"}},
+	}
+	result, _, callErr := tk.handleApplyKnowledge(ctxWithUser("admin-1", "s", "admin"), nil, input)
+	require.Nil(t, callErr)
+	require.False(t, result.IsError, "got error: %v", result.Content)
+
+	var raisedDetail string
+	for _, wc := range writer.WriteCalls {
+		if wc.Method == "RaiseIncident" {
+			raisedDetail = wc.Arg2
+		}
+	}
+	assert.Equal(t, "amount column has nulls", raisedDetail, "the detail is raised as an incident")
+
+	// The created incident URN is recorded on the changeset for rollback.
+	require.Len(t, csStore.Changesets, 1)
+	assert.Equal(t, []string{"urn:li:incident:generated-id"}, strsFromMap(csStore.Changesets[0].NewValue, "created_urns"))
+}
+
+// TestHandleApply_FlagQualityIssueNoDetailNoIncident verifies a flag_quality_issue
+// without a detail sets only the tag and raises no (empty) incident.
+func TestHandleApply_FlagQualityIssueNoDetailNoIncident(t *testing.T) {
+	store := &fullSpyStore{}
+	csStore := &spyChangesetStore{}
+	writer := &spyWriter{}
+	tk := newApplyToolkit(t, store, csStore, writer)
+
+	input := applyKnowledgeInput{
+		Action:    "apply",
+		EntityURN: testEntityURN,
+		Changes:   []ApplyChange{{ChangeType: "flag_quality_issue", Detail: ""}},
+	}
+	result, _, callErr := tk.handleApplyKnowledge(ctxWithUser("admin-1", "s", "admin"), nil, input)
+	require.Nil(t, callErr)
+	require.False(t, result.IsError)
+
+	for _, wc := range writer.WriteCalls {
+		assert.NotEqual(t, "RaiseIncident", wc.Method, "no incident without a detail")
+	}
+	assert.Contains(t, writer.TagState[testEntityURN], "urn:li:tag:QualityIssue")
+}
+
+// TestExecuteChanges_FlagQualityIssueDedup verifies that when an active quality
+// incident with the same detail already exists, a re-apply does not raise a duplicate
+// (and does not record a created incident, since none was created).
+func TestExecuteChanges_FlagQualityIssueDedup(t *testing.T) {
+	writer := &spyWriter{Incidents: []types.Incident{
+		{URN: "urn:li:incident:existing", Title: "Data quality issue", Description: "nulls", State: "ACTIVE"},
+	}}
+	tk := &Toolkit{datahubWriter: writer}
+
+	created, err := tk.executeChanges(context.Background(), testEntityURN, []ApplyChange{
+		{ChangeType: "flag_quality_issue", Detail: "nulls"},
+	})
+	require.NoError(t, err)
+	for _, wc := range writer.WriteCalls {
+		assert.NotEqual(t, "RaiseIncident", wc.Method, "deduped: no new incident raised")
+	}
+	assert.Empty(t, created, "a reused (deduped) incident is not recorded as created")
+}
+
+// TestExecuteChanges_FlagQualityIssueDedupReadErrorRaises verifies that a failed
+// incident read does not block the apply: it falls back to raising the incident.
+func TestExecuteChanges_FlagQualityIssueDedupReadErrorRaises(t *testing.T) {
+	writer := &spyWriter{IncidentsErr: errors.New("incident read boom")}
+	tk := &Toolkit{datahubWriter: writer}
+
+	_, err := tk.executeChanges(context.Background(), testEntityURN, []ApplyChange{
+		{ChangeType: "flag_quality_issue", Detail: "nulls"},
+	})
+	require.NoError(t, err)
+	var raised bool
+	for _, wc := range writer.WriteCalls {
+		if wc.Method == "RaiseIncident" {
+			raised = true
+		}
+	}
+	assert.True(t, raised, "a dedup read failure falls back to raising the incident")
+}
+
+// TestExecuteChanges_FlagQualityIssueIncidentError verifies a failed incident raise
+// surfaces as an apply error.
+func TestExecuteChanges_FlagQualityIssueIncidentError(t *testing.T) {
+	writer := &spyWriter{FailAtCall: 2} // tag batch (call 1) ok, RaiseIncident (call 2) fails
+	tk := &Toolkit{datahubWriter: writer}
+
+	_, err := tk.executeChanges(context.Background(), testEntityURN, []ApplyChange{
+		{ChangeType: "flag_quality_issue", Detail: "nulls"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "flag_quality_issue")
 }
 
 func TestExecuteChanges_GlossaryTermNormalization(t *testing.T) {
@@ -2823,10 +2957,15 @@ func TestHandleApply_AddTagOnNonDatasetSucceeds(t *testing.T) {
 	require.Nil(t, callErr)
 	require.False(t, result.IsError, "tag/glossary/doc/quality ops should work on domains: %v", result.Content)
 
-	// add_tag, remove_tag, and flag_quality_issue batch into one ApplyTagChanges,
-	// leaving add_glossary_term and add_documentation as individual writes.
+	// add_tag, remove_tag, and flag_quality_issue's tag batch into one
+	// ApplyTagChanges, leaving add_glossary_term and add_documentation as individual
+	// writes. A domain does not support incidents, so flag_quality_issue raises none
+	// (it stays tag-only on unsupported types, #722).
 	assert.Len(t, writer.WriteCalls, 3)
 	assert.Equal(t, "ApplyTagChanges", writer.WriteCalls[0].Method)
+	for _, wc := range writer.WriteCalls {
+		assert.NotEqual(t, "RaiseIncident", wc.Method, "no incident on a domain")
+	}
 }
 
 func TestHandleApply_MixedChangesRejectsBeforeExecution(t *testing.T) {


### PR DESCRIPTION
Closes #722

## Problem

`apply_knowledge` `change_type: flag_quality_issue` accepts a `detail` description, but it only set a fixed `QualityIssue` tag and dropped the detail (it lived only in the changeset record). After applying, the detail was nowhere on the DataHub entity, so a reviewer could not verify what was recorded via `datahub_get_entity` or `resulting_state`.

The issue's other ask, "make the `QualityIssue` tag additive," was already delivered by #721 (the `globalTags` read-modify-write batching), so a co-applied `add_tag` no longer clobbers it. This PR covers the remaining "make the detail verifiable" half.

## Fix

`flag_quality_issue` keeps setting the `QualityIssue` tag (the at-a-glance signal) and now also raises a DataHub incident titled "Data quality issue" whose description is the detail, so the issue is verifiable on the entity.

The first pass at this surfaced several real failure modes in code review (a second DataHub write breaks the prior atomic tag-only behavior); the implementation is hardened against them:

- **Entity-type gating.** The incident is raised only for entity types DataHub supports incidents on (dataset, dashboard, chart, dataFlow, dataJob, container, dataProduct). On any other type (glossaryTerm, glossaryNode, domain, document, ...) it sets the tag alone. This avoids both an apply failure on an unsupported type and an orphaned incident on a `document` (whose rollback is refused per #723). Being conservative here cannot regress: `flag_quality_issue` was tag-only everywhere before this change.
- **Dedup.** Before raising, it checks the entity's incidents (`GetIncidents`); if an active "Data quality issue" with the same detail already exists, it reuses that one instead of piling up duplicates on a re-apply or retry. The dedup is best-effort (a failed read falls back to raising). A reused incident is intentionally **not** recorded as created-by-this-changeset, so rollback only resolves incidents this changeset actually created.
- **Rollback.** The created incident URN is recorded in the changeset's `new_value.created_urns`; rolling the changeset back removes the `QualityIssue` tag and resolves that incident.

The remaining orphan-on-partial-failure cases (tag written, then incident raise fails; or `ResolveIncident` fails mid-rollback) are the same pre-existing non-transactional behavior that affects every multi-write apply, narrowed by the type gate and idempotent incident resolve.

## Plumbing / cleanup

- Added `GetIncidents` to the `DataHubWriter` interface (delegates to the existing upstream `client.GetIncidents`).
- Extracted a shared `raiseIncident` helper used by both `flag_quality_issue` and the existing `raise_incident` action.
- Reused the existing `strsFromMap` helper for the `created_urns` decode.

## Tests

- Apply: raises an incident with the detail on a dataset and records the URN; sets only the tag (no incident) when there is no detail or on an unsupported entity type (domain); dedup skips a duplicate when an active matching incident exists; a dedup read failure falls back to raising; an incident-raise failure surfaces as an apply error.
- Rollback: resolves the recorded incident (and only incident-prefixed URNs, not query/document URNs); reports a resolve failure.
- Writer: `GetIncidents` (real GraphQL response and noop).

`make verify` passes locally (race tests, coverage >=80%, lint, gosec/govulncheck, semgrep, mutation, GoReleaser dry-run).

## Docs

`docs/knowledge/governance.md`, `docs/reference/tools-api.md`, `docs/llms-full.txt`, and the in-tool description now describe the incident behavior, the supported-type gating, the dedup, and the rollback resolution.