### PR TITLE
feat(enrichment): budget the memory-enrichment payload (#761)

### DIFF
--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -310,6 +310,15 @@ enrichment:
   # shows all columns. PII/sensitive columns are always included for safety.
   # column_context_filtering: true   # Default: true
 
+  # Memory-enrichment payload budget (issue #761)
+  # Bounds the memory_context block attached to each tool response so recalled
+  # memories stay a supporting note rather than crowding out the analyzed data.
+  # Records are rendered summary-first with a fetch reference (mcp:memory:<id>);
+  # the agent fetches the full record only when the excerpt is not enough.
+  # memory_limit: 5                     # Max records recalled per tool call. Default: 5
+  # memory_context_budget_bytes: 1500   # Byte budget for rendered summaries; over-budget records become fetchable id+reference stubs; 0 disables. Default: 1500
+  # memory_summary_bytes: 280           # Per-record excerpt cap; 0 = full content. Default: 280
+
   # Session metadata deduplication
   # Avoids repeating large semantic metadata blocks for previously-enriched
   # tables within the same client session, saving LLM context tokens.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -267,6 +267,9 @@ enrichment:
   column_context_filtering: true   # Only enrich columns referenced in SQL (default: true)
   semantic_fallback: false         # Fallback to similarity search on URN miss (default: false, issue #444)
   semantic_fallback_top_k: 1       # Suggested matches per miss (default: 1, max: 10)
+  memory_limit: 5                     # Max memory records recalled per tool call (default: 5, issue #761)
+  memory_context_budget_bytes: 1500   # Byte budget for rendered summaries; over-budget records become fetchable stubs; 0 disables (default: 1500)
+  memory_summary_bytes: 280           # Per-record summary excerpt cap; 0 = full content (default: 280)
 ```
 
 ## Server Configuration
@@ -642,6 +645,9 @@ Explicit session handles (`sessions.handles`, issue #792) adopt the pattern the 
 | `schema_preview_max_columns` | int | 15 | Max columns per entity in schema preview |
 | `semantic_fallback` | bool | false | When a Trino-table URN lookup misses on the semantic provider, fall back to a similarity search and surface the top-K hits as SUGGESTED matches annotated with `match_kind: semantic`. Default off; operators opt in. Issue #444. |
 | `semantic_fallback_top_k` | int | 1 | Number of similarity-search hits surfaced per URN miss when `semantic_fallback` is on. Clamped to [1, 10]. |
+| `memory_limit` | int | 5 | Max memory records recalled and rendered into `memory_context` per tool call. Issue #761. |
+| `memory_context_budget_bytes` | int | 1500 | Byte budget for the rendered memory summaries; records beyond it are listed as compact `id`+`reference` stubs in `memory_context_omitted` (still fetchable, at least one always rendered). `0` disables the budget. |
+| `memory_summary_bytes` | int | 280 | Per-record summary-first excerpt cap; the full record is fetchable via its `mcp:memory:<id>` reference. `0` renders full content. |
 
 When `semantic_fallback` fires, the appended content carries `semantic_fallback.match_kind: semantic`, a human-readable note, the queried table identifier, and a list of suggested matches (urn, name, platform, description, tags, domain). The audit row's `enrichment_match_kind` column records `semantic` for these calls and `urn` for exact lookups, so operators can compute the false-positive rate of similarity-based suggestions with a SQL aggregate.
 
@@ -911,6 +917,7 @@ Metrics are enabled by default. Configuration is environment-only for Phase 1 to
 | `mcp_tool_calls_total` | counter | `tool`, `toolkit_kind`, `persona`, `status_category` |
 | `mcp_tool_call_duration_seconds` | histogram | `tool`, `toolkit_kind`, `persona`, `status_category` |
 | `mcp_inflight_tool_calls` | gauge | (none) |
+| `mcp_enrichment_bytes_total` | counter | `tool`, `toolkit_kind`, `persona` |
 | `apigateway_outbound_total` | counter | `connection`, `http_status_class`, `status_category` |
 | `apigateway_outbound_duration_seconds` | histogram | `connection`, `http_status_class`, `status_category` |
 | `apigateway_inbound_requests_total` | counter | `connection`, `operation_id`, `method`, `status_class`, `identity` |

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -717,6 +717,12 @@ enrichment:
   unwrap_json: true               # Auto-unwrap single-row VARCHAR-of-JSON (default: true)
   column_context_filtering: true     # Only include SQL-referenced columns (default: true)
 
+  # Memory-enrichment payload budget (issue #761): keeps recalled memories a
+  # supporting note rather than crowding out the analyzed data.
+  memory_limit: 5                    # Max memory records recalled per tool call (default: 5)
+  memory_context_budget_bytes: 1500  # Byte budget for rendered summaries; over-budget records become fetchable stubs; 0 disables (default: 1500)
+  memory_summary_bytes: 280          # Per-record summary excerpt cap; 0 = full content (default: 280)
+
   # Session metadata deduplication (avoids repeating metadata for same table)
   session_dedup:
     enabled: true             # Default: true
@@ -733,6 +739,9 @@ enrichment:
 | `datahub_storage_enrichment` | bool | `true` | Add S3 availability to DataHub results. Default on; set `false` to disable. |
 | `unwrap_json` | bool | `true` | Auto-unwrap single-row VARCHAR-of-JSON results |
 | `column_context_filtering` | bool | `true` | Limit column enrichment to SQL-referenced columns |
+| `memory_limit` | int | `5` | Max memory records recalled and rendered into `memory_context` per tool call |
+| `memory_context_budget_bytes` | int | `1500` | Byte budget for the rendered memory summaries; records beyond it are listed as compact `id`+`reference` stubs in `memory_context_omitted` (still fetchable, at least one always rendered). `0` disables the budget |
+| `memory_summary_bytes` | int | `280` | Per-record summary-first excerpt cap; the full record is fetchable via its `mcp:memory:<id>` reference. `0` renders full content |
 | `session_dedup.enabled` | bool | `true` | Whether session dedup is active |
 | `session_dedup.mode` | string | `reference` | Repeat query content: `reference`, `summary`, `none` |
 | `session_dedup.entry_ttl` | duration | semantic cache TTL | How long a table stays "already sent" |

--- a/docs/server/observability.md
+++ b/docs/server/observability.md
@@ -82,6 +82,7 @@ and a README covering how to load them and confirm scraping with
 | `mcp_tool_calls_total` | counter | `tool`, `toolkit_kind`, `persona`, `status_category` |
 | `mcp_tool_call_duration_seconds` | histogram | `tool`, `toolkit_kind`, `persona`, `status_category` |
 | `mcp_inflight_tool_calls` | gauge | (none) |
+| `mcp_enrichment_bytes_total` | counter | `tool`, `toolkit_kind`, `persona` |
 | `apigateway_outbound_total` | counter | `connection`, `http_status_class`, `status_category` |
 | `apigateway_outbound_duration_seconds` | histogram | `connection`, `http_status_class`, `status_category` |
 | `apigateway_inbound_requests_total` | counter | `connection`, `operation_id`, `method`, `status_class`, `identity` |
@@ -113,6 +114,14 @@ queries, or the metadata operation (`list_catalogs`, `list_schemas`,
 implemented: the mcp-trino client (v1.3.0) does not expose a
 bytes-scanned figure in its query stats, so there is no honest source
 for it.
+
+**Enrichment overhead**: `mcp_enrichment_bytes_total` accumulates the byte
+size of the cross-enrichment content (semantic context, memories, knowledge
+pages, discovery notes) appended to each tool response. It is recorded only on
+enriched successes, so divide by the matching `mcp_tool_calls_total` to get the
+average per-call overhead an agent's context window pays:
+`rate(mcp_enrichment_bytes_total[5m]) / rate(mcp_tool_calls_total[5m])`. Use it
+to size the memory-enrichment budget (`enrichment.memory_context_budget_bytes`).
 
 **DataHub** `operation` is one of `get_entity`, `get_schema`,
 `get_schemas`, `get_lineage`, `get_column_lineage`, `get_glossary_term`,

--- a/pkg/middleware/context.go
+++ b/pkg/middleware/context.go
@@ -81,6 +81,19 @@ type PlatformContext struct {
 	// enrichment ran. See pkg/audit.Event.EnrichmentMatchKind.
 	EnrichmentMatchKind string
 
+	// EnrichmentBytes is the total serialized size, in bytes, of ALL
+	// enrichment content blocks the middleware appended to this call's
+	// response (semantic context, memories, knowledge pages, discovery
+	// note). Read by the metrics middleware to record the per-response
+	// enrichment overhead (issue #761). Zero when nothing was appended.
+	//
+	// This is intentionally broader than EnrichmentApplied, which flags
+	// only the semantic/query/storage enrichment step: a call that appends
+	// memory context but no semantic context has EnrichmentBytes > 0 while
+	// EnrichmentApplied stays false. EnrichmentBytes answers "how much did
+	// enrichment cost the context window", not "did semantic enrichment run".
+	EnrichmentBytes int
+
 	// Results (populated after handler)
 	Success      bool
 	ErrorMessage string

--- a/pkg/middleware/mcp_enrichment.go
+++ b/pkg/middleware/mcp_enrichment.go
@@ -133,12 +133,16 @@ func applyEnrichment(
 	}
 
 	// Attach relevant memories from the memory layer.
-	enrichedResult = enrichWithMemories(ctx, enricher.memoryProvider, enrichedResult, pc)
+	enrichedResult = enrichWithMemories(ctx, enricher.memoryProvider, enrichedResult, pc, enricher.cfg)
 
 	// Attach the canonical knowledge pages that document the named entities (#634).
 	enrichedResult = enrichWithKnowledgePages(ctx, enricher.pageProvider, enrichedResult, entityURNs)
 
 	appendDiscoveryNoteIfNeeded(ctx, enrichedResult, pc, enricher.cfg.WorkflowTracker)
+
+	// Record how many bytes of enrichment this call appended so the metrics
+	// middleware can surface the per-response overhead (issue #761).
+	pc.EnrichmentBytes = enrichmentContentBytes(enrichedResult, beforeLen)
 
 	// Mirror every platform-added enrichment block into the structured result so
 	// MCP clients that render only structured output still receive the semantic
@@ -220,6 +224,23 @@ func appendDiscoveryNoteIfNeeded(ctx context.Context, result *mcp.CallToolResult
 		return
 	}
 	result.Content = append(result.Content, &mcp.TextContent{Text: string(noteJSON)})
+}
+
+// enrichmentContentBytes sums the byte length of the text content blocks the
+// enrichment pipeline appended (indices >= fromIndex), giving the per-response
+// enrichment overhead the metrics layer reports (issue #761). Non-text blocks
+// (resource links, images) carry no enrichment prose and are not counted.
+func enrichmentContentBytes(result *mcp.CallToolResult, fromIndex int) int {
+	if result == nil || fromIndex < 0 || fromIndex >= len(result.Content) {
+		return 0
+	}
+	total := 0
+	for _, c := range result.Content[fromIndex:] {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			total += len(tc.Text)
+		}
+	}
+	return total
 }
 
 // inferToolkitKind determines the toolkit kind from a tool name prefix.

--- a/pkg/middleware/mcp_metrics.go
+++ b/pkg/middleware/mcp_metrics.go
@@ -53,6 +53,12 @@ func recordToolCall(
 	pc := GetPlatformContext(ctx)
 	attrs := toolCallAttrs(pc, result, err)
 	metrics.RecordToolCall(ctx, attrs, duration)
+
+	// Enrichment runs inner to this middleware, so pc.EnrichmentBytes is set
+	// on the shared PlatformContext by the time next() returns (issue #761).
+	if pc != nil && pc.EnrichmentBytes > 0 {
+		metrics.RecordEnrichmentBytes(ctx, attrs, pc.EnrichmentBytes)
+	}
 	return result, err
 }
 

--- a/pkg/middleware/mcp_metrics_test.go
+++ b/pkg/middleware/mcp_metrics_test.go
@@ -81,6 +81,70 @@ func TestMCPMetricsMiddleware_IntegrationRecordsToolCall(t *testing.T) {
 	}
 }
 
+// TestMCPMetricsMiddleware_RecordsEnrichmentBytes proves the issue #761 wiring
+// end-to-end: a middleware inner to the metrics middleware (mimicking the
+// enrichment middleware's position) sets PlatformContext.EnrichmentBytes on the
+// shared context, and the metrics middleware records it as mcp_enrichment_bytes
+// after the inner handler returns.
+func TestMCPMetricsMiddleware_RecordsEnrichmentBytes(t *testing.T) {
+	m, err := observability.New(observability.Config{Enabled: true})
+	if err != nil {
+		t.Fatalf("observability.New: %v", err)
+	}
+	defer func() { _ = m.Shutdown(context.Background()) }()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "enrich-bytes-test", Version: "v0.0.0"}, nil)
+	server.AddTool(&mcp.Tool{
+		Name:        "trino_query",
+		Description: "test",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+	}, func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil
+	})
+
+	authenticator := &fakeAuthn{user: &middleware.UserInfo{UserID: "u1", Roles: []string{"analyst"}}}
+	authorizer := &fakeAuthz{persona: "analyst"}
+	lookup := &fakeLookup{kind: "trino", name: "prod", conn: "primary"}
+
+	// Enrichment simulator (innermost) sets EnrichmentBytes on the shared
+	// PlatformContext, exactly where the real enrichment middleware sits.
+	enrichSim := func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			if pc := middleware.GetPlatformContext(ctx); pc != nil {
+				pc.EnrichmentBytes = 777
+			}
+			return next(ctx, method, req)
+		}
+	}
+
+	// Innermost first: enrichSim, then Metrics (must be OUTER to enrichSim so it
+	// reads EnrichmentBytes after next returns), then ToolCall (outermost).
+	server.AddReceivingMiddleware(enrichSim)
+	server.AddReceivingMiddleware(middleware.MCPMetricsMiddleware(m))
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(
+		authenticator, authorizer, lookup,
+		middleware.ToolCallConfig{Transport: "stdio", AdminPersona: "admin"},
+	))
+
+	ctx := context.Background()
+	sess := mustConnect(ctx, t, server)
+	defer func() { _ = sess.Close() }()
+
+	res, err := sess.CallTool(ctx, &mcp.CallToolParams{Name: "trino_query"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool returned error: %v", res.Content)
+	}
+
+	body := scrape(t, m.Handler())
+	want := `mcp_enrichment_bytes_total{persona="analyst",tool="trino_query",toolkit_kind="trino"} 777`
+	if !strings.Contains(body, want) {
+		t.Errorf("scrape missing enrichment-bytes series: %q\n--- body ---\n%s", want, body)
+	}
+}
+
 // TestMCPMetricsMiddleware_DisabledIsNoOp verifies that wiring the
 // middleware with a nil recorder does not panic and does not interfere
 // with normal tool execution. This is the path operators take when

--- a/pkg/middleware/memory_enrichment.go
+++ b/pkg/middleware/memory_enrichment.go
@@ -3,7 +3,9 @@ package middleware
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -28,7 +30,12 @@ type MemoryProvider interface {
 
 // MemorySnippet is a lightweight memory representation for cross-enrichment.
 type MemorySnippet struct {
-	ID         string    `json:"id"`
+	ID string `json:"id"`
+	// Reference is the canonical fetch handle for the full record
+	// (mcp:memory:<id>), surfaced so the agent can retrieve the untruncated
+	// content when a summary is not enough. Empty when the provider does not
+	// supply one. Issue #761.
+	Reference  string    `json:"reference,omitempty"`
 	Content    string    `json:"content"`
 	Dimension  string    `json:"dimension"`
 	Category   string    `json:"category"`
@@ -36,9 +43,36 @@ type MemorySnippet struct {
 	CreatedAt  time.Time `json:"created_at"`
 }
 
+// memoryStub is the reference-only form of a budget-omitted record: enough for
+// the agent to fetch the full record without spending the summary's bytes. It
+// keeps every recalled record retrievable even when the byte budget trims the
+// rendered summaries. Issue #761.
+type memoryStub struct {
+	ID        string `json:"id"`
+	Reference string `json:"reference,omitempty"`
+}
+
+// renderedMemory is the summary-first shape of a memory record as it appears in
+// the memory_context enrichment block. It carries a bounded Summary plus the
+// Reference the agent uses to fetch the full record, rather than the record's
+// full content. Issue #761.
+type renderedMemory struct {
+	ID         string    `json:"id"`
+	Reference  string    `json:"reference,omitempty"`
+	Summary    string    `json:"summary"`
+	Truncated  bool      `json:"truncated,omitempty"`
+	Dimension  string    `json:"dimension,omitempty"`
+	Category   string    `json:"category,omitempty"`
+	Confidence string    `json:"confidence,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
 // enrichWithMemories appends memory context to a tool call result.
-// It extracts entity URNs from the result content and recalls related memories.
-func enrichWithMemories(ctx context.Context, mp MemoryProvider, result *mcp.CallToolResult, pc *PlatformContext) *mcp.CallToolResult {
+// It extracts entity URNs from the result content and recalls related memories,
+// then renders them summary-first under a configurable record limit and total
+// byte budget so the enrichment does not crowd out the data the agent is
+// analyzing (issue #761).
+func enrichWithMemories(ctx context.Context, mp MemoryProvider, result *mcp.CallToolResult, pc *PlatformContext, cfg EnrichmentConfig) *mcp.CallToolResult {
 	if mp == nil || result == nil || pc == nil {
 		return result
 	}
@@ -48,21 +82,45 @@ func enrichWithMemories(ctx context.Context, mp MemoryProvider, result *mcp.Call
 		return result
 	}
 
-	memories, err := mp.RecallForEntities(ctx, urns, pc.PersonaName, defaultMemoryEnrichmentLimit)
+	limit := cfg.MemoryLimit
+	if limit <= 0 {
+		limit = defaultMemoryEnrichmentLimit
+	}
+
+	memories, err := mp.RecallForEntities(ctx, urns, pc.PersonaName, limit)
 	if err != nil {
 		slog.Debug("memory enrichment failed", "error", err)
 		return result
 	}
-
 	if len(memories) == 0 {
 		return result
 	}
 
-	memoryContext := map[string]any{
-		"memory_context": memories,
+	return appendMemoryContextBlock(result, memories, cfg)
+}
+
+// appendMemoryContextBlock renders recalled memories summary-first and appends
+// the memory_context block (with an omitted-stub list when the budget trims
+// records) to result. Returns result unchanged if nothing is rendered or the
+// block fails to marshal. Split out of enrichWithMemories to keep each function
+// under the cyclomatic-complexity ceiling.
+func appendMemoryContextBlock(result *mcp.CallToolResult, memories []MemorySnippet, cfg EnrichmentConfig) *mcp.CallToolResult {
+	rendered, omitted := renderMemoryContext(memories, cfg.MemorySummaryBytes, cfg.MemoryContextBudgetBytes)
+	if len(rendered) == 0 {
+		return result
 	}
 
-	data, err := json.Marshal(memoryContext)
+	block := map[string]any{"memory_context": rendered}
+	if len(omitted) > 0 {
+		// Omitted records are still listed as compact id+reference stubs so the
+		// agent can fetch any of them — the note promises exactly that (#761).
+		block["memory_context_omitted"] = omitted
+		block["memory_context_note"] = fmt.Sprintf(
+			"%d additional related memory record(s) omitted to stay within the enrichment budget; "+
+				"fetch any by its reference in memory_context_omitted for full detail.", len(omitted))
+	}
+
+	data, err := json.Marshal(block)
 	if err != nil {
 		slog.Debug("failed to marshal memory context", "error", err)
 		return result
@@ -73,6 +131,97 @@ func enrichWithMemories(ctx context.Context, mp MemoryProvider, result *mcp.Call
 	})
 
 	return result
+}
+
+// renderMemoryContext turns recalled snippets into the summary-first
+// memory_context payload, applying (in order) near-duplicate collapsing, summary
+// truncation, and a byte budget over the rendered summaries. Records beyond the
+// budget are returned as compact id+reference stubs (not dropped) so they stay
+// fetchable. At least one record is always rendered so a small budget never
+// suppresses memory enrichment entirely.
+//
+// The budget bounds the rendered summaries only; the small, memory_limit-bounded
+// stub list and the note deliberately sit outside it so the budget can be set
+// low without making any recalled record unretrievable.
+func renderMemoryContext(memories []MemorySnippet, summaryBytes, budgetBytes int) (rendered []renderedMemory, omitted []memoryStub) {
+	seen := make(map[string]bool, len(memories))
+	total := 0
+
+	for _, m := range memories {
+		// Dedup on the FULL content, not the truncated summary: two distinct
+		// records that merely share a common prefix must not collapse to one
+		// (that would silently drop the second). Only genuine near-duplicates
+		// (same text, cosmetic differences) share a full-content key.
+		key := dedupKey(m.Content)
+		if key != "" && seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		summary, truncated := summarizeMemory(m.Content, summaryBytes)
+		rec := renderedMemory{
+			ID:         m.ID,
+			Reference:  m.Reference,
+			Summary:    summary,
+			Truncated:  truncated,
+			Dimension:  m.Dimension,
+			Category:   m.Category,
+			Confidence: m.Confidence,
+			CreatedAt:  m.CreatedAt,
+		}
+
+		size := recordSizeEstimate(rec)
+		if budgetBytes > 0 && len(rendered) > 0 && total+size > budgetBytes {
+			omitted = append(omitted, memoryStub{ID: m.ID, Reference: m.Reference})
+			continue
+		}
+
+		total += size
+		rendered = append(rendered, rec)
+	}
+
+	return rendered, omitted
+}
+
+// summarizeMemory reduces a memory record's content to a summary-first excerpt:
+// the first paragraph when it fits, otherwise the first summaryBytes bytes on a
+// rune boundary. The bool reports whether any content was dropped, signaling
+// the agent to fetch the full record when the excerpt is not enough. A
+// non-positive summaryBytes disables truncation.
+func summarizeMemory(content string, summaryBytes int) (summary string, truncated bool) {
+	content = strings.TrimSpace(content)
+
+	// Prefer the first paragraph as a natural summary boundary.
+	if idx := strings.Index(content, "\n\n"); idx > 0 {
+		firstPara := strings.TrimSpace(content[:idx])
+		if firstPara != "" && (summaryBytes <= 0 || len(firstPara) <= summaryBytes) {
+			return firstPara, len(firstPara) < len(content)
+		}
+	}
+
+	if summaryBytes <= 0 || len(content) <= summaryBytes {
+		return content, false
+	}
+	// clampUTF8 (mcp_reflexive_capture.go) does the rune-boundary back-off; trim
+	// any whitespace the cut exposed.
+	return strings.TrimSpace(clampUTF8(content, summaryBytes)), true
+}
+
+// dedupKey normalizes text to a whitespace- and case-insensitive form so
+// near-identical records (the same text captured twice, or the same fact with
+// cosmetic differences) collapse to one at render time.
+func dedupKey(text string) string {
+	return strings.Join(strings.Fields(strings.ToLower(text)), " ")
+}
+
+// recordSizeEstimate approximates a rendered record's serialized JSON size for
+// budget accounting, without a throwaway marshal on the enrichment hot path: the
+// variable field lengths plus a fixed allowance for the JSON keys, quoting, and
+// the RFC-3339 created_at value.
+func recordSizeEstimate(rec renderedMemory) int {
+	const fixedKeyOverhead = 120
+	return len(rec.ID) + len(rec.Reference) + len(rec.Summary) +
+		len(rec.Dimension) + len(rec.Category) + len(rec.Confidence) + fixedKeyOverhead
 }
 
 // extractEntityURNsFromResult scans result content for DataHub URNs.

--- a/pkg/middleware/memory_enrichment_test.go
+++ b/pkg/middleware/memory_enrichment_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
@@ -34,7 +36,7 @@ func TestEnrichWithMemories_NilProvider(t *testing.T) {
 	}
 	pc := &PlatformContext{PersonaName: "analyst"}
 
-	got := enrichWithMemories(context.Background(), nil, result, pc)
+	got := enrichWithMemories(context.Background(), nil, result, pc, EnrichmentConfig{})
 	assert.Equal(t, result, got)
 	assert.Len(t, got.Content, 1) // unchanged
 }
@@ -43,7 +45,7 @@ func TestEnrichWithMemories_NilResult(t *testing.T) {
 	mp := &mockMemoryProvider{}
 	pc := &PlatformContext{PersonaName: "analyst"}
 
-	got := enrichWithMemories(context.Background(), mp, nil, pc)
+	got := enrichWithMemories(context.Background(), mp, nil, pc, EnrichmentConfig{})
 	assert.Nil(t, got)
 }
 
@@ -53,7 +55,7 @@ func TestEnrichWithMemories_NilContext(t *testing.T) {
 		Content: []mcp.Content{&mcp.TextContent{Text: "hello"}},
 	}
 
-	got := enrichWithMemories(context.Background(), mp, result, nil)
+	got := enrichWithMemories(context.Background(), mp, result, nil, EnrichmentConfig{})
 	assert.Equal(t, result, got)
 	assert.Len(t, got.Content, 1)
 }
@@ -65,7 +67,7 @@ func TestEnrichWithMemories_NoURNsInResult(t *testing.T) {
 	}
 	pc := &PlatformContext{PersonaName: "analyst"}
 
-	got := enrichWithMemories(context.Background(), mp, result, pc)
+	got := enrichWithMemories(context.Background(), mp, result, pc, EnrichmentConfig{})
 	assert.Len(t, got.Content, 1) // no enrichment
 	assert.Nil(t, mp.recallURNs)  // RecallForEntities was not called
 }
