### PR TITLE
feat(knowledge): surface review-queue staleness so pending insights do not silently age

### DIFF
--- a/docs/knowledge/governance.md
+++ b/docs/knowledge/governance.md
@@ -50,11 +50,23 @@ Response:
     "high": 3,
     "medium": 4
   },
+  "oldest_pending_at": "2025-01-15T14:30:00Z",
+  "oldest_pending_age_days": 94,
+  "pending_over_30d": 2,
   "note": "Counts are pending insights only (the global review queue). by_entity counts an insight once per entity URN it carries and omits insights that have no entity URN, so it does not sum to total_pending. Pass itemize:true to enumerate every pending insight (with id, captured_by and sink_class)."
 }
 ```
 
 The counts label their own scope: `total_pending` is the size of the global pending queue, while `by_entity` counts a multi-entity insight once per URN and omits entity-agnostic insights, so it does not sum to `total_pending`.
+
+### Review-Queue Staleness
+
+The knowledge flywheel only turns if humans work the queue, so `bulk_review` also reports how stale the pending queue is (present on both the counts and `itemize` paths, omitted when the queue is empty):
+
+- `oldest_pending_at` / `oldest_pending_age_days`: the age of the oldest pending insight, so a long-unreviewed queue is visible at a glance.
+- `pending_over_30d`: the count of pending insights aged 30 or more days (the accumulating review debt). The portal's per-row age badge flags a row stale at the same 30-day mark, so the count and the badge agree.
+
+An agent can use these to nudge a reviewer (for example, "6 insights are pending review, the oldest is 94 days old"). The same rollup appears in `platform_info` under `features.knowledge_apply.review_queue` for any caller who can reach `apply_knowledge`. In the admin portal, the review queue view badges each pending insight by age and can be sorted oldest-first (`order=oldest` on the insights API) to work the stalest debt first.
 
 ### Enumerate the Review Queue
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1792,7 +1792,7 @@ Admin-only tool for reviewing and applying captured insights. Requires the `admi
 
 ### Actions
 
-**bulk_review**: Counts of all pending insights (total_pending, by_entity, by_category, by_confidence). Pass itemize:true to enumerate the queue itself, paginated by offset/limit, each insight carrying its full insight_text body, captured_by (author), sink_class and suggested_actions_count (full suggested_actions omitted, fetch for it); the relevance-ranked search tool cannot list it completely. The response is bounded so it stays under the output limit: page_size_capped:true flags a short insights page (continue with next_offset) and by_entity_truncated:true flags a capped by_entity.
+**bulk_review**: Counts of all pending insights (total_pending, by_entity, by_category, by_confidence) plus a review-queue staleness rollup (oldest_pending_at, oldest_pending_age_days, pending_over_30d, omitted when the queue is empty) so aging review debt is visible; the same rollup appears in platform_info under features.knowledge_apply.review_queue. Pass itemize:true to enumerate the queue itself, paginated by offset/limit, each insight carrying its full insight_text body, captured_by (author), sink_class and suggested_actions_count (full suggested_actions omitted, fetch for it); the relevance-ranked search tool cannot list it completely. The response is bounded so it stays under the output limit: page_size_capped:true flags a short insights page (continue with next_offset) and by_entity_truncated:true flags a capped by_entity.
 
 ```json
 {"action": "bulk_review"}

--- a/docs/server/tools.md
+++ b/docs/server/tools.md
@@ -781,7 +781,7 @@ Both sinks record a **changeset** (page promotions use `target_urn = "kp:<slug>"
 
 **Actions:**
 
