### PR TITLE
fix(config): default progress, client_logging, icons, elicitation to on

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,6 +345,31 @@ database:
   dsn: "${DATABASE_URL}"
 ```
 
+### Progress, Client Logging, Icons & Elicitation
+
+All four are enabled by default (`*bool` field, nil = enabled); set `enabled: false` to opt out. No block is needed to turn them on.
+
+```yaml
+progress:
+  enabled: false        # opt out of Trino query progress notifications
+
+client_logging:
+  enabled: false        # opt out of server-to-client log messages
+
+icons:
+  enabled: false        # opt out of icon injection middleware
+
+elicitation:
+  enabled: false        # opt out of all elicitation (also disables the two below)
+  cost_estimation:
+    enabled: false      # opt out of pre-query cost-estimation prompts
+    row_threshold: 1000000
+  pii_consent:
+    enabled: false      # opt out of PII-access consent prompts
+```
+
+Elicitation is user-facing: with no config at all, cost-estimation and PII-consent prompts fire out of the box (`cost_estimation` still respects `row_threshold`, so it only prompts above 1M estimated rows).
+
 ## Core Interfaces
 
 ### SemanticMetadataProvider

--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -418,33 +418,37 @@ tuning:
 # Progress notifications
 # Sends granular progress updates to MCP clients during long-running
 # Trino queries (requires client to send _meta.progressToken).
+# Enabled by default; set enabled: false to opt out.
 # progress:
-#   enabled: true
+#   enabled: false
 
 # Client logging
 # Sends server-to-client log messages (enrichment decisions, timing)
 # via MCP logging/setLevel protocol. Zero overhead if client hasn't
-# called setLevel.
+# called setLevel. Enabled by default; set enabled: false to opt out.
 # client_logging:
-#   enabled: true
+#   enabled: false
 
 # Elicitation (user confirmation prompts)
 # Requests user confirmation before expensive queries or PII access.
 # Requires client-side elicitation support (e.g., Claude Desktop).
 # Gracefully degrades to no-op if the client doesn't support elicitation.
+# Enabled by default (including cost_estimation and pii_consent); set
+# enabled: false at any level to opt out.
 # elicitation:
-#   enabled: true
+#   enabled: false
 #   cost_estimation:
-#     enabled: true
+#     enabled: false
 #     row_threshold: 1000000    # prompt when EXPLAIN IO estimates > 1M rows
 #   pii_consent:
-#     enabled: true             # prompt when query accesses PII-tagged columns
+#     enabled: false            # prompt when query accesses PII-tagged columns
 
 # Icons (tool/resource/prompt visual metadata)
 # Override or add icons to MCP list responses.
 # Upstream toolkits provide default icons; use this to customize.
+# Enabled by default; set enabled: false to opt out.
 # icons:
-#   enabled: true
+#   enabled: false
 #   tools:
 #     trino_query:
 #       src: "https://example.com/custom-trino.svg"

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -84,9 +84,8 @@ enrichment:
   column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
 
 elicitation:
-  enabled: true
   pii_consent:
-    enabled: true   # Require confirmation before a tool call touches a PII-tagged table
+    enabled: true   # Enabled by default; explicit here for clarity, confirms before a tool call touches a PII-tagged table
 
 personas:
   analyst:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -30,13 +30,13 @@ The only requirement is DataHub (https://datahubproject.io/). Add Trino (https:/
 
 - **Managed Resources**: Human-uploaded reference material (samples, playbooks, templates, references) surfaced directly to AI assistants via MCP `resources/list` and `resources/read`. Three visibility scopes: global, persona, and user. PostgreSQL metadata with S3 blob storage. REST API for CRUD, Admin Portal page for management. Auto-enabled when a database is available.
 
-- **Progress Notifications**: Long-running Trino queries send granular progress updates (executing, formatting, complete) to clients that provide `_meta.progressToken`. Zero overhead when disabled.
+- **Progress Notifications**: Long-running Trino queries send granular progress updates (executing, formatting, complete) to clients that provide `_meta.progressToken`. Zero overhead when the client doesn't send a token. Enabled by default; set `progress.enabled: false` to opt out.
 
-- **Client Logging**: Server-to-client log messages for platform decisions (enrichment, timing) via MCP `logging/setLevel` protocol. Zero overhead if the client hasn't opted in.
+- **Client Logging**: Server-to-client log messages for platform decisions (enrichment, timing) via MCP `logging/setLevel` protocol. Zero overhead if the client hasn't opted in. Enabled by default; set `client_logging.enabled: false` to opt out.
 
-- **Elicitation**: User confirmation prompts before expensive queries (EXPLAIN IO cost estimation) or PII access (sensitive column detection). Requires client-side elicitation support; gracefully degrades when unavailable.
+- **Elicitation**: User confirmation prompts before expensive queries (EXPLAIN IO cost estimation) or PII access (sensitive column detection). Requires client-side elicitation support; gracefully degrades when unavailable. Enabled by default, including `cost_estimation` and `pii_consent`; set `enabled: false` at any level to opt out.
 
-- **Icons**: Visual metadata for tools, resources, and prompts. Upstream toolkits provide default icons; deployers can override via configuration.
+- **Icons**: Visual metadata for tools, resources, and prompts. Upstream toolkits provide default icons; deployers can override via configuration. Enabled by default; set `icons.enabled: false` to opt out.
 
 - **Dynamic Prompts**: Three-tier prompt system: auto-registered `platform-overview` built from description and enabled toolkits, operator-configured prompts with `{placeholder}` argument substitution, and conditional workflow prompts (explore-available-data, create-interactive-dashboard, create-a-report, trace-data-lineage) registered when required toolkits are present. Toolkits implement `PromptDescriber` to advertise their own prompts. Operator prompts override auto-registered ones by name. All prompts included in `platform_info` response and the platform-info app Prompts tab.
 
@@ -533,40 +533,42 @@ The Admin Portal includes a Resources page for uploading, browsing, editing, and
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `progress.enabled` | bool | `false` | Enable progress notifications for Trino queries |
+| `progress.enabled` | `*bool` | `true` (nil = enabled) | Enable progress notifications for Trino queries |
 
-When enabled, Trino query tools send three progress notifications per query: before execution, after query returns, and after formatting. Clients must include `_meta.progressToken` in their tool call to receive notifications.
+Enabled by default; set `enabled: false` to opt out. When enabled, Trino query tools send three progress notifications per query: before execution, after query returns, and after formatting. Clients must include `_meta.progressToken` in their tool call to receive notifications.
 
 ## Client Logging Configuration
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `client_logging.enabled` | bool | `false` | Enable server-to-client log messages |
+| `client_logging.enabled` | `*bool` | `true` (nil = enabled) | Enable server-to-client log messages |
 
-When enabled, the platform sends log notifications to clients after enrichment is applied (tool name, duration). Uses MCP `logging/setLevel` protocol — zero overhead if the client hasn't called `setLevel`.
+Enabled by default; set `enabled: false` to opt out. When enabled, the platform sends log notifications to clients after enrichment is applied (tool name, duration). Uses MCP `logging/setLevel` protocol, with zero overhead if the client hasn't called `setLevel`.
 
 ## Elicitation Configuration
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `elicitation.enabled` | bool | `false` | Enable user confirmation prompts |
-| `elicitation.cost_estimation.enabled` | bool | `false` | Prompt when EXPLAIN IO estimates exceed the row threshold |
+| `elicitation.enabled` | `*bool` | `true` (nil = enabled) | Enable user confirmation prompts |
+| `elicitation.cost_estimation.enabled` | `*bool` | `true` (nil = enabled) | Prompt when EXPLAIN IO estimates exceed the row threshold |
 | `elicitation.cost_estimation.row_threshold` | int | `1000000` | Row estimate threshold for cost prompts |
-| `elicitation.pii_consent.enabled` | bool | `false` | Prompt when query accesses PII-tagged columns |
+| `elicitation.pii_consent.enabled` | `*bool` | `true` (nil = enabled) | Prompt when query accesses PII-tagged columns |
 
-Elicitation requires client-side support (MCP `elicitation/create` capability). When the client doesn't support it, elicitation gracefully degrades to a no-op. If a user declines the confirmation, the tool returns an informational message instead of executing the query.
+Enabled by default (including `cost_estimation` and `pii_consent`); set `enabled: false` at any level to opt out. Elicitation requires client-side support (MCP `elicitation/create` capability). When the client doesn't support it, elicitation gracefully degrades to a no-op. If a user declines the confirmation, the tool returns an informational message instead of executing the query.
+
+Behavior change: with no `elicitation` block at all, cost-estimation and PII-consent prompts now fire out of the box (`cost_estimation` still respects `row_threshold`, default 1,000,000 rows, so it only prompts on large queries). Deployments that relied on the previous silent-off default should add `elicitation.enabled: false` to keep the prior behavior.
 
 ## Icons Configuration
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `icons.enabled` | bool | `false` | Enable icon enrichment middleware |
+| `icons.enabled` | `*bool` | `true` (nil = enabled) | Enable icon enrichment middleware |
 | `icons.tools.<name>.src` | string | - | Icon URI for a tool |
 | `icons.tools.<name>.mime_type` | string | - | Icon MIME type |
 | `icons.resources.<uri>.src` | string | - | Icon URI for a resource template |
 | `icons.prompts.<name>.src` | string | - | Icon URI for a prompt |
 
-Upstream toolkits (Trino, DataHub, S3) provide default icons on all tools. This configuration overrides or adds icons for tools, resource templates, and prompts in list responses.
+Enabled by default; set `enabled: false` to opt out. Upstream toolkits (Trino, DataHub, S3) provide default icons on all tools. This configuration overrides or adds icons for tools, resource templates, and prompts in list responses.
 
 ## Audit Configuration
 

--- a/docs/reference/middleware.md
+++ b/docs/reference/middleware.md
@@ -230,7 +230,7 @@ func MCPIconMiddleware(cfg IconsMiddlewareConfig) mcp.Middleware
 3. Appends configured icons to matching entries
 4. Passes through all other methods unchanged
 
-Only registered when `icons.enabled: true` in configuration.
+Registered by default (`icons.enabled` defaults to `true`); set `icons.enabled: false` to disable.
 
 ### MCPClientLoggingMiddleware
 
@@ -243,7 +243,7 @@ Sends server-to-client log messages via the MCP `logging/setLevel` protocol. Rep
 3. Messages include enrichment details, query timing, and semantic cache hits
 4. No-op if the client hasn't subscribed via `logging/setLevel`
 
-Only registered when `client_logging.enabled: true` in configuration.
+Registered by default (`client_logging.enabled` defaults to `true`); set `client_logging.enabled: false` to disable.
 
 ### ToolMetadataMiddleware (MCP Apps)
 

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -1008,65 +1008,68 @@ resources:
 
 ## Progress Notifications Configuration
 
-Progress notifications send granular updates to MCP clients during long-running Trino queries. The client must include `_meta.progressToken` in the request to receive updates.
+Progress notifications send granular updates to MCP clients during long-running Trino queries. The client must include `_meta.progressToken` in the request to receive updates. Enabled by default; set `enabled: false` to opt out.
 
 ```yaml
 progress:
-  enabled: true
+  enabled: false   # only needed to opt out; defaults to true
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `enabled` | bool | `false` | Enable progress notifications |
+| `enabled` | `*bool` | `true` (nil = enabled) | Enable progress notifications |
 
 When enabled, Trino query execution sends progress updates including rows scanned, bytes processed, and query stage information. Clients that don't send a `progressToken` receive no notifications (zero overhead).
 
 ## Client Logging Configuration
 
-Client logging sends server-to-client log messages via the MCP `logging/setLevel` protocol. Messages include enrichment decisions, timing data, and platform diagnostics.
+Client logging sends server-to-client log messages via the MCP `logging/setLevel` protocol. Messages include enrichment decisions, timing data, and platform diagnostics. Enabled by default; set `enabled: false` to opt out.
 
 ```yaml
 client_logging:
-  enabled: true
+  enabled: false   # only needed to opt out; defaults to true
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `enabled` | bool | `false` | Enable client logging |
+| `enabled` | `*bool` | `true` (nil = enabled) | Enable client logging |
 
 Zero overhead if the client hasn't subscribed via `logging/setLevel`. When active, log messages report semantic cache hits/misses, enrichment timing, and cross-enrichment decisions.
 
 ## Elicitation Configuration
 
-Elicitation requests user confirmation before potentially expensive or sensitive operations. Requires client-side elicitation support (e.g., Claude Desktop). Gracefully degrades to a no-op if the client doesn't support elicitation.
+Elicitation requests user confirmation before potentially expensive or sensitive operations. Requires client-side elicitation support (e.g., Claude Desktop). Gracefully degrades to a no-op if the client doesn't support elicitation. Enabled by default (including `cost_estimation` and `pii_consent`); set `enabled: false` at any level to opt out.
 
 ```yaml
 elicitation:
-  enabled: true
+  enabled: false        # only needed to opt out; defaults to true
   cost_estimation:
-    enabled: true
+    enabled: false      # only needed to opt out; defaults to true
     row_threshold: 1000000
   pii_consent:
-    enabled: true
+    enabled: false      # only needed to opt out; defaults to true
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `enabled` | bool | `false` | Enable elicitation |
-| `cost_estimation.enabled` | bool | `false` | Prompt before expensive queries |
+| `enabled` | `*bool` | `true` (nil = enabled) | Enable elicitation |
+| `cost_estimation.enabled` | `*bool` | `true` (nil = enabled) | Prompt before expensive queries |
 | `cost_estimation.row_threshold` | int | `1000000` | Row count threshold from `EXPLAIN` IO estimates |
-| `pii_consent.enabled` | bool | `false` | Prompt when query accesses PII-tagged columns |
+| `pii_consent.enabled` | `*bool` | `true` (nil = enabled) | Prompt when query accesses PII-tagged columns |
 
 !!! note "Client support required"
     Elicitation uses the MCP `elicitation/create` capability. Clients that don't support elicitation will not receive prompts — queries proceed without confirmation.
 
+!!! warning "Behavior change for existing deployments"
+    Elicitation is user-facing: with no `elicitation` block at all, cost-estimation and PII-consent prompts now fire out of the box. `cost_estimation` still respects `row_threshold` (default 1,000,000 rows), so it only prompts on large queries. Deployments that relied on the previous silent-off default should add `elicitation.enabled: false` (or disable the sub-features individually) to keep the prior behavior.
+
 ## Icons Configuration
 
