### PR TITLE
fix(memory): consolidate near-duplicate captures via recall-first supersede

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1423,7 +1423,7 @@ Copy an object. Only available when `read_only: false`. Parameters: `source_buck
 
 ### memory_capture
 
-The one way to record knowledge, in the memory toolkit. The `type` (sink-class) drives routing: `personal_preference` and `episodic_event` write live to memory; `business_knowledge`, `schema_entity`, and `operational_rule` write a knowledge-dimension record carrying a pending insight overlay (`insight_status=pending`) that `apply_knowledge` can promote. Capture is recall-first: a near-duplicate of the caller's existing memory is superseded, not appended.
+The one way to record knowledge, in the memory toolkit. The `type` (sink-class) drives routing: `personal_preference` and `episodic_event` write live to memory; `business_knowledge`, `schema_entity`, and `operational_rule` write a knowledge-dimension record carrying a pending insight overlay (`insight_status=pending`) that `apply_knowledge` can promote. Capture is recall-first over the caller's memory (superseded rows excluded so a dead predecessor never absorbs the supersede; stale rows stay matchable, since a restatement corrects them): every near-duplicate at or above the supersede threshold (0.9 cosine) is superseded by the new capture, not appended (all of them, so a capture over an already-duplicated pair consolidates the whole set); the response's `superseded` field carries the best match id and `superseded_ids` the complete list. Matches in the 0.75-0.9 band are returned as `similar_existing` candidates (id + score) so the agent can consolidate (`memory_manage` update/consolidate) instead of leaving a near-duplicate. When the capture carries `entity_urns`, only records sharing an entity URN can match. Recall requires an embedding provider; without one, captures append.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
@@ -1498,12 +1498,13 @@ Persistent memory for agent and analyst sessions. Requires `memory.enabled: true
 
 ### memory_manage
 
-Lifecycle operations for existing memory records; create new records with `memory_capture`. Commands: `update`, `forget` (soft-delete), `list` (persona-scoped), `review_stale` (admin review of stale memories).
+Lifecycle operations for existing memory records; create new records with `memory_capture`. Commands: `update`, `forget` (soft-delete), `list` (persona-scoped), `review_stale` (admin review of stale memories), `review_duplicates` (list the caller's own active pairs at or above 0.75 cosine similarity, the backstop for near-duplicates the capture-time recall gate missed; requires the database-backed store with vector search), `consolidate` (supersede a duplicate by the record kept: `id` = keep, `duplicate_id` = supersede; both must belong to the caller, the record kept must be active, and the correction chain is preserved via `metadata.superseded_by`).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `command` | string | No | update, forget, list, review_stale (create with memory_capture) |
-| `id` | string | For update/forget | Memory record ID |
+| `command` | string | No | update, forget, list, review_stale, review_duplicates, consolidate (create with memory_capture) |
+| `id` | string | For update/forget/consolidate | Memory record ID (for consolidate: the record to keep) |
+| `duplicate_id` | string | For consolidate | The duplicate record the kept record supersedes |
 | `dimension` | string | No | LOCOMO: knowledge, event, entity, relationship, preference |
 | `category` | string | No | correction, business_context, data_quality, usage_guidance, relationship, enhancement, general |
 | `confidence` | string | No | high, medium, low |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -62,7 +62,7 @@ mcp-data-platform is the orchestration layer for the txn2 MCP ecosystem. DataHub
 
 ## Memory Layer
 
-- [Overview](https://mcp-data-platform.txn2.com/memory/overview/): Persistent memory for agent and analyst sessions backed by PostgreSQL + pgvector, with hybrid semantic/lexical recall, cross-enrichment attachment, staleness detection, and embedding backfill
+- [Overview](https://mcp-data-platform.txn2.com/memory/overview/): Persistent memory for agent and analyst sessions backed by PostgreSQL + pgvector, with hybrid semantic/lexical recall, cross-enrichment attachment, recall-first capture dedup with duplicate consolidation review, staleness detection, and embedding backfill
 - [Configuration](https://mcp-data-platform.txn2.com/memory/configuration/): Memory configuration reference: embedding provider, input caps, staleness watcher, persona opt-in, and pgvector setup
 
 ## Managed Resources

--- a/docs/memory/overview.md
+++ b/docs/memory/overview.md
@@ -63,6 +63,8 @@ Memories are classified by LOCOMO dimension for structured retrieval:
 
 The one way to create a memory record. Routed by `type` (sink-class): `personal_preference` and `episodic_event` are live for the capturer immediately; `business_knowledge`, `schema_entity`, and `operational_rule` are recorded as pending insights reviewed via `apply_knowledge`.
 
+Capture is **recall-first**: before inserting, the new content is compared (by embedding cosine similarity) against the caller's records. Superseded rows are excluded from matching (a dead predecessor must not absorb a new capture's supersede); stale rows remain matchable, since a restatement is exactly how a stale record gets corrected. Every match at or above the supersede threshold (0.9) is superseded by the new capture; the response's `superseded` field carries the best match id and `superseded_ids` the complete list. When the capture names entities (`entity_urns`), only records sharing an entity can match, so knowledge about one table never supersedes knowledge about another. Matches that are similar but below the supersede bar (0.75 to 0.9) are returned as `similar_existing` candidates (id + score) so the agent can decide update-vs-create instead of leaving a near-duplicate behind. Recall requires an embedding provider; without one, captures simply append.
+
 ### memory_manage
 
 Lifecycle operations for existing memory records. Opt-in per persona (requires `memory_*` in `tools.allow`).
@@ -73,6 +75,10 @@ Lifecycle operations for existing memory records. Opt-in per persona (requires `
 | `forget` | Soft-delete (archive) a memory |
 | `list` | Query memories with filters, persona-scoped by default |
 | `review_stale` | List memories flagged as stale by the lineage watcher |
+| `review_duplicates` | List the caller's high-similarity active memory pairs for consolidation review |
+| `consolidate` | Supersede a duplicate record by the record kept (`id` = keep, `duplicate_id` = supersede) |
+
+`review_duplicates` is the backstop for near-duplicates the capture-time recall gate missed (captures made before dedup existed, or pairs scoring below the auto-supersede threshold). It lists the caller's own active pairs at or above 0.75 cosine similarity, highest first: memory content is per-user, so the listing shares the ownership boundary `consolidate`/`update`/`forget` enforce, keeping every listed pair actionable. `consolidate` completes the loop, preserving the correction chain via `metadata.superseded_by` rather than discarding the duplicate; both records must belong to the caller and the record kept must be active (so the only live copy of a fact can never be retired behind a dead record). Requires the database-backed memory store with vector search.
 
 ### Recall (via search)
 

--- a/docs/server/tools.md
+++ b/docs/server/tools.md
@@ -44,7 +44,7 @@ mcp-data-platform provides tools from five integrated toolkits. Each tool can be
 | Knowledge | `fetch` | Read a search result in full: dereferences any reference search emits (knowledge page, context document, dataset, asset, prompt, connection) to its complete content, under the same per-user scope |
 | Memory | `memory_capture` | The one way to record knowledge: sink-class routed, recall-first |
 | Knowledge | `apply_knowledge` | Review and promote reviewed captures to the catalog (admin-only) |
-| Memory | `memory_manage` | Manage existing memories: update, forget, list, review_stale (opt-in per persona) |
+| Memory | `memory_manage` | Manage existing memories: update, forget, list, review_stale, review_duplicates, consolidate (opt-in per persona) |
 | Portal | `save_artifact` | Save an AI-generated artifact (JSX, HTML, SVG, etc.) |
 | Portal | `manage_artifact` | List, get, update, delete, or relevance-search saved artifacts and collections |
 | Portal | `manage_feedback` | Review and respond to human feedback (list pending across everything, get, reply, resolve, request/respond validation) |
@@ -551,7 +551,7 @@ Copy an object. Only available when `read_only: false`.
 
 The one way to record knowledge. The `type` (sink-class) is the single organizing axis and drives routing: `personal_preference` and `episodic_event` are live for the capturer immediately; `business_knowledge`, `schema_entity`, and `operational_rule` are recorded as **pending** and reviewed before promotion to a shared catalog via `apply_knowledge`. Lives in the memory toolkit so creating memory never requires the knowledge toolkit.
 
-Capture is **recall-first**: before writing, it runs a similarity check over the caller's own memory and, on a near-duplicate, supersedes the prior record instead of appending. `schema_entity` carries `entity_urns` and optional `suggested_actions` (the catalog-change payload `apply_knowledge` later applies).
+Capture is **recall-first**: before writing, it runs a similarity check over the caller's own memory (superseded rows excluded; stale rows stay matchable, since a restatement corrects them). Every near-duplicate at or above the supersede threshold (0.9 cosine) is superseded by the new capture (`superseded` in the response carries the best match id, `superseded_ids` the complete list); matches in the 0.75-0.9 band are returned as `similar_existing` candidates (id + score) so the agent can consolidate instead of creating a near-duplicate. `schema_entity` carries `entity_urns` and optional `suggested_actions` (the catalog-change payload `apply_knowledge` later applies).
 
 **Parameters:**
 
@@ -826,8 +826,9 @@ Manages the lifecycle of existing persistent memory. Create new memory with `mem
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `command` | string | No | Operation: `update`, `forget`, `list`, `review_stale`. Omit for help. (Create with `memory_capture`.) |
-| `id` | string | For `update`, `forget` | Memory record ID |
+| `command` | string | No | Operation: `update`, `forget`, `list`, `review_stale`, `review_duplicates`, `consolidate`. Omit for help. (Create with `memory_capture`.) |
+| `id` | string | For `update`, `forget`, `consolidate` | Memory record ID (for `consolidate`: the record to keep) |
+| `duplicate_id` | string | For `consolidate` | The duplicate record the kept record supersedes |
 | `dimension` | string | No | LOCOMO dimension: `knowledge`, `event`, `entity`, `relationship`, `preference` |
 | `category` | string | No | Category: `correction`, `business_context`, `data_quality`, `usage_guidance`, `relationship`, `enhancement`, `general` |
 | `confidence` | string | No | `high`, `medium`, `low` (default: `medium`) |

--- a/pkg/memory/duplicates.go
+++ b/pkg/memory/duplicates.go
@@ -1,0 +1,153 @@
+package memory
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// SimilarPair is a pair of active records owned by the same user whose
+// embeddings are highly similar — a likely duplicate the capture-time recall
+// gate missed (#762). Older/Newer are ordered by creation time so the default
+// consolidation (keep the newer restatement, supersede the older) is explicit.
+type SimilarPair struct {
+	Older Record  `json:"older"`
+	Newer Record  `json:"newer"`
+	Score float64 `json:"score"`
+}
+
+// DuplicateFinder is the optional store capability behind the memory_manage
+// review_duplicates backstop: it lists high-similarity active pairs for human
+// consolidation. Only the postgres store implements it (the search needs
+// pgvector); callers type-assert the wired Store against this and degrade
+// gracefully when it is absent, mirroring knowledge.InsightSearcher.
+type DuplicateFinder interface {
+	// SimilarActivePairs returns the createdBy owner's pairs of active,
+	// embedded records with cosine similarity at or above minScore, highest
+	// first, at most limit pairs. createdBy is required — memory content is
+	// per-user, so an unscoped listing would expose other users' records.
+	// Each record contributes its nearest neighbors only, so the listing is a
+	// best-effort review queue, not an exhaustive join.
+	SimilarActivePairs(ctx context.Context, createdBy string, minScore float64, limit int) ([]SimilarPair, error)
+}
+
+// pairNeighborK is how many nearest neighbors each record contributes to the
+// pair scan. Duplicates are near-identical, so the counterpart is virtually
+// always the first neighbor; a small k keeps the lateral scan cheap while
+// tolerating a couple of interleaved near-matches.
+const pairNeighborK = 3
+
+// SimilarActivePairs implements DuplicateFinder over pgvector: for every
+// active embedded record of the owner, its k nearest active neighbors (same
+// owner) are scored, and pairs clearing minScore are deduplicated (each pair
+// is seen from both sides) and returned highest-similarity first.
+func (s *postgresStore) SimilarActivePairs(ctx context.Context, createdBy string, minScore float64, limit int) ([]SimilarPair, error) {
+	if createdBy == "" {
+		return nil, fmt.Errorf("similar-pair search requires an owner scope (createdBy)")
+	}
+	limit = clampStoreLimit(limit)
+
+	// Raw SQL for the same reason as VectorSearch: the vector expressions use
+	// positional parameters squirrel would misnumber. Each side of the pair is
+	// an alias-qualified copy of the standard record projection; the lateral
+	// fetches ordered neighbors so the ANN index drives the scan. The SQL LIMIT
+	// is 2x the requested pairs because every pair can appear once per side.
+	activeEmbedded := func(alias string) string {
+		return alias + ".status = '" + StatusActive + "' AND " + alias + ".embedding IS NOT NULL"
+	}
+	sqlStr := fmt.Sprintf( // #nosec G201 -- tableName/cols are constants, limit is a sanitized int, minScore/createdBy bind as $1/$2
+		`SELECT %s, %s, 1 - (a.embedding <=> b.embedding) AS score
+FROM %s a
+JOIN LATERAL (
+    SELECT * FROM %s m
+    WHERE %s AND m.created_by = a.created_by AND m.id <> a.id
+    ORDER BY m.embedding <=> a.embedding
+    LIMIT %d
+) b ON 1 - (a.embedding <=> b.embedding) >= $1
+WHERE %s AND a.created_by = $2
+ORDER BY score DESC
+LIMIT %d`,
+		qualifiedRecordCols("a"), qualifiedRecordCols("b"),
+		tableName, tableName, activeEmbedded("m"), pairNeighborK, activeEmbedded("a"), 2*limit,
+	)
+
+	rows, err := s.db.QueryContext(ctx, sqlStr, minScore, createdBy)
+	if err != nil {
+		return nil, fmt.Errorf("executing similar-pair search: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // best-effort cleanup
+
+	pairs, err := collectPairRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	return dedupePairs(pairs, limit), nil
+}
+
+// qualifiedRecordCols returns the standard record projection with every column
+// prefixed by the table alias, for queries joining the table to itself.
+func qualifiedRecordCols(alias string) string {
+	cols := recordColumns()
+	for i, c := range cols {
+		cols[i] = alias + "." + c
+	}
+	return strings.Join(cols, ", ")
+}
+
+// collectPairRows scans (record, record, score) rows.
+func collectPairRows(rows *sql.Rows) ([]SimilarPair, error) {
+	var out []SimilarPair
+	for rows.Next() {
+		var a, b recordScanBuf
+		var score float64
+		dest := append(a.dest(), b.dest()...)
+		dest = append(dest, &score)
+		if err := rows.Scan(dest...); err != nil {
+			return nil, fmt.Errorf("scanning similar-pair row: %w", err)
+		}
+		ra, err := a.finish()
+		if err != nil {
+			return nil, err
+		}
+		rb, err := b.finish()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, orderPair(*ra, *rb, score))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating similar-pair rows: %w", err)
+	}
+	return out, nil
+}
+
+// orderPair arranges a pair as (older, newer) by creation time, falling back
+// to id order for identical timestamps so deduplication is deterministic.
+func orderPair(a, b Record, score float64) SimilarPair {
+	if a.CreatedAt.After(b.CreatedAt) || (a.CreatedAt.Equal(b.CreatedAt) && a.ID > b.ID) {
+		a, b = b, a
+	}
+	return SimilarPair{Older: a, Newer: b, Score: score}
+}
+
+// dedupePairs drops the mirror-image duplicates (each pair is found from both
+// sides of the lateral join) and trims to limit. Rows arrive already sorted
+// highest-score-first (the SQL orders by score DESC and collectPairRows
+// preserves row order), so plain iteration keeps that order.
+func dedupePairs(pairs []SimilarPair, limit int) []SimilarPair {
+	seen := make(map[string]struct{}, len(pairs))
+	out := make([]SimilarPair, 0, len(pairs))
+	for _, p := range pairs {
+		key := p.Older.ID + "\x00" + p.Newer.ID
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, p)
+		if len(out) == limit {
+			break
+		}
+	}
+	return out
+}

--- a/pkg/memory/duplicates_test.go
+++ b/pkg/memory/duplicates_test.go
@@ -1,0 +1,168 @@
+package memory
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func pairRec(id string, createdAt time.Time) Record {
+	return Record{ID: id, CreatedAt: createdAt, Status: StatusActive}
+}
+
+func TestOrderPair(t *testing.T) {
+	t0 := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Minute)
+
+	t.Run("orders by creation time", func(t *testing.T) {
+		p := orderPair(pairRec("newer", t1), pairRec("older", t0), 0.95)
+		assert.Equal(t, "older", p.Older.ID)
+		assert.Equal(t, "newer", p.Newer.ID)
+		assert.Equal(t, 0.95, p.Score)
+	})
+
+	t.Run("equal timestamps fall back to id order", func(t *testing.T) {
+		p := orderPair(pairRec("b", t0), pairRec("a", t0), 0.9)
+		assert.Equal(t, "a", p.Older.ID)
+		assert.Equal(t, "b", p.Newer.ID)
+	})
+
+	t.Run("already ordered is preserved", func(t *testing.T) {
+		p := orderPair(pairRec("older", t0), pairRec("newer", t1), 0.9)
+		assert.Equal(t, "older", p.Older.ID)
+		assert.Equal(t, "newer", p.Newer.ID)
+	})
+}
+
+func TestDedupePairs(t *testing.T) {
+	t0 := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	mk := func(older, newer string, score float64) SimilarPair {
+		return SimilarPair{Older: pairRec(older, t0), Newer: pairRec(newer, t0.Add(time.Minute)), Score: score}
+	}
+
+	t.Run("drops mirror duplicates and preserves input order", func(t *testing.T) {
+		// Input arrives pre-sorted (the SQL orders by score DESC).
+		out := dedupePairs([]SimilarPair{
+			mk("c", "d", 0.97),
+			mk("a", "b", 0.95),
+			mk("a", "b", 0.95), // the same pair seen from the other side
+		}, 10)
+		require.Len(t, out, 2)
+		assert.Equal(t, "c", out[0].Older.ID)
+		assert.Equal(t, "a", out[1].Older.ID)
+	})
+
+	t.Run("trims to limit", func(t *testing.T) {
+		out := dedupePairs([]SimilarPair{mk("a", "b", 0.95), mk("c", "d", 0.9)}, 1)
+		require.Len(t, out, 1)
+		assert.Equal(t, "a", out[0].Older.ID)
+	})
+
+	t.Run("empty input yields empty output", func(t *testing.T) {
+		assert.Empty(t, dedupePairs(nil, 5))
+	})
+}
+
+// pairRowColumns is the 37-column projection SimilarActivePairs selects: both
+// sides' record columns plus the score.
+func pairRowColumns() []string {
+	cols := make([]string, 0, 37)
+	for _, alias := range []string{"a", "b"} {
+		for _, c := range memorySelectColumns {
+			cols = append(cols, alias+"_"+c)
+		}
+	}
+	return append(cols, "score")
+}
+
+// pairRowValues renders one result row: record a, record b, score.
+func pairRowValues(aID string, aCreated time.Time, bID string, bCreated time.Time, score float64) []driver.Value {
+	recVals := func(id string, created time.Time) []driver.Value {
+		return []driver.Value{
+			id, created, created, "user@example.com", "analyst", DimensionKnowledge, SinkBusinessKnowledge,
+			"content of " + id, CategoryBusinessCtx, ConfidenceMedium, SourceUser,
+			[]byte(`[]`), []byte(`[]`), []byte(`{}`),
+			StatusActive, nil, nil, nil,
+		}
+	}
+	vals := append(recVals(aID, aCreated), recVals(bID, bCreated)...)
+	return append(vals, score)
+}
+
+func TestPostgresStore_SimilarActivePairs(t *testing.T) {
+	t0 := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Minute)
+
+	t.Run("returns ordered deduplicated pairs", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close() //nolint:errcheck // test cleanup
+
+		rows := sqlmock.NewRows(pairRowColumns()).
+			AddRow(pairRowValues("m2", t1, "m1", t0, 0.96)...).
+			AddRow(pairRowValues("m1", t0, "m2", t1, 0.96)...) // mirror image from the other side
+		mock.ExpectQuery("SELECT .* FROM memory_records a").
+			WithArgs(0.75, "user@example.com").
+			WillReturnRows(rows)
+
+		store := NewPostgresStore(db)
+		finder, ok := store.(DuplicateFinder)
+		require.True(t, ok, "postgres store must implement DuplicateFinder")
+
+		pairs, err := finder.SimilarActivePairs(context.Background(), "user@example.com", 0.75, 10)
+		require.NoError(t, err)
+		require.Len(t, pairs, 1, "mirror-image rows must collapse to one pair")
+		assert.Equal(t, "m1", pairs[0].Older.ID, "pair must be ordered older first")
+		assert.Equal(t, "m2", pairs[0].Newer.ID)
+		assert.Equal(t, 0.96, pairs[0].Score)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("query error propagates", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close() //nolint:errcheck // test cleanup
+
+		mock.ExpectQuery("SELECT .* FROM memory_records a").
+			WillReturnError(errors.New("boom"))
+
+		finder, ok := NewPostgresStore(db).(DuplicateFinder)
+		require.True(t, ok)
+		_, err = finder.SimilarActivePairs(context.Background(), "user@example.com", 0.75, 10)
+		require.Error(t, err)
+	})
+
+	t.Run("missing owner scope is rejected", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close() //nolint:errcheck // test cleanup
+
+		finder, ok := NewPostgresStore(db).(DuplicateFinder)
+		require.True(t, ok)
+		_, err = finder.SimilarActivePairs(context.Background(), "", 0.75, 10)
+		require.Error(t, err, "an unscoped pair listing would expose other users' records")
+		require.NoError(t, mock.ExpectationsWereMet(), "no query must run without an owner scope")
+	})
+
+	t.Run("scan error propagates", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close() //nolint:errcheck // test cleanup
+
+		rows := sqlmock.NewRows(pairRowColumns()).
+			AddRow(pairRowValues("m2", t1, "m1", t0, 0.96)...).
+			RowError(0, errors.New("row boom"))
+		mock.ExpectQuery("SELECT .* FROM memory_records a").WillReturnRows(rows)
+
+		finder, ok := NewPostgresStore(db).(DuplicateFinder)
+		require.True(t, ok)
+		_, err = finder.SimilarActivePairs(context.Background(), "user@example.com", 0.75, 10)
+		require.Error(t, err)
+	})
+}

