### PR TITLE
feat(session): explicit session handles from platform_info (#792)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Each feature links to its full documentation.
 | [Audit logging](https://mcp-data-platform.txn2.com/server/audit/) | Every tool call logged to PostgreSQL with identity, persona, sanitized parameters, and timing |
 | [Observability](https://mcp-data-platform.txn2.com/server/observability/) | Prometheus metrics and optional OpenTelemetry distributed tracing |
 | [Session externalization](https://mcp-data-platform.txn2.com/server/session-externalization/) | PostgreSQL-backed sessions for zero-downtime restarts, horizontal scaling, and live tool-inventory updates |
+| [Explicit session handles](https://mcp-data-platform.txn2.com/server/configuration/#explicit-session-handles) | `platform_info` mints a `session_id` the agent threads on every call, making orientation unskippable and readying the platform for the sessionless MCP 2026-07-28 protocol |
 | [Multi-provider](https://mcp-data-platform.txn2.com/server/multi-provider/) | Multiple instances of each service behind one endpoint, with isolated failure domains |
 | [Operating modes](https://mcp-data-platform.txn2.com/server/operating-modes/) | Standalone (no database) or file + database with hot-reloaded config overrides |
 

--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -29,6 +29,13 @@ server:
 #   store: memory               # "memory" (default) or "database"
 #   ttl: 30m                    # session lifetime (defaults to streamable.session_timeout)
 #   cleanup_interval: 1m        # cleanup routine frequency
+#   # Explicit session handles (#792): platform_info mints a session_id the model
+#   # threads on every subsequent tool call — the pattern the MCP 2026-07-28 spec
+#   # recommends after removing the Mcp-Session-Id header (SEP-2567).
+#   handles:
+#     enabled: false            # opt out of explicit session handles (default on)
+#     ttl: 8h                   # handle lifetime, refreshed on use (default 8h)
+#     require: false            # accept legacy transport sessions without a handle (default on)
 
 # Generic OIDC authentication
 auth:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -580,8 +580,13 @@ Requires `database.dsn`. With a database available and no `audit:` block, both a
 | `sessions.store` | string | `memory` | Backend: `memory` or `database` |
 | `sessions.ttl` | duration | streamable session_timeout | Session lifetime |
 | `sessions.cleanup_interval` | duration | `1m` | Cleanup routine interval |
+| `sessions.handles.enabled` | bool | `true` | Explicit session handles (#792): platform_info mints a session_id the model threads on every subsequent tool call. Set false for legacy transport-session behavior. |
+| `sessions.handles.ttl` | duration | `8h` | Handle lifetime, refreshed on use |
+| `sessions.handles.require` | bool | `true` | Refuse a call with neither a valid handle nor a legacy transport session (SESSION_REQUIRED) |
 
 The `database` store requires `database.dsn`. Database-backed sessions survive restarts and support multi-replica deployments.
+
+Explicit session handles (`sessions.handles`, issue #792) adopt the pattern the MCP 2026-07-28 release candidate recommends after removing the `Mcp-Session-Id` header (SEP-2567): `platform_info` mints a `session_id`, every tool advertises it as an input argument (except `platform_info`), and `MCPToolCallMiddleware` validates it against the session store (must exist, be unexpired, and belong to the same authenticated identity), adopts it onto `PlatformContext.SessionID`, and strips it before the handler runs. This makes `platform_info` structurally unskippable and gives audit and provenance a deliberate session key. Unknown/expired/cross-identity handles are refused with `SESSION_EXPIRED`; a missing handle (with no legacy transport session and `require: true`) with `SESSION_REQUIRED`. The `mcp_session_resolution_total{source}` metric tracks migration from transport sessions to explicit handles.
 
 ## Toolkit Configuration
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -8,7 +8,7 @@ mcp-data-platform is the orchestration layer for the txn2 MCP ecosystem. DataHub
 
 - [Server Overview](https://mcp-data-platform.txn2.com/server/overview/): What the platform does, architecture, request flow
 - [Installation](https://mcp-data-platform.txn2.com/server/installation/): Install via go install, Homebrew, Docker, or from source
-- [Configuration](https://mcp-data-platform.txn2.com/server/configuration/): Full YAML reference with environment variable expansion: server, auth, personas, toolkits, enrichment, workflow gating, prompts, resources, portal, database, audit, and session settings. Includes config versioning and hot-reloaded per-key database overrides
+- [Configuration](https://mcp-data-platform.txn2.com/server/configuration/): Full YAML reference with environment variable expansion: server, auth, personas, toolkits, enrichment, workflow gating, prompts, resources, portal, database, audit, session settings, and explicit session handles (platform_info-minted session_id, MCP 2026-07-28 sessionless readiness). Includes config versioning and hot-reloaded per-key database overrides
 - [The Data Stack](https://mcp-data-platform.txn2.com/concepts/components/): Why DataHub, Trino, and S3, what each component brings, and how cross-enrichment makes them greater than the sum of their parts
 - [Operating Modes](https://mcp-data-platform.txn2.com/server/operating-modes/): Two deployment modes, standalone (no database) and file + database. Feature availability by mode, example configurations, decision guide
 - [Deployment](https://mcp-data-platform.txn2.com/server/deployment/): Docker Compose and Kubernetes/Helm deployment guides, including how connected agents pick up tool-contract changes across an upgrade

--- a/docs/reference/middleware.md
+++ b/docs/reference/middleware.md
@@ -120,9 +120,10 @@ func MCPToolCallMiddleware(
 4. Looks up toolkit metadata (kind, name, connection) via `ToolkitLookup`
 5. Runs authenticator to identify user (populates UserID, Email, Roles)
 6. Runs authorizer to check tool access (populates PersonaName, Authorized)
-7. Returns error result if auth fails, otherwise proceeds
+7. Resolves the explicit session handle (issue #792) via the optional `SessionResolver`: extracts the `session_id` argument, validates it against the session store (must exist, be unexpired, and belong to the same authenticated identity), adopts it onto `PlatformContext.SessionID`, and strips it before the handler runs. A missing handle (with no legacy transport session) yields `SESSION_REQUIRED`; an unknown, expired, or cross-identity handle yields `SESSION_EXPIRED`.
+8. Returns error result if auth or session resolution fails, otherwise proceeds
 
-The `toolkitLookup` parameter is optional; if `nil`, toolkit metadata fields remain empty.
+The `toolkitLookup` parameter is optional; if `nil`, toolkit metadata fields remain empty. The session resolver is supplied via `ToolCallConfig.SessionResolver` and is a valid `nil` no-op when explicit handles are disabled.
 
 ### MCPAuditMiddleware
 
@@ -169,6 +170,16 @@ Modeled on `MCPSessionGateMiddleware`: it is positioned inner to `MCPToolCallMid
 - **Write resilience:** a failed discovery write persists nothing (there is no divergent local state); a forced discovery write always re-attempts, so the agent's next `search` retries persistence once writes recover.
 - **Fail-open on read error (deliberate):** the gate decision follows the read. A total store outage (reads fail) fails open (allows queries, logged) rather than blocking every one, since the gate is a workflow quality guard, not a security boundary.
 - **Fail-closed on write outage (deliberate):** a store that accepts reads but rejects writes leaves discovery un-persisted, so the read returns not-discovered and the caller is gated (`SEARCH_REQUIRED`) until writes recover. This is intentional: failing open on a write error would let one caller's transient write blip open the gate for everyone. If queries must proceed during a store-write outage, disable the gate (`workflow.require_search: false`).
+
+### MCPSessionHandleSchemaMiddleware
+
+Advertises the explicit session handle (issue #792) by injecting a `session_id` string property into every tool's input schema on `tools/list` responses, except the init tool (`platform_info`, which mints the handle and takes no `session_id`).
+
+```go
+func MCPSessionHandleSchemaMiddleware(initTool string) mcp.Middleware
+```
+
+A list decorator like `ToolMetadataMiddleware`: it replaces each `Tool` in the response with a shallow copy carrying the augmented schema, so neither the server's shared tool registry nor upstream toolkits (mcp-trino, mcp-datahub, mcp-s3, gateway-proxied tools) are ever modified. Any schema representation (`*jsonschema.Schema`, `json.RawMessage`, or a map) is normalized via a JSON round-trip. Registered only when `sessions.handles.enabled` is on. The complementary extraction, validation, and stripping happens inside `MCPToolCallMiddleware` (see step 7 above).
 
 ### MCPDescriptionOverrideMiddleware
 

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -536,6 +536,28 @@ sessions:
 
 See [Session Externalization](session-externalization.md) for architecture details and multi-replica considerations.
 
+### Explicit Session Handles
+
+The `sessions.handles` block controls explicit session handles (issue #792). When enabled, `platform_info` mints a `session_id` that the model passes back as an ordinary argument on every subsequent tool call. This is the pattern the [MCP 2026-07-28 release candidate](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) recommends after removing the protocol-level session and the `Mcp-Session-Id` header ([SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567)).
+
+This makes `platform_info` structurally unskippable (no handle exists until it is called, and gated tools require one), gives audit and provenance a deliberate session key, and keeps the platform working unchanged when clients move to the sessionless protocol.
+
+```yaml
+sessions:
+  handles:
+    enabled: true      # mint, advertise, and validate handles (default on)
+    ttl: 8h            # handle lifetime, refreshed on use
+    require: true      # refuse calls with neither a handle nor a legacy transport session
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Mint a `session_id` from `platform_info`, advertise it on every tool's input schema, validate and strip it on each call. Set `false` for byte-identical legacy transport-session behavior. |
+| `ttl` | duration | `8h` | Handle lifetime, refreshed on use. |
+| `require` | bool | `true` | Refuse a tool call carrying neither a valid handle nor a legacy transport session with `SESSION_REQUIRED`. Set `false` for a softer landing during rollout. |
+
+Every tool advertises the injected `session_id` argument except `platform_info` (which mints it). Upstream toolkits never see the argument: the platform strips it before the handler runs. A handle presented by a different authenticated identity, or an unknown/expired handle, is refused with `SESSION_EXPIRED`. The `mcp_session_resolution_total{source}` metric (`explicit`, `transport`, `stdio`, `none`) shows migration progress from transport sessions to explicit handles.
+
 ## Toolkit Configuration
 
 ### Trino

--- a/pkg/middleware/error_contract.go
+++ b/pkg/middleware/error_contract.go
@@ -35,6 +35,8 @@ const (
 	CodeUnauthorized       = "unauthorized"
 	CodeSetupRequired      = "setup_required"
 	CodeSearchRequired     = "search_required"
+	CodeSessionRequired    = "session_required"
+	CodeSessionExpired     = "session_expired"
 	CodeFeatureUnavailable = "feature_unavailable"
 	CodeInternalError      = "internal_error"
 	CodeToolError          = "tool_error"

--- a/pkg/middleware/mcp.go
+++ b/pkg/middleware/mcp.go
@@ -96,6 +96,7 @@ type ToolCallConfig struct {
 	Transport       string                  // "stdio" or "http"
 	AdminPersona    string                  // persona name that grants platform admin
 	WorkflowTracker *SessionWorkflowTracker // optional workflow tracker
+	SessionResolver *SessionResolver        // optional explicit session-handle resolver (#792)
 }
 
 // MCPToolCallMiddleware creates MCP protocol-level middleware that intercepts
@@ -142,6 +143,7 @@ func MCPToolCallMiddleware(authenticator Authenticator, authorizer Authorizer, t
 				toolName:        toolName,
 				adminPersona:    cfg.AdminPersona,
 				workflowTracker: tracker,
+				sessionResolver: cfg.SessionResolver,
 			})
 		}
 	}
@@ -233,6 +235,7 @@ type authParams struct {
 	toolName        string
 	adminPersona    string
 	workflowTracker *SessionWorkflowTracker
+	sessionResolver *SessionResolver
 }
 
 // authenticateAndAuthorize runs authentication and authorization, returning
@@ -311,6 +314,15 @@ func authenticateAndAuthorize(
 		"auth_type", authType,
 		"request_id", params.pc.RequestID,
 	)
+
+	// Resolve and enforce the explicit session handle (#792). This runs after
+	// authentication (so pc.UserID is available for the same-identity check),
+	// updates pc.SessionID to the validated handle, strips the session_id
+	// argument before the handler sees it, and short-circuits a handle-less
+	// gated call with SESSION_REQUIRED before it is recorded or executed.
+	if errResult := params.sessionResolver.resolve(ctx, req, params.pc, params.toolName); errResult != nil {
+		return errResult, nil
+	}
 
 	// Record tool call for workflow tracking (after successful auth, so the
 	// user identity is resolved). Keyed on DiscoveryScopeKey (user-first), not

--- a/pkg/middleware/mcp_session_handle.go
+++ b/pkg/middleware/mcp_session_handle.go
@@ -1,0 +1,401 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"maps"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	pkgsession "github.com/txn2/mcp-data-platform/pkg/session"
+)
+
+// ErrCategorySessionRequired is the error category for explicit session-handle
+// violations (missing or expired handle).
+const ErrCategorySessionRequired = "session_required"
+
+// sessionHandleArg is the tool-call argument name carrying the explicit session
+// handle minted by platform_info (issue #792).
+const sessionHandleArg = "session_id"
+
+// sessionHandleSchemaDescription is the description advertised on the injected
+// session_id property so the model learns where the handle comes from.
+const sessionHandleSchemaDescription = "Session handle returned by platform_info. Call platform_info first, " +
+	"then pass the session_id it returns on every subsequent tool call so the platform can " +
+	"associate your calls, enforce workflow gates, and attribute audit and provenance records."
+
+// Session resolution sources, reported to the session_resolution_source metric
+// so operators can watch traffic move from transport sessions to explicit
+// handles during the deprecation window.
+const (
+	sessionSourceExplicit  = "explicit"
+	sessionSourceTransport = "transport"
+	sessionSourceStdio     = "stdio"
+	sessionSourceNone      = "none"
+)
+
+// refreshTimeout bounds the detached handle-refresh upsert.
+const refreshTimeout = 5 * time.Second
+
+// SessionResolverConfig configures a SessionResolver.
+type SessionResolverConfig struct {
+	// Enabled activates handle extraction, validation, and enforcement. When
+	// false the resolver is a no-op and transport resolution stands alone.
+	Enabled bool
+
+	// Require refuses calls that carry neither a valid handle nor a legacy
+	// transport session with SESSION_REQUIRED.
+	Require bool
+
+	// TTL is the handle lifetime applied on refresh-on-use. Non-positive
+	// disables refresh (the mint-time expiry stands).
+	TTL time.Duration
+
+	// InitTool is the tool that mints handles (platform_info); it is never
+	// gated, since the handle does not exist until it runs.
+	InitTool string
+
+	// ExemptTools are additional tools that bypass the SESSION_REQUIRED refusal
+	// (they may still carry and validate a handle). This carries the legacy
+	// session gate's exempt_tools forward when explicit handles supersede it, so
+	// an operator's discovery/orientation exemptions (e.g. list_connections) are
+	// honored.
+	ExemptTools []string
+
+	// Metric records the resolution source per tool call. May be nil.
+	Metric func(ctx context.Context, source string)
+}
+
+// SessionResolver extracts, validates, strips, and enforces the explicit
+// session_id handle on tools/call requests (issue #792). It is consulted by
+// MCPToolCallMiddleware after authentication so the caller's identity is
+// available for the same-identity check.
+//
+// A nil *SessionResolver is a valid no-op, so callers need not branch on
+// whether handles are configured.
+type SessionResolver struct {
+	store    pkgsession.Store
+	enabled  bool
+	require  bool
+	ttl      time.Duration
+	initTool string
+	exempt   map[string]bool
+	metric   func(ctx context.Context, source string)
+}
+
+// NewSessionResolver builds a SessionResolver. store may be nil, in which case
+// the resolver behaves as disabled.
+func NewSessionResolver(store pkgsession.Store, cfg SessionResolverConfig) *SessionResolver {
+	var exempt map[string]bool
+	if len(cfg.ExemptTools) > 0 {
+		exempt = make(map[string]bool, len(cfg.ExemptTools))
+		for _, t := range cfg.ExemptTools {
+			exempt[t] = true
+		}
+	}
+	return &SessionResolver{
+		store:    store,
+		enabled:  cfg.Enabled,
+		require:  cfg.Require,
+		ttl:      cfg.TTL,
+		initTool: cfg.InitTool,
+		exempt:   exempt,
+		metric:   cfg.Metric,
+	}
+}
+
+// resolve applies explicit-handle resolution for a tools/call request. It
+// returns a non-nil error result when the call must be refused (SESSION_REQUIRED
+// or SESSION_EXPIRED); nil means the call may proceed, with pc.SessionID set to
+// the resolved handle and the session_id argument stripped from the request.
+//
+// It runs after authentication so pc.UserID is populated for the same-identity
+// check, and before the tool call is recorded for workflow tracking so the gate
+// keys on the explicit handle.
+func (r *SessionResolver) resolve(ctx context.Context, req mcp.Request, pc *PlatformContext, toolName string) mcp.Result {
+	if r == nil || !r.enabled || r.store == nil {
+		return nil
+	}
+
+	// Always take (and strip) the handle before the tool handler or any
+	// gateway-proxied upstream server can observe the platform-injected arg.
+	handle, present := takeSessionHandleArg(req)
+
+	// The init tool mints the handle in its own handler, so it is never gated
+	// OR validated. This must precede the explicit-handle branch: an agent told
+	// to thread the handle on every call may still send a now-expired one on a
+	// platform_info re-call, and platform_info is the recovery path from
+	// SESSION_EXPIRED — validating it would refuse the very call that mints a
+	// fresh handle, deadlocking the agent.
+	if toolName == r.initTool {
+		r.recordMetric(ctx, transportSource(pc.SessionID))
+		return nil
+	}
+
+	if present && handle != "" {
+		return r.resolveExplicit(ctx, pc, toolName, handle)
+	}
+
+	// A legacy transport session (or the stdio sentinel) satisfies require
+	// during the deprecation window; an empty SessionID means no session.
+	if pc.SessionID != "" {
+		r.recordMetric(ctx, transportSource(pc.SessionID))
+		return nil
+	}
+
+	r.recordMetric(ctx, sessionSourceNone)
+	if r.require && !r.exempt[toolName] {
+		slog.Warn("session handle: missing on gated tool call",
+			logKeyTool, toolName, logKeyUserID, pc.UserID)
+		return createSessionRequiredError(r.initTool)
+	}
+	return nil
+}
+
+// resolveExplicit validates a presented handle and, on success, adopts it as
+// the session ID and refreshes its TTL. Unknown, expired, and cross-identity
+// handles are rejected identically so a caller cannot probe handle existence.
+func (r *SessionResolver) resolveExplicit(ctx context.Context, pc *PlatformContext, toolName, handle string) mcp.Result {
+	sess, err := r.store.Get(ctx, handle)
+	if err != nil {
+		// Fail OPEN on an infrastructure error, matching the search-first gate's
+		// deliberate fail-open (docs/reference/middleware.md): a transient
+		// session-store outage must degrade to allowing the call rather than
+		// locking out every handle-bearing caller. The authenticator, not the
+		// handle, is the security boundary; the handle is a session key, so an
+		// unvalidated call during an outage risks only session-scoping coherence,
+		// which self-corrects when the store recovers. The handle is adopted
+		// best-effort so audit/provenance stay coherent.
+		slog.Warn("session handle: store unavailable, allowing call unvalidated",
+			logKeyTool, toolName, logKeyError, err)
+		pc.SessionID = handle
+		r.recordMetric(ctx, sessionSourceExplicit)
+		return nil
+	}
+	if sess == nil || sess.UserID != pc.UserID {
+		slog.Warn("session handle: rejected (unknown, expired, or identity mismatch)",
+			logKeyTool, toolName, logKeyUserID, pc.UserID)
+		r.recordMetric(ctx, sessionSourceNone)
+		return createSessionExpiredError(r.initTool)
+	}
+	pc.SessionID = handle
+	r.recordMetric(ctx, sessionSourceExplicit)
+	r.refresh(sess)
+	return nil
+}
+
+// refresh extends a validated handle's expiry to now+TTL via a detached upsert,
+// preserving the handle's identity, creation time, and state. Detached so the
+// refresh outlives the request that triggered it.
+//
+// The write is throttled to the second half of the handle's lifetime: a handle
+// still more than TTL/2 from expiry is left alone, so an active session triggers
+// at most one upsert per TTL/2 rather than a full-row write on every tool call.
+func (r *SessionResolver) refresh(sess *pkgsession.Session) {
+	if r.ttl <= 0 || time.Until(sess.ExpiresAt) > r.ttl/2 {
+		return
+	}
+	extended := *sess
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), refreshTimeout)
+		defer cancel()
+		now := time.Now()
+		extended.LastActiveAt = now
+		extended.ExpiresAt = now.Add(r.ttl)
+		if err := r.store.Create(ctx, &extended); err != nil {
+			slog.Debug("session handle: refresh failed", logKeyError, err)
+		}
+	}()
+}
+
+func (r *SessionResolver) recordMetric(ctx context.Context, source string) {
+	if r.metric != nil {
+		r.metric(ctx, source)
+	}
+}
+
+// transportSource classifies a transport-derived session ID for the metric.
+func transportSource(sid string) string {
+	switch sid {
+	case "":
+		return sessionSourceNone
+	case defaultSessionID:
+		return sessionSourceStdio
+	default:
+		return sessionSourceTransport
+	}
+}
+
+// takeSessionHandleArg removes a platform-minted session handle from a
+// tools/call request's arguments and returns it. present is true only when the
+// session_id argument held a value with the platform handle prefix; that value
+// is removed so upstream tool handlers and gateway-proxied servers never see it.
+//
+// A session_id argument whose value is NOT a platform handle (a tool that
+// legitimately defines its own session_id parameter, e.g. a proxied upstream
+// tool) is left untouched and reported absent, so the handler still receives it.
+// Platform handles are prefix-tagged and unguessable, so this cannot be spoofed
+// by an ordinary caller value.
+//
+// The re-encode uses a json.Number decoder so that removing the handle does not
+// silently rewrite the other arguments' numbers (a large int64 ID would
+// otherwise round-trip through float64 and lose precision). When nothing is
+// removed, the arguments are left byte-identical.
+func takeSessionHandleArg(req mcp.Request) (handle string, present bool) {
+	callParams := toolCallParams(req)
+	if callParams == nil || len(callParams.Arguments) == 0 {
+		return "", false
+	}
+	dec := json.NewDecoder(bytes.NewReader(callParams.Arguments))
+	dec.UseNumber()
+	var args map[string]any
+	if err := dec.Decode(&args); err != nil {
+		return "", false
+	}
+	v, ok := args[sessionHandleArg]
+	if !ok {
+		return "", false
+	}
+	s, _ := v.(string)
+	// Only consume a value that looks like a platform-minted handle; a tool's
+	// own session_id argument is left in place for the handler.
+	if !pkgsession.IsHandle(s) {
+		return "", false
+	}
+	delete(args, sessionHandleArg)
+	if updated, err := json.Marshal(args); err == nil {
+		callParams.Arguments = updated
+	}
+	return s, true
+}
+
+// toolCallParams returns the raw tool-call params, or nil if the request does
+// not carry them.
+func toolCallParams(req mcp.Request) *mcp.CallToolParamsRaw {
+	if req == nil {
+		return nil
+	}
+	params := req.GetParams()
+	if params == nil {
+		return nil
+	}
+	cp, _ := params.(*mcp.CallToolParamsRaw)
+	return cp
+}
+
+// createSessionRequiredError builds a SESSION_REQUIRED error result. It emits
+// the full self-describing envelope because the resolver short-circuits before
+// the error-contract normalizer (which is registered inner to it).
+func createSessionRequiredError(initTool string) mcp.Result {
+	msg := fmt.Sprintf(
+		"SESSION_REQUIRED: Call %s first. It returns a session_id you must pass as the "+
+			"session_id argument on every subsequent tool call.",
+		initTool,
+	)
+	return BuildErrorResult(NewToolError(
+		CodeSessionRequired, ErrCategorySessionRequired, msg,
+		fmt.Sprintf("Call %s first, then retry with the session_id it returns. "+
+			"This is a session-setup requirement, not a platform outage.", initTool),
+	))
+}
+
+// createSessionExpiredError builds a SESSION_EXPIRED error result for a handle
+// that is unknown, expired, or presented by a different identity.
+func createSessionExpiredError(initTool string) mcp.Result {
+	msg := fmt.Sprintf(
+		"SESSION_EXPIRED: Your session_id is unknown or expired. Call %s again to mint a "+
+			"fresh session_id, then pass it on every subsequent tool call.",
+		initTool,
+	)
+	return BuildErrorResult(NewToolError(
+		CodeSessionExpired, ErrCategorySessionRequired, msg,
+		fmt.Sprintf("Call %s to mint a fresh session_id, then retry. "+
+			"This is a session-setup requirement, not a platform outage.", initTool),
+	))
+}
+
+// MCPSessionHandleSchemaMiddleware creates MCP protocol-level middleware that
+// injects a session_id string property into every tool's input schema on
+// tools/list responses, except the init tool (which mints the handle and takes
+// no session_id). It mirrors the MCPAppsMetadataMiddleware / description-override
+// decorators: it touches only the list response, so upstream toolkits
+// (mcp-trino, mcp-datahub, mcp-s3, gateway-proxied tools) are never modified.
+func MCPSessionHandleSchemaMiddleware(initTool string) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			result, err := next(ctx, method, req)
+			if err != nil {
+				return result, err
+			}
+			if method != methodToolsList {
+				return result, nil
+			}
+			return injectSessionHandleSchema(initTool, result), nil
+		}
+	}
+}
+
+// injectSessionHandleSchema adds the session_id property to each listed tool's
+// input schema. It replaces the Tool pointer in the result slice with a shallow
+// copy carrying the augmented schema, so the server's shared tool registry is
+// never mutated.
+func injectSessionHandleSchema(initTool string, result mcp.Result) mcp.Result {
+	listResult, ok := result.(*mcp.ListToolsResult)
+	if !ok || listResult == nil {
+		return result
+	}
+	for i, tool := range listResult.Tools {
+		if tool == nil || tool.Name == initTool {
+			continue
+		}
+		injected, ok := withSessionHandleProperty(tool.InputSchema)
+		if !ok {
+			continue
+		}
+		cp := *tool
+		cp.InputSchema = injected
+		listResult.Tools[i] = &cp
+	}
+	return listResult
+}
+
+// withSessionHandleProperty returns a copy of a tool input schema with a
+// session_id string property added to its properties. It normalizes any schema
+// representation (*jsonschema.Schema, json.RawMessage, or map) via a JSON
+// round-trip, so one code path covers every registration style. The second
+// return is false when the schema is not a JSON object (the tool is then left
+// unchanged).
+func withSessionHandleProperty(schema any) (any, bool) {
+	if schema == nil {
+		return nil, false
+	}
+	raw, err := json.Marshal(schema)
+	if err != nil {
+		return nil, false
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, false
+	}
+	// Only object schemas carry named properties.
+	if t, _ := obj["type"].(string); t != "" && t != "object" {
+		return nil, false
+	}
+	existing, _ := obj["properties"].(map[string]any)
+	// No capacity hint: len(existing) derives from a decoded schema, which the
+	// allocation-size-overflow analysis treats as untrusted; the map grows fine.
+	props := make(map[string]any)
+	maps.Copy(props, existing)
+	if _, exists := props[sessionHandleArg]; !exists {
+		props[sessionHandleArg] = map[string]any{
+			"type":        "string",
+			"description": sessionHandleSchemaDescription,
+		}
+	}
+	obj["properties"] = props
+	return obj, true
+}

--- a/pkg/middleware/mcp_session_handle_integration_test.go
+++ b/pkg/middleware/mcp_session_handle_integration_test.go
@@ -1,0 +1,276 @@
+package middleware_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/searchgate"
+	pkgsession "github.com/txn2/mcp-data-platform/pkg/session"
+)
+
+const shInitTool = "platform_info"
+
+type shSQLInput struct {
+	SQL string `json:"sql,omitempty"`
+}
+
+// shHarness bundles the assembled server and the stores/loggers a test asserts
+// against.
+type shHarness struct {
+	server     *mcp.Server
+	audit      *recordingAuditLogger
+	store      pkgsession.Store
+	provenance *middleware.ProvenanceTracker
+}
+
+// sessionHandleServer wires the real assembled middleware chain (tool-call
+// middleware with the session-handle resolver, the search-first workflow gate,
+// and audit) plus the schema-injection list decorator, then registers a
+// platform_info tool that mints handles into the shared store, a search tool,
+// and a trino_query tool.
+func sessionHandleServer(t *testing.T) shHarness {
+	t.Helper()
+	store := pkgsession.NewMemoryStore(time.Hour)
+	sgStore := searchgate.NewMemoryStore(time.Hour)
+	tracker := middleware.NewSessionWorkflowTracker(
+		[]string{"search"}, []string{"trino_query"}, sgStore, time.Hour)
+	auditLog := &recordingAuditLogger{}
+	provenance := middleware.NewProvenanceTracker()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "session-handle-test", Version: "v0"}, nil)
+
+	// platform_info mints a handle owned by the caller and returns it, mirroring
+	// the real info_tool mint.
+	mcp.AddTool(server, &mcp.Tool{Name: shInitTool, Description: "init"},
+		func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+			handle, err := pkgsession.GenerateHandle()
+			if err != nil {
+				return nil, nil, fmt.Errorf("mint handle: %w", err)
+			}
+			uid := ""
+			if pc := middleware.GetPlatformContext(ctx); pc != nil {
+				uid = pc.UserID
+			}
+			now := time.Now()
+			if cerr := store.Create(ctx, &pkgsession.Session{
+				ID: handle, UserID: uid, CreatedAt: now, LastActiveAt: now,
+				ExpiresAt: now.Add(time.Hour),
+				State:     map[string]any{pkgsession.StateKeyMintedBy: pkgsession.MintedByPlatformInfo},
+			}); cerr != nil {
+				return nil, nil, fmt.Errorf("persist handle: %w", cerr)
+			}
+			return &mcp.CallToolResult{
+				Content:           []mcp.Content{&mcp.TextContent{Text: handle}},
+				StructuredContent: map[string]any{"session_id": handle},
+			}, nil, nil
+		})
+
+	okHandler := func(_ context.Context, _ *mcp.CallToolRequest, _ shSQLInput) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil, nil
+	}
+	mcp.AddTool(server, &mcp.Tool{Name: "search", Description: "discover"}, okHandler)
+	mcp.AddTool(server, &mcp.Tool{Name: "trino_query", Description: "query"}, okHandler)
+
+	// Chain, innermost added first (last-added runs first).
+	server.AddReceivingMiddleware(middleware.MCPProvenanceMiddleware(provenance))
+	server.AddReceivingMiddleware(middleware.MCPAuditMiddleware(auditLog))
+	server.AddReceivingMiddleware(middleware.MCPWorkflowGateMiddleware(tracker))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(
+		&fakeAuthn{user: &middleware.UserInfo{UserID: "user-1", Email: "analyst@example.com", Roles: []string{"analyst"}}},
+		&fakeAuthz{persona: "analyst"},
+		&fakeLookup{kind: "trino", name: "prod", conn: "primary"},
+		middleware.ToolCallConfig{
+			Transport:       "http",
+			AdminPersona:    "admin",
+			WorkflowTracker: tracker,
+			SessionResolver: middleware.NewSessionResolver(store, middleware.SessionResolverConfig{
+				Enabled:  true,
+				Require:  true,
+				TTL:      time.Hour,
+				InitTool: shInitTool,
+			}),
+		},
+	))
+	server.AddReceivingMiddleware(middleware.MCPSessionHandleSchemaMiddleware(shInitTool))
+	return shHarness{server: server, audit: auditLog, store: store, provenance: provenance}
+}
+
+// mintViaPlatformInfo calls platform_info and returns the minted handle.
+func mintViaPlatformInfo(ctx context.Context, t *testing.T, sess *mcp.ClientSession) string {
+	t.Helper()
+	res, err := sess.CallTool(ctx, &mcp.CallToolParams{Name: shInitTool})
+	require.NoError(t, err)
+	require.False(t, res.IsError, "platform_info must succeed")
+	require.NotEmpty(t, res.Content)
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	require.True(t, pkgsession.IsHandle(tc.Text), "platform_info must return a dps_ handle")
+	return tc.Text
+}
+
+// TestIntegration_SessionHandle_ThreadedFlow proves the assembled chain end to
+// end: platform_info mints a handle, the handle threads through the resolver,
+// the search-first gate keys on it, and the audit rows share it (acceptance
+// criteria 4 and 7).
+func TestIntegration_SessionHandle_ThreadedFlow(t *testing.T) {
+	ctx := context.Background()
+	h := sessionHandleServer(t)
+	sess := mustConnect(ctx, t, h.server)
+	defer func() { _ = sess.Close() }()
+
+	handle := mintViaPlatformInfo(ctx, t, sess)
+
+	// trino_query BEFORE search under the handle -> SEARCH_REQUIRED (init gate
+	// passed, discovery gate not yet).
+	res, err := sess.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "trino_query",
+		Arguments: map[string]any{"sql": "SELECT 1", "session_id": handle},
+	})
+	require.NoError(t, err)
+	require.True(t, res.IsError, "query before search must be refused")
+	assert.Equal(t, middleware.CodeSearchRequired, clientErrCode(t, res))
+
+	// search under the handle opens the gate.
+	res, err = sess.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "search",
+		Arguments: map[string]any{"session_id": handle},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError, "search must succeed: %v", res)
+
+	// trino_query AFTER search executes.
+	res, err = sess.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "trino_query",
+		Arguments: map[string]any{"sql": "SELECT 1", "session_id": handle},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError, "query after search must execute: %v", res)
+
+	// Criterion 7: audit rows for search and trino_query share the minted handle.
+	searchEvent, ok := waitForAuditEvent(h.audit, "search", 2*time.Second)
+	require.True(t, ok, "expected an audit row for search")
+	assert.Equal(t, handle, searchEvent.SessionID)
+	queryEvent, ok := waitForAuditEvent(h.audit, "trino_query", 2*time.Second)
+	require.True(t, ok, "expected an audit row for trino_query")
+	assert.Equal(t, handle, queryEvent.SessionID)
+
+	// Criterion 6: provenance is keyed by the threaded handle, so the calls are
+	// recorded under it (not dropped as they would be under an empty session on
+	// a headerless transport).
+	calls := h.provenance.Harvest(handle)
+	tools := make([]string, 0, len(calls))
+	for _, c := range calls {
+		tools = append(tools, c.ToolName)
+	}
+	assert.Contains(t, tools, "search")
+	assert.Contains(t, tools, "trino_query")
+}
+
+// TestIntegration_SessionHandle_ExpiredRejectedBeforeHandler proves an unknown
+// handle is refused with SESSION_EXPIRED before the handler or audit run
+// (acceptance criterion 3's mechanism: refused before execution, no handler
+// audit row).
+func TestIntegration_SessionHandle_ExpiredRejectedBeforeHandler(t *testing.T) {
+	ctx := context.Background()
+	h := sessionHandleServer(t)
+	sess := mustConnect(ctx, t, h.server)
+	defer func() { _ = sess.Close() }()
+
+	res, err := sess.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "trino_query",
+		Arguments: map[string]any{"sql": "SELECT 1", "session_id": "dps_unknownhandle"},
+	})
+	require.NoError(t, err)
+	require.True(t, res.IsError)
+	assert.Equal(t, middleware.CodeSessionExpired, clientErrCode(t, res))
+
+	// No audit row for a handler execution of trino_query.
+	if e, ok := waitForAuditEvent(h.audit, "trino_query", 300*time.Millisecond); ok {
+		t.Fatalf("a refused call must not produce a handler audit row: %+v", e)
+	}
+}
+
+// TestIntegration_SessionHandle_IdentityMismatch is acceptance criterion 5: a
+// handle minted under one identity, presented by another, is rejected.
+func TestIntegration_SessionHandle_IdentityMismatch(t *testing.T) {
+	ctx := context.Background()
+	h := sessionHandleServer(t)
+	sess := mustConnect(ctx, t, h.server)
+	defer func() { _ = sess.Close() }()
+
+	// A handle owned by a DIFFERENT identity than the fake authenticator's user-1.
+	other, err := pkgsession.GenerateHandle()
+	require.NoError(t, err)
+	now := time.Now()
+	require.NoError(t, h.store.Create(ctx, &pkgsession.Session{
+		ID: other, UserID: "user-2", CreatedAt: now, LastActiveAt: now, ExpiresAt: now.Add(time.Hour),
+	}))
+
+	res, err := sess.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "trino_query",
+		Arguments: map[string]any{"sql": "SELECT 1", "session_id": other},
+	})
+	require.NoError(t, err)
+	require.True(t, res.IsError, "cross-identity handle must be rejected")
+	assert.Equal(t, middleware.CodeSessionExpired, clientErrCode(t, res))
+}
+
+// TestIntegration_SessionHandle_ListSchemaInjection is acceptance criterion 2:
+// tools/list advertises session_id on every tool except platform_info.
+func TestIntegration_SessionHandle_ListSchemaInjection(t *testing.T) {
+	ctx := context.Background()
+	h := sessionHandleServer(t)
+	sess := mustConnect(ctx, t, h.server)
+	defer func() { _ = sess.Close() }()
+
+	res, err := sess.ListTools(ctx, &mcp.ListToolsParams{})
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Tools)
+
+	seen := map[string]bool{}
+	for _, tool := range res.Tools {
+		seen[tool.Name] = true
+		hasSessionID := toolSchemaHasProperty(t, tool, "session_id")
+		if tool.Name == shInitTool {
+			assert.False(t, hasSessionID, "platform_info must NOT advertise session_id")
+		} else {
+			assert.True(t, hasSessionID, "%s must advertise session_id", tool.Name)
+		}
+	}
+	require.True(t, seen[shInitTool] && seen["search"] && seen["trino_query"], "all tools listed")
+}
+
+// clientErrCode extracts the structured error code from a tool result as it
+// arrives over the wire.
+func clientErrCode(t *testing.T, r *mcp.CallToolResult) string {
+	t.Helper()
+	sc, ok := r.StructuredContent.(map[string]any)
+	require.True(t, ok, "structuredContent must round-trip as a map")
+	e, ok := sc["error"].(map[string]any)
+	require.True(t, ok, "structuredContent.error must be present")
+	code, _ := e["code"].(string)
+	return code
+}
+
+// toolSchemaHasProperty reports whether the tool's input schema (as received by
+// the client, a map[string]any) declares the named property.
+func toolSchemaHasProperty(t *testing.T, tool *mcp.Tool, name string) bool {
+	t.Helper()
+	schema, ok := tool.InputSchema.(map[string]any)
+	if !ok {
+		return false
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return false
+	}
+	_, present := props[name]
+	return present
+}

