### PR TITLE
fix(session): exempt stateless in-memory shims from the session-handle gate (#811)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2797,6 +2797,8 @@ POST /api/v1/gateway/{connection}/invoke
 
 Auth uses the same headers as every other REST surface on the platform (`Authorization: Bearer ...` or `X-API-Key: ...`). The request goes through an in-memory MCP session against the assembled server, so the authenticator, persona authorization, route-policy, and audit middleware all apply identically to MCP and REST callers — no auth or audit logic is forked. Persona allowlists for `api_invoke_endpoint` govern access; tool-error envelopes from the toolkit map to HTTP status codes (`401` for auth failure, `403` for not authorized, `404` for unknown connection, `400` for validation).
 
+The REST surface is exempt from the agent-oriented session-handle requirement (`session.require`): stateless automation callers (NiFi, cronjobs, `curl`) cannot mint or thread a `platform_info` `session_id`, so they are not refused with `SESSION_REQUIRED`. The exemption is scoped to the session handshake only; authentication, persona authorization, route policy, and audit still apply.
+
 Request body mirrors `InvokeInput` (the connection is taken from the URL):
 
 ```json

--- a/docs/server/api-gateway.md
+++ b/docs/server/api-gateway.md
@@ -279,6 +279,8 @@ POST /api/v1/gateway/{connection}/invoke
 
 Auth is the same as every other REST surface on the platform: `Authorization: Bearer <token>` or `X-API-Key: <key>`. The credential resolves to a user identity, persona, and audit subject through the same MCP middleware chain the MCP transport uses, so persona allowlists for `api_invoke_endpoint` and route-policy rules apply identically.
 
+The REST surface is exempt from the agent-oriented **session-handle requirement**. When the explicit session gate is enabled (`session.require`), MCP agents must call `platform_info` to mint a `session_id` and thread it on every subsequent tool call, or the call is refused with `SESSION_REQUIRED`. REST callers are stateless automation (NiFi, cronjobs, `curl`): each request is an independent HTTP call with no way to mint or carry a session handle, so the gate does not apply to them. Authentication, persona authorization, route policy, and audit still apply in full. The exemption is scoped narrowly to the session-handle handshake, not to access control.
+
 Request body (the `connection` is taken from the URL and overrides any value in the body):
 
 ```json

--- a/pkg/gatewayhttp/handler_test.go
+++ b/pkg/gatewayhttp/handler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	pkgsession "github.com/txn2/mcp-data-platform/pkg/session"
 	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
 )
 
@@ -836,17 +837,8 @@ func TestIntegration_SourceTaggedRest(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	tk := apigatewaykit.New("apigateway")
-	require.NoError(t, tk.AddConnection("acme", map[string]any{
-		"base_url":        upstream.URL,
-		"auth_mode":       apigatewaykit.AuthModeNone,
-		"call_timeout":    "5s",
-		"connect_timeout": "2s",
-	}))
-
 	captured := &capturedAuditSource{}
-	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "v1"}, nil)
-	tk.RegisterTools(mcpServer)
+	mcpServer := buildAPIGatewayServer(t, upstream.URL, "acme")
 
 	// Capture middleware reads PlatformContext.Source after the tool-call
 	// middleware has populated it. Wrapping order (LAST added runs FIRST):
