### PR TITLE
feat(platform): make receiving-middleware order a checked invariant (#758)

### DIFF
--- a/pkg/platform/middleware_chain.go
+++ b/pkg/platform/middleware_chain.go
@@ -1,0 +1,222 @@
+package platform
+
+import (
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/platform/mwchain"
+)
+
+// mwName identifies a receiving middleware within the canonical chain order.
+// Names are stable identifiers used both to declare ordering dependencies and
+// to produce named errors when the declared order is invalid.
+type mwName = mwchain.Name
+
+const (
+	mwIcons               mwName = "icons"
+	mwDescriptionOverride mwName = "description_override"
+	mwPromptVisibility    mwName = "prompt_visibility"
+	mwToolVisibility      mwName = "tool_visibility"
+	mwSessionHandleSchema mwName = "session_handle_schema"
+	mwMCPApps             mwName = "mcp_apps"
+	mwToolCall            mwName = "tool_call" // auth/authz; writes PlatformContext via context.WithValue
+	mwSessionGate         mwName = "session_gate"
+	mwWorkflowGate        mwName = "workflow_gate"
+	mwReflexiveCapture    mwName = "reflexive_capture"
+	mwTracing             mwName = "tracing"
+	mwMetrics             mwName = "metrics"
+	mwAudit               mwName = "audit"
+	mwErrorContract       mwName = "error_contract"
+	mwClientLogging       mwName = "client_logging"
+	mwManagedResource     mwName = "managed_resource"
+	mwProvenance          mwName = "provenance"
+	mwEnrichment          mwName = "enrichment"
+	mwUnwrapJSON          mwName = "unwrap_json"
+)
+
+// mwSpec declares one receiving middleware's identity, the middlewares that
+// MUST be outer to it (run earlier on a tools/call request), and how to
+// register it on the server. A middleware that reads a value another writes
+// via context.WithValue — the canonical case is every PlatformContext reader
+// depending on the auth/authz middleware — must never be positioned outer to
+// its writer, or the value is invisible downstream.
+type mwSpec = mwchain.Spec
+
+// receivingMiddlewareChain declares the canonical receiving-middleware chain in
+// execution order: outermost (index 0, runs first on a tools/call request) to
+// innermost (runs last, closest to the handler). The declared order and the
+// per-middleware Requires list make the ordering a checked invariant rather
+// than a comment (issue #758): mwchain.Validate rejects any arrangement in
+// which a required (outer) middleware is positioned inner to the middleware
+// that depends on it.
+//
+// Register funcs may skip their AddReceivingMiddleware call when the feature is
+// disabled; the declared position is what the invariant protects, independent
+// of which middlewares are enabled at runtime.
+func (p *Platform) receivingMiddlewareChain() []mwSpec {
+	return []mwSpec{
+		// List decorators (outermost): shape tools/list, prompts/list, and
+		// resources/list responses. They do not touch PlatformContext.
+		{Name: mwIcons, Register: p.addIconMiddleware},
+		{Name: mwDescriptionOverride, Register: p.addDescriptionOverrideMiddleware},
+		{Name: mwPromptVisibility, Register: p.addPromptVisibilityMiddleware},
+		{Name: mwToolVisibility, Register: p.addToolVisibilityMiddleware},
+		{Name: mwSessionHandleSchema, Register: p.addSessionHandleSchemaMiddleware},
+		{Name: mwMCPApps, Register: p.addMCPAppsMiddleware},
+
+		// Auth/authz writes PlatformContext; it must be outer to every reader below.
+		{Name: mwToolCall, Register: p.addToolCallMiddleware},
+
+		// Gates: block tools before they reach audit/enrichment. Both read
+		// PlatformContext, and the workflow gate is inner to the session gate so
+		// platform_info takes precedence.
+		{Name: mwSessionGate, Requires: []mwName{mwToolCall}, Register: p.addSessionGateMiddleware},
+		{Name: mwWorkflowGate, Requires: []mwName{mwToolCall, mwSessionGate}, Register: p.addWorkflowGateMiddleware},
+
+		// Observers: read PlatformContext (identity/session/tool metadata), so
+		// they require the auth/authz middleware that writes it. Reflexive
+		// capture observes the tool result on the way out and must see the
+		// normalized error the error contract produces, so it is outer to it
+		// (encoded on mwErrorContract's Requires below).
+		{Name: mwReflexiveCapture, Requires: []mwName{mwToolCall}, Register: p.addReflexiveCaptureMiddleware},
+		{Name: mwTracing, Requires: []mwName{mwToolCall}, Register: p.addTracingMiddleware},
+		{Name: mwMetrics, Requires: []mwName{mwToolCall}, Register: p.addMetricsMiddleware},
+		{Name: mwAudit, Requires: []mwName{mwToolCall}, Register: p.addAuditMiddleware},
+
+		// Error contract normalizes handler errors; it is inner to audit/metrics
+		// and reflexive capture so they observe the normalized {code, category}
+		// on the way out rather than the raw handler error.
+		{Name: mwErrorContract, Requires: []mwName{mwAudit, mwMetrics, mwReflexiveCapture}, Register: p.addErrorContractMiddleware},
+
+		{Name: mwClientLogging, Register: p.addClientLoggingMiddleware},
+		{Name: mwManagedResource, Register: p.addManagedResourceMiddleware},
+
+		// Provenance reads PlatformContext (pc.SessionID) to accumulate per-session
+		// tool calls, so it requires the auth/authz middleware that writes it.
+		{Name: mwProvenance, Requires: []mwName{mwToolCall}, Register: p.addProvenanceMiddleware},
+
+		// Enrichment reads PlatformContext (session dedup) and sets
+		// EnrichmentApplied on the way out. The observers that record it —
+		// audit, tracing, and client logging — read it after next() returns, so
+		// they must be outer to enrichment (enrichment inner to them), or they
+		// record enrichment as not-applied. Metrics does not read the flag, so
+		// it is intentionally absent here.
+		{Name: mwEnrichment, Requires: []mwName{mwToolCall, mwTracing, mwAudit, mwClientLogging}, Register: p.addEnrichmentMiddleware},
+
+		// Unwrap JSON (innermost): rewrites tool arguments before the handler runs.
+		{Name: mwUnwrapJSON, Register: p.addUnwrapJSONMiddleware},
+	}
+}
+
+// --- Receiving-middleware registration helpers ---
+//
+// Each helper performs the AddReceivingMiddleware call for one entry in the
+// canonical chain, applying that middleware's enablement condition. They are
+// invoked by finalizeSetup in innermost-first order so the declared
+// outermost-first chain is realized on the server.
+
+// addUnwrapJSONMiddleware injects unwrap_json=true into trino_query and
+// trino_execute arguments so single-row VARCHAR-of-JSON results are returned as
+// parsed objects. Innermost so the modified arguments reach the handler.
+func (p *Platform) addUnwrapJSONMiddleware() {
+	if p.config.Enrichment.IsUnwrapJSONEnabled() {
+		p.mcpServer.AddReceivingMiddleware(middleware.MCPUnwrapJSONMiddleware())
+	}
+}
+
+// addClientLoggingMiddleware sends enrichment info to the client via session.Log().
+func (p *Platform) addClientLoggingMiddleware() {
+	if p.config.ClientLogging.IsEnabled() {
+		p.mcpServer.AddReceivingMiddleware(
+			middleware.MCPClientLoggingMiddleware(middleware.ClientLoggingConfig{
+				Enabled: true,
+			}),
+		)
+	}
+}
+
+// addErrorContractMiddleware normalizes every tools/call error result into a
+// self-describing {code, category, message, hint} envelope and recovers a
+// panicking handler into a categorized internal error (#539). Registered inner
+// to Audit/Metrics so they observe the normalized category, and outer to the
+// handler whose results it normalizes. Always on: an uncategorized error result
+// must never reach the agent as an opaque string.
+func (p *Platform) addErrorContractMiddleware() {
+	p.mcpServer.AddReceivingMiddleware(
+		middleware.MCPErrorContractMiddleware(),
+	)
+}
+
+// addAuditMiddleware logs tool calls, reading PlatformContext set by
+// auth/authz. Must be inner to MCPToolCallMiddleware.
+func (p *Platform) addAuditMiddleware() {
+	if p.config.Audit.IsToolCallLoggingEnabled() {
+		p.mcpServer.AddReceivingMiddleware(
+			middleware.MCPAuditMiddleware(p.auditLogger),
+		)
+	}
+}
+
+// addMetricsMiddleware records tool_calls_total / tool_call_duration_seconds
+// and the in-flight gauge. Reads PlatformContext (tool, toolkit_kind, persona)
+// populated by MCPToolCallMiddleware, so it must be inner to that middleware.
+// Safe to register unconditionally: the middleware short-circuits on a
+// nil-or-disabled recorder.
+func (p *Platform) addMetricsMiddleware() {
+	if p.metrics.Enabled() {
+		p.mcpServer.AddReceivingMiddleware(
+			middleware.MCPMetricsMiddleware(p.metrics),
+		)
+	}
+}
+
+// addTracingMiddleware opens the per-tool-call OTel span that becomes the
+// parent of every downstream adapter span via context propagation. Like Metrics
+// it reads PlatformContext and so sits inner to MCPToolCallMiddleware and outer
+// to the handler. Safe to register unconditionally: the middleware
+// short-circuits on a nil/disabled tracer.
+func (p *Platform) addTracingMiddleware() {
+	if p.tracer.Enabled() {
+		p.mcpServer.AddReceivingMiddleware(
+			middleware.MCPTracingMiddleware(p.tracer),
+		)
+	}
+}
+
+// addWorkflowGateMiddleware refuses query tools until search has been called in
+// the session (issue #787). It short-circuits a blocked call with a
+// SEARCH_REQUIRED error result and never runs the handler. Inner to the session
+// gate so platform_info takes precedence, but outer to Audit/enrichment so
+// blocked calls don't produce audit events or enrichment.
+func (p *Platform) addWorkflowGateMiddleware() {
+	if p.workflowTracker != nil {
+		p.mcpServer.AddReceivingMiddleware(
+			middleware.MCPWorkflowGateMiddleware(p.workflowTracker),
+		)
+	}
+}
+
+// addSessionGateMiddleware blocks non-exempt tools until platform_info is
+// called. Inner to Auth/Authz so PlatformContext is available; outer to Audit
+// so gated calls don't produce audit events.
+func (p *Platform) addSessionGateMiddleware() {
+	if p.sessionGate != nil {
+		p.mcpServer.AddReceivingMiddleware(
+			middleware.MCPSessionGateMiddleware(p.sessionGate),
+		)
+	}
+}
+
+// addToolCallMiddleware authenticates and authorizes users and creates
+// PlatformContext. Must be outer to Audit (and every other PlatformContext
+// reader) so PlatformContext is available in the ctx they receive. The
+// session-handle resolver (#792) runs inside it, adopting the explicit handle
+// onto pc.SessionID before the gates and audit observe it.
+func (p *Platform) addToolCallMiddleware() {
+	p.mcpServer.AddReceivingMiddleware(
+		middleware.MCPToolCallMiddleware(p.authenticator, p.authorizer, p.toolkitRegistry, middleware.ToolCallConfig{
+			Transport:       p.config.Server.Transport,
+			AdminPersona:    p.config.Admin.Persona,
+			WorkflowTracker: p.workflowTracker,
+			SessionResolver: p.buildSessionResolver(),
+		}),
+	)
+}

--- a/pkg/platform/middleware_chain_test.go
+++ b/pkg/platform/middleware_chain_test.go
@@ -1,0 +1,166 @@
+package platform
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/observability"
+	"github.com/txn2/mcp-data-platform/pkg/platform/mwchain"
+)
+
+// TestReceivingMiddlewareChain_CanonicalOrder pins the exact execution order of
+// the receiving-middleware chain (outermost first). Any deliberate reorder must
+// update this list, so the change is an explicit, reviewable diff rather than a
+// silent one-line move at the registration site (issue #758).
+func TestReceivingMiddlewareChain_CanonicalOrder(t *testing.T) {
+	// Method values are captured without invoking the registrations, so a
+	// zero-value Platform is sufficient to inspect names and requires.
+	p := &Platform{}
+
+	want := []mwName{
+		mwIcons,
+		mwDescriptionOverride,
+		mwPromptVisibility,
+		mwToolVisibility,
+		mwSessionHandleSchema,
+		mwMCPApps,
+		mwToolCall,
+		mwSessionGate,
+		mwWorkflowGate,
+		mwReflexiveCapture,
+		mwTracing,
+		mwMetrics,
+		mwAudit,
+		mwErrorContract,
+		mwClientLogging,
+		mwManagedResource,
+		mwProvenance,
+		mwEnrichment,
+		mwUnwrapJSON,
+	}
+
+	specs := p.receivingMiddlewareChain()
+	if len(specs) != len(want) {
+		t.Fatalf("chain length = %d, want %d", len(specs), len(want))
+	}
+	for i, s := range specs {
+		if s.Name != want[i] {
+			t.Errorf("position %d: name = %q, want %q", i, s.Name, want[i])
+		}
+		if s.Register == nil {
+			t.Errorf("position %d (%q): register func is nil", i, s.Name)
+		}
+	}
+}
+
+// TestReceivingMiddlewareChain_Validates proves the shipped chain satisfies
+// every declared ordering dependency. This is the same check finalizeSetup runs
+// at startup; asserting it in a unit test surfaces a violation as a test
+// failure rather than only as a runtime panic.
+func TestReceivingMiddlewareChain_Validates(t *testing.T) {
+	if err := mwchain.Validate((&Platform{}).receivingMiddlewareChain()); err != nil {
+		t.Fatalf("canonical middleware chain failed validation: %v", err)
+	}
+}
+
+// TestReceivingMiddlewareChain_PlatformContextReadersRequireAuth guards the
+// central invariant: every PlatformContext reader declares a dependency on the
+// auth/authz middleware that writes it. If a new reader is added without the
+// requires entry, this test fails.
+func TestReceivingMiddlewareChain_PlatformContextReadersRequireAuth(t *testing.T) {
+	specs := (&Platform{}).receivingMiddlewareChain()
+
+	readers := map[mwName]bool{
+		mwSessionGate:      true,
+		mwWorkflowGate:     true,
+		mwReflexiveCapture: true,
+		mwTracing:          true,
+		mwMetrics:          true,
+		mwAudit:            true,
+		mwProvenance:       true,
+		mwEnrichment:       true,
+	}
+
+	for _, s := range specs {
+		if !readers[s.Name] {
+			continue
+		}
+		if !requires(s, mwToolCall) {
+			t.Errorf("middleware %q reads PlatformContext but does not require %q", s.Name, mwToolCall)
+		}
+	}
+}
+
+// TestReceivingMiddlewareChain_DeclaredDependencies pins the ordering edges
+// that the old linear registration guaranteed only by position. Each edge here
+// corresponds to a real cross-middleware data dependency (verified against the
+// middleware sources); if a future edit drops one of these Requires entries,
+// the validator would silently stop protecting that ordering, so this test
+// fails loudly instead.
+func TestReceivingMiddlewareChain_DeclaredDependencies(t *testing.T) {
+	byName := make(map[mwName]mwSpec)
+	for _, s := range (&Platform{}).receivingMiddlewareChain() {
+		byName[s.Name] = s
+	}
+
+	// want[X] lists middlewares that MUST be outer to X.
+	want := map[mwName][]mwName{
+		// PlatformContext readers depend on the auth/authz writer.
+		mwProvenance: {mwToolCall},
+		// Observers of EnrichmentApplied (set on the way out) must be outer to
+		// enrichment; metrics is deliberately excluded (it does not read it).
+		mwEnrichment: {mwToolCall, mwTracing, mwAudit, mwClientLogging},
+		// audit/metrics/reflexive-capture observe the normalized error, so the
+		// error contract is inner to all three.
+		mwErrorContract: {mwAudit, mwMetrics, mwReflexiveCapture},
+	}
+
+	for name, reqs := range want {
+		s, ok := byName[name]
+		if !ok {
+			t.Fatalf("middleware %q not present in chain", name)
+		}
+		for _, r := range reqs {
+			if !requires(s, r) {
+				t.Errorf("middleware %q must declare requires %q", name, r)
+			}
+		}
+	}
+}
+
+func requires(s mwSpec, name mwName) bool {
+	return slices.Contains(s.Requires, name)
+}
+
+// TestAddSessionGateMiddleware covers both branches of the session-gate
+// registration helper: nil gate is a no-op, a configured gate registers
+// without panic.
+func TestAddSessionGateMiddleware(_ *testing.T) {
+	p := &Platform{config: &Config{}}
+	p.mcpServer = mcp.NewServer(&mcp.Implementation{Name: "t", Version: "v0"}, nil)
+
+	p.addSessionGateMiddleware() // disabled: nil gate → no-op
+
+	p.sessionGate = middleware.NewSessionGate(middleware.SessionGateConfig{InitTool: "platform_info"})
+	p.addSessionGateMiddleware() // enabled: registers without panic
+}
+
+// TestAddTracingMiddleware covers both branches of the tracing registration
+// helper: a nil (disabled) tracer is a no-op, an enabled tracer registers
+// without panic.
+func TestAddTracingMiddleware(t *testing.T) {
+	p := &Platform{config: &Config{}}
+	p.mcpServer = mcp.NewServer(&mcp.Implementation{Name: "t", Version: "v0"}, nil)
+
+	p.addTracingMiddleware() // disabled: nil tracer → Enabled()==false → no-op
+
+	tp := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	p.tracer = observability.NewTracerFromProvider(tp, observability.TracingConfig{Enabled: true})
+	p.addTracingMiddleware() // enabled: registers without panic
+}