-Icons add visual metadata to tools, resources, and prompts in MCP list responses. Upstream toolkits (Trino, DataHub, S3) provide default icons; this configuration overrides or extends them.
+Icons add visual metadata to tools, resources, and prompts in MCP list responses. Upstream toolkits (Trino, DataHub, S3) provide default icons; this configuration overrides or extends them. Enabled by default; set `enabled: false` to opt out.
 
 ```yaml
 icons:
-  enabled: true
+  enabled: false   # only needed to opt out; defaults to true
   tools:
     trino_query:
       src: "https://example.com/custom-trino.svg"
@@ -1081,7 +1084,7 @@ icons:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `enabled` | bool | `false` | Enable icon injection middleware |
+| `enabled` | `*bool` | `true` (nil = enabled) | Enable icon injection middleware |
 | `tools` | map | - | Icon overrides keyed by tool name |
 | `resources` | map | - | Icon overrides keyed by resource URI |
 | `prompts` | map | - | Icon overrides keyed by prompt name |
@@ -1211,17 +1214,9 @@ enrichment:
 resources:
   enabled: true
 
-progress:
-  enabled: true
-
-client_logging:
-  enabled: true
-
-elicitation:
-  enabled: true
-  cost_estimation:
-    enabled: true
-    row_threshold: 1000000
+# progress, client_logging, and elicitation (with cost_estimation and
+# pii_consent) are all enabled by default, so no block is needed here unless
+# you want to opt out or customize (e.g. a lower cost_estimation.row_threshold).
 
 personas:
   analyst:

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -899,19 +899,34 @@ type CustomResourceDef struct {
 }
 
 // ProgressConfig configures progress notifications during tool execution.
+// Enabled by default (nil = enabled); set enabled: false to disable.
 type ProgressConfig struct {
-	Enabled bool `yaml:"enabled"`
+	Enabled *bool `yaml:"enabled"`
+}
+
+// IsEnabled reports whether progress notifications are enabled, defaulting
+// to true when not explicitly set.
+func (c *ProgressConfig) IsEnabled() bool {
+	return !isExplicitlyDisabled(c.Enabled)
 }
 
 // ClientLoggingConfig configures server-to-client log message notifications.
+// Enabled by default (nil = enabled); set enabled: false to disable.
 type ClientLoggingConfig struct {
-	Enabled bool `yaml:"enabled"`
+	Enabled *bool `yaml:"enabled"`
+}
+
+// IsEnabled reports whether client logging is enabled, defaulting to true
+// when not explicitly set.
+func (c *ClientLoggingConfig) IsEnabled() bool {
+	return !isExplicitlyDisabled(c.Enabled)
 }
 
 // IconsConfig configures visual metadata for tools, resources, and prompts.
 type IconsConfig struct {
 	// Enabled is the master switch for icon injection.
-	Enabled bool `yaml:"enabled"`
+	// Enabled by default (nil = enabled); set enabled: false to disable.
+	Enabled *bool `yaml:"enabled"`
 
 	// Tools maps tool names to their icon definitions.
 	Tools map[string]IconDef `yaml:"tools"`
@@ -921,6 +936,12 @@ type IconsConfig struct {
 
 	// Prompts maps prompt names to their icon definitions.
 	Prompts map[string]IconDef `yaml:"prompts"`
+}
+
+// IsEnabled reports whether icon injection is enabled, defaulting to true
+// when not explicitly set.
+func (c *IconsConfig) IsEnabled() bool {
+	return !isExplicitlyDisabled(c.Enabled)
 }
 
 // IconDef defines an icon for config-driven injection.
@@ -935,7 +956,8 @@ type IconDef struct {
 // ElicitationConfig configures user confirmation for expensive operations.
 type ElicitationConfig struct {
 	// Enabled is the master switch for all elicitation features.
-	Enabled bool `yaml:"enabled"`
+	// Enabled by default (nil = enabled); set enabled: false to disable.
+	Enabled *bool `yaml:"enabled"`
 
 	// CostEstimation configures query cost estimation and confirmation.
 	CostEstimation CostEstimationConfig `yaml:"cost_estimation"`
@@ -944,20 +966,40 @@ type ElicitationConfig struct {
 	PIIConsent PIIConsentConfig `yaml:"pii_consent"`
 }
 
+// IsEnabled reports whether elicitation is enabled, defaulting to true when
+// not explicitly set.
+func (c *ElicitationConfig) IsEnabled() bool {
+	return !isExplicitlyDisabled(c.Enabled)
+}
+
 // CostEstimationConfig configures query cost estimation.
 type CostEstimationConfig struct {
 	// Enabled controls whether query cost estimation triggers elicitation.
-	Enabled bool `yaml:"enabled"`
+	// Enabled by default (nil = enabled); set enabled: false to disable.
+	Enabled *bool `yaml:"enabled"`
 
 	// RowThreshold is the estimated row count above which confirmation is requested.
 	// Default: 1000000 (1 million rows).
 	RowThreshold int64 `yaml:"row_threshold"`
 }
 
+// IsEnabled reports whether cost estimation is enabled, defaulting to true
+// when not explicitly set.
+func (c *CostEstimationConfig) IsEnabled() bool {
+	return !isExplicitlyDisabled(c.Enabled)
+}
+
 // PIIConsentConfig configures PII access consent.
 type PIIConsentConfig struct {
 	// Enabled controls whether PII table access triggers elicitation.
-	Enabled bool `yaml:"enabled"`
+	// Enabled by default (nil = enabled); set enabled: false to disable.
+	Enabled *bool `yaml:"enabled"`
+}
+
+// IsEnabled reports whether PII consent prompting is enabled, defaulting to
+// true when not explicitly set.
+func (c *PIIConsentConfig) IsEnabled() bool {
+	return !isExplicitlyDisabled(c.Enabled)
 }
 
 // WorkflowConfig configures session-aware workflow gating that encourages

--- a/pkg/platform/config_test.go
+++ b/pkg/platform/config_test.go
@@ -1847,3 +1847,304 @@ func TestToolDescriptionKey(t *testing.T) {
 		}
 	}
 }
+
+func TestProgressConfig_IsEnabled(t *testing.T) {
+	t.Run("nil defaults to true", func(t *testing.T) {
+		cfg := &ProgressConfig{}
+		if !cfg.IsEnabled() {
+			t.Error("expected nil Enabled to default to true")
+		}
+	})
+
+	t.Run("explicit true", func(t *testing.T) {
+		cfg := &ProgressConfig{Enabled: new(true)}
+		if !cfg.IsEnabled() {
+			t.Error("expected explicit true to return true")
+		}
+	})
+
+	t.Run("explicit false", func(t *testing.T) {
+		cfg := &ProgressConfig{Enabled: new(false)}
+		if cfg.IsEnabled() {
+			t.Error("expected explicit false to return false")
+		}
+	})
+
+	t.Run("YAML loading with progress.enabled false", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+progress:
+  enabled: false
+`)
+		if cfg.Progress.IsEnabled() {
+			t.Error("expected progress.enabled: false to disable progress notifications")
+		}
+	})
+
+	t.Run("YAML loading without progress block", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+`)
+		if !cfg.Progress.IsEnabled() {
+			t.Error("expected missing progress block to default to true")
+		}
+	})
+}
+
+func TestClientLoggingConfig_IsEnabled(t *testing.T) {
+	t.Run("nil defaults to true", func(t *testing.T) {
+		cfg := &ClientLoggingConfig{}
+		if !cfg.IsEnabled() {
+			t.Error("expected nil Enabled to default to true")
+		}
+	})
+
+	t.Run("explicit true", func(t *testing.T) {
+		cfg := &ClientLoggingConfig{Enabled: new(true)}
+		if !cfg.IsEnabled() {
+			t.Error("expected explicit true to return true")
+		}
+	})
+
+	t.Run("explicit false", func(t *testing.T) {
+		cfg := &ClientLoggingConfig{Enabled: new(false)}
+		if cfg.IsEnabled() {
+			t.Error("expected explicit false to return false")
+		}
+	})
+
+	t.Run("YAML loading with client_logging.enabled false", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+client_logging:
+  enabled: false
+`)
+		if cfg.ClientLogging.IsEnabled() {
+			t.Error("expected client_logging.enabled: false to disable client logging")
+		}
+	})
+
+	t.Run("YAML loading without client_logging block", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+`)
+		if !cfg.ClientLogging.IsEnabled() {
+			t.Error("expected missing client_logging block to default to true")
+		}
+	})
+}
+
+func TestIconsConfig_IsEnabled(t *testing.T) {
+	t.Run("nil defaults to true", func(t *testing.T) {
+		cfg := &IconsConfig{}
+		if !cfg.IsEnabled() {
+			t.Error("expected nil Enabled to default to true")
+		}
+	})
+
+	t.Run("explicit true", func(t *testing.T) {
+		cfg := &IconsConfig{Enabled: new(true)}
+		if !cfg.IsEnabled() {
+			t.Error("expected explicit true to return true")
+		}
+	})
+
+	t.Run("explicit false", func(t *testing.T) {
+		cfg := &IconsConfig{Enabled: new(false)}
+		if cfg.IsEnabled() {
+			t.Error("expected explicit false to return false")
+		}
+	})
+
+	t.Run("YAML loading with icons.enabled false", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+icons:
+  enabled: false
+`)
+		if cfg.Icons.IsEnabled() {
+			t.Error("expected icons.enabled: false to disable icon injection")
+		}
+	})
+
+	t.Run("YAML loading without icons block", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+`)
+		if !cfg.Icons.IsEnabled() {
+			t.Error("expected missing icons block to default to true")
+		}
+	})
+}
+
+func TestElicitationConfig_IsEnabled(t *testing.T) {
+	t.Run("nil defaults to true", func(t *testing.T) {
+		cfg := &ElicitationConfig{}
+		if !cfg.IsEnabled() {
+			t.Error("expected nil Enabled to default to true")
+		}
+	})
+
+	t.Run("explicit true", func(t *testing.T) {
+		cfg := &ElicitationConfig{Enabled: new(true)}
+		if !cfg.IsEnabled() {
+			t.Error("expected explicit true to return true")
+		}
+	})
+
+	t.Run("explicit false", func(t *testing.T) {
+		cfg := &ElicitationConfig{Enabled: new(false)}
+		if cfg.IsEnabled() {
+			t.Error("expected explicit false to return false")
+		}
+	})
+
+	t.Run("YAML loading with elicitation.enabled false", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+elicitation:
+  enabled: false
+`)
+		if cfg.Elicitation.IsEnabled() {
+			t.Error("expected elicitation.enabled: false to disable elicitation")
+		}
+	})
+
+	t.Run("YAML loading without elicitation block", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+`)
+		if !cfg.Elicitation.IsEnabled() {
+			t.Error("expected missing elicitation block to default to true")
+		}
+	})
+}
+
+func TestCostEstimationConfig_IsEnabled(t *testing.T) {
+	t.Run("nil defaults to true", func(t *testing.T) {
+		cfg := &CostEstimationConfig{}
+		if !cfg.IsEnabled() {
+			t.Error("expected nil Enabled to default to true")
+		}
+	})
+
+	t.Run("explicit true", func(t *testing.T) {
+		cfg := &CostEstimationConfig{Enabled: new(true)}
+		if !cfg.IsEnabled() {
+			t.Error("expected explicit true to return true")
+		}
+	})
+
+	t.Run("explicit false", func(t *testing.T) {
+		cfg := &CostEstimationConfig{Enabled: new(false)}
+		if cfg.IsEnabled() {
+			t.Error("expected explicit false to return false")
+		}
+	})
+
+	t.Run("YAML loading with cost_estimation.enabled false", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+elicitation:
+  cost_estimation:
+    enabled: false
+`)
+		if cfg.Elicitation.CostEstimation.IsEnabled() {
+			t.Error("expected cost_estimation.enabled: false to disable cost estimation")
+		}
+	})
+
+	t.Run("YAML loading without cost_estimation block", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+`)
+		if !cfg.Elicitation.CostEstimation.IsEnabled() {
+			t.Error("expected missing cost_estimation block to default to true")
+		}
+	})
+}
+
+func TestPIIConsentConfig_IsEnabled(t *testing.T) {
+	t.Run("nil defaults to true", func(t *testing.T) {
+		cfg := &PIIConsentConfig{}
+		if !cfg.IsEnabled() {
+			t.Error("expected nil Enabled to default to true")
+		}
+	})
+
+	t.Run("explicit true", func(t *testing.T) {
+		cfg := &PIIConsentConfig{Enabled: new(true)}
+		if !cfg.IsEnabled() {
+			t.Error("expected explicit true to return true")
+		}
+	})
+
+	t.Run("explicit false", func(t *testing.T) {
+		cfg := &PIIConsentConfig{Enabled: new(false)}
+		if cfg.IsEnabled() {
+			t.Error("expected explicit false to return false")
+		}
+	})
+
+	t.Run("YAML loading with pii_consent.enabled false", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+elicitation:
+  pii_consent:
+    enabled: false
+`)
+		if cfg.Elicitation.PIIConsent.IsEnabled() {
+			t.Error("expected pii_consent.enabled: false to disable PII consent prompts")
+		}
+	})
+
+	t.Run("YAML loading without pii_consent block", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+`)
+		if !cfg.Elicitation.PIIConsent.IsEnabled() {
+			t.Error("expected missing pii_consent block to default to true")
+		}
+	})
+}
+
+// TestDefaultOnFeatures_NoConfigBlocks is the acceptance test for issue #784:
+// with none of progress/client_logging/icons/elicitation present in config,
+// all six gated switches must resolve active.
+func TestDefaultOnFeatures_NoConfigBlocks(t *testing.T) {
+	cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+`)
+
+	if !cfg.Progress.IsEnabled() {
+		t.Error("progress should default to enabled")
+	}
+	if !cfg.ClientLogging.IsEnabled() {
+		t.Error("client_logging should default to enabled")
+	}
+	if !cfg.Icons.IsEnabled() {
+		t.Error("icons should default to enabled")
+	}
+	if !cfg.Elicitation.IsEnabled() {
+		t.Error("elicitation should default to enabled")
+	}
+	if !cfg.Elicitation.CostEstimation.IsEnabled() {
+		t.Error("elicitation.cost_estimation should default to enabled")
+	}
+	if !cfg.Elicitation.PIIConsent.IsEnabled() {
+		t.Error("elicitation.pii_consent should default to enabled")
+	}
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -2589,7 +2589,7 @@ func (p *Platform) finalizeSetup() {
 	p.addManagedResourceMiddleware()
 
 	// 2. Client logging - sends enrichment info to client via session.Log()
-	if p.config.ClientLogging.Enabled {
+	if p.config.ClientLogging.IsEnabled() {
 		p.mcpServer.AddReceivingMiddleware(
 			middleware.MCPClientLoggingMiddleware(middleware.ClientLoggingConfig{
 				Enabled: true,
@@ -2875,7 +2875,7 @@ func (p *Platform) addDescriptionOverrideMiddleware() {
 
 // addIconMiddleware registers icon injection middleware when icons are configured.
 func (p *Platform) addIconMiddleware() {
-	if !p.config.Icons.Enabled {
+	if !p.config.Icons.IsEnabled() {
 		return
 	}
 	cfg := middleware.IconsMiddlewareConfig{
@@ -3906,14 +3906,19 @@ func resolveDefaultInstance(kindCfg, instances map[string]any) string {
 // toolkit instance config maps before the registry loader processes them.
 // This allows platform-wide settings (e.g., progress.enabled, elicitation)
 // to reach toolkit factories via the normal config parsing path.
+//
+// Both progress.enabled and elicitation.enabled default to true, so this
+// runs on nearly every config. It must not clobber an instance that already
+// sets progress_enabled or elicitation explicitly under
+// toolkits.trino.instances.<name> — those per-instance overrides win.
 func (p *Platform) injectToolkitPlatformConfig() {
 	instances := p.trinoInstanceConfigs()
 	if instances == nil {
 		return
 	}
 
-	needsProgress := p.config.Progress.Enabled
-	needsElicitation := p.config.Elicitation.Enabled
+	needsProgress := p.config.Progress.IsEnabled()
+	needsElicitation := p.config.Elicitation.IsEnabled()
 
 	if !needsProgress && !needsElicitation {
 		return
@@ -3925,18 +3930,22 @@ func (p *Platform) injectToolkitPlatformConfig() {
 			continue
 		}
 		if needsProgress {
-			instanceCfg["progress_enabled"] = true
+			if _, exists := instanceCfg["progress_enabled"]; !exists {
+				instanceCfg["progress_enabled"] = true
+			}
 		}
 		if needsElicitation {
-			instanceCfg["elicitation"] = map[string]any{
-				cfgKeyEnabled: true,
-				"cost_estimation": map[string]any{
-					cfgKeyEnabled:   p.config.Elicitation.CostEstimation.Enabled,
-					"row_threshold": p.config.Elicitation.CostEstimation.RowThreshold,
-				},
-				"pii_consent": map[string]any{
-					cfgKeyEnabled: p.config.Elicitation.PIIConsent.Enabled,
-				},
+			if _, exists := instanceCfg["elicitation"]; !exists {
+				instanceCfg["elicitation"] = map[string]any{
+					cfgKeyEnabled: true,
+					"cost_estimation": map[string]any{
+						cfgKeyEnabled:   p.config.Elicitation.CostEstimation.IsEnabled(),
+						"row_threshold": p.config.Elicitation.CostEstimation.RowThreshold,
+					},
+					"pii_consent": map[string]any{
+						cfgKeyEnabled: p.config.Elicitation.PIIConsent.IsEnabled(),
+					},
+				}
 			}
 		}
 		instances[name] = instanceCfg

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -3227,7 +3227,7 @@ func TestPlatformTools(t *testing.T) {
 func TestInjectToolkitPlatformConfig(t *testing.T) {
 	t.Run("nil toolkits", func(_ *testing.T) {
 		p := &Platform{config: &Config{
-			Progress: ProgressConfig{Enabled: true},
+			Progress: ProgressConfig{Enabled: new(true)},
 		}}
 		// Should not panic when Toolkits is nil.
 		p.injectToolkitPlatformConfig()
@@ -3242,7 +3242,7 @@ func TestInjectToolkitPlatformConfig(t *testing.T) {
 					},
 				},
 			},
-			Progress: ProgressConfig{Enabled: false},
+			Progress: ProgressConfig{Enabled: new(false)},
 		}}
 		p.injectToolkitPlatformConfig()
 
@@ -3260,7 +3260,7 @@ func TestInjectToolkitPlatformConfig(t *testing.T) {
 			Toolkits: map[string]any{
 				"datahub": map[string]any{},
 			},
-			Progress: ProgressConfig{Enabled: true},
+			Progress: ProgressConfig{Enabled: new(true)},
 		}}
 		// Should not panic when no trino toolkit exists.
 		p.injectToolkitPlatformConfig()
@@ -3271,7 +3271,7 @@ func TestInjectToolkitPlatformConfig(t *testing.T) {
 			Toolkits: map[string]any{
 				"trino": "invalid",
 			},
-			Progress: ProgressConfig{Enabled: true},
+			Progress: ProgressConfig{Enabled: new(true)},
 		}}
 		// Should not panic when trino config is not a map.
 		p.injectToolkitPlatformConfig()
@@ -3284,7 +3284,7 @@ func TestInjectToolkitPlatformConfig(t *testing.T) {
 					"instances": "invalid",
 				},
 			},
-			Progress: ProgressConfig{Enabled: true},
+			Progress: ProgressConfig{Enabled: new(true)},
 		}}
 		// Should not panic when instances is not a map.
 		p.injectToolkitPlatformConfig()
@@ -3300,7 +3300,7 @@ func TestInjectToolkitPlatformConfig(t *testing.T) {
 					},
 				},
 			},
-			Progress: ProgressConfig{Enabled: true},
+			Progress: ProgressConfig{Enabled: new(true)},
 		}}
 		p.injectToolkitPlatformConfig()
 
@@ -3320,6 +3320,41 @@ func TestInjectToolkitPlatformConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("respects explicit per-instance progress_enabled override", func(t *testing.T) {
+		p := &Platform{config: &Config{
+			Toolkits: map[string]any{
+				"trino": map[string]any{
+					"instances": map[string]any{
+						"legacy":  map[string]any{"host": "host1", "progress_enabled": false},
+						"default": map[string]any{"host": "host2"},
+					},
+				},
+			},
+			// Progress defaults to enabled (nil), matching a config with no
+			// top-level progress: block — the case that regressed in #784.
+		}}
+		p.injectToolkitPlatformConfig()
+
+		instances, ok := p.config.Toolkits["trino"].(map[string]any)["instances"].(map[string]any) //nolint:errcheck // test assertion chain
+		if !ok {
+			t.Fatal("unexpected config structure")
+		}
+		legacyCfg, ok := instances["legacy"].(map[string]any) //nolint:errcheck // test assertion chain
+		if !ok {
+			t.Fatal("legacy instance config not found")
+		}
+		if got, _ := legacyCfg["progress_enabled"].(bool); got {
+			t.Error("legacy instance's explicit progress_enabled: false was overwritten by the platform default")
+		}
+		defaultCfg, ok := instances["default"].(map[string]any) //nolint:errcheck // test assertion chain
+		if !ok {
+			t.Fatal("default instance config not found")
+		}
+		if got, gotOK := defaultCfg["progress_enabled"].(bool); !gotOK || !got {
+			t.Errorf("default instance: progress_enabled = %v, want true", got)
+		}
+	})
+
 	t.Run("instance not map skipped", func(t *testing.T) {
 		p := &Platform{config: &Config{
 			Toolkits: map[string]any{
@@ -3330,7 +3365,7 @@ func TestInjectToolkitPlatformConfig(t *testing.T) {
 					},
 				},
 			},
-			Progress: ProgressConfig{Enabled: true},
+			Progress: ProgressConfig{Enabled: new(true)},
 		}}
 		// Should not panic when an instance is not a map.
 		p.injectToolkitPlatformConfig()
@@ -3494,7 +3529,7 @@ func TestConvertIconDefs(t *testing.T) {
 func TestAddIconMiddleware(t *testing.T) {
 	t.Run("disabled does nothing", func(_ *testing.T) {
 		p := &Platform{
-			config: &Config{Icons: IconsConfig{Enabled: false}},
+			config: &Config{Icons: IconsConfig{Enabled: new(false)}},
 		}
 		// Should not panic even without mcpServer
 		p.addIconMiddleware()
@@ -3505,7 +3540,7 @@ func TestAddIconMiddleware(t *testing.T) {
 		p := &Platform{
 			config: &Config{
 				Icons: IconsConfig{
-					Enabled: true,
+					Enabled: new(true),
 					Tools: map[string]IconDef{
 						"trino_query": {Source: "https://example.com/trino.svg", MIMEType: "image/svg+xml"},
 					},
@@ -3529,12 +3564,12 @@ func TestInjectToolkitPlatformConfig_Elicitation(t *testing.T) {
 		p := &Platform{
 			config: &Config{
 				Elicitation: ElicitationConfig{
-					Enabled: true,
+					Enabled: new(true),
 					CostEstimation: CostEstimationConfig{
-						Enabled:      true,
+						Enabled:      new(true),
 						RowThreshold: 500000,
 					},
-					PIIConsent: PIIConsentConfig{Enabled: true},
+					PIIConsent: PIIConsentConfig{Enabled: new(true)},
 				},
 				Toolkits: map[string]any{
 					toolkitKindTrino: map[string]any{
@@ -3583,11 +3618,62 @@ func TestInjectToolkitPlatformConfig_Elicitation(t *testing.T) {
 		}
 	})
 
+	t.Run("respects explicit per-instance elicitation override", func(t *testing.T) {
+		p := &Platform{
+			config: &Config{
+				// Elicitation defaults to enabled (nil), matching a config with
+				// no top-level elicitation: block — the case that regressed in #784.
+				Toolkits: map[string]any{
+					toolkitKindTrino: map[string]any{
+						"instances": map[string]any{
+							"trusted": map[string]any{
+								"host": "localhost",
+								"elicitation": map[string]any{
+									cfgKeyEnabled: false,
+								},
+							},
+							"default": map[string]any{
+								"host": "other-host",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		p.injectToolkitPlatformConfig()
+
+		instances := p.trinoInstanceConfigs()
+		trustedCfg, ok := instances["trusted"].(map[string]any)
+		if !ok {
+			t.Fatal("trusted instance config not found")
+		}
+		trustedElicit, ok := trustedCfg["elicitation"].(map[string]any)
+		if !ok {
+			t.Fatal("trusted instance elicitation config missing")
+		}
+		if enabled, _ := trustedElicit[cfgKeyEnabled].(bool); enabled {
+			t.Error("trusted instance's explicit elicitation.enabled: false was overwritten by the platform default")
+		}
+
+		defaultCfg, ok := instances["default"].(map[string]any)
+		if !ok {
+			t.Fatal("default instance config not found")
+		}
+		defaultElicit, ok := defaultCfg["elicitation"].(map[string]any)
+		if !ok {
+			t.Fatal("elicitation config not injected for default instance")
+		}
+		if enabled, _ := defaultElicit[cfgKeyEnabled].(bool); !enabled {
+			t.Error("default instance should get the platform-derived elicitation config")
+		}
+	})
+
 	t.Run("both progress and elicitation", func(t *testing.T) {
 		p := &Platform{
 			config: &Config{
-				Progress:    ProgressConfig{Enabled: true},
-				Elicitation: ElicitationConfig{Enabled: true},
+				Progress:    ProgressConfig{Enabled: new(true)},
+				Elicitation: ElicitationConfig{Enabled: new(true)},
 				Toolkits: map[string]any{
 					toolkitKindTrino: map[string]any{
 						"instances": map[string]any{


### PR DESCRIPTION
## Summary

Closes #784.

Four platform features were gated on plain `bool` config fields whose zero value is `false`, so they were off unless every config explicitly opted in — contradicting the project's "important features default ON" design goal. This PR flips them to the established `*bool` + `IsEnabled()` accessor pattern (`nil` = enabled) already used by `MCPAppsConfig` and `ResourcesConfig`.

Switches flipped to default-on:
- `progress.enabled`
- `client_logging.enabled`
- `icons.enabled`
- `elicitation.enabled`
- `elicitation.cost_estimation.enabled`
- `elicitation.pii_consent.enabled`

- `pkg/platform/config.go`: `ProgressConfig`, `ClientLoggingConfig`, `IconsConfig`, `ElicitationConfig`, `CostEstimationConfig`, `PIIConsentConfig` — `Enabled bool` → `Enabled *bool`, plus an `IsEnabled()` method on each.
- `pkg/platform/platform.go`: all consumers (`finalizeSetup`'s client-logging/icon middleware registration, `injectToolkitPlatformConfig`'s progress/elicitation injection) updated to call `.IsEnabled()` instead of reading the raw field.
- `injectToolkitPlatformConfig` now runs on effectively every config (since progress/elicitation default to enabled), so it was changed to skip injecting `progress_enabled` or `elicitation` into a Trino instance that already sets that key explicitly — otherwise a per-instance opt-out would be silently clobbered by the new platform-level default. This surfaced during review of this change, not from a prior release.

## Behavior change

Elicitation is user-facing: with no `elicitation` block at all, cost-estimation and PII-consent confirmation prompts now fire out of the box. `cost_estimation` still respects `row_threshold` (default 1,000,000 rows), so it only prompts on large queries. Deployments that relied on the previous silent-off default should add `elicitation.enabled: false` (or disable the sub-features individually) to keep the prior behavior. Progress notifications, client logging, and icon injection are lower-risk (read-only / notification-only) but follow the same opt-out pattern.

## Docs

Updated `CLAUDE.md`, `configs/platform.yaml`, `docs/server/configuration.md`, `docs/llms-full.txt`, `docs/reference/middleware.md`, and `docs/examples/index.md` to describe the new defaults and opt-out semantics, and to note that the example/demo configs no longer need these four blocks.

## Test plan

- [x] `TestProgressConfig_IsEnabled`, `TestClientLoggingConfig_IsEnabled`, `TestIconsConfig_IsEnabled`, `TestElicitationConfig_IsEnabled`, `TestCostEstimationConfig_IsEnabled`, `TestPIIConsentConfig_IsEnabled` — tri-state (`nil`/`true`/`false`) coverage for each accessor, including YAML-load cases
- [x] `TestDefaultOnFeatures_NoConfigBlocks` — acceptance test: with none of the four blocks present, all six switches resolve active
- [x] `TestInjectToolkitPlatformConfig/respects_explicit_per-instance_progress_enabled_override` and `TestInjectToolkitPlatformConfig_Elicitation/respects_explicit_per-instance_elicitation_override` — regression tests for the per-instance clobber fix
- [x] `make verify` (full CI-equivalent suite: fmt, race tests, coverage ≥80%, patch coverage ≥80%, lint, gosec, govulncheck, semgrep, CodeQL, doc-check, dead-code, mutation testing, GoReleaser dry-run) — all green
- [x] Patch coverage on the two touched Go files: 100%