### PR TITLE
fix(knowledge): bound itemized bulk_review under the output token limit (#724)

### DIFF
--- a/docs/knowledge/governance.md
+++ b/docs/knowledge/governance.md
@@ -64,7 +64,9 @@ The counts label their own scope: `total_pending` is the size of the global pend
 {"action": "bulk_review", "itemize": true, "limit": 50}
 ```
 
-Each returned insight includes its `id`, `captured_by` (the author), `sink_class`, `category`, `confidence`, `status`, `entity_urns`, and `created_at`, so an entity-agnostic insight (one with no `entity_urns`, invisible to per-entity review) is still enumerable here. Page through by passing the previous response's `next_offset` as the next `offset`.
+Each returned insight is the full record, including its `insight_text` body so a review pass can read every insight without a per-insight `fetch`, plus `id`, `captured_by` (the author), `session_id`, `persona`, `sink_class`, `category`, `confidence`, `status`, `entity_urns`, `related_columns`, and `created_at`. The `suggested_actions` array is replaced by `suggested_actions_count` to keep the listing bounded (`fetch mcp:insight:<id>` for the full actions). An entity-agnostic insight (one with no `entity_urns`, invisible to per-entity review) is still enumerable here. Page through by passing the previous response's `next_offset` as the next `offset`.
+
+Each part of the response is bounded so it stays under the tool output limit even for a large queue: the insights window is byte-budgeted (when the budget is reached the page returns fewer than `limit` insights and sets `page_size_capped: true`), and `by_entity` is capped to the busiest entities (`by_entity_truncated: true` flags the cut; each insight still carries its full `entity_urns`). Treat `page_size_capped` as a normal "more remain" signal and continue paging with `next_offset`.
 
 ### Review by Entity
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1469,7 +1469,7 @@ The sink router (#633). Review, synthesize, and promote captured insights to the
 | `changeset_id` | string | Conditional | Required for rollback |
 | `confirm` | bool | No | Required when `require_confirmation` is true (apply and rollback) |
 | `review_notes` | string | No | Notes for approve/reject actions |
-| `itemize` | bool | No | With bulk_review, also return the pending insights themselves (each with captured_by, sink_class), paginated by offset/limit |
+| `itemize` | bool | No | With bulk_review, also return the pending insights themselves (full insight_text body, captured_by, sink_class, created_at, suggested_actions_count, ...; full suggested_actions omitted, fetch for it), paginated by offset/limit. The response is bounded so it stays under the output limit: page_size_capped:true flags a short insights page (continue with next_offset) and by_entity_truncated:true flags a capped by_entity |
 | `limit` | int | No | Page size for itemized bulk_review (default 20, max 100) |
 | `offset` | int | No | Page start for itemized bulk_review; pass the previous next_offset to continue |
 
@@ -1755,7 +1755,7 @@ Admin-only tool for reviewing and applying captured insights. Requires the `admi
 
 ### Actions
 
-**bulk_review**: Counts of all pending insights (total_pending, by_entity, by_category, by_confidence). Pass itemize:true to enumerate the queue itself, paginated by offset/limit, each insight carrying its captured_by (author) and sink_class; the relevance-ranked search tool cannot list it completely.
+**bulk_review**: Counts of all pending insights (total_pending, by_entity, by_category, by_confidence). Pass itemize:true to enumerate the queue itself, paginated by offset/limit, each insight carrying its full insight_text body, captured_by (author), sink_class and suggested_actions_count (full suggested_actions omitted, fetch for it); the relevance-ranked search tool cannot list it completely. The response is bounded so it stays under the output limit: page_size_capped:true flags a short insights page (continue with next_offset) and by_entity_truncated:true flags a capped by_entity.
 
 ```json
 {"action": "bulk_review"}

--- a/docs/reference/tools-api.md
+++ b/docs/reference/tools-api.md
@@ -1042,7 +1042,7 @@ Review, synthesize, and apply captured insights to the data catalog. Admin-only.
 | `changeset_id` | string | Conditional | Required for `rollback` |
 | `confirm` | bool | No | Required when `require_confirmation` is enabled (for `apply` and `rollback`) |
 | `review_notes` | string | No | Notes for `approve`/`reject` actions |
-| `itemize` | bool | No | With `bulk_review`, also return the pending insights themselves (each with `captured_by`, `sink_class`), paginated by `offset`/`limit` |
+| `itemize` | bool | No | With `bulk_review`, also return the pending insights themselves (full `insight_text` body, `captured_by`, `sink_class`, `created_at`, `suggested_actions_count`, ...; full `suggested_actions` omitted, `fetch` for it), paginated by `offset`/`limit`. The insights window is byte-budgeted (`page_size_capped: true` flags a short page, continue with `next_offset`) and `by_entity` is capped (`by_entity_truncated: true`) so the response stays under the output limit |
 | `limit` | int | No | Page size for itemized `bulk_review` (default 20, max 100) |
 | `offset` | int | No | Page start for itemized `bulk_review`; pass the previous `next_offset` to continue |
 
@@ -1078,7 +1078,7 @@ Review, synthesize, and apply captured insights to the data catalog. Admin-only.
 
 | Action | Description | Required Params |
 |--------|-------------|-----------------|
-| `bulk_review` | Counts of all pending insights; pass optional `itemize: true` (with `limit`/`offset`) to enumerate the queue, each with `captured_by` and `sink_class` | None |
+| `bulk_review` | Counts of all pending insights; pass optional `itemize: true` (with `limit`/`offset`) to enumerate the queue, each with its full `insight_text` body, `captured_by`, `sink_class`, and `suggested_actions_count` (response bounded per page; `page_size_capped`/`by_entity_truncated` flag any cut) | None |
 | `review` | Insights for a specific entity with current DataHub metadata | `entity_urn` |
 | `approve` | Transition insights to approved status | `insight_ids` |
 | `reject` | Transition insights to rejected status | `insight_ids` |

--- a/docs/server/tools.md
+++ b/docs/server/tools.md
@@ -774,13 +774,13 @@ Both sinks record a **changeset** (page promotions use `target_urn = "kp:<slug>"
 | `changeset_id` | string | Conditional | Required for rollback |
 | `confirm` | bool | No | Required when `require_confirmation` is true (apply and rollback) |
 | `review_notes` | string | No | Notes for approve/reject actions |
-| `itemize` | bool | No | With `bulk_review`, also return the pending insights themselves (each with `captured_by`, `sink_class`, etc.), paginated by `offset`/`limit` |
+| `itemize` | bool | No | With `bulk_review`, also return the pending insights themselves (full `insight_text` body, `captured_by`, `sink_class`, `created_at`, `suggested_actions_count`, etc.; full `suggested_actions` omitted, `fetch` for it), paginated by `offset`/`limit`. The response is bounded (`page_size_capped`/`by_entity_truncated` flag any cut) so it stays under the output limit |
 | `limit` | int | No | Page size for itemized `bulk_review` (default 20, max 100) |
 | `offset` | int | No | Page start for itemized `bulk_review`; pass the previous `next_offset` to continue |
 
 **Actions:**
 
-- **bulk_review**: Counts of all pending insights (`total_pending`, `by_entity`, `by_category`, `by_confidence`). Pass `itemize: true` to enumerate the queue itself, paginated, with each insight's `id`, `captured_by`, and `sink_class` (the relevance-ranked `search` tool cannot list it completely)
+- **bulk_review**: Counts of all pending insights (`total_pending`, `by_entity`, `by_category`, `by_confidence`). Pass `itemize: true` to enumerate the queue itself, paginated, with each insight's full `insight_text` body, `id`, `captured_by`, `sink_class`, and `suggested_actions_count` (full `suggested_actions` omitted, `fetch` for it; the relevance-ranked `search` tool cannot list the queue completely). The response is bounded so it stays under the output limit: `page_size_capped: true` flags a short insights page (continue with `next_offset`) and `by_entity_truncated: true` flags a capped `by_entity`
 - **review**: Insights for a specific entity with current DataHub metadata
 - **approve/reject**: Transition insight status with optional notes
 - **synthesize**: Structured change proposals from approved insights

--- a/pkg/toolkits/knowledge/schemas.go
+++ b/pkg/toolkits/knowledge/schemas.go
@@ -15,7 +15,7 @@ var applyKnowledgeSchema = json.RawMessage(`{
     },
     "itemize": {
       "type": "boolean",
-      "description": "With action=bulk_review, also return the pending insights themselves (each with id, captured_by, sink_class, category, confidence, status, entity_urns, created_at), windowed by offset/limit. This is how you enumerate the global review queue."
+      "description": "With action=bulk_review, also return the pending insights themselves: each is the full insight record (id, captured_by, session_id, persona, category, confidence, status, sink_class, entity_urns, related_columns, created_at and the full insight_text body, so a review pass needs no per-insight fetch), with the suggested_actions array replaced by suggested_actions_count to keep the listing bounded (fetch mcp:insight:<id> for the full actions). Windowed by offset/limit. This is how you enumerate the global review queue. A page is additionally capped by a byte budget so the response stays under the output limit: when page_size_capped is true the page returned fewer than limit insights, page on with next_offset. by_entity is likewise capped (by_entity_truncated flags the cut; each insight still carries its full entity_urns)."
     },
     "limit": {
       "type": "integer",

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -63,11 +64,15 @@ type applyKnowledgeInput struct {
 	// ChangesetID is the target changeset for the rollback action.
 	ChangesetID string `json:"changeset_id,omitempty"`
 	// Itemize, with action=bulk_review, returns the pending insights themselves
-	// (each a full record with id, captured_by, sink_class, status and
-	// entity_urns), windowed by Offset/Limit, in addition to the aggregate
-	// counts. It is how an agent enumerates the review queue; the relevance
-	// ranked search tool cannot list it completely. Limit defaults to
-	// DefaultLimit and is capped at MaxLimit; Offset is the page start.
+	// (toReviewItems): each is the full insight record, including the insight_text
+	// body, with the uncapped suggested_actions array replaced by
+	// suggested_actions_count. Carrying the body lets a review pass read every
+	// insight without a per-insight fetch (#724). It is how an agent enumerates the
+	// review queue; the relevance-ranked search tool cannot list it completely.
+	// Limit defaults to DefaultLimit and is capped at MaxLimit; Offset is the page
+	// start. A page is additionally bounded by a byte budget so the response never
+	// exceeds the output token cap (see pageInsightsBudgeted), which can return
+	// fewer than Limit insights and set page_size_capped on the response.
 	Itemize bool `json:"itemize,omitempty"`
 	Limit   int  `json:"limit,omitempty"`
 	Offset  int  `json:"offset,omitempty"`
@@ -331,9 +336,13 @@ func (t *Toolkit) bulkReviewCounts(ctx context.Context) (*mcp.CallToolResult, an
 	return jsonResult(result)
 }
 
-// bulkReviewItemized returns the complete pending queue: aggregates and by_entity
-// from one full walk, plus the windowed insights themselves (id, captured_by,
-// sink_class, ...) so a reviewer can enumerate and act on every pending insight.
+// bulkReviewItemized returns the complete pending queue: aggregate counts and a
+// bounded by_entity summary computed over the pending set, plus the windowed
+// insights themselves projected for review so a reviewer can enumerate and act on
+// every pending insight. Each part of the response is independently bounded so a large
+// queue never pushes the response past the MCP tool output token limit (#724):
+// the insights window is byte-budgeted (pageInsightsBudgeted), by_entity is capped
+// (boundedEntitySummaries), and by_category/by_confidence are inherently small.
 func (t *Toolkit) bulkReviewItemized(ctx context.Context, input applyKnowledgeInput) (*mcp.CallToolResult, any, error) {
 	pending, err := t.collectPending(ctx)
 	if err != nil {
@@ -347,21 +356,65 @@ func (t *Toolkit) bulkReviewItemized(ctx context.Context, input applyKnowledgeIn
 		byConfidence[pending[i].Confidence]++
 	}
 
-	page, offset, next := pageInsights(pending, input.Offset, input.Limit)
+	page := pageInsightsBudgeted(pending, input.Offset, input.Limit, bulkReviewItemBudgetBytes)
+	entities, entitiesTruncated := boundedEntitySummaries(pending, maxBulkReviewEntitySummaries)
 	result := map[string]any{
 		"total_pending": len(pending),
-		"by_entity":     buildEntitySummaries(pending),
+		"by_entity":     entities,
 		"by_category":   byCategory,
 		"by_confidence": byConfidence,
 		"note":          bulkReviewScopeNote,
-		"insights":      page,
-		"returned":      len(page),
-		"offset":        offset,
+		"insights":      toReviewItems(page.insights),
+		"returned":      len(page.insights),
+		"offset":        page.offset,
 	}
-	if next >= 0 {
-		result["next_offset"] = next
+	if entitiesTruncated {
+		// by_entity was capped to the busiest entities so the response stays
+		// bounded; the full per-insight entity_urns remain on each insight.
+		result["by_entity_truncated"] = true
+	}
+	if page.next >= 0 {
+		result["next_offset"] = page.next
+	}
+	if page.capped {
+		// The byte budget, not the requested limit, ended this page: fewer than
+		// limit insights were returned so the response stays under the output cap.
+		// Page on with next_offset to read the rest (#724).
+		result["page_size_capped"] = true
 	}
 	return jsonResult(result)
+}
+
+// bulkReviewItem is the per-insight shape returned by itemized bulk_review. It is
+// the full Insight (so every field a reviewer had before this change, including
+// session_id, persona and related_columns, is preserved and no per-insight fetch
+// is needed, #724) with one substitution: the suggested_actions array is hidden
+// and replaced by suggested_actions_count. suggested_actions carry uncapped query
+// SQL, so including them inline let a single insight overflow the output token
+// limit and stall paging; the full array remains available via fetch
+// mcp:insight:<id>. The outer SuggestedActions field shadows the embedded one (same
+// JSON name, shallower depth) so the array is omitted from the output.
+type bulkReviewItem struct {
+	Insight
+	SuggestedActions      []SuggestedAction `json:"suggested_actions,omitempty"`
+	SuggestedActionsCount int               `json:"suggested_actions_count"`
+}
+
+// toReviewItem wraps one insight as a review item: the suggested_actions array is
+// dropped from the embedded copy and replaced by its count.
+func toReviewItem(in Insight) bulkReviewItem {
+	count := len(in.SuggestedActions)
+	in.SuggestedActions = nil
+	return bulkReviewItem{Insight: in, SuggestedActionsCount: count}
+}
+
+// toReviewItems maps insights to the review-item shape.
+func toReviewItems(insights []Insight) []bulkReviewItem {
+	items := make([]bulkReviewItem, len(insights))
+	for i := range insights {
+		items[i] = toReviewItem(insights[i])
+	}
+	return items
 }
 
 // collectPending returns every pending insight in the global review queue by
@@ -392,11 +445,12 @@ func (t *Toolkit) collectPending(ctx context.Context) ([]Insight, error) {
 	}
 }
 
-// pageInsights returns the window [offset, offset+limit) of insights together
-// with the offset used and the next offset to request, or -1 when the window
-// reaches the end. A non-positive limit defaults to DefaultLimit and is capped
-// at MaxLimit; a negative offset is treated as 0.
-func pageInsights(all []Insight, offset, limit int) (page []Insight, usedOffset, nextOffset int) {
+// normalizeWindow clamps a requested offset/limit against a record count, returning
+// the usable start offset and the exclusive end of the limit window (end == start
+// when the offset is past the data). A non-positive limit defaults to DefaultLimit
+// and is capped at MaxLimit; a negative offset is treated as 0. pageInsights and
+// pageInsightsBudgeted share it so the paging bounds have one definition.
+func normalizeWindow(offset, limit, n int) (start, end int) {
 	if offset < 0 {
 		offset = 0
 	}
@@ -406,14 +460,115 @@ func pageInsights(all []Insight, offset, limit int) (page []Insight, usedOffset,
 	case limit > MaxLimit:
 		limit = MaxLimit
 	}
-	if offset >= len(all) {
-		return []Insight{}, offset, -1
+	if offset >= n {
+		return offset, offset
 	}
-	end := offset + limit
+	return offset, min(offset+limit, n)
+}
+
+// pageInsights returns the window [offset, offset+limit) of insights together
+// with the offset used and the next offset to request, or -1 when the window
+// reaches the end.
+func pageInsights(all []Insight, offset, limit int) (page []Insight, usedOffset, nextOffset int) {
+	start, end := normalizeWindow(offset, limit, len(all))
+	if start >= len(all) {
+		return []Insight{}, start, -1
+	}
 	if end >= len(all) {
-		return all[offset:], offset, -1
+		return all[start:], start, -1
 	}
-	return all[offset:end], offset, end
+	return all[start:end], start, end
+}
+
+// bulkReviewItemBudgetBytes bounds the cumulative serialized size of the insights
+// returned by one itemized bulk_review page (measured by reviewItemSize against the
+// emitted indented form), so a queue of large insights never pushes the response
+// past the MCP tool output token limit (#724). It is chosen together with
+// maxBulkReviewEntitySummaries so their joint worst case (this budget of insights
+// plus that many bounded entity summaries, the only two queue-sized parts of the
+// response) stays well under a ~25k-token output cap at roughly four bytes/token.
+const bulkReviewItemBudgetBytes = 40000
+
+// budgetedPage is the result of one byte-budgeted itemized bulk_review window:
+// the page of insights, the offset it started at, the next offset to request
+// (-1 at the end of the queue), and whether the byte budget ended the page.
+type budgetedPage struct {
+	insights []Insight
+	offset   int
+	next     int
+	capped   bool
+}
+
+// pageInsightsBudgeted windows all from offset like pageInsights, but additionally
+// ends the page once including the next insight would push the cumulative serialized
+// size past byteBudget, so an itemized bulk_review page stays under the output cap
+// regardless of individual insight sizes (#724). At least one insight is always
+// returned when offset is in range, so paging always makes progress; this is safe
+// because the projected item (toReviewItems) drops the only uncapped field
+// (suggested_actions), leaving the body (capped at MaxInsightTextLen) the largest
+// part, so no single item approaches the output cap. The result's capped field
+// reports whether the byte budget, rather than the limit or the end of the queue,
+// ended the page.
+func pageInsightsBudgeted(all []Insight, offset, limit, byteBudget int) budgetedPage {
+	start, end := normalizeWindow(offset, limit, len(all))
+	if start >= len(all) {
+		return budgetedPage{insights: []Insight{}, offset: start, next: -1}
+	}
+	size := 0
+	i := start
+	capped := false
+	for ; i < end; i++ {
+		itemSize := reviewItemSize(all[i])
+		// Always include the first insight of the page so a single large insight
+		// does not stall paging; stop before a later insight overflows the budget.
+		if i > start && size+itemSize > byteBudget {
+			capped = true
+			break
+		}
+		size += itemSize
+	}
+	page := budgetedPage{insights: all[start:i], offset: start, next: i, capped: capped}
+	if i >= len(all) {
+		page.next = -1
+	}
+	return page
+}
+
+// reviewItemSize reports the serialized size of the review item for an insight,
+// measured against the same indented form jsonResult emits so the byte budget
+// reflects the bytes actually sent. It marshals the projected item (rather than
+// estimating per field) so the budget cannot drift as the item shape changes;
+// json.Marshal of the item cannot fail (no unmarshalable fields), so the error is
+// intentionally ignored. The second marshal here (jsonResult re-marshals the whole
+// response) is negligible against the budget it guards.
+func reviewItemSize(in Insight) int {
+	b, _ := json.MarshalIndent(toReviewItem(in), "", "  ")
+	return len(b)
+}
+
+// maxBulkReviewEntitySummaries caps the by_entity array on an itemized bulk_review
+// response. by_entity carries one entry per distinct entity URN across the whole
+// pending queue, which is otherwise unbounded, so capping it (with by_entity_truncated
+// signaling the cut) keeps the whole response bounded, not just the insights array.
+const maxBulkReviewEntitySummaries = 100
+
+// boundedEntitySummaries returns buildEntitySummaries ordered by descending insight
+// count (ties broken by URN for a stable order) and capped at maxEntries, so the
+// itemized bulk_review response stays bounded even for a queue spanning many
+// distinct entities. truncated reports whether the cap dropped any entry; the
+// per-insight entity_urns still carry the complete entity set.
+func boundedEntitySummaries(insights []Insight, maxEntries int) (summaries []EntityInsightSummary, truncated bool) {
+	all := buildEntitySummaries(insights)
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].Count != all[j].Count {
+			return all[i].Count > all[j].Count
+		}
+		return all[i].EntityURN < all[j].EntityURN
+	})
+	if len(all) > maxEntries {
+		return all[:maxEntries], true
+	}
+	return all, false
 }
 
 // buildEntitySummaries groups insights by entity URN.

--- a/pkg/toolkits/knowledge/toolkit_test.go
+++ b/pkg/toolkits/knowledge/toolkit_test.go
@@ -979,6 +979,257 @@ func TestHandleBulkReview_ItemizeEnumeratesPendingBehindApplied(t *testing.T) {
 	assert.Len(t, seen, 30, "every pending insight enumerated across pages")
 }
 
+// TestHandleBulkReview_ItemizeIncludesBody locks issue #724 ask 1: an itemized
+// bulk_review page carries the full insight_text body so a review pass can read
+// every insight without a per-insight fetch.
+func TestHandleBulkReview_ItemizeIncludesBody(t *testing.T) {
+	body := "The amount column is gross margin before returns, not revenue."
+	store := &fullSpyStore{Insights: []Insight{
+		{
+			ID: "i1", Status: StatusPending, CapturedBy: "alice@example.com", Category: "correction",
+			Confidence: "high", InsightText: body, CreatedAt: time.Now(),
+		},
+	}}
+	tk := newApplyToolkit(t, store, &spyChangesetStore{}, &spyWriter{})
+
+	result, _, callErr := tk.handleApplyKnowledge(context.Background(), nil,
+		applyKnowledgeInput{Action: "bulk_review", Itemize: true})
+	require.Nil(t, callErr)
+	require.False(t, result.IsError)
+	m := parseJSONResult(t, result)
+
+	items, ok := m["insights"].([]any)
+	require.True(t, ok)
+	require.Len(t, items, 1)
+	row, ok := items[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, body, row["insight_text"], "the body is included so no per-insight fetch is needed")
+	assert.NotContains(t, m, "page_size_capped", "a small queue is not size-capped")
+}
+
+// TestHandleBulkReview_ItemizeBudgetCapsPage locks issue #724 ask 2: a queue of
+// large insights returns fewer than the requested limit per page (so the response
+// stays under the output cap), flags page_size_capped, and still enumerates every
+// insight (with its body) across pages via next_offset.
+func TestHandleBulkReview_ItemizeBudgetCapsPage(t *testing.T) {
+	base := time.Now()
+	const count = 25
+	bigBody := strings.Repeat("x", 4000) // near the real per-insight body ceiling
+	insights := make([]Insight, 0, count)
+	for i := range count {
+		insights = append(insights, Insight{
+			ID: fmt.Sprintf("pending-%02d", i), Status: StatusPending,
+			CapturedBy: "analyst@example.com", Category: "correction", Confidence: "high",
+			InsightText: bigBody, CreatedAt: base.Add(time.Duration(count-i) * time.Minute),
+		})
+	}
+	store := &fullSpyStore{Insights: insights}
+	tk := newApplyToolkit(t, store, &spyChangesetStore{}, &spyWriter{})
+
+	// First page: requested limit is the max, but the byte budget cuts it short.
+	first, _, callErr := tk.handleApplyKnowledge(context.Background(), nil,
+		applyKnowledgeInput{Action: "bulk_review", Itemize: true, Limit: MaxLimit})
+	require.Nil(t, callErr)
+	require.False(t, first.IsError)
+	fm := parseJSONResult(t, first)
+	firstItems, _ := fm["insights"].([]any)
+	require.NotEmpty(t, firstItems)
+	assert.Less(t, len(firstItems), count, "the byte budget returns fewer than the whole queue")
+	assert.Equal(t, true, fm["page_size_capped"], "page_size_capped signals a budget-truncated page")
+	require.Contains(t, fm, "next_offset", "more insights remain to page through")
+
+	// Page through to the end; every insight is enumerated once, with its body.
+	seen := map[string]bool{}
+	offset := 0
+	for range count + 5 {
+		result, _, err := tk.handleApplyKnowledge(context.Background(), nil,
+			applyKnowledgeInput{Action: "bulk_review", Itemize: true, Limit: MaxLimit, Offset: offset})
+		require.Nil(t, err)
+		m := parseJSONResult(t, result)
+		items, _ := m["insights"].([]any)
+
+		// The marshaled insights array stays within the budget (the always-take-one
+		// rule allows a single item to exceed it, but here no single body does).
+		raw, mErr := json.Marshal(items)
+		require.NoError(t, mErr)
+		assert.LessOrEqual(t, len(raw), bulkReviewItemBudgetBytes, "page insights fit the byte budget")
+
+		for _, it := range items {
+			row, _ := it.(map[string]any)
+			id, _ := row["id"].(string)
+			require.False(t, seen[id], "no duplicate %s", id)
+			seen[id] = true
+			assert.Equal(t, bigBody, row["insight_text"], "body carried on every page")
+		}
+		next, ok := m["next_offset"]
+		if !ok {
+			break
+		}
+		nextF, _ := next.(float64)
+		offset = int(nextF)
+	}
+	assert.Len(t, seen, count, "every insight enumerated across budget-capped pages")
+}
+
+// TestHandleBulkReview_ItemizeProjectsSuggestedActions locks the projection: the
+// uncapped suggested_actions array is replaced by suggested_actions_count so a
+// single insight's query SQL cannot overflow the output cap (issue #724 [1]).
+func TestHandleBulkReview_ItemizeProjectsSuggestedActions(t *testing.T) {
+	store := &fullSpyStore{Insights: []Insight{
+		{
+			ID: "i1", Status: StatusPending, CapturedBy: "alice@example.com", SessionID: "sess-1",
+			Persona: "analyst", Category: "correction",
+			Confidence: "high", InsightText: "body", CreatedAt: time.Now(),
+			EntityURNs:     []string{testEntityURN},
+			RelatedColumns: []RelatedColumn{{URN: testEntityURN, Column: "amount", Relevance: "direct"}},
+			SuggestedActions: []SuggestedAction{
+				{ActionType: testActionAddTag},
+				{ActionType: "add_curated_query", QuerySQL: strings.Repeat("SELECT 1 ", 100)},
+			},
+		},
+	}}
+	tk := newApplyToolkit(t, store, &spyChangesetStore{}, &spyWriter{})
+
+	result, _, callErr := tk.handleApplyKnowledge(context.Background(), nil,
+		applyKnowledgeInput{Action: "bulk_review", Itemize: true})
+	require.Nil(t, callErr)
+	m := parseJSONResult(t, result)
+	items, _ := m["insights"].([]any)
+	require.Len(t, items, 1)
+	row, _ := items[0].(map[string]any)
+	assert.Equal(t, float64(2), row["suggested_actions_count"], "the count replaces the full array")
+	assert.NotContains(t, row, "suggested_actions", "the heavy suggested_actions array is dropped from the listing")
+	assert.Contains(t, row, "created_at", "created_at is still present for time-based triage")
+	// The full record is preserved (only suggested_actions is substituted), so
+	// fields like session_id that callers grouped on are not silently dropped.
+	assert.Equal(t, "sess-1", row["session_id"], "session_id preserved on the full record")
+	assert.Equal(t, "analyst", row["persona"], "persona preserved on the full record")
+}
+
+// TestHandleBulkReview_ItemizeCapsByEntity locks issue #724 [0]: by_entity is built
+// over the whole queue and is otherwise unbounded, so it is capped and the cut is
+// flagged with by_entity_truncated.
+func TestHandleBulkReview_ItemizeCapsByEntity(t *testing.T) {
+	base := time.Now()
+	// One insight per distinct entity URN, more than the cap.
+	total := maxBulkReviewEntitySummaries + 15
+	insights := make([]Insight, 0, total)
+	for i := range total {
+		insights = append(insights, Insight{
+			ID: fmt.Sprintf("i%03d", i), Status: StatusPending, CapturedBy: "a@example.com",
+			Category: "correction", Confidence: "high", InsightText: "b",
+			EntityURNs: []string{fmt.Sprintf("urn:li:dataset:(urn:li:dataPlatform:trino,db.t%03d,PROD)", i)},
+			CreatedAt:  base.Add(time.Duration(i) * time.Minute),
+		})
+	}
+	store := &fullSpyStore{Insights: insights}
+	tk := newApplyToolkit(t, store, &spyChangesetStore{}, &spyWriter{})
+
+	result, _, callErr := tk.handleApplyKnowledge(context.Background(), nil,
+		applyKnowledgeInput{Action: "bulk_review", Itemize: true, Limit: 5})
+	require.Nil(t, callErr)
+	m := parseJSONResult(t, result)
+
+	byEntity, ok := m["by_entity"].([]any)
+	require.True(t, ok)
+	assert.Len(t, byEntity, maxBulkReviewEntitySummaries, "by_entity is capped")
+	assert.Equal(t, true, m["by_entity_truncated"], "the cut is flagged")
+	assert.Equal(t, float64(total), m["total_pending"], "the count still reflects the whole queue")
+}
+
+// TestPageInsightsBudgeted covers the windowing arithmetic: limit-bound vs
+// budget-bound vs end-of-queue termination, the always-take-at-least-one rule for
+// an oversized leading insight, and out-of-range offsets.
+func TestPageInsightsBudgeted(t *testing.T) {
+	// Uniformly sized insights so item size is predictable via reviewItemSize.
+	mk := func(n int) []Insight {
+		out := make([]Insight, n)
+		for i := range out {
+			out[i] = Insight{ID: fmt.Sprintf("i%02d", i), InsightText: strings.Repeat("y", 100)}
+		}
+		return out
+	}
+	all := mk(10)
+	itemSize := reviewItemSize(all[0])
+
+	t.Run("empty input returns empty page and no next", func(t *testing.T) {
+		p := pageInsightsBudgeted(nil, 0, 10, 1<<20)
+		assert.Empty(t, p.insights)
+		assert.Equal(t, 0, p.offset)
+		assert.Equal(t, -1, p.next)
+		assert.False(t, p.capped)
+	})
+
+	t.Run("offset past end returns empty and no next", func(t *testing.T) {
+		p := pageInsightsBudgeted(all, 100, 10, 1<<20)
+		assert.Empty(t, p.insights)
+		assert.Equal(t, 100, p.offset)
+		assert.Equal(t, -1, p.next)
+		assert.False(t, p.capped)
+	})
+
+	t.Run("whole queue under limit and budget", func(t *testing.T) {
+		p := pageInsightsBudgeted(all, 0, MaxLimit, 1<<20)
+		assert.Len(t, p.insights, 10)
+		assert.Equal(t, 0, p.offset)
+		assert.Equal(t, -1, p.next)
+		assert.False(t, p.capped)
+	})
+
+	t.Run("limit-bound page is not flagged capped", func(t *testing.T) {
+		p := pageInsightsBudgeted(all, 0, 4, 1<<20)
+		assert.Len(t, p.insights, 4)
+		assert.Equal(t, 0, p.offset)
+		assert.Equal(t, 4, p.next, "next_offset advances by the limit")
+		assert.False(t, p.capped, "the limit, not the budget, ended the page")
+	})
+
+	t.Run("budget-bound page is flagged capped and pages on", func(t *testing.T) {
+		// Budget fits exactly three items, well under the requested limit.
+		budget := itemSize*3 + itemSize/2
+		p := pageInsightsBudgeted(all, 0, MaxLimit, budget)
+		assert.Len(t, p.insights, 3)
+		assert.Equal(t, 0, p.offset)
+		assert.Equal(t, 3, p.next)
+		assert.True(t, p.capped)
+	})
+
+	t.Run("single oversized insight is always returned", func(t *testing.T) {
+		// A budget smaller than one item must still make progress.
+		p := pageInsightsBudgeted(all, 0, MaxLimit, 1)
+		assert.Len(t, p.insights, 1, "always take at least one so paging never stalls")
+		assert.Equal(t, 0, p.offset)
+		assert.Equal(t, 1, p.next)
+		assert.True(t, p.capped)
+	})
+
+	t.Run("limit above max is clamped to MaxLimit", func(t *testing.T) {
+		big := mk(MaxLimit + 5)
+		p := pageInsightsBudgeted(big, 0, MaxLimit+50, 1<<30)
+		assert.Len(t, p.insights, MaxLimit, "page is clamped to MaxLimit even with a generous budget")
+		assert.Equal(t, 0, p.offset)
+		assert.Equal(t, MaxLimit, p.next, "the clamped limit, not the budget, ended the page")
+		assert.False(t, p.capped)
+	})
+
+	t.Run("non-positive limit defaults to DefaultLimit", func(t *testing.T) {
+		big := mk(DefaultLimit + 5)
+		p := pageInsightsBudgeted(big, 0, 0, 1<<30)
+		assert.Len(t, p.insights, DefaultLimit, "a zero limit defaults to DefaultLimit")
+		assert.Equal(t, DefaultLimit, p.next)
+		assert.False(t, p.capped)
+	})
+
+	t.Run("budget cut on the final stretch returns no next", func(t *testing.T) {
+		budget := itemSize*3 + itemSize/2
+		p := pageInsightsBudgeted(all, 8, MaxLimit, budget)
+		assert.Len(t, p.insights, 2, "only two insights remain from offset 8")
+		assert.Equal(t, 8, p.offset)
+		assert.Equal(t, -1, p.next, "the end of the queue, reached within budget, returns no next")
+		assert.False(t, p.capped)
+	})
+}
+
 // ---------------------------------------------------------------------------
 // AC-4: review returns entity insights + metadata
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #724

## Summary

Reviewing the insight queue with `apply_knowledge action=bulk_review itemize:true` could exceed the MCP tool output token limit, forcing the response to be retrieved from a saved file. This PR bounds every queue-sized part of the itemized response so a page always stays under the cap, while keeping the full insight body inline so a review pass needs no per-insight `fetch`.

The itemized response already returned the full `insight_text` body (verified against the live v1.94.1 deployment), so the issue's first ask was already met. The work here is bounding the response so itemized review never errors out of the box.

## What caused the overflow

- **`suggested_actions`** was serialized inline on every listed insight, and `add_curated_query` actions carry uncapped query SQL, so a single insight could exceed the output cap on its own.
- **`by_entity`** was built over the entire pending queue (one entry per distinct entity URN) with no cap, so a many-entity queue could blow the response independent of the insights array.

## Changes (`pkg/toolkits/knowledge/`)

- **Byte-budgeted insights window** (`pageInsightsBudgeted`): a page ends once including the next insight would push the cumulative serialized size past a budget, returning fewer than `limit` insights and setting `page_size_capped: true`. At least one insight is always returned so paging never stalls; size is measured against the same indented form the response is emitted in, so the budget cannot drift.
- **Projected review item** (`bulkReviewItem`): each listed insight is the full record with only `suggested_actions` replaced by `suggested_actions_count`. Every other field (including `session_id`, `persona`, `related_columns`) is preserved by embedding `Insight`; the full actions remain available via `fetch mcp:insight:<id>`. This removes the only uncapped field, so a single item can no longer overflow the cap.
- **Bounded `by_entity`** (`boundedEntitySummaries`): capped to the busiest entities (by insight count) with a `by_entity_truncated: true` flag; each insight still carries its complete `entity_urns`. The byte budget and entity cap are chosen so their joint worst case stays well under the output cap.
- **Shared paging clamp** (`normalizeWindow`): one definition of the offset/limit normalization, used by both `pageInsights` and `pageInsightsBudgeted`.

## Response shape

A reviewer paging the queue now gets, per insight: the full `insight_text` body plus `id`, `captured_by`, `session_id`, `persona`, `sink_class`, `category`, `confidence`, `status`, `entity_urns`, `related_columns`, `created_at`, and `suggested_actions_count`. New response signals: `page_size_capped` (insights page cut short by the byte budget) and `by_entity_truncated` (entity summary capped) — both mean "more remain", continue with `next_offset`.

## Tests

- `TestHandleBulkReview_ItemizeIncludesBody` — the body is returned inline.
- `TestHandleBulkReview_ItemizeProjectsSuggestedActions` — `suggested_actions` is replaced by `suggested_actions_count`; `session_id`/`persona` are preserved.
- `TestHandleBulkReview_ItemizeBudgetCapsPage` — large insights return fewer than `limit`, set `page_size_capped`, and the whole queue is still enumerated across pages.
- `TestHandleBulkReview_ItemizeCapsByEntity` — `by_entity` is capped and `by_entity_truncated` is set while `total_pending` reflects the whole queue.
- `TestPageInsightsBudgeted` — windowing arithmetic: limit-bound vs budget-bound vs end-of-queue, always-take-one, and offset/limit clamping.

## Docs

Updated the tool schema description and `docs/knowledge/governance.md`, `docs/server/tools.md`, `docs/reference/tools-api.md`, `docs/llms-full.txt` to describe the field set, `suggested_actions_count`, and the `page_size_capped` / `by_entity_truncated` signals.

## Verification

`make verify` passes (tests with race, total + patch coverage ≥80%, lint, gosec, govulncheck, semgrep, CodeQL, dead-code, mutation ≥60%, doc-check, GoReleaser dry-run).