@@ -93,7 +95,7 @@ func TestEnrichWithMemories_URNsFound_MemoriesAttached(t *testing.T) {
 	}
 	pc := &PlatformContext{PersonaName: "analyst"}
 
-	got := enrichWithMemories(context.Background(), mp, result, pc)
+	got := enrichWithMemories(context.Background(), mp, result, pc, EnrichmentConfig{})
 	require.Len(t, got.Content, 2) // original + memory context
 
 	// Verify the recall was called with correct args
@@ -124,7 +126,7 @@ func TestEnrichWithMemories_RecallError(t *testing.T) {
 	}
 	pc := &PlatformContext{PersonaName: "analyst"}
 
-	got := enrichWithMemories(context.Background(), mp, result, pc)
+	got := enrichWithMemories(context.Background(), mp, result, pc, EnrichmentConfig{})
 	assert.Len(t, got.Content, 1) // no enrichment appended on error
 }
 
@@ -142,7 +144,7 @@ func TestEnrichWithMemories_EmptyMemories(t *testing.T) {
 	}
 	pc := &PlatformContext{PersonaName: "analyst"}
 
-	got := enrichWithMemories(context.Background(), mp, result, pc)
+	got := enrichWithMemories(context.Background(), mp, result, pc, EnrichmentConfig{})
 	assert.Len(t, got.Content, 1) // no enrichment for empty memories
 }
 
