### PR TITLE
feat(knowledge): give the search embedding its own timeout, separate from the fan-out (#795)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1703,7 +1703,8 @@ knowledge:
 | `knowledge.apply.datahub_connection` | string | - | DataHub instance name for write-back operations |
 | `knowledge.apply.require_confirmation` | bool | `false` | When true, the `apply` action requires `confirm: true` in the request |
 | `knowledge.reflexive_capture.enabled` | bool | `true` | Auto-capture a "misconception + fix" correction (source `automation`, reviewed sink-class) when a Trino query errors and a later same-session query over the same table(s) succeeds (#635). Default-on when the memory subsystem is available; set `false` to disable |
-| `knowledge.search_provider_timeout` | duration | `5s` | Per-provider deadline for the `search` fan-out and the intent embedding, so one slow knowledge source drops out as a collected error rather than stalling the whole search. Set a negative duration to disable the bound. |
+| `knowledge.search_provider_timeout` | duration | `5s` | Per-provider deadline for the `search` fan-out arms, so one slow knowledge source drops out as a collected error rather than stalling the whole search. Set a negative duration to disable the bound. |
+| `knowledge.search_embed_timeout` | duration | `5s` | Deadline for the serial intent-embedding step in `search`, independent of `search_provider_timeout`. A slow or unreachable embedder degrades to lexical ranking rather than stalling the search; this knob lets you give a slow (cold or CPU-only) embedder headroom to preserve `hybrid` ranking without loosening the fan-out bound. Set a negative duration to disable the bound. |
 
 Prerequisites: `database.dsn` must be configured. The `apply_knowledge` tool requires the admin persona.
 

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -861,6 +861,7 @@ knowledge:
   reflexive_capture:
     enabled: true
   search_provider_timeout: 5s
+  search_embed_timeout: 5s
 ```
 
 | Field | Type | Default | Description |
@@ -870,7 +871,8 @@ knowledge:
 | `apply.datahub_connection` | string | - | DataHub instance name for write-back operations |
 | `apply.require_confirmation` | bool | `false` | Require explicit `confirm: true` on apply actions |
 | `reflexive_capture.enabled` | bool | `true` | Auto-capture a "misconception + fix" correction when a Trino query errors and a later related same-session query on the same connection succeeds (#635). Source `automation`, reviewed sink-class (enters review, never live), gated by the persona's `memory_capture` grant. Default-on when the memory subsystem is available; set `false` to disable |
-| `search_provider_timeout` | duration | `5s` | Per-provider deadline for the `search` fan-out. Each knowledge source (catalog, memory, insights, endpoints, …) and the intent embedding are bounded by this, so one slow source drops out as a collected error while the rest still return, instead of stalling the whole search. Set a negative duration to disable the bound (a search then waits for its slowest provider). |
+| `search_provider_timeout` | duration | `5s` | Per-provider deadline for the `search` fan-out arms. Each knowledge source (catalog, memory, insights, endpoints, …) is bounded by this, so one slow source drops out as a collected error while the rest still return, instead of stalling the whole search. Set a negative duration to disable the bound (a search then waits for its slowest provider). |
+| `search_embed_timeout` | duration | `5s` | Deadline for the serial intent-embedding step in `search`, independent of `search_provider_timeout`. A slow or unreachable embedder degrades to lexical ranking rather than stalling the search; because that silently loses semantic relevance, this knob lets you give a slow (cold or CPU-only) embedder more headroom to preserve `hybrid` ranking without loosening the fan-out bound. Set a negative duration to disable the bound. |
 
 !!! note "Prerequisites"
     Knowledge capture requires `database.dsn` to be configured. The `apply_knowledge` tool requires the admin persona.

--- a/pkg/admin/handler.go
+++ b/pkg/admin/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/pkcestore"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
+	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
 	"github.com/txn2/mcp-data-platform/pkg/portal"
 	"github.com/txn2/mcp-data-platform/pkg/prompt"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
@@ -134,7 +135,7 @@ type Deps struct {
 	ConnectionStore     ConnectionStore
 	ConnectionSources   *platform.ConnectionSourceMap
 	ToolkitsConfig      map[string]any
-	PersonaStore        platform.PersonaStore
+	PersonaStore        personastore.Store
 	APIKeyStore         platform.APIKeyStore
 	// UserStore is the known-users directory (#614). nil disables the
 	// /api/v1/admin/users routes (no database configured).

--- a/pkg/admin/persona_handler.go
+++ b/pkg/admin/persona_handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
+	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
 )
 
 // personaSummary is a lightweight persona representation for list responses.
@@ -227,7 +228,7 @@ func (h *Handler) createPersona(w http.ResponseWriter, r *http.Request) {
 	// Persist to database FIRST — if it fails, don't register in-memory.
 	if h.deps.PersonaStore != nil {
 		author := extractAuthor(r)
-		def := platform.PersonaDefinitionFromPersona(p, author)
+		def := personastore.DefinitionFromPersona(p, author)
 		if err := h.deps.PersonaStore.Set(r.Context(), def); err != nil {
 			slog.Warn("failed to persist persona", logKeyName, p.Name, logKeyError, err)
 			writeError(w, http.StatusInternalServerError, "failed to persist persona")
@@ -287,7 +288,7 @@ func (h *Handler) updatePersona(w http.ResponseWriter, r *http.Request) {
 	// Persist to database FIRST — if it fails, don't update in-memory.
 	if h.deps.PersonaStore != nil {
 		author := extractAuthor(r)
-		def := platform.PersonaDefinitionFromPersona(p, author)
+		def := personastore.DefinitionFromPersona(p, author)
 		if err := h.deps.PersonaStore.Set(r.Context(), def); err != nil {
 			slog.Warn("failed to persist persona update", logKeyName, p.Name, logKeyError, err)
 			writeError(w, http.StatusInternalServerError, "failed to persist persona")
@@ -380,7 +381,7 @@ func (h *Handler) deletePersonaFromStore(r *http.Request, name string) error {
 	}
 	// Tolerate "not found" when a file fallback exists — the DB entry
 	// may have already been removed or never existed.
-	if errors.Is(err, platform.ErrPersonaNotFound) && h.deps.FilePersonaNames[name] {
+	if errors.Is(err, personastore.ErrNotFound) && h.deps.FilePersonaNames[name] {
 		return nil
 	}
 	slog.Warn("failed to delete persona from database", logKeyName, sanitizeLogValue(name), logKeyError, err) // #nosec G706 -- name is sanitized

--- a/pkg/admin/persona_handler_test.go
+++ b/pkg/admin/persona_handler_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
+	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
 )
 
 const testPriority = 10
@@ -659,7 +660,7 @@ func TestPersonaSourceTracking(t *testing.T) {
 		p.Source = "both"
 		pReg := &mockPersonaRegistry{allResult: []*persona.Persona{p}}
 		cs := &mockConfigStore{mode: "database"}
-		ps := &mockPersonaStore{deleteErr: platform.ErrPersonaNotFound}
+		ps := &mockPersonaStore{deleteErr: personastore.ErrNotFound}
 		cfg := testConfig()
 		cfg.Personas.Definitions = map[string]platform.PersonaDef{
 			"analyst": {

--- a/pkg/admin/testhelpers_test.go
+++ b/pkg/admin/testhelpers_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/configstore"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
+	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
 	"github.com/txn2/mcp-data-platform/pkg/query"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
@@ -392,23 +393,23 @@ var _ ConfigStore = (*mockConfigStore)(nil)
 // --- Mock PersonaStore ---
 
 type mockPersonaStore struct {
-	listResult  []platform.PersonaDefinition
+	listResult  []personastore.Definition
 	listErr     error
 	setErr      error
 	deleteErr   error
-	setCalls    []platform.PersonaDefinition
+	setCalls    []personastore.Definition
 	deleteCalls []string
 }
 
-func (m *mockPersonaStore) List(_ context.Context) ([]platform.PersonaDefinition, error) {
+func (m *mockPersonaStore) List(_ context.Context) ([]personastore.Definition, error) {
 	return m.listResult, m.listErr
 }
 
-func (*mockPersonaStore) Get(_ context.Context, _ string) (*platform.PersonaDefinition, error) {
-	return nil, platform.ErrPersonaNotFound
+func (*mockPersonaStore) Get(_ context.Context, _ string) (*personastore.Definition, error) {
+	return nil, personastore.ErrNotFound
 }
 
-func (m *mockPersonaStore) Set(_ context.Context, def platform.PersonaDefinition) error {
+func (m *mockPersonaStore) Set(_ context.Context, def personastore.Definition) error {
 	m.setCalls = append(m.setCalls, def)
 	return m.setErr
 }
@@ -419,7 +420,7 @@ func (m *mockPersonaStore) Delete(_ context.Context, name string) error {
 }
 
 // Verify interface compliance.
-var _ platform.PersonaStore = (*mockPersonaStore)(nil)
+var _ personastore.Store = (*mockPersonaStore)(nil)
 
 // --- Test helpers ---
 

--- a/pkg/admin/tools_detail_test.go
+++ b/pkg/admin/tools_detail_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/configstore"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
+	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
 	"github.com/txn2/mcp-data-platform/pkg/toolkits/gateway/enrichment"
 )
 
@@ -45,7 +46,7 @@ func TestGetToolDetail_FullJoin(t *testing.T) {
 	// connection (prod-trino) only via an explicit ConnsAllow. analyst and
 	// admin grant it; viewer is tool-denied anyway (datahub_* vs trino_query).
 	personaStore := &mockPersonaStore{
-		listResult: []platform.PersonaDefinition{
+		listResult: []personastore.Definition{
 			{Name: "analyst", ToolsAllow: []string{"trino_*"}, ToolsDeny: []string{}, ConnsAllow: []string{"prod-trino"}},
 			{Name: "viewer", ToolsAllow: []string{"datahub_*"}, ToolsDeny: []string{}},
 			{Name: "admin", ToolsAllow: []string{"*"}, ToolsDeny: []string{"*_delete_*"}, ConnsAllow: []string{"*"}},

--- a/pkg/knowledge/router.go
+++ b/pkg/knowledge/router.go
@@ -13,14 +13,25 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/embedding"
 )
 
-// defaultProviderSearchTimeout bounds each knowledge provider's search arm (and
-// the intent-embedding step) in the fan-out. Without a per-provider deadline the
-// fan-out is only as fast as its slowest source: a WaitGroup awaits every arm,
-// so one slow store (a lagging catalog index, an unreachable embedder) stalls
-// the whole search until the client's own timeout fires. Five seconds is well
-// above a healthy provider's latency yet bounds the worst case; override with
-// knowledge.search.provider_timeout.
+// defaultProviderSearchTimeout bounds each knowledge provider's search arm in
+// the fan-out. Without a per-provider deadline the fan-out is only as fast as
+// its slowest source: a WaitGroup awaits every arm, so one slow store (a lagging
+// catalog index, an unreachable provider) stalls the whole search until the
+// client's own timeout fires. Five seconds is well above a healthy provider's
+// latency yet bounds the worst case; override with
+// knowledge.search_provider_timeout.
 const defaultProviderSearchTimeout = 5 * time.Second
+
+// defaultSearchEmbedTimeout bounds the serial intent-embedding step in Search.
+// It is a distinct knob from the fan-out timeout because the two have different
+// failure semantics: a slow fan-out arm should drop out quickly so it does not
+// hold up the others, whereas cutting the embedding short silently downgrades
+// ranking from hybrid to lexical and loses semantic relevance. Keeping the same
+// 5s default preserves v1.98.2 behavior byte-for-byte; operators who want to
+// protect ranking quality on a slow (e.g. cold, CPU-only) embedder can raise
+// knowledge.search_embed_timeout without loosening the fan-out bound. Override
+// with knowledge.search_embed_timeout.
+const defaultSearchEmbedTimeout = 5 * time.Second
 
 // Result ranking modes, reported so the caller knows how results were ranked:
 // semantically, by keyword, or by exact entity lookup (no text arm).
@@ -82,6 +93,7 @@ type Router struct {
 	lineage         LineageExpander
 	providers       []Provider
 	providerTimeout time.Duration
+	embedTimeout    time.Duration
 }
 
 // NewRouter builds a router over an embedder, an optional lineage expander, and
@@ -89,13 +101,16 @@ type Router struct {
 // router then ranks lexically. lineage may be nil, leaving entity-keyed lookups
 // unexpanded. Provider order does not affect ranking (scores are fused), only
 // the deterministic tie-break. The per-provider fan-out timeout defaults to
-// defaultProviderSearchTimeout; override with SetProviderTimeout.
+// defaultProviderSearchTimeout and the search-embedding timeout to
+// defaultSearchEmbedTimeout; override with SetProviderTimeout and
+// SetEmbedTimeout respectively.
 func NewRouter(embedder embedding.Provider, lineage LineageExpander, providers ...Provider) *Router {
 	return &Router{
 		embedder:        embedder,
 		lineage:         lineage,
 		providers:       providers,
 		providerTimeout: defaultProviderSearchTimeout,
+		embedTimeout:    defaultSearchEmbedTimeout,
 	}
 }
 
@@ -118,6 +133,29 @@ func (r *Router) providerContext(ctx context.Context) (context.Context, context.
 		return ctx, func() {}
 	}
 	return context.WithTimeout(ctx, r.providerTimeout)
+}
+
+// SetEmbedTimeout overrides the deadline on the serial search-embedding step. It
+// mirrors SetProviderTimeout's semantics: a zero duration leaves the default in
+// place (so callers can pass an unset config value unconditionally); a negative
+// duration disables the bound (the embed then runs under the request context
+// only). It is a separate knob from SetProviderTimeout so an operator can give a
+// slow embedder headroom without loosening the fan-out bound. Not safe for
+// concurrent use with Search; call once at wiring time.
+func (r *Router) SetEmbedTimeout(d time.Duration) {
+	if d != 0 {
+		r.embedTimeout = d
+	}
+}
+
+// embedContext derives the context for the intent-embedding call: the request
+// context bounded by embedTimeout, or the request context unchanged (with a
+// no-op cancel) when the bound is disabled.
+func (r *Router) embedContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if r.embedTimeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, r.embedTimeout)
 }
 
 // Providers returns the registered providers, for introspection and wiring
@@ -234,9 +272,12 @@ func (r *Router) Search(ctx context.Context, q Query) (Result, error) {
 
 	ranking := rankingEntity
 	if q.Intent != "" {
-		// Bound the embedding call: a slow or unreachable embedder must degrade to
-		// lexical ranking, not stall the whole search before the fan-out even runs.
-		embCtx, cancel := r.providerContext(ctx)
+		// Bound the embedding call with its own timeout (separate from the fan-out
+		// bound): a slow or unreachable embedder must degrade to lexical ranking,
+		// not stall the whole search before the fan-out even runs. The embed step
+		// is serial and downgrading it loses semantic relevance, so it gets its own
+		// knob and can be given more headroom than a fan-out arm.
+		embCtx, cancel := r.embedContext(ctx)
 		q.Embedding = embedding.EmbedForSearch(embCtx, r.embedder, q.Intent)
 		cancel()
 		if len(q.Embedding) > 0 {

--- a/pkg/knowledge/router_timeout_test.go
+++ b/pkg/knowledge/router_timeout_test.go
@@ -97,3 +97,111 @@ func TestNewRouter_DefaultProviderTimeout(t *testing.T) {
 		t.Fatalf("SetProviderTimeout(2s) = %v", r.providerTimeout)
 	}
 }
+
+// slowEmbedder returns a non-zero vector after delay, but honors context
+// cancellation (returning an error, which EmbedForSearch maps to lexical
+// fallback). It models a cold or CPU-throttled embed backend.
+type slowEmbedder struct{ delay time.Duration }
+
+func (s slowEmbedder) Embed(ctx context.Context, _ string) ([]float32, error) {
+	select {
+	case <-time.After(s.delay):
+		return []float32{0.1, 0.2, 0.3}, nil
+	case <-ctx.Done():
+		return nil, fmt.Errorf("embed canceled: %w", ctx.Err())
+	}
+}
+
+func (s slowEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		v, err := s.Embed(ctx, texts[i])
+		if err != nil {
+			return nil, err
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+func (slowEmbedder) Dimension() int { return 3 }
+func (slowEmbedder) Kind() string   { return "slow" }
+
+// TestRouter_EmbedTimeoutSeparateFromFanOut is the #795 fix: the search-path
+// embedding and the per-provider fan-out arms use independent deadlines. An
+// embedder slower than the (tight) fan-out bound but faster than the (generous)
+// embed bound still produces hybrid ranking, while a genuinely slow provider
+// still drops out at the fan-out bound. Under the old shared knob the embedder
+// would have been cut at the fan-out bound and silently degraded to lexical.
+func TestRouter_EmbedTimeoutSeparateFromFanOut(t *testing.T) {
+	fast := &fakeProvider{name: "fast", scope: ScopeShared, hits: []Hit{{Source: "fast", Ref: "f1", Score: 1}}}
+	slow := &blockingProvider{name: "slow", scope: ScopeShared}
+	// Embedder takes 150ms: longer than the 40ms fan-out bound, shorter than the
+	// 2s embed bound.
+	r := NewRouter(slowEmbedder{delay: 150 * time.Millisecond}, nil, fast, slow)
+	r.SetProviderTimeout(40 * time.Millisecond)
+	r.SetEmbedTimeout(2 * time.Second)
+
+	res, err := r.Search(context.Background(), Query{Intent: "anything"})
+	if err != nil {
+		t.Fatalf("partial success expected (fast provider returned), got error: %v", err)
+	}
+	if res.Ranking != rankingHybrid {
+		t.Fatalf("embedder was slower than the fan-out bound but faster than the embed bound: "+
+			"expected %q ranking (its own timeout applied), got %q", rankingHybrid, res.Ranking)
+	}
+	hits := flatHits(res)
+	if len(hits) != 1 || hits[0].Ref != "f1" {
+		t.Fatalf("expected only the fast provider's hit (slow arm dropped at the fan-out bound), got %+v", hits)
+	}
+}
+
+// TestRouter_EmbedTimeoutCutShortDegradesToLexical proves the embed bound still
+// bites: an embedder slower than its own timeout degrades to lexical rather than
+// stalling the search.
+func TestRouter_EmbedTimeoutCutShortDegradesToLexical(t *testing.T) {
+	fast := &fakeProvider{name: "fast", scope: ScopeShared, hits: []Hit{{Source: "fast", Ref: "f1", Score: 1}}}
+	r := NewRouter(slowEmbedder{delay: time.Second}, nil, fast)
+	r.SetEmbedTimeout(30 * time.Millisecond)
+
+	res, err := r.Search(context.Background(), Query{Intent: "anything"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Ranking != rankingLexical {
+		t.Fatalf("embedder slower than its own bound must degrade to %q, got %q", rankingLexical, res.Ranking)
+	}
+}
+
+// TestNewRouter_DefaultEmbedTimeout mirrors the provider-timeout guard: the
+// default is set, SetEmbedTimeout(0) (an unset config value) preserves it, and a
+// positive value overrides.
+func TestNewRouter_DefaultEmbedTimeout(t *testing.T) {
+	r := NewRouter(nil, nil)
+	if r.embedTimeout != defaultSearchEmbedTimeout {
+		t.Fatalf("default embedTimeout = %v, want %v", r.embedTimeout, defaultSearchEmbedTimeout)
+	}
+	r.SetEmbedTimeout(0) // unset config: must not clobber the default
+	if r.embedTimeout != defaultSearchEmbedTimeout {
+		t.Fatalf("SetEmbedTimeout(0) changed default to %v", r.embedTimeout)
+	}
+	r.SetEmbedTimeout(8 * time.Second)
+	if r.embedTimeout != 8*time.Second {
+		t.Fatalf("SetEmbedTimeout(8s) = %v", r.embedTimeout)
+	}
+}
+
+// TestRouter_EmbedTimeoutDisabled proves a non-positive embed timeout runs the
+// embed under the request context only (no derived deadline).
+func TestRouter_EmbedTimeoutDisabled(t *testing.T) {
+	fast := &fakeProvider{name: "fast", scope: ScopeShared, hits: []Hit{{Source: "fast", Ref: "f1", Score: 1}}}
+	r := NewRouter(slowEmbedder{delay: 20 * time.Millisecond}, nil, fast)
+	r.SetEmbedTimeout(-1)
+
+	res, err := r.Search(context.Background(), Query{Intent: "anything"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Ranking != rankingHybrid {
+		t.Fatalf("with the embed bound disabled the embedder should complete: want %q, got %q", rankingHybrid, res.Ranking)
+	}
+}

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -250,9 +250,12 @@ type KnowledgeConfig struct {
 	// subsystem; see pkg/platform/reflexivecapture.
 	ReflexiveCapture reflexivecapture.Config `yaml:"reflexive_capture"`
 
-	// SearchProviderTimeout bounds each knowledge provider (and the intent
-	// embedding) in the `search` fan-out; default 5s, a negative value disables it.
+	// SearchProviderTimeout bounds each knowledge provider arm in the `search`
+	// fan-out; default 5s, a negative value disables it.
 	SearchProviderTimeout time.Duration `yaml:"search_provider_timeout"`
+	// SearchEmbedTimeout bounds the serial intent-embedding step in `search`,
+	// independent of the fan-out bound; default 5s, a negative value disables it.
+	SearchEmbedTimeout time.Duration `yaml:"search_embed_timeout"`
 }
 
 // KnowledgeApplyConfig configures the apply_knowledge tool.

--- a/pkg/platform/personastore/store.go
+++ b/pkg/platform/personastore/store.go
@@ -1,4 +1,9 @@
-package platform
+// Package personastore persists database-managed persona definitions,
+// independent of the platform assembly. It holds the persona_definitions
+// storage model (Definition), its Store interface, and the PostgreSQL and no-op
+// implementations. Extracted from pkg/platform so the persona storage layer can
+// be reasoned about (and size-budgeted) on its own.
+package personastore
 
 import (
 	"context"
@@ -11,11 +16,11 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 )
 
-// ErrPersonaNotFound is returned when a persona definition does not exist in the database.
-var ErrPersonaNotFound = errors.New("persona not found")
+// ErrNotFound is returned when a persona definition does not exist in the database.
+var ErrNotFound = errors.New("persona not found")
 
-// PersonaDefinition represents a database-managed persona.
-type PersonaDefinition struct {
+// Definition represents a database-managed persona.
+type Definition struct {
 	Name        string                   `json:"name"`
 	DisplayName string                   `json:"display_name"`
 	Description string                   `json:"description,omitempty"`
@@ -30,8 +35,8 @@ type PersonaDefinition struct {
 	UpdatedAt   time.Time                `json:"updated_at"`
 }
 
-// ToPersona converts a PersonaDefinition to a persona.Persona.
-func (d *PersonaDefinition) ToPersona() *persona.Persona {
+// ToPersona converts a Definition to a persona.Persona.
+func (d *Definition) ToPersona() *persona.Persona {
 	return &persona.Persona{
 		Name:        d.Name,
 		DisplayName: d.DisplayName,
@@ -50,9 +55,9 @@ func (d *PersonaDefinition) ToPersona() *persona.Persona {
 	}
 }
 
-// PersonaDefinitionFromPersona converts a persona.Persona to a PersonaDefinition.
-func PersonaDefinitionFromPersona(p *persona.Persona, author string) PersonaDefinition {
-	return PersonaDefinition{
+// DefinitionFromPersona converts a persona.Persona to a Definition.
+func DefinitionFromPersona(p *persona.Persona, author string) Definition {
+	return Definition{
 		Name:        p.Name,
 		DisplayName: p.DisplayName,
 		Description: p.Description,
@@ -67,26 +72,26 @@ func PersonaDefinitionFromPersona(p *persona.Persona, author string) PersonaDefi
 	}
 }
 
-// PersonaStore manages persona definition persistence.
-type PersonaStore interface {
-	List(ctx context.Context) ([]PersonaDefinition, error)
-	Get(ctx context.Context, name string) (*PersonaDefinition, error)
-	Set(ctx context.Context, def PersonaDefinition) error
+// Store manages persona definition persistence.
+type Store interface {
+	List(ctx context.Context) ([]Definition, error)
+	Get(ctx context.Context, name string) (*Definition, error)
+	Set(ctx context.Context, def Definition) error
 	Delete(ctx context.Context, name string) error
 }
 
-// PostgresPersonaStore implements PersonaStore backed by PostgreSQL.
-type PostgresPersonaStore struct {
+// PostgresStore implements Store backed by PostgreSQL.
+type PostgresStore struct {
 	db *sql.DB
 }
 
-// NewPostgresPersonaStore creates a new PostgreSQL-backed persona store.
-func NewPostgresPersonaStore(db *sql.DB) *PostgresPersonaStore {
-	return &PostgresPersonaStore{db: db}
+// NewPostgresStore creates a new PostgreSQL-backed persona store.
+func NewPostgresStore(db *sql.DB) *PostgresStore {
+	return &PostgresStore{db: db}
 }
 
 // List returns all persona definitions.
-func (s *PostgresPersonaStore) List(ctx context.Context) ([]PersonaDefinition, error) {
+func (s *PostgresStore) List(ctx context.Context) ([]Definition, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT name, display_name, description, roles, tools_allow, tools_deny,
 		        connections_allow, connections_deny, context, priority, created_by, updated_at
@@ -96,9 +101,9 @@ func (s *PostgresPersonaStore) List(ctx context.Context) ([]PersonaDefinition, e
 	}
 	defer rows.Close() //nolint:errcheck // best-effort cleanup
 
-	var defs []PersonaDefinition
+	var defs []Definition
 	for rows.Next() {
-		d, err := scanPersonaDef(rows)
+		d, err := scanDef(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -111,25 +116,25 @@ func (s *PostgresPersonaStore) List(ctx context.Context) ([]PersonaDefinition, e
 }
 
 // Get returns a single persona definition by name.
-func (s *PostgresPersonaStore) Get(ctx context.Context, name string) (*PersonaDefinition, error) {
+func (s *PostgresStore) Get(ctx context.Context, name string) (*Definition, error) {
 	row := s.db.QueryRowContext(ctx,
 		`SELECT name, display_name, description, roles, tools_allow, tools_deny,
 		        connections_allow, connections_deny, context, priority, created_by, updated_at
 		 FROM persona_definitions WHERE name = $1`, name)
 
-	var d PersonaDefinition
+	var d Definition
 	var roles, toolsAllow, toolsDeny, connsAllow, connsDeny, contextJSON []byte
 	err := row.Scan(&d.Name, &d.DisplayName, &d.Description,
 		&roles, &toolsAllow, &toolsDeny, &connsAllow, &connsDeny, &contextJSON,
 		&d.Priority, &d.CreatedBy, &d.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrPersonaNotFound
+		return nil, ErrNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("querying persona definition: %w", err)
 	}
 
-	if err := unmarshalPersonaJSON(&d, personaJSONFields{
+	if err := unmarshalJSON(&d, jsonFields{
 		roles: roles, toolsAllow: toolsAllow, toolsDeny: toolsDeny,
 		connsAllow: connsAllow, connsDeny: connsDeny, contextJSON: contextJSON,
 	}); err != nil {
@@ -139,7 +144,7 @@ func (s *PostgresPersonaStore) Get(ctx context.Context, name string) (*PersonaDe
 }
 
 // Set creates or updates a persona definition.
-func (s *PostgresPersonaStore) Set(ctx context.Context, def PersonaDefinition) error {
+func (s *PostgresStore) Set(ctx context.Context, def Definition) error {
 	roles, _ := json.Marshal(def.Roles)
 	toolsAllow, _ := json.Marshal(def.ToolsAllow)
 	toolsDeny, _ := json.Marshal(def.ToolsDeny)
@@ -167,7 +172,7 @@ func (s *PostgresPersonaStore) Set(ctx context.Context, def PersonaDefinition) e
 }
 
 // Delete removes a persona definition by name.
-func (s *PostgresPersonaStore) Delete(ctx context.Context, name string) error {
+func (s *PostgresStore) Delete(ctx context.Context, name string) error {
 	result, err := s.db.ExecContext(ctx,
 		`DELETE FROM persona_definitions WHERE name = $1`, name)
 	if err != nil {
@@ -178,21 +183,21 @@ func (s *PostgresPersonaStore) Delete(ctx context.Context, name string) error {
 		return fmt.Errorf("checking delete result: %w", err)
 	}
 	if affected == 0 {
-		return ErrPersonaNotFound
+		return ErrNotFound
 	}
 	return nil
 }
 
-// scanPersonaDef scans a row into a PersonaDefinition.
-func scanPersonaDef(rows *sql.Rows) (PersonaDefinition, error) {
-	var d PersonaDefinition
+// scanDef scans a row into a Definition.
+func scanDef(rows *sql.Rows) (Definition, error) {
+	var d Definition
 	var roles, toolsAllow, toolsDeny, connsAllow, connsDeny, contextJSON []byte
 	if err := rows.Scan(&d.Name, &d.DisplayName, &d.Description,
 		&roles, &toolsAllow, &toolsDeny, &connsAllow, &connsDeny, &contextJSON,
 		&d.Priority, &d.CreatedBy, &d.UpdatedAt); err != nil {
 		return d, fmt.Errorf("scanning persona definition: %w", err)
 	}
-	if err := unmarshalPersonaJSON(&d, personaJSONFields{
+	if err := unmarshalJSON(&d, jsonFields{
 		roles: roles, toolsAllow: toolsAllow, toolsDeny: toolsDeny,
 		connsAllow: connsAllow, connsDeny: connsDeny, contextJSON: contextJSON,
 	}); err != nil {
@@ -201,8 +206,8 @@ func scanPersonaDef(rows *sql.Rows) (PersonaDefinition, error) {
 	return d, nil
 }
 
-// personaJSONFields holds the raw JSONB byte slices scanned from the database.
-type personaJSONFields struct {
+// jsonFields holds the raw JSONB byte slices scanned from the database.
+type jsonFields struct {
 	roles       []byte
 	toolsAllow  []byte
 	toolsDeny   []byte
@@ -211,8 +216,8 @@ type personaJSONFields struct {
 	contextJSON []byte
 }
 
-// unmarshalPersonaJSON deserializes JSONB columns into the PersonaDefinition.
-func unmarshalPersonaJSON(d *PersonaDefinition, f personaJSONFields) error {
+// unmarshalJSON deserializes JSONB columns into the Definition.
+func unmarshalJSON(d *Definition, f jsonFields) error {
 	if err := json.Unmarshal(f.roles, &d.Roles); err != nil {
 		return fmt.Errorf("unmarshaling roles: %w", err)
 	}
@@ -234,23 +239,23 @@ func unmarshalPersonaJSON(d *PersonaDefinition, f personaJSONFields) error {
 	return nil
 }
 
-// NoopPersonaStore is a no-op implementation for when no database is available.
-type NoopPersonaStore struct{}
+// NoopStore is a no-op implementation for when no database is available.
+type NoopStore struct{}
 
 // List returns an empty list (no database available).
-func (*NoopPersonaStore) List(_ context.Context) ([]PersonaDefinition, error) {
+func (*NoopStore) List(_ context.Context) ([]Definition, error) {
 	return nil, nil
 }
 
-// Get always returns ErrPersonaNotFound (no database available).
-func (*NoopPersonaStore) Get(_ context.Context, _ string) (*PersonaDefinition, error) {
-	return nil, ErrPersonaNotFound
+// Get always returns ErrNotFound (no database available).
+func (*NoopStore) Get(_ context.Context, _ string) (*Definition, error) {
+	return nil, ErrNotFound
 }
 
 // Set is a no-op (no database available).
-func (*NoopPersonaStore) Set(_ context.Context, _ PersonaDefinition) error { return nil }
+func (*NoopStore) Set(_ context.Context, _ Definition) error { return nil }
 
-// Delete always returns ErrPersonaNotFound (no database available).
-func (*NoopPersonaStore) Delete(_ context.Context, _ string) error {
-	return ErrPersonaNotFound
+// Delete always returns ErrNotFound (no database available).
+func (*NoopStore) Delete(_ context.Context, _ string) error {
+	return ErrNotFound
 }

--- a/pkg/platform/personastore/store_test.go
+++ b/pkg/platform/personastore/store_test.go
@@ -1,4 +1,4 @@
-package platform
+package personastore
 
 import (
 	"context"
@@ -23,18 +23,18 @@ var personaColumns = []string{
 	"connections_allow", "connections_deny", "context", "priority", "created_by", "updated_at",
 }
 
-func newTestPersonaStore(t *testing.T) (*PostgresPersonaStore, sqlmock.Sqlmock) {
+func newTestPersonaStore(t *testing.T) (*PostgresStore, sqlmock.Sqlmock) {
 	t.Helper()
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("creating sqlmock: %v", err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
-	return NewPostgresPersonaStore(db), mock
+	return NewPostgresStore(db), mock
 }
 
 func TestToPersona(t *testing.T) {
-	def := &PersonaDefinition{
+	def := &Definition{
 		Name:        "analyst",
 		DisplayName: "Data Analyst",
 		Description: "Analyzes data",
@@ -72,7 +72,7 @@ func TestToPersona(t *testing.T) {
 }
 
 func TestToPersona_EmptyFields(t *testing.T) {
-	def := &PersonaDefinition{
+	def := &Definition{
 		Name: "minimal",
 	}
 
@@ -88,7 +88,7 @@ func TestToPersona_EmptyFields(t *testing.T) {
 	assert.Equal(t, 0, p.Priority)
 }
 
-func TestPersonaDefinitionFromPersona(t *testing.T) {
+func TestDefinitionFromPersona(t *testing.T) {
 	p := &persona.Persona{
 		Name:        "engineer",
 		DisplayName: "Data Engineer",
@@ -111,7 +111,7 @@ func TestPersonaDefinitionFromPersona(t *testing.T) {
 		Priority: 5,
 	}
 
-	def := PersonaDefinitionFromPersona(p, "creator@example.com")
+	def := DefinitionFromPersona(p, "creator@example.com")
 
 	assert.Equal(t, "engineer", def.Name)
 	assert.Equal(t, "Data Engineer", def.DisplayName)
@@ -141,7 +141,7 @@ func TestUnmarshalPersonaJSON(t *testing.T) {
 		contextJSON []byte
 		wantErr     bool
 		errContains string
-		check       func(t *testing.T, d *PersonaDefinition)
+		check       func(t *testing.T, d *Definition)
 	}{
 		{
 			name:        "valid JSON for all fields",
@@ -151,7 +151,7 @@ func TestUnmarshalPersonaJSON(t *testing.T) {
 			connsAllow:  []byte(`["prod_*"]`),
 			connsDeny:   []byte(`["staging_*"]`),
 			contextJSON: []byte(`{"description_prefix":"Hello"}`),
-			check: func(t *testing.T, d *PersonaDefinition) {
+			check: func(t *testing.T, d *Definition) {
 				t.Helper()
 				assert.Equal(t, []string{"analyst", "viewer"}, d.Roles)
 				assert.Equal(t, []string{"trino_*"}, d.ToolsAllow)
@@ -169,7 +169,7 @@ func TestUnmarshalPersonaJSON(t *testing.T) {
 			connsAllow:  []byte(`[]`),
 			connsDeny:   []byte(`[]`),
 			contextJSON: []byte{},
-			check: func(t *testing.T, d *PersonaDefinition) {
+			check: func(t *testing.T, d *Definition) {
 				t.Helper()
 				assert.Empty(t, d.Roles)
 				assert.Equal(t, persona.ContextOverrides{}, d.Context)
@@ -239,7 +239,7 @@ func TestUnmarshalPersonaJSON(t *testing.T) {
 			connsDeny:   []byte(`[]`),
 			contextJSON: []byte(`{bad`),
 			wantErr:     false,
-			check: func(t *testing.T, d *PersonaDefinition) {
+			check: func(t *testing.T, d *Definition) {
 				t.Helper()
 				// Context should remain zero-value since unmarshal failed silently.
 				assert.Equal(t, persona.ContextOverrides{}, d.Context)
@@ -249,8 +249,8 @@ func TestUnmarshalPersonaJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var d PersonaDefinition
-			err := unmarshalPersonaJSON(&d, personaJSONFields{
+			var d Definition
+			err := unmarshalJSON(&d, jsonFields{
 				roles: tt.roles, toolsAllow: tt.toolsAllow, toolsDeny: tt.toolsDeny,
 				connsAllow: tt.connsAllow, connsDeny: tt.connsDeny, contextJSON: tt.contextJSON,
 			})
@@ -267,8 +267,8 @@ func TestUnmarshalPersonaJSON(t *testing.T) {
 	}
 }
 
-func TestNoopPersonaStore(t *testing.T) {
-	store := &NoopPersonaStore{}
+func TestNoopStore(t *testing.T) {
+	store := &NoopStore{}
 	ctx := context.Background()
 
 	t.Run("List returns nil nil", func(t *testing.T) {
@@ -277,30 +277,30 @@ func TestNoopPersonaStore(t *testing.T) {
 		assert.Nil(t, defs)
 	})
 
-	t.Run("Get returns ErrPersonaNotFound", func(t *testing.T) {
+	t.Run("Get returns ErrNotFound", func(t *testing.T) {
 		def, err := store.Get(ctx, "anything")
 		assert.Nil(t, def)
-		assert.ErrorIs(t, err, ErrPersonaNotFound)
+		assert.ErrorIs(t, err, ErrNotFound)
 	})
 
 	t.Run("Set returns nil", func(t *testing.T) {
-		err := store.Set(ctx, PersonaDefinition{Name: "test"})
+		err := store.Set(ctx, Definition{Name: "test"})
 		assert.NoError(t, err)
 	})
 
-	t.Run("Delete returns ErrPersonaNotFound", func(t *testing.T) {
+	t.Run("Delete returns ErrNotFound", func(t *testing.T) {
 		err := store.Delete(ctx, "anything")
-		assert.ErrorIs(t, err, ErrPersonaNotFound)
+		assert.ErrorIs(t, err, ErrNotFound)
 	})
 }
 
-func TestNewPostgresPersonaStore(t *testing.T) {
-	store := NewPostgresPersonaStore(nil)
+func TestNewPostgresStore(t *testing.T) {
+	store := NewPostgresStore(nil)
 	require.NotNil(t, store)
 	assert.Nil(t, store.db)
 }
 
-func TestPersonaDefinitionRoundTrip(t *testing.T) {
+func TestDefinitionRoundTrip(t *testing.T) {
 	original := &persona.Persona{
 		Name:        "roundtrip",
 		DisplayName: "Round Trip Test",
@@ -321,7 +321,7 @@ func TestPersonaDefinitionRoundTrip(t *testing.T) {
 		Priority: 42,
 	}
 
-	def := PersonaDefinitionFromPersona(original, "tester@example.com")
+	def := DefinitionFromPersona(original, "tester@example.com")
 	converted := def.ToPersona()
 
 	assert.Equal(t, original.Name, converted.Name)
@@ -334,9 +334,9 @@ func TestPersonaDefinitionRoundTrip(t *testing.T) {
 	assert.Equal(t, original.Priority, converted.Priority)
 }
 
-// --- PostgresPersonaStore sqlmock tests ---
+// --- PostgresStore sqlmock tests ---
 
-func TestPostgresPersonaStoreList(t *testing.T) {
+func TestPostgresStoreList(t *testing.T) {
 	store, mock := newTestPersonaStore(t)
 	now := time.Now()
 
@@ -382,7 +382,7 @@ func TestPostgresPersonaStoreList(t *testing.T) {
 	}
 }
 
-func TestPostgresPersonaStoreList_QueryError(t *testing.T) {
+func TestPostgresStoreList_QueryError(t *testing.T) {
 	store, mock := newTestPersonaStore(t)
 
 	mock.ExpectQuery("SELECT name, display_name, description, roles, tools_allow, tools_deny").
@@ -399,7 +399,7 @@ func TestPostgresPersonaStoreList_QueryError(t *testing.T) {
 	}
 }
 
-func TestPostgresPersonaStoreGet(t *testing.T) {
+func TestPostgresStoreGet(t *testing.T) {
 	store, mock := newTestPersonaStore(t)
 	now := time.Now()
 
@@ -435,7 +435,7 @@ func TestPostgresPersonaStoreGet(t *testing.T) {
 	}
 }
 
-func TestPostgresPersonaStoreGet_NotFound(t *testing.T) {
+func TestPostgresStoreGet_NotFound(t *testing.T) {
 	store, mock := newTestPersonaStore(t)
 
 	rows := sqlmock.NewRows(personaColumns) // empty result set
@@ -445,18 +445,18 @@ func TestPostgresPersonaStoreGet_NotFound(t *testing.T) {
 
 	def, err := store.Get(context.Background(), "nonexistent")
 	assert.Nil(t, def)
-	assert.ErrorIs(t, err, ErrPersonaNotFound)
+	assert.ErrorIs(t, err, ErrNotFound)
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf(personaFmtUnmetExpect, err)
 	}
 }
 
-func TestPostgresPersonaStoreSet(t *testing.T) {
+func TestPostgresStoreSet(t *testing.T) {
 	store, mock := newTestPersonaStore(t)
 	now := time.Now()
 
-	def := PersonaDefinition{
+	def := Definition{
 		Name:        "analyst",
 		DisplayName: "Data Analyst",
 		Description: "Analyzes data",
@@ -488,7 +488,7 @@ func TestPostgresPersonaStoreSet(t *testing.T) {
 	}
 }
 
-func TestPostgresPersonaStoreDelete(t *testing.T) {
+func TestPostgresStoreDelete(t *testing.T) {
 	store, mock := newTestPersonaStore(t)
 
 	mock.ExpectExec("DELETE FROM persona_definitions WHERE name").
@@ -503,7 +503,7 @@ func TestPostgresPersonaStoreDelete(t *testing.T) {
 	}
 }
 
-func TestPostgresPersonaStoreDelete_NotFound(t *testing.T) {
+func TestPostgresStoreDelete_NotFound(t *testing.T) {
 	store, mock := newTestPersonaStore(t)
 
 	mock.ExpectExec("DELETE FROM persona_definitions WHERE name").
@@ -511,14 +511,14 @@ func TestPostgresPersonaStoreDelete_NotFound(t *testing.T) {
 		WillReturnResult(driver.RowsAffected(0))
 
 	err := store.Delete(context.Background(), "nonexistent")
-	assert.ErrorIs(t, err, ErrPersonaNotFound)
+	assert.ErrorIs(t, err, ErrNotFound)
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf(personaFmtUnmetExpect, err)
 	}
 }
 
-func TestPostgresPersonaStoreDelete_ExecError(t *testing.T) {
+func TestPostgresStoreDelete_ExecError(t *testing.T) {
 	store, mock := newTestPersonaStore(t)
 
 	mock.ExpectExec("DELETE FROM persona_definitions WHERE name").
@@ -534,7 +534,7 @@ func TestPostgresPersonaStoreDelete_ExecError(t *testing.T) {
 	}
 }
 
-func TestPostgresPersonaStoreList_ScanError(t *testing.T) {
+func TestPostgresStoreList_ScanError(t *testing.T) {
 	store, mock := newTestPersonaStore(t)
 
 	// Return a row with invalid data types to trigger scan error
@@ -551,7 +551,7 @@ func TestPostgresPersonaStoreList_ScanError(t *testing.T) {
 	}
 }
 
-func TestPostgresPersonaStoreGet_QueryError(t *testing.T) {
+func TestPostgresStoreGet_QueryError(t *testing.T) {
 	store, mock := newTestPersonaStore(t)
 
 	mock.ExpectQuery("SELECT .+ FROM persona_definitions WHERE name").

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -48,6 +48,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/observability"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/platform/fieldcrypt"
+	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
 	"github.com/txn2/mcp-data-platform/pkg/platform/reflexivecapture"
 	"github.com/txn2/mcp-data-platform/pkg/portal"
 	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
@@ -144,7 +145,7 @@ type Platform struct {
 	authEventWriter    *authevents.Writer
 	connOAuthRefresher *connoauth.Refresher
 	restEncryptor      *fieldcrypt.RestFieldEncryptor
-	personaStore       PersonaStore
+	personaStore       personastore.Store
 	apiKeyStore        APIKeyStore
 
 	// Providers
@@ -944,10 +945,10 @@ func (p *Platform) DB() *sql.DB {
 // initPersonaStore initializes the persona definition store.
 func (p *Platform) initPersonaStore() {
 	if p.db != nil {
-		p.personaStore = NewPostgresPersonaStore(p.db)
+		p.personaStore = personastore.NewPostgresStore(p.db)
 		slog.Info("persona store: postgres")
 	} else {
-		p.personaStore = &NoopPersonaStore{}
+		p.personaStore = &personastore.NoopStore{}
 		slog.Info("persona store: noop (no database)")
 	}
 }
@@ -1740,6 +1741,7 @@ func (p *Platform) initSearch() error {
 
 	router := knowledge.NewRouter(p.embeddingProv, lineage, providers...)
 	router.SetProviderTimeout(p.config.Knowledge.SearchProviderTimeout) // 0 keeps the 5s default
+	router.SetEmbedTimeout(p.config.Knowledge.SearchEmbedTimeout)       // 0 keeps the 5s default
 	p.knowledgeRouter = router
 	tk := searchkit.New(instanceDefault, router)
 	if err := p.toolkitRegistry.Register(tk); err != nil {
@@ -3533,7 +3535,7 @@ func (p *Platform) ConfigStore() configstore.Store {
 }
 
 // PersonaStore returns the persona definition store, or nil if not initialized.
-func (p *Platform) PersonaStore() PersonaStore {
+func (p *Platform) PersonaStore() personastore.Store {
 	return p.personaStore
 }
 

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/platform/instructions"
+	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
 	"github.com/txn2/mcp-data-platform/pkg/query"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/resource"
@@ -4494,22 +4495,22 @@ func (m *mockConnectionStoreForTest) Persistent() bool {
 
 // mockPersonaStoreForTest is a simple mock for testing loadDBPersonas.
 type mockPersonaStoreForTest struct {
-	defs    []PersonaDefinition
+	defs    []personastore.Definition
 	listErr error
 }
 
-func (m *mockPersonaStoreForTest) List(_ context.Context) ([]PersonaDefinition, error) {
+func (m *mockPersonaStoreForTest) List(_ context.Context) ([]personastore.Definition, error) {
 	return m.defs, m.listErr
 }
 
-func (*mockPersonaStoreForTest) Get(_ context.Context, _ string) (*PersonaDefinition, error) {
-	return nil, ErrPersonaNotFound
+func (*mockPersonaStoreForTest) Get(_ context.Context, _ string) (*personastore.Definition, error) {
+	return nil, personastore.ErrNotFound
 }
 
-func (*mockPersonaStoreForTest) Set(_ context.Context, _ PersonaDefinition) error { return nil }
+func (*mockPersonaStoreForTest) Set(_ context.Context, _ personastore.Definition) error { return nil }
 
 func (*mockPersonaStoreForTest) Delete(_ context.Context, _ string) error {
-	return ErrPersonaNotFound
+	return personastore.ErrNotFound
 }
 
 func TestLoadDBPersonas(t *testing.T) {
@@ -4520,7 +4521,7 @@ func TestLoadDBPersonas(t *testing.T) {
 		p := &Platform{
 			personaRegistry: reg,
 			personaStore: &mockPersonaStoreForTest{
-				defs: []PersonaDefinition{
+				defs: []personastore.Definition{
 					{
 						Name:        "analyst",
 						DisplayName: "Data Analyst",
@@ -4551,7 +4552,7 @@ func TestLoadDBPersonas(t *testing.T) {
 		p := &Platform{
 			personaRegistry: reg,
 			personaStore: &mockPersonaStoreForTest{
-				defs: []PersonaDefinition{
+				defs: []personastore.Definition{
 					{
 						Name:        "analyst",
 						DisplayName: "New Name",
@@ -4600,8 +4601,8 @@ func TestInitPersonaStore(t *testing.T) {
 		if p.personaStore == nil {
 			t.Fatal("personaStore should not be nil")
 		}
-		if _, ok := p.personaStore.(*NoopPersonaStore); !ok {
-			t.Error("expected NoopPersonaStore when db is nil")
+		if _, ok := p.personaStore.(*personastore.NoopStore); !ok {
+			t.Error("expected personastore.NoopStore when db is nil")
 		}
 	})
 
@@ -4618,14 +4619,14 @@ func TestInitPersonaStore(t *testing.T) {
 		if p.personaStore == nil {
 			t.Fatal("personaStore should not be nil")
 		}
-		if _, ok := p.personaStore.(*PostgresPersonaStore); !ok {
-			t.Error("expected PostgresPersonaStore when db is set")
+		if _, ok := p.personaStore.(*personastore.PostgresStore); !ok {
+			t.Error("expected personastore.PostgresStore when db is set")
 		}
 	})
 }
 
 func TestPersonaStoreAccessor(t *testing.T) {
-	noop := &NoopPersonaStore{}
+	noop := &personastore.NoopStore{}
 	p := &Platform{personaStore: noop}
 	if p.PersonaStore() != noop {
 		t.Error("PersonaStore() should return the assigned store")

--- a/pkg/platform/reload_test.go
+++ b/pkg/platform/reload_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/txn2/mcp-data-platform/pkg/auth"
+	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/session"
 	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
@@ -48,7 +49,7 @@ func TestPlatform_ReloadWiring(t *testing.T) {
 		config:          &Config{},
 		toolkitRegistry: reg,
 		connectionStore: fakeConnStore{cfg: map[string]any{"base_url": "https://x"}},
-		personaStore:    &NoopPersonaStore{},
+		personaStore:    &personastore.NoopStore{},
 		apiKeyStore:     fakeAPIKeyStore{},
 		apiKeyAuth:      auth.NewAPIKeyAuthenticator(auth.APIKeyConfig{}),
 	}


### PR DESCRIPTION
## Summary

Splits the search-path intent-embedding timeout from the per-provider fan-out timeout so the two can be tuned independently. Closes #795.

v1.98.2 (#794) bounded the `search` fan-out with a single knob, `knowledge.search_provider_timeout` (default 5s), applied via `Router.providerContext(ctx)` in two structurally different places:

1. Each **provider arm** in `fanOut` (the parallel knowledge sources).
2. The serial **intent-embedding** call (`embedding.EmbedForSearch`) at the top of `Router.Search`.

These have different failure semantics:

- A **fan-out arm** should drop out quickly so one slow source does not hold up the others — a tight bound is correct.
- The **intent embedding** is a serial front-step. When it is cut short, the search silently falls back to **lexical** ranking and loses semantic relevance. It is reasonable to give it more headroom.

Under one knob, an operator who wanted to protect ranking quality by giving the embedder more time had to also loosen the fan-out bound (reintroducing the stall risk #794 fixed), and vice versa. This PR gives the embedding its own knob.

## What changed

### The timeout split (`pkg/knowledge/router.go`)

- New `Router.embedTimeout` field, `SetEmbedTimeout`, and `embedContext`, mirroring the existing `providerTimeout` / `SetProviderTimeout` / `providerContext` trio.
- `Router.Search` now bounds `EmbedForSearch` with `embedContext` instead of `providerContext`. The fan-out arms are untouched — they still use `providerContext`.
- `SetEmbedTimeout` follows the same keep-default/disable semantics as `SetProviderTimeout`: `0` keeps the default (so an unset config value can be passed unconditionally), a negative value disables the bound.

### Config + wiring (`pkg/platform/config.go`, `pkg/platform/platform.go`)

- New `knowledge.search_embed_timeout` (duration). **Default 5s** — identical to the fan-out default, so existing deployments behave exactly as they do in v1.98.2 (a search still completes even when the embedder is slow). Operators who want to protect `hybrid` ranking on a slow/cold embedder can now raise it without loosening the fan-out bound.
- One wiring line: `router.SetEmbedTimeout(p.config.Knowledge.SearchEmbedTimeout)`.

### `pkg/platform/personastore` extraction (budget gate)

`pkg/platform` was sitting at **exactly** its 11800-LOC `TestPackageSizeBudget` ceiling, so adding the config field tripped the gate — which by design requires decomposition rather than raising the budget. The persona storage layer is fully decoupled from `*Platform` (it only depends on `*sql.DB` and `pkg/persona`), so it is a clean extraction target:

- Moved `persona_store.go` and its test into a new `pkg/platform/personastore` package, de-stuttering the exported names (`PersonaStore` → `Store`, `PersonaDefinition` → `Definition`, `PostgresPersonaStore` → `PostgresStore`, `NoopPersonaStore` → `NoopStore`, `ErrPersonaNotFound` → `ErrNotFound`, `PersonaDefinitionFromPersona` → `DefinitionFromPersona`, `NewPostgresPersonaStore` → `NewPostgresStore`).
- Updated the callers directly (`pkg/platform` internals and the 5 `pkg/admin` files) to import the new package — no compatibility shim.
- **`pkg/platform`: 11800 → 11549 LOC**, restoring ~250 lines of headroom under the budget.

### Docs

- `docs/server/configuration.md` and `docs/llms-full.txt`: document `search_embed_timeout`, and clarify that `search_provider_timeout` now bounds the fan-out arms only.

## Acceptance criteria (from #795)

- [x] The search-path embedding and the per-provider fan-out arms use separate, independently configurable timeouts.
- [x] With defaults unchanged, existing deployments behave as they do in v1.98.2 (a search still completes even when the embedder is slow) — default remains 5s.
- [x] Unit test: with a short fan-out timeout and a longer embed timeout, an embedder slower than the fan-out timeout but faster than the embed timeout still produces `hybrid` ranking, while a genuinely slow provider still drops out at the fan-out bound (`TestRouter_EmbedTimeoutSeparateFromFanOut`).
- [x] Docs updated (`docs/server/configuration.md`, `docs/llms-full.txt`).

## Tests

New tests in `pkg/knowledge/router_timeout_test.go`:

- `TestRouter_EmbedTimeoutSeparateFromFanOut` — the core proof: a `slowEmbedder` (150ms) slower than a 40ms fan-out bound but faster than a 2s embed bound still yields `hybrid` ranking, while a blocking provider drops at the fan-out bound.
- `TestRouter_EmbedTimeoutCutShortDegradesToLexical` — the embed bound still bites: an embedder slower than its own bound degrades to `lexical`.
- `TestNewRouter_DefaultEmbedTimeout` — default is set; `SetEmbedTimeout(0)` preserves it; a positive value overrides.
- `TestRouter_EmbedTimeoutDisabled` — a non-positive bound runs the embed under the request context only.

New router functions are at 100% coverage; the moved `personastore` package is at 92.9%.

## Verification

`make verify` passes end-to-end (fmt, `go test -race`, total + patch coverage ≥80%, `golangci-lint` incl. `--new-from-rev`, gosec + govulncheck, semgrep, CodeQL, dead-code, mutation ≥60%, doc-check, GoReleaser dry-run). Playwright e2e suite green. `TestPackageSizeBudget`, `TestNoDeadPackages`, `TestNoopOnlyInterfaces`, and `TestMigrationTablesHaveConsumers` all pass.

## Notes / out of scope

Per #795, the observability follow-up noted in #794 is deliberately not included here: a silently degraded embedding (lexical instead of hybrid) still has no distinct log line, metric, or `degraded_sources` signal to the agent. That is tracked separately; this PR is only the timeout split (plus the budget-driven extraction).