--- a/pkg/middleware/mcp_session_handle_test.go
+++ b/pkg/middleware/mcp_session_handle_test.go
@@ -1,0 +1,507 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	pkgsession "github.com/txn2/mcp-data-platform/pkg/session"
+)
+
+const testInitTool = "platform_info"
+
+func makeCallReq(toolName string, args map[string]any) mcp.Request {
+	var raw json.RawMessage
+	if args != nil {
+		raw, _ = json.Marshal(args)
+	}
+	return &mcp.ServerRequest[*mcp.CallToolParamsRaw]{
+		Params: &mcp.CallToolParamsRaw{Name: toolName, Arguments: raw},
+	}
+}
+
+func reqArgs(t *testing.T, req mcp.Request) map[string]any {
+	t.Helper()
+	cp, ok := req.GetParams().(*mcp.CallToolParamsRaw)
+	if !ok {
+		t.Fatal("expected *CallToolParamsRaw")
+	}
+	if len(cp.Arguments) == 0 {
+		return map[string]any{}
+	}
+	var m map[string]any
+	if err := json.Unmarshal(cp.Arguments, &m); err != nil {
+		t.Fatalf("unmarshal args: %v", err)
+	}
+	return m
+}
+
+// mintHandle inserts a valid handle owned by userID into the store.
+func mintHandle(t *testing.T, store pkgsession.Store, userID string) string {
+	t.Helper()
+	h, err := pkgsession.GenerateHandle()
+	if err != nil {
+		t.Fatalf("GenerateHandle: %v", err)
+	}
+	now := time.Now()
+	if err := store.Create(context.Background(), &pkgsession.Session{
+		ID: h, UserID: userID, CreatedAt: now, LastActiveAt: now,
+		ExpiresAt: now.Add(time.Hour),
+		State:     map[string]any{pkgsession.StateKeyMintedBy: pkgsession.MintedByPlatformInfo},
+	}); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+	return h
+}
+
+func newResolver(store pkgsession.Store, require bool) *SessionResolver {
+	return NewSessionResolver(store, SessionResolverConfig{
+		Enabled:  true,
+		Require:  require,
+		TTL:      time.Hour,
+		InitTool: testInitTool,
+	})
+}
+
+func errCode(t *testing.T, result mcp.Result) string {
+	t.Helper()
+	ctr, ok := result.(*mcp.CallToolResult)
+	if !ok || ctr == nil {
+		t.Fatalf("expected *CallToolResult, got %T", result)
+	}
+	sc, ok := ctr.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("expected structured error content, got %T", ctr.StructuredContent)
+	}
+	env, ok := sc[errorEnvelopeKey].(errorPayload)
+	if !ok {
+		t.Fatalf("expected errorPayload envelope, got %T", sc[errorEnvelopeKey])
+	}
+	return env.Code
+}
+
+func TestSessionResolver_ValidHandle(t *testing.T) {
+	store := pkgsession.NewMemoryStore(time.Hour)
+	r := newResolver(store, true)
+	h := mintHandle(t, store, "user-1")
+
+	pc := NewPlatformContext("req")
+	pc.UserID = "user-1"
+	pc.SessionID = "" // stateless HTTP, no transport session
+	req := makeCallReq("trino_query", map[string]any{"sql": "SELECT 1", sessionHandleArg: h})
+
+	if got := r.resolve(context.Background(), req, pc, "trino_query"); got != nil {
+		t.Fatalf("valid handle rejected: code=%s", errCode(t, got))
+	}
+	if pc.SessionID != h {
+		t.Errorf("pc.SessionID = %q, want handle %q", pc.SessionID, h)
+	}
+	// The session_id argument must be stripped before the handler.
+	if _, present := reqArgs(t, req)[sessionHandleArg]; present {
+		t.Error("session_id argument was not stripped from the request")
+	}
+	// Other arguments are preserved.
+	if reqArgs(t, req)["sql"] != "SELECT 1" {
+		t.Error("sql argument was not preserved")
+	}
+}
+
+// TestSessionResolver_RefreshExtendsNearExpiry proves refresh-on-use fires once
+// a handle is past the halfway point of its lifetime (the throttle's fire path;
+// TestSessionResolver_ValidHandle covers the skip path with a fresh handle).
+func TestSessionResolver_RefreshExtendsNearExpiry(t *testing.T) {
+	store := pkgsession.NewMemoryStore(time.Hour)
+	r := newResolver(store, true) // ttl 1h
+	h, err := pkgsession.GenerateHandle()
+	if err != nil {
+		t.Fatalf("GenerateHandle: %v", err)
+	}
+	now := time.Now()
+	// Expires in a minute: well past the TTL/2 (30m) throttle point.
+	if err := store.Create(context.Background(), &pkgsession.Session{
+		ID: h, UserID: "u", CreatedAt: now, LastActiveAt: now, ExpiresAt: now.Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+
+	pc := NewPlatformContext("req")
+	pc.UserID = "u"
+	req := makeCallReq("trino_query", map[string]any{sessionHandleArg: h})
+	if got := r.resolve(context.Background(), req, pc, "trino_query"); got != nil {
+		t.Fatalf("near-expiry valid handle rejected: %s", errCode(t, got))
+	}
+
+	// The detached refresh should extend the expiry well beyond the original minute.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if s, _ := store.Get(context.Background(), h); s != nil && s.ExpiresAt.After(now.Add(30*time.Minute)) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("handle expiry was not refreshed on use")
+}
+
+func TestSessionResolver_UnknownAndExpiredRejected(t *testing.T) {
+	store := pkgsession.NewMemoryStore(time.Hour)
+	r := newResolver(store, true)
+
+	pc := NewPlatformContext("req")
+	pc.UserID = "user-1"
+	req := makeCallReq("trino_query", map[string]any{sessionHandleArg: "dps_deadbeef"})
+
+	result := r.resolve(context.Background(), req, pc, "trino_query")
+	if result == nil {
+		t.Fatal("unknown handle should be rejected")
+	}
+	if code := errCode(t, result); code != CodeSessionExpired {
+		t.Errorf("code = %q, want %q", code, CodeSessionExpired)
+	}
+	// Even rejected, the argument is stripped.
+	if _, present := reqArgs(t, req)[sessionHandleArg]; present {
+		t.Error("session_id must be stripped even when rejected")
+	}
+}
+
+// TestSessionResolver_IdentityMismatch is acceptance criterion 5.
+func TestSessionResolver_IdentityMismatch(t *testing.T) {
+	store := pkgsession.NewMemoryStore(time.Hour)
+	r := newResolver(store, true)
+	h := mintHandle(t, store, "user-A")
+
+	pc := NewPlatformContext("req")
+	pc.UserID = "user-B" // different identity presents A's handle
+	req := makeCallReq("trino_query", map[string]any{sessionHandleArg: h})
+
+	result := r.resolve(context.Background(), req, pc, "trino_query")
+	if result == nil {
+		t.Fatal("cross-identity handle should be rejected")
+	}
+	if code := errCode(t, result); code != CodeSessionExpired {
+		t.Errorf("code = %q, want %q", code, CodeSessionExpired)
+	}
+	if pc.SessionID == h {
+		t.Error("pc.SessionID must not adopt a cross-identity handle")
+	}
+}
+
+// TestSessionResolver_NonHandleSessionIDPreserved proves a tool that legitimately
+// defines its own session_id parameter (e.g. a proxied upstream tool) is not
+// hijacked: a value without the platform handle prefix is neither stripped nor
+// treated as a handle, so the handler still receives it.
+func TestSessionResolver_NonHandleSessionIDPreserved(t *testing.T) {
+	store := pkgsession.NewMemoryStore(time.Hour)
+	r := newResolver(store, false) // require off: the call must pass through
+	pc := NewPlatformContext("req")
+	pc.UserID = "user-1"
+	pc.SessionID = "transport"
+	req := makeCallReq("proxied_tool", map[string]any{"session_id": "upstream-uuid-1234", "q": "x"})
+
+	if got := r.resolve(context.Background(), req, pc, "proxied_tool"); got != nil {
+		t.Fatalf("a non-handle session_id must not be treated as a platform handle: %s", errCode(t, got))
+	}
+	args := reqArgs(t, req)
+	if args[sessionHandleArg] != "upstream-uuid-1234" {
+		t.Errorf("tool's own session_id must survive, got %v", args[sessionHandleArg])
+	}
+}
+
+func TestSessionResolver_MissingHandleRequired(t *testing.T) {
+	store := pkgsession.NewMemoryStore(time.Hour)
+	r := newResolver(store, true)
+
+	pc := NewPlatformContext("req")
+	pc.UserID = "user-1"
+	pc.SessionID = "" // no transport session
+	req := makeCallReq("trino_query", map[string]any{"sql": "SELECT 1"})
+
+	result := r.resolve(context.Background(), req, pc, "trino_query")
+	if result == nil {
+		t.Fatal("missing handle with require=on should be refused")
+	}
+	if code := errCode(t, result); code != CodeSessionRequired {
+		t.Errorf("code = %q, want %q", code, CodeSessionRequired)
+	}
+}
+
+// TestSessionResolver_ExemptToolBypassesRequire proves an exempt tool (carried
+// from the legacy gate's exempt_tools) is reachable without a handle even when
+// require is on.
+func TestSessionResolver_ExemptToolBypassesRequire(t *testing.T) {
+	store := pkgsession.NewMemoryStore(time.Hour)
+	r := NewSessionResolver(store, SessionResolverConfig{
+		Enabled: true, Require: true, TTL: time.Hour, InitTool: testInitTool,
+		ExemptTools: []string{"list_connections"},
+	})
+
+	pc := NewPlatformContext("req")
+	pc.UserID = "user-1"
+	pc.SessionID = "" // no handle, no transport session
+
+	if got := r.resolve(context.Background(), makeCallReq("list_connections", nil), pc, "list_connections"); got != nil {
+		t.Fatalf("exempt tool must bypass SESSION_REQUIRED: code=%s", errCode(t, got))
+	}
+	// A non-exempt tool under the same conditions is still refused.
+	if got := r.resolve(context.Background(), makeCallReq("trino_query", nil), pc, "trino_query"); got == nil {
+		t.Fatal("non-exempt tool must still be refused")
+	}
+}
+
+func TestSessionResolver_MissingHandleNotRequired(t *testing.T) {
+	store := pkgsession.NewMemoryStore(time.Hour)
+	r := newResolver(store, false) // require=off
+
+	pc := NewPlatformContext("req")
+	pc.UserID = "user-1"
+	pc.SessionID = ""
+	req := makeCallReq("trino_query", map[string]any{"sql": "SELECT 1"})
+
+	if got := r.resolve(context.Background(), req, pc, "trino_query"); got != nil {
+		t.Fatalf("require=off should allow handle-less calls, got code=%s", errCode(t, got))
+	}
+}
+
+func TestSessionResolver_LegacyTransportSessionSatisfiesRequire(t *testing.T) {
+	store := pkgsession.NewMemoryStore(time.Hour)
+	r := newResolver(store, true)
+
+	pc := NewPlatformContext("req")
+	pc.UserID = "user-1"
+	pc.SessionID = "legacy-transport-hex" // resolved from Mcp-Session-Id
+	req := makeCallReq("trino_query", map[string]any{"sql": "SELECT 1"})
+
+	if got := r.resolve(context.Background(), req, pc, "trino_query"); got != nil {
+		t.Fatalf("legacy transport session should satisfy require, got code=%s", errCode(t, got))
+	}
+	if pc.SessionID != "legacy-transport-hex" {
+		t.Errorf("transport session must be preserved, got %q", pc.SessionID)
+	}
+}
+
+func TestSessionResolver_InitToolExempt(t *testing.T) {
+	store := pkgsession.NewMemoryStore(time.Hour)
+	r := newResolver(store, true)
+
+	pc := NewPlatformContext("req")
+	pc.UserID = "user-1"
+	pc.SessionID = "" // platform_info can be the very first call
+	req := makeCallReq(testInitTool, nil)
+
+	if got := r.resolve(context.Background(), req, pc, testInitTool); got != nil {
+		t.Fatalf("init tool must never be gated, got code=%s", errCode(t, got))
+	}
+}
+
+// TestSessionResolver_InitToolExemptEvenWithStaleHandle guards the recovery
+// path: an agent that threads a now-expired handle on a platform_info re-call
+// must NOT be refused, or it can never mint a fresh handle.
+func TestSessionResolver_InitToolExemptEvenWithStaleHandle(t *testing.T) {
+	store := pkgsession.NewMemoryStore(time.Hour)
+	r := newResolver(store, true)
+
+	pc := NewPlatformContext("req")
+	pc.UserID = "user-1"
+	req := makeCallReq(testInitTool, map[string]any{sessionHandleArg: "dps_expiredstale"})
+
+	if got := r.resolve(context.Background(), req, pc, testInitTool); got != nil {
+		t.Fatalf("platform_info must never be refused, even with a stale handle: code=%s", errCode(t, got))
+	}
+	// The stale handle argument is still stripped before the handler.
+	if _, present := reqArgs(t, req)[sessionHandleArg]; present {
+		t.Error("session_id must be stripped from platform_info calls too")
+	}
+}
+
+func TestSessionResolver_StdioSentinelSatisfiesRequire(t *testing.T) {
+	store := pkgsession.NewMemoryStore(time.Hour)
+	r := newResolver(store, true)
+
+	pc := NewPlatformContext("req")
+	pc.SessionID = defaultSessionID // "stdio"
+	req := makeCallReq("trino_query", map[string]any{"sql": "SELECT 1"})
+
+	if got := r.resolve(context.Background(), req, pc, "trino_query"); got != nil {
+		t.Fatalf("stdio sentinel should keep stdio usable, got code=%s", errCode(t, got))
+	}
+}
+
+func TestSessionResolver_DisabledIsNoop(t *testing.T) {
+	store := pkgsession.NewMemoryStore(time.Hour)
+	r := NewSessionResolver(store, SessionResolverConfig{Enabled: false, Require: true, InitTool: testInitTool})
+
+	pc := NewPlatformContext("req")
+	pc.SessionID = "transport"
+	req := makeCallReq("trino_query", map[string]any{"sql": "SELECT 1", sessionHandleArg: "dps_x"})
+
+	if got := r.resolve(context.Background(), req, pc, "trino_query"); got != nil {
+		t.Fatal("disabled resolver must be a no-op")
+	}
+	// Disabled: the argument is NOT stripped and SessionID is untouched.
+	if _, present := reqArgs(t, req)[sessionHandleArg]; !present {
+		t.Error("disabled resolver must not strip the argument")
+	}
+	if pc.SessionID != "transport" {
+		t.Error("disabled resolver must not alter SessionID")
+	}
+}
+
+func TestSessionResolver_NilIsNoop(t *testing.T) {
+	var r *SessionResolver
+	pc := NewPlatformContext("req")
+	pc.SessionID = "x"
+	req := makeCallReq("trino_query", map[string]any{"sql": "SELECT 1"})
+	if got := r.resolve(context.Background(), req, pc, "trino_query"); got != nil {
+		t.Fatal("nil resolver must be a no-op")
+	}
+}
+
+func TestSessionResolver_MetricSources(t *testing.T) {
+	store := pkgsession.NewMemoryStore(time.Hour)
+	var got []string
+	r := NewSessionResolver(store, SessionResolverConfig{
+		Enabled: true, Require: false, TTL: time.Hour, InitTool: testInitTool,
+		Metric: func(_ context.Context, source string) { got = append(got, source) },
+	})
+	h := mintHandle(t, store, "u")
+
+	cases := []struct {
+		name     string
+		pcSID    string
+		args     map[string]any
+		tool     string
+		wantLast string
+	}{
+		{"explicit", "", map[string]any{sessionHandleArg: h}, "trino_query", sessionSourceExplicit},
+		{"transport", "hex", map[string]any{"sql": "x"}, "trino_query", sessionSourceTransport},
+		{"stdio", defaultSessionID, map[string]any{"sql": "x"}, "trino_query", sessionSourceStdio},
+		{"none", "", map[string]any{"sql": "x"}, "trino_query", sessionSourceNone},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got = nil
+			pc := NewPlatformContext("req")
+			pc.UserID = "u"
+			pc.SessionID = tc.pcSID
+			r.resolve(context.Background(), makeCallReq(tc.tool, tc.args), pc, tc.tool)
+			if len(got) == 0 || got[len(got)-1] != tc.wantLast {
+				t.Errorf("metric source = %v, want last %q", got, tc.wantLast)
+			}
+		})
+	}
+}
+
+// getErrorStore embeds a MemoryStore but forces Get to error, exercising the
+// resolver's fail-closed path.
+type getErrorStore struct {
+	*pkgsession.MemoryStore
+}
+
+func (getErrorStore) Get(context.Context, string) (*pkgsession.Session, error) {
+	return nil, errStoreDown
+}
+
+var errStoreDown = &storeError{}
+
+type storeError struct{}
+
+func (*storeError) Error() string { return "store down" }
+
+// TestSessionResolver_StoreErrorFailsOpen proves a transient session-store
+// outage degrades to allowing the call (matching the search-first gate) rather
+// than locking out every handle-bearing caller.
+func TestSessionResolver_StoreErrorFailsOpen(t *testing.T) {
+	store := getErrorStore{pkgsession.NewMemoryStore(time.Hour)}
+	r := newResolver(store, true)
+
+	pc := NewPlatformContext("req")
+	pc.UserID = "user-1"
+	req := makeCallReq("trino_query", map[string]any{sessionHandleArg: "dps_whatever"})
+
+	if result := r.resolve(context.Background(), req, pc, "trino_query"); result != nil {
+		t.Fatalf("a store error must fail open, got refusal code=%s", errCode(t, result))
+	}
+	// The handle is adopted best-effort so session-scoped records stay coherent.
+	if pc.SessionID != "dps_whatever" {
+		t.Errorf("pc.SessionID = %q, want handle adopted best-effort", pc.SessionID)
+	}
+}
+
+func TestToolCallParams_NilRequest(t *testing.T) {
+	if toolCallParams(nil) != nil {
+		t.Error("toolCallParams(nil) must be nil")
+	}
+	if _, present := takeSessionHandleArg(nil); present {
+		t.Error("takeSessionHandleArg(nil) must report no handle")
+	}
+}
+
+func TestWithSessionHandleProperty(t *testing.T) {
+	t.Run("map schema", func(t *testing.T) {
+		in := map[string]any{"type": "object", "properties": map[string]any{"sql": map[string]any{"type": "string"}}}
+		out, ok := withSessionHandleProperty(in)
+		if !ok {
+			t.Fatal("expected injection into object schema")
+		}
+		assertHasSessionProp(t, out)
+	})
+
+	t.Run("json.RawMessage schema", func(t *testing.T) {
+		in := json.RawMessage(`{"type":"object","properties":{"sql":{"type":"string"}},"additionalProperties":false}`)
+		out, ok := withSessionHandleProperty(in)
+		if !ok {
+			t.Fatal("expected injection into raw schema")
+		}
+		assertHasSessionProp(t, out)
+	})
+
+	t.Run("nil schema skipped", func(t *testing.T) {
+		if _, ok := withSessionHandleProperty(nil); ok {
+			t.Error("nil schema must be skipped")
+		}
+	})
+
+	t.Run("non-object schema skipped", func(t *testing.T) {
+		if _, ok := withSessionHandleProperty(map[string]any{"type": "string"}); ok {
+			t.Error("non-object schema must be skipped")
+		}
+	})
+
+	t.Run("idempotent when already present", func(t *testing.T) {
+		in := map[string]any{"type": "object", "properties": map[string]any{sessionHandleArg: map[string]any{"type": "string"}}}
+		out, ok := withSessionHandleProperty(in)
+		if !ok {
+			t.Fatal("expected ok")
+		}
+		obj, _ := out.(map[string]any)
+		props, _ := obj["properties"].(map[string]any)
+		if len(props) != 1 {
+			t.Errorf("expected no duplicate property, got %d", len(props))
+		}
+	})
+}
+
+func assertHasSessionProp(t *testing.T, schema any) {
+	t.Helper()
+	obj, ok := schema.(map[string]any)
+	if !ok {
+		t.Fatalf("schema is not a map: %T", schema)
+	}
+	props, ok := obj["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("no properties map")
+	}
+	prop, ok := props[sessionHandleArg].(map[string]any)
+	if !ok {
+		t.Fatal("session_id property missing")
+	}
+	if prop["type"] != "string" {
+		t.Errorf("session_id type = %v, want string", prop["type"])
+	}
+	if _, stillHasSQL := props["sql"]; !stillHasSQL {
+		// sql only present in the non-idempotent cases; guard optional.
+		_ = stillHasSQL
+	}
+}