@@ -366,4 +368,221 @@ func TestIsDataHubURN_TooLong(t *testing.T) {
 		long += "x"
 	}
 	assert.False(t, isDataHubURN(long))
+}
+
+// --- Issue #761: summary-first rendering, budget, dedup ---
+
+func TestSummarizeMemory(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      string
+		summaryBytes int
+		wantSummary  string
+		wantTrunc    bool
+	}{
+		{
+			name:         "no truncation when disabled",
+			content:      "the full content stays intact",
+			summaryBytes: 0,
+			wantSummary:  "the full content stays intact",
+			wantTrunc:    false,
+		},
+		{
+			name:         "short content under cap is untouched",
+			content:      "brief note",
+			summaryBytes: 100,
+			wantSummary:  "brief note",
+			wantTrunc:    false,
+		},
+		{
+			name:         "first paragraph preferred as summary boundary",
+			content:      "Revenue is recognized on delivery.\n\nSee the policy doc for edge cases and deferrals.",
+			summaryBytes: 100,
+			wantSummary:  "Revenue is recognized on delivery.",
+			wantTrunc:    true,
+		},
+		{
+			name:         "byte truncation when over cap and no paragraph break",
+			content:      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			summaryBytes: 10,
+			wantSummary:  "aaaaaaaaaa",
+			wantTrunc:    true,
+		},
+		{
+			name:         "leading and trailing whitespace trimmed",
+			content:      "   padded content   ",
+			summaryBytes: 0,
+			wantSummary:  "padded content",
+			wantTrunc:    false,
+		},
+		{
+			name:         "first paragraph too long falls through to byte truncation",
+			content:      "this first paragraph is quite long and exceeds the cap\n\nsecond",
+			summaryBytes: 20,
+			wantSummary:  "this first paragraph",
+			wantTrunc:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, trunc := summarizeMemory(tt.content, tt.summaryBytes)
+			assert.Equal(t, tt.wantSummary, got)
+			assert.Equal(t, tt.wantTrunc, trunc)
+		})
+	}
+}
+
+func TestSummarizeMemory_RuneBoundary(t *testing.T) {
+	// "héllo" — é is 2 bytes (0xc3 0xa9); a cap of 2 would split it, so
+	// summarizeMemory must back off to the rune start and stay valid UTF-8.
+	got, trunc := summarizeMemory("héllo", 2)
+	assert.Equal(t, "h", got)
+	assert.True(t, trunc)
+	assert.True(t, utf8.ValidString(got))
+}
+
+func TestDedupKey(t *testing.T) {
+	// Case and whitespace differences normalize to the same key.
+	assert.Equal(t, dedupKey("Revenue  Includes\nDeferred"), dedupKey("revenue includes deferred"))
+	assert.Equal(t, "", dedupKey("   "))
+	assert.NotEqual(t, dedupKey("alpha"), dedupKey("beta"))
+}
+
+func TestRenderMemoryContext_Dedup(t *testing.T) {
+	memories := []MemorySnippet{
+		{ID: "a", Content: "Revenue includes deferred amounts"},
+		{ID: "b", Content: "revenue  includes   deferred amounts"}, // near-identical
+		{ID: "c", Content: "Distinct fact about churn"},
+	}
+	rendered, omitted := renderMemoryContext(memories, 0, 0)
+	require.Len(t, rendered, 2)
+	assert.Empty(t, omitted)
+	assert.Equal(t, "a", rendered[0].ID)
+	assert.Equal(t, "c", rendered[1].ID)
+}
+
+// TestRenderMemoryContext_DedupKeysOnFullContent guards the finding-#1 fix:
+// two DISTINCT records that share an identical prefix longer than the summary
+// cap must NOT collapse — dedup keys on full content, not the truncated summary.
+func TestRenderMemoryContext_DedupKeysOnFullContent(t *testing.T) {
+	prefix := strings.Repeat("shared boilerplate heading ", 5) // > 50 bytes
+	memories := []MemorySnippet{
+		{ID: "a", Content: prefix + "FIRST record distinct tail"},
+		{ID: "b", Content: prefix + "SECOND record distinct tail"},
+	}
+	// Summary cap shorter than the shared prefix: both summaries are identical.
+	rendered, omitted := renderMemoryContext(memories, 30, 0)
+	require.Len(t, rendered, 2, "records sharing only a truncated-summary prefix must not collapse")
+	assert.Empty(t, omitted)
+	assert.Equal(t, "a", rendered[0].ID)
+	assert.Equal(t, "b", rendered[1].ID)
+}
+
+func TestRenderMemoryContext_BudgetOmitsAsStubs(t *testing.T) {
+	memories := []MemorySnippet{
+		{ID: "a", Reference: "mcp:memory:a", Content: strings.Repeat("x", 200)},
+		{ID: "b", Reference: "mcp:memory:b", Content: strings.Repeat("y", 200)},
+		{ID: "c", Reference: "mcp:memory:c", Content: strings.Repeat("z", 200)},
+	}
+	// Budget large enough for one full summary only.
+	rendered, omitted := renderMemoryContext(memories, 0, 120)
+	require.Len(t, rendered, 1)
+	assert.Equal(t, "a", rendered[0].ID)
+
+	// The over-budget records survive as fetchable stubs carrying references.
+	require.Len(t, omitted, 2)
+	assert.Equal(t, "b", omitted[0].ID)
+	assert.Equal(t, "mcp:memory:b", omitted[0].Reference)
+	assert.Equal(t, "c", omitted[1].ID)
+	assert.Equal(t, "mcp:memory:c", omitted[1].Reference)
+}
+
+func TestRenderMemoryContext_AlwaysRendersAtLeastOne(t *testing.T) {
+	memories := []MemorySnippet{
+		{ID: "a", Content: strings.Repeat("x", 5000)},
+	}
+	// Budget smaller than the single record; it must still be rendered.
+	rendered, omitted := renderMemoryContext(memories, 0, 10)
+	require.Len(t, rendered, 1)
+	assert.Empty(t, omitted)
+}
+
+func TestRenderMemoryContext_SummaryAndTruncationFlag(t *testing.T) {
+	memories := []MemorySnippet{
+		{ID: "a", Reference: "mcp:memory:a", Content: strings.Repeat("w", 500)},
+	}
+	rendered, _ := renderMemoryContext(memories, 100, 0)
+	require.Len(t, rendered, 1)
+	assert.True(t, rendered[0].Truncated)
+	assert.Equal(t, "mcp:memory:a", rendered[0].Reference)
+	assert.LessOrEqual(t, len(rendered[0].Summary), 100)
+}
+
+func TestEnrichWithMemories_SummaryFirstWithReferenceAndBudget(t *testing.T) {
+	mp := &mockMemoryProvider{
+		recallResult: []MemorySnippet{
+			{ID: "m1", Reference: "mcp:memory:m1", Content: strings.Repeat("a", 400), Dimension: "knowledge"},
+			{ID: "m2", Reference: "mcp:memory:m2", Content: strings.Repeat("b", 400), Dimension: "knowledge"},
+			{ID: "m3", Reference: "mcp:memory:m3", Content: strings.Repeat("c", 400), Dimension: "knowledge"},
+		},
+	}
+	data, _ := json.Marshal(map[string]any{
+		"table": "urn:li:dataset:(urn:li:dataPlatform:trino,cat.schema.revenue,PROD)",
+	})
+	result := &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(data)}}}
+	pc := &PlatformContext{PersonaName: "analyst"}
+
+	cfg := EnrichmentConfig{MemoryLimit: 10, MemorySummaryBytes: 80, MemoryContextBudgetBytes: 200}
+	got := enrichWithMemories(context.Background(), mp, result, pc, cfg)
+	require.Len(t, got.Content, 2)
+
+	// The configured limit is passed through to recall.
+	assert.Equal(t, 10, mp.recallLimit)
+
+	tc, ok := got.Content[1].(*mcp.TextContent)
+	require.True(t, ok)
+	var block map[string]any
+	require.NoError(t, json.Unmarshal([]byte(tc.Text), &block))
+
+	records, ok := block["memory_context"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, records)
+
+	first, ok := records[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "mcp:memory:m1", first["reference"])
+	assert.Equal(t, true, first["truncated"])
+	summary, ok := first["summary"].(string)
+	require.True(t, ok)
+	assert.LessOrEqual(t, len(summary), 80)
+	// summary-first: the full 400-char content is NOT present.
+	assert.NotContains(t, first, "content")
+
+	// Budget forced omissions, so the note AND the fetchable stub list are present.
+	assert.Contains(t, block, "memory_context_note")
+	omitted, ok := block["memory_context_omitted"].([]any)
+	require.True(t, ok, "omitted records must be listed as fetchable stubs")
+	require.NotEmpty(t, omitted)
+	stub, ok := omitted[0].(map[string]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, stub["id"])
+	assert.NotEmpty(t, stub["reference"])
+}
+
+func TestEnrichmentContentBytes(t *testing.T) {
+	result := &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "original"},
+			&mcp.TextContent{Text: "12345"},
+			&mcp.ImageContent{Data: []byte("ignored"), MIMEType: "image/png"},
+			&mcp.TextContent{Text: "678"},
+		},
+	}
+	// From index 1: "12345" (5) + image (0) + "678" (3) = 8.
+	assert.Equal(t, 8, enrichmentContentBytes(result, 1))
+	// Out-of-range indices are safe.
+	assert.Equal(t, 0, enrichmentContentBytes(result, 99))
+	assert.Equal(t, 0, enrichmentContentBytes(result, -1))
+	assert.Equal(t, 0, enrichmentContentBytes(nil, 0))
 }