-- **bulk_review**: Counts of all pending insights (`total_pending`, `by_entity`, `by_category`, `by_confidence`). Pass `itemize: true` to enumerate the queue itself, paginated, with each insight's full `insight_text` body, `id`, `captured_by`, `sink_class`, and `suggested_actions_count` (full `suggested_actions` omitted, `fetch` for it; the relevance-ranked `search` tool cannot list the queue completely). The response is bounded so it stays under the output limit: `page_size_capped: true` flags a short insights page (continue with `next_offset`) and `by_entity_truncated: true` flags a capped `by_entity`
+- **bulk_review**: Counts of all pending insights (`total_pending`, `by_entity`, `by_category`, `by_confidence`) plus a review-queue staleness rollup (`oldest_pending_at`, `oldest_pending_age_days`, `pending_over_30d`, omitted when the queue is empty) so aging review debt is visible. Pass `itemize: true` to enumerate the queue itself, paginated, with each insight's full `insight_text` body, `id`, `captured_by`, `sink_class`, and `suggested_actions_count` (full `suggested_actions` omitted, `fetch` for it; the relevance-ranked `search` tool cannot list the queue completely). The response is bounded so it stays under the output limit: `page_size_capped: true` flags a short insights page (continue with `next_offset`) and `by_entity_truncated: true` flags a capped `by_entity`
 - **review**: Insights for a specific entity with current DataHub metadata
 - **approve/reject**: Transition insight status with optional notes
 - **synthesize**: Structured change proposals from approved insights

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -4621,6 +4621,12 @@ const docTemplate = `{
                         "description": "Results per page (default: 20)",
                         "name": "per_page",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort by created_at: 'oldest' for oldest-first, default newest-first",
+                        "name": "order",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -14687,6 +14693,14 @@ const docTemplate = `{
                     "additionalProperties": {
                         "type": "integer"
                     }
+                },
+                "oldest_pending_at": {
+                    "description": "OldestPendingAt is the created_at of the oldest pending insight, or nil\nwhen the pending queue is empty. It surfaces review-queue staleness so\npending insights do not silently age (#764).",
+                    "type": "string"
+                },
+                "pending_over_30d": {
+                    "description": "PendingOver30d counts pending insights older than\nPendingStalenessThresholdDays, the accumulating review debt (#764).",
+                    "type": "integer"
                 },
                 "total_pending": {
                     "type": "integer"

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -4615,6 +4615,12 @@
                         "description": "Results per page (default: 20)",
                         "name": "per_page",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort by created_at: 'oldest' for oldest-first, default newest-first",
+                        "name": "order",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -14681,6 +14687,14 @@
                     "additionalProperties": {
                         "type": "integer"
                     }
+                },
+                "oldest_pending_at": {
+                    "description": "OldestPendingAt is the created_at of the oldest pending insight, or nil\nwhen the pending queue is empty. It surfaces review-queue staleness so\npending insights do not silently age (#764).",
+                    "type": "string"
+                },
+                "pending_over_30d": {
+                    "description": "PendingOver30d counts pending insights older than\nPendingStalenessThresholdDays, the accumulating review debt (#764).",
+                    "type": "integer"
                 },
                 "total_pending": {
                     "type": "integer"

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -2221,6 +2221,17 @@ definitions:
         additionalProperties:
           type: integer
         type: object
+      oldest_pending_at:
+        description: |-
+          OldestPendingAt is the created_at of the oldest pending insight, or nil
+          when the pending queue is empty. It surfaces review-queue staleness so
+          pending insights do not silently age (#764).
+        type: string
+      pending_over_30d:
+        description: |-
+          PendingOver30d counts pending insights older than
+          PendingStalenessThresholdDays, the accumulating review debt (#764).
+        type: integer
       total_pending:
         type: integer
     type: object
@@ -6609,6 +6620,10 @@ paths:
         in: query
         name: per_page
         type: integer
+      - description: 'Sort by created_at: ''oldest'' for oldest-first, default newest-first'
+        in: query
+        name: order
+        type: string
       produces:
       - application/json
       responses:

--- a/pkg/admin/knowledge.go
+++ b/pkg/admin/knowledge.go
@@ -61,6 +61,7 @@ type insightListResponse struct {
 // @Param        until        query  string  false  "Insights before this time (RFC 3339)"
 // @Param        page         query  integer false  "Page number, 1-based (default: 1)"
 // @Param        per_page     query  integer false  "Results per page (default: 20)"
+// @Param        order        query  string  false  "Sort by created_at: 'oldest' for oldest-first, default newest-first"
 // @Success      200  {object}  insightListResponse
 // @Failure      500  {object}  problemDetail
 // @Security     ApiKeyAuth
@@ -431,6 +432,9 @@ func parseInsightFilter(r *http.Request) knowledge.InsightFilter {
 		Since:      parseTimeParam(q, "since"),
 		Until:      parseTimeParam(q, "until"),
 		Limit:      parseLimit(q),
+		// order=oldest sorts the review queue oldest-first so reviewers can work
+		// the stalest debt first (#764); any other value keeps newest-first.
+		OrderCreatedAsc: q.Get("order") == "oldest",
 	}
 	filter.Offset = parsePageOffset(q, filter.EffectiveLimit())
 

--- a/pkg/admin/knowledge_test.go
+++ b/pkg/admin/knowledge_test.go
@@ -1023,6 +1023,15 @@ func TestParseInsightFilter(t *testing.T) {
 		assert.Equal(t, 10, filter.Limit)
 		// Page 3 with per_page 10 means offset = (3-1)*10 = 20
 		assert.Equal(t, 20, filter.Offset)
+		assert.False(t, filter.OrderCreatedAsc, "default order is newest-first")
+	})
+
+	t.Run("order=oldest sorts oldest-first", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/insights?order=oldest", http.NoBody)
+		assert.True(t, parseInsightFilter(req).OrderCreatedAsc)
+
+		req = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/insights?order=newest", http.NoBody)
+		assert.False(t, parseInsightFilter(req).OrderCreatedAsc, "any non-oldest value stays newest-first")
 	})
 
 	t.Run("defaults for empty parameters", func(t *testing.T) {

--- a/pkg/platform/info_tool.go
+++ b/pkg/platform/info_tool.go
@@ -15,6 +15,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/platform/instructions"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/session"
+	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
 )
 
 // resourcesDiscoverabilityNote is the runtime note appended to agent
@@ -70,8 +71,19 @@ type Features struct {
 
 // KnowledgeApplyInfo provides information about the knowledge apply feature.
 type KnowledgeApplyInfo struct {
-	Enabled           bool   `json:"enabled"`
-	DataHubConnection string `json:"datahub_connection,omitempty"`
+	Enabled           bool             `json:"enabled"`
+	DataHubConnection string           `json:"datahub_connection,omitempty"`
+	ReviewQueue       *ReviewQueueInfo `json:"review_queue,omitempty"`
+}
+
+// ReviewQueueInfo summarizes the pending apply_knowledge review queue so an agent
+// can nudge a reviewer about aging review debt, e.g. "6 insights pending review,
+// oldest 94 days" (#764). It is present only for a caller who can reach
+// apply_knowledge and only when the queue is non-empty.
+type ReviewQueueInfo struct {
+	Pending              int `json:"pending"`
+	OldestPendingAgeDays int `json:"oldest_pending_age_days,omitempty"`
+	PendingOver30d       int `json:"pending_over_30d,omitempty"`
 }
 
 // Tool names whose platform_info feature flags are gated by persona access, so a
@@ -85,7 +97,7 @@ const (
 // knowledge feature flags to the tools the caller's persona can actually reach
 // (accessibleTools) so the orientation never advertises a lifecycle the caller
 // cannot drive.
-func (p *Platform) buildFeatures(accessibleTools []string) Features {
+func (p *Platform) buildFeatures(ctx context.Context, accessibleTools []string) Features {
 	canReach := func(tool string) bool { return slices.Contains(accessibleTools, tool) }
 	// Enrichment is reported on only when both its flag is enabled (default-on)
 	// AND the provider that performs it is configured. Reporting it on without a
@@ -106,10 +118,41 @@ func (p *Platform) buildFeatures(accessibleTools []string) Features {
 		f.KnowledgeApply = &KnowledgeApplyInfo{
 			Enabled:           true,
 			DataHubConnection: p.config.Knowledge.Apply.DataHubConnection,
+			ReviewQueue:       p.reviewQueueInfo(ctx),
 		}
 	}
 
 	return f
+}
+
+// reviewQueueInfo summarizes the pending review queue for platform_info so an
+// agent can nudge a reviewer about aging review debt (#764). It returns nil when
+// knowledge is disabled (no insight store), when the stats lookup fails, or when
+// the queue is empty; a failed lookup must not fail orientation, so the error is
+// logged and swallowed rather than propagated.
+func (p *Platform) reviewQueueInfo(ctx context.Context) *ReviewQueueInfo {
+	if p.knowledgeInsightStore == nil {
+		return nil
+	}
+	// Prefer the store's cheap pending-count + staleness path over the full Stats
+	// fan-out: platform_info runs once per session and needs only the review-debt
+	// nudge, not the category/confidence group-bys (#764).
+	review, err := knowledgekit.PendingReviewOf(ctx, p.knowledgeInsightStore)
+	if err != nil {
+		slog.WarnContext(ctx, "platform_info: pending review queue stats unavailable", "error", err)
+		return nil
+	}
+	if review.TotalPending == 0 {
+		return nil
+	}
+	info := &ReviewQueueInfo{
+		Pending:        review.TotalPending,
+		PendingOver30d: review.PendingOver30d,
+	}
+	if review.OldestPendingAt != nil {
+		info.OldestPendingAgeDays = knowledgekit.AgeDays(*review.OldestPendingAt, time.Now())
+	}
+	return info
 }
 
 // resolveCallerPersona returns a PersonaInfo for the calling user.
@@ -249,7 +292,7 @@ func (p *Platform) handleInfo(ctx context.Context, _ *mcp.CallToolRequest) (*mcp
 		PortalURL:           p.config.Portal.PublicBaseURL,
 		Persona:             persona,
 		Prompts:             p.AllPromptInfos(),
-		Features:            p.buildFeatures(accessibleTools),
+		Features:            p.buildFeatures(ctx, accessibleTools),
 		ConfigVersion: ConfigVersionInfo{
 			APIVersion:        p.config.APIVersion,
 			SupportedVersions: reg.ListSupported(),

--- a/pkg/platform/info_tool_test.go
+++ b/pkg/platform/info_tool_test.go
@@ -3,8 +3,10 @@ package platform
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
@@ -16,7 +18,66 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
 	"github.com/txn2/mcp-data-platform/pkg/storage"
+	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
 )
+
+// stubInsightStore overrides Stats on the noop insight store so reviewQueueInfo
+// can be tested without a database. Other InsightStore methods are inherited
+// from the noop and are unused here.
+type stubInsightStore struct {
+	knowledgekit.InsightStore
+	stats *knowledgekit.InsightStats
+	err   error
+}
+
+func (s stubInsightStore) Stats(context.Context, knowledgekit.InsightFilter) (*knowledgekit.InsightStats, error) {
+	return s.stats, s.err
+}
+
+func TestReviewQueueInfo(t *testing.T) {
+	oldest := time.Now().Add(-94 * 24 * time.Hour)
+	tests := []struct {
+		name  string
+		store knowledgekit.InsightStore
+		want  *ReviewQueueInfo
+	}{
+		{name: "nil store returns nil", store: nil, want: nil},
+		{
+			name:  "stats error returns nil (orientation must not fail)",
+			store: stubInsightStore{InsightStore: knowledgekit.NewNoopStore(), err: errors.New("db down")},
+			want:  nil,
+		},
+		{
+			name:  "empty queue returns nil",
+			store: stubInsightStore{InsightStore: knowledgekit.NewNoopStore(), stats: &knowledgekit.InsightStats{TotalPending: 0}},
+			want:  nil,
+		},
+		{
+			name: "pending queue with staleness is summarized",
+			store: stubInsightStore{InsightStore: knowledgekit.NewNoopStore(), stats: &knowledgekit.InsightStats{
+				TotalPending:    6,
+				OldestPendingAt: &oldest,
+				PendingOver30d:  2,
+			}},
+			want: &ReviewQueueInfo{Pending: 6, OldestPendingAgeDays: 94, PendingOver30d: 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Platform{knowledgeInsightStore: tt.store}
+			got := p.reviewQueueInfo(context.Background())
+			if tt.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want.Pending, got.Pending)
+			assert.Equal(t, tt.want.PendingOver30d, got.PendingOver30d)
+			assert.InDelta(t, tt.want.OldestPendingAgeDays, got.OldestPendingAgeDays, 1)
+		})
+	}
+}
 
 const (
 	testInfoVersion      = "1.0.0"
@@ -45,14 +106,14 @@ func TestBuildFeatures_GatesKnowledgeByPersonaTools(t *testing.T) {
 	}}
 
 	t.Run("persona with the tools sees the knowledge features", func(t *testing.T) {
-		f := p.buildFeatures([]string{"memory_capture", "apply_knowledge"})
+		f := p.buildFeatures(context.Background(), []string{"memory_capture", "apply_knowledge"})
 		assert.True(t, f.KnowledgeCapture)
 		require.NotNil(t, f.KnowledgeApply)
 		assert.True(t, f.KnowledgeApply.Enabled)
 	})
 
 	t.Run("persona without the tools sees neither", func(t *testing.T) {
-		f := p.buildFeatures([]string{"trino_query"})
+		f := p.buildFeatures(context.Background(), []string{"trino_query"})
 		assert.False(t, f.KnowledgeCapture, "capture hidden from a persona without memory_capture")
 		assert.Nil(t, f.KnowledgeApply, "apply hidden from a persona without apply_knowledge")
 	})

--- a/pkg/toolkits/knowledge/memory_adapter.go
+++ b/pkg/toolkits/knowledge/memory_adapter.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
+	"time"
 
 	"github.com/txn2/mcp-data-platform/pkg/memory"
 )
@@ -140,9 +142,16 @@ func (a *memoryInsightAdapter) List(ctx context.Context, filter InsightFilter) (
 		return nil, 0, err
 	}
 
+	// The walk preserves the store's created_at DESC order (newest-first). When the
+	// caller wants oldest-first (the age-ordered review queue, #764), reverse the
+	// fully materialized set before paging so every page is in ascending order.
+	if filter.OrderCreatedAsc {
+		slices.Reverse(matched)
+	}
+
 	// total is the exact matching count so the caller's pagination footer agrees
-	// with the stat card; pageInsights returns the requested window in the same
-	// created_at DESC order the walk preserved.
+	// with the stat card; pageInsights returns the requested window in the walk's
+	// order (or its reverse when oldest-first was requested).
 	page, _, _ := pageInsights(matched, filter.Offset, filter.Limit)
 	return page, len(matched), nil
 }
@@ -285,6 +294,8 @@ func (a *memoryInsightAdapter) Stats(ctx context.Context, filter InsightFilter) 
 		ByStatus:     make(map[string]int),
 	}
 
+	cutoff := pendingStalenessCutoff(time.Now())
+	var oldestPending *time.Time
 	err := a.eachActiveInsightRecord(ctx, mf, func(r memory.Record) {
 		// Recover the insight status (pending/approved/applied/...) from the lossy
 		// memory status, so the keys match what callers and the postgres store
@@ -304,11 +315,23 @@ func (a *memoryInsightAdapter) Stats(ctx context.Context, filter InsightFilter) 
 		stats.ByStatus[st]++
 		stats.ByCategory[r.Category]++
 		stats.ByConfidence[r.Confidence]++
+		// Track pending-queue staleness alongside the pending tally so the
+		// rollup always agrees with TotalPending (#764).
+		if st == StatusPending {
+			if oldestPending == nil || r.CreatedAt.Before(*oldestPending) {
+				created := r.CreatedAt
+				oldestPending = &created
+			}
+			if isStalePending(r.CreatedAt, cutoff) {
+				stats.PendingOver30d++
+			}
+		}
 	})
 	if err != nil {
 		return nil, fmt.Errorf("listing records for insight stats: %w", err)
 	}
 	stats.TotalPending = stats.ByStatus[StatusPending]
+	stats.OldestPendingAt = oldestPending
 
 	return stats, nil
 }

--- a/pkg/toolkits/knowledge/memory_adapter_test.go
+++ b/pkg/toolkits/knowledge/memory_adapter_test.go
@@ -624,6 +624,86 @@ func TestMemoryInsightAdapter_Stats(t *testing.T) {
 	assert.Equal(t, 1, stats.ByConfidence["low"])
 }
 
+// TestMemoryInsightAdapter_Stats_Staleness verifies the pending-queue staleness
+// rollup (#764): OldestPendingAt tracks the oldest pending record and
+// PendingOver30d counts only pending records past the threshold, ignoring
+// non-pending records however old.
+func TestMemoryInsightAdapter_Stats_Staleness(t *testing.T) {
+	now := time.Now()
+	oldPending := now.Add(-94 * 24 * time.Hour)
+	midPending := now.Add(-40 * 24 * time.Hour)
+	freshPending := now.Add(-3 * 24 * time.Hour)
+	store := &mockMemoryStore{
+		listRecords: []memory.Record{
+			{ID: "p1", Status: memory.StatusActive, CreatedAt: freshPending},
+			{ID: "p2", Status: memory.StatusActive, CreatedAt: oldPending},
+			{ID: "p3", Status: memory.StatusActive, CreatedAt: midPending},
+			// Archived (rejected) and very old: must not count toward staleness.
+			{ID: "r1", Status: memory.StatusArchived, CreatedAt: now.Add(-300 * 24 * time.Hour)},
+		},
+		listTotal: 4,
+	}
+	adapter := NewMemoryInsightAdapter(store)
+
+	stats, err := adapter.Stats(context.Background(), InsightFilter{Status: StatusPending})
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+
+	assert.Equal(t, 3, stats.TotalPending)
+	require.NotNil(t, stats.OldestPendingAt)
+	assert.WithinDuration(t, oldPending, *stats.OldestPendingAt, time.Second)
+	// Only the two pending records older than 30 days count; the fresh pending
+	// and the 300-day archived record do not.
+	assert.Equal(t, 2, stats.PendingOver30d)
+}
+
+// TestMemoryInsightAdapter_Stats_Staleness_EmptyQueue verifies OldestPendingAt is
+// nil and PendingOver30d is 0 when no pending records exist (#764).
+func TestMemoryInsightAdapter_Stats_Staleness_EmptyQueue(t *testing.T) {
+	store := &mockMemoryStore{
+		listRecords: []memory.Record{
+			{ID: "r1", Status: memory.StatusArchived, CreatedAt: time.Now().Add(-90 * 24 * time.Hour)},
+		},
+		listTotal: 1,
+	}
+	adapter := NewMemoryInsightAdapter(store)
+
+	stats, err := adapter.Stats(context.Background(), InsightFilter{Status: StatusPending})
+	require.NoError(t, err)
+	assert.Equal(t, 0, stats.TotalPending)
+	assert.Nil(t, stats.OldestPendingAt)
+	assert.Equal(t, 0, stats.PendingOver30d)
+}
+
+// TestMemoryInsightAdapter_List_OrderCreatedAsc verifies the oldest-first review
+// ordering reverses the store's default newest-first walk (#764).
+func TestMemoryInsightAdapter_List_OrderCreatedAsc(t *testing.T) {
+	now := time.Now()
+	// mockMemoryStore returns records verbatim; the real store yields created_at
+	// DESC, so mirror that (newest first) as the walk's input.
+	store := &mockMemoryStore{
+		listRecords: []memory.Record{
+			{ID: "newest", Status: memory.StatusActive, CreatedAt: now.Add(-1 * time.Hour)},
+			{ID: "middle", Status: memory.StatusActive, CreatedAt: now.Add(-24 * time.Hour)},
+			{ID: "oldest", Status: memory.StatusActive, CreatedAt: now.Add(-72 * time.Hour)},
+		},
+		listTotal: 3,
+	}
+	adapter := NewMemoryInsightAdapter(store)
+
+	asc, total, err := adapter.List(context.Background(), InsightFilter{OrderCreatedAsc: true})
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+	require.Len(t, asc, 3)
+	assert.Equal(t, "oldest", asc[0].ID)
+	assert.Equal(t, "newest", asc[2].ID)
+
+	desc, _, err := adapter.List(context.Background(), InsightFilter{})
+	require.NoError(t, err)
+	require.Len(t, desc, 3)
+	assert.Equal(t, "newest", desc[0].ID, "default order stays newest-first")
+}
+
 // paginatingMemoryStore returns records in MaxLimit-sized pages so the
 // Stats pagination loop can be exercised end to end. Without this, the
 // single-page mock would never drive the offset increment, and a broken

--- a/pkg/toolkits/knowledge/store.go
+++ b/pkg/toolkits/knowledge/store.go
@@ -175,6 +175,15 @@ func applyInsightFilter(qb sq.SelectBuilder, filter InsightFilter) sq.SelectBuil
 	return qb
 }
 
+// listOrderDirection returns the created_at sort direction for a list query:
+// ASC (oldest-first) when the filter opts into age order, DESC otherwise (#764).
+func listOrderDirection(filter InsightFilter) string {
+	if filter.OrderCreatedAsc {
+		return "ASC"
+	}
+	return "DESC"
+}
+
 // List returns insights matching the filter with pagination.
 func (s *postgresStore) List(ctx context.Context, filter InsightFilter) ([]Insight, int, error) {
 	// Count total matching rows.
@@ -197,7 +206,7 @@ func (s *postgresStore) List(ctx context.Context, filter InsightFilter) ([]Insig
 		"suggested_actions", colStatus, "reviewed_by", "reviewed_at",
 		"review_notes", colAppliedBy, "applied_at", "changeset_ref",
 	).From("knowledge_insights"), filter).
-		OrderBy(colCreatedAt + " DESC")
+		OrderBy(colCreatedAt + " " + listOrderDirection(filter))
 	if limit > 0 {
 		selectQB = selectQB.Limit(uint64(limit))
 	}
@@ -351,7 +360,109 @@ func (s *postgresStore) Stats(ctx context.Context, filter InsightFilter) (*Insig
 		return nil, fmt.Errorf("counting by confidence: %w", err)
 	}
 
+	oldest, over30d, err := s.pendingStaleness(ctx, filter, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("computing pending staleness: %w", err)
+	}
+	stats.OldestPendingAt = oldest
+	stats.PendingOver30d = over30d
+
 	return stats, nil
+}
+
+// pendingStaleness returns the oldest pending insight's created_at (nil when the
+// pending queue is empty) and the count of pending insights older than the
+// staleness threshold (#764). Both are scoped to the pending subset of filter:
+// the extra status=pending predicate is redundant when filter already selects
+// pending and yields an empty result (nil, 0) when it selects another status, so
+// the rollup always agrees with TotalPending, which is likewise pending-scoped.
+func (s *postgresStore) pendingStaleness(ctx context.Context, filter InsightFilter, now time.Time) (*time.Time, int, error) {
+	cutoff := pendingStalenessCutoff(now)
+	qb := applyInsightFilter(
+		psq.Select("MIN("+colCreatedAt+")").
+			Column("COUNT(*) FILTER (WHERE "+colCreatedAt+" <= ?)", cutoff).
+			From("knowledge_insights"),
+		filter,
+	)
+	// Scope to pending. When filter already selects pending the predicate is
+	// redundant, so skip it; when it selects another status the added predicate
+	// yields an empty result (nil, 0), matching TotalPending for that filter.
+	if filter.Status != StatusPending {
+		qb = qb.Where(sq.Eq{colStatus: StatusPending})
+	}
+
+	query, args, err := qb.ToSql()
+	if err != nil {
+		return nil, 0, fmt.Errorf("building staleness query: %w", err)
+	}
+
+	var oldest sql.NullTime
+	var over30d int
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(&oldest, &over30d); err != nil {
+		return nil, 0, fmt.Errorf("scanning staleness row: %w", err)
+	}
+	if oldest.Valid {
+		return &oldest.Time, over30d, nil
+	}
+	return nil, over30d, nil
+}
+
+// PendingReviewStater is an optional InsightStore capability: a cheap pending
+// count plus staleness rollup, without the by-category/by-confidence group-bys
+// the full Stats issues. platform_info needs only the review-debt nudge, so it
+// prefers this fast path (via PendingReviewOf) to avoid a four-query fan-out on
+// every per-session orientation call (#764).
+type PendingReviewStater interface {
+	PendingReviewStats(ctx context.Context) (*PendingReview, error)
+}
+
+// PendingReviewOf returns the lightweight review-queue summary, using the store's
+// PendingReviewStats fast path when it implements PendingReviewStater and falling
+// back to the full Stats otherwise (so every InsightStore, including test doubles
+// and the noop, is supported without change).
+func PendingReviewOf(ctx context.Context, store InsightStore) (*PendingReview, error) {
+	if fast, ok := store.(PendingReviewStater); ok {
+		review, err := fast.PendingReviewStats(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("pending review stats: %w", err)
+		}
+		return review, nil
+	}
+	stats, err := store.Stats(ctx, InsightFilter{Status: StatusPending})
+	if err != nil {
+		return nil, fmt.Errorf("pending review stats via stats fallback: %w", err)
+	}
+	return &PendingReview{
+		TotalPending:    stats.TotalPending,
+		OldestPendingAt: stats.OldestPendingAt,
+		PendingOver30d:  stats.PendingOver30d,
+	}, nil
+}
+
+// PendingReviewStats returns the pending count and staleness rollup in a single
+// aggregate query, the fast path for platform_info (#764).
+func (s *postgresStore) PendingReviewStats(ctx context.Context) (*PendingReview, error) {
+	cutoff := pendingStalenessCutoff(time.Now())
+	qb := psq.Select("COUNT(*)", "MIN("+colCreatedAt+")").
+		Column("COUNT(*) FILTER (WHERE "+colCreatedAt+" <= ?)", cutoff).
+		From("knowledge_insights").
+		Where(sq.Eq{colStatus: StatusPending})
+
+	query, args, err := qb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("building pending review query: %w", err)
+	}
+
+	var total, over30d int
+	var oldest sql.NullTime
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(&total, &oldest, &over30d); err != nil {
+		return nil, fmt.Errorf("scanning pending review row: %w", err)
+	}
+	review := &PendingReview{TotalPending: total, PendingOver30d: over30d}
+	if oldest.Valid {
+		review.OldestPendingAt = &oldest.Time
+	}
+	return review, nil
 }
 
 // countGroupBy queries a group-by count and populates a map.