@@ -870,6 +862,115 @@ func TestIntegration_SourceTaggedRest(t *testing.T) {
 	require.Equal(t, http.StatusOK, status)
 	assert.Equal(t, middleware.SourceREST, captured.get(),
 		"REST shim must tag the in-memory MCP session with Source=rest")
+}
+
+// TestIntegration_SessionGateExemptsREST is the regression test for issue #811:
+// the explicit session-handle gate (Require=on, #800) refuses any agent tool
+// call that lacks a platform_info-minted handle, but a REST caller is stateless
+// and can never obtain or thread one. This drives the REAL MCPToolCallMiddleware
+// with a Require=true SessionResolver over the SAME assembled server two ways:
+//
+//  1. Through the REST shim: it must succeed (HTTP 200, upstream hit), proving
+//     Source=rest — set by the shim — reaches the resolver and is exempted.
+//  2. Directly as a real MCP agent (Source=mcp, no shim): it must be refused with
+//     SESSION_REQUIRED, proving the gate stays live for agents through the exact
+//     same wiring. Without this counter-case a regression that fails the gate open
+//     for every source would pass unnoticed here (review #811, finding 2).
+func TestIntegration_SessionGateExemptsREST(t *testing.T) {
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer upstream.Close()
+
+	resolver := middleware.NewSessionResolver(
+		pkgsession.NewMemoryStore(time.Hour),
+		middleware.SessionResolverConfig{
+			Enabled:  true,
+			Require:  true, // #800: agents must thread a handle
+			InitTool: "platform_info",
+		},
+	)
+
+	mcpServer := buildAPIGatewayServer(t, upstream.URL, "acme")
+	mcpServer.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(
+		&middleware.NoopAuthenticator{DefaultUserID: "u1", DefaultRoles: []string{"analyst"}},
+		middleware.AllowAllAuthorizer(),
+		nil,
+		middleware.ToolCallConfig{Transport: "http", SessionResolver: resolver},
+	))
+
+	// (1) REST shim path: exempt, reaches the upstream.
+	handler, err := NewHandler(Deps{MCPServer: mcpServer})
+	require.NoError(t, err)
+	gateway := httptest.NewServer(handler)
+	defer gateway.Close()
+
+	status, respBody := postJSON(t, gateway.URL+"/api/v1/gateway/acme/invoke",
+		`{"method":"GET","path":"/x"}`)
+
+	require.Equal(t, http.StatusOK, status,
+		"REST invoke must not be refused with SESSION_REQUIRED (issue #811); body=%s", respBody)
+	assert.Equal(t, 1, upstreamHits,
+		"the REST call must reach the upstream, proving the session gate did not short-circuit it")
+	assert.NotContains(t, string(respBody), "SESSION_REQUIRED",
+		"the REST response must not carry the agent session-gate error")
+
+	// (2) Direct agent path (Source=mcp): the gate must still refuse it. The tool
+	// never reaches the upstream, so upstreamHits stays at 1.
+	agentResult := callToolDirect(t, mcpServer, apigatewaykit.ToolInvokeEndpoint, map[string]any{
+		"connection": "acme", "method": "GET", "path": "/x",
+	})
+	require.True(t, agentResult.IsError,
+		"a real MCP agent (Source=mcp) with no handle must be refused when require=on")
+	agentText, _ := firstTextContent(agentResult.Content)
+	assert.Contains(t, agentText, "SESSION_REQUIRED",
+		"the agent refusal must be the session gate, not some other error")
+	assert.Equal(t, 1, upstreamHits,
+		"the gated agent call must not reach the upstream")
+}
+
+// buildAPIGatewayServer builds an MCP server with the apigateway toolkit and a
+// single connection named connName pointed at upstreamURL, with no middleware
+// attached — callers add whatever middleware the test needs. Shared by the
+// resolver and source-tagging integration tests so the toolkit/connection wiring
+// stays in lockstep (review #811, finding 3).
+func buildAPIGatewayServer(t *testing.T, upstreamURL, connName string) *mcp.Server {
+	t.Helper()
+	tk := apigatewaykit.New("apigateway")
+	require.NoError(t, tk.AddConnection(connName, map[string]any{
+		"base_url":        upstreamURL,
+		"auth_mode":       apigatewaykit.AuthModeNone,
+		"call_timeout":    "5s",
+		"connect_timeout": "2s",
+	}))
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "v1"}, nil)
+	tk.RegisterTools(mcpServer)
+	return mcpServer
+}
+
+// callToolDirect connects an in-memory MCP client straight to the assembled
+// server (no REST shim, so no Source override) and calls one tool, returning the
+// tool result. This exercises the middleware chain as a real MCP agent would,
+// where resolveSource defaults the source to "mcp".
+func callToolDirect(t *testing.T, server *mcp.Server, tool string, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	t1, t2 := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(context.Background(), t1, nil)
+	require.NoError(t, err)
+	defer func() { _ = serverSession.Close() }()
+	client := mcp.NewClient(&mcp.Implementation{Name: "agent", Version: "v1"}, nil)
+	clientSession, err := client.Connect(context.Background(), t2, nil)
+	require.NoError(t, err)
+	defer func() { _ = clientSession.Close() }()
+	result, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      tool,
+		Arguments: args,
+	})
+	require.NoError(t, err)
+	return result
 }
 
 // capturedAuditSource records the PlatformContext.Source value seen by a

