### PR TITLE
fix(config,docs): strict YAML parsing + config/docs drift sweep

### DIFF
--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -180,7 +180,7 @@ toolkits:
     enabled: false
     instances:
       primary:
-        endpoint: "https://datahub.example.com/api/graphql"
+        url: "https://datahub.example.com/api/graphql"
         token: "${DATAHUB_TOKEN}"
         debug: false            # Enable debug logging for GraphQL operations
         read_only: true         # Restrict to read operations

--- a/docs/auth/overview.md
+++ b/docs/auth/overview.md
@@ -19,12 +19,18 @@ When running mcp-data-platform locally via stdio (Claude Desktop, Claude Code), 
 ```yaml
 toolkits:
   trino:
-    primary:
-      user: ${TRINO_USER}        # Your credentials
-      password: ${TRINO_PASSWORD}
+    enabled: true
+    instances:
+      primary:
+        user: ${TRINO_USER}        # Your credentials
+        password: ${TRINO_PASSWORD}
+    default: primary
   datahub:
-    primary:
-      token: ${DATAHUB_TOKEN}    # Your token
+    enabled: true
+    instances:
+      primary:
+        token: ${DATAHUB_TOKEN}    # Your token
+    default: primary
 ```
 
 You're authenticated implicitly. It's your machine, your config, your credentials.

--- a/docs/cross-enrichment/overview.md
+++ b/docs/cross-enrichment/overview.md
@@ -363,7 +363,6 @@ semantic:
   cache:
     enabled: true
     ttl: 5m
-    max_entries: 10000
 
 # Configure the query provider (for DataHub enrichment)
 query:
@@ -389,9 +388,12 @@ enrichment:
 # Only DataHub toolkit, no cross-enrichment
 toolkits:
   datahub:
-    primary:
-      url: https://datahub.example.com
-      token: ${DATAHUB_TOKEN}
+    enabled: true
+    instances:
+      primary:
+        url: https://datahub.example.com
+        token: ${DATAHUB_TOKEN}
+    default: primary
 ```
 
 ### Full Cross-Enrichment
@@ -424,22 +426,31 @@ storage:
 
 toolkits:
   datahub:
-    primary:
-      url: https://datahub.example.com
-      token: ${DATAHUB_TOKEN}
+    enabled: true
+    instances:
+      primary:
+        url: https://datahub.example.com
+        token: ${DATAHUB_TOKEN}
+    default: primary
 
   trino:
-    production:
-      host: trino.example.com
-      port: 443
-      ssl: true
-      catalog: hive
+    enabled: true
+    instances:
+      production:
+        host: trino.example.com
+        port: 443
+        ssl: true
+        catalog: hive
+    default: production
 
   s3:
-    data_lake:
-      region: us-east-1
-      access_key_id: ${AWS_ACCESS_KEY_ID}
-      secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+    enabled: true
+    instances:
+      data_lake:
+        region: us-east-1
+        access_key_id: ${AWS_ACCESS_KEY_ID}
+        secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+    default: data_lake
 ```
 
 ---
@@ -517,17 +528,19 @@ semantic:
   cache:
     enabled: true
     ttl: 5m           # How long to cache entries
-    max_entries: 10000 # Maximum cache size
 ```
 
-**Recommended settings by use case:**
+The cache is time-based only; entries expire after `ttl` and there is no
+per-count size cap.
 
-| Use Case | TTL | Max Entries |
-|----------|-----|-------------|
-| Development | 1m | 1000 |
-| Production | 5m | 10000 |
-| High-traffic | 15m | 50000 |
-| Real-time requirements | 30s | 5000 |
+**Recommended TTL by use case:**
+
+| Use Case | TTL |
+|----------|-----|
+| Development | 1m |
+| Production | 5m |
+| High-traffic | 15m |
+| Real-time requirements | 30s |
 
 ### Cache Invalidation
 
@@ -647,50 +660,21 @@ enrichment:
 
 ## Advanced Patterns
 
-### Multi-Cluster Enrichment
+### URN Mapping
 
-When you have multiple Trino clusters:
+When Trino catalog names differ from the platform or catalog identifiers
+DataHub uses, the query provider can translate them so URN lookups resolve.
+`platform` overrides the DataHub platform name and `catalog_mapping` maps
+catalog names between the two systems:
 
 ```yaml
-toolkits:
-  trino:
-    production:
-      host: trino-prod.example.com
-    analytics:
-      host: trino-analytics.example.com
-
 query:
   provider: trino
-  # Map DataHub URNs to specific clusters
-  mappings:
-    "urn:li:dataset:(urn:li:dataPlatform:trino,hive.*,PROD)": production
-    "urn:li:dataset:(urn:li:dataPlatform:trino,analytics.*,PROD)": analytics
-```
-
-### Custom Enrichment Fields
-
-Extend enrichment with custom DataHub properties:
-
-```yaml
-semantic:
-  custom_properties:
-    - data_owner_team
-    - pii_classification
-    - retention_policy
-```
-
-These appear in the response:
-
-```json
-{
-  "semantic_context": {
-    "custom_properties": {
-      "data_owner_team": "platform",
-      "pii_classification": "internal",
-      "retention_policy": "365d"
-    }
-  }
-}
+  instance: production
+  urn_mapping:
+    platform: trino
+    catalog_mapping:
+      hive: warehouse
 ```
 
 ---

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -168,41 +168,47 @@ Lock down production data access to read-only operations.
 ```yaml
 toolkits:
   trino:
-    production:
-      host: trino-prod.example.com
-      port: 443
-      ssl: true
-      ssl_verify: true
+    enabled: true
+    instances:
+      production:
+        host: trino-prod.example.com
+        port: 443
+        ssl: true
+        ssl_verify: true
 
-      # Enforce read-only at the toolkit level
-      read_only: true
+        # Enforce read-only at the toolkit level
+        read_only: true
 
-      # Additional query restrictions
-      default_limit: 1000
-      max_limit: 50000
-      timeout: 300s
+        # Additional query restrictions
+        default_limit: 1000
+        max_limit: 50000
+        timeout: 300s
 
-      # Blocked SQL patterns (defense in depth)
-      blocked_patterns:
-        - "INSERT"
-        - "UPDATE"
-        - "DELETE"
-        - "DROP"
-        - "CREATE"
-        - "ALTER"
-        - "TRUNCATE"
+        # Blocked SQL patterns (defense in depth)
+        blocked_patterns:
+          - "INSERT"
+          - "UPDATE"
+          - "DELETE"
+          - "DROP"
+          - "CREATE"
+          - "ALTER"
+          - "TRUNCATE"
+    default: production
 
   s3:
-    data_lake:
-      region: us-east-1
+    enabled: true
+    instances:
+      data_lake:
+        region: us-east-1
 
-      # Read-only S3 access
-      read_only: true
+        # Read-only S3 access
+        read_only: true
 
-      # Restrict to specific buckets
-      allowed_buckets:
-        - data-lake-prod
-        - analytics-exports
+        # Restrict to specific buckets
+        allowed_buckets:
+          - data-lake-prod
+          - analytics-exports
+    default: data_lake
 ```
 
 ---
@@ -221,27 +227,33 @@ server:
 
 toolkits:
   datahub:
-    primary:
-      url: https://datahub.example.com
-      token: ${DATAHUB_TOKEN}
+    enabled: true
+    instances:
+      primary:
+        url: https://datahub.example.com
+        token: ${DATAHUB_TOKEN}
 
-      # Higher limits for exploration
-      default_limit: 25
-      max_limit: 100
+        # Higher limits for exploration
+        default_limit: 25
+        max_limit: 100
+    default: primary
 
   trino:
-    analytics:
-      host: trino-analytics.example.com
-      port: 443
-      ssl: true
-      catalog: analytics
-      schema: curated
+    enabled: true
+    instances:
+      analytics:
+        host: trino-analytics.example.com
+        port: 443
+        ssl: true
+        catalog: analytics
+        schema: curated
 
-      # Reasonable limits for interactive use
-      default_limit: 100
-      max_limit: 10000
-      timeout: 60s
-      read_only: true
+        # Reasonable limits for interactive use
+        default_limit: 100
+        max_limit: 10000
+        timeout: 60s
+        read_only: true
+    default: analytics
 
 # Enable all enrichment for maximum context
 enrichment:
@@ -257,7 +269,6 @@ semantic:
   cache:
     enabled: true
     ttl: 15m
-    max_entries: 10000
 
 personas:
   business_analyst:
@@ -299,38 +310,44 @@ Multi-Trino cluster setup for organization-wide data discovery.
 ```yaml
 toolkits:
   datahub:
-    # Central metadata catalog
-    central:
-      url: https://datahub.example.com
-      token: ${DATAHUB_TOKEN}
+    enabled: true
+    instances:
+      # Central metadata catalog
+      central:
+        url: https://datahub.example.com
+        token: ${DATAHUB_TOKEN}
+    default: central
 
   trino:
