### PR TITLE
fix(middleware): make the search-first gate replica-shared (#789)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ AI-generated prose (PR descriptions, commit messages, reviews, explanations) is 
 
 ## Project Structure
 
-`pkg/` holds 39 top-level packages (all public API). Depth-2 subdirectories are
+`pkg/` holds 40 top-level packages (all public API). Depth-2 subdirectories are
 shown where they represent a distinct implementation (a storage backend, an
 adapter, an indexjobs consumer); helper subpackages are omitted for brevity.
 Regenerate this list with `find pkg -mindepth 1 -maxdepth 1 -type d | sort` and
@@ -159,7 +159,7 @@ diff against the packages below when adding or removing a `pkg/` directory.
 ```
 mcp-data-platform/
 ├── cmd/mcp-data-platform/          # Entry point (main.go)
-├── pkg/                            # PUBLIC API (39 top-level packages)
+├── pkg/                            # PUBLIC API (40 top-level packages)
 │   ├── admin/                      # REST API endpoints for administrative operations
 │   ├── audit/                      # Audit logging (postgres/ = PostgreSQL implementation)
 │   ├── auth/                       # Authentication: OIDC, API keys, claims, middleware
@@ -191,6 +191,7 @@ mcp-data-platform/
 │   ├── query/                      # Query execution provider abstraction (trino/ = Trino adapter)
 │   ├── registry/                   # Toolkit registration and management
 │   ├── resource/                   # Managed resources: human-uploaded reference files
+│   ├── searchgate/                 # Per-session discovery signal for the search-first gate (postgres/ = replica-shared backend)
 │   ├── semantic/                   # Semantic layer abstraction (datahub/ = DataHub adapter)
 │   ├── session/                    # Session externalization (postgres/ = multi-replica backend)
 │   ├── storage/                    # Storage provider abstraction (s3/ = S3 adapter)

--- a/docs/reference/middleware.md
+++ b/docs/reference/middleware.md
@@ -160,6 +160,13 @@ func MCPWorkflowGateMiddleware(tracker *SessionWorkflowTracker) mcp.Middleware
 
 Modeled on `MCPSessionGateMiddleware`: it is positioned inner to `MCPToolCallMiddleware` (so `PlatformContext` is populated and the current call is recorded on the tracker) and outer to audit/enrichment (so a blocked call never reaches those layers). Enabled by default; disabled only when `workflow.require_search: false` leaves the tracker unconfigured. The former `MCPRuleEnforcementMiddleware` (a warn-after-execution mechanism) and the static `tuning.rules.require_datahub_check` hint have been removed.
 
+**Replica-shared discovery state (#789):** the per-session "has performed discovery" signal lives in a `searchgate.Store`. When a database is configured the tracker uses the Postgres store (`pkg/searchgate/postgres`), so discovery recorded on one replica is visible to a query handled by another; without a database it uses an in-memory store, which is correct only for single-replica deployments. Semantics:
+
+- **Single source of truth:** the shared store is authoritative; the tracker holds no replica-local "discovered" bit that could diverge from it, so the gate is consistent across replicas.
+- **Sliding window:** ongoing query activity by a discovered session refreshes the shared record (store writes throttled to at most once per half of the session timeout), so a long active session is not re-gated mid-workflow.
+- **Write resilience:** a failed discovery write persists nothing (there is no divergent local state), but the throttle is cleared so the agent's next `search` retries; the worst case is one repeated `SEARCH_REQUIRED`, which self-heals, never a permanent or cross-replica-inconsistent block.
+- **Fail-open on read error (deliberate):** the gate is a workflow quality guard, not a security boundary, so a database outage allows queries (logged) rather than blocking every one.
+
 ### MCPDescriptionOverrideMiddleware
 
 Replaces tool descriptions in `tools/list` responses to inject workflow guidance (e.g., "call datahub_search first"). Built-in overrides for `trino_query` and `trino_execute` are always active; config overrides take precedence.

--- a/pkg/database/migrate/migrate_realpg_test.go
+++ b/pkg/database/migrate/migrate_realpg_test.go
@@ -14,7 +14,7 @@ import (
 
 // expectedFinalVersion is the highest migration the embedded set defines. Bump
 // this when adding a migration so the gate asserts the full set applied.
-const expectedFinalVersion = 76
+const expectedFinalVersion = 77
 
 // TestMigrationsAgainstRealPostgres applies the embedded migrations to a real
 // PostgreSQL (pgvector) instance and exercises the full lifecycle: up, seed,

--- a/pkg/database/migrate/migrate_unit_test.go
+++ b/pkg/database/migrate/migrate_unit_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	migrateTestFileCount    = 152
+	migrateTestFileCount    = 154
 	migrateTestSuccess      = "success"
 	migrateTestFactoryError = "factory error"
 )

--- a/pkg/database/migrate/migrations/000077_search_gate_discovery.down.sql
+++ b/pkg/database/migrate/migrations/000077_search_gate_discovery.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_search_gate_discovery_expires_at;
+DROP TABLE IF EXISTS search_gate_discovery;

--- a/pkg/database/migrate/migrations/000077_search_gate_discovery.up.sql
+++ b/pkg/database/migrate/migrations/000077_search_gate_discovery.up.sql
@@ -1,0 +1,15 @@
+-- search_gate_discovery records, per session, that a discovery tool (search or
+-- a datahub_* tool) has been called, so the search-first gate
+-- (middleware.MCPWorkflowGateMiddleware) can share that signal across replicas.
+-- Without a shared store the in-memory tracker is per-pod, and a query
+-- load-balanced to a replica that did not handle the search is wrongly refused
+-- with SEARCH_REQUIRED even though discovery happened (#789).
+CREATE TABLE IF NOT EXISTS search_gate_discovery (
+    session_id    TEXT        PRIMARY KEY,
+    discovered_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at    TIMESTAMPTZ NOT NULL
+);
+
+-- Supports the cleanup delete of expired rows.
+CREATE INDEX IF NOT EXISTS idx_search_gate_discovery_expires_at
+    ON search_gate_discovery (expires_at);

--- a/pkg/middleware/mcp.go
+++ b/pkg/middleware/mcp.go
@@ -313,7 +313,7 @@ func authenticateAndAuthorize(
 
 	// Record tool call for workflow tracking (after successful auth)
 	if params.workflowTracker != nil {
-		params.workflowTracker.RecordToolCall(params.pc.SessionID, params.toolName)
+		params.workflowTracker.RecordToolCall(ctx, params.pc.SessionID, params.toolName)
 	}
 
 	return next(ctx, method, req)

--- a/pkg/middleware/mcp_enrichment.go
+++ b/pkg/middleware/mcp_enrichment.go
@@ -138,7 +138,7 @@ func applyEnrichment(
 	// Attach the canonical knowledge pages that document the named entities (#634).
 	enrichedResult = enrichWithKnowledgePages(ctx, enricher.pageProvider, enrichedResult, entityURNs)
 
-	appendDiscoveryNoteIfNeeded(enrichedResult, pc, enricher.cfg.WorkflowTracker)
+	appendDiscoveryNoteIfNeeded(ctx, enrichedResult, pc, enricher.cfg.WorkflowTracker)
 
 	// Mirror every platform-added enrichment block into the structured result so
 	// MCP clients that render only structured output still receive the semantic
@@ -205,11 +205,11 @@ func structuredAsMap(sc any) map[string]any {
 
 // appendDiscoveryNoteIfNeeded appends a soft discovery note to enriched results
 // when the session has not yet performed DataHub discovery.
-func appendDiscoveryNoteIfNeeded(result *mcp.CallToolResult, pc *PlatformContext, tracker *SessionWorkflowTracker) {
+func appendDiscoveryNoteIfNeeded(ctx context.Context, result *mcp.CallToolResult, pc *PlatformContext, tracker *SessionWorkflowTracker) {
 	if tracker == nil || !pc.EnrichmentApplied {
 		return
 	}
-	if tracker.HasPerformedDiscovery(pc.SessionID) {
+	if tracker.HasPerformedDiscovery(ctx, pc.SessionID) {
 		return
 	}
 

--- a/pkg/middleware/mcp_enrichment_test.go
+++ b/pkg/middleware/mcp_enrichment_test.go
@@ -405,7 +405,7 @@ func TestMCPSemanticEnrichmentMiddleware_NoEnrichmentAppliedForUnknownTool(t *te
 
 func TestAppendDiscoveryNoteIfNeeded(t *testing.T) {
 	t.Run("no discovery appends note", func(t *testing.T) {
-		tracker := NewSessionWorkflowTracker(nil, nil, 30*time.Minute)
+		tracker := NewSessionWorkflowTracker(nil, nil, nil, 30*time.Minute)
 		pc := NewPlatformContext("req")
 		pc.SessionID = "s1"
 		pc.EnrichmentApplied = true
@@ -413,7 +413,7 @@ func TestAppendDiscoveryNoteIfNeeded(t *testing.T) {
 		result := &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "data"}},
 		}
-		appendDiscoveryNoteIfNeeded(result, pc, tracker)
+		appendDiscoveryNoteIfNeeded(context.Background(), result, pc, tracker)
 
 		require.Len(t, result.Content, 2)
 		tc, ok := result.Content[1].(*mcp.TextContent)
@@ -423,8 +423,8 @@ func TestAppendDiscoveryNoteIfNeeded(t *testing.T) {
 	})
 
 	t.Run("discovery done skips note", func(t *testing.T) {
-		tracker := NewSessionWorkflowTracker(nil, nil, 30*time.Minute)
-		tracker.RecordToolCall("s1", "search")
+		tracker := NewSessionWorkflowTracker(nil, nil, nil, 30*time.Minute)
+		tracker.RecordToolCall(context.Background(), "s1", "search")
 
 		pc := NewPlatformContext("req")
 		pc.SessionID = "s1"
@@ -433,13 +433,13 @@ func TestAppendDiscoveryNoteIfNeeded(t *testing.T) {
 		result := &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "data"}},
 		}
-		appendDiscoveryNoteIfNeeded(result, pc, tracker)
+		appendDiscoveryNoteIfNeeded(context.Background(), result, pc, tracker)
 
 		assert.Len(t, result.Content, 1, "no note after discovery")
 	})
 
 	t.Run("no enrichment applied skips note", func(t *testing.T) {
-		tracker := NewSessionWorkflowTracker(nil, nil, 30*time.Minute)
+		tracker := NewSessionWorkflowTracker(nil, nil, nil, 30*time.Minute)
 		pc := NewPlatformContext("req")
 		pc.SessionID = "s1"
 		pc.EnrichmentApplied = false
@@ -447,7 +447,7 @@ func TestAppendDiscoveryNoteIfNeeded(t *testing.T) {
 		result := &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "data"}},
 		}
-		appendDiscoveryNoteIfNeeded(result, pc, tracker)
+		appendDiscoveryNoteIfNeeded(context.Background(), result, pc, tracker)
 
 		assert.Len(t, result.Content, 1, "no note when enrichment not applied")
 	})
@@ -460,7 +460,7 @@ func TestAppendDiscoveryNoteIfNeeded(t *testing.T) {
 		result := &mcp.CallToolResult{
 			Content: []mcp.Content{&mcp.TextContent{Text: "data"}},
 		}
-		appendDiscoveryNoteIfNeeded(result, pc, nil)
+		appendDiscoveryNoteIfNeeded(context.Background(), result, pc, nil)
 
 		assert.Len(t, result.Content, 1, "no note with nil tracker")
 	})

--- a/pkg/middleware/mcp_workflow_gate.go
+++ b/pkg/middleware/mcp_workflow_gate.go
@@ -34,7 +34,7 @@ func MCPWorkflowGateMiddleware(tracker *SessionWorkflowTracker) mcp.Middleware {
 			if pc == nil {
 				return next(ctx, method, req)
 			}
-			if errResult := checkWorkflowGate(tracker, pc); errResult != nil {
+			if errResult := checkWorkflowGate(ctx, tracker, pc); errResult != nil {
 				return errResult, nil
 			}
 			return next(ctx, method, req)
@@ -45,13 +45,13 @@ func MCPWorkflowGateMiddleware(tracker *SessionWorkflowTracker) mcp.Middleware {
 // checkWorkflowGate evaluates whether a query tool call should proceed or be
 // gated. It returns nil when the call is allowed and an error result when the
 // session has not yet performed discovery.
-func checkWorkflowGate(tracker *SessionWorkflowTracker, pc *PlatformContext) mcp.Result {
+func checkWorkflowGate(ctx context.Context, tracker *SessionWorkflowTracker, pc *PlatformContext) mcp.Result {
 	// Only query tools are gated; everything else passes through.
 	if !tracker.IsQueryTool(pc.ToolName) {
 		return nil
 	}
 	// Once discovery has happened in the session, the gate stays open.
-	if tracker.HasPerformedDiscovery(pc.SessionID) {
+	if tracker.HasPerformedDiscovery(ctx, pc.SessionID) {
 		return nil
 	}
 

--- a/pkg/middleware/middleware_chain_test.go
+++ b/pkg/middleware/middleware_chain_test.go
@@ -1939,7 +1939,7 @@ func TestMiddlewareChain_ToolVisibility_NoPatterns(t *testing.T) {
 // and a SEARCH_REQUIRED error result is returned instructing the agent to call
 // search first. This exercises the real assembled middleware chain.
 func TestWorkflowGating_NoDiscovery(t *testing.T) {
-	tracker := middleware.NewSessionWorkflowTracker(nil, nil, 30*time.Minute)
+	tracker := middleware.NewSessionWorkflowTracker(nil, nil, nil, 30*time.Minute)
 	authenticator := &testAuthenticator{
 		userInfo: &middleware.UserInfo{UserID: chainTestUser, Roles: []string{chainTestAnalyst}},
 	}
@@ -1988,7 +1988,7 @@ func TestWorkflowGating_NoDiscovery(t *testing.T) {
 // TestWorkflowGating_WithDiscovery verifies that calling search
 // then trino_query produces no warning.
 func TestWorkflowGating_WithDiscovery(t *testing.T) {
-	tracker := middleware.NewSessionWorkflowTracker(nil, nil, 30*time.Minute)
+	tracker := middleware.NewSessionWorkflowTracker(nil, nil, nil, 30*time.Minute)
 	authenticator := &testAuthenticator{
 		userInfo: &middleware.UserInfo{UserID: chainTestUser, Roles: []string{chainTestAnalyst}},
 	}
@@ -2054,7 +2054,7 @@ func TestWorkflowGating_WithDiscovery(t *testing.T) {
 // where a persona granted datahub_* but not search could never satisfy a
 // narrower gate and would be locked out of query tools forever.
 func TestWorkflowGating_DataHubDiscoveryOpensGate(t *testing.T) {
-	tracker := middleware.NewSessionWorkflowTracker(nil, nil, 30*time.Minute)
+	tracker := middleware.NewSessionWorkflowTracker(nil, nil, nil, 30*time.Minute)
 	authenticator := &testAuthenticator{
 		userInfo: &middleware.UserInfo{UserID: chainTestUser, Roles: []string{chainTestAnalyst}},
 	}

--- a/pkg/middleware/session_workflow.go
+++ b/pkg/middleware/session_workflow.go
@@ -1,8 +1,12 @@
 package middleware
 
 import (
+	"context"
+	"log/slog"
 	"sync"
 	"time"
+
+	"github.com/txn2/mcp-data-platform/pkg/searchgate"
 )
 
 // DefaultDiscoveryTools lists the tool names that satisfy the search-first gate.
@@ -31,33 +35,57 @@ var DefaultQueryTools = []string{
 	toolNameTrinoExecute,
 }
 
-// workflowState tracks per-session workflow state.
-type workflowState struct {
-	discoveryTools map[string]time.Time
-	queryTools     map[string]time.Time
-	lastAccess     time.Time
-}
+// defaultWorkflowSessionTimeout guards the constructor against a non-positive
+// timeout (the platform always supplies a positive one; a direct caller might
+// not). It bounds the discovery record's lifetime and the slide throttle.
+const defaultWorkflowSessionTimeout = 30 * time.Minute
 
 // SessionWorkflowTracker tracks whether agents perform discovery before
-// querying, per session. It is safe for concurrent use.
+// querying, per session. The shared searchgate.Store is the single source of
+// truth so the signal is consistent across replicas (#789): the tracker never
+// holds a replica-local "discovered" bit that could diverge from it. Discovery
+// reads consult the store; an active session's record is slid forward on any
+// tool activity (store writes throttled per slideEvery) so a long session is not
+// re-gated mid-workflow. It is safe for concurrent use.
+//
+// Two costs are inherent to backing the signal with a shared store rather than a
+// per-process map, and are accepted deliberately:
+//   - The gate's HasPerformedDiscovery and the enrichment discovery-note both do
+//     a store read (a primary-key EXISTS lookup) per call; this is negligible
+//     next to the Trino query or enrichment work on the same path.
+//   - The slide throttle (lastSlide) is per replica, so an active session
+//     load-balanced across R replicas may refresh the shared record up to R
+//     times per window instead of once. The refresh is an idempotent upsert.
 type SessionWorkflowTracker struct {
-	mu             sync.RWMutex
-	sessions       map[string]*workflowState
-	sessionTimeout time.Duration
-	discoverySet   map[string]bool
-	querySet       map[string]bool
-	done           chan struct{}
-	stopOnce       sync.Once
+	discoverySet map[string]bool
+	querySet     map[string]bool
+
+	store      searchgate.Store
+	slideEvery time.Duration
+
+	mu        sync.RWMutex
+	lastSlide map[string]time.Time // per-session throttle for store writes
+
+	done     chan struct{}
+	stopOnce sync.Once
 }
 
 // NewSessionWorkflowTracker creates a new tracker. If discoveryTools or
-// queryTools are nil/empty, the respective defaults are used.
-func NewSessionWorkflowTracker(discoveryTools, queryTools []string, sessionTimeout time.Duration) *SessionWorkflowTracker {
+// queryTools are nil/empty, the respective defaults are used. If store is nil,
+// an in-memory store is used (correct for single-replica / no-database
+// deployments only).
+func NewSessionWorkflowTracker(discoveryTools, queryTools []string, store searchgate.Store, sessionTimeout time.Duration) *SessionWorkflowTracker {
 	if len(discoveryTools) == 0 {
 		discoveryTools = DefaultDiscoveryTools
 	}
 	if len(queryTools) == 0 {
 		queryTools = DefaultQueryTools
+	}
+	if sessionTimeout <= 0 {
+		sessionTimeout = defaultWorkflowSessionTimeout
+	}
+	if store == nil {
+		store = searchgate.NewMemoryStore(sessionTimeout)
 	}
 
 	dSet := make(map[string]bool, len(discoveryTools))
@@ -70,55 +98,90 @@ func NewSessionWorkflowTracker(discoveryTools, queryTools []string, sessionTimeo
 	}
 
 	return &SessionWorkflowTracker{
-		sessions:       make(map[string]*workflowState),
-		sessionTimeout: sessionTimeout,
-		discoverySet:   dSet,
-		querySet:       qSet,
-		done:           make(chan struct{}),
+		discoverySet: dSet,
+		querySet:     qSet,
+		store:        store,
+		// Refresh the shared record at least twice per session-timeout window so
+		// an active session's record never lapses before the next slide.
+		slideEvery: sessionTimeout / 2,
+		lastSlide:  make(map[string]time.Time),
+		done:       make(chan struct{}),
 	}
 }
 
-// RecordToolCall records a tool invocation for the session.
-func (t *SessionWorkflowTracker) RecordToolCall(sessionID, toolName string) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+// RecordToolCall records a tool invocation for the session. A discovery tool
+// records/refreshes discovery in the shared store. Any other tool call by a
+// session this replica already knows has discovered slides the record forward
+// (throttled), so continuous activity of any kind keeps the gate open for the
+// life of the session rather than only query activity.
+func (t *SessionWorkflowTracker) RecordToolCall(ctx context.Context, sessionID, toolName string) {
+	switch {
+	case t.discoverySet[toolName]:
+		t.mark(ctx, sessionID, true) // a discovery call always (re)persists
+	case t.locallyKnownDiscovered(sessionID):
+		t.mark(ctx, sessionID, false) // other activity slides, throttled
+	}
+}
 
-	state := t.getOrCreate(sessionID)
+// HasPerformedDiscovery returns true if a discovery tool has been called in the
+// session. The shared store is authoritative. On a positive result the record
+// is slid forward (throttled) so continuous query activity keeps the gate open.
+// On a store error it deliberately fails open (returns true): the gate is a
+// workflow quality guard, not a security boundary, so a database outage should
+// not wall off every query. The error is logged. (Note: a fail-open true also
+// suppresses the soft discovery note in appendDiscoveryNoteIfNeeded for the
+// outage; the nudge is non-essential and returns once the store recovers.)
+func (t *SessionWorkflowTracker) HasPerformedDiscovery(ctx context.Context, sessionID string) bool {
+	ok, err := t.store.HasDiscovered(ctx, sessionID)
+	if err != nil {
+		slog.Warn("search gate: discovery check failed; allowing the call (fail-open)",
+			"error", err, "session_id", sessionID)
+		return true
+	}
+	if ok {
+		t.mark(ctx, sessionID, false) // slide the shared TTL on active use (throttled)
+	}
+	return ok
+}
+
+// locallyKnownDiscovered reports whether this replica has already recorded or
+// confirmed discovery for the session (a cheap read used to decide whether a
+// non-discovery tool call should slide the shared record).
+func (t *SessionWorkflowTracker) locallyKnownDiscovered(sessionID string) bool {
+	t.mu.RLock()
+	_, ok := t.lastSlide[sessionID]
+	t.mu.RUnlock()
+	return ok
+}
+
+// mark records or extends the session's discovery in the shared store. A
+// force=true call (a discovery tool, or a retry after a gated query) always
+// writes, so a failed discovery write is re-attempted the next time the agent
+// calls search — a failed write therefore degrades to at most one repeated
+// SEARCH_REQUIRED, never a permanent or cross-replica-inconsistent block.
+// force=false calls (activity slides) are throttled to at most once per
+// slideEvery, and a failed slide is NOT retried until the next window: this
+// keeps the gate from hammering an unhealthy database with a write on every
+// query when writes fail but reads still succeed.
+func (t *SessionWorkflowTracker) mark(ctx context.Context, sessionID string, force bool) {
 	now := time.Now()
-	state.lastAccess = now
 
-	if t.discoverySet[toolName] {
-		state.discoveryTools[toolName] = now
+	t.mu.Lock()
+	last, seen := t.lastSlide[sessionID]
+	due := force || !seen || now.Sub(last) >= t.slideEvery
+	if due {
+		t.lastSlide[sessionID] = now
 	}
-	if t.querySet[toolName] {
-		state.queryTools[toolName] = now
+	t.mu.Unlock()
+
+	if !due {
+		return
 	}
-}
 
-// HasPerformedDiscovery returns true if at least one discovery tool has been
-// called in the session.
-func (t *SessionWorkflowTracker) HasPerformedDiscovery(sessionID string) bool {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	state, ok := t.sessions[sessionID]
-	if !ok {
-		return false
+	if err := t.store.MarkDiscovered(ctx, sessionID); err != nil {
+		slog.Warn("search gate: failed to persist discovery",
+			"error", err, "session_id", sessionID, "forced", force)
 	}
-	return len(state.discoveryTools) > 0
-}
-
-// DiscoveryToolCount returns the number of distinct discovery tools called
-// in the session.
-func (t *SessionWorkflowTracker) DiscoveryToolCount(sessionID string) int {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	state, ok := t.sessions[sessionID]
-	if !ok {
-		return 0
-	}
-	return len(state.discoveryTools)
 }
 
 // IsQueryTool returns true if the given tool name is in the query tool set.
@@ -144,7 +207,8 @@ func (t *SessionWorkflowTracker) QueryToolNames() []string {
 	return names
 }
 
-// StartCleanup starts a background goroutine that evicts idle sessions.
+// StartCleanup starts a background goroutine that evicts expired store entries
+// and stale throttle stamps.
 func (t *SessionWorkflowTracker) StartCleanup(interval time.Duration) {
 	go func() {
 		ticker := time.NewTicker(interval)
@@ -155,44 +219,36 @@ func (t *SessionWorkflowTracker) StartCleanup(interval time.Duration) {
 			case <-t.done:
 				return
 			case <-ticker.C:
-				t.cleanup()
+				if err := t.store.Cleanup(context.Background()); err != nil {
+					slog.Warn("search gate: store cleanup failed", "error", err)
+				}
+				t.evictStaleThrottle()
 			}
 		}
 	}()
 }
 
-// Stop stops the background cleanup goroutine. It is idempotent: calling it
-// more than once (e.g. Close called twice) is safe.
+// Stop stops the background cleanup goroutine and closes the store. It is
+// idempotent: calling it more than once (e.g. Close called twice) is safe.
 func (t *SessionWorkflowTracker) Stop() {
 	t.stopOnce.Do(func() {
 		close(t.done)
+		if err := t.store.Close(); err != nil {
+			slog.Warn("search gate: store close failed", "error", err)
+		}
 	})
 }
 
-// getOrCreate returns the session state, creating it if needed.
-// Caller must hold the write lock.
-func (t *SessionWorkflowTracker) getOrCreate(sessionID string) *workflowState {
-	state, ok := t.sessions[sessionID]
-	if !ok {
-		state = &workflowState{
-			discoveryTools: make(map[string]time.Time),
-			queryTools:     make(map[string]time.Time),
-			lastAccess:     time.Now(),
-		}
-		t.sessions[sessionID] = state
-	}
-	return state
-}
-
-// cleanup evicts sessions that have been idle longer than sessionTimeout.
-func (t *SessionWorkflowTracker) cleanup() {
+// evictStaleThrottle drops throttle stamps whose session has surely ended (no
+// activity for longer than the store record could survive without a slide).
+func (t *SessionWorkflowTracker) evictStaleThrottle() {
+	cutoff := 2 * t.slideEvery
 	t.mu.Lock()
 	defer t.mu.Unlock()
-
 	now := time.Now()
-	for id, state := range t.sessions {
-		if now.Sub(state.lastAccess) > t.sessionTimeout {
-			delete(t.sessions, id)
+	for id, last := range t.lastSlide {
+		if now.Sub(last) > cutoff {
+			delete(t.lastSlide, id)
 		}
 	}
 }

--- a/pkg/middleware/session_workflow_test.go
+++ b/pkg/middleware/session_workflow_test.go
@@ -1,44 +1,56 @@
 package middleware
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/searchgate"
 )
 
 func TestSessionWorkflowTracker_RecordDiscovery(t *testing.T) {
-	tracker := NewSessionWorkflowTracker(nil, nil, 30*time.Minute)
+	tracker := NewSessionWorkflowTracker(nil, nil, nil, 30*time.Minute)
+	ctx := context.Background()
 
-	assert.False(t, tracker.HasPerformedDiscovery("s1"))
-	assert.Equal(t, 0, tracker.DiscoveryToolCount("s1"))
+	assert.False(t, tracker.HasPerformedDiscovery(ctx, "s1"))
 
-	tracker.RecordToolCall("s1", "search")
-	assert.True(t, tracker.HasPerformedDiscovery("s1"))
-	assert.Equal(t, 1, tracker.DiscoveryToolCount("s1"))
+	tracker.RecordToolCall(ctx, "s1", "search")
+	assert.True(t, tracker.HasPerformedDiscovery(ctx, "s1"))
 
-	tracker.RecordToolCall("s1", "datahub_get_entity")
-	assert.Equal(t, 2, tracker.DiscoveryToolCount("s1"))
+	// A datahub_* tool also counts as discovery (broad default set).
+	tracker.RecordToolCall(ctx, "s2", "datahub_get_entity")
+	assert.True(t, tracker.HasPerformedDiscovery(ctx, "s2"))
+}
+
+func TestSessionWorkflowTracker_NonPositiveTimeoutGuarded(t *testing.T) {
+	// A non-positive timeout must be defaulted, not left to make slideEvery 0
+	// and the store TTL 0 (which would expire every record instantly).
+	tracker := NewSessionWorkflowTracker(nil, nil, nil, 0)
+	ctx := context.Background()
+	tracker.RecordToolCall(ctx, "s", "search")
+	assert.True(t, tracker.HasPerformedDiscovery(ctx, "s"),
+		"a guarded default timeout keeps discovery records alive")
 }
 
 func TestSessionWorkflowTracker_RecordQuery(t *testing.T) {
-	tracker := NewSessionWorkflowTracker(nil, nil, 30*time.Minute)
+	tracker := NewSessionWorkflowTracker(nil, nil, nil, 30*time.Minute)
+	ctx := context.Background()
 
-	tracker.RecordToolCall("s1", "trino_query")
-	assert.False(t, tracker.HasPerformedDiscovery("s1"), "query tool should not count as discovery")
+	tracker.RecordToolCall(ctx, "s1", "trino_query")
+	assert.False(t, tracker.HasPerformedDiscovery(ctx, "s1"), "query tool should not count as discovery")
 }
 
 func TestSessionWorkflowTracker_EmptySession(t *testing.T) {
-	tracker := NewSessionWorkflowTracker(nil, nil, 30*time.Minute)
-
-	assert.False(t, tracker.HasPerformedDiscovery("nonexistent"))
-	assert.Equal(t, 0, tracker.DiscoveryToolCount("nonexistent"))
+	tracker := NewSessionWorkflowTracker(nil, nil, nil, 30*time.Minute)
+	assert.False(t, tracker.HasPerformedDiscovery(context.Background(), "nonexistent"))
 }
 
 func TestSessionWorkflowTracker_IsQueryTool(t *testing.T) {
-	tracker := NewSessionWorkflowTracker(nil, nil, 30*time.Minute)
+	tracker := NewSessionWorkflowTracker(nil, nil, nil, 30*time.Minute)
 
 	assert.True(t, tracker.IsQueryTool("trino_query"))
 	assert.True(t, tracker.IsQueryTool("trino_execute"))
@@ -50,28 +62,159 @@ func TestSessionWorkflowTracker_CustomTools(t *testing.T) {
 	tracker := NewSessionWorkflowTracker(
 		[]string{"my_discover"},
 		[]string{"my_query"},
+		nil,
 		30*time.Minute,
 	)
+	ctx := context.Background()
 
 	// Custom query tool recognized
 	assert.True(t, tracker.IsQueryTool("my_query"))
 	assert.False(t, tracker.IsQueryTool("trino_query")) // default not included
 
 	// Custom discovery tool recognized
-	tracker.RecordToolCall("s1", "my_discover")
-	assert.True(t, tracker.HasPerformedDiscovery("s1"))
+	tracker.RecordToolCall(ctx, "s1", "my_discover")
+	assert.True(t, tracker.HasPerformedDiscovery(ctx, "s1"))
 }
 
 func TestSessionWorkflowTracker_SessionIsolation(t *testing.T) {
-	tracker := NewSessionWorkflowTracker(nil, nil, 30*time.Minute)
+	tracker := NewSessionWorkflowTracker(nil, nil, nil, 30*time.Minute)
+	ctx := context.Background()
 
-	tracker.RecordToolCall("s1", "search")
-	assert.True(t, tracker.HasPerformedDiscovery("s1"))
-	assert.False(t, tracker.HasPerformedDiscovery("s2"), "sessions should be isolated")
+	tracker.RecordToolCall(ctx, "s1", "search")
+	assert.True(t, tracker.HasPerformedDiscovery(ctx, "s1"))
+	assert.False(t, tracker.HasPerformedDiscovery(ctx, "s2"), "sessions should be isolated")
+}
+
+// TestSessionWorkflowTracker_SharedStoreAcrossReplicas is the regression test
+// for #789: two trackers backed by ONE shared store (simulating two replicas
+// pointed at the same database) must see each other's discovery. Discovery
+// recorded via tracker A opens the gate for a query checked on tracker B.
+func TestSessionWorkflowTracker_SharedStoreAcrossReplicas(t *testing.T) {
+	ctx := context.Background()
+	shared := searchgate.NewMemoryStore(30 * time.Minute)
+
+	replicaA := NewSessionWorkflowTracker(nil, nil, shared, 30*time.Minute)
+	replicaB := NewSessionWorkflowTracker(nil, nil, shared, 30*time.Minute)
+
+	// Before discovery, neither replica reports it.
+	assert.False(t, replicaB.HasPerformedDiscovery(ctx, "sess"))
+
+	// search lands on replica A.
+	replicaA.RecordToolCall(ctx, "sess", "search")
+
+	// A query load-balanced to replica B must now be allowed.
+	assert.True(t, replicaB.HasPerformedDiscovery(ctx, "sess"),
+		"discovery recorded on one replica must be visible to another via the shared store")
+}
+
+// errStore is a searchgate.Store whose read/write always error, used to verify
+// the tracker's fail-open behavior on a transient store fault.
+type errStore struct{}
+
+func (errStore) MarkDiscovered(context.Context, string) error        { return assert.AnError }
+func (errStore) HasDiscovered(context.Context, string) (bool, error) { return false, assert.AnError }
+func (errStore) Cleanup(context.Context) error                       { return assert.AnError }
+func (errStore) Close() error                                        { return assert.AnError }
+
+// flakyStore fails the first failWrites MarkDiscovered calls, then persists.
+// Reads reflect only what has actually persisted (the store is source of truth).
+type flakyStore struct {
+	failWrites int
+	writes     int
+	marked     map[string]bool
+}
+
+func (f *flakyStore) MarkDiscovered(_ context.Context, s string) error {
+	f.writes++
+	if f.writes <= f.failWrites {
+		return assert.AnError
+	}
+	if f.marked == nil {
+		f.marked = map[string]bool{}
+	}
+	f.marked[s] = true
+	return nil
+}
+
+func (f *flakyStore) HasDiscovered(_ context.Context, s string) (bool, error) {
+	return f.marked[s], nil
+}
+func (*flakyStore) Cleanup(context.Context) error { return nil }
+func (*flakyStore) Close() error                  { return nil }
+
+// TestSessionWorkflowTracker_RetriesAfterWriteFailure covers #789 review
+// finding: because the store is the single source of truth (no divergent
+// replica-local bit), a failed discovery write is not yet visible anywhere, but
+// the throttle is cleared so the agent's next search retries and persists it.
+func TestSessionWorkflowTracker_RetriesAfterWriteFailure(t *testing.T) {
+	store := &flakyStore{failWrites: 1}
+	tracker := NewSessionWorkflowTracker(nil, nil, store, 30*time.Minute)
+	ctx := context.Background()
+
+	tracker.RecordToolCall(ctx, "s", "search") // write 1 fails, nothing persisted
+	assert.False(t, tracker.HasPerformedDiscovery(ctx, "s"),
+		"a failed write leaves no shared record; the gate stays closed until it persists")
+
+	tracker.RecordToolCall(ctx, "s", "search") // write 2 succeeds (throttle was cleared)
+	assert.True(t, tracker.HasPerformedDiscovery(ctx, "s"),
+		"re-searching after a failed write persists and opens the gate on every replica")
+}
+
+// TestSessionWorkflowTracker_FailsOpenOnReadError covers the deliberate
+// fail-open policy: a store read error for an un-cached session allows the call
+// rather than walling off every query during a database outage.
+func TestSessionWorkflowTracker_FailsOpenOnReadError(t *testing.T) {
+	tracker := NewSessionWorkflowTracker(nil, nil, errStore{}, 30*time.Minute)
+	assert.True(t, tracker.HasPerformedDiscovery(context.Background(), "never-recorded"),
+		"a store read error should fail open (allow), not block every query")
+}
+
+// TestSessionWorkflowTracker_SlidesWithActivity covers #789 review finding #1:
+// a session that discovered once and stays active must not be re-gated when the
+// original discovery TTL elapses — activity slides the window.
+func TestSessionWorkflowTracker_SlidesWithActivity(t *testing.T) {
+	const ttl = 100 * time.Millisecond
+	store := searchgate.NewMemoryStore(ttl)
+	tracker := NewSessionWorkflowTracker(nil, nil, store, ttl)
+	ctx := context.Background()
+
+	tracker.RecordToolCall(ctx, "s", "search") // discover once at t0
+
+	// Stay active with query-tool calls past the original TTL. Each call goes
+	// through RecordToolCall (as the real middleware does) before the gate check.
+	for range 3 {
+		time.Sleep(60 * time.Millisecond)
+		tracker.RecordToolCall(ctx, "s", "trino_query")
+		require.True(t, tracker.HasPerformedDiscovery(ctx, "s"),
+			"an active session must stay discovered as the window slides")
+	}
+	// ~180ms elapsed, well past the 100ms TTL, yet still discovered.
+}
+
+// TestSessionWorkflowTracker_SlidesOnNonQueryActivity covers the third-round
+// review finding: a discovered session doing only non-query, non-discovery work
+// must still keep the gate open (the window slides on any activity, not just
+// query tools).
+func TestSessionWorkflowTracker_SlidesOnNonQueryActivity(t *testing.T) {
+	const ttl = 100 * time.Millisecond
+	store := searchgate.NewMemoryStore(ttl)
+	tracker := NewSessionWorkflowTracker(nil, nil, store, ttl)
+	ctx := context.Background()
+
+	tracker.RecordToolCall(ctx, "s", "search") // discover once
+
+	// Only non-query, non-discovery activity from here, past the original TTL.
+	for range 3 {
+		time.Sleep(60 * time.Millisecond)
+		tracker.RecordToolCall(ctx, "s", "s3_list_objects")
+	}
+	assert.True(t, tracker.HasPerformedDiscovery(ctx, "s"),
+		"non-query activity by a discovered session must keep the gate open")
 }
 
 func TestSessionWorkflowTracker_ConcurrentAccess(t *testing.T) {
-	tracker := NewSessionWorkflowTracker(nil, nil, 30*time.Minute)
+	tracker := NewSessionWorkflowTracker(nil, nil, nil, 30*time.Minute)
+	ctx := context.Background()
 
 	var wg sync.WaitGroup
 	for i := range 100 {
@@ -80,48 +223,50 @@ func TestSessionWorkflowTracker_ConcurrentAccess(t *testing.T) {
 			defer wg.Done()
 			sid := "session-concurrent"
 			if n%2 == 0 {
-				tracker.RecordToolCall(sid, "search")
+				tracker.RecordToolCall(ctx, sid, "search")
 			} else {
-				tracker.RecordToolCall(sid, "trino_query")
+				tracker.RecordToolCall(ctx, sid, "trino_query")
 			}
-			_ = tracker.HasPerformedDiscovery(sid)
+			_ = tracker.HasPerformedDiscovery(ctx, sid)
 		}(i)
 	}
 	wg.Wait()
 
 	// No panics means the test passed; just verify state is readable
-	assert.True(t, tracker.HasPerformedDiscovery("session-concurrent"))
+	assert.True(t, tracker.HasPerformedDiscovery(ctx, "session-concurrent"))
 }
 
 func TestSessionWorkflowTracker_Cleanup(t *testing.T) {
-	tracker := NewSessionWorkflowTracker(nil, nil, 50*time.Millisecond)
+	// A short-TTL store lets the discovery record expire; the store is the
+	// source of truth, so once its row is cleaned the gate closes again.
+	store := searchgate.NewMemoryStore(50 * time.Millisecond)
+	tracker := NewSessionWorkflowTracker(nil, nil, store, 50*time.Millisecond)
+	ctx := context.Background()
 
-	tracker.RecordToolCall("s-expire", "search")
-	require.True(t, tracker.HasPerformedDiscovery("s-expire"))
+	tracker.RecordToolCall(ctx, "s-expire", "search")
+	require.True(t, tracker.HasPerformedDiscovery(ctx, "s-expire"))
 
-	// Wait for the session to expire
-	time.Sleep(60 * time.Millisecond)
+	// Wait for the store record to expire, with no activity to slide it.
+	time.Sleep(80 * time.Millisecond)
 
-	// Run cleanup directly (don't rely on background goroutine for test reliability)
-	tracker.cleanup()
+	require.NoError(t, store.Cleanup(ctx))
+	tracker.evictStaleThrottle()
 
-	assert.False(t, tracker.HasPerformedDiscovery("s-expire"), "expired session should be cleaned up")
+	assert.False(t, tracker.HasPerformedDiscovery(ctx, "s-expire"), "expired discovery should be gone")
 }
 
 func TestSessionWorkflowTracker_StartCleanupAndStop(t *testing.T) {
-	tracker := NewSessionWorkflowTracker(nil, nil, 10*time.Millisecond)
+	tracker := NewSessionWorkflowTracker(nil, nil, nil, 10*time.Millisecond)
 	tracker.StartCleanup(10 * time.Millisecond)
 
-	tracker.RecordToolCall("s-bg", "search")
+	tracker.RecordToolCall(context.Background(), "s-bg", "search")
 
 	// Give cleanup time to run
 	time.Sleep(50 * time.Millisecond)
 
-	// Stop should not panic
+	// Stop should not panic, and is idempotent.
 	tracker.Stop()
-
-	// Session should be cleaned up
-	assert.False(t, tracker.HasPerformedDiscovery("s-bg"))
+	tracker.Stop()
 }
 
 func TestDefaultDiscoveryTools(t *testing.T) {
@@ -148,6 +293,7 @@ func TestSessionWorkflowTracker_DiscoveryToolNames(t *testing.T) {
 	tracker := NewSessionWorkflowTracker(
 		[]string{"datahub_search", "datahub_get_entity"},
 		nil,
+		nil,
 		30*time.Minute,
 	)
 	names := tracker.DiscoveryToolNames()
@@ -159,6 +305,7 @@ func TestSessionWorkflowTracker_QueryToolNames(t *testing.T) {
 	tracker := NewSessionWorkflowTracker(
 		nil,
 		[]string{"trino_query", "trino_execute"},
+		nil,
 		30*time.Minute,
 	)
 	names := tracker.QueryToolNames()

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -58,6 +58,8 @@ import (
 	trinoquery "github.com/txn2/mcp-data-platform/pkg/query/trino"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/resource"
+	"github.com/txn2/mcp-data-platform/pkg/searchgate"
+	searchgatepostgres "github.com/txn2/mcp-data-platform/pkg/searchgate/postgres"
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
 	datahubsemantic "github.com/txn2/mcp-data-platform/pkg/semantic/datahub"
 	"github.com/txn2/mcp-data-platform/pkg/session"
@@ -1528,9 +1530,22 @@ func (p *Platform) initWorkflow() {
 		sessionTimeout = defaultSessionTimeout
 	}
 
+	// The discovery signal must be shared across replicas: with only an
+	// in-memory store, a query load-balanced to a replica that did not handle
+	// the search is wrongly refused (#789). Use the Postgres store whenever a
+	// database is available (the same condition under which sessions
+	// externalize); fall back to in-memory for single-replica / no-DB runs.
+	var store searchgate.Store
+	if p.db != nil {
+		store = searchgatepostgres.New(p.db, sessionTimeout)
+	} else {
+		store = searchgate.NewMemoryStore(sessionTimeout)
+	}
+
 	p.workflowTracker = middleware.NewSessionWorkflowTracker(
 		p.config.Workflow.DiscoveryTools,
 		p.config.Workflow.QueryTools,
+		store,
 		sessionTimeout,
 	)
 	p.workflowTracker.StartCleanup(1 * time.Minute)
@@ -1538,7 +1553,16 @@ func (p *Platform) initWorkflow() {
 	slog.Info("search-first gate enabled",
 		"discovery_tools", len(p.workflowTracker.DiscoveryToolNames()),
 		"query_tools", len(p.workflowTracker.QueryToolNames()),
+		"store", searchgateStoreKind(p.db),
 	)
+}
+
+// searchgateStoreKind names the discovery store backing for logging.
+func searchgateStoreKind(db *sql.DB) string {
+	if db != nil {
+		return "postgres"
+	}
+	return "memory"
 }
 
 // initSessionGate initializes the session initialization gate if configured.

--- a/pkg/platform/searchgate_wiring_test.go
+++ b/pkg/platform/searchgate_wiring_test.go
@@ -1,0 +1,21 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSearchgateStoreKind locks the branch that decides whether the search-first
+// gate's discovery signal is replica-shared: with a database it must be the
+// Postgres store, without one the in-memory store (#789).
+func TestSearchgateStoreKind(t *testing.T) {
+	assert.Equal(t, "memory", searchgateStoreKind(nil))
+
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	assert.Equal(t, "postgres", searchgateStoreKind(db))
+}

--- a/pkg/searchgate/postgres/store.go
+++ b/pkg/searchgate/postgres/store.go
@@ -1,0 +1,68 @@
+// Package postgres provides a PostgreSQL-backed searchgate.Store so the
+// search-first gate's per-session discovery signal is shared across replicas.
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// Store implements searchgate.Store using PostgreSQL.
+type Store struct {
+	db  *sql.DB
+	ttl time.Duration
+}
+
+// New creates a PostgreSQL discovery store. Discovery records expire ttl after
+// the most recent MarkDiscovered.
+func New(db *sql.DB, ttl time.Duration) *Store {
+	return &Store{db: db, ttl: ttl}
+}
+
+// MarkDiscovered records discovery for the session, upserting its expiry.
+func (s *Store) MarkDiscovered(ctx context.Context, sessionID string) error {
+	const q = `
+		INSERT INTO search_gate_discovery (session_id, discovered_at, expires_at)
+		VALUES ($1, now(), now() + $2::interval)
+		ON CONFLICT (session_id) DO UPDATE SET
+			discovered_at = EXCLUDED.discovered_at,
+			expires_at = EXCLUDED.expires_at
+	`
+	if _, err := s.db.ExecContext(ctx, q, sessionID, intervalString(s.ttl)); err != nil {
+		return fmt.Errorf("marking discovery: %w", err)
+	}
+	return nil
+}
+
+// HasDiscovered reports whether the session has a non-expired discovery record.
+func (s *Store) HasDiscovered(ctx context.Context, sessionID string) (bool, error) {
+	const q = `SELECT EXISTS (
+		SELECT 1 FROM search_gate_discovery
+		WHERE session_id = $1 AND expires_at > now()
+	)`
+	var exists bool
+	if err := s.db.QueryRowContext(ctx, q, sessionID).Scan(&exists); err != nil {
+		return false, fmt.Errorf("checking discovery: %w", err)
+	}
+	return exists, nil
+}
+
+// Cleanup deletes expired discovery records.
+func (s *Store) Cleanup(ctx context.Context) error {
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM search_gate_discovery WHERE expires_at <= now()`); err != nil {
+		return fmt.Errorf("cleaning up discovery: %w", err)
+	}
+	return nil
+}
+
+// Close is a no-op; the underlying *sql.DB is owned by the platform.
+func (*Store) Close() error { return nil }
+
+// intervalString renders a duration as a PostgreSQL interval literal (seconds),
+// so the TTL is applied server-side against now() rather than a client clock.
+func intervalString(d time.Duration) string {
+	secs := max(int64(d/time.Second), 1)
+	return fmt.Sprintf("%d seconds", secs)
+}