--- a/pkg/memory/hybrid_search_test.go
+++ b/pkg/memory/hybrid_search_test.go
@@ -420,6 +420,63 @@ func TestVectorSearch_CreatedByAndDimensionFilters(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestVectorSearch_MalformedRowJSON pins the scored-row scan error path: a
+// row whose JSON column does not unmarshal must fail the search, not scan a
+// half-populated record.
+func TestVectorSearch_MalformedRowJSON(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	store := NewPostgresStore(db)
+
+	rows := sqlmock.NewRows(lexicalColumns).AddRow(
+		"bad", time.Now(), time.Now(), "u@example.com", "analyst", DimensionKnowledge, SinkBusinessKnowledge,
+		"content", CategoryBusinessCtx, ConfidenceMedium, SourceUser,
+		[]byte(`not-json`), []byte(`[]`), []byte(`{}`),
+		StatusActive, nil, nil, nil,
+		0.9,
+	)
+	mock.ExpectQuery("ORDER BY embedding").WillReturnRows(rows)
+
+	_, err = store.VectorSearch(context.Background(), VectorQuery{Embedding: []float32{0.1}, Limit: 5})
+	require.Error(t, err, "a malformed JSON column must fail the scan")
+}
+
+// TestVectorSearch_ExcludeStatuses covers the negative status scope the
+// recall-first capture check uses (#762): superseded rows must be dropped by
+// an `status <> $n` predicate bound after the positive scope args, while the
+// default archived exclusion still applies (no explicit Status set).
+func TestVectorSearch_ExcludeStatuses(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	store := NewPostgresStore(db)
+
+	rows := sqlmock.NewRows(lexicalColumns)
+	addLexicalRow(rows, "active-match", true, 0.95)
+	mock.ExpectQuery(`status <> 'archived'.* AND status <> \$3`).
+		WithArgs(sqlmock.AnyArg(), "user@example.com", StatusSuperseded).
+		WillReturnRows(rows)
+
+	got, err := store.VectorSearch(context.Background(), VectorQuery{
+		Embedding:       []float32{0.1, 0.2},
+		CreatedBy:       "user@example.com",
+		ExcludeStatuses: []string{StatusSuperseded},
+		MinScore:        0.9,
+		Limit:           5,
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "active-match", got[0].Record.ID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 // TestArchivedExclusion pins the rule that resolves the archived-status
 // search contradiction: the default `status <> 'archived'` predicate is
 // emitted only when no explicit status is requested. An explicit status

--- a/pkg/memory/postgres.go
+++ b/pkg/memory/postgres.go
@@ -334,7 +334,8 @@ func (s *postgresStore) VectorSearch(ctx context.Context, query VectorQuery) ([]
 	// vector parameter ($1) used in the ORDER BY and SELECT expressions.
 	// Optional scope predicates start at $2 (only $1=vector is fixed).
 	filterClause, filterArgs := scopeFilters(scope{
-		createdBy: query.CreatedBy, dimension: query.Dimension, persona: query.Persona, status: query.Status,
+		createdBy: query.CreatedBy, dimension: query.Dimension, persona: query.Persona,
+		status: query.Status, excludeStatuses: query.ExcludeStatuses,
 	}, 2)
 	args := append([]any{pgvector.NewVector(query.Embedding)}, filterArgs...)
 
@@ -415,14 +416,15 @@ func archivedExclusion(status string) string {
 }
 
 // scope holds the optional predicates shared by the search arms. created_by is
-// the portal's per-user security boundary; excludeDimension is the negative
-// complement of dimension (drop one rather than restrict to one).
+// the portal's per-user security boundary; excludeDimension and excludeStatuses
+// are the negative complements of dimension/status (drop rather than restrict).
 type scope struct {
 	createdBy        string
 	dimension        string
 	persona          string
 	status           string
 	excludeDimension string
+	excludeStatuses  []string
 }
 
 // scopeFilters builds the optional scope predicates, parameterized from
@@ -449,6 +451,12 @@ func scopeFilters(s scope, startIdx int) (clause string, args []any) {
 	if s.excludeDimension != "" {
 		clause += fmt.Sprintf(" AND %s <> $%d", colDimension, idx)
 		args = append(args, s.excludeDimension)
+		idx++
+	}
+	for _, st := range s.excludeStatuses {
+		clause += fmt.Sprintf(" AND %s <> $%d", colStatus, idx)
+		args = append(args, st)
+		idx++
 	}
 	return clause, args
 }
@@ -863,115 +871,85 @@ func recordColumns() []string {
 	}
 }
 
-// scanRecord scans a single row from QueryRow into a Record.
-func scanRecord(row *sql.Row) (*Record, error) {
-	var r Record
-	var entityURNs, relatedCols, metadata []byte
-	var sinkClass, staleReason sql.NullString
-	var staleAt, lastVerified sql.NullTime
+// recordScanBuf holds the scan destinations for one record's standard
+// projection (recordColumns/rawRecordCols order) and converts them into a
+// Record. It is THE record scanner: every scan path (single row, row set,
+// scored row, hybrid row, pair row) builds on dest()+finish(), so a column
+// added to recordColumns() is threaded through exactly one place.
+type recordScanBuf struct {
+	r                                 Record
+	entityURNs, relatedCols, metadata []byte
+	sinkClass, staleReason            sql.NullString
+	staleAt, lastVerified             sql.NullTime
+}
 
-	err := row.Scan(
-		&r.ID, &r.CreatedAt, &r.UpdatedAt, &r.CreatedBy, &r.Persona, &r.Dimension, &sinkClass,
-		&r.Content, &r.Category, &r.Confidence, &r.Source,
-		&entityURNs, &relatedCols, &metadata,
-		&r.Status, &staleReason, &staleAt, &lastVerified,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("scanning memory record: %w", err)
+// dest returns the scan destinations in recordColumns order.
+func (b *recordScanBuf) dest() []any {
+	return []any{
+		&b.r.ID, &b.r.CreatedAt, &b.r.UpdatedAt, &b.r.CreatedBy, &b.r.Persona, &b.r.Dimension, &b.sinkClass,
+		&b.r.Content, &b.r.Category, &b.r.Confidence, &b.r.Source,
+		&b.entityURNs, &b.relatedCols, &b.metadata,
+		&b.r.Status, &b.staleReason, &b.staleAt, &b.lastVerified,
 	}
+}
 
-	if err := unmarshalRecordJSON(&r, entityURNs, relatedCols, metadata); err != nil {
+// finish unmarshals the JSON columns and applies nullable values.
+func (b *recordScanBuf) finish() (*Record, error) {
+	if err := unmarshalRecordJSON(&b.r, b.entityURNs, b.relatedCols, b.metadata); err != nil {
 		return nil, err
 	}
+	b.r.SinkClass = b.sinkClass.String
+	applyNullables(&b.r, b.staleReason, b.staleAt, b.lastVerified)
+	return &b.r, nil
+}
 
-	r.SinkClass = sinkClass.String
-	applyNullables(&r, staleReason, staleAt, lastVerified)
-	return &r, nil
+// scanRecord scans a single row from QueryRow into a Record.
+func scanRecord(row *sql.Row) (*Record, error) {
+	var b recordScanBuf
+	if err := row.Scan(b.dest()...); err != nil {
+		return nil, fmt.Errorf("scanning memory record: %w", err)
+	}
+	return b.finish()
 }
 
 // scanRecordRow scans a single row from Rows into a Record.
 func scanRecordRow(rows *sql.Rows) (*Record, error) {
-	var r Record
-	var entityURNs, relatedCols, metadata []byte
-	var sinkClass, staleReason sql.NullString
-	var staleAt, lastVerified sql.NullTime
-
-	err := rows.Scan(
-		&r.ID, &r.CreatedAt, &r.UpdatedAt, &r.CreatedBy, &r.Persona, &r.Dimension, &sinkClass,
-		&r.Content, &r.Category, &r.Confidence, &r.Source,
-		&entityURNs, &relatedCols, &metadata,
-		&r.Status, &staleReason, &staleAt, &lastVerified,
-	)
-	if err != nil {
+	var b recordScanBuf
+	if err := rows.Scan(b.dest()...); err != nil {
 		return nil, fmt.Errorf("scanning memory row: %w", err)
 	}
-
-	if err := unmarshalRecordJSON(&r, entityURNs, relatedCols, metadata); err != nil {
-		return nil, err
-	}
-
-	r.SinkClass = sinkClass.String
-	applyNullables(&r, staleReason, staleAt, lastVerified)
-	return &r, nil
+	return b.finish()
 }
 
 // scanScoredRow scans a row with an appended score column.
 func scanScoredRow(rows *sql.Rows) (*Record, float64, error) {
-	var r Record
-	var entityURNs, relatedCols, metadata []byte
-	var sinkClass, staleReason sql.NullString
-	var staleAt, lastVerified sql.NullTime
+	var b recordScanBuf
 	var score float64
-
-	err := rows.Scan(
-		&r.ID, &r.CreatedAt, &r.UpdatedAt, &r.CreatedBy, &r.Persona, &r.Dimension, &sinkClass,
-		&r.Content, &r.Category, &r.Confidence, &r.Source,
-		&entityURNs, &relatedCols, &metadata,
-		&r.Status, &staleReason, &staleAt, &lastVerified,
-		&score,
-	)
-	if err != nil {
+	if err := rows.Scan(append(b.dest(), &score)...); err != nil {
 		return nil, 0, fmt.Errorf("scanning scored row: %w", err)
 	}
-
-	if err := unmarshalRecordJSON(&r, entityURNs, relatedCols, metadata); err != nil {
+	r, err := b.finish()
+	if err != nil {
 		return nil, 0, err
 	}
-
-	r.SinkClass = sinkClass.String
-	applyNullables(&r, staleReason, staleAt, lastVerified)
-	return &r, score, nil
+	return r, score, nil
 }
 
 // scanHybridRow scans a row with appended vec_score and lex_match
 // columns (the HybridSearch arms) into a candidate. The 18 record
 // columns must match rawRecordCols in order.
 func scanHybridRow(rows *sql.Rows) (*hybridCandidate, error) {
-	var r Record
-	var entityURNs, relatedCols, metadata []byte
-	var sinkClass, staleReason sql.NullString
-	var staleAt, lastVerified sql.NullTime
+	var b recordScanBuf
 	var vecScore float64
 	var lexMatch bool
-
-	err := rows.Scan(
-		&r.ID, &r.CreatedAt, &r.UpdatedAt, &r.CreatedBy, &r.Persona, &r.Dimension, &sinkClass,
-		&r.Content, &r.Category, &r.Confidence, &r.Source,
-		&entityURNs, &relatedCols, &metadata,
-		&r.Status, &staleReason, &staleAt, &lastVerified,
-		&vecScore, &lexMatch,
-	)
-	if err != nil {
+	if err := rows.Scan(append(b.dest(), &vecScore, &lexMatch)...); err != nil {
 		return nil, fmt.Errorf("scanning hybrid row: %w", err)
 	}
-
-	if err := unmarshalRecordJSON(&r, entityURNs, relatedCols, metadata); err != nil {
+	r, err := b.finish()
+	if err != nil {
 		return nil, err
 	}
-
-	r.SinkClass = sinkClass.String
-	applyNullables(&r, staleReason, staleAt, lastVerified)
-	return &hybridCandidate{record: r, vecScore: vecScore, lexMatch: lexMatch}, nil
+	return &hybridCandidate{record: *r, vecScore: vecScore, lexMatch: lexMatch}, nil
 }
 
 // unmarshalRecordJSON unmarshals JSON columns into Record fields.

--- a/pkg/memory/postgres_test.go
+++ b/pkg/memory/postgres_test.go
@@ -393,6 +393,55 @@ func TestPostgresStore_List_EmptyResult(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestPostgresStore_List_MalformedRowJSON pins the row-scan error path: a row
+// whose JSON column does not unmarshal must fail the listing, not yield a
+// half-populated record.
+func TestPostgresStore_List_MalformedRowJSON(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	store := NewPostgresStore(db)
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	rows := sqlmock.NewRows(memorySelectColumns).AddRow(
+		"mem-bad", now, now, "user-abc", "analyst", DimensionKnowledge, "schema_entity",
+		"content", CategoryGeneral, ConfidenceMedium, SourceUser,
+		[]byte(`not-json`), []byte(`[]`), []byte(`{}`),
+		StatusActive, nil, nil, nil,
+	)
+	mock.ExpectQuery("SELECT .+ FROM memory_records").WillReturnRows(rows)
+
+	_, _, err = store.List(context.Background(), Filter{})
+	require.Error(t, err, "a malformed JSON column must fail the scan")
+}
+
+// TestPostgresStore_List_ScanTypeMismatch pins the Scan-error branch itself:
+// a column value that cannot convert to its destination type (a non-time
+// created_at) must fail the listing.
+func TestPostgresStore_List_ScanTypeMismatch(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	store := NewPostgresStore(db)
+
+	mock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	rows := sqlmock.NewRows(memorySelectColumns).AddRow(
+		"mem-bad", "not-a-time", "not-a-time", "user-abc", "analyst", DimensionKnowledge, "schema_entity",
+		"content", CategoryGeneral, ConfidenceMedium, SourceUser,
+		[]byte(`[]`), []byte(`[]`), []byte(`{}`),
+		StatusActive, nil, nil, nil,
+	)
+	mock.ExpectQuery("SELECT .+ FROM memory_records").WillReturnRows(rows)
+
+	_, _, err = store.List(context.Background(), Filter{})
+	require.Error(t, err, "a scan type mismatch must fail the listing")
+}
+
 func TestPostgresStore_List_Pagination(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/pkg/memory/search_types.go
+++ b/pkg/memory/search_types.go
@@ -16,6 +16,13 @@ type VectorQuery struct {
 	Dimension string
 	Persona   string
 	Status    string
+	// ExcludeStatuses drops rows of the listed statuses, the complement of
+	// Status (which restricts to one). It composes with the default archived
+	// exclusion (applied when Status is empty). The recall-first capture check
+	// uses it to skip superseded rows (a dead predecessor must not absorb a
+	// new capture's supersede, #762) while still matching stale rows (a
+	// restatement is exactly how a stale record gets corrected).
+	ExcludeStatuses []string
 }
 
 // HybridQuery defines parameters for hybrid (vector + lexical) recall.

--- a/pkg/memory/store_realdb_integration_test.go
+++ b/pkg/memory/store_realdb_integration_test.go
@@ -285,3 +285,56 @@ func TestMemoryStore_EntityLookup_RealDB_PushPathGatesPending(t *testing.T) {
 	assert.True(t, gotOwn[migratedPending.ID], "owner sees their own legacy_status=pending candidate")
 	assert.Len(t, own, 6, "user-scoped lookup returns all of the owner's entity-linked records")
 }
+
+// TestMemoryStore_SimilarActivePairs_RealDB exercises the #762 backstop query
+// against real pgvector: the lateral self-join must pair a user's two
+// near-identical ACTIVE records exactly once (mirror rows deduplicated, older
+// first), and must not pair across owners, against superseded records, or
+// across dissimilar content. sqlmock cannot validate any of this SQL.
+func TestMemoryStore_SimilarActivePairs_RealDB(t *testing.T) {
+	store := NewPostgresStore(testdb.New(t))
+	ctx := context.Background()
+
+	// 768-dim embeddings: base and near are almost parallel (cosine ~0.995);
+	// distinct is orthogonal to both.
+	base := make([]float32, 768)
+	base[0] = 1
+	near := make([]float32, 768)
+	near[0] = 1
+	near[1] = 0.1
+	distinct := make([]float32, 768)
+	distinct[2] = 1
+
+	rec := func(id, owner, status string, emb []float32) Record {
+		return Record{
+			ID: id, CreatedBy: owner, Dimension: DimensionKnowledge, SinkClass: SinkBusinessKnowledge,
+			Content: "content for " + id, Category: CategoryBusinessCtx, Confidence: ConfidenceMedium,
+			Source: SourceUser, Status: status, Embedding: emb, EmbeddingModel: "test",
+		}
+	}
+	for _, r := range []Record{
+		rec("mem_762_dup_a", "a@example.com", StatusActive, base),
+		rec("mem_762_dup_b", "a@example.com", StatusActive, near),
+		rec("mem_762_distinct", "a@example.com", StatusActive, distinct),
+		rec("mem_762_superseded_twin", "a@example.com", StatusSuperseded, base),
+		rec("mem_762_other_user_twin", "b@example.com", StatusActive, base),
+	} {
+		require.NoError(t, store.Insert(ctx, r))
+	}
+
+	finder, ok := any(store).(DuplicateFinder)
+	require.True(t, ok, "postgres store must implement DuplicateFinder")
+
+	pairs, err := finder.SimilarActivePairs(ctx, "a@example.com", 0.9, 10)
+	require.NoError(t, err)
+	require.Len(t, pairs, 1, "exactly one active pair must be found for the owner (no mirrors, no superseded)")
+	assert.Equal(t, "mem_762_dup_a", pairs[0].Older.ID)
+	assert.Equal(t, "mem_762_dup_b", pairs[0].Newer.ID)
+	assert.Greater(t, pairs[0].Score, 0.9)
+
+	// The owner scope is the per-user privacy boundary: user B has only one
+	// active embedded record, so no pair — and never user A's content.
+	pairsB, err := finder.SimilarActivePairs(ctx, "b@example.com", 0.9, 10)
+	require.NoError(t, err)
+	assert.Empty(t, pairsB, "another user's records must never appear in a caller's pair listing")
+}

--- a/pkg/platform/memory_dedup_realdb_integration_test.go
+++ b/pkg/platform/memory_dedup_realdb_integration_test.go
@@ -1,0 +1,87 @@
+//go:build integration
+
+package platform
+
+// Real-Postgres acceptance test for #762: rapid restatements of the same fact
+// must consolidate to a single active record, not accumulate active
+// near-duplicates. It wires the real capture pipeline (memory toolkit ->
+// memoryRecallChecker -> postgres store with pgvector) and captures the same
+// content three times. Before the fix, the third capture's recall could match
+// the already-superseded first record (VectorSearch had no status scope),
+// re-supersede it, and leave two active duplicates standing — exactly the pair
+// observed on a live deployment. Run under `make test-realdb`.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/internal/testdb"
+	"github.com/txn2/mcp-data-platform/pkg/memory"
+	memorykit "github.com/txn2/mcp-data-platform/pkg/toolkits/memory"
+)
+
+// fixedVecEmbedder is a real (non-noop) provider returning one fixed vector,
+// so every capture in the test embeds identically (cosine 1.0).
+type fixedVecEmbedder struct{ vec []float32 }
+
+func (f fixedVecEmbedder) Embed(context.Context, string) ([]float32, error) { return f.vec, nil }
+func (f fixedVecEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range out {
+		out[i] = f.vec
+	}
+	return out, nil
+}
+func (f fixedVecEmbedder) Dimension() int { return len(f.vec) }
+func (fixedVecEmbedder) Kind() string     { return "test" }
+
+func TestRealDB_MemoryCaptureDedup_ConsolidatesRestatements(t *testing.T) {
+	db := testdb.New(t)
+	ctx := context.Background()
+
+	store := memory.NewPostgresStore(db)
+	vec := make([]float32, 768)
+	vec[0] = 1
+
+	tk, err := memorykit.New("memory", store, fixedVecEmbedder{vec: vec})
+	require.NoError(t, err)
+	tk.SetRecallChecker(&memoryRecallChecker{store: store})
+
+	const owner = "dedup@example.com"
+	capture := func(content string) *memorykit.CaptureResult {
+		res, err := tk.AutoCapture(ctx, memorykit.AutoCaptureInput{
+			SinkClass: memory.SinkBusinessKnowledge,
+			Content:   content,
+			CreatedBy: owner,
+		})
+		require.NoError(t, err)
+		return res
+	}
+
+	r1 := capture("The orders feed refreshes nightly at 2am UTC.")
+	assert.Empty(t, r1.Superseded, "first capture has nothing to supersede")
+
+	r2 := capture("The orders feed is refreshed each night at 2am UTC.")
+	assert.Equal(t, []string{r1.ID}, r2.Superseded, "a restatement supersedes the original")
+
+	// The regression: recall for the third capture must match the ACTIVE second
+	// record, not the already-superseded first one.
+	r3 := capture("Orders data refreshes nightly at 2am UTC.")
+	assert.Equal(t, []string{r2.ID}, r3.Superseded,
+		"the third capture must supersede the active duplicate, not re-supersede the dead one")
+
+	active, _, err := store.List(ctx, memory.Filter{CreatedBy: owner, Status: memory.StatusActive, Limit: 50})
+	require.NoError(t, err)
+	require.Len(t, active, 1, "rapid restatements must consolidate to a single active record (#762)")
+	assert.Equal(t, r3.ID, active[0].ID)
+
+	// Stale records must remain supersedable: a restatement is exactly how a
+	// stale record gets corrected (superseded rows are the only recall
+	// exclusion beyond archived).
+	require.NoError(t, store.MarkStale(ctx, []string{r3.ID}, "schema drift"))
+	r4 := capture("Orders data is refreshed nightly at 2am UTC.")
+	assert.Equal(t, []string{r3.ID}, r4.Superseded, "a capture restating a stale record must supersede it")
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1576,37 +1576,44 @@ func (p *Platform) initSessionGate() {
 const recallCandidateK = 5
 
 // memoryRecallChecker implements memorykit.RecallChecker by running a raw cosine
-// (vector-only) similarity search over the caller's own memory and returning the
-// best match that also shares an entity URN with the candidate (when it has any).
-// It uses VectorSearch's raw cosine (not the search router's min-max
-// normalization, nor the fused hybrid score) so MinScore reads as a true cosine.
-// The candidate embedding is supplied by the caller (memory_capture reuses the
-// vector it already computed), so this type needs no embedder of its own.
+// (vector-only) similarity search over the caller's own memory and returning
+// every match clearing the threshold that also shares an entity URN with the
+// candidate (when it has any). It uses VectorSearch's raw cosine (not the
+// search router's min-max normalization, nor the fused hybrid score) so
+// MinScore reads as a true cosine. The candidate embedding is supplied by the
+// caller (memory_capture reuses the vector it already computed), so this type
+// needs no embedder of its own.
 type memoryRecallChecker struct {
 	store memory.Store
 }
 
-// ExistingMatch returns the caller's best-matching memory id and cosine score, or
-// ("", 0) when there is no precomputed embedding, no caller, or nothing clears
-// MinScore and the entity-URN gate. The caller (memory_capture) precomputes the
-// embedding and runs this BEFORE inserting the new row, so a capture never
-// matches itself.
-func (c *memoryRecallChecker) ExistingMatch(ctx context.Context, q memorykit.RecallQuery) (id string, score float64, err error) {
+// Matches returns the caller's memories similar to the candidate, best first,
+// or nil when there is no precomputed embedding, no caller, or nothing clears
+// MinScore and the entity-URN gate. The caller (memory_capture) precomputes
+// the embedding and runs this BEFORE inserting the new row, so a capture never
+// matches itself. Superseded rows are excluded from the search: without that,
+// a superseded (near-identical) predecessor can outrank its active successor,
+// absorb the supersede, and leave two active duplicates standing (#762). Stale
+// rows remain matchable — a restatement is exactly how a stale record gets
+// corrected — and archived rows are excluded by the store's default.
+func (c *memoryRecallChecker) Matches(ctx context.Context, q memorykit.RecallQuery) ([]memorykit.RecallMatch, error) {
 	if q.CallerEmail == "" || c.store == nil || len(q.Embedding) == 0 {
-		return "", 0, nil
+		return nil, nil
 	}
 	res, err := c.store.VectorSearch(ctx, memory.VectorQuery{
-		Embedding: q.Embedding,
-		CreatedBy: q.CallerEmail,
-		MinScore:  q.MinScore,
-		Limit:     recallCandidateK,
+		Embedding:       q.Embedding,
+		CreatedBy:       q.CallerEmail,
+		MinScore:        q.MinScore,
+		ExcludeStatuses: []string{memory.StatusSuperseded},
+		Limit:           recallCandidateK,
 	})
 	if err != nil {
-		return "", 0, fmt.Errorf("recall-first similarity: %w", err)
+		return nil, fmt.Errorf("recall-first similarity: %w", err)
 	}
-	// Results are sorted by descending similarity. Take the best one that clears
+	// Results are sorted by descending similarity. Keep every one that clears
 	// the threshold and, when the candidate concerns specific entities, shares an
 	// entity URN — so knowledge about table A never supersedes knowledge about B.
+	var matches []memorykit.RecallMatch
 	for i := range res {
 		if res[i].Score < q.MinScore {
 			break
@@ -1614,9 +1621,9 @@ func (c *memoryRecallChecker) ExistingMatch(ctx context.Context, q memorykit.Rec
 		if len(q.EntityURNs) > 0 && !sharesAny(res[i].Record.EntityURNs, q.EntityURNs) {
 			continue
 		}
-		return res[i].Record.ID, res[i].Score, nil
+		matches = append(matches, memorykit.RecallMatch{ID: res[i].Record.ID, Score: res[i].Score})
 	}
-	return "", 0, nil
+	return matches, nil
 }
 
 // sharesAny reports whether a and b have at least one element in common.

--- a/pkg/platform/recall_checker_test.go
+++ b/pkg/platform/recall_checker_test.go
@@ -58,50 +58,56 @@ func scoredRec(id string, score float64, urns ...string) memory.ScoredRecord {
 	return memory.ScoredRecord{Record: memory.Record{ID: id, EntityURNs: urns}, Score: score}
 }
 
-func TestMemoryRecallChecker_ExistingMatch(t *testing.T) {
+func TestMemoryRecallChecker_Matches(t *testing.T) {
 	emb := []float32{0.1, 0.2, 0.3}
 
 	t.Run("no embedding skips search", func(t *testing.T) {
 		store := &recallFakeStore{results: []memory.ScoredRecord{scoredRec("x", 0.99)}}
 		c := &memoryRecallChecker{store: store}
-		id, _, err := c.ExistingMatch(context.Background(), memorykit.RecallQuery{CallerEmail: "a@x.com", MinScore: 0.9})
+		matches, err := c.Matches(context.Background(), memorykit.RecallQuery{CallerEmail: "a@x.com", MinScore: 0.9})
 		require.NoError(t, err)
-		assert.Empty(t, id)
+		assert.Empty(t, matches)
 		assert.False(t, store.called, "must not search without an embedding")
 	})
 
 	t.Run("no caller skips search", func(t *testing.T) {
 		store := &recallFakeStore{}
 		c := &memoryRecallChecker{store: store}
-		id, _, err := c.ExistingMatch(context.Background(), memorykit.RecallQuery{Embedding: emb, MinScore: 0.9})
+		matches, err := c.Matches(context.Background(), memorykit.RecallQuery{Embedding: emb, MinScore: 0.9})
 		require.NoError(t, err)
-		assert.Empty(t, id)
+		assert.Empty(t, matches)
 		assert.False(t, store.called)
 	})
 
-	t.Run("top match returned and query scoped", func(t *testing.T) {
-		store := &recallFakeStore{results: []memory.ScoredRecord{scoredRec("m1", 0.95)}}
+	t.Run("matches returned and query scoped to caller's active records", func(t *testing.T) {
+		store := &recallFakeStore{results: []memory.ScoredRecord{scoredRec("m1", 0.95), scoredRec("m2", 0.92)}}
 		c := &memoryRecallChecker{store: store}
-		id, score, err := c.ExistingMatch(context.Background(), memorykit.RecallQuery{
+		matches, err := c.Matches(context.Background(), memorykit.RecallQuery{
 			Embedding: emb, CallerEmail: "a@x.com", MinScore: 0.9,
 		})
 		require.NoError(t, err)
-		assert.Equal(t, "m1", id)
-		assert.InDelta(t, 0.95, score, 1e-9)
+		assert.Equal(t, []memorykit.RecallMatch{{ID: "m1", Score: 0.95}, {ID: "m2", Score: 0.92}}, matches)
 		assert.Equal(t, "a@x.com", store.gotQ.CreatedBy)
 		assert.Equal(t, 0.9, store.gotQ.MinScore)
 		assert.Equal(t, recallCandidateK, store.gotQ.Limit)
 		assert.Equal(t, emb, store.gotQ.Embedding)
+		// Regression (#762): recall must exclude superseded records. Without
+		// that a superseded predecessor can outrank its active successor,
+		// absorb the supersede, and leave two active duplicates standing.
+		// Stale records stay matchable (a restatement corrects them), so the
+		// scope is an exclusion, not a Status=active restriction.
+		assert.Equal(t, []string{memory.StatusSuperseded}, store.gotQ.ExcludeStatuses)
+		assert.Empty(t, store.gotQ.Status)
 	})
 
 	t.Run("below threshold yields no match", func(t *testing.T) {
 		store := &recallFakeStore{results: []memory.ScoredRecord{scoredRec("m1", 0.5)}}
 		c := &memoryRecallChecker{store: store}
-		id, _, err := c.ExistingMatch(context.Background(), memorykit.RecallQuery{
+		matches, err := c.Matches(context.Background(), memorykit.RecallQuery{
 			Embedding: emb, CallerEmail: "a@x.com", MinScore: 0.9,
 		})
 		require.NoError(t, err)
-		assert.Empty(t, id)
+		assert.Empty(t, matches)
 	})
 
 	t.Run("entity-URN gate skips non-matching higher score", func(t *testing.T) {
@@ -111,29 +117,30 @@ func TestMemoryRecallChecker_ExistingMatch(t *testing.T) {
 			scoredRec("same-table", 0.93, "urn:li:dataset:A"),
 		}}
 		c := &memoryRecallChecker{store: store}
-		id, _, err := c.ExistingMatch(context.Background(), memorykit.RecallQuery{
+		matches, err := c.Matches(context.Background(), memorykit.RecallQuery{
 			Embedding: emb, CallerEmail: "a@x.com", MinScore: 0.9,
 			EntityURNs: []string{"urn:li:dataset:A"},
 		})
 		require.NoError(t, err)
-		assert.Equal(t, "same-table", id, "must not supersede knowledge about a different entity")
+		assert.Equal(t, []memorykit.RecallMatch{{ID: "same-table", Score: 0.93}}, matches,
+			"must not supersede knowledge about a different entity")
 	})
 
 	t.Run("entity-URN gate with no overlap yields no match", func(t *testing.T) {
 		store := &recallFakeStore{results: []memory.ScoredRecord{scoredRec("other", 0.99, "urn:li:dataset:B")}}
 		c := &memoryRecallChecker{store: store}
-		id, _, err := c.ExistingMatch(context.Background(), memorykit.RecallQuery{
+		matches, err := c.Matches(context.Background(), memorykit.RecallQuery{
 			Embedding: emb, CallerEmail: "a@x.com", MinScore: 0.9,
 			EntityURNs: []string{"urn:li:dataset:A"},
 		})
 		require.NoError(t, err)
-		assert.Empty(t, id)
+		assert.Empty(t, matches)
 	})
 
 	t.Run("store error propagates", func(t *testing.T) {
 		store := &recallFakeStore{err: errors.New("boom")}
 		c := &memoryRecallChecker{store: store}
-		_, _, err := c.ExistingMatch(context.Background(), memorykit.RecallQuery{
+		_, err := c.Matches(context.Background(), memorykit.RecallQuery{
 			Embedding: emb, CallerEmail: "a@x.com", MinScore: 0.9,
 		})
 		require.Error(t, err)

--- a/pkg/toolkits/memory/autocapture.go
+++ b/pkg/toolkits/memory/autocapture.go
@@ -35,7 +35,7 @@ type CaptureResult struct {
 	ID         string
 	SinkClass  string
 	Status     string
-	Superseded string
+	Superseded []string
 }
 
 // AutoCapture persists a server-initiated capture, reusing the full

--- a/pkg/toolkits/memory/autocapture_test.go
+++ b/pkg/toolkits/memory/autocapture_test.go
@@ -100,7 +100,7 @@ func TestAutoCapture_Validation(t *testing.T) {
 func TestAutoCapture_RecallFirstSupersedes(t *testing.T) {
 	store := &mockStore{}
 	tk := newTestToolkit(store, nil)
-	tk.SetRecallChecker(&fakeRecallChecker{id: "old-mem", score: 0.95})
+	tk.SetRecallChecker(&fakeRecallChecker{matches: []RecallMatch{{ID: "old-mem", Score: 0.95}}})
 
 	res, err := tk.AutoCapture(context.Background(), AutoCaptureInput{
 		SinkClass: memstore.SinkSchemaEntity,
@@ -110,11 +110,11 @@ func TestAutoCapture_RecallFirstSupersedes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AutoCapture: %v", err)
 	}
-	if res.Superseded != "old-mem" {
-		t.Errorf("Superseded = %q, want old-mem (recall-first supersede)", res.Superseded)
+	if len(res.Superseded) != 1 || res.Superseded[0] != "old-mem" {
+		t.Errorf("Superseded = %v, want [old-mem] (recall-first supersede)", res.Superseded)
 	}
-	if store.supersededOld != "old-mem" || store.supersededNew != res.ID {
-		t.Errorf("supersede call = (%q,%q), want (old-mem,%q)", store.supersededOld, store.supersededNew, res.ID)
+	if len(store.supersedeCalls) != 1 || store.supersedeCalls[0] != [2]string{"old-mem", res.ID} {
+		t.Errorf("supersede calls = %v, want [(old-mem,%s)]", store.supersedeCalls, res.ID)
 	}
 }
 

--- a/pkg/toolkits/memory/capture.go
+++ b/pkg/toolkits/memory/capture.go
@@ -26,6 +26,13 @@ const memoryCaptureToolName = "memory_capture"
 // returned by VectorSearch, so 0.9 means "near-identical text". Tunable.
 const recallSupersedeThreshold = 0.9
 
+// recallSuggestThreshold is the minimum cosine similarity at which an existing
+// record is surfaced as a similar_existing candidate in the capture response
+// (#762): close enough that the agent should decide update-vs-create, but not
+// close enough to auto-supersede. Matches in [suggest, supersede) are returned;
+// matches at or above recallSupersedeThreshold are superseded automatically.
+const recallSuggestThreshold = 0.75
+
 // maxSuggestedActions caps the catalog-change proposals a single capture may
 // carry, mirroring knowledge.MaxSuggestedActions.
 const maxSuggestedActions = 5
@@ -35,7 +42,7 @@ const logKeyError = "error"
 
 // RecallQuery is the recall-first lookup: the precomputed embedding of the
 // candidate content, the entities it concerns, and the caller's email, plus the
-// cosine threshold above which a prior record counts as a restatement. Embedding
+// cosine threshold above which a prior record counts as similar. Embedding
 // is empty when no embedder is configured; in that case recall is skipped (no
 // reliable similarity, so the capture simply appends).
 type RecallQuery struct {
@@ -45,12 +52,26 @@ type RecallQuery struct {
 	MinScore    float64
 }
 
-// RecallChecker finds an existing record a new capture restates, so the write
-// path can supersede instead of appending (recall-first, #633). Implemented by
+// RecallMatch is one existing record similar to a new capture, with its raw
+// cosine score. The capture path splits matches by score: at or above
+// recallSupersedeThreshold the record is superseded; below it the match is
+// returned to the agent as a similar_existing candidate.
+type RecallMatch struct {
+	ID    string  `json:"id"`
+	Score float64 `json:"score"`
+}
+
+// RecallChecker finds the caller's active records a new capture restates, so
+// the write path can supersede instead of appending (recall-first, #633) and
+// surface near-matches for the agent to consolidate (#762). Implemented by
 // the platform over the memory store; declared here so this package does not
 // import pkg/knowledge.
 type RecallChecker interface {
-	ExistingMatch(ctx context.Context, q RecallQuery) (id string, score float64, err error)
+	// Matches returns the caller's active records with cosine similarity at or
+	// above q.MinScore, best first. When the candidate carries entity URNs,
+	// matches must share at least one (knowledge about table A never matches
+	// knowledge about table B).
+	Matches(ctx context.Context, q RecallQuery) ([]RecallMatch, error)
 }
 
 // ThreadLinker bridges a reviewed capture back to the feedback thread(s) it
@@ -108,13 +129,23 @@ type memoryCaptureInput struct {
 
 // memoryCaptureOutput is the memory_capture success response.
 type memoryCaptureOutput struct {
-	ID                string   `json:"id"`
-	SinkClass         string   `json:"sink_class"`
-	Status            string   `json:"status"`
-	Superseded        string   `json:"superseded,omitempty"`
-	Message           string   `json:"message"`
-	LinkedThreadCount int      `json:"linked_thread_count,omitempty"`
-	UnlinkedThreadIDs []string `json:"unlinked_thread_ids,omitempty"`
+	ID        string `json:"id"`
+	SinkClass string `json:"sink_class"`
+	Status    string `json:"status"`
+	// Superseded keeps the original wire shape (a single id, the best match)
+	// so existing consumers of the field keep parsing; SupersededIDs carries
+	// the complete list now that one capture can consolidate several
+	// restatements (#762).
+	Superseded    string   `json:"superseded,omitempty"`
+	SupersededIDs []string `json:"superseded_ids,omitempty"`
+	// SimilarExisting lists active records similar to this capture but below
+	// the auto-supersede threshold, so the agent can decide whether the new
+	// capture restates one of them and consolidate (memory_manage update /
+	// consolidate) instead of leaving a near-duplicate behind (#762).
+	SimilarExisting   []RecallMatch `json:"similar_existing,omitempty"`
+	Message           string        `json:"message"`
+	LinkedThreadCount int           `json:"linked_thread_count,omitempty"`
+	UnlinkedThreadIDs []string      `json:"unlinked_thread_ids,omitempty"`
 }
 
 // handleMemoryCapture is the unified write verb. It validates the input, finds
@@ -147,12 +178,13 @@ func (t *Toolkit) handleMemoryCapture(ctx context.Context, _ *mcp.CallToolReques
 		return errorResult("failed to capture: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
 	}
 
-	return captureSuccess(rec, out.Superseded, out.Linked, out.Unlinked)
+	return captureSuccess(rec, out)
 }
 
 // captureOutcome carries the side results of the shared write pipeline.
 type captureOutcome struct {
-	Superseded string
+	Superseded []string
+	Similar    []RecallMatch
 	Linked     int
 	Unlinked   []string
 }
@@ -177,7 +209,7 @@ func (t *Toolkit) applyCapture(ctx context.Context, rec *memstore.Record, sinkCl
 	t.embedCaptureRecord(ctx, rec, rec.Content)
 
 	// Recall-first reuses the embedding just computed (no second embed call).
-	matchID := t.findPriorMatch(ctx, *rec)
+	restated, similar := t.findPriorMatches(ctx, *rec)
 
 	if err := t.store.Insert(ctx, *rec); err != nil {
 		return captureOutcome{}, fmt.Errorf("insert capture: %w", err)
@@ -185,7 +217,8 @@ func (t *Toolkit) applyCapture(ctx context.Context, rec *memstore.Record, sinkCl
 
 	linked, unlinked := t.linkCaptureThreads(ctx, actor, rec.ID, sinkClass, threadIDs)
 	return captureOutcome{
-		Superseded: t.applySupersede(ctx, matchID, rec.ID),
+		Superseded: t.applySupersedes(ctx, restated, rec.ID),
+		Similar:    similar,
 		Linked:     linked,
 		Unlinked:   unlinked,
 	}, nil
@@ -289,38 +322,57 @@ func (t *Toolkit) embedCaptureRecord(ctx context.Context, rec *memstore.Record, 
 	rec.EmbeddingModel, rec.EmbeddingTextHash = t.embeddingBreadcrumbs(emb, content)
 }
 
-// findPriorMatch returns the id of an existing record this capture restates, or
-// "" when recall is unavailable (no checker, no embedding) or nothing clears the
-// threshold. Best-effort: a recall error never fails the capture.
-func (t *Toolkit) findPriorMatch(ctx context.Context, rec memstore.Record) string {
+// findPriorMatches returns the existing records this capture restates
+// (similarity at or above the supersede threshold, all of them — so a capture
+// arriving over an already-duplicated pair consolidates the whole set; the
+// blast radius is bounded by the recall candidate limit and by the threshold,
+// which at 0.9 raw cosine means near-identical text, and every superseded id
+// is reported in the response) and the records similar enough to surface as
+// candidates but not to auto-supersede.
+// Both are empty when recall is unavailable (no checker, no embedding) or
+// nothing clears the suggest threshold. Best-effort: a recall error never
+// fails the capture.
+func (t *Toolkit) findPriorMatches(ctx context.Context, rec memstore.Record) (restated, similar []RecallMatch) {
 	if t.recallChecker == nil || len(rec.Embedding) == 0 {
-		return ""
+		return nil, nil
 	}
-	matchID, _, err := t.recallChecker.ExistingMatch(ctx, RecallQuery{
+	matches, err := t.recallChecker.Matches(ctx, RecallQuery{
 		Embedding:   rec.Embedding,
 		EntityURNs:  rec.EntityURNs,
 		CallerEmail: rec.CreatedBy,
-		MinScore:    recallSupersedeThreshold,
+		MinScore:    recallSuggestThreshold,
 	})
 	if err != nil {
 		slog.Debug("memory_capture: recall-first check failed", logKeyError, err)
-		return ""
+		return nil, nil
 	}
-	return matchID
+	for _, m := range matches {
+		if m.Score >= recallSupersedeThreshold {
+			restated = append(restated, m)
+		} else {
+			similar = append(similar, m)
+		}
+	}
+	return restated, similar
 }
 
-// applySupersede marks the prior record superseded by the new capture. Best-
-// effort: a failure is logged and the capture still succeeds (the new row is
-// already stored), returning "" so the caller does not falsely claim a supersede.
-func (t *Toolkit) applySupersede(ctx context.Context, matchID, newID string) string {
-	if matchID == "" || matchID == newID {
-		return ""
+// applySupersedes marks every restated record superseded by the new capture.
+// Best-effort per record: a failure is logged and the capture still succeeds
+// (the new row is already stored); only records actually superseded are
+// returned so the caller never falsely claims a supersede.
+func (t *Toolkit) applySupersedes(ctx context.Context, restated []RecallMatch, newID string) []string {
+	var superseded []string
+	for _, m := range restated {
+		if m.ID == "" || m.ID == newID {
+			continue
+		}
+		if err := t.store.Supersede(ctx, m.ID, newID); err != nil {
+			slog.Warn("memory_capture: failed to supersede prior record", "old", m.ID, "new", newID, logKeyError, err)
+			continue
+		}
+		superseded = append(superseded, m.ID)
 	}
-	if err := t.store.Supersede(ctx, matchID, newID); err != nil {
-		slog.Warn("memory_capture: failed to supersede prior record", "old", matchID, "new", newID, logKeyError, err)
-		return ""
-	}
-	return matchID
+	return superseded
 }
 
 // linkCaptureThreads bridges a reviewed capture to feedback threads (#602).
@@ -343,24 +395,36 @@ func (t *Toolkit) linkCaptureThreads(ctx context.Context, actor captureActor, id
 }
 
 // captureSuccess marshals the success response.
-func captureSuccess(rec memstore.Record, superseded string, linked int, unlinked []string) (*mcp.CallToolResult, any, error) {
+func captureSuccess(rec memstore.Record, out captureOutcome) (*mcp.CallToolResult, any, error) {
 	msg := "Captured. "
 	if memstore.SinkClassIsLive(rec.SinkClass) {
 		msg += "Available to you immediately."
 	} else {
 		msg += "It will be reviewed before promotion to a shared catalog."
 	}
-	if superseded != "" {
-		msg += " A prior record was superseded."
+	if n := len(out.Superseded); n > 0 {
+		msg += fmt.Sprintf(" %d prior record(s) superseded.", n)
+	}
+	if len(out.Similar) > 0 {
+		msg += " Similar existing records found (similar_existing): if this restates one," +
+			" consolidate with memory_manage (update the existing record, or consolidate the duplicate)."
+	}
+	// Matches arrive best-first, so the first superseded id is the best match
+	// (the singular field's original meaning).
+	var best string
+	if len(out.Superseded) > 0 {
+		best = out.Superseded[0]
 	}
 	return jsonResult(memoryCaptureOutput{
 		ID:                rec.ID,
 		SinkClass:         rec.SinkClass,
 		Status:            rec.Status,
-		Superseded:        superseded,
+		Superseded:        best,
+		SupersededIDs:     out.Superseded,
+		SimilarExisting:   out.Similar,
 		Message:           msg,
-		LinkedThreadCount: linked,
-		UnlinkedThreadIDs: unlinked,
+		LinkedThreadCount: out.Linked,
+		UnlinkedThreadIDs: out.Unlinked,
 	}), nil, nil
 }
 

--- a/pkg/toolkits/memory/capture_test.go
+++ b/pkg/toolkits/memory/capture_test.go
@@ -15,18 +15,19 @@ import (
 // errBoom is a sentinel error for failure-path tests.
 var errBoom = errors.New("boom")
 
-// fakeRecallChecker returns a fixed match for recall-first tests and records the
-// embedding it was handed (recall reuses the capture's precomputed vector).
+// fakeRecallChecker returns fixed matches for recall-first tests and records the
+// query it was handed (recall reuses the capture's precomputed vector).
 type fakeRecallChecker struct {
-	id           string
-	score        float64
+	matches      []RecallMatch
 	err          error
 	gotEmbedding []float32
+	gotMinScore  float64
 }
 
-func (f *fakeRecallChecker) ExistingMatch(_ context.Context, q RecallQuery) (id string, score float64, err error) {
+func (f *fakeRecallChecker) Matches(_ context.Context, q RecallQuery) ([]RecallMatch, error) {
 	f.gotEmbedding = q.Embedding
-	return f.id, f.score, f.err
+	f.gotMinScore = q.MinScore
+	return f.matches, f.err
 }
 
 // captureToolkitEmbedded builds a toolkit whose embedder produces a non-empty
@@ -113,7 +114,7 @@ func TestMemoryCapture_ReviewedClassWritesPendingInsight(t *testing.T) {
 
 func TestMemoryCapture_RecallFirstSupersedes(t *testing.T) {
 	tk, store := captureToolkitEmbedded(t)
-	rc := &fakeRecallChecker{id: "old-mem", score: 0.95}
+	rc := &fakeRecallChecker{matches: []RecallMatch{{ID: "old-mem", Score: 0.95}}}
 	tk.SetRecallChecker(rc)
 
 	res, _, err := tk.handleMemoryCapture(ctxWithPC("a@example.com", "analyst"), nil, memoryCaptureInput{
@@ -123,22 +124,99 @@ func TestMemoryCapture_RecallFirstSupersedes(t *testing.T) {
 	require.False(t, res.IsError)
 	require.Len(t, store.insertedRecords, 1)
 	newID := store.insertedRecords[0].ID
-	assert.Equal(t, "old-mem", store.supersededOld)
-	assert.Equal(t, newID, store.supersededNew)
-	// Recall must reuse the precomputed embedding, not re-embed.
+	assert.Equal(t, [][2]string{{"old-mem", newID}}, store.supersedeCalls)
+	// Recall must reuse the precomputed embedding, not re-embed, and query at
+	// the suggest threshold so near-matches below the supersede bar surface.
 	assert.NotEmpty(t, rc.gotEmbedding, "recall must receive the capture's embedding")
+	assert.Equal(t, recallSuggestThreshold, rc.gotMinScore)
+}
+
+// TestMemoryCapture_SupersedesAllRestatements verifies that a capture arriving
+// over an already-duplicated pair consolidates the whole set (#762): every
+// match at or above the supersede threshold is superseded and reported.
+func TestMemoryCapture_SupersedesAllRestatements(t *testing.T) {
+	tk, store := captureToolkitEmbedded(t)
+	tk.SetRecallChecker(&fakeRecallChecker{matches: []RecallMatch{
+		{ID: "dup-a", Score: 0.97},
+		{ID: "dup-b", Score: 0.93},
+	}})
+
+	res, _, err := tk.handleMemoryCapture(ctxWithPC("a@example.com", "analyst"), nil, memoryCaptureInput{
+		Type: memstore.SinkBusinessKnowledge, Content: "The feed refreshes nightly at 2am.",
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.Len(t, store.insertedRecords, 1)
+	newID := store.insertedRecords[0].ID
+	assert.Equal(t, [][2]string{{"dup-a", newID}, {"dup-b", newID}}, store.supersedeCalls)
+	out := extractJSON(t, res)
+	// `superseded` keeps its original single-id wire shape (the best match);
+	// `superseded_ids` carries the complete consolidated set.
+	assert.Equal(t, "dup-a", out["superseded"])
+	assert.Equal(t, []any{"dup-a", "dup-b"}, out["superseded_ids"])
+	assert.NotContains(t, out, "similar_existing")
+}
+
+// TestMemoryCapture_SimilarBelowSupersedeReturnsCandidates verifies the
+// suggest band (#762): a match below the supersede threshold is not
+// superseded, but is returned as a similar_existing candidate so the agent
+// can choose update-vs-create.
+func TestMemoryCapture_SimilarBelowSupersedeReturnsCandidates(t *testing.T) {
+	tk, store := captureToolkitEmbedded(t)
+	tk.SetRecallChecker(&fakeRecallChecker{matches: []RecallMatch{{ID: "near-mem", Score: 0.8}}})
+
+	res, _, err := tk.handleMemoryCapture(ctxWithPC("a@example.com", "analyst"), nil, memoryCaptureInput{
+		Type: memstore.SinkBusinessKnowledge, Content: "The feed refreshes nightly at 2am.",
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	assert.Empty(t, store.supersedeCalls, "a below-threshold match must not supersede")
+	out := extractJSON(t, res)
+	require.Contains(t, out, "similar_existing")
+	similar, ok := out["similar_existing"].([]any)
+	require.True(t, ok)
+	require.Len(t, similar, 1)
+	candidate, ok := similar[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "near-mem", candidate["id"])
+	assert.Equal(t, 0.8, candidate["score"])
+	assert.Contains(t, out["message"], "consolidate")
+}
+
+// TestMemoryCapture_MixedMatchesSplitByThreshold verifies the split: matches
+// at or above the supersede threshold are superseded, the rest surface as
+// candidates.
+func TestMemoryCapture_MixedMatchesSplitByThreshold(t *testing.T) {
+	tk, store := captureToolkitEmbedded(t)
+	tk.SetRecallChecker(&fakeRecallChecker{matches: []RecallMatch{
+		{ID: "restated", Score: 0.95},
+		{ID: "nearby", Score: 0.82},
+	}})
+
+	res, _, err := tk.handleMemoryCapture(ctxWithPC("a@example.com", "analyst"), nil, memoryCaptureInput{
+		Type: memstore.SinkBusinessKnowledge, Content: "The feed refreshes nightly at 2am.",
+	})
+	require.NoError(t, err)
+	newID := store.insertedRecords[0].ID
+	assert.Equal(t, [][2]string{{"restated", newID}}, store.supersedeCalls)
+	out := extractJSON(t, res)
+	assert.Equal(t, "restated", out["superseded"])
+	assert.Equal(t, []any{"restated"}, out["superseded_ids"])
+	similar, ok := out["similar_existing"].([]any)
+	require.True(t, ok)
+	require.Len(t, similar, 1)
 }
 
 func TestMemoryCapture_RecallNoMatchDoesNotSupersede(t *testing.T) {
 	tk, store := captureToolkitEmbedded(t)
-	// ExistingMatch applies the threshold/URN gate itself; "" means no qualifying match.
-	tk.SetRecallChecker(&fakeRecallChecker{id: "", score: 0})
+	// Matches applies the threshold/URN gate itself; empty means no qualifying match.
+	tk.SetRecallChecker(&fakeRecallChecker{})
 
 	_, _, err := tk.handleMemoryCapture(ctxWithPC("a@example.com", "analyst"), nil, memoryCaptureInput{
 		Type: memstore.SinkBusinessKnowledge, Content: "Stores close at 9pm.",
 	})
 	require.NoError(t, err)
-	assert.Empty(t, store.supersededOld, "no qualifying match must not supersede")
+	assert.Empty(t, store.supersedeCalls, "no qualifying match must not supersede")
 }
 
 func TestMemoryCapture_NoEmbeddingSkipsRecall(t *testing.T) {
@@ -147,14 +225,14 @@ func TestMemoryCapture_NoEmbeddingSkipsRecall(t *testing.T) {
 	store := &mockStore{}
 	tk, err := New("test", store, nil)
 	require.NoError(t, err)
-	rc := &fakeRecallChecker{id: "old-mem", score: 0.99}
+	rc := &fakeRecallChecker{matches: []RecallMatch{{ID: "old-mem", Score: 0.99}}}
 	tk.SetRecallChecker(rc)
 
 	_, _, err = tk.handleMemoryCapture(ctxWithPC("a@example.com", "analyst"), nil, memoryCaptureInput{
 		Type: memstore.SinkBusinessKnowledge, Content: "Stores close at 9pm.",
 	})
 	require.NoError(t, err)
-	assert.Empty(t, store.supersededOld, "recall must be skipped when there is no embedding")
+	assert.Empty(t, store.supersedeCalls, "recall must be skipped when there is no embedding")
 	assert.Nil(t, rc.gotEmbedding, "recall checker must not be consulted without an embedding")
 }
 
@@ -256,13 +334,13 @@ func TestMemoryCapture_RecallErrorToleratedNoSupersede(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.False(t, res.IsError, "a recall-check error must not fail the capture")
-	assert.Empty(t, store.supersededOld)
+	assert.Empty(t, store.supersedeCalls)
 }
 
 func TestMemoryCapture_SupersedeErrorTolerated(t *testing.T) {
 	store := &mockStore{supersedeErr: errBoom}
 	tk := newTestToolkit(store, &mockEmbedder{embedResult: []float32{0.1, 0.2, 0.3}})
-	tk.SetRecallChecker(&fakeRecallChecker{id: "old-mem", score: 0.95})
+	tk.SetRecallChecker(&fakeRecallChecker{matches: []RecallMatch{{ID: "old-mem", Score: 0.95}}})
 
 	res, _, err := tk.handleMemoryCapture(ctxWithPC("a@example.com", "analyst"), nil, memoryCaptureInput{
 		Type: memstore.SinkBusinessKnowledge, Content: "Stores close at 9pm.",

--- a/pkg/toolkits/memory/manage.go
+++ b/pkg/toolkits/memory/manage.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/txn2/mcp-data-platform/pkg/embedding"
 	memstore "github.com/txn2/mcp-data-platform/pkg/memory"
@@ -22,10 +23,12 @@ const idLength = 16
 // switch, the help map, and any audit/log statements all reference
 // the same literal — and goconst doesn't flag the repeats.
 const (
-	cmdUpdate      = "update"
-	cmdForget      = "forget"
-	cmdList        = "list"
-	cmdReviewStale = "review_stale"
+	cmdUpdate           = "update"
+	cmdForget           = "forget"
+	cmdList             = "list"
+	cmdReviewStale      = "review_stale"
+	cmdReviewDuplicates = "review_duplicates"
+	cmdConsolidate      = "consolidate"
 	// fieldMessage is the JSON key used in successful command results.
 	fieldMessage = "message"
 )
@@ -43,10 +46,14 @@ func (t *Toolkit) handleManage(ctx context.Context, _ *mcp.CallToolRequest, inpu
 		return t.handleList(ctx, input)
 	case cmdReviewStale:
 		return t.handleReviewStale(ctx, input)
+	case cmdReviewDuplicates:
+		return t.handleReviewDuplicates(ctx, input)
+	case cmdConsolidate:
+		return t.handleConsolidate(ctx, input)
 	case "":
 		return helpResult(), nil, nil
 	default:
-		return errorResult(fmt.Sprintf("unknown command %q: use update, forget, list, or review_stale (create with memory_capture)", input.Command)), nil, nil
+		return errorResult(fmt.Sprintf("unknown command %q: use update, forget, list, review_stale, review_duplicates, or consolidate (create with memory_capture)", input.Command)), nil, nil
 	}
 }
 
@@ -211,14 +218,116 @@ func (t *Toolkit) handleReviewStale(ctx context.Context, input manageInput) (*mc
 	}), nil, nil
 }
 
+// handleReviewDuplicates lists the caller's high-similarity active record
+// pairs for consolidation review, the backstop for near-duplicates the
+// capture-time recall gate missed (#762). Memory content is per-user, so the
+// listing is scoped to the caller's own records — the same boundary
+// consolidate/update/forget enforce, keeping every listed pair actionable.
+// The similarity floor is the capture-time suggest threshold: the backstop
+// exists precisely for pairs below the auto-supersede bar.
+func (t *Toolkit) handleReviewDuplicates(ctx context.Context, input manageInput) (*mcp.CallToolResult, any, error) {
+	finder, ok := t.store.(memstore.DuplicateFinder)
+	if !ok {
+		return errorResult("review_duplicates requires the database-backed memory store with vector search"), nil, nil
+	}
+	pc := middleware.GetPlatformContext(ctx)
+	if pc == nil || pc.UserEmail == "" {
+		return errorResult("a user identity (email) is required to review duplicates"), nil, nil
+	}
+
+	pairs, err := finder.SimilarActivePairs(ctx, pc.UserEmail, recallSuggestThreshold, input.Limit)
+	if err != nil {
+		return errorResult("failed to list duplicate candidates: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	return jsonResult(map[string]any{
+		"pairs": pairs,
+		"total": len(pairs),
+		fieldMessage: fmt.Sprintf("%d high-similarity active pair(s) found. To consolidate a pair, use"+
+			" command=consolidate with id (the record to keep) and duplicate_id (the record it supersedes).", len(pairs)),
+	}), nil, nil
+}
+
+// handleConsolidate supersedes a duplicate record by the record being kept,
+// completing the review_duplicates loop. Both records must belong to the
+// caller (same ownership rule as update/forget) and the kept record must be
+// active — otherwise the "duplicate" could be the only live copy of the fact
+// and consolidating would silently retire it behind a dead record. The
+// supersede preserves the correction chain via metadata.superseded_by rather
+// than discarding the duplicate outright.
+func (t *Toolkit) handleConsolidate(ctx context.Context, input manageInput) (*mcp.CallToolResult, any, error) {
+	if input.ID == "" || input.DuplicateID == "" {
+		return errorResult("consolidate requires id (the record to keep) and duplicate_id (the record it supersedes)"), nil, nil
+	}
+	if input.ID == input.DuplicateID {
+		return errorResult("id and duplicate_id must differ"), nil, nil
+	}
+
+	keep, result := t.fetchConsolidatePair(ctx, input.ID, input.DuplicateID)
+	if result != nil {
+		return result, nil, nil
+	}
+	if keep.Status != memstore.StatusActive {
+		return errorResult("the record to keep must be active (status: " + keep.Status + ")"), nil, nil
+	}
+
+	if err := t.store.Supersede(ctx, input.DuplicateID, input.ID); err != nil {
+		return errorResult("failed to consolidate: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+	}
+
+	return jsonResult(map[string]any{
+		"id":         input.ID,
+		"superseded": input.DuplicateID,
+		fieldMessage: "Duplicate consolidated: the kept record now supersedes it.",
+	}), nil, nil
+}
+
+// fetchConsolidatePair loads the two consolidate operands concurrently
+// (independent PK lookups) and enforces caller ownership on both. It returns
+// the kept record, or a non-nil error result when either record is missing or
+// foreign.
+func (t *Toolkit) fetchConsolidatePair(ctx context.Context, keepID, duplicateID string) (*memstore.Record, *mcp.CallToolResult) {
+	var keep, dup *memstore.Record
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		r, err := t.store.Get(gctx, keepID)
+		if err != nil {
+			return fmt.Errorf("loading record to keep: %w", err)
+		}
+		keep = r
+		return nil
+	})
+	g.Go(func() error {
+		r, err := t.store.Get(gctx, duplicateID)
+		if err != nil {
+			return fmt.Errorf("loading duplicate record: %w", err)
+		}
+		dup = r
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		return nil, errorResult("memory not found")
+	}
+
+	pc := middleware.GetPlatformContext(ctx)
+	for _, r := range []*memstore.Record{keep, dup} {
+		if pc != nil && pc.UserEmail != "" && r.CreatedBy != pc.UserEmail {
+			return nil, errorResult("you can only " + cmdConsolidate + " your own memories")
+		}
+	}
+	return keep, nil
+}
+
 // helpResult returns the list of available commands.
 func helpResult() *mcp.CallToolResult {
 	return jsonResult(map[string]any{
 		"commands": map[string]string{
-			cmdUpdate:      "Update an existing memory (requires id)",
-			cmdForget:      "Archive a memory (requires id)",
-			cmdList:        "List memories with optional filters",
-			cmdReviewStale: "List memories flagged as stale",
+			cmdUpdate:           "Update an existing memory (requires id)",
+			cmdForget:           "Archive a memory (requires id)",
+			cmdList:             "List memories with optional filters",
+			cmdReviewStale:      "List memories flagged as stale",
+			cmdReviewDuplicates: "List high-similarity active memory pairs for consolidation",
+			cmdConsolidate:      "Supersede a duplicate record by the one kept (requires id and duplicate_id)",
 		},
 	})
 }

--- a/pkg/toolkits/memory/manage_test.go
+++ b/pkg/toolkits/memory/manage_test.go
@@ -49,8 +49,7 @@ type mockStore struct {
 	deletedIDs      []string
 	updatedID       string
 	updatedFields   memstore.RecordUpdate
-	supersededOld   string
-	supersededNew   string
+	supersedeCalls  [][2]string
 }
 
 func (m *mockStore) Insert(_ context.Context, record memstore.Record) error {
@@ -137,7 +136,7 @@ func (m *mockStore) Supersede(_ context.Context, oldID, newID string) error {
 	if m.supersedeErr != nil {
 		return m.supersedeErr
 	}
-	m.supersededOld, m.supersededNew = oldID, newID
+	m.supersedeCalls = append(m.supersedeCalls, [2]string{oldID, newID})
 	return nil
 }
 
@@ -797,4 +796,190 @@ func TestHelpResult(t *testing.T) {
 	assert.Contains(t, commands, "forget")
 	assert.Contains(t, commands, "list")
 	assert.Contains(t, commands, "review_stale")
+	assert.Contains(t, commands, "review_duplicates")
+	assert.Contains(t, commands, "consolidate")
+}
+
+// ---------------------------------------------------------------------------
+// review_duplicates / consolidate tests (#762)
+// ---------------------------------------------------------------------------
+
+// duplicateFinderStore is a mockStore that also implements the optional
+// memstore.DuplicateFinder capability.
+type duplicateFinderStore struct {
+	mockStore
+	pairs        []memstore.SimilarPair
+	pairsErr     error
+	gotCreatedBy string
+	gotMinScore  float64
+	gotLimit     int
+}
+
+func (d *duplicateFinderStore) SimilarActivePairs(_ context.Context, createdBy string, minScore float64, limit int) ([]memstore.SimilarPair, error) {
+	d.gotCreatedBy, d.gotMinScore, d.gotLimit = createdBy, minScore, limit
+	return d.pairs, d.pairsErr
+}
+
+func TestHandleReviewDuplicates_ReturnsPairs(t *testing.T) {
+	t.Parallel()
+
+	store := &duplicateFinderStore{pairs: []memstore.SimilarPair{{
+		Older: memstore.Record{ID: "dup-old"},
+		Newer: memstore.Record{ID: "dup-new"},
+		Score: 0.96,
+	}}}
+	tk := newTestToolkit(store, nil)
+
+	result, _, err := tk.handleManage(ctxWithPC("user@example.com", "analyst"), nil,
+		manageInput{Command: "review_duplicates", Limit: 7})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	data := extractJSON(t, result)
+	assert.Equal(t, float64(1), data["total"])
+	assert.Contains(t, data["message"], "consolidate")
+	// Memory content is per-user: the listing must be scoped to the caller.
+	assert.Equal(t, "user@example.com", store.gotCreatedBy)
+	// The listing floor is the capture-time suggest threshold: the backstop
+	// exists for pairs below the auto-supersede bar.
+	assert.Equal(t, recallSuggestThreshold, store.gotMinScore)
+	assert.Equal(t, 7, store.gotLimit)
+	pairs, ok := data["pairs"].([]any)
+	require.True(t, ok)
+	require.Len(t, pairs, 1)
+}
+
+func TestHandleReviewDuplicates_RequiresIdentity(t *testing.T) {
+	t.Parallel()
+
+	store := &duplicateFinderStore{}
+	tk := newTestToolkit(store, nil)
+	result, _, err := tk.handleManage(ctxWithPC("", "analyst"), nil,
+		manageInput{Command: "review_duplicates"})
+	require.NoError(t, err)
+	require.True(t, result.IsError, "an anonymous caller must not list duplicate pairs")
+	assert.Empty(t, store.gotCreatedBy)
+}
+
+func TestHandleReviewDuplicates_StoreWithoutCapability(t *testing.T) {
+	t.Parallel()
+
+	tk := newTestToolkit(&mockStore{}, nil)
+	result, _, err := tk.handleManage(ctxWithPC("user@example.com", "analyst"), nil,
+		manageInput{Command: "review_duplicates"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	data := extractJSON(t, result)
+	assert.Contains(t, data["error"], "requires the database-backed memory store")
+}
+
+func TestHandleReviewDuplicates_FinderError(t *testing.T) {
+	t.Parallel()
+
+	store := &duplicateFinderStore{pairsErr: errBoom}
+	tk := newTestToolkit(store, nil)
+	result, _, err := tk.handleManage(ctxWithPC("user@example.com", "analyst"), nil,
+		manageInput{Command: "review_duplicates"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	data := extractJSON(t, result)
+	assert.Contains(t, data["error"], "failed to list duplicate candidates")
+}
+
+func TestHandleConsolidate_SupersedesDuplicate(t *testing.T) {
+	t.Parallel()
+
+	store := &mockStore{getResult: &memstore.Record{
+		ID: "keep", CreatedBy: "user@example.com", Status: memstore.StatusActive,
+	}}
+	tk := newTestToolkit(store, nil)
+
+	result, _, err := tk.handleManage(ctxWithPC("user@example.com", "analyst"), nil,
+		manageInput{Command: "consolidate", ID: "keep", DuplicateID: "dup"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	assert.Equal(t, [][2]string{{"dup", "keep"}}, store.supersedeCalls,
+		"the duplicate must be superseded by the kept record")
+	data := extractJSON(t, result)
+	assert.Equal(t, "keep", data["id"])
+	assert.Equal(t, "dup", data["superseded"])
+}
+
+// TestHandleConsolidate_KeptRecordMustBeActive guards against silent data
+// loss: if the record to keep is itself superseded or archived, consolidating
+// would retire the only live copy of the fact behind a dead record.
+func TestHandleConsolidate_KeptRecordMustBeActive(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []string{memstore.StatusSuperseded, memstore.StatusArchived, memstore.StatusStale} {
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			store := &mockStore{getResult: &memstore.Record{
+				ID: "keep", CreatedBy: "user@example.com", Status: status,
+			}}
+			tk := newTestToolkit(store, nil)
+			result, _, err := tk.handleManage(ctxWithPC("user@example.com", "analyst"), nil,
+				manageInput{Command: "consolidate", ID: "keep", DuplicateID: "dup"})
+			require.NoError(t, err)
+			require.True(t, result.IsError)
+			assert.Empty(t, store.supersedeCalls, "a non-active keeper must not absorb a supersede")
+			data := extractJSON(t, result)
+			assert.Contains(t, data["error"], "must be active")
+		})
+	}
+}
+
+func TestHandleConsolidate_Validation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input manageInput
+	}{
+		{"missing id", manageInput{Command: "consolidate", DuplicateID: "dup"}},
+		{"missing duplicate_id", manageInput{Command: "consolidate", ID: "keep"}},
+		{"identical ids", manageInput{Command: "consolidate", ID: "same", DuplicateID: "same"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			store := &mockStore{getResult: &memstore.Record{ID: "x", CreatedBy: "user@example.com"}}
+			tk := newTestToolkit(store, nil)
+			result, _, err := tk.handleManage(ctxWithPC("user@example.com", "analyst"), nil, tt.input)
+			require.NoError(t, err)
+			assert.True(t, result.IsError)
+			assert.Empty(t, store.supersedeCalls)
+		})
+	}
+}
+
+func TestHandleConsolidate_OwnershipEnforced(t *testing.T) {
+	t.Parallel()
+
+	store := &mockStore{getResult: &memstore.Record{ID: "keep", CreatedBy: "other@example.com"}}
+	tk := newTestToolkit(store, nil)
+
+	result, _, err := tk.handleManage(ctxWithPC("user@example.com", "analyst"), nil,
+		manageInput{Command: "consolidate", ID: "keep", DuplicateID: "dup"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	assert.Empty(t, store.supersedeCalls, "consolidating another user's records must be blocked")
+	data := extractJSON(t, result)
+	assert.Contains(t, data["error"], "your own memories")
+}
+
+func TestHandleConsolidate_SupersedeError(t *testing.T) {
+	t.Parallel()
+
+	store := &mockStore{
+		getResult:    &memstore.Record{ID: "keep", CreatedBy: "user@example.com", Status: memstore.StatusActive},
+		supersedeErr: errBoom,
+	}
+	tk := newTestToolkit(store, nil)
+
+	result, _, err := tk.handleManage(ctxWithPC("user@example.com", "analyst"), nil,
+		manageInput{Command: "consolidate", ID: "keep", DuplicateID: "dup"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	data := extractJSON(t, result)
+	assert.Contains(t, data["error"], "failed to consolidate")
 }

--- a/pkg/toolkits/memory/schemas.go
+++ b/pkg/toolkits/memory/schemas.go
@@ -10,7 +10,7 @@ var memoryManageSchema = json.RawMessage(`{
   "properties": {
     "command": {
       "type": "string",
-      "description": "Operation: update, forget, list, review_stale. Call without a command to see available commands. To CREATE memory or knowledge, use memory_capture."
+      "description": "Operation: update, forget, list, review_stale, review_duplicates, consolidate. Call without a command to see available commands. To CREATE memory or knowledge, use memory_capture."
     },
     "content": {
       "type": "string",
@@ -18,7 +18,11 @@ var memoryManageSchema = json.RawMessage(`{
     },
     "id": {
       "type": "string",
-      "description": "Memory record ID. Required for 'update' and 'forget'."
+      "description": "Memory record ID. Required for 'update' and 'forget'; for 'consolidate' it is the record to KEEP."
+    },
+    "duplicate_id": {
+      "type": "string",
+      "description": "For 'consolidate': the duplicate record the kept record supersedes."
     },
     "dimension": {
       "type": "string",

--- a/pkg/toolkits/memory/toolkit.go
+++ b/pkg/toolkits/memory/toolkit.go
@@ -58,7 +58,8 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 		Name:  manageToolName,
 		Title: "Memory Manage",
 		Description: "Manage the lifecycle of EXISTING persistent memory. " +
-			"Commands: update, forget (archive), list, review_stale. " +
+			"Commands: update, forget (archive), list, review_stale, review_duplicates (list " +
+			"high-similarity active pairs), consolidate (supersede a duplicate by the record kept). " +
 			"To CREATE memory or knowledge, use memory_capture (call it proactively to record corrections, " +
 			"preferences, business context, and data-quality observations). " +
 			"To find memory back, use search.",
@@ -74,7 +75,8 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 			"schema_entity (with entity_urns), and operational_rule are reviewed before promotion to a shared " +
 			"catalog. Examples: 'stores close at 9pm' -> business_knowledge; 'the amount column excludes returns' " +
 			"-> schema_entity. Capture is recall-first: a restatement of something already known supersedes it " +
-			"instead of duplicating.",
+			"instead of duplicating, and near-matches below the supersede bar are returned as similar_existing " +
+			"so you can consolidate instead of creating a duplicate.",
 		InputSchema: memoryCaptureSchema,
 	}, t.handleMemoryCapture)
 }

--- a/pkg/toolkits/memory/types.go
+++ b/pkg/toolkits/memory/types.go
@@ -5,6 +5,7 @@ type manageInput struct {
 	Command         string         `json:"command"`
 	Content         string         `json:"content,omitempty"`
 	ID              string         `json:"id,omitempty"`
+	DuplicateID     string         `json:"duplicate_id,omitempty"`
 	Dimension       string         `json:"dimension,omitempty"`
 	Category        string         `json:"category,omitempty"`
 	Confidence      string         `json:"confidence,omitempty"`


### PR DESCRIPTION
Fixes #762

## Problem

`memory_capture` documents recall-first behavior (a restatement of something already known supersedes it instead of duplicating), yet a live deployment showed one entity carrying two active data-freshness memories captured 19 seconds apart with ~90% identical content, both returned side by side in `memory_context` enrichment.

## Root cause

The recall-first similarity search (`memoryRecallChecker` in `pkg/platform/platform.go`) ran `VectorSearch` with no status scope; the store's default exclusion hides only `archived` rows, so **superseded records remained match candidates**. Sequence that produces the observed pair:

1. Capture A.
2. Capture B (near-identical): recall matches A, A is superseded. Correct so far.
3. Capture C (near-identical): the nearest neighbor by cosine is often the *superseded* A rather than the active B. Recall returns A, the write path re-supersedes the already-dead A, and the active duplicate B survives alongside C.

Two active near-duplicates remain, exactly as reported.

## Changes

### 1. Capture-time dedup (issue item 1)

- Recall now excludes `superseded` rows via a new `VectorQuery.ExcludeStatuses` predicate (`pkg/memory/search_types.go`, `pkg/memory/postgres.go`). Stale rows deliberately stay matchable: a restatement is exactly how a stale record gets corrected.
- A capture supersedes **every** match at or above the 0.9 cosine threshold, not just the best one, so a capture arriving over an already-duplicated set consolidates the whole set. Blast radius is bounded by the recall candidate limit (5) and the near-identical threshold; every superseded id is reported in the response.
- The entity-URN gate is unchanged: when the capture carries `entity_urns`, only records sharing an entity can match.
- Response shape: `superseded` keeps its original single-id wire form (the best match) for existing consumers; new `superseded_ids` carries the complete list.

### 2. Update-vs-create candidates (issue item 2)

Matches similar to the capture but below the auto-supersede bar (0.75 to 0.9 cosine) are returned as `similar_existing` (id + score), with the response message directing the agent to consolidate via `memory_manage` instead of leaving a near-duplicate behind.

### 3. Consolidation review backstop (issue item 3)

Two new `memory_manage` commands for duplicates the capture-time gate cannot reach (records captured before dedup existed, or pairs scoring below 0.9):

- `review_duplicates`: lists the caller's own active high-similarity pairs (>= 0.75 cosine, highest first), via a pgvector lateral self-join. Implemented as an optional `DuplicateFinder` store capability (same pattern as `knowledge.InsightSearcher`); deployments without the database-backed store get a structured error. The store method requires an owner scope, so the listing is per-user by construction, matching the ownership boundary `update`/`forget`/`consolidate` enforce and keeping every listed pair actionable.
- `consolidate`: supersedes `duplicate_id` by `id` (the record kept), preserving the correction chain via `metadata.superseded_by`. Both records must belong to the caller and are fetched concurrently; the kept record must be `active`, so the only live copy of a fact can never be retired behind a dead record.

### Supporting changes

- The five near-identical 18-column record scanners in `pkg/memory/postgres.go` now delegate to a single `recordScanBuf`, so a future column addition is threaded through one place.
- `AutoCapture` (`pkg/toolkits/memory/autocapture.go`) shares the pipeline, so server-initiated captures get identical semantics; its `CaptureResult.Superseded` is now the full list.
- Docs updated: `docs/memory/overview.md`, `docs/server/tools.md`, `docs/llms.txt`, `docs/llms-full.txt`.

## Testing

- **Real-Postgres acceptance test for the reported failure** (`pkg/platform/memory_dedup_realdb_integration_test.go`, pgvector testcontainer): three rapid restatements converge to a single active record, with the third capture superseding the *active* duplicate rather than the dead one; a stale record is superseded by a correcting capture.
- **Real-Postgres pair-scan test** (`pkg/memory/store_realdb_integration_test.go`): the lateral self-join finds exactly the same-owner active pair (mirror rows deduplicated, ordered older-first), skips superseded twins, and never returns another owner's records. This test caught an ambiguous-column reference in the SQL that sqlmock accepted.
- Unit tests across `pkg/memory`, `pkg/toolkits/memory`, `pkg/platform`: multi-supersede, suggest band, threshold split, recall status scoping, consolidate validation/ownership/active-keeper guards, pair dedup/ordering, malformed-row scan errors.
- `make verify` green end to end (patch coverage 95.0% against the 80% gate).