-    # Marketing team's cluster
-    marketing:
-      host: trino-marketing.example.com
-      port: 443
-      ssl: true
-      catalog: marketing
-      default_limit: 1000
-      read_only: true
+    enabled: true
+    instances:
+      # Marketing team's cluster
+      marketing:
+        host: trino-marketing.example.com
+        port: 443
+        ssl: true
+        catalog: marketing
+        default_limit: 1000
+        read_only: true
 
-    # Sales team's cluster
-    sales:
-      host: trino-sales.example.com
-      port: 443
-      ssl: true
-      catalog: sales
-      default_limit: 1000
-      read_only: true
+      # Sales team's cluster
+      sales:
+        host: trino-sales.example.com
+        port: 443
+        ssl: true
+        catalog: sales
+        default_limit: 1000
+        read_only: true
 
-    # Finance team's cluster (restricted)
-    finance:
-      host: trino-finance.example.com
-      port: 443
-      ssl: true
-      catalog: finance
-      default_limit: 500
-      read_only: true
+      # Finance team's cluster (restricted)
+      finance:
+        host: trino-finance.example.com
+        port: 443
+        ssl: true
+        catalog: finance
+        default_limit: 500
+        read_only: true
+    default: marketing
 
 # Cross-enrichment from central DataHub to all Trino clusters
 enrichment:
@@ -342,13 +359,10 @@ semantic:
   provider: datahub
   instance: central
 
-# Query provider maps DataHub URNs to correct Trino cluster
+# Query provider binds to a single Trino instance for availability checks
 query:
   provider: trino
-  mappings:
-    "urn:li:dataset:(urn:li:dataPlatform:trino,marketing.*,PROD)": marketing
-    "urn:li:dataset:(urn:li:dataPlatform:trino,sales.*,PROD)": sales
-    "urn:li:dataset:(urn:li:dataPlatform:trino,finance.*,PROD)": finance
+  instance: marketing
 
 personas:
   cross_team_analyst:
@@ -439,20 +453,26 @@ server:
 
 toolkits:
   datahub:
-    primary:
-      url: https://datahub.example.com
-      token: ${DATAHUB_TOKEN}
-      default_limit: 50  # More results for exploration
+    enabled: true
+    instances:
+      primary:
+        url: https://datahub.example.com
+        token: ${DATAHUB_TOKEN}
+        default_limit: 50  # More results for exploration
+    default: primary
 
   trino:
-    ml_cluster:
-      host: trino-ml.example.com
-      port: 443
-      ssl: true
-      catalog: feature_store
-      read_only: true
-      default_limit: 100
-      max_limit: 10000
+    enabled: true
+    instances:
+      ml_cluster:
+        host: trino-ml.example.com
+        port: 443
+        ssl: true
+        catalog: feature_store
+        read_only: true
+        default_limit: 100
+        max_limit: 10000
+    default: ml_cluster
 
 enrichment:
   trino_semantic_enrichment: true
@@ -464,8 +484,8 @@ semantic:
   provider: datahub
   instance: primary
   lineage:
-    max_depth: 5
-    include_column_lineage: true
+    max_hops: 5
+    prefer_column_lineage: true
 
 personas:
   ml_agent:
@@ -487,11 +507,6 @@ personas:
         - "*_delete_*"
         - "*_put_*"
 
-    # Rate limiting for automated access
-    rate_limit:
-      requests_per_minute: 60
-      requests_per_hour: 1000
-
     context:
       description_prefix: |
         You are an ML data exploration agent. Your goal is to discover
@@ -509,45 +524,25 @@ personas:
 
 ### Feature Store Integration
 
-Connecting to a feature store with quality gates.
+Connecting to a feature store for ML feature selection.
 
 ```yaml
 toolkits:
   trino:
-    feature_store:
-      host: trino-features.example.com
-      port: 443
-      ssl: true
-      catalog: feature_store
-      schema: production
-      read_only: true
+    enabled: true
+    instances:
+      feature_store:
+        host: trino-features.example.com
+        port: 443
+        ssl: true
+        catalog: feature_store
+        schema: production
+        read_only: true
+    default: feature_store
 
 enrichment:
   trino_semantic_enrichment: true
   column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
-
-  # Quality gates for feature selection
-  quality_gates:
-    enabled: true
-    minimum_quality_score: 0.75
-    maximum_null_percentage: 10
-    require_documentation: true
-
-    # Warn but don't block
-    soft_gates:
-      - name: freshness
-        max_age_days: 7
-        message: "Feature data is over 7 days old"
-      - name: coverage
-        min_coverage: 0.90
-        message: "Feature coverage is below 90%"
-
-    # Block features that don't meet criteria
-    hard_gates:
-      - name: deprecated
-        message: "Cannot use deprecated features"
-      - name: pii
-        message: "PII features require explicit approval"
 
 personas:
   ml_engineer:
@@ -568,10 +563,9 @@ personas:
         - Quality score and null percentage
         - Last update time
         - Upstream dependencies (lineage)
-        - Any quality gate warnings
 
-        Reject features that fail hard quality gates.
-        Flag features with soft gate warnings but allow their use.
+        Recommend against deprecated or low-quality features, and flag
+        stale or poorly-covered features so the engineer can judge fitness.
 ```
 
 ### Pipeline Lineage Exploration
@@ -584,25 +578,17 @@ semantic:
   instance: primary
 
   lineage:
-    max_depth: 10                    # Deep lineage traversal
-    include_column_lineage: true     # Column-level lineage
-    include_process_lineage: true    # Show transformation steps
+    max_hops: 5                      # Deep lineage traversal (max 5)
+    prefer_column_lineage: true      # Prefer column-level lineage
+    cache_ttl: 1m                    # Shorter TTL for lineage queries
 
   cache:
     enabled: true
     ttl: 5m
-    # Separate cache for lineage queries
-    lineage_ttl: 1m  # Shorter TTL for lineage
 
 enrichment:
   trino_semantic_enrichment: true
   column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
-
-  # Include full lineage in enrichment
-  enrichment:
-    include_lineage: true
-    lineage_depth: 3
-    lineage_direction: both
 
 personas:
   data_engineer:
@@ -642,52 +628,61 @@ Connect multiple instances of each service type.
 ```yaml
 toolkits:
   datahub:
-    # Production DataHub
-    production:
-      url: https://datahub.example.com
-      token: ${DATAHUB_TOKEN_PROD}
+    enabled: true
+    instances:
+      # Production DataHub
+      production:
+        url: https://datahub.example.com
+        token: ${DATAHUB_TOKEN_PROD}
 
-    # Development DataHub
-    development:
-      url: https://datahub-dev.example.com
-      token: ${DATAHUB_TOKEN_DEV}
+      # Development DataHub
+      development:
+        url: https://datahub-dev.example.com
+        token: ${DATAHUB_TOKEN_DEV}
+    default: production
 
   trino:
-    # Production Trino (read-only)
-    production:
-      host: trino.example.com
-      port: 443
-      ssl: true
-      read_only: true
+    enabled: true
+    instances:
+      # Production Trino (read-only)
+      production:
+        host: trino.example.com
+        port: 443
+        ssl: true
+        read_only: true
 
-    # Development Trino (read-write)
-    development:
-      host: trino-dev.example.com
-      port: 8080
-      ssl: false
-      read_only: false
+      # Development Trino (read-write)
+      development:
+        host: trino-dev.example.com
+        port: 8080
+        ssl: false
+        read_only: false
 
-    # Analytics Trino
-    analytics:
-      host: trino-analytics.example.com
-      port: 443
-      ssl: true
-      read_only: true
+      # Analytics Trino
+      analytics:
+        host: trino-analytics.example.com
+        port: 443
+        ssl: true
+        read_only: true
+    default: production
 
   s3:
-    # AWS S3
-    aws:
-      region: us-east-1
-      access_key_id: ${AWS_ACCESS_KEY_ID}
-      secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+    enabled: true
+    instances:
+      # AWS S3
+      aws:
+        region: us-east-1
+        access_key_id: ${AWS_ACCESS_KEY_ID}
+        secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 
-    # MinIO (on-prem)
-    minio:
-      endpoint: http://minio.local:9000
-      use_path_style: true
-      disable_ssl: true
-      access_key_id: ${MINIO_ACCESS_KEY}
-      secret_access_key: ${MINIO_SECRET_KEY}
+      # MinIO (on-prem)
+      minio:
+        endpoint: http://minio.local:9000
+        use_path_style: true
+        disable_ssl: true
+        access_key_id: ${MINIO_ACCESS_KEY}
+        secret_access_key: ${MINIO_SECRET_KEY}
+    default: aws
 
 # Configure which instances to use for enrichment
 semantic:
@@ -771,10 +766,13 @@ Register the custom toolkit in configuration:
 ```yaml
 toolkits:
   custom:
-    my_custom:
-      # Custom toolkit configuration
-      api_endpoint: https://custom-api.example.com
-      api_key: ${CUSTOM_API_KEY}
+    enabled: true
+    instances:
+      my_custom:
+        # Custom toolkit configuration
+        api_endpoint: https://custom-api.example.com
+        api_key: ${CUSTOM_API_KEY}
+    default: my_custom
 ```
 
 ---

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -190,6 +190,8 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 
 Configuration uses YAML with environment variable expansion (`${VAR_NAME}`).
 
+By default, unrecognized config keys are logged as a `WARN` and ignored so older configs keep loading. Detection applies at every level that maps to a defined field (a stray key under `server:`, `auth.oidc:`, or inside a persona definition is flagged, not just stray top-level keys). Set `config.strict: true` to reject unknown keys with a hard startup error instead (recommended: turns typos and stale keys into an immediate failure rather than a silent no-op). Free-form maps are exempt because they accept arbitrary keys by design: the `toolkits` tree, each toolkit's `config:` map, and the persona *names* under `personas:` (the fields within a persona definition are still validated). A future release will make strict rejection the default, opt-out via `config.strict: false`.
+
 ## Config Versioning
 
 Every configuration file should include an `apiVersion` field as the first key. This enables safe schema evolution with deprecation warnings and migration tooling.
@@ -239,18 +241,24 @@ server:
 
 toolkits:
   datahub:
-    primary:
-      url: https://datahub.example.com
-      token: ${DATAHUB_TOKEN}
+    enabled: true
+    instances:
+      primary:
+        url: https://datahub.example.com
+        token: ${DATAHUB_TOKEN}
+    default: primary
 
   trino:
-    primary:
-      host: trino.example.com
-      port: 443
-      user: ${TRINO_USER}
-      password: ${TRINO_PASSWORD}
-      ssl: true
-      catalog: hive
+    enabled: true
+    instances:
+      primary:
+        host: trino.example.com
+        port: 443
+        user: ${TRINO_USER}
+        password: ${TRINO_PASSWORD}
+        ssl: true
+        catalog: hive
+    default: primary
 
 enrichment:
   trino_semantic_enrichment: true

--- a/docs/personas/overview.md
+++ b/docs/personas/overview.md
@@ -97,12 +97,13 @@ The platform includes two built-in personas that can be overridden:
 
 **Default Persona:**
 ```yaml
-default:
-  display_name: "Default User (No Access)"
-  roles: []
-  tools:
-    allow: []
-    deny: ["*"]
+personas:
+  default:
+    display_name: "Default User (No Access)"
+    roles: []
+    tools:
+      allow: []
+      deny: ["*"]
 ```
 
 The built-in default persona is **deny-all**, not allow-all: a user who
@@ -113,15 +114,16 @@ matching `roles`) for every group of users you want to grant tool access to.
 
 **Admin Persona:**
 ```yaml
-admin:
-  display_name: "Administrator"
-  roles: ["admin"]
-  tools:
-    allow: ["*"]
-    deny: []
-  connections:
-    allow: ["*"]
-  priority: 100
+personas:
+  admin:
+    display_name: "Administrator"
+    roles: ["admin"]
+    tools:
+      allow: ["*"]
+      deny: []
+    connections:
+      allow: ["*"]
+    priority: 100
 ```
 
 The built-in admin persona also grants `connections.allow: ["*"]`. Since

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -16,6 +16,30 @@ mcp-data-platform uses YAML configuration with environment variable expansion. V
 
 See [Operating Modes](operating-modes.md) for the full comparison and [Admin API](admin-api.md) for the REST endpoints.
 
+### Unknown keys and strict parsing
+
+By default the loader accepts a config file that contains keys it does not
+recognize: each unknown key is logged as a prominent `WARN` at startup and then
+ignored. This applies at every level that maps to a defined config field: a
+stray key under `server:`, `auth.oidc:`, or inside a persona definition is
+flagged just like a stray top-level key. This keeps older configs loading, but
+it also means a typo or a renamed key silently does nothing.
+
+Set `config.strict: true` to reject unknown keys with a hard error at startup
+instead. This is recommended, since it turns typos and stale keys into an
+immediate, actionable failure rather than a silent no-op:
+
+```yaml
+config:
+  strict: true
+```
+
+Free-form maps are exempt because they accept arbitrary keys by design: the
+`toolkits` tree, each toolkit's `config:` map, and the persona *names* under
+`personas:` (the fields *within* a persona definition, such as `display_name`
+and `tools`, are still validated). A future release will make strict rejection
+the default; you will be able to opt back out with `config.strict: false`.
+
 ## Configuration File
 
 Create a `platform.yaml` file:
@@ -29,25 +53,34 @@ server:
 
 toolkits:
   trino:
-    primary:
-      host: trino.example.com
-      port: 443
-      user: ${TRINO_USER}
-      password: ${TRINO_PASSWORD}
-      ssl: true
-      catalog: hive
-      schema: default
+    enabled: true
+    instances:
+      primary:
+        host: trino.example.com
+        port: 443
+        user: ${TRINO_USER}
+        password: ${TRINO_PASSWORD}
+        ssl: true
+        catalog: hive
+        schema: default
+    default: primary
 
   datahub:
-    primary:
-      url: https://datahub.example.com
-      token: ${DATAHUB_TOKEN}
+    enabled: true
+    instances:
+      primary:
+        url: https://datahub.example.com
+        token: ${DATAHUB_TOKEN}
+    default: primary
 
   s3:
-    primary:
-      region: us-east-1
-      access_key_id: ${AWS_ACCESS_KEY_ID}
-      secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+    enabled: true
+    instances:
+      primary:
+        region: us-east-1
+        access_key_id: ${AWS_ACCESS_KEY_ID}
+        secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+    default: primary
 
 enrichment:
   trino_semantic_enrichment: true
@@ -510,20 +543,23 @@ See [Session Externalization](session-externalization.md) for architecture detai
 ```yaml
 toolkits:
   trino:
-    primary:                   # Instance name (can be any identifier)
-      host: trino.example.com
-      port: 443
-      user: analyst
-      password: ${TRINO_PASSWORD}
-      catalog: hive
-      schema: default
-      ssl: true
-      ssl_verify: true
-      timeout: 120s
-      default_limit: 1000
-      max_limit: 10000
-      read_only: false
-      connection_name: primary
+    enabled: true
+    instances:
+      primary:                   # Instance name (can be any identifier)
+        host: trino.example.com
+        port: 443
+        user: analyst
+        password: ${TRINO_PASSWORD}
+        catalog: hive
+        schema: default
+        ssl: true
+        ssl_verify: true
+        timeout: 120s
+        default_limit: 1000
+        max_limit: 10000
+        read_only: false
+        connection_name: primary
+    default: primary
 ```
 
 | Field | Type | Default | Description |
@@ -548,15 +584,18 @@ toolkits:
 ```yaml
 toolkits:
   datahub:
-    primary:
-      url: https://datahub.example.com
-      token: ${DATAHUB_TOKEN}
-      timeout: 30s
-      default_limit: 10
-      max_limit: 100
-      max_lineage_depth: 5
-      connection_name: primary
-      read_only: true
+    enabled: true
+    instances:
+      primary:
+        url: https://datahub.example.com
+        token: ${DATAHUB_TOKEN}
+        timeout: 30s
+        default_limit: 10
+        max_limit: 100
+        max_lineage_depth: 5
+        connection_name: primary
+        read_only: true
+    default: primary
 ```
 
 | Field | Type | Default | Description |
@@ -576,22 +615,25 @@ toolkits:
 ```yaml
 toolkits:
   s3:
-    primary:
-      region: us-east-1
-      endpoint: ""                    # Custom endpoint for MinIO, etc.
-      public_endpoint: ""             # Public endpoint for presigned URLs (see below)
-      access_key_id: ${AWS_ACCESS_KEY_ID}
-      secret_access_key: ${AWS_SECRET_ACCESS_KEY}
-      session_token: ""
-      profile: ""                     # AWS profile name
-      use_path_style: false           # Use path-style URLs
-      timeout: 30s
-      disable_ssl: false
-      read_only: true                 # Restrict to read operations
-      max_get_size: 10485760          # 10MB
-      max_put_size: 104857600         # 100MB
-      connection_name: primary
-      bucket_prefix: ""               # Filter to buckets with this prefix
+    enabled: true
+    instances:
+      primary:
+        region: us-east-1
+        endpoint: ""                    # Custom endpoint for MinIO, etc.
+        public_endpoint: ""             # Public endpoint for presigned URLs (see below)
+        access_key_id: ${AWS_ACCESS_KEY_ID}
+        secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+        session_token: ""
+        profile: ""                     # AWS profile name
+        use_path_style: false           # Use path-style URLs
+        timeout: 30s
+        disable_ssl: false
+        read_only: true                 # Restrict to read operations
+        max_get_size: 10485760          # 10MB
+        max_put_size: 104857600         # 100MB
+        connection_name: primary
+        bucket_prefix: ""               # Filter to buckets with this prefix
+    default: primary
 ```
 
 | Field | Type | Default | Description |
@@ -1112,28 +1154,37 @@ auth:
 
 toolkits:
   trino:
-    primary:
-      host: trino.example.com
-      port: 443
-      user: ${TRINO_USER}
-      password: ${TRINO_PASSWORD}
-      ssl: true
-      catalog: hive
-      schema: default
-      default_limit: 1000
-      max_limit: 10000
+    enabled: true
+    instances:
+      primary:
+        host: trino.example.com
+        port: 443
+        user: ${TRINO_USER}
+        password: ${TRINO_PASSWORD}
+        ssl: true
+        catalog: hive
+        schema: default
+        default_limit: 1000
+        max_limit: 10000
+    default: primary
 
   datahub:
-    primary:
-      url: https://datahub.example.com
-      token: ${DATAHUB_TOKEN}
-      default_limit: 10
-      max_limit: 100
+    enabled: true
+    instances:
+      primary:
+        url: https://datahub.example.com
+        token: ${DATAHUB_TOKEN}
+        default_limit: 10
+        max_limit: 100
+    default: primary
 
   s3:
-    primary:
-      region: us-east-1
-      read_only: true
+    enabled: true
+    instances:
+      primary:
+        region: us-east-1
+        read_only: true
+    default: primary
 
 semantic:
   provider: datahub

--- a/docs/server/deployment.md
+++ b/docs/server/deployment.md
@@ -194,17 +194,23 @@ server:
 
 toolkits:
   datahub:
-    primary:
-      url: http://datahub-gms:8080
-      token: ${DATAHUB_TOKEN}
+    enabled: true
+    instances:
+      primary:
+        url: http://datahub-gms:8080
+        token: ${DATAHUB_TOKEN}
+    default: primary
 
   trino:
-    primary:
-      host: trino
-      port: 8080
-      user: trino
-      catalog: memory
-      ssl: false
+    enabled: true
+    instances:
+      primary:
+        host: trino
+        port: 8080
+        user: trino
+        catalog: memory
+        ssl: false
+    default: primary
 
 oauth:
   enabled: true
@@ -403,15 +409,21 @@ config:
 
   toolkits:
     datahub:
-      primary:
-        url: http://datahub-gms.datahub:8080
+      enabled: true
+      instances:
+        primary:
+          url: http://datahub-gms.datahub:8080
+      default: primary
     trino:
-      primary:
-        host: trino.trino
-        port: 8080
-        user: mcp-platform
-        catalog: hive
-        ssl: false
+      enabled: true
+      instances:
+        primary:
+          host: trino.trino
+          port: 8080
+          user: mcp-platform
+          catalog: hive
+          ssl: false
+      default: primary
 
   enrichment:
     trino_semantic_enrichment: true

--- a/docs/server/multi-provider.md
+++ b/docs/server/multi-provider.md
@@ -13,53 +13,62 @@ Each toolkit section accepts multiple named instances:
 ```yaml
 toolkits:
   trino:
-    production:
-      host: trino-prod.example.com
-      port: 443
-      user: analyst
-      ssl: true
-      catalog: hive
-      connection_name: Production
+    enabled: true
+    instances:
+      production:
+        host: trino-prod.example.com
+        port: 443
+        user: analyst
+        ssl: true
+        catalog: hive
+        connection_name: Production
 
-    staging:
-      host: trino-staging.example.com
-      port: 443
-      user: analyst
-      ssl: true
-      catalog: hive
-      connection_name: Staging
+      staging:
+        host: trino-staging.example.com
+        port: 443
+        user: analyst
+        ssl: true
+        catalog: hive
+        connection_name: Staging
 
-    warehouse:
-      host: trino-dw.example.com
-      port: 443
-      user: analyst
-      ssl: true
-      catalog: iceberg
-      connection_name: Data Warehouse
+      warehouse:
+        host: trino-dw.example.com
+        port: 443
+        user: analyst
+        ssl: true
+        catalog: iceberg
+        connection_name: Data Warehouse
+    default: production
 
   datahub:
-    primary:
-      url: https://datahub.example.com
-      token: ${DATAHUB_TOKEN}
-      connection_name: Primary Catalog
+    enabled: true
+    instances:
+      primary:
+        url: https://datahub.example.com
+        token: ${DATAHUB_TOKEN}
+        connection_name: Primary Catalog
 
-    legacy:
-      url: https://datahub-legacy.example.com
-      token: ${DATAHUB_LEGACY_TOKEN}
-      connection_name: Legacy Catalog
+      legacy:
+        url: https://datahub-legacy.example.com
+        token: ${DATAHUB_LEGACY_TOKEN}
+        connection_name: Legacy Catalog
+    default: primary
 
   s3:
-    data_lake:
-      region: us-east-1
-      access_key_id: ${AWS_ACCESS_KEY_ID}
-      secret_access_key: ${AWS_SECRET_ACCESS_KEY}
-      connection_name: Data Lake
+    enabled: true
+    instances:
+      data_lake:
+        region: us-east-1
+        access_key_id: ${AWS_ACCESS_KEY_ID}
+        secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+        connection_name: Data Lake
 
-    archive:
-      region: us-west-2
-      access_key_id: ${ARCHIVE_AWS_ACCESS_KEY_ID}
-      secret_access_key: ${ARCHIVE_AWS_SECRET_ACCESS_KEY}
-      connection_name: Archive
+      archive:
+        region: us-west-2
+        access_key_id: ${ARCHIVE_AWS_ACCESS_KEY_ID}
+        secret_access_key: ${ARCHIVE_AWS_SECRET_ACCESS_KEY}
+        connection_name: Archive
+    default: data_lake
 ```
 
 ## Using Connections in Tools
@@ -156,12 +165,15 @@ Use environment variables to manage different environments:
 ```yaml
 toolkits:
   trino:
-    main:
-      host: ${TRINO_HOST}
-      port: ${TRINO_PORT}
-      user: ${TRINO_USER}
-      password: ${TRINO_PASSWORD}
-      ssl: true
+    enabled: true
+    instances:
+      main:
+        host: ${TRINO_HOST}
+        port: ${TRINO_PORT}
+        user: ${TRINO_USER}
+        password: ${TRINO_PASSWORD}
+        ssl: true
+    default: main
 ```
 
 Development:
@@ -216,20 +228,23 @@ Note: Connection-level filtering requires custom middleware. The built-in person
 ```yaml
 toolkits:
   datahub:
-    sales:
-      url: https://datahub-sales.example.com
-      token: ${SALES_DATAHUB_TOKEN}
-      connection_name: Sales Domain
+    enabled: true
+    instances:
+      sales:
+        url: https://datahub-sales.example.com
+        token: ${SALES_DATAHUB_TOKEN}
+        connection_name: Sales Domain
 
-    marketing:
-      url: https://datahub-marketing.example.com
-      token: ${MARKETING_DATAHUB_TOKEN}
-      connection_name: Marketing Domain
+      marketing:
+        url: https://datahub-marketing.example.com
+        token: ${MARKETING_DATAHUB_TOKEN}
+        connection_name: Marketing Domain
 
-    finance:
-      url: https://datahub-finance.example.com
-      token: ${FINANCE_DATAHUB_TOKEN}
-      connection_name: Finance Domain
+      finance:
+        url: https://datahub-finance.example.com
+        token: ${FINANCE_DATAHUB_TOKEN}
+        connection_name: Finance Domain
+    default: sales
 ```
 
 ### Hybrid Cloud
@@ -237,24 +252,27 @@ toolkits:
 ```yaml
 toolkits:
   s3:
-    aws:
-      region: us-east-1
-      connection_name: AWS S3
+    enabled: true
+    instances:
+      aws:
+        region: us-east-1
+        connection_name: AWS S3
 
-    gcs:
-      endpoint: https://storage.googleapis.com
-      region: auto
-      access_key_id: ${GCS_ACCESS_KEY}
-      secret_access_key: ${GCS_SECRET_KEY}
-      connection_name: Google Cloud Storage
+      gcs:
+        endpoint: https://storage.googleapis.com
+        region: auto
+        access_key_id: ${GCS_ACCESS_KEY}
+        secret_access_key: ${GCS_SECRET_KEY}
+        connection_name: Google Cloud Storage
 
