### PR TITLE
fix(knowledge): warn in the search tool that catalog results can lag recent writes (#728)

### DIFF
--- a/pkg/toolkits/search/toolkit.go
+++ b/pkg/toolkits/search/toolkit.go
@@ -190,7 +190,11 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 			"you know about specific datasets. Personal results are scoped to you. To enumerate a whole source " +
 			"instead of relevance-ranking it (to audit or migrate it), call with exactly one `sources` entry, " +
 			"no intent, and an `offset`: this browses the complete set with a total count (browsable: " +
-			"knowledge_pages, context_documents).",
+			"knowledge_pages, context_documents). Freshness: catalog and context-document results come from " +
+			"DataHub's search index, which is eventually consistent and can briefly lag a recent catalog write, so " +
+			"a result may still show pre-edit text right after you change it. To confirm a specific entity's " +
+			"current state after a write, read it directly (datahub_get_entity, or the resulting_state in the " +
+			"apply_knowledge apply response), not search.",
 		InputSchema: searchSchema,
 	}, t.handleSearch)
 


### PR DESCRIPTION
## Summary

`search` (sources=`catalog`) could return the pre-edit description of an entity that was just corrected, while `datahub_get_entity` showed the new text immediately, with no signal that the search result was stale (#728). This adds an agent-facing freshness caveat so the model knows not to trust `search` to confirm a recent write.

## Why this is the right fix

Catalog and context-document search go through DataHub's `SearchAcrossEntities` (`pkg/semantic/datahub/adapter.go`), which reads DataHub's **eventually-consistent search index**, whereas `datahub_get_entity` reads the entity's aspects directly (read-your-writes). So the staleness is inherent to DataHub, not a bug on our side.

Of the three options the issue lists:

- **Reduce the index lag** is DataHub's ingestion pipeline, not something this platform controls.
- **A per-result freshness signal would be unreliable**: DataHub's `LastModified` reflects the entity's edit time, not when the search index observed it, and it cannot tell a caller that a result predates *their own* recent write.
- **Document / guide the agent** is the tractable, honest fix, and it is where the problem actually bites (the agent using `search` to verify).

This mirrors the fix for the sibling issue #725: the behavior is correct, the agent-facing contract just needed to say so.

## Change

The `search` tool description (`pkg/toolkits/search/toolkit.go`) now states that catalog and context-document results come from an eventually-consistent index that can briefly lag a recent catalog write (so a result may still show pre-edit text right after a change), and that to confirm a specific entity's current state after a write you read it directly (`datahub_get_entity`, or the `resulting_state` in the `apply_knowledge` apply response), not `search`.

## Testing

`make verify` green. This is an agent-facing description string; there is no behavior change to test. A drift guard would require extracting the inline tool `Description` to a named constant first (as `knowledge_apply_guidance` already is); happy to do that as a follow-up if a regression test is wanted here.

Closes #728