--- a/pkg/middleware/mcp_session_handle.go
+++ b/pkg/middleware/mcp_session_handle.go
@@ -154,7 +154,23 @@ func (r *SessionResolver) resolve(ctx context.Context, req mcp.Request, pc *Plat
 	// session as a fallback) makes the requirement real for the exact clients the
 	// feature targets, and self-heals: a compliant caller sees SESSION_REQUIRED,
 	// calls platform_info, and threads the handle.
-	if r.require && !r.exempt[toolName] {
+	//
+	// Stateless in-memory shim callers are exempt (issue #811): the gateway HTTP
+	// shim (Source=rest — NiFi's InvokeHTTP, cronjobs, curl) and the admin
+	// "Call a tool" shim (Source=admin — the portal tool runner) both drive the
+	// same assembled server over a fresh in-memory MCP session per HTTP request.
+	// There is no platform_info call to mint a handle and no way to thread one
+	// across separate, independent HTTP requests, so the handle requirement — which
+	// exists to make MCP AGENTS thread a durable session identity — is inapplicable
+	// by construction to them. This is not an agent-reachable bypass: a real MCP
+	// transport call always resolves to Source=mcp (resolveSource's default), and
+	// the shim sources are set only in-process via middleware.WithSource on the
+	// server connection context (pkg/gatewayhttp, pkg/admin), which an external
+	// caller cannot inject. An unset/unknown source stays gated (fail closed). The
+	// authenticator, not the handle, remains the security boundary; shim callers
+	// still authenticate and remain subject to persona authorization, route policy,
+	// and audit.
+	if r.require && !r.exempt[toolName] && !isStatelessShimSource(pc.Source) {
 		r.recordMetric(ctx, sessionSourceNone)
 		slog.Warn("session handle: missing on gated tool call",
 			logKeyTool, toolName, logKeyUserID, pc.UserID)
@@ -232,6 +248,17 @@ func (r *SessionResolver) recordMetric(ctx context.Context, source string) {
 	if r.metric != nil {
 		r.metric(ctx, source)
 	}
+}
+
+// isStatelessShimSource reports whether an audit source belongs to one of the
+// stateless in-memory shims that drive the assembled server over a fresh
+// per-request MCP session (the gateway REST shim, Source=rest, and the admin
+// tool-runner shim, Source=admin). Such callers cannot perform the platform_info
+// session handshake, so they are exempt from the SESSION_REQUIRED gate (issue
+// #811). A real MCP-transport agent resolves to Source=mcp and is NOT exempt; an
+// unset/unknown source is likewise not exempt, so the gate fails closed.
+func isStatelessShimSource(source string) bool {
+	return source == SourceREST || source == SourceAdmin
 }
 
 // transportSource classifies a transport-derived session ID for the metric.

--- a/pkg/middleware/mcp_session_handle_test.go
+++ b/pkg/middleware/mcp_session_handle_test.go
@@ -227,6 +227,57 @@ func TestSessionResolver_MissingHandleRequired(t *testing.T) {
 	}
 }
 
+// TestSessionResolver_StatelessShimSourcesBypassRequire proves issue #811's fix:
+// a call from a stateless in-memory shim (Source=rest, the gateway HTTP shim; or
+// Source=admin, the admin tool-runner shim) is not refused with SESSION_REQUIRED
+// even when require is on and no handle is presented, because those callers cannot
+// perform the platform_info handshake. A real MCP-transport call (Source=mcp), and
+// an unset/unknown source, are still refused so the gate stays real for agents and
+// fails closed.
+func TestSessionResolver_StatelessShimSourcesBypassRequire(t *testing.T) {
+	store := pkgsession.NewMemoryStore(time.Hour)
+	r := newResolver(store, true)
+
+	exempt := []struct {
+		name   string
+		source string
+	}{
+		{"rest gateway shim", SourceREST},
+		{"admin tool-runner shim", SourceAdmin},
+	}
+	for _, tc := range exempt {
+		t.Run("exempt/"+tc.name, func(t *testing.T) {
+			pc := NewPlatformContext("req")
+			pc.UserID = "user-1"
+			pc.SessionID = "" // no handle, no transport session
+			pc.Source = tc.source
+			req := makeCallReq("trino_query", map[string]any{"sql": "SELECT 1"})
+			if got := r.resolve(context.Background(), req, pc, "trino_query"); got != nil {
+				t.Fatalf("%s must bypass SESSION_REQUIRED, got code=%s", tc.name, errCode(t, got))
+			}
+		})
+	}
+
+	gated := []struct {
+		name   string
+		source string
+	}{
+		{"real MCP agent", SourceMCP},
+		{"unset source fails closed", ""},
+	}
+	for _, tc := range gated {
+		t.Run("gated/"+tc.name, func(t *testing.T) {
+			pc := NewPlatformContext("req")
+			pc.UserID = "user-1"
+			pc.SessionID = ""
+			pc.Source = tc.source
+			if got := r.resolve(context.Background(), makeCallReq("trino_query", nil), pc, "trino_query"); got == nil {
+				t.Fatalf("%s must still be refused with SESSION_REQUIRED", tc.name)
+			}
+		})
+	}
+}
+
 // TestSessionResolver_ExemptToolBypassesRequire proves an exempt tool (carried
 // from the legacy gate's exempt_tools) is reachable without a handle even when
 // require is on.


### PR DESCRIPTION
## Summary

`POST /api/v1/gateway/{connection}/invoke` (and `/invoke-raw`) was refused with:

```json
{"error":"SESSION_REQUIRED: Call platform_info first. It returns a session_id you must pass as the session_id argument on every subsequent tool call. (code: session_required) ..."}
```

The REST gateway surface exists for **stateless automation** (Apache NiFi's InvokeHTTP, Airflow's HttpOperator, cronjobs, `curl`). These callers cannot perform the agent session-handshake, so the gate made the surface unusable.

This PR exempts stateless in-memory shim callers from the session-handle gate. It also fixes the **same latent bug on the admin "Call a tool" shim**, which was surfaced during review.

Closes #811.

## Root cause

The REST shim (`pkg/gatewayhttp`) routes every request through an in-memory MCP session against the fully-assembled platform server, tagged `Source=rest`, so the real auth / persona / route-policy / audit middleware applies uniformly. That in-memory call also passes through the explicit session-handle resolver (`pkg/middleware/mcp_session_handle.go`, #792 / #800). With `Require` on (the default), any non-exempt tool call that does not carry a `platform_info`-minted `session_id` handle is refused with `SESSION_REQUIRED` before the handler runs.

A stateless HTTP caller cannot satisfy this:

- Each request opens a **fresh** in-memory MCP session, calls the tool once, and closes it. There is no `platform_info` call to mint a handle.
- Even if one request minted a handle, there is no way to thread it across subsequent, independent HTTP requests.

The admin tool-runner (`POST /api/v1/admin/tools/call`, `pkg/admin/tools.go`) is the **same class of surface**: it connects the same assembled server over a fresh in-memory session tagged `Source=admin` and calls arbitrary tools with no `session_id`. Under the default `require=on`, the portal "Call a tool" feature was therefore also broken for any gated tool.

Note: the search-first workflow gate (`MCPWorkflowGateMiddleware`) does **not** block these paths — it only gates `trino_query` / `trino_execute`. The session-handle gate was the sole blocker.

## The fix

`SessionResolver.resolve` now skips the `SESSION_REQUIRED` refusal for the two stateless in-memory shim sources, via a small `isStatelessShimSource(source)` helper:

- `Source=rest` — the gateway HTTP shim (the reported bug)
- `Source=admin` — the admin portal tool-runner shim (the latent bug)

The requirement remains fully in force for real MCP-transport agents (`Source=mcp`, which is `resolveSource`'s default). An **unset or unknown source stays gated** — the check is a positive allowlist, so the gate fails closed.

### Why this is safe

- **Not agent-reachable.** The shim sources are set only in-process via `middleware.WithSource(...)` on the server connection context (`pkg/gatewayhttp`, `pkg/admin`). A real MCP transport call has no source override and resolves to `mcp`; an external caller cannot inject a Go context value.
- **Access control is untouched.** The exemption is scoped strictly to the session-handle handshake. Shim callers still authenticate (`X-API-Key` / `Bearer`), still resolve to a persona, and remain subject to persona allowlists, route policy, and audit. The authenticator, not the handle, is the security boundary.

## Changes

| File | Change |
| --- | --- |
| `pkg/middleware/mcp_session_handle.go` | Add `isStatelessShimSource`; exempt `rest`/`admin` sources from the require refusal (fail-closed on unset/unknown). |
| `pkg/middleware/mcp_session_handle_test.go` | Table-driven resolver test: `rest`/`admin` exempt, `mcp`/unset gated. |
| `pkg/gatewayhttp/handler_test.go` | Integration test through the real middleware with `Require=on`; shared `buildAPIGatewayServer` helper; direct `Source=mcp` counter-case. |
| `docs/server/api-gateway.md`, `docs/llms-full.txt` | Document the exemption. |

## Testing

- **Unit** (`TestSessionResolver_StatelessShimSourcesBypassRequire`): `rest` and `admin` sources bypass `SESSION_REQUIRED` with `require=on` and no handle; `mcp` and unset sources are still refused.
- **Integration** (`TestIntegration_SessionGateExemptsREST`): drives the *real* `MCPToolCallMiddleware` + `SessionResolver{Require:true}` over one assembled server two ways —
  1. through the REST shim: HTTP 200, upstream is hit (gate did not short-circuit);
  2. as a direct `Source=mcp` agent (no shim): refused with `SESSION_REQUIRED`, upstream never reached — proving the gate stays live for agents through the exact same wiring.
- **`make verify`**: full CI-equivalent suite green; patch coverage 100% (4/4 changed executable lines in the resolver).

## Acceptance criteria

- [x] `POST /api/v1/gateway/{connection}/invoke` with a valid credential succeeds without any `session_id` (no `SESSION_REQUIRED`).
- [x] The admin "Call a tool" endpoint runs gated tools under the default `require=on`.
- [x] A real MCP transport tool call with no handle is still refused with `SESSION_REQUIRED`.
- [x] Auth / persona / route-policy / audit behavior unchanged for all callers.
