### PR TITLE
fix(memory): gate pending insight candidates out of the enrichment push path (#745)

### DIFF
--- a/pkg/memory/postgres.go
+++ b/pkg/memory/postgres.go
@@ -630,6 +630,40 @@ func (s *postgresStore) EntityLookup(ctx context.Context, urn, persona, createdB
 	// memories. Empty leaves the lookup persona-scoped (the enrichment path).
 	if createdBy != "" {
 		qb = qb.Where(sq.Eq{colCreatedBy: createdBy})
+	} else {
+		// Persona-scoped lookup (createdBy == "") is the enrichment push path:
+		// it injects entity-linked knowledge into any same-persona agent's tool
+		// results. A pending insight candidate has not been evaluated by anyone
+		// yet, so it must not be pushed before it is grounded (#745). Any
+		// transition off pending lifts this gate.
+		//
+		// Every live path that creates a pending candidate stamps an explicit
+		// marker: memory_capture and the portal capture set metadata.insight_status
+		// = pending; insights migrated from knowledge_insights carry no
+		// insight_status and record their state under metadata.legacy_status
+		// (migration 000031). The gate keys off those explicit markers, applying
+		// resolveInsightStatus's precedence between them: insight_status is
+		// authoritative and legacy_status is only the fallback. That precedence
+		// matters when a migrated candidate is later approved: UpdateStatus merges
+		// the new insight_status without clearing the stale legacy_status='pending',
+		// and a naive "either key is pending" gate would keep excluding the
+		// now-grounded insight forever. COALESCE(insight_status, legacy_status)
+		// resolves to the authoritative value, so the record is gated only while it
+		// is truly pending.
+		//
+		// The gate deliberately stops at the explicit markers and does NOT apply
+		// resolveInsightStatus's third-level status-column fallback (an active
+		// knowledge record with no marker maps to pending). That fallback is an
+		// insight-lens default; applying it here would exclude markerless active
+		// memories that are not pending candidates: non-insight memories and
+		// established knowledge captured before the marker convention. A record with
+		// neither marker therefore resolves to NULL, which IS DISTINCT FROM keeps.
+		//
+		// A user-scoped lookup (createdBy set) is the caller reading their own
+		// memories and may include their own candidates.
+		qb = qb.Where(sq.Expr(
+			"COALESCE(NULLIF(metadata ->> ?, ''), NULLIF(metadata ->> ?, '')) IS DISTINCT FROM ?",
+			MetaKeyInsightStatus, MetaKeyLegacyStatus, InsightStatusPending))
 	}
 
 	query, args, err := qb.ToSql()

--- a/pkg/memory/postgres_test.go
+++ b/pkg/memory/postgres_test.go
@@ -448,6 +448,9 @@ func TestPostgresStore_EntityLookup_WithPersona(t *testing.T) {
 			sqlmock.AnyArg(), // entity_urns @> JSON
 			StatusActive,
 			"analyst",
+			MetaKeyInsightStatus, // authoritative pending marker (push path)
+			MetaKeyLegacyStatus,  // fallback marker (migrated candidates)
+			InsightStatusPending,
 		).
 		WillReturnRows(rows)
 
@@ -458,7 +461,38 @@ func TestPostgresStore_EntityLookup_WithPersona(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestPostgresStore_EntityLookup_WithoutPersona covers the persona-scoped enrichment
+// push path (persona == "", createdBy == ""). It asserts the precedence-honoring
+// COALESCE(insight_status, legacy_status) pending-exclusion predicate is emitted so an
+// un-evaluated candidate (live or migrated) is never pushed into an agent's context
+// before it is grounded (#745).
 func TestPostgresStore_EntityLookup_WithoutPersona(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	store := NewPostgresStore(db)
+
+	mock.ExpectQuery("SELECT .+ FROM memory_records WHERE .+COALESCE.NULLIF.metadata ->> .+ IS DISTINCT FROM").
+		WithArgs(
+			sqlmock.AnyArg(), // entity_urns @> JSON
+			StatusActive,
+			MetaKeyInsightStatus, // authoritative pending marker (push path)
+			MetaKeyLegacyStatus,  // fallback marker (migrated candidates)
+			InsightStatusPending,
+		).
+		WillReturnRows(sqlmock.NewRows(memorySelectColumns))
+
+	records, err := store.EntityLookup(context.Background(), "urn:li:dataset:bar", "", "")
+	require.NoError(t, err)
+	assert.Empty(t, records)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestPostgresStore_EntityLookup_UserScopedKeepsPending asserts the user-scoped
+// search path (createdBy set) does NOT apply the pending exclusion: a caller may see
+// their own un-evaluated candidates. The query filters by created_by instead (#745).
+func TestPostgresStore_EntityLookup_UserScopedKeepsPending(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer db.Close() //nolint:errcheck // test cleanup
@@ -469,10 +503,11 @@ func TestPostgresStore_EntityLookup_WithoutPersona(t *testing.T) {
 		WithArgs(
 			sqlmock.AnyArg(), // entity_urns @> JSON
 			StatusActive,
+			"user@example.com", // created_by scope, no pending exclusion
 		).
 		WillReturnRows(sqlmock.NewRows(memorySelectColumns))
 
-	records, err := store.EntityLookup(context.Background(), "urn:li:dataset:bar", "", "")
+	records, err := store.EntityLookup(context.Background(), "urn:li:dataset:qux", "", "user@example.com")
 	require.NoError(t, err)
 	assert.Empty(t, records)
 	assert.NoError(t, mock.ExpectationsWereMet())

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -32,7 +32,10 @@ type Store interface {
 
 	// EntityLookup returns active memories linked to a DataHub URN. persona
 	// narrows to one persona when set; createdBy narrows to one owner (the
-	// per-user scope for search) when set. Either may be empty.
+	// per-user scope for search) when set. Either may be empty. When createdBy
+	// is empty (the persona-scoped enrichment push path), pending insight
+	// candidates are excluded so un-evaluated knowledge is not pushed into an
+	// agent's context before it is grounded (#745).
 	EntityLookup(ctx context.Context, urn, persona, createdBy string) ([]Record, error)
 
 	// MarkStale flags memory records as stale with a reason.

--- a/pkg/memory/store_realdb_integration_test.go
+++ b/pkg/memory/store_realdb_integration_test.go
@@ -181,3 +181,107 @@ func TestMemoryStore_Supersede_RealDB_AdvancesInsightStatus(t *testing.T) {
 	assert.False(t, hasInsightStatus, "a non-insight record must not be given an insight_status")
 	assert.Equal(t, "mem_successor", gotPref.Metadata["superseded_by"])
 }
+
+// TestMemoryStore_EntityLookup_RealDB_PushPathGatesPending is the #745 acceptance
+// test at the store level. The persona-scoped enrichment push path (createdBy == "")
+// must exclude un-evaluated candidates regardless of how their pending state is
+// encoded:
+//   - live captures set metadata.insight_status = pending
+//   - insights migrated from knowledge_insights carry no insight_status and record
+//     their state under metadata.legacy_status (migration 000031)
+//
+// Grounded records (any status off pending) and non-insight memories (no marker)
+// must still be pushed. The user-scoped path (createdBy set) is a caller reading
+// their own memories and keeps their own pending candidates.
+func TestMemoryStore_EntityLookup_RealDB_PushPathGatesPending(t *testing.T) {
+	store := NewPostgresStore(testdb.New(t))
+	ctx := context.Background()
+
+	const (
+		urn   = "urn:li:dataset:(urn:li:dataPlatform:trino,cat.sch.tbl,PROD)"
+		owner = "owner@example.com"
+		other = "analyst"
+	)
+	knowledgeRec := func(id, content string, meta map[string]any) Record {
+		return Record{
+			ID:         id,
+			CreatedBy:  owner,
+			Persona:    other,
+			Dimension:  DimensionKnowledge,
+			SinkClass:  SinkSchemaEntity,
+			Content:    content,
+			Category:   CategoryBusinessCtx,
+			Confidence: ConfidenceHigh,
+			Source:     SourceUser,
+			Status:     StatusActive,
+			EntityURNs: []string{urn},
+			Metadata:   meta,
+		}
+	}
+
+	// Two pending encodings that must be gated on the push path.
+	pendingInsight := knowledgeRec("mem_745_pending_insight", "Pending live capture.",
+		map[string]any{MetaKeyInsightStatus: InsightStatusPending})
+	migratedPending := knowledgeRec("mem_745_pending_legacy", "Pending migrated insight.",
+		map[string]any{MetaKeyLegacyStatus: InsightStatusPending})
+	// Grounded records that must still be pushed.
+	appliedInsight := knowledgeRec("mem_745_applied", "Grounded via apply.",
+		map[string]any{MetaKeyInsightStatus: "applied"})
+	migratedApproved := knowledgeRec("mem_745_legacy_approved", "Grounded migrated insight.",
+		map[string]any{MetaKeyLegacyStatus: "approved"})
+	// A migrated candidate later approved: UpdateStatus merges insight_status
+	// without clearing the stale legacy_status='pending', so the record carries
+	// BOTH keys. insight_status is authoritative (resolveInsightStatus precedence),
+	// so this grounded insight must still be pushed. Gating on "either key pending"
+	// would withhold it forever.
+	migratedThenApproved := knowledgeRec("mem_745_legacy_then_approved", "Migrated, then approved.",
+		map[string]any{MetaKeyInsightStatus: "approved", MetaKeyLegacyStatus: InsightStatusPending})
+	// A non-insight preference (no marker) must never be gated by the insight logic.
+	preference := Record{
+		ID:         "mem_745_pref",
+		CreatedBy:  owner,
+		Persona:    other,
+		Dimension:  DimensionPreference,
+		SinkClass:  SinkPersonalPreference,
+		Content:    "User prefers ISO dates.",
+		Category:   CategoryGeneral,
+		Confidence: ConfidenceHigh,
+		Source:     SourceUser,
+		Status:     StatusActive,
+		EntityURNs: []string{urn},
+	}
+	for _, r := range []Record{
+		pendingInsight, migratedPending, appliedInsight, migratedApproved, migratedThenApproved, preference,
+	} {
+		require.NoError(t, store.Insert(ctx, r))
+	}
+
+	ids := func(records []Record) map[string]bool {
+		set := make(map[string]bool, len(records))
+		for _, r := range records {
+			set[r.ID] = true
+		}
+		return set
+	}
+
+	// Push path: persona-scoped, createdBy == "".
+	pushed, err := store.EntityLookup(ctx, urn, other, "")
+	require.NoError(t, err)
+	got := ids(pushed)
+	assert.False(t, got[pendingInsight.ID], "insight_status=pending candidate must not be pushed")
+	assert.False(t, got[migratedPending.ID], "legacy_status=pending (migrated) candidate must not be pushed")
+	assert.True(t, got[appliedInsight.ID], "grounded (applied) insight must be pushed")
+	assert.True(t, got[migratedApproved.ID], "grounded (legacy approved) insight must be pushed")
+	assert.True(t, got[migratedThenApproved.ID],
+		"grounded insight with stale legacy_status=pending must be pushed (insight_status is authoritative)")
+	assert.True(t, got[preference.ID], "non-insight memory must be pushed")
+
+	// User-scoped path: createdBy set to the owner. The caller sees their own
+	// candidates; the pending gate does not apply.
+	own, err := store.EntityLookup(ctx, urn, other, owner)
+	require.NoError(t, err)
+	gotOwn := ids(own)
+	assert.True(t, gotOwn[pendingInsight.ID], "owner sees their own insight_status=pending candidate")
+	assert.True(t, gotOwn[migratedPending.ID], "owner sees their own legacy_status=pending candidate")
+	assert.Len(t, own, 6, "user-scoped lookup returns all of the owner's entity-linked records")
+}

--- a/pkg/memory/types.go
+++ b/pkg/memory/types.go
@@ -109,7 +109,13 @@ const (
 	MetaKeyInsightStatus    = "insight_status"
 	MetaKeySuggestedActions = "suggested_actions"
 	MetaKeySessionID        = "session_id"
-	InsightStatusPending    = "pending"
+	// MetaKeyLegacyStatus holds the original review status of an insight migrated
+	// from the old knowledge_insights table (migration 000031). Those rows carry
+	// no insight_status key, so legacy_status is the pending source for migrated
+	// candidates. resolveInsightStatus falls back to it after insight_status, and
+	// the enrichment push gate must honor both keys (#745).
+	MetaKeyLegacyStatus  = "legacy_status"
+	InsightStatusPending = "pending"
 	// InsightStatusSuperseded mirrors knowledgekit.StatusSuperseded. It is the
 	// review-status counterpart of the StatusSuperseded lifecycle column: when a
 	// record is superseded, its insight review status must follow, or the insights

--- a/pkg/toolkits/knowledge/memory_adapter.go
+++ b/pkg/toolkits/knowledge/memory_adapter.go
@@ -16,6 +16,10 @@ const (
 	// so memory_capture and this adapter agree on where review state lives.
 	metaKeyInsightStatus = memory.MetaKeyInsightStatus
 	metaKeyChangesetRef  = "changeset_ref"
+	// metaKeyLegacyStatus is the original review status of an insight migrated
+	// from knowledge_insights (migration 000031); those rows carry no
+	// insight_status, so this is the pending source for migrated candidates.
+	metaKeyLegacyStatus = memory.MetaKeyLegacyStatus
 )
 
 // memoryInsightAdapter implements InsightStore by delegating to a memory.Store.
@@ -514,7 +518,7 @@ func resolveInsightStatus(record memory.Record) string {
 		}
 	}
 	// Fall back to legacy_status (set by migration from knowledge_insights).
-	if v, ok := record.Metadata["legacy_status"]; ok {
+	if v, ok := record.Metadata[metaKeyLegacyStatus]; ok {
 		if s, ok := v.(string); ok && s != "" {
 			return s
 		}


### PR DESCRIPTION
## Summary

Pending (un-evaluated) knowledge-dimension memory records were leaking into the **enrichment push path**. When a tool result was cross-enriched, `MiddlewareAdapter.RecallForEntities` calls `Store.EntityLookup` with `createdBy = ""` (persona-scoped, not user-scoped). `EntityLookup` filtered only on `status = 'active'` and did not exclude pending candidates, so a candidate linked to an entity URN was injected into the tool-result context of **any same-persona agent** that later touched that entity, before anyone had validated it.

Enrichment is meant to inject established knowledge. This change gates the push path on the record's evaluation status so un-grounded candidates are held back until they are grounded (by human review via `apply_knowledge` or by an agent that validated them). Any transition off `pending` lifts the gate.

Closes #745

## The gate

`EntityLookup`'s persona-scoped branch (`createdBy == ""`) now excludes pending candidates. The user-scoped branch (`createdBy` set, the search path) is unchanged, so a caller still sees their own candidates.

```sql
COALESCE(NULLIF(metadata ->> 'insight_status', ''), NULLIF(metadata ->> 'legacy_status', '')) IS DISTINCT FROM 'pending'
```

Pending state is encoded two ways, and the predicate handles both while honoring `resolveInsightStatus`'s precedence:

| Record shape | `insight_status` | `legacy_status` | Effective | Push path |
|---|---|---|---|---|
| Live capture, pending | `pending` | absent | pending | **excluded** |
| Migrated candidate (migration `000031`) | absent | `pending` | pending | **excluded** |
| Migrated, then approved | `approved` | `pending` (stale) | approved | pushed |
| Grounded (applied/approved) | `applied` | absent | applied | pushed |
| Non-insight memory (preference/event) | absent | absent | NULL | pushed |

- **`legacy_status` matters:** insights migrated from the old `knowledge_insights` table (`000031`) carry no `insight_status`; they record their prior state under `metadata.legacy_status`. An `insight_status`-only gate would miss a migrated pending candidate.
- **Precedence matters:** when a migrated candidate is later approved, `UpdateStatus` merges the new `insight_status` (`metadata || jsonb`) without clearing the stale `legacy_status='pending'`. A naive "either key is pending" gate would withhold that now-grounded insight forever. `COALESCE(insight_status, legacy_status)` resolves to the authoritative value.
- **Deliberate scope:** the gate stops at explicit markers and does **not** apply `resolveInsightStatus`'s third-level `active -> pending` status-column fallback. That fallback is an insight-lens default; applying it here would wrongly exclude markerless-active memories that are not pending candidates (non-insight memories and established knowledge captured before the marker convention). Every live path that creates a pending candidate stamps an explicit marker (`memory_capture` and the portal capture set `insight_status = pending`; migration sets `legacy_status`), so keying off explicit markers covers all real data.

## Changes

- **`pkg/memory/postgres.go`** — the push-path pending gate + explanatory comment.
- **`pkg/memory/types.go`** — `MetaKeyLegacyStatus` constant, single source of truth for the `legacy_status` key.
- **`pkg/memory/store.go`** — `EntityLookup` interface doc updated to describe the push-path gating.
- **`pkg/toolkits/knowledge/memory_adapter.go`** — reference the shared constant instead of the `"legacy_status"` literal.
- **`pkg/memory/postgres_test.go`** — updated sqlmock expectations; a user-scoped-keeps-pending test.
- **`pkg/memory/store_realdb_integration_test.go`** — real-Postgres acceptance test proving both pending encodings (and the migrated-then-approved both-keys case) are gated on the push path, while grounded and non-insight records still flow; the user-scoped path keeps the owner's candidates.

## Testing

- Unit tests pass (`go test ./pkg/memory/ ./pkg/toolkits/knowledge/`).
- Real-Postgres integration acceptance test passes (`go test -tags integration -run TestMemoryStore_EntityLookup_RealDB_PushPathGatesPending ./pkg/memory/`, against `pgvector/pg16`).
- `make verify` green end-to-end (fmt, race tests, coverage >=80% + patch coverage, golangci-lint, gosec, govulncheck, semgrep, CodeQL, dead-code, mutation, GoReleaser dry-run).
