### PR TITLE
refactor(platform): extract auth-identity assembly into pkg/platform/iam (#828)

### DIFF
--- a/godobject_budget_test.go
+++ b/godobject_budget_test.go
@@ -2,8 +2,7 @@
 // (#756). The package-size (LOC) gate is gameable in the direction that matters
 // here: moving code out of platform.go into sibling files or helper subpackages
 // shrinks the line count while the Platform struct keeps every field and every
-// method — the god-object is untouched. LOC rewards line-shuffling; this gate
-// rewards actually shrinking the object.
+// method. This gate caps the struct itself.
 //
 // It caps two structural metrics that directly measure the god-object:
 //   - the number of fields on the Platform struct (what it HOLDS), and

--- a/pkg/indexjobs/types.go
+++ b/pkg/indexjobs/types.go
@@ -1,13 +1,9 @@
 // Package indexjobs is the Postgres-backed, source-kind-agnostic
 // embedding-index job queue the platform's semantic-search
-// consumers share. It is the generalization of the api-catalog
-// embedding queue (formerly pkg/toolkits/apigateway/embedjobs):
-// the queue mechanics (lease-based claim with FOR UPDATE SKIP
-// LOCKED, exponential-backoff retry, reaper sweep, LISTEN/NOTIFY
-// wake-ups, periodic gap reconciliation) carry over unchanged in
-// shape, but the unit of work is keyed on an opaque
-// (source_kind, source_id) pair instead of a catalog-specific
-// (catalog_id, spec_name) pair.
+// consumers share. The queue mechanics — lease-based claim with
+// FOR UPDATE SKIP LOCKED, exponential-backoff retry, reaper sweep,
+// LISTEN/NOTIFY wake-ups, and periodic gap reconciliation — key
+// each unit of work on an opaque (source_kind, source_id) pair.
 //
 // Each consumer plugs in two small contracts:
 //

--- a/pkg/platform/export_adapters_test.go
+++ b/pkg/platform/export_adapters_test.go
@@ -15,9 +15,7 @@ import (
 	trinokit "github.com/txn2/mcp-data-platform/pkg/toolkits/trino"
 )
 
-// stubShareStore is consumed by prompt_shared_serving_test.go (the export
-// adapters that formerly used it now live in the exportadapters subpackage
-// with their own stubs).
+// stubShareStore is consumed by prompt_shared_serving_test.go.
 type stubShareStore struct {
 	portal.ShareStore
 	inserted      *portal.Share

--- a/pkg/platform/exportadapters/adapters.go
+++ b/pkg/platform/exportadapters/adapters.go
@@ -10,8 +10,7 @@
 // One exporter per toolkit implements all three interfaces (asset store,
 // version store, share creator), so wiring is a single construction whose
 // result is assigned to each ExportDeps field. Each exporter takes its
-// dependencies as constructor parameters, so wiring is type-checked data flow
-// rather than field access on the platform god-object (issue #756).
+// dependencies as constructor parameters (issue #756).
 //
 // TrinoExporter and APIExporter are near-identical: the two toolkits define
 // field-identical-but-distinct ExportAsset/ExportVersion DTOs in separate

--- a/pkg/platform/iam/iam.go
+++ b/pkg/platform/iam/iam.go
@@ -1,0 +1,119 @@
+// Package iam assembles the platform's authentication and authorization
+// identity layer — the authenticator chain and the persona-based authorizer —
+// from explicit, foreign-typed inputs rather than by mutating fields on the
+// Platform god-object. Declaring dependencies as parameters makes the wiring
+// type-checked data flow and lets the layer be built and tested without a whole
+// Platform (issue #756).
+//
+// This package MUST NOT import pkg/platform: the platform-local config types
+// would create an import cycle, and taking narrow inputs instead is the point —
+// it makes each dependency explicit at the boundary.
+package iam
+
+import (
+	"fmt"
+
+	"github.com/txn2/mcp-data-platform/pkg/auth"
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/persona"
+)
+
+// Input carries everything needed to build the authentication and authorization
+// identity layer, translated from the platform config by the caller so this
+// package never depends on pkg/platform.
+type Input struct {
+	// OAuthEnabled gates the OAuth JWT authenticator (for tokens issued by our
+	// own OAuth server). It is only added when a signing key is also present.
+	OAuthEnabled bool
+	OAuthJWT     auth.OAuthJWTConfig
+
+	// OIDCEnabled gates the OIDC authenticator (for tokens from an external IdP).
+	OIDCEnabled bool
+	OIDC        auth.OIDCConfig
+
+	// APIKeysEnabled gates the API key authenticator.
+	APIKeysEnabled bool
+	APIKeys        []auth.APIKey
+
+	// AllowAnonymous permits unauthenticated access through the chained
+	// authenticator; ignored when no authenticators are configured (noop).
+	AllowAnonymous bool
+
+	// Authorizer inputs.
+	PersonaRegistry *persona.Registry
+	RoleClaimPath   string
+	RolePrefix      string
+	OIDCToPersona   map[string]string
+}
+
+// Identity is the authenticator half of the identity layer.
+type Identity struct {
+	// Authenticator is the assembled authenticator (a chain, or a noop when
+	// nothing is configured).
+	Authenticator middleware.Authenticator
+	// APIKeyAuth is the API key authenticator when API keys are enabled, or nil.
+	// The caller keeps it so DB-backed keys can be appended after startup.
+	APIKeyAuth *auth.APIKeyAuthenticator
+}
+
+// NewIdentity builds the authenticator chain from in. Authenticators are ordered
+// OAuth JWT → OIDC → API key so a token issued by our own OAuth server is
+// checked first; when none are configured a permissive noop is returned.
+func NewIdentity(in Input) (Identity, error) {
+	var authenticators []middleware.Authenticator
+
+	// OAuth JWT authenticator, checked first: tokens from our OAuth server use it.
+	if in.OAuthEnabled && len(in.OAuthJWT.SigningKey) > 0 {
+		oauthAuth, err := auth.NewOAuthJWTAuthenticator(in.OAuthJWT)
+		if err != nil {
+			return Identity{}, fmt.Errorf("creating OAuth JWT authenticator: %w", err)
+		}
+		authenticators = append(authenticators, oauthAuth)
+	}
+
+	// OIDC authenticator, for tokens from external IdPs (e.g. Keycloak).
+	if in.OIDCEnabled {
+		oidcAuth, err := auth.NewOIDCAuthenticator(in.OIDC)
+		if err != nil {
+			return Identity{}, fmt.Errorf("creating OIDC authenticator: %w", err)
+		}
+		authenticators = append(authenticators, oidcAuth)
+	}
+
+	// API key authenticator.
+	var apiKeyAuth *auth.APIKeyAuthenticator
+	if in.APIKeysEnabled {
+		apiKeyAuth = auth.NewAPIKeyAuthenticator(auth.APIKeyConfig{Keys: in.APIKeys})
+		authenticators = append(authenticators, apiKeyAuth)
+	}
+
+	// No authenticators configured: permissive noop (anonymous).
+	if len(authenticators) == 0 {
+		return Identity{
+			Authenticator: &middleware.NoopAuthenticator{
+				DefaultUserID: "anonymous",
+				DefaultRoles:  []string{},
+			},
+		}, nil
+	}
+
+	return Identity{
+		Authenticator: auth.NewChainedAuthenticator(
+			auth.ChainedAuthConfig{AllowAnonymous: in.AllowAnonymous},
+			authenticators...,
+		),
+		APIKeyAuth: apiKeyAuth,
+	}, nil
+}
+
+// NewAuthorizer builds the persona-based authorizer from in. It is independent
+// of NewIdentity so a caller can override one without constructing the other.
+func NewAuthorizer(in Input) middleware.Authorizer {
+	mapper := &persona.OIDCRoleMapper{
+		ClaimPath:      in.RoleClaimPath,
+		RolePrefix:     in.RolePrefix,
+		PersonaMapping: in.OIDCToPersona,
+		Registry:       in.PersonaRegistry,
+	}
+	return persona.NewAuthorizer(in.PersonaRegistry, mapper)
+}

--- a/pkg/platform/iam/iam.go
+++ b/pkg/platform/iam/iam.go
@@ -1,13 +1,11 @@
-// Package iam assembles the platform's authentication and authorization
-// identity layer — the authenticator chain and the persona-based authorizer —
-// from explicit, foreign-typed inputs rather than by mutating fields on the
-// Platform god-object. Declaring dependencies as parameters makes the wiring
-// type-checked data flow and lets the layer be built and tested without a whole
-// Platform (issue #756).
+// Package iam builds the platform's authentication and authorization identity
+// layer: the authenticator chain (NewIdentity) and the persona authorizer
+// (NewAuthorizer).
 //
-// This package MUST NOT import pkg/platform: the platform-local config types
-// would create an import cycle, and taking narrow inputs instead is the point —
-// it makes each dependency explicit at the boundary.
+// Constructors take an explicit Input rather than the platform config, so the
+// layer can be built and tested on its own. The package must not import
+// pkg/platform: the auth config types live there, so importing it would create a
+// cycle. Callers translate their config into Input at the boundary.
 package iam
 
 import (
@@ -18,9 +16,8 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 )
 
-// Input carries everything needed to build the authentication and authorization
-// identity layer, translated from the platform config by the caller so this
-// package never depends on pkg/platform.
+// Input holds the values NewIdentity and NewAuthorizer need. Callers build it
+// from their own config, keeping platform config types out of this package.
 type Input struct {
 	// OAuthEnabled gates the OAuth JWT authenticator (for tokens issued by our
 	// own OAuth server). It is only added when a signing key is also present.

--- a/pkg/platform/iam/iam_test.go
+++ b/pkg/platform/iam/iam_test.go
@@ -1,0 +1,107 @@
+package iam_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/auth"
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/persona"
+	"github.com/txn2/mcp-data-platform/pkg/platform/iam"
+)
+
+// signingKey is any non-empty HMAC key; NewOAuthJWTAuthenticator only requires
+// it to be non-empty.
+var signingKey = []byte("0123456789abcdef0123456789abcdef")
+
+// isNoop reports whether a is the permissive noop authenticator.
+func isNoop(a middleware.Authenticator) bool {
+	_, ok := a.(*middleware.NoopAuthenticator)
+	return ok
+}
+
+func TestNewIdentity_NoopWhenNothingEnabled(t *testing.T) {
+	res, err := iam.NewIdentity(iam.Input{})
+	require.NoError(t, err)
+	assert.True(t, isNoop(res.Authenticator),
+		"no authenticators configured must yield the permissive noop")
+	assert.Nil(t, res.APIKeyAuth)
+}
+
+func TestNewIdentity_APIKeyOnly(t *testing.T) {
+	res, err := iam.NewIdentity(iam.Input{
+		APIKeysEnabled: true,
+		APIKeys:        []auth.APIKey{{Key: "k1", Name: "admin", Roles: []string{"admin"}}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res.APIKeyAuth, "API key authenticator must be returned for loadDBAPIKeys")
+	assert.False(t, isNoop(res.Authenticator),
+		"a configured authenticator must chain, not fall back to noop")
+}
+
+func TestNewIdentity_OAuthJWTIncludedOnlyWithSigningKey(t *testing.T) {
+	// Enabled + key present: included, so the result is a real chain.
+	res, err := iam.NewIdentity(iam.Input{
+		OAuthEnabled: true,
+		OAuthJWT:     auth.OAuthJWTConfig{Issuer: "https://issuer.example", SigningKey: signingKey},
+	})
+	require.NoError(t, err)
+	assert.False(t, isNoop(res.Authenticator))
+
+	// Enabled but no signing key: skipped, and with nothing else it is noop.
+	res, err = iam.NewIdentity(iam.Input{
+		OAuthEnabled: true,
+		OAuthJWT:     auth.OAuthJWTConfig{Issuer: "https://issuer.example"},
+	})
+	require.NoError(t, err)
+	assert.True(t, isNoop(res.Authenticator))
+}
+
+func TestNewIdentity_OIDCIncluded(t *testing.T) {
+	// SkipSignatureVerification avoids the startup JWKS fetch so the OIDC
+	// authenticator constructs without network in the test.
+	res, err := iam.NewIdentity(iam.Input{
+		OIDCEnabled: true,
+		OIDC: auth.OIDCConfig{
+			Issuer:                    "https://issuer.example",
+			SkipSignatureVerification: true,
+		},
+	})
+	require.NoError(t, err)
+	assert.False(t, isNoop(res.Authenticator), "an enabled OIDC authenticator must chain")
+}
+
+func TestNewIdentity_PropagatesConstructionError(t *testing.T) {
+	// OAuth enabled with a signing key but no issuer: NewOAuthJWTAuthenticator
+	// rejects it, and NewIdentity must surface the error, not swallow it.
+	_, err := iam.NewIdentity(iam.Input{
+		OAuthEnabled: true,
+		OAuthJWT:     auth.OAuthJWTConfig{SigningKey: signingKey},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OAuth JWT authenticator")
+}
+
+func TestNewAuthorizer_WiresMappingAndRegistry(t *testing.T) {
+	reg := persona.NewRegistry()
+	require.NoError(t, reg.Register(&persona.Persona{Name: "special"}))
+
+	authz := iam.NewAuthorizer(iam.Input{
+		PersonaRegistry: reg,
+		RoleClaimPath:   "realm_access.roles",
+		RolePrefix:      "dp_",
+		OIDCToPersona:   map[string]string{"role_x": "special"},
+	})
+	require.NotNil(t, authz)
+
+	// A request carrying role_x must resolve to the "special" persona through the
+	// OIDCToPersona mapping and the registry. If NewAuthorizer dropped either
+	// field, this would fall back to a different persona — asserting non-nil alone
+	// would not catch that.
+	_, personaName, _ := authz.IsAuthorized(context.Background(), "", []string{"role_x"}, "any_tool", "any_conn")
+	assert.Equal(t, "special", personaName,
+		"OIDCToPersona mapping and persona registry must be wired into the authorizer")
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -49,6 +49,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/platform/dedup"
 	"github.com/txn2/mcp-data-platform/pkg/platform/exportadapters"
 	"github.com/txn2/mcp-data-platform/pkg/platform/fieldcrypt"
+	"github.com/txn2/mcp-data-platform/pkg/platform/iam"
 	"github.com/txn2/mcp-data-platform/pkg/platform/mwchain"
 	"github.com/txn2/mcp-data-platform/pkg/platform/obs"
 	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
@@ -1152,16 +1153,22 @@ func (p *Platform) initRegistries(opts *Options) error {
 	return nil
 }
 
-// initAuth initializes authentication and authorization components.
+// initAuth initializes authentication and authorization components. The
+// authenticator and authorizer are built by pkg/platform/iam from an
+// explicit input; each is skipped when the caller injects its own (test wiring),
+// so an override never triggers construction of the other (#756, #828).
 func (p *Platform) initAuth(opts *Options) error {
+	in := p.authInput()
+
 	if opts.Authenticator != nil {
 		p.authenticator = opts.Authenticator
 	} else {
-		authenticator, err := p.createAuthenticator()
+		identity, err := iam.NewIdentity(in)
 		if err != nil {
 			return fmt.Errorf("creating authenticator: %w", err)
 		}
-		p.authenticator = authenticator
+		p.authenticator = identity.Authenticator
+		p.apiKeyAuth = identity.APIKeyAuth
 	}
 
 	// Record every authenticated person in the known-users directory (#614).
@@ -1175,7 +1182,7 @@ func (p *Platform) initAuth(opts *Options) error {
 	if opts.Authorizer != nil {
 		p.authorizer = opts.Authorizer
 	} else {
-		p.authorizer = p.createAuthorizer()
+		p.authorizer = iam.NewAuthorizer(in)
 	}
 
 	// Initialize browser session (OIDC login + cookie auth) when enabled.
@@ -1184,6 +1191,49 @@ func (p *Platform) initAuth(opts *Options) error {
 	}
 
 	return nil
+}
+
+// authInput translates the platform config, OAuth signing key and persona
+// registry into the explicit input the iam package consumes, keeping the
+// platform-local config types on this side of the package boundary.
+func (p *Platform) authInput() iam.Input {
+	oidc := p.config.Auth.OIDC
+
+	keys := make([]auth.APIKey, 0, len(p.config.Auth.APIKeys.Keys))
+	for _, k := range p.config.Auth.APIKeys.Keys {
+		keys = append(keys, auth.APIKey{
+			Key:         k.Key,
+			Name:        k.Name,
+			Email:       k.Email,
+			Description: k.Description,
+			Roles:       k.Roles,
+		})
+	}
+
+	return iam.Input{
+		OAuthEnabled: p.config.OAuth.Enabled,
+		OAuthJWT: auth.OAuthJWTConfig{
+			Issuer:        p.config.OAuth.Issuer,
+			SigningKey:    p.oauthSigningKey,
+			RoleClaimPath: oidc.RoleClaimPath,
+			RolePrefix:    oidc.RolePrefix,
+		},
+		OIDCEnabled: oidc.Enabled,
+		OIDC: auth.OIDCConfig{
+			Issuer:        oidc.Issuer,
+			ClientID:      oidc.ClientID,
+			Audience:      oidc.Audience,
+			RoleClaimPath: oidc.RoleClaimPath,
+			RolePrefix:    oidc.RolePrefix,
+		},
+		APIKeysEnabled:  p.config.Auth.APIKeys.Enabled,
+		APIKeys:         keys,
+		AllowAnonymous:  p.config.Auth.AllowAnonymous,
+		PersonaRegistry: p.personaRegistry,
+		RoleClaimPath:   oidc.RoleClaimPath,
+		RolePrefix:      oidc.RolePrefix,
+		OIDCToPersona:   p.config.Personas.RoleMapping.OIDCToPersona,
+	}
 }
 
 // initBrowserSession sets up OIDC login flow and cookie authenticator.
@@ -3111,85 +3161,6 @@ func (p *Platform) loadDBAPIKeys() {
 	if len(defs) > 0 {
 		slog.Info("loaded DB api keys", logKeyCount, len(defs))
 	}
-}
-
-// createAuthenticator creates the authenticator based on config.
-func (p *Platform) createAuthenticator() (middleware.Authenticator, error) {
-	var authenticators []middleware.Authenticator
-
-	// OAuth JWT authenticator (for tokens issued by our OAuth server)
-	// This is checked first because OAuth tokens from Claude Desktop will use this
-	if p.config.OAuth.Enabled && len(p.oauthSigningKey) > 0 {
-		oauthAuth, err := auth.NewOAuthJWTAuthenticator(auth.OAuthJWTConfig{
-			Issuer:        p.config.OAuth.Issuer,
-			SigningKey:    p.oauthSigningKey,
-			RoleClaimPath: p.config.Auth.OIDC.RoleClaimPath,
-			RolePrefix:    p.config.Auth.OIDC.RolePrefix,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("creating OAuth JWT authenticator: %w", err)
-		}
-		authenticators = append(authenticators, oauthAuth)
-	}
-
-	// OIDC authenticator (for tokens from external IdPs like Keycloak)
-	if p.config.Auth.OIDC.Enabled {
-		oidcAuth, err := auth.NewOIDCAuthenticator(auth.OIDCConfig{
-			Issuer:        p.config.Auth.OIDC.Issuer,
-			ClientID:      p.config.Auth.OIDC.ClientID,
-			Audience:      p.config.Auth.OIDC.Audience,
-			RoleClaimPath: p.config.Auth.OIDC.RoleClaimPath,
-			RolePrefix:    p.config.Auth.OIDC.RolePrefix,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("creating OIDC authenticator: %w", err)
-		}
-		authenticators = append(authenticators, oidcAuth)
-	}
-
-	// API key authenticator
-	if p.config.Auth.APIKeys.Enabled {
-		var keys []auth.APIKey
-		for _, k := range p.config.Auth.APIKeys.Keys {
-			keys = append(keys, auth.APIKey{
-				Key:         k.Key,
-				Name:        k.Name,
-				Email:       k.Email,
-				Description: k.Description,
-				Roles:       k.Roles,
-			})
-		}
-		apiKeyAuth := auth.NewAPIKeyAuthenticator(auth.APIKeyConfig{Keys: keys})
-		p.apiKeyAuth = apiKeyAuth
-		authenticators = append(authenticators, apiKeyAuth)
-	}
-
-	// If no authenticators configured, use noop
-	if len(authenticators) == 0 {
-		return &middleware.NoopAuthenticator{
-			DefaultUserID: "anonymous",
-			DefaultRoles:  []string{},
-		}, nil
-	}
-
-	// Chain authenticators - anonymous access disabled by default
-	return auth.NewChainedAuthenticator(
-		auth.ChainedAuthConfig{AllowAnonymous: p.config.Auth.AllowAnonymous},
-		authenticators...,
-	), nil
-}
-
-// createAuthorizer creates the authorizer.
-func (p *Platform) createAuthorizer() middleware.Authorizer {
-	// Create role mapper
-	mapper := &persona.OIDCRoleMapper{
-		ClaimPath:      p.config.Auth.OIDC.RoleClaimPath,
-		RolePrefix:     p.config.Auth.OIDC.RolePrefix,
-		PersonaMapping: p.config.Personas.RoleMapping.OIDCToPersona,
-		Registry:       p.personaRegistry,
-	}
-
-	return persona.NewAuthorizer(p.personaRegistry, mapper)
 }
 
 // Start starts the platform.

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -130,6 +130,7 @@ pkg/platform -> pkg/platform/connsource
 pkg/platform -> pkg/platform/dedup
 pkg/platform -> pkg/platform/exportadapters
 pkg/platform -> pkg/platform/fieldcrypt
+pkg/platform -> pkg/platform/iam
 pkg/platform -> pkg/platform/instructions
 pkg/platform -> pkg/platform/mwchain
 pkg/platform -> pkg/platform/obs
@@ -176,6 +177,9 @@ pkg/platform/dedup -> pkg/middleware
 pkg/platform/exportadapters -> pkg/portal
 pkg/platform/exportadapters -> pkg/toolkits/apigateway
 pkg/platform/exportadapters -> pkg/toolkits/trino
+pkg/platform/iam -> pkg/auth
+pkg/platform/iam -> pkg/middleware
+pkg/platform/iam -> pkg/persona
 pkg/platform/instructions -> pkg/persona
 pkg/platform/obs -> pkg/observability
 pkg/platform/personastore -> pkg/persona


### PR DESCRIPTION
## Summary

First concrete seam of the **Platform god-object decomposition** (#756). The `Platform` struct is a ~80-field hub that imports 69 of the module's packages; its subsystems are wired by ordering-sensitive `init*` methods that mutate fields in place, an invisible contract that compiles and unit-tests fine but only fails at runtime.

This PR extracts the **authentication/authorization identity layer** — the authenticator chain and the persona authorizer — out of `platform.go` into a new `pkg/platform/iam` package whose constructors **declare their dependencies as explicit parameters**. The wiring becomes type-checked data flow instead of field mutation, and the layer can now be built and tested without a whole `Platform`.

It is deliberately a small, low-risk first seam: it establishes the decomposition pattern (a domain-named package per subsystem) that later seams follow, without a big-bang refactor.

## The package: `pkg/platform/iam`

```go
iam.Input                              // explicit, foreign-typed inputs (no platform.Config)
iam.Identity{ Authenticator, APIKeyAuth }
iam.NewIdentity(in Input) (Identity, error)      // OAuth JWT → OIDC → API key → noop
iam.NewAuthorizer(in Input) middleware.Authorizer // persona authorizer
```

The package **must not import `pkg/platform`**: the auth config types (`AuthConfig`, `OAuthConfig`, `PersonasConfig`) are platform-local, so accepting `*platform.Config` would create an import cycle. Taking narrow, foreign-typed inputs instead is the whole point — it makes every dependency explicit at the boundary. `Platform.initAuth` translates its config into `iam.Input` via a small `authInput()` helper and delegates; `createAuthenticator`/`createAuthorizer` are removed from `platform.go`.

### Naming

The package is named for the *artifact* it provides (Identity & Access Management), matching the repo's existing convention of domain-named single-purpose subpackages (`mwchain`, `obs`, `dedup`, `exportadapters`, `personastore`, …). Earlier drafts named it `assemble` and then `authwiring` — both verbs, and `assemble` would have become a grab-bag home for every subsystem's constructors that the cohesion gate (#738) would rightly flag. Each seam gets its own domain-named package instead.

## Behavioural equivalence

The extraction is behaviour-preserving. Verified against the original inline code:

- Identical authenticator **chain order** (OAuth JWT → OIDC → API key) and the `OAuth.Enabled && len(signingKey) > 0` guard.
- Same **noop fallback** when nothing is configured; `AllowAnonymous` honored.
- `p.apiKeyAuth` still populated for `loadDBAPIKeys` (returned from `iam.Identity`).
- The `ObservingAuthenticator` wrap (#614) is still applied after construction.
- `opts.Authenticator` / `opts.Authorizer` overrides (test injection) still **skip construction of the other** — a provided authenticator does not trigger authorizer construction or set `apiKeyAuth`.

## Testing & verification

- **Unit tests exercise `iam` directly** (95% coverage) — construction is now testable without a whole `Platform`: chain composition, noop fallback, API-key population, OIDC branch (via `SkipSignatureVerification` to avoid network), error propagation, and a **behavioural** authorizer test proving the persona mapping + registry are actually wired (a role resolves to its configured persona), not just a non-nil assertion.
- The **import ratchet** (#738) caught the four new first-party edges on its own; the golden is regenerated for `platform → iam` and `iam → auth/middleware/persona`, the intended new coupling.
- A high-effort adversarial review found **no correctness defects**; its one finding (a weak authorizer test) is fixed above.
- `make verify` passes the full CI-equivalent suite.

## Scope / follow-ups

Deliberately left in `platform.go` for later seams (each its own domain-named package, per this pattern):

- the OAuth 2.1 server (`initOAuth`) — entangled with sessions, DB, connoauth;
- browser-session login (`initBrowserSession`) — portal config + DB-backed stores;
- the `ObservingAuthenticator` wrap and signing-key generation.

Closes #828. Part of #756.