--- a/pkg/searchgate/postgres/store_test.go
+++ b/pkg/searchgate/postgres/store_test.go
@@ -1,0 +1,126 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testTTL = 30 * time.Minute
+
+func TestMarkDiscovered(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("INSERT INTO search_gate_discovery").
+		WithArgs("sess-1", "1800 seconds").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	s := New(db, testTTL)
+	require.NoError(t, s.MarkDiscovered(context.Background(), "sess-1"))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMarkDiscovered_Error(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("INSERT INTO search_gate_discovery").
+		WillReturnError(errors.New("boom"))
+
+	s := New(db, testTTL)
+	err = s.MarkDiscovered(context.Background(), "sess-1")
+	assert.Error(t, err)
+}
+
+func TestHasDiscovered(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("sess-1").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	s := New(db, testTTL)
+	ok, err := s.HasDiscovered(context.Background(), "sess-1")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHasDiscovered_False(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("sess-1").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	s := New(db, testTTL)
+	ok, err := s.HasDiscovered(context.Background(), "sess-1")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestHasDiscovered_Error(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("SELECT EXISTS").
+		WillReturnError(errors.New("boom"))
+
+	s := New(db, testTTL)
+	_, err = s.HasDiscovered(context.Background(), "sess-1")
+	assert.Error(t, err)
+}
+
+func TestCleanup(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("DELETE FROM search_gate_discovery").
+		WillReturnResult(sqlmock.NewResult(0, 5))
+
+	s := New(db, testTTL)
+	require.NoError(t, s.Cleanup(context.Background()))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCleanup_Error(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("DELETE FROM search_gate_discovery").
+		WillReturnError(errors.New("boom"))
+
+	s := New(db, testTTL)
+	assert.Error(t, s.Cleanup(context.Background()))
+}
+
+func TestClose(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	assert.NoError(t, New(db, testTTL).Close())
+}
+
+// TestIntervalString verifies the TTL is rendered as a positive integer-seconds
+// interval (and never sub-second, which Postgres would treat as 0).
+func TestIntervalString(t *testing.T) {
+	assert.Equal(t, "1800 seconds", intervalString(30*time.Minute))
+	assert.Equal(t, "1 seconds", intervalString(0))
+	assert.Equal(t, "1 seconds", intervalString(500*time.Millisecond))
+}

--- a/pkg/searchgate/searchgate.go
+++ b/pkg/searchgate/searchgate.go
@@ -1,0 +1,84 @@
+// Package searchgate stores, per session, whether a discovery tool has been
+// called — the signal the search-first gate (middleware.MCPWorkflowGateMiddleware)
+// blocks query tools on. It exposes a small Store interface with an in-memory
+// default and a PostgreSQL implementation (pkg/searchgate/postgres) so the
+// signal is shared across replicas, the same way sessions and audit externalize.
+//
+// The in-memory store is correct for single-replica / no-database deployments.
+// A multi-replica deployment must use a shared store: otherwise a discovery
+// recorded on one replica is invisible to a query handled by another, and the
+// hard gate refuses the query even though the agent did call search (#789).
+package searchgate
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Store records and reports per-session discovery. Discovery is monotonic:
+// once a session has performed discovery, it stays discovered until its entry
+// expires (bounded by the session timeout).
+type Store interface {
+	// MarkDiscovered records that the session has performed discovery.
+	MarkDiscovered(ctx context.Context, sessionID string) error
+
+	// HasDiscovered reports whether the session has performed discovery and
+	// the record has not expired.
+	HasDiscovered(ctx context.Context, sessionID string) (bool, error)
+
+	// Cleanup evicts expired entries.
+	Cleanup(ctx context.Context) error
+
+	// Close releases any resources held by the store.
+	Close() error
+}
+
+// MemoryStore is an in-memory Store. It is correct for single-replica or
+// no-database deployments; it is NOT shared across replicas.
+type MemoryStore struct {
+	mu  sync.RWMutex
+	ttl time.Duration
+	m   map[string]time.Time // sessionID -> expiry
+}
+
+// NewMemoryStore creates an in-memory discovery store. Entries expire ttl after
+// the most recent MarkDiscovered.
+func NewMemoryStore(ttl time.Duration) *MemoryStore {
+	return &MemoryStore{ttl: ttl, m: make(map[string]time.Time)}
+}
+
+// MarkDiscovered records discovery for the session, (re)setting its expiry.
+func (s *MemoryStore) MarkDiscovered(_ context.Context, sessionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[sessionID] = time.Now().Add(s.ttl)
+	return nil
+}
+
+// HasDiscovered reports whether the session has a live discovery record.
+func (s *MemoryStore) HasDiscovered(_ context.Context, sessionID string) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	exp, ok := s.m[sessionID]
+	if !ok {
+		return false, nil
+	}
+	return time.Now().Before(exp), nil
+}
+
+// Cleanup removes expired entries.
+func (s *MemoryStore) Cleanup(_ context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	for id, exp := range s.m {
+		if now.After(exp) {
+			delete(s.m, id)
+		}
+	}
+	return nil
+}
+
+// Close is a no-op for the in-memory store.
+func (*MemoryStore) Close() error { return nil }

--- a/pkg/searchgate/searchgate_test.go
+++ b/pkg/searchgate/searchgate_test.go
@@ -1,0 +1,64 @@
+package searchgate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryStore_MarkAndHas(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore(30 * time.Minute)
+
+	ok, err := s.HasDiscovered(ctx, "sess")
+	require.NoError(t, err)
+	assert.False(t, ok, "unknown session has not discovered")
+
+	require.NoError(t, s.MarkDiscovered(ctx, "sess"))
+
+	ok, err = s.HasDiscovered(ctx, "sess")
+	require.NoError(t, err)
+	assert.True(t, ok, "marked session has discovered")
+
+	ok, err = s.HasDiscovered(ctx, "other")
+	require.NoError(t, err)
+	assert.False(t, ok, "sessions are isolated")
+}
+
+func TestMemoryStore_Expiry(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore(20 * time.Millisecond)
+
+	require.NoError(t, s.MarkDiscovered(ctx, "sess"))
+	ok, _ := s.HasDiscovered(ctx, "sess")
+	require.True(t, ok)
+
+	time.Sleep(40 * time.Millisecond)
+
+	ok, err := s.HasDiscovered(ctx, "sess")
+	require.NoError(t, err)
+	assert.False(t, ok, "discovery record expires after the TTL")
+}
+
+func TestMemoryStore_Cleanup(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore(20 * time.Millisecond)
+
+	require.NoError(t, s.MarkDiscovered(ctx, "a"))
+	require.NoError(t, s.MarkDiscovered(ctx, "b"))
+	time.Sleep(40 * time.Millisecond)
+
+	require.NoError(t, s.Cleanup(ctx))
+
+	s.mu.RLock()
+	remaining := len(s.m)
+	s.mu.RUnlock()
+	assert.Equal(t, 0, remaining, "cleanup evicts expired entries")
+}
+
+func TestMemoryStore_Close(t *testing.T) {
+	assert.NoError(t, NewMemoryStore(time.Minute).Close())
+}


### PR DESCRIPTION
## Summary

Fixes the v1.97.0 search-first gate regression: on a multi-replica deployment the gate refused `trino_query` / `trino_execute` with `SEARCH_REQUIRED` **even after the agent correctly called `search`**, non-deterministically (~(R-1)/R of the time for R replicas).

Root cause: the gate stored per-session discovery in an **in-memory map per pod**. A `search` recorded on replica A was invisible to a query load-balanced to replica B. As a pre-1.97.0 soft warning this was harmless; v1.97.0 turned it into a hard block, so it broke queries in the common production topology (>1 replica). Verified live on a `replicas: 2` deployment.

Closes #789.

## Fix

Back the discovery signal with a **replica-shared store** so it is consistent across pods, mirroring how sessions and audit already externalize (`pkg/session/postgres`, `pkg/audit/postgres`):

- **New `pkg/searchgate`** — a small `Store` interface (`MarkDiscovered` / `HasDiscovered` / `Cleanup` / `Close`) with an in-memory implementation.
- **New `pkg/searchgate/postgres`** — the replica-shared implementation, backed by migration `000077_search_gate_discovery` (`session_id` PK, `expires_at` + cleanup index).
- **`initWorkflow`** selects the Postgres store when a database is available (the same condition under which sessions externalize) and the in-memory store otherwise (correct for single-replica / no-DB).
- **The store is the single source of truth.** The tracker keeps no replica-local "discovered" bit that could diverge from it — that divergence was the source of two of the bugs found during review (below).

### Semantics (documented in `session_workflow.go` and `docs/reference/middleware.md`)
- **Sliding window:** any tool call by a discovered session refreshes the shared record (store writes throttled to once per half the session timeout), so a long active session is not re-gated mid-workflow.
- **Write-failure self-heal:** a discovery write always retries on the agent's next `search`; a *slide* failure is not retried until the next window, so a degraded database is not hammered with a write on every query.
- **Fail-open on read error (deliberate):** the gate is a workflow quality guard, not a security boundary, so a database outage allows queries (logged) rather than blocking every one.

### Accepted, documented tradeoffs (inherent to a shared store; the per-pod map was the bug)
- A primary-key `EXISTS` read per gated call — negligible next to the Trino query / enrichment on the same path.
- The slide throttle is per replica, so an active session across R replicas may refresh the record up to R times per window (an idempotent upsert).

## How this was hardened

The core fix is small; getting the lifetime/reliability semantics right took three rounds of adversarial review, each of which caught a real defect:

1. First cut hard-expired discovery 30 min after `search` → long sessions re-gated. 
2. A local-cache-with-retry fix introduced replica-local divergence (failed writes / confirmed reads didn't reach the shared store). 
3. The store-authoritative rewrite still re-gated on non-query-only activity and could hammer a degraded DB on write failure.

All three are resolved in the final design (sliding on any activity; forced-retry vs. throttled-slide split; single source of truth).

## Tests
- **Cross-replica regression** (`TestSessionWorkflowTracker_SharedStoreAcrossReplicas`): two trackers sharing one store — discovery on A opens the gate for a query on B.
- Sliding on query activity and on non-query activity; write-failure retry; fail-open on read error; guarded non-positive timeout.
- In-memory store tests and sqlmock tests for the Postgres store.
- 100% coverage on the tracker's logic; `make verify` green (including the real-Postgres migration gate, which applies `000077` cleanly).

## Docs
`CLAUDE.md` (package list + count), `docs/reference/middleware.md` (replica-shared semantics).

## Deploy note
The gate is only replica-safe when a database is configured (multi-replica deployments already externalize sessions to a database, so this is satisfied). Single-replica / no-DB deployments continue to use the in-memory store, which is correct for them.

## Diff
19 files changed, +754 / −139.