--- a/pkg/middleware/semantic.go
+++ b/pkg/middleware/semantic.go
@@ -141,6 +141,25 @@ type EnrichmentConfig struct {
 	// the fallback returns per miss. Caller is expected to clamp to
 	// a sane range (the platform-level config helper does this).
 	SemanticFallbackTopK int
+
+	// MemoryLimit caps how many memory records are recalled and rendered
+	// into the memory_context enrichment block per tool call. Zero falls
+	// back to defaultMemoryEnrichmentLimit (issue #761).
+	MemoryLimit int
+
+	// MemoryContextBudgetBytes bounds the byte size of the rendered memory
+	// summaries appended per tool call. Records beyond the budget are listed
+	// as compact id+reference stubs in memory_context_omitted (still
+	// fetchable, not dropped); at least one record is always rendered so a
+	// tiny budget does not silently suppress all memory enrichment. Zero
+	// disables the budget (every recalled record is rendered). Issue #761.
+	MemoryContextBudgetBytes int
+
+	// MemorySummaryBytes caps each rendered memory record to a summary-first
+	// excerpt (first paragraph, or the first N bytes on a rune boundary), so
+	// the agent fetches the full record via its reference only when it
+	// matters. Zero disables truncation (full content is rendered). Issue #761.
+	MemorySummaryBytes int
 }
 
 // schemaPreviewColumn is a minimal column entry for search result schema previews.