--- a/pkg/observability/metrics.go
+++ b/pkg/observability/metrics.go
@@ -48,6 +48,7 @@ const (
 	instToolCalls            = "mcp_tool_calls"
 	instToolCallDuration     = "mcp_tool_call_duration"
 	instInflightToolCalls    = "mcp_inflight_tool_calls"
+	instSessionResolution    = "mcp_session_resolution"
 	instAPIGwOutbound        = "apigateway_outbound"
 	instAPIGwOutboundLatency = "apigateway_outbound_duration"
 	instAPIGwInbound         = "apigateway_inbound_requests"
@@ -128,6 +129,7 @@ const (
 	attrPersona        = "persona"
 	attrStatusCategory = "status_category"
 	attrConnection     = "connection"
+	attrSource         = "source"
 	attrHTTPStatus     = "http_status_class"
 	attrOperationID    = "operation_id"
 	attrMethod         = "method"
@@ -192,6 +194,7 @@ type Metrics struct {
 	toolCallsTotal        metric.Int64Counter
 	toolCallDuration      metric.Float64Histogram
 	inflightToolCalls     metric.Int64UpDownCounter
+	sessionResolutions    metric.Int64Counter
 	apigwOutboundTotal    metric.Int64Counter
 	apigwOutboundDuration metric.Float64Histogram
 	apigwInboundTotal     metric.Int64Counter
@@ -345,6 +348,13 @@ func (m *Metrics) registerInstruments(meter metric.Meter) error {
 	if err != nil {
 		return fmt.Errorf(instErrFmt, instInflightToolCalls, err)
 	}
+	m.sessionResolutions, err = meter.Int64Counter(
+		instSessionResolution,
+		metric.WithDescription("Total MCP tool calls by how their session was resolved (explicit handle, transport session, stdio sentinel, or none), for watching migration to explicit session handles (#792)."),
+	)
+	if err != nil {
+		return fmt.Errorf(instErrFmt, instSessionResolution, err)
+	}
 	m.apigwOutboundTotal, err = meter.Int64Counter(
 		instAPIGwOutbound,
 		metric.WithDescription("Total number of outbound HTTP calls made by the apigateway toolkit, labeled by connection, http_status_class, and status_category."),
@@ -495,6 +505,15 @@ func (m *Metrics) RecordToolCall(ctx context.Context, attrs ToolCallAttrs, durat
 	)
 	m.toolCallsTotal.Add(ctx, 1, set)
 	m.toolCallDuration.Record(ctx, duration.Seconds(), set)
+}
+
+// RecordSessionResolution records one tool call labeled by how its session was
+// resolved (source: explicit, transport, stdio, or none). Nil-safe.
+func (m *Metrics) RecordSessionResolution(ctx context.Context, source string) {
+	if m == nil {
+		return
+	}
+	m.sessionResolutions.Add(ctx, 1, metric.WithAttributes(attribute.String(attrSource, source)))
 }
 
 // IncInflightToolCalls increments the in-flight gauge. Paired with

--- a/pkg/observability/metrics_test.go
+++ b/pkg/observability/metrics_test.go
@@ -26,6 +26,7 @@ func TestNewDisabledReturnsNoOpRecorder(t *testing.T) {
 	m.IncInflightToolCalls(context.Background())
 	m.DecInflightToolCalls(context.Background())
 	m.RecordAPIGatewayOutbound(context.Background(), APIGatewayAttrs{}, time.Millisecond)
+	m.RecordSessionResolution(context.Background(), "none")
 
 	if got := m.Enabled(); got {
 		t.Errorf("Enabled() on nil = %v, want false", got)
@@ -65,6 +66,8 @@ func TestNewEnabledRecordsAllInstruments(t *testing.T) {
 	m.RecordAPIGatewayOutbound(ctx, APIGatewayAttrs{
 		Connection: "primary", HTTPStatusClass: StatusClass5xx, StatusCategory: StatusUpstreamErr,
 	}, 1200*time.Millisecond)
+	m.RecordSessionResolution(ctx, "explicit")
+	m.RecordSessionResolution(ctx, "transport")
 
 	body := scrapeMetrics(t, m.Handler())
 
@@ -81,6 +84,9 @@ func TestNewEnabledRecordsAllInstruments(t *testing.T) {
 		`http_status_class="2xx"`,
 		`http_status_class="5xx"`,
 		"apigateway_outbound_duration_seconds",
+		"mcp_session_resolution_total",
+		`source="explicit"`,
+		`source="transport"`,
 		// Go runtime collectors registered by New.
 		"go_goroutines",
 		"process_cpu_seconds_total",

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -1250,6 +1250,56 @@ type SessionsConfig struct {
 	// single postgres instance and must NOT cross-broadcast
 	// tools/list_changed events to each other's downstream agents.
 	BroadcastChannel string `yaml:"broadcast_channel"`
+
+	// Handles configures explicit session handles (issue #792). When enabled,
+	// platform_info mints a session_id that the model threads back as an
+	// ordinary argument on every subsequent tool call — the pattern the MCP
+	// 2026-07-28 spec recommends after removing the protocol-level session and
+	// the Mcp-Session-Id header (SEP-2567).
+	Handles SessionHandlesConfig `yaml:"handles"`
+}
+
+// defaultSessionHandleTTL is the lifetime of an explicit session handle when
+// sessions.handles.ttl is unset.
+const defaultSessionHandleTTL = 8 * time.Hour
+
+// SessionHandlesConfig configures explicit session handles (issue #792): the
+// platform_info-minted session_id that the model passes back on every tool
+// call, replacing reliance on the transport-level Mcp-Session-Id header.
+type SessionHandlesConfig struct {
+	// Enabled activates handle minting, schema advertisement, and validation.
+	// Default on (nil = enabled); set enabled: false for byte-identical legacy
+	// transport-session behavior.
+	Enabled *bool `yaml:"enabled"`
+
+	// TTL is the handle lifetime, refreshed on use. Defaults to 8h.
+	TTL time.Duration `yaml:"ttl"`
+
+	// Require refuses tool calls that carry neither a valid handle nor a legacy
+	// transport session (SESSION_REQUIRED). Default on (nil = required); set
+	// require: false for a softer landing during rollout.
+	Require *bool `yaml:"require"`
+}
+
+// IsEnabled reports whether explicit session handles are enabled, defaulting to
+// true when not explicitly set.
+func (c SessionHandlesConfig) IsEnabled() bool {
+	return !isExplicitlyDisabled(c.Enabled)
+}
+
+// IsRequired reports whether a handle (or legacy transport session) is required
+// on every tool call, defaulting to true when not explicitly set.
+func (c SessionHandlesConfig) IsRequired() bool {
+	return !isExplicitlyDisabled(c.Require)
+}
+
+// HandleTTL returns the configured handle lifetime, or the 8h default when
+// unset or non-positive.
+func (c SessionHandlesConfig) HandleTTL() time.Duration {
+	if c.TTL > 0 {
+		return c.TTL
+	}
+	return defaultSessionHandleTTL
 }
 
 // LoadConfig loads configuration from a file.

--- a/pkg/platform/config_session_handles_test.go
+++ b/pkg/platform/config_session_handles_test.go
@@ -1,0 +1,45 @@
+package platform
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSessionHandlesConfig_Defaults(t *testing.T) {
+	var c SessionHandlesConfig // zero value
+
+	if !c.IsEnabled() {
+		t.Error("IsEnabled() = false, want true by default")
+	}
+	if !c.IsRequired() {
+		t.Error("IsRequired() = false, want true by default")
+	}
+	if got := c.HandleTTL(); got != defaultSessionHandleTTL {
+		t.Errorf("HandleTTL() = %v, want %v", got, defaultSessionHandleTTL)
+	}
+}
+
+func TestSessionHandlesConfig_Overrides(t *testing.T) {
+	off := false
+	c := SessionHandlesConfig{
+		Enabled: &off,
+		Require: &off,
+		TTL:     2 * time.Hour,
+	}
+	if c.IsEnabled() {
+		t.Error("IsEnabled() = true, want false when explicitly disabled")
+	}
+	if c.IsRequired() {
+		t.Error("IsRequired() = true, want false when explicitly disabled")
+	}
+	if got := c.HandleTTL(); got != 2*time.Hour {
+		t.Errorf("HandleTTL() = %v, want 2h", got)
+	}
+}
+
+func TestSessionHandlesConfig_NonPositiveTTLFallsBack(t *testing.T) {
+	c := SessionHandlesConfig{TTL: -1 * time.Second}
+	if got := c.HandleTTL(); got != defaultSessionHandleTTL {
+		t.Errorf("HandleTTL() = %v, want default %v for non-positive TTL", got, defaultSessionHandleTTL)
+	}
+}

--- a/pkg/platform/info_tool.go
+++ b/pkg/platform/info_tool.go
@@ -4,7 +4,9 @@ package platform
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"slices"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -12,6 +14,7 @@ import (
 	personapkg "github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/platform/instructions"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/session"
 )
 
 // resourcesDiscoverabilityNote is the runtime note appended to agent
@@ -28,6 +31,8 @@ type Info struct {
 	Version             string                `json:"version"`
 	Description         string                `json:"description,omitempty"`
 	Tags                []string              `json:"tags,omitempty"`
+	SessionID           string                `json:"session_id,omitempty"`
+	SessionExpiresAt    string                `json:"session_expires_at,omitempty"`
 	AgentInstructions   string                `json:"agent_instructions,omitempty"`
 	Toolkits            []string              `json:"toolkits"`
 	ToolkitDescriptions map[string]string     `json:"toolkit_descriptions,omitempty"`
@@ -221,12 +226,23 @@ func (p *Platform) handleInfo(ctx context.Context, _ *mcp.CallToolRequest) (*mcp
 		notes...,
 	)
 
+	// Mint an explicit session handle (#792). platform_info is the only tool
+	// that mints; every other tool requires the returned session_id, which
+	// makes platform_info structurally unskippable and gives every downstream
+	// consumer (gates, provenance, audit) a deliberate session key.
+	sessionID, sessionExpiresAt := p.mintSessionHandle(ctx, personaName(persona))
+	if sessionID != "" {
+		agentInstructions = sessionThreadingInstruction(sessionID) + agentInstructions
+	}
+
 	reg := DefaultRegistry()
 	info := Info{
 		Name:                p.config.Server.Name,
 		Version:             p.config.Server.Version,
 		Description:         description,
 		Tags:                p.config.Server.Tags,
+		SessionID:           sessionID,
+		SessionExpiresAt:    sessionExpiresAt,
 		AgentInstructions:   agentInstructions,
 		Toolkits:            toolkits,
 		ToolkitDescriptions: toolkitDescriptions,
@@ -256,4 +272,43 @@ func (p *Platform) handleInfo(ctx context.Context, _ *mcp.CallToolRequest) (*mcp
 			&mcp.TextContent{Text: string(data)},
 		},
 	}, nil, nil
+}
+
+// personaName returns the persona's name, or "" when no persona applies.
+func personaName(p *PersonaInfo) string {
+	if p == nil {
+		return ""
+	}
+	return p.Name
+}
+
+// sessionThreadingInstruction is the prominent header prepended to the composed
+// agent instructions telling the model to thread the minted handle on every
+// call. It is the model-facing complement to the machine-readable session_id
+// field.
+func sessionThreadingInstruction(sessionID string) string {
+	return "SESSION HANDLE: This call issued you session_id \"" + sessionID + "\". " +
+		"Pass it as the session_id argument on EVERY subsequent tool call. Tool calls " +
+		"without it are refused (SESSION_REQUIRED). Do not call platform_info again unless " +
+		"a call returns SESSION_EXPIRED.\n\n"
+}
+
+// mintSessionHandle creates an explicit session handle in the session store and
+// returns it with its RFC3339 expiry. It returns empty strings (and mints
+// nothing) when handles are disabled or no session store is configured, so the
+// caller can omit the fields for a byte-identical legacy response.
+func (p *Platform) mintSessionHandle(ctx context.Context, persona string) (id, expiresAt string) {
+	if !p.config.Sessions.Handles.IsEnabled() || p.sessionStore == nil {
+		return "", ""
+	}
+	userID := ""
+	if pc := middleware.GetPlatformContext(ctx); pc != nil {
+		userID = pc.UserID
+	}
+	sess, err := session.MintHandle(ctx, p.sessionStore, userID, persona, p.config.Sessions.Handles.HandleTTL())
+	if err != nil {
+		slog.Error("platform_info: failed to mint session handle", "error", err)
+		return "", ""
+	}
+	return sess.ID, sess.ExpiresAt.UTC().Format(time.RFC3339)
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1571,6 +1571,18 @@ func (p *Platform) initSessionGate() {
 		return
 	}
 
+	// Explicit session handles (#792) supersede the legacy transport-keyed
+	// session gate and enforce platform_info-first more strongly. Running both
+	// double-gates (platform_info records init under the transport session while
+	// later calls carry the handle), so skip the legacy gate when handles are on.
+	if p.config.Sessions.Handles.IsEnabled() {
+		slog.Info("session gate: superseded by explicit session handles (sessions.handles); "+
+			"not registering the legacy transport-keyed session gate. Its exempt_tools are "+
+			"carried into the handle resolver's SESSION_REQUIRED exemptions.",
+			"exempt_tools", p.config.SessionGate.ExemptTools)
+		return
+	}
+
 	sessionTTL := p.config.Sessions.TTL
 	if sessionTTL == 0 {
 		sessionTTL = p.config.Server.Streamable.SessionTimeout
@@ -2692,17 +2704,26 @@ func (p *Platform) finalizeSetup() {
 
 	// 7. Auth/Authz (outermost for tools/call) - authenticates and authorizes
 	// users, creates PlatformContext. Must be outer to Audit so PlatformContext
-	// is available in the ctx that Audit receives.
+	// is available in the ctx that Audit receives. The session-handle resolver
+	// (#792) runs inside this middleware after authentication so it can adopt
+	// the explicit handle onto pc.SessionID before the gates and audit observe
+	// it.
 	p.mcpServer.AddReceivingMiddleware(
 		middleware.MCPToolCallMiddleware(p.authenticator, p.authorizer, p.toolkitRegistry, middleware.ToolCallConfig{
 			Transport:       p.config.Server.Transport,
 			AdminPersona:    p.config.Admin.Persona,
 			WorkflowTracker: p.workflowTracker,
+			SessionResolver: p.buildSessionResolver(),
 		}),
 	)
 
 	// 8. MCP Apps metadata - injects _meta.ui into tools/list
 	p.addMCPAppsMiddleware()
+
+	// 8.5 Session-handle schema injection (#792) - advertises the session_id
+	// argument on every tool except platform_info. A list decorator like the
+	// apps-metadata middleware, so upstream toolkits are never modified.
+	p.addSessionHandleSchemaMiddleware()
 
 	// 9. Tool visibility - reduces tools/list for token savings
 	p.addToolVisibilityMiddleware()
@@ -2820,6 +2841,44 @@ func (p *Platform) addMCPAppsMiddleware() {
 		mcpapps.ToolMetadataMiddleware(p.mcpAppsRegistry),
 	)
 	p.mcpAppsRegistry.RegisterResources(p.mcpServer)
+}
+
+// buildSessionResolver constructs the explicit session-handle resolver (#792),
+// or nil when handles are disabled (a valid no-op in MCPToolCallMiddleware).
+func (p *Platform) buildSessionResolver() *middleware.SessionResolver {
+	if !p.config.Sessions.Handles.IsEnabled() || p.sessionStore == nil {
+		return nil
+	}
+	metrics := p.metrics
+	// Carry the superseded legacy gate's exempt_tools forward so operator
+	// exemptions are honored rather than silently dropped.
+	var exempt []string
+	if p.config.SessionGate.Enabled {
+		exempt = p.config.SessionGate.ExemptTools
+	}
+	return middleware.NewSessionResolver(p.sessionStore, middleware.SessionResolverConfig{
+		Enabled:     true,
+		Require:     p.config.Sessions.Handles.IsRequired(),
+		TTL:         p.config.Sessions.Handles.HandleTTL(),
+		InitTool:    defaultInitTool,
+		ExemptTools: exempt,
+		Metric: func(ctx context.Context, source string) {
+			metrics.RecordSessionResolution(ctx, source)
+		},
+	})
+}
+
+// addSessionHandleSchemaMiddleware advertises the session_id argument on every
+// tool's input schema (except platform_info) when explicit handles are enabled.
+func (p *Platform) addSessionHandleSchemaMiddleware() {
+	// Gate on the same conditions as buildSessionResolver / mintSessionHandle so
+	// a tool never advertises a session_id the platform neither issues nor validates.
+	if !p.config.Sessions.Handles.IsEnabled() || p.sessionStore == nil {
+		return
+	}
+	p.mcpServer.AddReceivingMiddleware(
+		middleware.MCPSessionHandleSchemaMiddleware(defaultInitTool),
+	)
 }
 
 // addToolVisibilityMiddleware registers tool visibility filtering middleware.

--- a/pkg/platform/session_handle_mint_test.go
+++ b/pkg/platform/session_handle_mint_test.go
@@ -1,0 +1,194 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/persona"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/session"
+)
+
+// mintTestPlatform builds a minimal Platform wired with a memory session store
+// and the given handles config, sufficient to exercise handleInfo minting.
+func mintTestPlatform(t *testing.T, handles SessionHandlesConfig) (*Platform, *session.MemoryStore) {
+	t.Helper()
+	store := session.NewMemoryStore(time.Hour)
+	p := &Platform{
+		config: &Config{
+			Server:   ServerConfig{Name: "mint-test", Version: "1.0.0"},
+			Sessions: SessionsConfig{Handles: handles},
+		},
+		personaRegistry: persona.NewRegistry(),
+		toolkitRegistry: registry.NewRegistry(),
+		sessionStore:    store,
+	}
+	return p, store
+}
+
+// ctxWithUser returns a context carrying a PlatformContext with the given user
+// identity, as MCPToolCallMiddleware would set before the handler runs.
+func ctxWithUser(userID string) context.Context {
+	pc := middleware.NewPlatformContext("req-test")
+	pc.UserID = userID
+	return middleware.WithPlatformContext(context.Background(), pc)
+}
+
+// TestHandleInfo_MintsSessionHandle covers acceptance criterion 1: platform_info
+// returns a non-empty session_id and a matching row exists in the session store
+// with the caller's identity and a future expiry.
+func TestHandleInfo_MintsSessionHandle(t *testing.T) {
+	p, store := mintTestPlatform(t, SessionHandlesConfig{})
+
+	result, _, err := p.handleInfo(ctxWithUser("user-hash-1"), nil)
+	require.NoError(t, err)
+	info := requireInfoFromResult(t, result)
+
+	require.NotEmpty(t, info.SessionID, "session_id must be minted")
+	assert.True(t, session.IsHandle(info.SessionID), "session_id must carry the dps_ prefix")
+	require.NotEmpty(t, info.SessionExpiresAt)
+
+	expiry, err := time.Parse(time.RFC3339, info.SessionExpiresAt)
+	require.NoError(t, err)
+	assert.True(t, expiry.After(time.Now()), "session_expires_at must be in the future")
+
+	// The agent instructions must tell the model to thread the handle.
+	assert.Contains(t, info.AgentInstructions, info.SessionID)
+	assert.Contains(t, info.AgentInstructions, "session_id")
+
+	// The store row exists, carries the caller's identity, and is marked as
+	// minted by platform_info.
+	sess, err := store.Get(context.Background(), info.SessionID)
+	require.NoError(t, err)
+	require.NotNil(t, sess, "a session row must exist for the minted handle")
+	assert.Equal(t, "user-hash-1", sess.UserID)
+	assert.Equal(t, session.MintedByPlatformInfo, sess.State[session.StateKeyMintedBy])
+	assert.True(t, sess.ExpiresAt.After(time.Now()))
+}
+
+// TestHandleInfo_DisabledMintsNothing covers acceptance criterion 8: with
+// handles disabled the response carries no session_id and no row is created.
+func TestHandleInfo_DisabledMintsNothing(t *testing.T) {
+	off := false
+	p, store := mintTestPlatform(t, SessionHandlesConfig{Enabled: &off})
+
+	result, _, err := p.handleInfo(ctxWithUser("user-hash-1"), nil)
+	require.NoError(t, err)
+	info := requireInfoFromResult(t, result)
+
+	assert.Empty(t, info.SessionID, "no handle when disabled")
+	assert.Empty(t, info.SessionExpiresAt)
+	assert.NotContains(t, info.AgentInstructions, "SESSION HANDLE")
+
+	sessions, err := store.List(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, sessions, "no session row created when disabled")
+}
+
+// failCreateStore embeds a MemoryStore but fails every Create, exercising the
+// mint error path.
+type failCreateStore struct {
+	*session.MemoryStore
+}
+
+func (failCreateStore) Create(context.Context, *session.Session) error {
+	return errors.New("insert failed")
+}
+
+// TestHandleInfo_MintCreateErrorOmitsHandle proves a store failure degrades to a
+// handle-less response rather than failing the whole platform_info call.
+func TestHandleInfo_MintCreateErrorOmitsHandle(t *testing.T) {
+	p, _ := mintTestPlatform(t, SessionHandlesConfig{})
+	p.sessionStore = failCreateStore{session.NewMemoryStore(time.Hour)}
+
+	result, _, err := p.handleInfo(ctxWithUser("u"), nil)
+	require.NoError(t, err, "a mint failure must not fail platform_info")
+	info := requireInfoFromResult(t, result)
+	assert.Empty(t, info.SessionID, "no handle surfaced when the store fails")
+}
+
+// TestBuildSessionResolver covers the enabled/disabled construction glue and the
+// carry-forward of the legacy gate's exempt_tools.
+func TestBuildSessionResolver(t *testing.T) {
+	p, _ := mintTestPlatform(t, SessionHandlesConfig{})
+	if p.buildSessionResolver() == nil {
+		t.Error("enabled handles must produce a resolver")
+	}
+
+	// With the legacy session gate enabled, its exempt_tools carry forward.
+	p.config.SessionGate = SessionGateConfig{Enabled: true, ExemptTools: []string{"list_connections"}}
+	if p.buildSessionResolver() == nil {
+		t.Error("resolver must build with carried-over exempt_tools")
+	}
+
+	off := false
+	p.config.Sessions.Handles.Enabled = &off
+	if p.buildSessionResolver() != nil {
+		t.Error("disabled handles must produce a nil resolver")
+	}
+}
+
+// TestAddSessionHandleSchemaMiddleware covers both branches of the list-decorator
+// registration.
+func TestAddSessionHandleSchemaMiddleware(t *testing.T) {
+	p, _ := mintTestPlatform(t, SessionHandlesConfig{})
+	p.mcpServer = mcp.NewServer(&mcp.Implementation{Name: "t", Version: "v0"}, nil)
+	p.addSessionHandleSchemaMiddleware() // enabled: registers without panic
+
+	off := false
+	p.config.Sessions.Handles.Enabled = &off
+	p.addSessionHandleSchemaMiddleware() // disabled: no-op
+}
+
+// TestInitSessionGate_SupersededByHandles proves the legacy transport-keyed
+// session gate is not registered when explicit handles are enabled (they are
+// the stronger, non-conflicting mechanism).
+func TestInitSessionGate_SupersededByHandles(t *testing.T) {
+	p := &Platform{config: &Config{
+		SessionGate: SessionGateConfig{Enabled: true, InitTool: "platform_info"},
+		Sessions:    SessionsConfig{Handles: SessionHandlesConfig{}}, // enabled by default
+	}}
+	p.initSessionGate()
+	if p.sessionGate != nil {
+		t.Error("legacy session gate must be skipped when handles are enabled")
+	}
+}
+
+// TestInitSessionGate_RunsWhenHandlesDisabled proves the legacy gate still works
+// for operators who explicitly disable handles.
+func TestInitSessionGate_RunsWhenHandlesDisabled(t *testing.T) {
+	off := false
+	p := &Platform{config: &Config{
+		SessionGate: SessionGateConfig{Enabled: true, InitTool: "platform_info"},
+		Sessions:    SessionsConfig{Handles: SessionHandlesConfig{Enabled: &off}},
+	}}
+	p.initSessionGate()
+	if p.sessionGate == nil {
+		t.Fatal("legacy session gate must run when handles are disabled")
+	}
+	p.sessionGate.Stop()
+}
+
+// TestHandleInfo_CustomTTL verifies the configured handle TTL is honored.
+func TestHandleInfo_CustomTTL(t *testing.T) {
+	p, _ := mintTestPlatform(t, SessionHandlesConfig{TTL: 30 * time.Minute})
+
+	result, _, err := p.handleInfo(ctxWithUser("u"), nil)
+	require.NoError(t, err)
+	info := requireInfoFromResult(t, result)
+
+	expiry, err := time.Parse(time.RFC3339, info.SessionExpiresAt)
+	require.NoError(t, err)
+	// Expiry should be ~30m out, comfortably under the 8h default.
+	assert.True(t, expiry.Before(time.Now().Add(time.Hour)), "expiry honors the 30m TTL")
+	assert.True(t, expiry.After(time.Now().Add(20*time.Minute)))
+	assert.False(t, strings.HasPrefix(info.SessionID, "stdio"))
+}

--- a/pkg/session/handles.go
+++ b/pkg/session/handles.go
@@ -1,0 +1,80 @@
+package session
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Explicit session handle constants (issue #792). A handle is minted by the
+// platform_info tool and threaded by the model as the session_id argument on
+// every subsequent tool call — the pattern the MCP 2026-07-28 spec recommends
+// after removing the protocol-level session and the Mcp-Session-Id header
+// (SEP-2567).
+const (
+	// HandlePrefix is the recognizable, unguessable prefix on every minted
+	// handle. It distinguishes explicit handles from legacy transport session
+	// IDs (bare hex) in logs and audit rows.
+	HandlePrefix = "dps_"
+
+	// handleRandomBytes is the number of random bytes in a handle (128 bits).
+	handleRandomBytes = 16
+
+	// MintedByPlatformInfo marks a session row as an explicit handle minted by
+	// platform_info, distinguishing it from a transport session created by the
+	// AwareHandler initialize path.
+	MintedByPlatformInfo = "platform_info"
+
+	// StateKeyMintedBy is the session State key holding the mint marker.
+	StateKeyMintedBy = "minted_by"
+
+	// StateKeyPersona is the session State key holding the persona the handle
+	// was minted under, for session-scoped analysis.
+	StateKeyPersona = "persona"
+)
+
+// GenerateHandle returns a new explicit session handle: the HandlePrefix
+// followed by 128 bits of cryptographically random hex.
+func GenerateHandle() (string, error) {
+	b := make([]byte, handleRandomBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating session handle: %w", err)
+	}
+	return HandlePrefix + hex.EncodeToString(b), nil
+}
+
+// IsHandle reports whether id has the explicit-handle prefix. It is a cheap
+// syntactic check, not a validity check: a well-formed handle may still be
+// expired or unknown to the store.
+func IsHandle(id string) bool {
+	return strings.HasPrefix(id, HandlePrefix)
+}
+
+// MintHandle generates a new handle and persists a session for it, owned by
+// userID and marked as minted by platform_info, expiring ttl from now. It
+// returns the stored session so callers can surface its ID and expiry (#792).
+func MintHandle(ctx context.Context, store Store, userID, persona string, ttl time.Duration) (*Session, error) {
+	handle, err := GenerateHandle()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	sess := &Session{
+		ID:           handle,
+		UserID:       userID,
+		CreatedAt:    now,
+		LastActiveAt: now,
+		ExpiresAt:    now.Add(ttl),
+		State: map[string]any{
+			StateKeyMintedBy: MintedByPlatformInfo,
+			StateKeyPersona:  persona,
+		},
+	}
+	if err := store.Create(ctx, sess); err != nil {
+		return nil, fmt.Errorf("persisting session handle: %w", err)
+	}
+	return sess, nil
+}

--- a/pkg/session/handles_test.go
+++ b/pkg/session/handles_test.go
@@ -1,0 +1,80 @@
+package session
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGenerateHandle(t *testing.T) {
+	seen := make(map[string]bool)
+	for range 1000 {
+		h, err := GenerateHandle()
+		if err != nil {
+			t.Fatalf("GenerateHandle: %v", err)
+		}
+		if !strings.HasPrefix(h, HandlePrefix) {
+			t.Fatalf("handle %q missing prefix %q", h, HandlePrefix)
+		}
+		// dps_ (4) + 32 hex chars for 16 random bytes.
+		if want := len(HandlePrefix) + 32; len(h) != want {
+			t.Fatalf("handle %q length = %d, want %d", h, len(h), want)
+		}
+		if seen[h] {
+			t.Fatalf("duplicate handle generated: %q", h)
+		}
+		seen[h] = true
+		if !IsHandle(h) {
+			t.Fatalf("IsHandle(%q) = false, want true", h)
+		}
+	}
+}
+
+func TestIsHandle(t *testing.T) {
+	cases := map[string]bool{
+		"dps_abc123":                      true,
+		"dps_":                            true,
+		"":                                false,
+		"9f2c41e7a8b34d6c":                false, // legacy transport ID (bare hex)
+		"stdio":                           false,
+		"DPS_uppercaseprefixdoesnotmatch": false,
+	}
+	for id, want := range cases {
+		if got := IsHandle(id); got != want {
+			t.Errorf("IsHandle(%q) = %v, want %v", id, got, want)
+		}
+	}
+}
+
+func TestMintHandle(t *testing.T) {
+	store := NewMemoryStore(time.Hour)
+	sess, err := MintHandle(context.Background(), store, "user-1", "analyst", 2*time.Hour)
+	if err != nil {
+		t.Fatalf("MintHandle: %v", err)
+	}
+	if !IsHandle(sess.ID) {
+		t.Errorf("minted ID %q is not a handle", sess.ID)
+	}
+	if sess.UserID != "user-1" {
+		t.Errorf("UserID = %q, want user-1", sess.UserID)
+	}
+	if sess.State[StateKeyMintedBy] != MintedByPlatformInfo {
+		t.Errorf("minted_by = %v, want %q", sess.State[StateKeyMintedBy], MintedByPlatformInfo)
+	}
+	if sess.State[StateKeyPersona] != "analyst" {
+		t.Errorf("persona = %v, want analyst", sess.State[StateKeyPersona])
+	}
+	if !sess.ExpiresAt.After(time.Now().Add(time.Hour)) {
+		t.Errorf("ExpiresAt %v should honor the 2h TTL", sess.ExpiresAt)
+	}
+
+	// The session is retrievable from the store.
+	got, err := store.Get(context.Background(), sess.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got == nil || got.ID != sess.ID {
+		t.Fatal("minted handle not persisted")
+	}
+}


### PR DESCRIPTION
Closes #792

## Summary

Adopts the MCP 2026-07-28 explicit-handle pattern ([SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567)): `platform_info` mints a `session_id` that the model threads as an ordinary argument on every subsequent tool call, replacing reliance on the transport-level `Mcp-Session-Id` header the spec is removing. This makes `platform_info` structurally unskippable (no handle exists until it runs, and gated tools require one), gives audit and provenance a deliberate session key, and keeps the platform working unchanged when clients move to the sessionless protocol.

Default-on (`sessions.handles`), with a legacy transport-session fallback so existing clients are unaffected during the deprecation window.

## How it works

```mermaid
sequenceDiagram
    participant M as Model
    participant TC as MCPToolCallMiddleware
    participant S as Session store
    participant T as Tool handler

    M->>TC: platform_info (no handle)
    TC->>S: mint session (user, persona, TTL)
    S-->>TC: dps_9f2c…
    TC-->>M: info + session_id + instructions

    M->>TC: trino_query {session_id: dps_9f2c…, sql}
    TC->>S: validate (exists, unexpired, same identity)
    TC->>T: call with session_id stripped

    M->>TC: trino_query (handle omitted, no transport session)
    TC-->>M: SESSION_REQUIRED (handler never runs)
```

- **Minting** (`pkg/session/handles.go`, `pkg/platform/info_tool.go`): `platform_info` mints a `dps_`-prefixed 128-bit handle, persists a session row (`user_id`, `persona`, `minted_by: platform_info`), and returns `session_id` + `session_expires_at`, prepending a threading instruction to the composed agent instructions.
- **Schema advertisement** (`MCPSessionHandleSchemaMiddleware`): a `tools/list` decorator injects a `session_id` string property into every tool's input schema except `platform_info`. It replaces each `Tool` with a shallow copy, so the shared tool registry and upstream toolkits (mcp-trino, mcp-datahub, mcp-s3, gateway-proxied tools) are never modified.
- **Resolution & enforcement** (`SessionResolver` in `MCPToolCallMiddleware`): after authentication, extracts the `session_id` argument, validates it against the session store (exists, unexpired, same authenticated identity), adopts it onto `PlatformContext.SessionID`, and strips it before the handler runs. Resolution order: explicit handle → legacy transport session → `stdio` sentinel. A gated call with no handle and no transport session is refused with `SESSION_REQUIRED`; an unknown/expired/cross-identity handle with `SESSION_EXPIRED` — both before the handler runs.
- **Downstream consumers unchanged**: gates, provenance, audit, and knowledge stamping already key on `pc.SessionID`, so they pick up the deliberate handle with no schema or interface changes.

## Configuration

Default-on `*bool` per platform convention:

```yaml
sessions:
  handles:
    enabled: true      # mint, advertise, validate (set false for legacy transport-session behavior)
    ttl: 8h            # handle lifetime, refreshed on use
    require: true      # refuse calls with neither a handle nor a legacy transport session
```

A `mcp_session_resolution_total{source}` counter (`explicit` / `transport` / `stdio` / `none`) tracks migration off transport sessions.

## Acceptance criteria

All eight criteria from the issue are covered by unit tests plus an integration test that wires the real `mcp.Server` with the full middleware chain (`AddReceivingMiddleware`) and an in-memory transport:

| # | Criterion | Test |
|---|---|---|
| 1 | `platform_info` returns a non-empty `session_id`; a store row exists with the caller's identity and future expiry | `TestHandleInfo_MintsSessionHandle` |
| 2 | `tools/list` shows `session_id` on every tool except `platform_info` | `TestIntegration_SessionHandle_ListSchemaInjection` |
| 3 | A call without a handle (and no transport session) is refused before the handler; no handler audit row | `TestSessionResolver_MissingHandleRequired`, `TestIntegration_SessionHandle_ExpiredRejectedBeforeHandler` |
| 4 | With the handle, the call passes the init gate, is refused `SEARCH_REQUIRED` until `search`, then executes | `TestIntegration_SessionHandle_ThreadedFlow` |
| 5 | A handle minted under one identity, presented by another, is rejected | `TestSessionResolver_IdentityMismatch`, `TestIntegration_SessionHandle_IdentityMismatch` |
| 6 | `save_artifact`/export provenance contains the calls made under that handle | `TestIntegration_SessionHandle_ThreadedFlow` (provenance harvest) |
| 7 | Audit rows for the flow share the minted `session_id` | `TestIntegration_SessionHandle_ThreadedFlow` (audit assertions) |
| 8 | With `handles.enabled: false`, behavior is byte-identical (no schema injection, no minting) | `TestHandleInfo_DisabledMintsNothing`, `TestSessionResolver_DisabledIsNoop` |

## Hardening (from adversarial review)

- **Proxied-tool collision**: only a `dps_`-prefixed value is consumed/stripped, so a tool that legitimately defines its own `session_id` parameter still receives it (`TestSessionResolver_NonHandleSessionIDPreserved`).
- **Availability**: the resolver fails **open** on a session-store error (matching the search-first gate's documented fail-open) rather than locking out every handle-bearing caller during a transient DB blip (`TestSessionResolver_StoreErrorFailsOpen`).
- **Recovery loop**: `platform_info` is exempt from handle *validation*, so an agent that threads a now-stale handle on a `platform_info` re-call is not refused — it can always mint a fresh handle (`TestSessionResolver_InitToolExemptEvenWithStaleHandle`).
- **Legacy gate**: explicit handles supersede the transport-keyed `session_gate` (running both would double-gate); its `exempt_tools` are carried into the resolver (`TestInitSessionGate_SupersededByHandles`, `TestSessionResolver_ExemptToolBypassesRequire`).
- **Numeric fidelity**: the strip re-encode uses a `json.Number` decoder so other arguments' large integers are not corrupted through `float64`.
- **Refresh cost**: refresh-on-use is throttled to the second half of the handle's lifetime (`TestSessionResolver_RefreshExtendsNearExpiry`).

## Testing

`make verify` passes the full CI-equivalent suite (fmt, race tests, ≥80% coverage, patch coverage 92.9%, lint, gosec, semgrep, CodeQL, dead-code, GoReleaser dry-run). 36 new tests were added.

## Out of scope (follow-ups)

- Portal post-session analysis views built on the now-reliable key.
- Precise artifact↔query matching within a session.
- Removing the legacy transport-session fallback after the deprecation window.

## Files

20 files changed (+1,836 −4): `pkg/session/handles.go`, `pkg/middleware/mcp_session_handle.go`, `pkg/middleware/mcp.go`, `pkg/platform/info_tool.go`, `pkg/platform/config.go`, `pkg/platform/platform.go`, `pkg/observability/metrics.go`, plus tests, docs (`configuration.md`, `reference/middleware.md`, `llms.txt`, `llms-full.txt`), `configs/platform.yaml`, and `README.md`.