--- a/pkg/toolkits/knowledge/store_test.go
+++ b/pkg/toolkits/knowledge/store_test.go
@@ -675,6 +675,13 @@ func TestPostgresStore_Update_RowsAffectedError(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestListOrderDirection covers the created_at sort direction toggle (#764):
+// oldest-first (ASC) when the filter opts in, newest-first (DESC) otherwise.
+func TestListOrderDirection(t *testing.T) {
+	assert.Equal(t, "ASC", listOrderDirection(InsightFilter{OrderCreatedAsc: true}))
+	assert.Equal(t, "DESC", listOrderDirection(InsightFilter{}))
+}
+
 // --- postgresStore Stats tests ---
 
 func TestPostgresStore_Stats(t *testing.T) {
@@ -706,6 +713,14 @@ func TestPostgresStore_Stats(t *testing.T) {
 	mock.ExpectQuery("SELECT confidence, COUNT\\(\\*\\) FROM knowledge_insights").
 		WillReturnRows(confRows)
 
+	// Pending-staleness query (#764): MIN(created_at) and the over-30d count,
+	// scoped to pending. The cutoff arg is time.Now()-30d, so match it loosely.
+	oldest := time.Now().Add(-94 * 24 * time.Hour)
+	staleRows := sqlmock.NewRows([]string{"min", "over30d"}).AddRow(oldest, 2)
+	mock.ExpectQuery("SELECT MIN\\(created_at\\), COUNT\\(\\*\\) FILTER").
+		WithArgs(sqlmock.AnyArg(), "pending").
+		WillReturnRows(staleRows)
+
 	stats, err := store.Stats(context.Background(), InsightFilter{})
 	require.NoError(t, err)
 	require.NotNil(t, stats)
@@ -718,6 +733,9 @@ func TestPostgresStore_Stats(t *testing.T) {
 	assert.Equal(t, 6, stats.ByCategory["business_context"]) //nolint:revive // test value
 	assert.Equal(t, 3, stats.ByConfidence["high"])           //nolint:revive // test value
 	assert.Equal(t, 7, stats.ByConfidence["medium"])         //nolint:revive // test value
+	require.NotNil(t, stats.OldestPendingAt)
+	assert.WithinDuration(t, oldest, *stats.OldestPendingAt, time.Second)
+	assert.Equal(t, 2, stats.PendingOver30d) //nolint:revive // test value
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -746,9 +764,18 @@ func TestPostgresStore_Stats_WithFilter(t *testing.T) {
 		WithArgs("pending").
 		WillReturnRows(confRows)
 
+	// Staleness query is pending-scoped; with filter.Status already pending the
+	// redundant predicate is skipped, so only the cutoff and one "pending" arg.
+	staleRows := sqlmock.NewRows([]string{"min", "over30d"}).AddRow(nil, 0)
+	mock.ExpectQuery("SELECT MIN\\(created_at\\), COUNT\\(\\*\\) FILTER").
+		WithArgs(sqlmock.AnyArg(), "pending").
+		WillReturnRows(staleRows)
+
 	stats, err := store.Stats(context.Background(), filter)
 	require.NoError(t, err)
 	assert.Equal(t, 5, stats.TotalPending) //nolint:revive // test value
+	assert.Nil(t, stats.OldestPendingAt, "NULL MIN over empty pending set yields nil")
+	assert.Equal(t, 0, stats.PendingOver30d)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -835,6 +862,121 @@ func TestPostgresStore_Stats_ScanError(t *testing.T) {
 	assert.Contains(t, err.Error(), "counting by status")
 	assert.Nil(t, stats)
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestPostgresStore_Stats_StalenessQueryError covers the staleness query failing
+// after the three count queries succeed (#764): Stats propagates the error.
+func TestPostgresStore_Stats_StalenessQueryError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // test cleanup
+
+	store := NewPostgresStore(db)
+
+	mock.ExpectQuery("SELECT status, COUNT\\(\\*\\) FROM knowledge_insights").
+		WillReturnRows(sqlmock.NewRows([]string{"status", "count"}).AddRow("pending", 1))
+	mock.ExpectQuery("SELECT category, COUNT\\(\\*\\) FROM knowledge_insights").
+		WillReturnRows(sqlmock.NewRows([]string{"category", "count"}))
+	mock.ExpectQuery("SELECT confidence, COUNT\\(\\*\\) FROM knowledge_insights").
+		WillReturnRows(sqlmock.NewRows([]string{"confidence", "count"}))
+	mock.ExpectQuery("SELECT MIN\\(created_at\\), COUNT\\(\\*\\) FILTER").
+		WillReturnError(errors.New("db error"))
+
+	stats, err := store.Stats(context.Background(), InsightFilter{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "computing pending staleness")
+	assert.Nil(t, stats)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- PendingReviewStats / PendingReviewOf tests (#764) ---
+
+func TestPostgresStore_PendingReviewStats(t *testing.T) {
+	t.Run("populated queue returns count and staleness", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close() //nolint:errcheck // test cleanup
+		store := &postgresStore{db: db}
+
+		oldest := time.Now().Add(-94 * 24 * time.Hour)
+		mock.ExpectQuery("SELECT COUNT\\(\\*\\), MIN\\(created_at\\), COUNT\\(\\*\\) FILTER").
+			WithArgs(sqlmock.AnyArg(), "pending").
+			WillReturnRows(sqlmock.NewRows([]string{"count", "min", "over30d"}).AddRow(6, oldest, 2))
+
+		review, err := store.PendingReviewStats(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, 6, review.TotalPending) //nolint:revive // test value
+		require.NotNil(t, review.OldestPendingAt)
+		assert.WithinDuration(t, oldest, *review.OldestPendingAt, time.Second)
+		assert.Equal(t, 2, review.PendingOver30d)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("empty queue yields zero count and nil oldest", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close() //nolint:errcheck // test cleanup
+		store := &postgresStore{db: db}
+
+		mock.ExpectQuery("SELECT COUNT\\(\\*\\), MIN\\(created_at\\), COUNT\\(\\*\\) FILTER").
+			WillReturnRows(sqlmock.NewRows([]string{"count", "min", "over30d"}).AddRow(0, nil, 0))
+
+		review, err := store.PendingReviewStats(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, 0, review.TotalPending)
+		assert.Nil(t, review.OldestPendingAt)
+		assert.Equal(t, 0, review.PendingOver30d)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("query error is propagated", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close() //nolint:errcheck // test cleanup
+		store := &postgresStore{db: db}
+
+		mock.ExpectQuery("SELECT COUNT\\(\\*\\), MIN\\(created_at\\), COUNT\\(\\*\\) FILTER").
+			WillReturnError(errors.New("db error"))
+
+		review, err := store.PendingReviewStats(context.Background())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "scanning pending review row")
+		assert.Nil(t, review)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestPendingReviewOf(t *testing.T) {
+	t.Run("fast path uses PendingReviewStats when available", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()              //nolint:errcheck // test cleanup
+		store := NewPostgresStore(db) // *postgresStore implements PendingReviewStater
+
+		mock.ExpectQuery("SELECT COUNT\\(\\*\\), MIN\\(created_at\\), COUNT\\(\\*\\) FILTER").
+			WillReturnRows(sqlmock.NewRows([]string{"count", "min", "over30d"}).AddRow(3, nil, 0))
+
+		review, err := PendingReviewOf(context.Background(), store)
+		require.NoError(t, err)
+		assert.Equal(t, 3, review.TotalPending) //nolint:revive // test value
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("falls back to Stats for stores without the fast path", func(t *testing.T) {
+		// noopStore does not implement PendingReviewStater, so PendingReviewOf
+		// falls back to its Stats (empty queue).
+		review, err := PendingReviewOf(context.Background(), NewNoopStore())
+		require.NoError(t, err)
+		assert.Equal(t, 0, review.TotalPending)
+		assert.Nil(t, review.OldestPendingAt)
+	})
+
+	t.Run("propagates the fallback Stats error", func(t *testing.T) {
+		store := &fullSpyStore{StatsErr: errors.New("boom")} // no fast path
+		review, err := PendingReviewOf(context.Background(), store)
+		assert.Error(t, err)
+		assert.Nil(t, review)
+	})
 }
 
 // --- postgresStore MarkApplied tests ---

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/txn2/mcp-datahub/pkg/types"
@@ -308,6 +309,32 @@ const bulkReviewScopeNote = "Counts are pending insights only (the global review
 	"that have no entity URN, so it does not sum to total_pending. " +
 	"Pass itemize:true to enumerate every pending insight (with id, captured_by and sink_class)."
 
+// addStalenessRollup adds the pending-queue staleness fields to a bulk_review
+// response so a reviewer (and an agent nudging one) can see how stale the review
+// debt is: oldest_pending_at, oldest_pending_age_days, and pending_over_30d
+// (#764). The fields are omitted for an empty queue (oldest == nil), where there
+// is no debt to report.
+func addStalenessRollup(result map[string]any, oldest *time.Time, over30d int, now time.Time) {
+	if oldest == nil {
+		return
+	}
+	result["oldest_pending_at"] = oldest.UTC().Format(time.RFC3339)
+	result["oldest_pending_age_days"] = AgeDays(*oldest, now)
+	result["pending_over_30d"] = over30d
+}
+
+// AgeDays returns the whole-day age of t relative to now, floored at 0 so a
+// clock skew that puts t slightly in the future never reports negative. It is the
+// single definition of whole-day insight age shared by bulk_review and
+// platform_info so the two never drift (#764); the portal mirrors it in TS.
+func AgeDays(t, now time.Time) int {
+	d := now.Sub(t)
+	if d < 0 {
+		return 0
+	}
+	return int(d.Hours() / 24)
+}
+
 // handleBulkReview summarizes the pending review queue. The default (counts-only)
 // path stays cheap and bounded; itemize:true enumerates the whole queue.
 func (t *Toolkit) handleBulkReview(ctx context.Context, input applyKnowledgeInput) (*mcp.CallToolResult, any, error) {
@@ -338,6 +365,7 @@ func (t *Toolkit) bulkReviewCounts(ctx context.Context) (*mcp.CallToolResult, an
 		"by_confidence": stats.ByConfidence,
 		"note":          bulkReviewScopeNote,
 	}
+	addStalenessRollup(result, stats.OldestPendingAt, stats.PendingOver30d, time.Now())
 	if stats.TotalPending > len(sample) {
 		// by_entity is built from one page, so it is a sample here; itemize:true
 		// returns every pending insight including entity-agnostic ones.
@@ -368,6 +396,8 @@ func (t *Toolkit) bulkReviewItemized(ctx context.Context, input applyKnowledgeIn
 
 	page := pageInsightsBudgeted(pending, input.Offset, input.Limit, bulkReviewItemBudgetBytes)
 	entities, entitiesTruncated := boundedEntitySummaries(pending, maxBulkReviewEntitySummaries)
+	now := time.Now()
+	oldest, over30d := pendingStalenessFromInsights(pending, pendingStalenessCutoff(now))
 	result := map[string]any{
 		"total_pending": len(pending),
 		"by_entity":     entities,
@@ -378,6 +408,7 @@ func (t *Toolkit) bulkReviewItemized(ctx context.Context, input applyKnowledgeIn
 		"returned":      len(page.insights),
 		"offset":        page.offset,
 	}
+	addStalenessRollup(result, oldest, over30d, now)
 	if entitiesTruncated {
 		// by_entity was capped to the busiest entities so the response stays
 		// bounded; the full per-insight entity_urns remain on each insight.

--- a/pkg/toolkits/knowledge/toolkit_test.go
+++ b/pkg/toolkits/knowledge/toolkit_test.go
@@ -185,8 +185,12 @@ func (s *fullSpyStore) Stats(_ context.Context, filter InsightFilter) (*InsightS
 		ByConfidence: map[string]int{},
 		ByStatus:     map[string]int{},
 	}
+	var pending []Insight
 	for _, ins := range s.Insights {
 		stats.ByStatus[ins.Status]++
+		if ins.Status == StatusPending {
+			pending = append(pending, ins)
+		}
 		if filter.Status != "" && ins.Status != filter.Status {
 			continue
 		}
@@ -194,6 +198,11 @@ func (s *fullSpyStore) Stats(_ context.Context, filter InsightFilter) (*InsightS
 		stats.ByConfidence[ins.Confidence]++
 	}
 	stats.TotalPending = stats.ByStatus[StatusPending]
+	// Mirror the real store's pending-queue staleness rollup (#764) so the
+	// counts path is exercised faithfully rather than stubbed.
+	stats.OldestPendingAt, stats.PendingOver30d = pendingStalenessFromInsights(
+		pending, pendingStalenessCutoff(time.Now()),
+	)
 	return stats, nil
 }
 
@@ -813,6 +822,69 @@ func TestHandleBulkReview_ReturnsSummary(t *testing.T) {
 	byEntity, ok := m["by_entity"].([]any)
 	require.True(t, ok, "by_entity should be an array")
 	assert.Len(t, byEntity, 2, "should have 2 distinct entities among pending")
+}
+
+// TestHandleBulkReview_StalenessRollup verifies the review-queue staleness
+// rollup (#764) is present on both the counts and itemized paths: the oldest
+// pending age and the over-30d count let a reviewer (and an agent nudging one)
+// see accumulating review debt.
+func TestHandleBulkReview_StalenessRollup(t *testing.T) {
+	now := time.Now()
+	oldest := now.Add(-94 * 24 * time.Hour)
+	store := &fullSpyStore{
+		Insights: []Insight{
+			{ID: "i1", Status: StatusPending, Category: "correction", Confidence: "high", CreatedAt: now.Add(-3 * 24 * time.Hour)},
+			{ID: "i2", Status: StatusPending, Category: "correction", Confidence: "low", CreatedAt: oldest},
+			{ID: "i3", Status: StatusPending, Category: "business_context", Confidence: "medium", CreatedAt: now.Add(-40 * 24 * time.Hour)},
+			// Applied and very old: excluded from the pending staleness rollup.
+			{ID: "i4", Status: StatusApplied, Category: "correction", Confidence: "high", CreatedAt: now.Add(-300 * 24 * time.Hour)},
+		},
+	}
+	tk := newApplyToolkit(t, store, &spyChangesetStore{}, &spyWriter{})
+
+	assertStaleness := func(t *testing.T, m map[string]any) {
+		t.Helper()
+		require.Contains(t, m, "oldest_pending_at")
+		age, ok := m["oldest_pending_age_days"].(float64)
+		require.True(t, ok, "oldest_pending_age_days should be numeric")
+		assert.InDelta(t, 94, age, 1, "oldest pending is ~94 days old")
+		assert.Equal(t, float64(2), m["pending_over_30d"], "two pending insights past 30 days")
+	}
+
+	t.Run("counts path", func(t *testing.T) {
+		result, _, callErr := tk.handleApplyKnowledge(context.Background(), nil,
+			applyKnowledgeInput{Action: "bulk_review"})
+		require.Nil(t, callErr)
+		require.False(t, result.IsError)
+		assertStaleness(t, parseJSONResult(t, result))
+	})
+
+	t.Run("itemized path", func(t *testing.T) {
+		result, _, callErr := tk.handleApplyKnowledge(context.Background(), nil,
+			applyKnowledgeInput{Action: "bulk_review", Itemize: true})
+		require.Nil(t, callErr)
+		require.False(t, result.IsError)
+		assertStaleness(t, parseJSONResult(t, result))
+	})
+}
+
+// TestHandleBulkReview_StalenessOmittedWhenEmpty verifies the staleness fields
+// are omitted when the pending queue is empty, so there is no false "0 days"
+// signal (#764).
+func TestHandleBulkReview_StalenessOmittedWhenEmpty(t *testing.T) {
+	store := &fullSpyStore{Insights: []Insight{
+		{ID: "i1", Status: StatusApplied, Category: "correction", Confidence: "high", CreatedAt: time.Now()},
+	}}
+	tk := newApplyToolkit(t, store, &spyChangesetStore{}, &spyWriter{})
+
+	result, _, callErr := tk.handleApplyKnowledge(context.Background(), nil,
+		applyKnowledgeInput{Action: "bulk_review"})
+	require.Nil(t, callErr)
+	require.False(t, result.IsError)
+	m := parseJSONResult(t, result)
+	assert.Equal(t, float64(0), m["total_pending"])
+	assert.NotContains(t, m, "oldest_pending_at")
+	assert.NotContains(t, m, "oldest_pending_age_days")
 }
 
 func TestHandleBulkReview_StatsError(t *testing.T) {

--- a/pkg/toolkits/knowledge/types.go
+++ b/pkg/toolkits/knowledge/types.go
@@ -345,6 +345,10 @@ type InsightFilter struct {
 	Until      *time.Time
 	Limit      int
 	Offset     int
+	// OrderCreatedAsc lists insights oldest-first (created_at ASC) instead of the
+	// default newest-first (created_at DESC). The review queue uses it to work the
+	// oldest, stalest review debt first (#764).
+	OrderCreatedAsc bool
 }
 
 // DefaultLimit is the default page size for list queries.
@@ -371,6 +375,63 @@ type InsightStats struct {
 	ByCategory   map[string]int         `json:"by_category"`
 	ByConfidence map[string]int         `json:"by_confidence"`
 	ByStatus     map[string]int         `json:"by_status"`
+	// OldestPendingAt is the created_at of the oldest pending insight, or nil
+	// when the pending queue is empty. It surfaces review-queue staleness so
+	// pending insights do not silently age (#764).
+	OldestPendingAt *time.Time `json:"oldest_pending_at,omitempty"`
+	// PendingOver30d counts pending insights older than
+	// PendingStalenessThresholdDays, the accumulating review debt (#764).
+	PendingOver30d int `json:"pending_over_30d"`
+}
+
+// PendingStalenessThresholdDays is the age, in days, at or past which a pending
+// insight is counted as stale review debt (reported as pending_over_30d). An
+// unreviewed queue erodes the knowledge flywheel, so this threshold makes the
+// aging visible to reviewers and to agents nudging them (#764). "At or past"
+// (age >= threshold) matches the portal's age badge, which flags a row stale at
+// the same 30-day mark, so the count and the badge never disagree.
+const PendingStalenessThresholdDays = 30
+
+// PendingReview is the lightweight review-queue summary: the pending count and
+// its staleness rollup, without the by-category/by-confidence group-bys that the
+// full InsightStats carries. It lets platform_info surface the review-debt nudge
+// per session without the heavier Stats fan-out (#764).
+type PendingReview struct {
+	TotalPending    int        `json:"total_pending"`
+	OldestPendingAt *time.Time `json:"oldest_pending_at,omitempty"`
+	PendingOver30d  int        `json:"pending_over_30d"`
+}
+
+// pendingStalenessCutoff returns the timestamp at or before which a pending
+// insight is counted as stale review debt (aged >= PendingStalenessThresholdDays).
+func pendingStalenessCutoff(now time.Time) time.Time {
+	return now.Add(-PendingStalenessThresholdDays * 24 * time.Hour)
+}
+
+// isStalePending reports whether a pending insight created at created is stale
+// review debt relative to cutoff, i.e. aged at least the threshold. The single
+// definition (created <= cutoff) is shared by every path that counts stale debt
+// so the postgres, memory, and in-memory rollups agree at the boundary.
+func isStalePending(created, cutoff time.Time) bool {
+	return !created.After(cutoff)
+}
+
+// pendingStalenessFromInsights computes the oldest pending created_at (nil when
+// none) and the stale count from an in-memory pending set, so the itemized
+// bulk_review path (which already holds every pending insight) reports the same
+// staleness rollup as the counts path without a second store query.
+func pendingStalenessFromInsights(pending []Insight, cutoff time.Time) (oldest *time.Time, over30d int) {
+	for i := range pending {
+		created := pending[i].CreatedAt
+		if oldest == nil || created.Before(*oldest) {
+			c := created
+			oldest = &c
+		}
+		if isStalePending(created, cutoff) {
+			over30d++
+		}
+	}
+	return oldest, over30d
 }
 
 // EntityInsightSummary summarizes insights for a single entity.

--- a/ui/src/api/admin/hooks.ts
+++ b/ui/src/api/admin/hooks.ts
@@ -233,6 +233,8 @@ interface InsightsParams {
   confidence?: string;
   entityUrn?: string;
   capturedBy?: string;
+  /** "oldest" sorts oldest-first (stalest review debt first); default newest-first. */
+  order?: "oldest" | "newest";
 }
 
 export function useInsights(params: InsightsParams = {}) {
@@ -244,6 +246,7 @@ export function useInsights(params: InsightsParams = {}) {
   if (params.confidence) searchParams.set("confidence", params.confidence);
   if (params.entityUrn) searchParams.set("entity_urn", params.entityUrn);
   if (params.capturedBy) searchParams.set("captured_by", params.capturedBy);
+  if (params.order) searchParams.set("order", params.order);
 
   const qs = searchParams.toString();
   return useQuery({

--- a/ui/src/api/admin/types.ts
+++ b/ui/src/api/admin/types.ts
@@ -217,6 +217,10 @@ export interface InsightStats {
   by_category: Record<string, number>;
   by_confidence: Record<string, number>;
   by_status: Record<string, number>;
+  /** created_at of the oldest pending insight; absent when the queue is empty. */
+  oldest_pending_at?: string;
+  /** Pending insights aged 30 or more days: the accumulating review debt. */
+  pending_over_30d?: number;
 }
 
 export interface Changeset {

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -252,10 +252,19 @@ function computeInsightStats(insights: Insight[]): InsightStats {
     { count: number; categories: Set<string>; latest: string }
   >();
 
+  const staleCutoff = Date.now() - 30 * 86_400_000;
+  let oldestPendingAt: string | undefined;
+  let pendingOver30d = 0;
   for (const ins of insights) {
     byStatus[ins.status] = (byStatus[ins.status] ?? 0) + 1;
     byCategory[ins.category] = (byCategory[ins.category] ?? 0) + 1;
     byConfidence[ins.confidence] = (byConfidence[ins.confidence] ?? 0) + 1;
+    if (ins.status === "pending") {
+      if (!oldestPendingAt || ins.created_at < oldestPendingAt) {
+        oldestPendingAt = ins.created_at;
+      }
+      if (new Date(ins.created_at).getTime() <= staleCutoff) pendingOver30d++;
+    }
     for (const urn of ins.entity_urns) {
       const existing = entityMap.get(urn);
       if (existing) {
@@ -285,6 +294,8 @@ function computeInsightStats(insights: Insight[]): InsightStats {
     by_category: byCategory,
     by_confidence: byConfidence,
     by_status: byStatus,
+    oldest_pending_at: oldestPendingAt,
+    pending_over_30d: pendingOver30d,
   };
 }
 
@@ -1079,6 +1090,7 @@ export const handlers = [
     const confidence = url.searchParams.get("confidence");
     const entityUrn = url.searchParams.get("entity_urn");
     const capturedBy = url.searchParams.get("captured_by");
+    const order = url.searchParams.get("order");
 
     let filtered = [...mockInsights];
     if (status) filtered = filtered.filter((i) => i.status === status);
@@ -1089,6 +1101,11 @@ export const handlers = [
       filtered = filtered.filter((i) => i.entity_urns.includes(entityUrn));
     if (capturedBy)
       filtered = filtered.filter((i) => i.captured_by === capturedBy);
+    filtered.sort((a, b) =>
+      order === "oldest"
+        ? a.created_at.localeCompare(b.created_at)
+        : b.created_at.localeCompare(a.created_at),
+    );
 
     const start = (page - 1) * perPage;
     const data = filtered.slice(start, start + perPage);

--- a/ui/src/pages/knowledge/KnowledgePage.test.tsx
+++ b/ui/src/pages/knowledge/KnowledgePage.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+
+// Mock the admin hooks so KnowledgeCaptureTab renders against controlled data
+// with no network. Each hook is a vi.fn configured per test.
+vi.mock("@/api/admin/hooks", () => ({
+  useInsights: vi.fn(),
+  useInsightStats: vi.fn(),
+  useUpdateInsightStatus: vi.fn(),
+  useChangesets: vi.fn(),
+  useRollbackChangeset: vi.fn(),
+  useAuditFilters: vi.fn(),
+}));
+
+import { KnowledgeCaptureTab } from "./KnowledgePage";
+import {
+  useInsights,
+  useInsightStats,
+  useUpdateInsightStatus,
+  useAuditFilters,
+} from "@/api/admin/hooks";
+import type { Insight, InsightStats } from "@/api/admin/types";
+
+const q = (data: unknown) =>
+  ({ data, isLoading: false, isError: false }) as never;
+const noopMut = () =>
+  ({ mutate: vi.fn(), isPending: false, isError: false, error: null }) as never;
+
+const DAY = 86_400_000;
+const iso = (daysAgo: number) => new Date(Date.now() - daysAgo * DAY).toISOString();
+
+function insight(over: Partial<Insight> & { id: string }): Insight {
+  return {
+    session_id: "s1",
+    captured_by: "user@example.com",
+    persona: "analyst",
+    category: "correction",
+    insight_text: "an insight",
+    confidence: "high",
+    entity_urns: [],
+    related_columns: [],
+    suggested_actions: [],
+    status: "pending",
+    created_at: iso(3),
+    ...over,
+  };
+}
+
+const stats: InsightStats = {
+  total_pending: 3,
+  by_entity: [],
+  by_category: { correction: 3 },
+  by_confidence: { high: 3 },
+  by_status: { pending: 3 },
+  oldest_pending_at: iso(94),
+  pending_over_30d: 2,
+};
+
+beforeEach(() => {
+  vi.mocked(useInsights).mockReturnValue(
+    q({
+      data: [
+        insight({ id: "fresh", created_at: iso(3) }),
+        insight({ id: "aging", created_at: iso(10) }),
+        insight({ id: "stale", created_at: iso(94) }),
+      ],
+      total: 3,
+      page: 1,
+      per_page: 20,
+    }),
+  );
+  vi.mocked(useInsightStats).mockReturnValue(q(stats));
+  vi.mocked(useUpdateInsightStatus).mockReturnValue(noopMut());
+  vi.mocked(useAuditFilters).mockReturnValue(q({ user_labels: {} }));
+});
+
+describe("KnowledgeCaptureTab staleness (#764)", () => {
+  it("shows oldest pending age and over-30d debt on the Pending Review card", () => {
+    render(<KnowledgeCaptureTab />);
+    // "Oldest 94 days · 2 over 30d": the accumulating review debt.
+    expect(screen.getByText(/Oldest 94 days/)).toBeInTheDocument();
+    expect(screen.getByText(/2 over 30d/)).toBeInTheDocument();
+  });
+
+  it("renders a per-row age badge for each insight", () => {
+    render(<KnowledgeCaptureTab />);
+    const rows = screen.getAllByRole("row");
+    // Header row + 3 data rows.
+    const staleRow = rows.find((r) => within(r).queryByText("94 days"));
+    expect(staleRow).toBeTruthy();
+    expect(screen.getByText("3 days")).toBeInTheDocument();
+    expect(screen.getByText("10 days")).toBeInTheDocument();
+  });
+
+  it("passes order=oldest to useInsights when Oldest First is selected", () => {
+    render(<KnowledgeCaptureTab />);
+    fireEvent.change(screen.getByLabelText("Sort by age"), {
+      target: { value: "oldest" },
+    });
+    const calls = vi.mocked(useInsights).mock.calls;
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall?.[0]).toMatchObject({ order: "oldest" });
+  });
+
+  it("defaults to newest-first order", () => {
+    render(<KnowledgeCaptureTab />);
+    const firstCall = vi.mocked(useInsights).mock.calls[0];
+    expect(firstCall?.[0]).toMatchObject({ order: "newest" });
+  });
+});

--- a/ui/src/pages/knowledge/KnowledgePage.tsx
+++ b/ui/src/pages/knowledge/KnowledgePage.tsx
@@ -58,6 +58,30 @@ function formatCategory(cat: string): string {
   return cat.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+const MS_PER_DAY = 86_400_000;
+const STALE_DAYS = 30;
+const AGING_DAYS = 7;
+
+// ageInDays returns the whole-day age of an ISO timestamp, floored at 0 so a
+// clock skew that puts created_at slightly in the future never goes negative.
+function ageInDays(iso: string): number {
+  return Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / MS_PER_DAY));
+}
+
+// ageBucketVariant buckets an age (days) into a badge color: red past the stale
+// threshold, amber while aging, neutral when fresh (#764).
+function ageBucketVariant(days: number): BadgeVariant {
+  if (days >= STALE_DAYS) return "error";
+  if (days >= AGING_DAYS) return "warning";
+  return "neutral";
+}
+
+function formatAge(days: number): string {
+  if (days <= 0) return "today";
+  if (days === 1) return "1 day";
+  return `${days} days`;
+}
+
 // ---------------------------------------------------------------------------
 // Knowledge Capture Tab
 // ---------------------------------------------------------------------------
@@ -67,6 +91,7 @@ export function KnowledgeCaptureTab() {
   const [statusFilter, setStatusFilter] = useState("");
   const [categoryFilter, setCategoryFilter] = useState("");
   const [confidenceFilter, setConfidenceFilter] = useState("");
+  const [order, setOrder] = useState<"newest" | "oldest">("newest");
   const [selectedInsight, setSelectedInsight] = useState<Insight | null>(null);
   const { data: filters } = useAuditFilters();
   const ul = filters?.user_labels ?? {};
@@ -78,13 +103,26 @@ export function KnowledgeCaptureTab() {
       status: statusFilter || undefined,
       category: categoryFilter || undefined,
       confidence: confidenceFilter || undefined,
+      order,
     }),
-    [page, statusFilter, categoryFilter, confidenceFilter],
+    [page, statusFilter, categoryFilter, confidenceFilter, order],
   );
 
   const { data, isLoading } = useInsights(params);
   const { data: stats } = useInsightStats();
   const totalPages = data ? Math.ceil(data.total / PER_PAGE) : 0;
+
+  // Review-queue staleness: how old the oldest pending insight is, and how much
+  // debt has crossed the 30-day threshold (#764).
+  const oldestPendingDays = stats?.oldest_pending_at
+    ? ageInDays(stats.oldest_pending_at)
+    : null;
+  const pendingOver30d = stats?.pending_over_30d ?? 0;
+  const pendingDetail =
+    oldestPendingDays !== null
+      ? `Oldest ${formatAge(oldestPendingDays)}` +
+        (pendingOver30d > 0 ? ` · ${pendingOver30d} over 30d` : "")
+      : undefined;
 
   const topCategory = useMemo(() => {
     if (!stats?.by_category) return "-";
@@ -101,8 +139,13 @@ export function KnowledgeCaptureTab() {
         <StatCard
           label="Pending Review"
           value={stats?.total_pending ?? "-"}
+          detail={pendingDetail}
           className={
-            stats && stats.total_pending > 0 ? "border-yellow-200" : undefined
+            pendingOver30d > 0
+              ? "border-red-300"
+              : stats && stats.total_pending > 0
+                ? "border-yellow-200"
+                : undefined
           }
         />
         <StatCard
@@ -169,6 +212,18 @@ export function KnowledgeCaptureTab() {
             </option>
           ))}
         </select>
+        <select
+          value={order}
+          onChange={(e) => {
+            setOrder(e.target.value as "newest" | "oldest");
+            setPage(1);
+          }}
+          className="rounded-md border bg-background px-3 py-1.5 text-sm outline-none ring-ring focus:ring-2"
+          aria-label="Sort by age"
+        >
+          <option value="newest">Newest First</option>
+          <option value="oldest">Oldest First</option>
+        </select>
       </div>
 
       {/* Table */}
@@ -177,6 +232,7 @@ export function KnowledgeCaptureTab() {
           <thead>
             <tr className="border-b bg-muted/50">
               <th className="px-3 py-2 text-left font-medium">Created At</th>
+              <th className="px-3 py-2 text-center font-medium">Age</th>
               <th className="px-3 py-2 text-left font-medium">Captured By</th>
               <th className="px-3 py-2 text-left font-medium">Category</th>
               <th className="px-3 py-2 text-center font-medium">Confidence</th>
@@ -188,7 +244,7 @@ export function KnowledgeCaptureTab() {
             {isLoading && (
               <tr>
                 <td
-                  colSpan={6}
+                  colSpan={7}
                   className="px-3 py-8 text-center text-muted-foreground"
                 >
                   Loading...
@@ -203,6 +259,19 @@ export function KnowledgeCaptureTab() {
               >
                 <td className="px-3 py-2 text-xs">
                   {new Date(insight.created_at).toLocaleString()}
+                </td>
+                <td className="px-3 py-2 text-center">
+                  {insight.status === "pending" ? (
+                    <StatusBadge
+                      variant={ageBucketVariant(ageInDays(insight.created_at))}
+                    >
+                      {formatAge(ageInDays(insight.created_at))}
+                    </StatusBadge>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">
+                      {formatAge(ageInDays(insight.created_at))}
+                    </span>
+                  )}
                 </td>
                 <td
                   className="px-3 py-2 text-xs"
@@ -239,7 +308,7 @@ export function KnowledgeCaptureTab() {
             {data?.data.length === 0 && (
               <tr>
                 <td
-                  colSpan={6}
+                  colSpan={7}
                   className="px-3 py-8 text-center text-muted-foreground"
                 >
                   No insights found


### PR DESCRIPTION
## Why

The knowledge flywheel only turns if humans work the `apply_knowledge` review queue. Today nothing surfaces queue age: `bulk_review` reports counts by category/confidence/entity and a `created_at` per insight, but there is no staleness rollup, no portal indicator, and no per-session nudge. A pending insight can sit unreviewed for months with no visible signal, and while it does, captures stop becoming shared knowledge and agents keep re-deriving facts.

Closes #764. The optional operator digest (part 3 of the issue) needs a notification substrate the platform does not yet have, so it is split out into #803, which depends on the email-notification epic #631.

## What

### Backend rollup
- `InsightStats` gains `oldest_pending_at` and `pending_over_30d`. The Postgres store computes both in a single aggregate query (`MIN(created_at)` + `COUNT(*) FILTER`), scoped to the pending subset so the rollup always agrees with `total_pending`; the memory-backed adapter tallies them in the walk it already performs.
- `bulk_review` returns `oldest_pending_at`, `oldest_pending_age_days`, and `pending_over_30d` on both the counts and `itemize` paths. The fields are omitted for an empty queue, so there is no misleading "0 days" signal.
- `platform_info` exposes `features.knowledge_apply.review_queue` (`pending`, `oldest_pending_age_days`, `pending_over_30d`) for callers who can reach `apply_knowledge`, so an agent can nudge a reviewer (e.g. "6 insights pending review, oldest 94 days"). This reads through a new optional `PendingReviewStater` fast path (mirroring the existing `SearchableInsightStore` pattern) so per-session orientation runs one lightweight query instead of the full four-query `Stats` fan-out; stores without the fast path fall back to `Stats`.

### Portal
- The review queue view badges each pending insight by age with color buckets (neutral < 7d, amber 7–30d, red ≥ 30d), shows the oldest age and over-30d debt as detail on the Pending Review card (red border when debt exists), and adds a Newest/Oldest sort selector.
- Oldest-first sorting is server-side: `order=oldest` on the insights API maps to `created_at ASC` in both store backends, so a reviewer can page the stalest debt first.

### Consistency
- Staleness has one definition (`isStalePending`: aged ≥ 30 days) shared by the Postgres, memory, and in-memory rollups, and whole-day age has one definition (`AgeDays`) shared by `bulk_review` and `platform_info`. The portal badge uses the same ≥ 30-day mark, so the count and the badge never disagree at the boundary and the two tools never drift.

## Testing

- `make verify` green end to end: unit tests with race, patch coverage (98%+ on changed lines), `golangci-lint` (including the `--new-from-rev` CI parity pass), `gosec`/`govulncheck`, Semgrep, CodeQL, mutation testing (≥ 60%), doc-check, emdash-check, swagger-check, and the GoReleaser dry-run.
- New Go tests cover the staleness rollup on both `bulk_review` paths, the memory-adapter staleness tally and oldest-first ordering, the Postgres `PendingReviewStats` query and its `PendingReviewOf` fast-path/fallback, `platform_info`'s `review_queue`, and the admin `order` parameter.
- New UI test (`KnowledgePage.test.tsx`) covers the age badges, the card staleness detail, and the sort selector wiring; UI typecheck, lint, and build pass, and all vitest suites are green.

## Docs

- `docs/knowledge/governance.md`, `docs/server/tools.md`, and `docs/llms-full.txt` document the staleness rollup and the `order=oldest` sort; Swagger (`internal/apidocs/`) is regenerated for the new `InsightStats` fields and the `order` query parameter.

## Follow-up

- Operator alert/digest when the queue crosses a staleness threshold (part 3 of #764): tracked in #803, blocked by the email-notification substrate #631.