--- a/pkg/observability/metrics.go
+++ b/pkg/observability/metrics.go
@@ -29,6 +29,7 @@ import (
 //   - mcp_tool_calls_total
 //   - mcp_tool_call_duration_seconds
 //   - mcp_inflight_tool_calls
+//   - mcp_enrichment_bytes_total{tool, toolkit_kind, persona}
 //   - apigateway_outbound_total
 //   - apigateway_outbound_duration_seconds
 //   - apigateway_inbound_requests_total{connection, operation_id, method, status_class, identity}
@@ -45,10 +46,16 @@ import (
 // to keep the histogram's bucket series from multiplying by the identity
 // dimension.
 const (
-	instToolCalls            = "mcp_tool_calls"
-	instToolCallDuration     = "mcp_tool_call_duration"
-	instInflightToolCalls    = "mcp_inflight_tool_calls"
-	instSessionResolution    = "mcp_session_resolution"
+	instToolCalls         = "mcp_tool_calls"
+	instToolCallDuration  = "mcp_tool_call_duration"
+	instInflightToolCalls = "mcp_inflight_tool_calls"
+	instSessionResolution = "mcp_session_resolution"
+	// Unit-less instrument name; the Prometheus exporter appends the "By"
+	// unit as "_bytes" (and "_total" for the counter), yielding
+	// mcp_enrichment_bytes_total — mirroring how mcp_tool_call_duration +
+	// unit "s" exports as mcp_tool_call_duration_seconds. Keeps the name from
+	// baking in the unit suffix twice.
+	instEnrichmentBytes      = "mcp_enrichment"
 	instAPIGwOutbound        = "apigateway_outbound"
 	instAPIGwOutboundLatency = "apigateway_outbound_duration"
 	instAPIGwInbound         = "apigateway_inbound_requests"
@@ -97,6 +104,10 @@ const (
 // unitSeconds is the OTel unit for duration histograms; the Prometheus exporter
 // turns it into the "_seconds" name suffix.
 const unitSeconds = "s"
+
+// unitBytes is the OTel unit for byte-count instruments; the Prometheus exporter
+// turns it into the "_bytes" name suffix.
+const unitBytes = "By"
 
 // UpstreamStatus maps an error from an external dependency (Trino, DataHub, S3,
 // an IdP) to a bounded status label: nil is StatusOK, anything else is
@@ -195,6 +206,7 @@ type Metrics struct {
 	toolCallDuration      metric.Float64Histogram
 	inflightToolCalls     metric.Int64UpDownCounter
 	sessionResolutions    metric.Int64Counter
+	enrichmentBytesTotal  metric.Int64Counter
 	apigwOutboundTotal    metric.Int64Counter
 	apigwOutboundDuration metric.Float64Histogram
 	apigwInboundTotal     metric.Int64Counter
@@ -355,6 +367,14 @@ func (m *Metrics) registerInstruments(meter metric.Meter) error {
 	if err != nil {
 		return fmt.Errorf(instErrFmt, instSessionResolution, err)
 	}
+	m.enrichmentBytesTotal, err = meter.Int64Counter(
+		instEnrichmentBytes,
+		metric.WithDescription("Total bytes of cross-enrichment content (semantic context, memories, knowledge pages, discovery notes) appended to tool responses, labeled by tool, toolkit_kind, and persona. Divide by mcp_tool_calls_total for average per-call overhead (#761)."),
+		metric.WithUnit(unitBytes),
+	)
+	if err != nil {
+		return fmt.Errorf(instErrFmt, instEnrichmentBytes, err)
+	}
 	m.apigwOutboundTotal, err = meter.Int64Counter(
 		instAPIGwOutbound,
 		metric.WithDescription("Total number of outbound HTTP calls made by the apigateway toolkit, labeled by connection, http_status_class, and status_category."),
@@ -505,6 +525,22 @@ func (m *Metrics) RecordToolCall(ctx context.Context, attrs ToolCallAttrs, durat
 	)
 	m.toolCallsTotal.Add(ctx, 1, set)
 	m.toolCallDuration.Record(ctx, duration.Seconds(), set)
+}
+
+// RecordEnrichmentBytes records the per-response cross-enrichment overhead in
+// bytes, labeled by tool, toolkit_kind, and persona (issue #761). Status is
+// deliberately omitted: enrichment only runs on successful results, so a status
+// dimension would carry no signal. Nil-safe; callers skip the call when bytes
+// is zero.
+func (m *Metrics) RecordEnrichmentBytes(ctx context.Context, attrs ToolCallAttrs, bytes int) {
+	if m == nil {
+		return
+	}
+	m.enrichmentBytesTotal.Add(ctx, int64(bytes), metric.WithAttributes(
+		attribute.String(attrTool, attrs.Tool),
+		attribute.String(attrToolkitKind, attrs.ToolkitKind),
+		attribute.String(attrPersona, attrs.Persona),
+	))
 }
 
 // RecordSessionResolution records one tool call labeled by how its session was

--- a/pkg/observability/metrics_test.go
+++ b/pkg/observability/metrics_test.go
@@ -68,6 +68,9 @@ func TestNewEnabledRecordsAllInstruments(t *testing.T) {
 	}, 1200*time.Millisecond)
 	m.RecordSessionResolution(ctx, "explicit")
 	m.RecordSessionResolution(ctx, "transport")
+	m.RecordEnrichmentBytes(ctx, ToolCallAttrs{
+		Tool: "trino_query", ToolkitKind: "trino", Persona: "analyst", StatusCategory: StatusOK,
+	}, 1234)
 
 	body := scrapeMetrics(t, m.Handler())
 
@@ -79,6 +82,7 @@ func TestNewEnabledRecordsAllInstruments(t *testing.T) {
 		`status_category="ok"`,
 		"mcp_tool_call_duration_seconds",
 		"mcp_inflight_tool_calls",
+		"mcp_enrichment_bytes_total",
 		"apigateway_outbound_total",
 		`connection="primary"`,
 		`http_status_class="2xx"`,
@@ -143,6 +147,58 @@ func TestRecordAPIGatewayInbound(t *testing.T) {
 			t.Errorf("duration histogram must not carry identity label; got line: %s", line)
 		}
 	}
+}
+
+func TestRecordEnrichmentBytes(t *testing.T) {
+	m, err := New(Config{Enabled: true, ListenAddr: ":0"})
+	if err != nil {
+		t.Fatalf("New(enabled) err = %v", err)
+	}
+	if m == nil {
+		t.Fatal("New(enabled) returned nil recorder")
+	}
+	defer func() { _ = m.Shutdown(context.Background()) }()
+
+	ctx := context.Background()
+	m.RecordEnrichmentBytes(ctx, ToolCallAttrs{
+		Tool: "trino_query", ToolkitKind: "trino", Persona: "analyst", StatusCategory: StatusOK,
+	}, 1000)
+	m.RecordEnrichmentBytes(ctx, ToolCallAttrs{
+		Tool: "trino_query", ToolkitKind: "trino", Persona: "analyst", StatusCategory: StatusOK,
+	}, 500)
+
+	body := scrapeMetrics(t, m.Handler())
+
+	for _, want := range []string{
+		"mcp_enrichment_bytes_total",
+		`tool="trino_query"`,
+		`toolkit_kind="trino"`,
+		`persona="analyst"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("scrape body missing %q\n--- body ---\n%s", want, body)
+		}
+	}
+
+	// Two records of 1000 + 500 accumulate on the same series.
+	if !strings.Contains(body, "mcp_enrichment_bytes_total{") ||
+		!strings.Contains(body, "} 1500") {
+		t.Errorf("expected enrichment bytes counter to read 1500; body:\n%s", body)
+	}
+
+	// The counter deliberately omits the status_category dimension.
+	for line := range strings.SplitSeq(body, "\n") {
+		if strings.HasPrefix(line, "mcp_enrichment_bytes_total") && strings.Contains(line, "status_category=") {
+			t.Errorf("enrichment bytes counter must not carry status_category label; got line: %s", line)
+		}
+	}
+}
+
+// TestRecordEnrichmentBytesNilSafe verifies the nil-recorder no-op path: the
+// call must not panic on a nil *Metrics.
+func TestRecordEnrichmentBytesNilSafe(_ *testing.T) {
+	var m *Metrics
+	m.RecordEnrichmentBytes(context.Background(), ToolCallAttrs{Tool: "trino_query"}, 42)
 }
 
 func TestNewListenerNilWhenDisabled(t *testing.T) {

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -666,6 +666,24 @@ type EnrichmentConfig struct {
 	// recall should adjust persona scope or query patterns, not
 	// flood the response with low-rank suggestions.
 	SemanticFallbackTopK *int `yaml:"semantic_fallback_top_k"`
+
+	// MemoryLimit caps how many memory records the platform recalls and
+	// renders into the memory_context enrichment block per tool call.
+	// Defaults to 5 (nil = 5). Issue #761.
+	MemoryLimit *int `yaml:"memory_limit"`
+
+	// MemoryContextBudgetBytes bounds the byte size of the rendered memory
+	// summaries appended per tool call. Records beyond the budget are listed
+	// as compact id+reference stubs (still fetchable, not dropped); at least
+	// one record is always rendered. Defaults to 1500 (nil = 1500). Set to 0
+	// to disable the budget (render every recalled record). Issue #761.
+	MemoryContextBudgetBytes *int `yaml:"memory_context_budget_bytes"`
+
+	// MemorySummaryBytes caps each rendered memory record to a summary-first
+	// excerpt so the agent fetches the full record by reference only when it
+	// matters. Defaults to 280 (nil = 280). Set to 0 to render full content.
+	// Issue #761.
+	MemorySummaryBytes *int `yaml:"memory_summary_bytes"`
 }
 
 // IsUnwrapJSONEnabled returns whether unwrap_json defaults to true,
@@ -767,6 +785,53 @@ func (c *EnrichmentConfig) EffectiveSemanticFallbackTopK() int {
 		return maxSemanticFallbackTopK
 	}
 	return k
+}
+
+// Memory-enrichment budget defaults (issue #761). The limit preserves the
+// historical hardcoded count; the byte budget and summary cap are new bounds
+// tuned so a mature deployment's per-query enrichment stays a supporting note
+// rather than crowding out the analyzed data.
+const (
+	defaultMemoryLimit              = 5
+	defaultMemoryContextBudgetBytes = 1500
+	defaultMemorySummaryBytes       = 280
+)
+
+// EffectiveMemoryLimit returns the configured memory-enrichment record limit,
+// defaulting to 5 when unset and flooring non-positive values at the default.
+func (c *EnrichmentConfig) EffectiveMemoryLimit() int {
+	if c.MemoryLimit == nil || *c.MemoryLimit <= 0 {
+		return defaultMemoryLimit
+	}
+	return *c.MemoryLimit
+}
+
+// EffectiveMemoryContextBudgetBytes returns the configured memory_context byte
+// budget, defaulting to 1500 when unset. A configured 0 disables the budget
+// (every recalled record is rendered); negative values are treated as the
+// default rather than as "disabled" to avoid a stray sign silently unbounding
+// the payload.
+func (c *EnrichmentConfig) EffectiveMemoryContextBudgetBytes() int {
+	if c.MemoryContextBudgetBytes == nil {
+		return defaultMemoryContextBudgetBytes
+	}
+	if *c.MemoryContextBudgetBytes < 0 {
+		return defaultMemoryContextBudgetBytes
+	}
+	return *c.MemoryContextBudgetBytes
+}
+
+// EffectiveMemorySummaryBytes returns the configured per-record summary cap,
+// defaulting to 280 when unset. A configured 0 disables truncation (full
+// content is rendered); negative values fall back to the default.
+func (c *EnrichmentConfig) EffectiveMemorySummaryBytes() int {
+	if c.MemorySummaryBytes == nil {
+		return defaultMemorySummaryBytes
+	}
+	if *c.MemorySummaryBytes < 0 {
+		return defaultMemorySummaryBytes
+	}
+	return *c.MemorySummaryBytes
 }
 
 // SessionDedupConfig configures session-level metadata deduplication. It lives in

--- a/pkg/platform/config_test.go
+++ b/pkg/platform/config_test.go
@@ -1606,6 +1606,100 @@ enrichment:
 	})
 }
 
+func TestEnrichmentConfig_EffectiveMemoryLimit(t *testing.T) {
+	t.Run("nil defaults to 5", func(t *testing.T) {
+		cfg := &EnrichmentConfig{}
+		if cfg.EffectiveMemoryLimit() != defaultMemoryLimit {
+			t.Errorf("expected %d, got %d", defaultMemoryLimit, cfg.EffectiveMemoryLimit())
+		}
+	})
+	t.Run("non-positive floors to default", func(t *testing.T) {
+		v := 0
+		cfg := &EnrichmentConfig{MemoryLimit: &v}
+		if cfg.EffectiveMemoryLimit() != defaultMemoryLimit {
+			t.Errorf("expected %d, got %d", defaultMemoryLimit, cfg.EffectiveMemoryLimit())
+		}
+	})
+	t.Run("explicit value", func(t *testing.T) {
+		v := 12
+		cfg := &EnrichmentConfig{MemoryLimit: &v}
+		if cfg.EffectiveMemoryLimit() != 12 {
+			t.Errorf("expected 12, got %d", cfg.EffectiveMemoryLimit())
+		}
+	})
+	t.Run("YAML loading", func(t *testing.T) {
+		cfg := loadTestConfig(t, `
+server:
+  name: test-platform
+enrichment:
+  memory_limit: 3
+`)
+		if cfg.Enrichment.EffectiveMemoryLimit() != 3 {
+			t.Errorf("expected 3, got %d", cfg.Enrichment.EffectiveMemoryLimit())
+		}
+	})
+}
+
+func TestEnrichmentConfig_EffectiveMemoryContextBudgetBytes(t *testing.T) {
+	t.Run("nil defaults", func(t *testing.T) {
+		cfg := &EnrichmentConfig{}
+		if cfg.EffectiveMemoryContextBudgetBytes() != defaultMemoryContextBudgetBytes {
+			t.Errorf("expected %d, got %d", defaultMemoryContextBudgetBytes, cfg.EffectiveMemoryContextBudgetBytes())
+		}
+	})
+	t.Run("zero disables the budget", func(t *testing.T) {
+		v := 0
+		cfg := &EnrichmentConfig{MemoryContextBudgetBytes: &v}
+		if cfg.EffectiveMemoryContextBudgetBytes() != 0 {
+			t.Errorf("expected 0 (disabled), got %d", cfg.EffectiveMemoryContextBudgetBytes())
+		}
+	})
+	t.Run("negative falls back to default", func(t *testing.T) {
+		v := -10
+		cfg := &EnrichmentConfig{MemoryContextBudgetBytes: &v}
+		if cfg.EffectiveMemoryContextBudgetBytes() != defaultMemoryContextBudgetBytes {
+			t.Errorf("expected %d, got %d", defaultMemoryContextBudgetBytes, cfg.EffectiveMemoryContextBudgetBytes())
+		}
+	})
+	t.Run("explicit value", func(t *testing.T) {
+		v := 4096
+		cfg := &EnrichmentConfig{MemoryContextBudgetBytes: &v}
+		if cfg.EffectiveMemoryContextBudgetBytes() != 4096 {
+			t.Errorf("expected 4096, got %d", cfg.EffectiveMemoryContextBudgetBytes())
+		}
+	})
+}
+
+func TestEnrichmentConfig_EffectiveMemorySummaryBytes(t *testing.T) {
+	t.Run("nil defaults", func(t *testing.T) {
+		cfg := &EnrichmentConfig{}
+		if cfg.EffectiveMemorySummaryBytes() != defaultMemorySummaryBytes {
+			t.Errorf("expected %d, got %d", defaultMemorySummaryBytes, cfg.EffectiveMemorySummaryBytes())
+		}
+	})
+	t.Run("zero disables truncation", func(t *testing.T) {
+		v := 0
+		cfg := &EnrichmentConfig{MemorySummaryBytes: &v}
+		if cfg.EffectiveMemorySummaryBytes() != 0 {
+			t.Errorf("expected 0 (disabled), got %d", cfg.EffectiveMemorySummaryBytes())
+		}
+	})
+	t.Run("negative falls back to default", func(t *testing.T) {
+		v := -1
+		cfg := &EnrichmentConfig{MemorySummaryBytes: &v}
+		if cfg.EffectiveMemorySummaryBytes() != defaultMemorySummaryBytes {
+			t.Errorf("expected %d, got %d", defaultMemorySummaryBytes, cfg.EffectiveMemorySummaryBytes())
+		}
+	})
+	t.Run("explicit value", func(t *testing.T) {
+		v := 500
+		cfg := &EnrichmentConfig{MemorySummaryBytes: &v}
+		if cfg.EffectiveMemorySummaryBytes() != 500 {
+			t.Errorf("expected 500, got %d", cfg.EffectiveMemorySummaryBytes())
+		}
+	})
+}
+
 func TestEnrichmentConfig_IsSemanticFallbackEnabled(t *testing.T) {
 	t.Run("nil defaults to off", func(t *testing.T) {
 		cfg := &EnrichmentConfig{}

--- a/pkg/platform/memory_bridge_test.go
+++ b/pkg/platform/memory_bridge_test.go
@@ -1,0 +1,47 @@
+package platform
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/memory"
+)
+
+// entityLookupStore embeds memory.Store so only EntityLookup needs a body; the
+// bridge's recall path calls EntityLookup exclusively. Any other method call
+// would panic on the nil embedded interface, which is the point: it proves the
+// bridge touches nothing else.
+type entityLookupStore struct {
+	memory.Store
+	records []memory.Record
+}
+
+func (s *entityLookupStore) EntityLookup(context.Context, string, string, string) ([]memory.Record, error) {
+	return s.records, nil
+}
+
+// TestMemoryMiddlewareBridge_PopulatesReference proves the bridge maps memory
+// records to middleware snippets and fills the canonical fetch reference
+// (mcp:memory:<id>) the summary-first rendering points at (issue #761).
+func TestMemoryMiddlewareBridge_PopulatesReference(t *testing.T) {
+	store := &entityLookupStore{records: []memory.Record{
+		{ID: "mem-abc", Content: "Revenue includes deferred amounts", Dimension: "knowledge", Category: "business_context", Confidence: "high"},
+	}}
+	bridge := &memoryMiddlewareBridge{store: store}
+
+	snippets, err := bridge.RecallForEntities(
+		context.Background(),
+		[]string{"urn:li:dataset:(urn:li:dataPlatform:trino,cat.schema.revenue,PROD)"},
+		"analyst", 5,
+	)
+	require.NoError(t, err)
+	require.Len(t, snippets, 1)
+
+	assert.Equal(t, "mem-abc", snippets[0].ID)
+	assert.Equal(t, "mcp:memory:mem-abc", snippets[0].Reference)
+	assert.Equal(t, "Revenue includes deferred amounts", snippets[0].Content)
+	assert.Equal(t, "knowledge", snippets[0].Dimension)
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -496,7 +496,10 @@ func (b *memoryMiddlewareBridge) RecallForEntities(ctx context.Context, urns []s
 	snippets := make([]middleware.MemorySnippet, len(memSnippets))
 	for i, ms := range memSnippets {
 		snippets[i] = middleware.MemorySnippet{
-			ID:         ms.ID,
+			ID: ms.ID,
+			// Canonical fetch handle (mcp:memory:<id>) so a summary-first
+			// rendering can point the agent at the full record (#761).
+			Reference:  knowledgepage.MemoryRef(ms.ID),
 			Content:    ms.Content,
 			Dimension:  ms.Dimension,
 			Category:   ms.Category,
@@ -3065,6 +3068,9 @@ func (p *Platform) buildEnrichmentConfig() middleware.EnrichmentConfig {
 		SchemaPreviewMaxColumns:     p.config.Enrichment.EffectiveSchemaPreviewMaxColumns(),
 		SemanticFallbackEnabled:     p.config.Enrichment.IsSemanticFallbackEnabled(),
 		SemanticFallbackTopK:        p.config.Enrichment.EffectiveSemanticFallbackTopK(),
+		MemoryLimit:                 p.config.Enrichment.EffectiveMemoryLimit(),
+		MemoryContextBudgetBytes:    p.config.Enrichment.EffectiveMemoryContextBudgetBytes(),
+		MemorySummaryBytes:          p.config.Enrichment.EffectiveMemorySummaryBytes(),
 	}
 
 	// Wire connection source map lookups as closures to avoid import cycles.


### PR DESCRIPTION
## Summary

Memory cross-enrichment attached up to a hardcoded 5 records per tool call (`defaultMemoryEnrichmentLimit`), with no size budget and no summary tier. Each record could carry its full capture content, and the block rode along on every enriched response, so on a mature deployment the per-query `memory_context` consumed a large share of the calling agent's context window and token spend. Operators had no knob and no visibility.

This PR bounds the memory-enrichment payload and adds an overhead metric, keeping recalled memories a supporting note rather than crowding out the data being analyzed.

Closes #761

## What changed

### 1. Configurable record limit

`enrichment.memory_limit` (default 5) replaces the hardcoded constant. Read via `EffectiveMemoryLimit()`; non-positive values floor to the default (`pkg/platform/config.go`).

### 2. Summary-first rendering

Each record is now rendered as a bounded excerpt instead of full content:

- `enrichment.memory_summary_bytes` (default 280) caps the excerpt. `summarizeMemory` prefers the first paragraph as a natural boundary, otherwise takes the first N bytes backed off to a UTF-8 rune boundary (reusing the existing `clampUTF8` helper).
- Each rendered record carries a `truncated` flag and a `reference` (`mcp:memory:<id>`), so the agent fetches the full record through the existing fetch mechanism only when the excerpt is not enough. The reference is populated in the platform's memory bridge via `knowledgepage.MemoryRef`.

Rendered shape:

```json
{
  "memory_context": [
    {"id": "...", "reference": "mcp:memory:...", "summary": "...", "truncated": true, "dimension": "knowledge", "created_at": "..."}
  ]
}
```

### 3. Per-response byte budget

`enrichment.memory_context_budget_bytes` (default 1500) bounds the rendered summaries. Records beyond the budget are not dropped: they are listed as compact `id`+`reference` stubs in `memory_context_omitted`, so every recalled record stays fetchable, and a `memory_context_note` reports the count. At least one record is always rendered, so a small budget never fully suppresses memory enrichment. Set to `0` to disable the budget.

```json
{
  "memory_context": [ { "id": "m1", "reference": "mcp:memory:m1", "summary": "..." } ],
  "memory_context_omitted": [ { "id": "m2", "reference": "mcp:memory:m2" } ],
  "memory_context_note": "1 additional related memory record(s) omitted to stay within the enrichment budget; fetch any by its reference in memory_context_omitted for full detail."
}
```

### 4. Render-time near-duplicate collapsing

Records whose normalized (case- and whitespace-insensitive) **full content** matches an already-rendered record are collapsed. Keying on full content (not the truncated summary) ensures records that share only a common prefix are not silently merged.

### 5. Enrichment-overhead metric

New counter `mcp_enrichment_bytes_total`, labeled `tool` / `toolkit_kind` / `persona`, accumulating the total bytes of cross-enrichment content (semantic context, memories, knowledge pages, discovery notes) appended per response. Recorded only on enriched responses, so average per-call overhead is:

```
rate(mcp_enrichment_bytes_total[5m]) / rate(mcp_tool_calls_total[5m])
```

The enrichment middleware records the appended byte count on `PlatformContext.EnrichmentBytes`; the metrics middleware, which sits outer to enrichment, reads it after the handler unwinds. The instrument is named `mcp_enrichment` with unit `By`, so the Prometheus exporter emits `mcp_enrichment_bytes_total`, matching the convention used by `mcp_tool_call_duration` → `mcp_tool_call_duration_seconds`.

## Configuration

All knobs are optional and default on with the values above:

```yaml
enrichment:
  memory_limit: 5                     # Max records recalled per tool call
  memory_context_budget_bytes: 1500   # Byte budget for rendered summaries; 0 disables
  memory_summary_bytes: 280           # Per-record excerpt cap; 0 = full content
```

## Testing

`make verify` passes end-to-end (race tests, total and patch coverage ≥ 80%, patch-scoped lint, gosec/govulncheck, semgrep, CodeQL, mutation ≥ 60%, goreleaser dry-run).

New and updated tests cover:

- `summarizeMemory`: first-paragraph boundary, byte truncation, rune-boundary back-off, whitespace trimming, truncation-disabled.
- `renderMemoryContext`: dedup on full content (including that a shared-prefix pair is **not** collapsed), budget omission emitting fetchable stubs, always-render-at-least-one, summary + truncation flag.
- `enrichWithMemories`: configured limit passthrough, summary-first output with reference, budget note and omitted-stub list.
- `enrichmentContentBytes` and the end-to-end metrics wiring (a middleware inner to metrics sets `EnrichmentBytes`; the scraped `mcp_enrichment_bytes_total` reflects it).
- Config `Effective*` helpers and the memory bridge's reference population.

## Docs

`docs/server/configuration.md`, `docs/server/observability.md`, `configs/platform.yaml`, and `docs/llms-full.txt` updated with the new config keys and the metric.