--- a/pkg/platform/mwchain/mwchain.go
+++ b/pkg/platform/mwchain/mwchain.go
@@ -1,0 +1,51 @@
+// Package mwchain validates an ordered middleware chain against declared
+// ordering dependencies.
+//
+// A chain is a slice of specs in execution order (outermost first); each spec
+// may name other specs that MUST be outer to it — the canonical case being a
+// middleware that reads a value another writes via context.WithValue, which is
+// invisible unless the writer runs first. Validate rejects any chain in which a
+// required dependency is positioned inner to (or at the same position as) the
+// spec that needs it, so an accidental reorder fails fast instead of silently
+// mis-wiring the chain (issue #758).
+package mwchain
+
+import "fmt"
+
+// Name identifies a middleware within a chain.
+type Name string
+
+// Spec declares one middleware's identity, the middlewares that must be outer
+// to it (run earlier in execution order), and how to register it.
+type Spec struct {
+	Name     Name
+	Requires []Name
+	Register func()
+}
+
+// Validate checks that the chain is internally consistent: names are unique,
+// every Requires target exists, and every required middleware is outer to (has
+// a lower index than) the middleware that depends on it. It returns a named
+// error on the first violation so a reorder is caught deterministically.
+func Validate(specs []Spec) error {
+	index := make(map[Name]int, len(specs))
+	for i, s := range specs {
+		if _, dup := index[s.Name]; dup {
+			return fmt.Errorf("middleware %q declared more than once", s.Name)
+		}
+		index[s.Name] = i
+	}
+	for i, s := range specs {
+		for _, req := range s.Requires {
+			reqIdx, ok := index[req]
+			if !ok {
+				return fmt.Errorf("middleware %q requires unknown middleware %q", s.Name, req)
+			}
+			if reqIdx >= i {
+				return fmt.Errorf("middleware %q requires %q to be outer, but %q is inner (%q at position %d, %q at position %d)",
+					s.Name, req, req, s.Name, i, req, reqIdx)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/platform/mwchain/mwchain_test.go
+++ b/pkg/platform/mwchain/mwchain_test.go
@@ -1,0 +1,78 @@
+package mwchain
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidate_ValidOrderingAccepted(t *testing.T) {
+	// Any order that satisfies the declared dependencies passes, so the
+	// validator flags genuine ordering bugs rather than every edit.
+	specs := []Spec{
+		{Name: "tool_call"},
+		{Name: "session_gate", Requires: []Name{"tool_call"}},
+		{Name: "workflow_gate", Requires: []Name{"tool_call", "session_gate"}},
+		{Name: "audit", Requires: []Name{"tool_call"}},
+	}
+	if err := Validate(specs); err != nil {
+		t.Fatalf("valid ordering rejected: %v", err)
+	}
+}
+
+func TestValidate_Violations(t *testing.T) {
+	tests := []struct {
+		name    string
+		specs   []Spec
+		wantErr string
+	}{
+		{
+			name: "required dependency is inner (reader outer to its writer)",
+			specs: []Spec{
+				{Name: "audit", Requires: []Name{"tool_call"}},
+				{Name: "tool_call"},
+			},
+			wantErr: `requires "tool_call" to be outer`,
+		},
+		{
+			name: "required dependency at same position (self-reference)",
+			specs: []Spec{
+				{Name: "audit", Requires: []Name{"audit"}},
+			},
+			wantErr: "to be outer",
+		},
+		{
+			name: "requires unknown middleware",
+			specs: []Spec{
+				{Name: "tool_call"},
+				{Name: "audit", Requires: []Name{"does_not_exist"}},
+			},
+			wantErr: "unknown middleware",
+		},
+		{
+			name: "duplicate middleware name",
+			specs: []Spec{
+				{Name: "tool_call"},
+				{Name: "tool_call"},
+			},
+			wantErr: "declared more than once",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(tt.specs)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidate_Empty(t *testing.T) {
+	if err := Validate(nil); err != nil {
+		t.Fatalf("empty chain should validate, got %v", err)
+	}
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -48,6 +48,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/observability"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/platform/fieldcrypt"
+	"github.com/txn2/mcp-data-platform/pkg/platform/mwchain"
 	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
 	"github.com/txn2/mcp-data-platform/pkg/platform/reflexivecapture"
 	"github.com/txn2/mcp-data-platform/pkg/portal"
@@ -2599,143 +2600,29 @@ func (p *Platform) finalizeSetup() {
 		Capabilities: p.buildServerCapabilities(),
 	})
 
-	// Add MCP protocol-level middleware.
+	// Add MCP protocol-level receiving middleware.
 	//
-	// IMPORTANT: AddReceivingMiddleware wraps the current handler, so each
-	// call makes its middleware the new outermost layer. The LAST middleware
-	// added runs FIRST. We add innermost middleware first and outermost last.
-	//
-	// Desired execution order (outermost → innermost → handler):
-	//   Tool visibility → Apps metadata → Auth/Authz → Session gate → Audit → Rules → Client logging → Enrichment → handler
-	//
-	// Therefore we add in reverse (innermost first):
-
-	// 0. Unwrap JSON default (innermost) — injects unwrap_json=true into trino_query
-	// and trino_execute arguments so single-row VARCHAR-of-JSON results are returned
-	// as parsed objects. Must be innermost so the modified arguments reach the handler.
-	if p.config.Enrichment.IsUnwrapJSONEnabled() {
-		p.mcpServer.AddReceivingMiddleware(middleware.MCPUnwrapJSONMiddleware())
+	// The chain order is a checked invariant, not a comment (issue #758).
+	// receivingMiddlewareChain() declares the canonical execution order
+	// (outermost first) and each middleware's ordering dependencies — the
+	// canonical case being that every PlatformContext reader (audit, metrics,
+	// tracing, reflexive capture, the gates, enrichment) must be inner to the
+	// auth/authz middleware that writes PlatformContext via context.WithValue,
+	// or the value is invisible downstream. We validate the declared order
+	// before touching the server so any accidental reorder fails fast at
+	// startup with a named error instead of silently mis-wiring the chain.
+	specs := p.receivingMiddlewareChain()
+	if err := mwchain.Validate(specs); err != nil {
+		panic(fmt.Sprintf("mcp-data-platform: invalid receiving-middleware chain order: %v", err))
 	}
 
-	// 1. Semantic enrichment - enriches responses with cross-service context.
-	p.addEnrichmentMiddleware()
-
-	// 1.5. Provenance tracking - accumulates tool calls per session for save_artifact
-	p.addProvenanceMiddleware()
-
-	// 1.6. Managed resources - injects database-backed resources into resources/list and resources/read
-	p.addManagedResourceMiddleware()
-
-	// 2. Client logging - sends enrichment info to client via session.Log()
-	if p.config.ClientLogging.IsEnabled() {
-		p.mcpServer.AddReceivingMiddleware(
-			middleware.MCPClientLoggingMiddleware(middleware.ClientLoggingConfig{
-				Enabled: true,
-			}),
-		)
+	// AddReceivingMiddleware wraps the current handler, so each call makes its
+	// middleware the new OUTERMOST layer: the last middleware added runs first.
+	// The chain is declared outermost-first, so we register it in reverse
+	// (innermost first) to realize that execution order.
+	for i := len(specs) - 1; i >= 0; i-- {
+		specs[i].Register()
 	}
-
-	// 3.5. Error contract - normalizes every tools/call error result into a
-	// self-describing {code, category, message, hint} envelope and recovers a
-	// panicking handler into a categorized internal error (#539). Registered
-	// inner to Audit/Metrics so they observe the normalized category, and outer
-	// to the handler whose results it normalizes. Always on: an uncategorized
-	// error result must never reach the agent as an opaque string.
-	p.mcpServer.AddReceivingMiddleware(
-		middleware.MCPErrorContractMiddleware(),
-	)
-
-	// 4. Audit - logs tool calls (reads PlatformContext set by Auth/Authz above)
-	if p.config.Audit.IsToolCallLoggingEnabled() {
-		p.mcpServer.AddReceivingMiddleware(
-			middleware.MCPAuditMiddleware(p.auditLogger),
-		)
-	}
-
-	// 4.5. Metrics - records tool_calls_total / tool_call_duration_seconds
-	// and the in-flight gauge. Reads PlatformContext (tool, toolkit_kind,
-	// persona) populated by MCPToolCallMiddleware, so it must be INNER
-	// to that middleware. Position next to Audit because both observe
-	// the same call boundary (outcome + duration) and both are
-	// strictly observational — neither mutates the request or result.
-	// Safe to register unconditionally: the middleware short-circuits
-	// on a nil-or-disabled recorder.
-	if p.metrics.Enabled() {
-		p.mcpServer.AddReceivingMiddleware(
-			middleware.MCPMetricsMiddleware(p.metrics),
-		)
-	}
-
-	// 4.6. Tracing - opens the per-tool-call OTel span that becomes the
-	// parent of every downstream adapter span (Trino/DataHub/S3/OAuth/
-	// enrichment) via context propagation, so one tool call is one flame
-	// graph. Like Metrics it reads PlatformContext and so sits INNER to
-	// MCPToolCallMiddleware and OUTER to the handler. Safe to register
-	// unconditionally: the middleware short-circuits on a nil/disabled
-	// tracer.
-	if p.tracer.Enabled() {
-		p.mcpServer.AddReceivingMiddleware(
-			middleware.MCPTracingMiddleware(p.tracer),
-		)
-	}
-
-	// 4.7. Reflexive capture (#635) - observes trino query outcomes and mints a
-	// correction memory when an error is followed by a same-table success in the
-	// session. Reads PlatformContext (identity/session) so it sits INNER to
-	// MCPToolCallMiddleware, and OUTER to the error contract so it sees the
-	// normalized error. Strictly observational: never mutates request or result.
-	p.addReflexiveCaptureMiddleware()
-
-	// 5. Search-first gate - refuses query tools until search has been called in
-	// the session (issue #787). Modeled on the session gate: it short-circuits a
-	// blocked call with a SEARCH_REQUIRED error result and never runs the handler.
-	// Inner to the session gate so platform_info takes precedence, but outer to
-	// Audit/enrichment so blocked calls don't produce audit events or enrichment.
-	if p.workflowTracker != nil {
-		p.mcpServer.AddReceivingMiddleware(
-			middleware.MCPWorkflowGateMiddleware(p.workflowTracker),
-		)
-	}
-
-	// 6. Session gate - blocks non-exempt tools until platform_info is called.
-	// Inner to Auth/Authz so PlatformContext is available; outer to Audit so
-	// gated calls don't produce audit events.
-	if p.sessionGate != nil {
-		p.mcpServer.AddReceivingMiddleware(
-			middleware.MCPSessionGateMiddleware(p.sessionGate),
-		)
-	}
-
-	// 7. Auth/Authz (outermost for tools/call) - authenticates and authorizes
-	// users, creates PlatformContext. Must be outer to Audit so PlatformContext
-	// is available in the ctx that Audit receives. The session-handle resolver
-	// (#792) runs inside it, adopting the explicit handle onto pc.SessionID
-	// before the gates and audit observe it.
-	p.mcpServer.AddReceivingMiddleware(
-		middleware.MCPToolCallMiddleware(p.authenticator, p.authorizer, p.toolkitRegistry, middleware.ToolCallConfig{
-			Transport:       p.config.Server.Transport,
-			AdminPersona:    p.config.Admin.Persona,
-			WorkflowTracker: p.workflowTracker,
-			SessionResolver: p.buildSessionResolver(),
-		}),
-	)
-
-	// 8. MCP Apps metadata - injects _meta.ui into tools/list
-	p.addMCPAppsMiddleware()
-
-	// 8.5 Session-handle schema injection (#792) - advertises session_id on every
-	// tool except platform_info. A list decorator; upstream toolkits are untouched.
-	p.addSessionHandleSchemaMiddleware()
-
-	// 9. Tool visibility - reduces tools/list for token savings
-	p.addToolVisibilityMiddleware()
-	p.addPromptVisibilityMiddleware()
-
-	// 9.5 Description overrides - replaces tool descriptions with workflow guidance
-	p.addDescriptionOverrideMiddleware()
-
-	// 10. Icons (outermost list decoration) - injects icons into list responses
-	p.addIconMiddleware()
 }
 
 // addReflexiveCaptureMiddleware wires reflexive query-error capture (#635) via


### PR DESCRIPTION
## Summary

`finalizeSetup` registered ~19 receiving middlewares in inverse execution order (the SDK's `AddReceivingMiddleware` makes the last-added layer outermost). Correctness depends on context-value visibility, for example auth/authz must be outer to audit, metrics, tracing, reflexive capture, and the gates so the `PlatformContext` it writes via `context.WithValue` is present downstream. That ordering lived only in comments at the registration site, so a reorder was a one-line change that compiled and could pass narrower tests.

This PR turns the ordering into a checked invariant, as requested in #758.

## What changed

- **Declarative chain.** The inline registration block is replaced by `receivingMiddlewareChain()`, an ordered slice of `{Name, Requires, Register}` specs in execution order (outermost first), plus one extracted `add*Middleware` helper per entry. The registration order is byte-for-byte identical to before, so runtime behavior is unchanged.
- **Startup validator.** `finalizeSetup` now calls `mwchain.Validate(specs)` before touching the server and panics with a named error if any middleware's declared `Requires` (a dependency that must be outer) is positioned inner to it. An accidental reorder fails fast at startup instead of silently mis-wiring the chain.
- **Decomposition.** The generic validator and its `Spec`/`Name` types moved into a new `pkg/platform/mwchain` subpackage, so the ordering concern is self-contained and independently tested, and `pkg/platform` stays under its package-size budget.

## The dependency edges

The `Requires` edges are not limited to the context-value case. They also encode the ordering constraints the old linear code guaranteed only by position. Each was verified against the middleware source before it was encoded:

| Middleware | Requires (must be outer) | Why |
| --- | --- | --- |
| session gate, workflow gate, reflexive capture, tracing, metrics, audit, provenance, enrichment | `tool_call` | all read `PlatformContext`, written by auth/authz via `context.WithValue` |
| workflow gate | `session_gate` | inner to the session gate so `platform_info` takes precedence |
| enrichment | `tracing`, `audit`, `client_logging` | these read `pc.EnrichmentApplied` after `next()` returns, so they must be outer to enrichment (metrics does not read the flag and is deliberately excluded) |
| error contract | `audit`, `metrics`, `reflexive_capture` | all three observe the normalized `{code, category}` error, so the error contract is inner to them |

## Testing

- `pkg/platform/mwchain`: unit tests for the validator (valid orderings, inner-dependency, self-reference, unknown target, duplicate name, empty chain). 100% coverage of `Validate`.
- `pkg/platform`: tests that pin the canonical order list, assert the shipped chain validates, assert every `PlatformContext` reader requires `tool_call`, and assert the critical enrichment / error-contract edges are declared. Any deliberate reorder is therefore an explicit, reviewable diff.
- `make verify` passes green (full CI-equivalent suite).

## Notes

- Runtime middleware order is unchanged; this is a structural guard plus decomposition.
- `pkg/platform/mwchain` is an internal helper subpackage (like the existing `fieldcrypt`, `personastore`, `reflexivecapture`, `dedup`, `connsource`, `instructions` siblings). Per the CLAUDE.md tree rule, helper subpackages are omitted from the structure list, so the tree is unchanged. `make doc-check` will emit a soft "new package" warning for it, consistent with those siblings; it does not fail the build.

Closes #758