-    minio:
-      endpoint: http://minio.internal:9000
-      use_path_style: true
-      disable_ssl: true
-      access_key_id: ${MINIO_ACCESS_KEY}
-      secret_access_key: ${MINIO_SECRET_KEY}
-      connection_name: On-Premise MinIO
+      minio:
+        endpoint: http://minio.internal:9000
+        use_path_style: true
+        disable_ssl: true
+        access_key_id: ${MINIO_ACCESS_KEY}
+        secret_access_key: ${MINIO_SECRET_KEY}
+        connection_name: On-Premise MinIO
+    default: aws
 ```
 
 ## Next Steps

--- a/docs/server/operating-modes.md
+++ b/docs/server/operating-modes.md
@@ -61,17 +61,23 @@ server:
 
 toolkits:
   datahub:
-    primary:
-      url: https://datahub.example.com
-      token: ${DATAHUB_TOKEN}
+    enabled: true
+    instances:
+      primary:
+        url: https://datahub.example.com
+        token: ${DATAHUB_TOKEN}
+    default: primary
 
   trino:
-    primary:
-      host: trino.example.com
-      port: 443
-      user: ${TRINO_USER}
-      password: ${TRINO_PASSWORD}
-      ssl: true
+    enabled: true
+    instances:
+      primary:
+        host: trino.example.com
+        port: 443
+        user: ${TRINO_USER}
+        password: ${TRINO_PASSWORD}
+        ssl: true
+    default: primary
 
 semantic:
   provider: datahub
@@ -150,17 +156,23 @@ auth:
 
 toolkits:
   datahub:
-    primary:
-      url: https://datahub.example.com
-      token: ${DATAHUB_TOKEN}
+    enabled: true
+    instances:
+      primary:
+        url: https://datahub.example.com
+        token: ${DATAHUB_TOKEN}
+    default: primary
 
   trino:
-    primary:
-      host: trino.example.com
-      port: 443
-      user: ${TRINO_USER}
-      password: ${TRINO_PASSWORD}
-      ssl: true
+    enabled: true
+    instances:
+      primary:
+        host: trino.example.com
+        port: 443
+        user: ${TRINO_USER}
+        password: ${TRINO_PASSWORD}
+        ssl: true
+    default: primary
 
 semantic:
   provider: datahub

--- a/docs/server/overview.md
+++ b/docs/server/overview.md
@@ -84,18 +84,24 @@ server:
 
 toolkits:
   datahub:
-    primary:
-      url: https://datahub.example.com
-      token: ${DATAHUB_TOKEN}
+    enabled: true
+    instances:
+      primary:
+        url: https://datahub.example.com
+        token: ${DATAHUB_TOKEN}
+    default: primary
 
   # Optional: add Trino for SQL queries
   trino:
-    primary:
-      host: trino.example.com
-      port: 443
-      user: analyst
-      ssl: true
-      catalog: hive
+    enabled: true
+    instances:
+      primary:
+        host: trino.example.com
+        port: 443
+        user: analyst
+        ssl: true
+        catalog: hive
+    default: primary
 
 enrichment:
   trino_semantic_enrichment: true

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -46,28 +46,43 @@ mcp-data-platform --config platform.yaml 2>&1 | grep -i "missing\|undefined\|req
 
 **Common configuration errors:**
 
-```yaml
-# WRONG: Missing quotes around URL with special characters
-toolkits:
-  datahub:
-    primary:
-      url: https://datahub.example.com:8080  # Might be parsed incorrectly
+WRONG: missing quotes around a URL with special characters (may be parsed
+incorrectly):
 
-# CORRECT: Quote URLs
+```yaml
 toolkits:
   datahub:
-    primary:
-      url: "https://datahub.example.com:8080"
+    enabled: true
+    instances:
+      primary:
+        url: https://datahub.example.com:8080
+    default: primary
 ```
 
