### PR TITLE
feat(verify): exported-surface budget gate (#825)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,15 +210,16 @@ maintainable as features accrete. Each was landed green against the tree at the
 time and is meant to be **ratcheted tighter in follow-up PRs**, never relaxed to
 make a violation pass.
 
-Size measures the *volume* of a package; the rest measure the *structure of its
-relationships* — which direction dependencies point (gates 1 and 4) and whether a
-package's own declarations actually cohere (gate 5). Structure is what
-distinguishes good decomposition from mechanical shattering. The direction gates
-(1 and 4) are **exact**: they cannot be satisfied by moving lines around. The
-cohesion gate (5) is a graph **heuristic** — much harder to game than size, but
-not impossible (see its section for the known blind spot). Together they raise
-the cost of the shattering move far above what the size budget alone does (issue
-#738).
+Two gates bound a package's *volume*: the LOC/file size budget (gate 3) and the
+exported-surface budget (gate 6, its harder-to-game public-API counterpart). The
+other three measure the *structure of its relationships* — which direction
+dependencies point (gates 1 and 4) and whether a package's own declarations
+actually cohere (gate 5). Structure is what distinguishes good decomposition from
+mechanical shattering. The direction gates (1 and 4) are **exact**: they cannot
+be satisfied by moving lines around. The cohesion gate (5) is a graph
+**heuristic** — much harder to game than size, but not impossible (see its
+section for the known blind spot). Together they raise the cost of the shattering
+move far above what the size budget alone does (issue #738).
 
 ### 1. Import boundaries (`depguard`)
 
@@ -332,6 +333,27 @@ author can evade it by threading one common reference through both halves. This 
 why cohesion is a heuristic backstop, not a proof; the exact direction gates (1
 and 4) are the un-gameable half. A future refinement could weight edges by the
 referenced symbol's kind (type vs. incidental value) to narrow the blind spot.
+
+### 6. Exported-surface budget (`TestPackageExportedSurfaceBudget`)
+
+The public-API counterpart to the LOC budget: where gate 3 bounds how much a
+package *weighs*, this bounds how much of it is *exported*. A small public
+surface is the idiomatic Go goal — minimal API, internals unexported — and
+unlike an LOC cap it cannot be satisfied by reshuffling whitespace or splitting
+files. The only way under the budget is to unexport helpers or move detail into
+`internal/`, which is the behaviour we want to pressure toward.
+
+`TestPackageExportedSurfaceBudget` (in `pkg_surface_budget_test.go`) counts
+**top-level exported identifiers** per `pkg/` package — exported package-scope
+funcs, types, vars and consts, one unit per exported name (each name in a grouped
+var/const block counts), regardless of a type's fields or methods — and fails any
+package exporting more than **150**. The
+ceiling sits just above today's largest surfaces (`pkg/middleware` and
+`pkg/portal` at 142, `pkg/platform` at 140). Like the LOC budget it is a
+**ceiling to ratchet down**: if a package hits it, shrink the public API
+(unexport module-internal helpers, hide detail behind interfaces or in
+`internal/`) rather than raising the constant. Run it with
+`go test -run TestPackageExportedSurfaceBudget .`.
 
 ## Security
 

--- a/pkg_relationship_fire_test.go
+++ b/pkg_relationship_fire_test.go
@@ -54,9 +54,10 @@ func TestFirstPartyEdgesAreFound(t *testing.T) {
 		"the composition root must import the platform package")
 }
 
-// loadCohesionFixture loads a single package by directory (used for the
-// testdata/ cohesion fixtures, which ./... deliberately excludes).
-func loadCohesionFixture(t *testing.T, dir string) *packages.Package {
+// loadFixturePackage loads a single package by directory, used for the
+// testdata/ fixtures that ./... deliberately excludes (cohesion and
+// exported-surface proof-of-firing).
+func loadFixturePackage(t *testing.T, dir string) *packages.Package {
 	t.Helper()
 	cfg := &packages.Config{
 		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
@@ -73,7 +74,7 @@ func loadCohesionFixture(t *testing.T, dir string) *packages.Package {
 // TestCohesionDetectsFragmentation proves the gate flags a package built from
 // two independent declaration islands.
 func TestCohesionDetectsFragmentation(t *testing.T) {
-	p := loadCohesionFixture(t, "testdata/cohesionfixture/fragmented")
+	p := loadFixturePackage(t, "testdata/cohesionfixture/fragmented")
 	clusters := significantClusters(p)
 	require.Len(t, clusters, 2, "fragmented fixture should surface two significant clusters")
 	// Each island has exactly five mutually-referencing declarations.
@@ -85,9 +86,20 @@ func TestCohesionDetectsFragmentation(t *testing.T) {
 // independent handlers over one Store a single cluster — the false-positive
 // case the naive call-graph definition would wrongly flag.
 func TestCohesionAcceptsSharedType(t *testing.T) {
-	p := loadCohesionFixture(t, "testdata/cohesionfixture/cohesive")
+	p := loadFixturePackage(t, "testdata/cohesionfixture/cohesive")
 	clusters := significantClusters(p)
 	assert.Len(t, clusters, 1, "handlers sharing one Store should be a single cluster")
+}
+
+// TestExportedSurfaceCounts proves exportedSurface counts exported package-scope
+// identifiers only: each exported NAME (including both names in a grouped const
+// block) counts, while methods and unexported decls do not. The fixture has six
+// exported package-scope names (Widget, New, Default, Version, Alpha, Beta), one
+// exported method (Do), and two unexported decls.
+func TestExportedSurfaceCounts(t *testing.T) {
+	p := loadFixturePackage(t, "testdata/surfacefixture")
+	assert.Equal(t, 6, exportedSurface(p),
+		"each exported package-scope name counts (grouped consts included); methods and unexported decls do not")
 }
 
 // TestPreviewTruncates pins the member-list preview at eight names.

--- a/pkg_surface_budget_test.go
+++ b/pkg_surface_budget_test.go
@@ -1,0 +1,87 @@
+// Package verify enforces project-level structural invariants.
+//
+// This file adds the exported-surface budget (issue #825, a follow-up to the
+// relationship gates in #738). It is the public-API counterpart to the
+// LOC/file size budget in package_budget_test.go: where TestPackageSizeBudget
+// bounds how much a package weighs, this bounds how much of a package is
+// EXPORTED. A small public surface is the idiomatic Go goal — minimal API,
+// internals unexported — and unlike an LOC cap it cannot be satisfied by
+// reshuffling whitespace or splitting files; the only way under the budget is
+// to unexport helpers or move them into internal/.
+//
+// It counts top-level exported identifiers per pkg/ package (exported
+// package-scope funcs, types, vars and consts — one unit per exported name, so
+// each name in a grouped var/const block counts, independent of a type's fields
+// or methods). Like the LOC budget it is seeded ABOVE today's largest surface so
+// it lands green, and is a ceiling to ratchet DOWN, not a number to raise when a
+// package bumps against it.
+//
+// Run: go test -run TestPackageExportedSurfaceBudget .
+package mcp_data_platform_test
+
+import (
+	"fmt"
+	"go/token"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+)
+
+// maxExportedSurface caps exported top-level identifiers per pkg/ package. The
+// largest today are pkg/middleware and pkg/portal (142) and pkg/platform (140);
+// this ceiling sits just above them so the gate is green, and ratchets down as
+// those packages shrink their public API (unexport helpers, move detail into
+// internal/ or unexported types).
+const maxExportedSurface = 150
+
+// exportedSurface counts the exported identifiers in p's package scope: the
+// top-level funcs, types, vars and consts a consumer can name. Methods and
+// struct fields live in a type's scope, not the package scope, so they are not
+// counted. The metric is one unit per exported name — each name in a grouped
+// var/const block is a separately-referenceable API element and counts.
+func exportedSurface(p *packages.Package) int {
+	scope := p.Types.Scope()
+	n := 0
+	for _, name := range scope.Names() {
+		if token.IsExported(name) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestPackageExportedSurfaceBudget fails when any package under pkg/ exports
+// more than maxExportedSurface top-level identifiers.
+//
+// This is the public-API counterpart to TestPackageSizeBudget: that bounds a
+// package's size, this bounds its exported surface. If it fails, shrink the
+// package's public API — unexport helpers only used within the module, move
+// implementation detail behind interfaces or into internal/ — rather than
+// raising the budget (that defeats the gate). See CONTRIBUTING.md, "Structural
+// maintainability gates".
+func TestPackageExportedSurfaceBudget(t *testing.T) {
+	pkgs := firstPartyPackages(t)
+
+	var violations []string
+	counted := 0
+	for _, p := range pkgs {
+		rel := relPath(p.PkgPath)
+		if !strings.HasPrefix(rel, "pkg/") {
+			continue
+		}
+		counted++
+		if n := exportedSurface(p); n > maxExportedSurface {
+			violations = append(violations, fmt.Sprintf(
+				"%s: %d exported identifiers exceeds budget of %d (shrink the public API; do not raise the budget)",
+				rel, n, maxExportedSurface))
+		}
+	}
+	require.NotZero(t, counted, "should find packages under pkg/")
+	sort.Strings(violations)
+
+	require.Empty(t, violations,
+		"exported-surface budget exceeded:\n  %s", strings.Join(violations, "\n  "))
+}

--- a/testdata/surfacefixture/surf.go
+++ b/testdata/surfacefixture/surf.go
@@ -1,0 +1,37 @@
+// Package surfacefixture is a fixture for the exported-surface budget gate:
+// six exported package-scope identifiers (Widget, New, Default, Version, and the
+// grouped consts Alpha + Beta), one exported method (Do — NOT package scope,
+// must not count), and unexported helpers (must not count).
+// TestExportedSurfaceCounts asserts the count is 6. The grouped const block
+// makes the fixture distinguish per-identifier counting (which is what the gate
+// does — each exported NAME is one unit) from per-declaration counting (which
+// would score the block as 1). It lives under testdata/ so the real gate (which
+// scans ./...) skips it.
+package surfacefixture
+
+// Widget is an exported type (1).
+type Widget struct{ n int }
+
+// New is an exported func (2).
+func New() *Widget { return &Widget{} }
+
+// Do is an exported METHOD — part of the method set, not package scope; the
+// surface metric must not count it.
+func (w *Widget) Do() int { return w.n }
+
+// Default is an exported var (3).
+var Default = New()
+
+// Version is an exported const (4).
+const Version = "1"
+
+// Alpha and Beta are two exported names in one grouped const block: each counts
+// (5, 6), pinning the per-identifier metric.
+const (
+	Alpha = "a"
+	Beta  = "b"
+)
+
+func helper() int { return 0 }
+
+var internalCount int


### PR DESCRIPTION
## Summary

Adds **Gate 4** from #738: an exported-surface budget that caps the public API of each `pkg/` package. This is the public-API counterpart to the LOC/file size budget (#594) — where the size budget bounds how much a package *weighs*, this bounds how much of it is *exported*.

A small public surface is the idiomatic Go goal (minimal API, internals unexported). Unlike an LOC cap, an exported-surface budget **cannot be satisfied by reshuffling whitespace or splitting files** — the only way under it is to unexport module-internal helpers or move detail into `internal/`, which is exactly the behaviour we want to pressure toward.

This is the concrete follow-up carved out of #738 when the primary pair (Gates 1 + 2) shipped in #826. It builds directly on the `firstPartyPackages` go/packages loader added there.

## What the gate does

`TestPackageExportedSurfaceBudget` (`pkg_surface_budget_test.go`) counts **top-level exported identifiers** per `pkg/` package:

- exported package-scope funcs, types, vars and consts;
- **one unit per exported name** — each name in a grouped `var`/`const` block counts, since each is separately referenceable by a consumer;
- methods and struct fields are **not** counted (they live in a type's scope, not the package scope).

It fails any package exporting more than **150**. The ceiling is seeded just above today's largest surfaces and is a **ceiling to ratchet down**, not a number to raise:

| Package | Exported surface |
|---------|------------------|
| `pkg/middleware` | 142 |
| `pkg/portal` | 142 |
| `pkg/platform` | 140 |
| `pkg/memory` | 84 |
| `pkg/toolkits/apigateway` | 83 |

If a package hits the budget, shrink its public API (unexport helpers, hide detail behind interfaces or in `internal/`) rather than bumping the constant.

## Testing & verification

- **Proof-of-firing** (`TestExportedSurfaceCounts`): a `testdata/surfacefixture` package with four plain exported decls **plus a grouped `const` block** (Alpha, Beta) and one exported method. Asserting the count is `6` pins the **per-identifier** semantics — the grouped block is what distinguishes it from per-declaration counting, so a future refactor that silently switched to per-decl counting (and loosened the gate) would break this test.
- Went through a high-effort adversarial code review; both findings addressed — they were a wording mismatch ("one unit per declaration" vs. the code's per-identifier count) fixed across the code comments and CONTRIBUTING.md, and the fixture hardening above.
- The shared single-package fixture loader is renamed `loadCohesionFixture` → `loadFixturePackage` now that two gates use it.
- **CONTRIBUTING.md** documents this as gate 6 under "Structural maintainability gates," and the section intro is reframed: two gates bound *volume* (LOC + exported surface), three measure *structure* (layering, ratchet, cohesion).
- **`make verify` passes** the full CI-equivalent suite (gofmt, race tests, coverage, lint incl. gocyclo/gocognit/depguard, gosec, govulncheck, semgrep, CodeQL, dead-code, mutation, GoReleaser dry-run).

## Closes / relates

- Closes #825.
- Closes #738 — this is the last actionable item in the epic (Gates 1+2 in #826, Gate 3 declined in #824, Gate 4 here).
- Part of #738. This is the last actionable item in that epic: Gates 1 + 2 shipped in #826, Gate 3 (the instability/abstractness diagnostic) was closed in #824 as not worth building in Go (weak abstractness proxy, redundant with the exact direction gates, non-blocking = no teeth), and Gate 4 lands here. #738 can be closed once this merges.