+CORRECT: quote URLs:
+
 ```yaml
-# WRONG: Environment variable without braces
+toolkits:
+  datahub:
+    enabled: true
+    instances:
+      primary:
+        url: "https://datahub.example.com:8080"
+    default: primary
+```
+
+WRONG: environment variable without braces (won't expand):
+
+```yaml
 auth:
   api_keys:
     keys:
-      - key: $API_KEY  # Won't expand
+      - key: $API_KEY
+```
 
-# CORRECT: Use ${} syntax
+CORRECT: use `${}` syntax:
+
+```yaml
 auth:
   api_keys:
     keys:
@@ -137,14 +152,17 @@ curl -v https://trino.example.com:443/v1/info
 ```yaml
 toolkits:
   trino:
-    primary:
-      host: trino.example.com
-      port: 443
-      ssl: true
-      ssl_verify: true  # Try false for self-signed certs
+    enabled: true
+    instances:
+      primary:
+        host: trino.example.com
+        port: 443
+        ssl: true
+        ssl_verify: true  # Try false for self-signed certs
 
-      # For custom CA certificates
-      ssl_ca_file: /path/to/ca.crt
+        # For custom CA certificates
+        ssl_ca_file: /path/to/ca.crt
+    default: primary
 ```
 
 **Step 3: Verify credentials**
@@ -172,12 +190,15 @@ Error: DataHub API error: 401 Unauthorized
 ```yaml
 toolkits:
   datahub:
-    primary:
-      # CORRECT: GMS URL (metadata service)
-      url: "https://datahub-gms.example.com"
+    enabled: true
+    instances:
+      primary:
+        # CORRECT: GMS URL (metadata service)
+        url: "https://datahub-gms.example.com"
 
-      # WRONG: Frontend URL
-      # url: "https://datahub.example.com"  # This is the UI
+        # WRONG: Frontend URL
+        # url: "https://datahub.example.com"  # This is the UI
+    default: primary
 ```
 
 **Step 2: Test token validity**
@@ -222,11 +243,14 @@ AWS_ACCESS_KEY_ID=$KEY AWS_SECRET_ACCESS_KEY=$SECRET \
 ```yaml
 toolkits:
   s3:
-    minio:
-      endpoint: "http://minio.local:9000"  # Include protocol
-      use_path_style: true                  # Required for MinIO
-      disable_ssl: true                     # For non-TLS endpoints
-      region: "us-east-1"                   # Still required
+    enabled: true
+    instances:
+      minio:
+        endpoint: "http://minio.local:9000"  # Include protocol
+        use_path_style: true                  # Required for MinIO
+        disable_ssl: true                     # For non-TLS endpoints
+        region: "us-east-1"                   # Still required
+    default: minio
 ```
 
 **Step 3: Verify bucket permissions**
@@ -273,13 +297,12 @@ auth:
     # issuer: "https://auth.example.com"  # WRONG
 ```
 
-**Step 3: Check token expiration and clock skew**
+**Step 3: Check token expiration and server clock**
 
-```yaml
-auth:
-  oidc:
-    clock_skew_seconds: 60  # Allow 60 seconds of clock drift
-```
+The platform validates `exp`/`nbf` with a fixed 30-second clock-skew
+tolerance; this is not currently configurable via YAML. If the server clock
+drifts by more than 30 seconds a valid token can be rejected, so keep the
+server clock synchronized (NTP) and confirm the token has not expired:
 
 ```bash
 # Check server time
@@ -511,14 +534,7 @@ semantic:
 WARN  enrichment failed for table orders: DataHub entity not found
 ```
 
-This is expected for tables that exist in Trino but aren't cataloged in DataHub. The platform returns the original result without enrichment.
-
-To suppress these warnings:
-
-```yaml
-enrichment:
-  suppress_enrichment_warnings: true
-```
+This is expected for tables that exist in Trino but aren't cataloged in DataHub. The platform returns the original result without enrichment, so these warnings are harmless. They are emitted at WARN level; raise the process log level (`LOG_LEVEL`) if they are noisy in your environment.
 
 ### Column enrichment shows all columns instead of referenced ones
 
@@ -542,8 +558,11 @@ Note: `trino_describe_table` always returns all columns. Filtering only applies 
 ```yaml
 toolkits:
   trino:
-    primary:
-      timeout: 300s  # Increase if needed
+    enabled: true
+    instances:
+      primary:
+        timeout: 300s  # Increase if needed
+    default: primary
 ```
 
 **Step 2: Verify row limits**
@@ -551,9 +570,12 @@ toolkits:
 ```yaml
 toolkits:
   trino:
-    primary:
-      default_limit: 1000   # Default rows returned
-      max_limit: 10000      # Maximum allowed
+    enabled: true
+    instances:
+      primary:
+        default_limit: 1000   # Default rows returned
+        max_limit: 10000      # Maximum allowed
+    default: primary
 ```
 
 **Step 3: Profile the query in Trino**
@@ -580,7 +602,6 @@ semantic:
   cache:
     enabled: true
     ttl: 5m
-    max_entries: 10000  # Increase for large catalogs
 ```
 
 **Step 2: Check DataHub response time**

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -1,7 +1,9 @@
 package platform
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -95,6 +97,7 @@ type ConfigStoreConfig struct {
 // Config holds the complete platform configuration.
 type Config struct {
 	APIVersion  string            `yaml:"apiVersion"`
+	Meta        ConfigMeta        `yaml:"config"`
 	ConfigStore ConfigStoreConfig `yaml:"config_store"`
 	Server      ServerConfig      `yaml:"server"`
 	Auth        AuthConfig        `yaml:"auth"`
@@ -135,6 +138,83 @@ type Config struct {
 	// loaded once from YAML and not protected here. Unexported so YAML
 	// marshaling ignores it.
 	runtimeMu sync.RWMutex
+}
+
+// ConfigMeta holds meta-configuration controlling how the config file itself is
+// parsed. It is read from the top-level `config:` block.
+type ConfigMeta struct {
+	// Strict controls how unrecognized YAML keys are handled. When nil (the
+	// default for this release) unknown keys are logged as a prominent warning
+	// and ignored, so existing configs keep loading while operators are alerted
+	// to drift. Set `config.strict: true` to reject unknown keys with a hard
+	// error instead (recommended: catches typos and stale keys at startup).
+	//
+	// A future release will flip the default so unknown keys are an error
+	// unless `config.strict: false` is set as a temporary escape hatch.
+	Strict *bool `yaml:"strict"`
+}
+
+// IsStrict reports whether unrecognized YAML keys should be a hard error.
+// Defaults to false (warn-and-continue) for this release.
+func (m ConfigMeta) IsStrict() bool {
+	return m.Strict != nil && *m.Strict
+}
+
+// strictDecode decodes expanded YAML into cfg with KnownFields(true). It
+// returns the list of unrecognized-key errors (empty when every key is
+// recognized) and a non-nil error only for malformed YAML. cfg is populated
+// with all recognized fields even when unknown keys are present, so a single
+// decode both parses the config and detects drift.
+//
+// Only keys that map to a typed struct field are inspected. Keys nested under
+// free-form maps — the `toolkits` tree, each persona definition's *name*, and a
+// toolkit's `config:` map — accept arbitrary keys by design and are not
+// flagged. (The fields *within* a persona definition are typed and are
+// checked.) The doc round-trip test validates toolkit shape separately.
+func strictDecode(expanded []byte, cfg *Config) ([]string, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(expanded))
+	dec.KnownFields(true)
+
+	if err := dec.Decode(cfg); err != nil {
+		var typeErr *yaml.TypeError
+		if errors.As(err, &typeErr) {
+			return typeErr.Errors, nil
+		}
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+	return nil, nil
+}
+
+// detectUnknownFields reports the unrecognized keys in expanded YAML, or nil
+// when every key maps to a known field. It decodes into a throwaway Config and
+// is intended for tests and validation tooling.
+func detectUnknownFields(expanded []byte) []string {
+	var probe Config
+	unknown, _ := strictDecode(expanded, &probe)
+	return unknown
+}
+
+// decodeConfigStrict parses expanded YAML into a Config in a single pass,
+// enforcing the config.strict unknown-key policy: unrecognized keys are a hard
+// error when config.strict is true, otherwise a logged warning.
+func decodeConfigStrict(expanded []byte) (*Config, error) {
+	cfg := &Config{}
+	unknown, err := strictDecode(expanded, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if len(unknown) > 0 {
+		if cfg.Meta.IsStrict() {
+			return nil, fmt.Errorf(
+				"strict config parsing: %d unrecognized key(s): %s",
+				len(unknown), strings.Join(unknown, "; "))
+		}
+		slog.Warn("config contains unrecognized keys that are ignored; "+
+			"fix or remove them, or set config.strict: true to reject them "+
+			"(a future release will make rejection the default)",
+			"unknown_keys", unknown)
+	}
+	return cfg, nil
 }
 
 // defaultAdminPersona is the persona name that grants platform admin.
@@ -1134,12 +1214,19 @@ func LoadConfig(path string) (*Config, error) {
 // Environment variables are expanded before parsing. The apiVersion field
 // is validated against the default version registry.
 func LoadConfigFromBytes(data []byte) (*Config, error) {
+	return loadConfigWithRegistry(data, DefaultRegistry())
+}
+
+// loadConfigWithRegistry is LoadConfigFromBytes with the version registry
+// injected so the version-dispatch branches (deprecated warning, converter
+// path) can be exercised in tests; the default registry ships only the current
+// v1.
+func loadConfigWithRegistry(data []byte, reg *VersionRegistry) (*Config, error) {
 	// Expand environment variables
 	expanded := []byte(expandEnvVars(string(data)))
 
 	// Peek at the version before full parse
 	version := PeekVersion(expanded)
-	reg := DefaultRegistry()
 
 	info, err := resolveVersion(reg, version)
 	if err != nil {
@@ -1157,15 +1244,16 @@ func LoadConfigFromBytes(data []byte) (*Config, error) {
 	// Parse the config
 	var cfg *Config
 	if info.Converter != nil {
+		// Legacy apiVersions are translated by their converter, which owns the
+		// legacy schema. Unknown-key detection (below) is scoped to the current
+		// schema and does not run here; today only v1 exists with a nil
+		// converter, so every real config takes the strict-checked path.
 		cfg, err = info.Converter(expanded)
 		if err != nil {
 			return nil, fmt.Errorf("converting config from %s: %w", version, err)
 		}
-	} else {
-		cfg = &Config{}
-		if err := yaml.Unmarshal(expanded, cfg); err != nil {
-			return nil, fmt.Errorf("parsing config: %w", err)
-		}
+	} else if cfg, err = decodeConfigStrict(expanded); err != nil {
+		return nil, err
 	}
 
 	// Ensure APIVersion is set

--- a/pkg/platform/config_docyaml_test.go
+++ b/pkg/platform/config_docyaml_test.go
@@ -1,0 +1,274 @@
+package platform
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// This test enforces that every platform-config YAML example in the docs stays
+// in sync with what the code actually parses. It is the CI gate that keeps the
+// class of drift fixed in #757/#769/#770/#775 from recurring:
+//
+//   - Phantom keys (keys no typed Config field reads) fail detectUnknownFields.
+//   - Toolkit blocks that omit the enabled/instances nesting fail the shape
+//     check (a bare instance name directly under a kind never loads).
+//
+// A block is treated as a platform-config example when it has at least one
+// top-level key and every top-level key maps to a known Config field. That
+// naturally excludes Kubernetes manifests, docker-compose, and CI YAML (whose
+// top-level keys are not Config fields) and indented fragments (no top-level
+// key). To deliberately exclude a config-shaped block, put an HTML comment
+// containing "config-test: skip" on the line immediately before the fence.
+
+// reservedToolkitKeys are the only keys the registry loader reads directly
+// under a toolkit kind (pkg/registry/loader.go). Any other direct child is a
+// misplaced instance name that silently never loads.
+var reservedToolkitKeys = map[string]bool{
+	"enabled":   true,
+	"instances": true,
+	"default":   true,
+	"config":    true,
+}
+
+var (
+	fencedYAMLRe = regexp.MustCompile("(?s)```ya?ml[^\n]*\n(.*?)\n```")
+	// Top-level keys may legitimately contain '-' and '.' (e.g. Kubernetes
+	// `runs-on:`, docker-compose `x-anchors:`). Capturing them ensures such a
+	// key marks its block as non-config so we don't misclassify and flag it.
+	topKeyRe = regexp.MustCompile(`(?m)^([A-Za-z0-9_.-]+):`)
+)
+
+func repoRootFromTest(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot determine caller path")
+	}
+	// file = <root>/pkg/platform/config_docyaml_test.go
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+// knownConfigTopKeys reflects the Config struct's yaml tags so the known-key
+// set stays authoritative as fields are added or removed. Inline fields are
+// excluded because they absorb arbitrary keys.
+func knownConfigTopKeys() map[string]bool {
+	keys := make(map[string]bool)
+	for _, f := range reflect.VisibleFields(reflect.TypeFor[Config]()) {
+		tag := f.Tag.Get("yaml")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if name == "" || strings.Contains(tag, "inline") {
+			continue
+		}
+		keys[name] = true
+	}
+	return keys
+}
+
+func docFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var files []string
+	// README at the repo root.
+	if _, err := os.Stat(filepath.Join(root, "README.md")); err == nil {
+		files = append(files, filepath.Join(root, "README.md"))
+	}
+	// Everything under docs/ that can carry fenced YAML.
+	err := filepath.WalkDir(filepath.Join(root, "docs"), func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(path, ".md") || strings.HasSuffix(path, ".txt") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking docs: %v", err)
+	}
+	return files
+}
+
+// topLevelKeys returns the set of column-0 keys in a YAML block.
+func topLevelKeys(block string) []string {
+	matches := topKeyRe.FindAllStringSubmatch(block, -1)
+	keys := make([]string, 0, len(matches))
+	for _, m := range matches {
+		keys = append(keys, m[1])
+	}
+	return keys
+}
+
+// blockTargetsOtherSchema reports whether a config block declares an
+// apiVersion other than the current one — a legacy version handled by a
+// converter, or an unsupported/future version. Such blocks illustrate a
+// different schema and must not be validated against the current Config
+// (LoadConfigFromBytes would reject an unknown apiVersion outright).
+func blockTargetsOtherSchema(block string) bool {
+	version := PeekVersion([]byte(block))
+	if version == "" {
+		return false // no apiVersion → current schema
+	}
+	info, err := resolveVersion(DefaultRegistry(), version)
+	return err != nil || info.Converter != nil
+}
+
+func isPlatformConfigBlock(block string, known map[string]bool) bool {
+	keys := topLevelKeys(block)
+	if len(keys) == 0 {
+		return false
+	}
+	for _, k := range keys {
+		if !known[k] {
+			return false
+		}
+	}
+	return true
+}
+
+// checkToolkitShape asserts no toolkit kind carries a bare instance name as a
+// direct child (the #775 defect). Returns a human-readable problem or "".
+func checkToolkitShape(block string) string {
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(block), &doc); err != nil {
+		return "" // parse errors are reported by the strict/load checks
+	}
+	toolkits, ok := doc["toolkits"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	for kind, v := range toolkits {
+		kindMap, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		for key := range kindMap {
+			if !reservedToolkitKeys[key] {
+				return "toolkit kind " + kind + " has bare child " + key +
+					" (instance configs must be nested under instances:)"
+			}
+		}
+	}
+	return ""
+}
+
+func TestDocsYAMLExamplesMatchConfig(t *testing.T) {
+	root := repoRootFromTest(t)
+	known := knownConfigTopKeys()
+
+	for _, f := range docFiles(t, root) {
+		data, err := os.ReadFile(f) //nolint:gosec // test reads project docs
+		if err != nil {
+			t.Fatalf("reading %s: %v", f, err)
+		}
+		rel, _ := filepath.Rel(root, f)
+		content := string(data)
+
+		for _, m := range fencedYAMLRe.FindAllStringSubmatchIndex(content, -1) {
+			blockStart, blockEnd := m[2], m[3]
+			block := content[blockStart:blockEnd]
+
+			// Honor an explicit skip marker on the preceding lines.
+			preceding := content[:m[0]]
+			if lastLine := lastNonEmptyLine(preceding); strings.Contains(lastLine, "config-test: skip") {
+				continue
+			}
+
+			if !isPlatformConfigBlock(block, known) {
+				continue
+			}
+			if blockTargetsOtherSchema(block) {
+				continue
+			}
+
+			expanded := []byte(expandEnvVars(block))
+			if unknown := detectUnknownFields(expanded); len(unknown) > 0 {
+				t.Errorf("%s: config example has unrecognized keys: %s\n---\n%s\n---",
+					rel, strings.Join(unknown, "; "), block)
+			}
+			if _, err := LoadConfigFromBytes(expanded); err != nil {
+				t.Errorf("%s: config example fails to load: %v\n---\n%s\n---", rel, err, block)
+			}
+			if problem := checkToolkitShape(block); problem != "" {
+				t.Errorf("%s: %s\n---\n%s\n---", rel, problem, block)
+			}
+		}
+	}
+}
+
+// TestShippedExampleConfigStrictClean asserts the canonical example config
+// (configs/platform.yaml) carries no unrecognized top-level keys and loads.
+// This is the config a new operator copies first, so it must be exemplary.
+func TestShippedExampleConfigStrictClean(t *testing.T) {
+	root := repoRootFromTest(t)
+	data, err := os.ReadFile(filepath.Join(root, "configs", "platform.yaml")) //nolint:gosec // test reads project example
+	if err != nil {
+		t.Fatalf("reading configs/platform.yaml: %v", err)
+	}
+	expanded := []byte(expandEnvVars(string(data)))
+	if unknown := detectUnknownFields(expanded); len(unknown) > 0 {
+		t.Errorf("configs/platform.yaml has unrecognized keys: %s", strings.Join(unknown, "; "))
+	}
+	if _, err := LoadConfigFromBytes(expanded); err != nil {
+		t.Errorf("configs/platform.yaml fails to load: %v", err)
+	}
+}
+
+// TestBlockTargetsOtherSchema guards the doc test against hard-failing on a
+// config-shaped example that declares a non-current apiVersion.
+func TestBlockTargetsOtherSchema(t *testing.T) {
+	cases := []struct {
+		name  string
+		block string
+		want  bool
+	}{
+		{"no apiVersion is current schema", "server:\n  name: p\n", false},
+		{"explicit v1 is current schema", "apiVersion: v1\nserver:\n  name: p\n", false},
+		{"unsupported future version skipped", "apiVersion: v99\nserver:\n  name: p\n", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := blockTargetsOtherSchema(c.block); got != c.want {
+				t.Fatalf("blockTargetsOtherSchema = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestIsPlatformConfigBlock_HyphenatedForeignKey ensures a block that mixes a
+// config-known key with a hyphenated non-config key is NOT misclassified as a
+// platform config (which would flag the hyphenated key and break CI).
+func TestIsPlatformConfigBlock_HyphenatedForeignKey(t *testing.T) {
+	known := knownConfigTopKeys()
+	// `runs-on:` is a GitHub Actions key; the regex must capture it so the
+	// block is recognized as non-config.
+	block := "server:\n  name: p\nruns-on: ubuntu-latest\n"
+	if isPlatformConfigBlock(block, known) {
+		t.Fatal("block with a hyphenated foreign key must not be treated as platform config")
+	}
+	// A pure-config block is still recognized.
+	if !isPlatformConfigBlock("server:\n  name: p\naudit:\n  enabled: true\n", known) {
+		t.Fatal("pure config block should be recognized")
+	}
+}
+
+func lastNonEmptyLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.TrimSpace(lines[i]) != "" {
+			return lines[i]
+		}
+	}
+	return ""
+}

--- a/pkg/platform/config_strict_test.go
+++ b/pkg/platform/config_strict_test.go
@@ -1,0 +1,187 @@
+package platform
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestDetectUnknownFields verifies that strict decoding flags keys that do not
+// map to a typed Config field, while leaving keys under untyped blocks alone.
+func TestDetectUnknownFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		yaml       string
+		wantSubstr string // a fragment expected in one of the reported errors, "" = expect none
+	}{
+		{
+			name: "known keys only",
+			yaml: "server:\n  name: p\naudit:\n  enabled: true\n  log_tool_calls: true\n",
+		},
+		{
+			name:       "phantom audit key",
+			yaml:       "audit:\n  enabled: true\n  log_parameters: true\n",
+			wantSubstr: "log_parameters",
+		},
+		{
+			name:       "phantom sessions key",
+			yaml:       "sessions:\n  idle_timeout: 5m\n",
+			wantSubstr: "idle_timeout",
+		},
+		{
+			name:       "phantom oidc key",
+			yaml:       "auth:\n  oidc:\n    enabled: true\n    clock_skew_seconds: 30\n",
+			wantSubstr: "clock_skew_seconds",
+		},
+		{
+			name:       "phantom role_mapping key",
+			yaml:       "personas:\n  role_mapping:\n    user_personas:\n      alice: analyst\n",
+			wantSubstr: "user_personas",
+		},
+		{
+			// Keys under the untyped toolkits map are not inspected by
+			// KnownFields; the doc round-trip test validates that shape.
+			name: "arbitrary toolkit keys not flagged",
+			yaml: "toolkits:\n  trino:\n    primary:\n      host: h\n",
+		},
+		{
+			// Persona names are absorbed by the inline map, so arbitrary
+			// persona keys are not flagged.
+			name: "arbitrary persona names not flagged",
+			yaml: "personas:\n  analyst:\n    display_name: Analyst\n",
+		},
+		{
+			// Deliberate legacy alias must remain accepted.
+			name: "injection legacy alias accepted",
+			yaml: "injection:\n  trino_semantic_enrichment: true\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectUnknownFields([]byte(tt.yaml))
+			if tt.wantSubstr == "" {
+				if len(got) != 0 {
+					t.Fatalf("expected no unknown fields, got %v", got)
+				}
+				return
+			}
+			joined := strings.Join(got, "; ")
+			if !strings.Contains(joined, tt.wantSubstr) {
+				t.Fatalf("expected an error mentioning %q, got %v", tt.wantSubstr, got)
+			}
+		})
+	}
+}
+
+// TestLoadConfig_UnknownKey_WarnsByDefault verifies that in this release an
+// unrecognized key does not fail the load (warn phase).
+func TestLoadConfig_UnknownKey_WarnsByDefault(t *testing.T) {
+	cfg, err := LoadConfigFromBytes([]byte("audit:\n  enabled: true\n  log_parameters: true\n"))
+	if err != nil {
+		t.Fatalf("expected warn-and-continue, got error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected config, got nil")
+	}
+}
+
+// TestLoadConfig_UnknownKey_StrictErrors verifies that config.strict: true
+// promotes unrecognized keys to a hard error.
+func TestLoadConfig_UnknownKey_StrictErrors(t *testing.T) {
+	_, err := LoadConfigFromBytes([]byte(
+		"config:\n  strict: true\naudit:\n  enabled: true\n  log_parameters: true\n"))
+	if err == nil {
+		t.Fatal("expected strict parsing error, got nil")
+	}
+	if !strings.Contains(err.Error(), "log_parameters") {
+		t.Fatalf("expected error to name the offending key, got: %v", err)
+	}
+}
+
+// TestLoadConfig_Strict_CleanConfigLoads verifies strict mode accepts a config
+// with only recognized keys.
+func TestLoadConfig_Strict_CleanConfigLoads(t *testing.T) {
+	cfg, err := LoadConfigFromBytes([]byte(
+		"config:\n  strict: true\nserver:\n  name: p\naudit:\n  enabled: true\n"))
+	if err != nil {
+		t.Fatalf("clean config under strict mode should load, got: %v", err)
+	}
+	if cfg.Server.Name != "p" {
+		t.Fatalf("expected server name p, got %q", cfg.Server.Name)
+	}
+}
+
+// TestLoadConfigFromBytes_DeprecatedVersion exercises the deprecated-version
+// warn branch and confirms the config still loads.
+func TestLoadConfigFromBytes_DeprecatedVersion(t *testing.T) {
+	reg := NewVersionRegistry()
+	reg.Register(&VersionInfo{Version: "v1", Status: VersionCurrent})
+	reg.Register(&VersionInfo{
+		Version:            "v0",
+		Status:             VersionDeprecated,
+		DeprecationMessage: "upgrade to v1",
+	})
+	cfg, err := loadConfigWithRegistry([]byte("apiVersion: v0\nserver:\n  name: p\n"), reg)
+	if err != nil {
+		t.Fatalf("deprecated version should still load: %v", err)
+	}
+	if cfg.Server.Name != "p" {
+		t.Fatalf("expected server name p, got %q", cfg.Server.Name)
+	}
+}
+
+// TestLoadConfigFromBytes_Converter exercises the converter dispatch branch,
+// both success and error.
+func TestLoadConfigFromBytes_Converter(t *testing.T) {
+	reg := NewVersionRegistry()
+	reg.Register(&VersionInfo{
+		Version: "vx",
+		Status:  VersionCurrent,
+		Converter: func([]byte) (*Config, error) {
+			return &Config{Server: ServerConfig{Name: "converted"}}, nil
+		},
+	})
+	cfg, err := loadConfigWithRegistry([]byte("apiVersion: vx\n"), reg)
+	if err != nil {
+		t.Fatalf("converter path should succeed: %v", err)
+	}
+	if cfg.Server.Name != "converted" {
+		t.Fatalf("expected converter output, got %q", cfg.Server.Name)
+	}
+
+	regErr := NewVersionRegistry()
+	regErr.Register(&VersionInfo{
+		Version: "vy",
+		Status:  VersionCurrent,
+		Converter: func([]byte) (*Config, error) {
+			return nil, errAssertConverter
+		},
+	})
+	if _, err := loadConfigWithRegistry([]byte("apiVersion: vy\n"), regErr); err == nil {
+		t.Fatal("converter error should propagate")
+	}
+}
+
+var errAssertConverter = errors.New("converter boom")
+
+// TestConfigMeta_IsStrict covers the tri-state of the strict escape hatch.
+func TestConfigMeta_IsStrict(t *testing.T) {
+	tr, fa := true, false
+	cases := []struct {
+		name string
+		in   *bool
+		want bool
+	}{
+		{"nil defaults to lenient", nil, false},
+		{"explicit false", &fa, false},
+		{"explicit true", &tr, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := (ConfigMeta{Strict: c.in}).IsStrict(); got != c.want {
+				t.Fatalf("IsStrict() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes a class of silent configuration drift: documented config keys and example
YAML that never actually took effect, plus toolkit examples that would load zero
toolkits if copied verbatim. Ships an enforcement mechanism (strict parsing + a
CI round-trip test) alongside the content fixes, so the drift can't quietly
return.

This is the "Cluster A" bundle from a bug triage. The four issues are causally
linked: the new CI test strict-loads every config example in the docs, so it
fails on the exact drift that #770/#775/#769 document. The parser and the doc
fixes therefore have to land together.

Closes #757
Closes #770
Closes #775
Closes #769

## What changed

### #757 - Strict YAML parsing with a `config.strict` escape hatch

`pkg/platform/config.go` previously used non-strict `yaml.Unmarshal`, so any
unrecognized key was silently dropped.

- Added a `config.strict` option. This release runs a **warn phase**:
  unrecognized keys are logged as a prominent `WARN` and loading continues, so
  existing configs keep working. Set `config.strict: true` to reject unknown
  keys with a hard startup error instead (recommended). A future release will
  flip the default, with `config.strict: false` as the temporary opt-out.
- Detection is a single `KnownFields(true)` decode (`strictDecode`) that both
  parses the config and reports drift in one pass. It covers every typed struct,
  top-level **and** nested (`server.*`, `auth.oidc.*`, the fields inside a
  persona definition). Free-form maps stay exempt by design: the `toolkits`
  tree, each toolkit's `config:` map, and the persona *names* under `personas:`.
- The deprecated `injection` alias still loads.
- `LoadConfigFromBytes` now delegates to `loadConfigWithRegistry`, injecting the
  version registry so the deprecated-version and converter dispatch branches are
  covered by tests.

### CI round-trip test - `config_docyaml_test.go`

The gate that keeps docs honest:

- Extracts every fenced `yaml` block from `README.md` and all of `docs/**`,
  strict-loads each config-shaped block, and validates toolkit shape.
- Also asserts the shipped `configs/platform.yaml` is strict-clean.
- Skips blocks that target a non-current `apiVersion` and non-config blocks
  (e.g. Kubernetes/compose/CI YAML), so it only flags real config drift.

New/changed functions are at 100% coverage; patch coverage is 100%.

### #775 - Toolkit YAML examples missing `enabled`/`instances` nesting

The registry loader (`pkg/registry/loader.go`) reads only `enabled`,
`instances`, `default`, `config` directly under a toolkit kind. Examples that
put an instance name directly under the kind load **zero** toolkits.

Reshaped ~34 toolkit blocks across 9 doc files to:

```yaml
toolkits:
  trino:
    enabled: true
    instances:
      primary:
        host: trino.example.com
    default: primary
```

### #770 - Documented keys / values the code never reads

Removed or corrected phantom config, each verified against the structs:

- `semantic.cache.max_entries` - `CacheConfig` has only `enabled`, `ttl`.
- `enrichment.quality_gates` (+ `soft_gates`) - not a field.
- persona `rate_limit` - not a `PersonaDef` field.
- `semantic.custom_properties` - not a field.
- `query.mappings` (per-URN cluster routing) - no such feature; the real knob is
  `query.urn_mapping` (`platform` + `catalog_mapping`).
- `auth.oidc.clock_skew_seconds` - not wired into the platform OIDC config (a
  fixed 30s skew applies and is not YAML-configurable; the troubleshooting doc
  now says so).
- `enrichment.suppress_enrichment_warnings` - not a field.
- nested `enrichment.enrichment` (`include_lineage`/`lineage_depth`/`lineage_direction`) - not real.
- phantom lineage knobs mapped to the real `datahub.LineageConfig`
  (`max_depth` -> `max_hops`, `include_column_lineage` -> `prefer_column_lineage`).
- `configs/platform.yaml` datahub `endpoint:` -> `url:` (the key the toolkit reads).
- Documented `config.strict` in `configuration.md` and `llms-full.txt`.

### #769 - Default persona documented as allow-all

The narrative in `docs/personas/overview.md` already showed the built-in default
persona as deny-all with the fail-closed rationale, matching
`pkg/persona/persona.go`. This PR makes the built-in persona *illustration
blocks* valid config (nested under `personas:`) so they pass the round-trip
gate.

## A note on scope

The four issues under-enumerated the drift. The new round-trip test surfaced a
superset (~47 points), all fixed here, and it is now the self-maintaining spec.
Several individually-listed items were already resolved on `main` (the
`--list-tools` flag was already gone, the audit SQL already used
`success`/`timestamp`, the `llms.txt` Quick Start was already nested, and
#769's narrative was already correct); those needed no change and were verified
against the current tree rather than trusted from the issue text.

`#762` (memory near-duplicate consolidation) is intentionally **not** in this PR:
it is a separate subsystem with no overlap with config parsing.

## Verification

- `make verify` green end to end: tests + race, 43 Playwright e2e, total and
  patch coverage (100% patch), lint, gosec/govulncheck, semgrep, CodeQL,
  doc-check, dead-code, mutation, GoReleaser dry-run.
- Adversarial code review run before the gate; all six findings fixed (a doc
  test false-positive on non-current `apiVersion`, a hyphen-blind top-key regex,
  an inaccurate "personas are exempt" doc claim, imprecise "top-level" wording,
  the converter-path strict gap, and a redundant double parse).
