### PR TITLE
refactor(platform): extract browser-session auth into pkg/platform/browserauth (#832)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Run golangci-lint
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Run tests with coverage
@@ -116,7 +116,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Build
@@ -202,7 +202,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Run Gosec Security Scanner
@@ -213,7 +213,7 @@ jobs:
       - name: Run govulncheck
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
-          go-version-input: '1.26.4'
+          go-version-input: '1.26.5'
           repo-checkout: false
 
       - name: Run Semgrep

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
 
       - name: Verify and prepare Go modules

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/txn2/mcp-data-platform
 
 go 1.26.2
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/godobject_budget_test.go
+++ b/godobject_budget_test.go
@@ -32,7 +32,7 @@ const (
 	// maxPlatformFields caps the number of fields on the Platform struct.
 	// Frozen at today's count; ratchet down as subsystems are grouped into
 	// owner structs (a subsystem's N fields become one owner field).
-	maxPlatformFields = 84
+	maxPlatformFields = 83
 
 	// maxPlatformMethods caps the number of methods with a *Platform receiver.
 	// Frozen at today's count; ratchet down as accessors move onto the

--- a/pkg/platform/browserauth/browserauth.go
+++ b/pkg/platform/browserauth/browserauth.go
@@ -1,0 +1,112 @@
+// Package browserauth builds the browser-facing authentication stack for the
+// portal and admin web UI: the OIDC login/callback flow and the cookie
+// authenticator, held together behind one Session handle.
+//
+// New takes an explicit Config so the stack can be built and tested on its own;
+// the package imports only pkg/browsersession, not pkg/platform.
+package browserauth
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/txn2/mcp-data-platform/pkg/browsersession"
+)
+
+// Config carries the values needed to build a Session. Callers translate their
+// own config into it so this package stays free of platform config types.
+type Config struct {
+	// Cookie settings.
+	CookieName string
+	Domain     string
+	SameSite   string
+	Secure     bool
+	TTL        time.Duration
+	SigningKey []byte
+
+	// OIDC / login-flow settings.
+	Issuer             string
+	ClientID           string
+	ClientSecret       string
+	Scopes             []string
+	RoleClaim          string
+	RolePrefix         string
+	RedirectURI        string
+	PostLogoutRedirect string
+
+	// OnLogin records a user at login; may be nil.
+	OnLogin func(email, firstName, lastName string)
+}
+
+// Session holds the login flow and cookie authenticator for the browser UI.
+type Session struct {
+	flow *browsersession.Flow
+	auth *browsersession.Authenticator
+}
+
+// New builds the login flow and cookie authenticator from cfg.
+func New(ctx context.Context, cfg Config) (*Session, error) {
+	cookieCfg := browsersession.CookieConfig{
+		Name:     cfg.CookieName,
+		Domain:   cfg.Domain,
+		Secure:   cfg.Secure,
+		TTL:      cfg.TTL,
+		Key:      cfg.SigningKey,
+		SameSite: browsersession.ParseSameSite(cfg.SameSite),
+	}
+
+	// SameSite=None disables the browser's built-in cross-site cookie defense,
+	// leaving the X-CSRF-Token check as the sole protection; warn on it.
+	if cookieCfg.IsCrossSiteCookieMode() {
+		slog.Warn("session cookie SameSite=None permits cross-site submission; " +
+			"the X-CSRF-Token header is the sole CSRF protection")
+	}
+
+	flowCfg := browsersession.FlowConfig{
+		Issuer:             cfg.Issuer,
+		ClientID:           cfg.ClientID,
+		ClientSecret:       cfg.ClientSecret,
+		RedirectURI:        cfg.RedirectURI,
+		Scopes:             cfg.Scopes,
+		RoleClaim:          cfg.RoleClaim,
+		RolePrefix:         cfg.RolePrefix,
+		Cookie:             cookieCfg,
+		PostLoginRedirect:  browsersession.DefaultPortalPath,
+		PostLogoutRedirect: cfg.PostLogoutRedirect,
+		OnLogin:            cfg.OnLogin,
+	}
+
+	flow, err := browsersession.NewFlow(ctx, flowCfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating OIDC flow: %w", err)
+	}
+
+	return NewSession(flow, browsersession.NewAuthenticator(cookieCfg)), nil
+}
+
+// NewSession wraps an already-built login flow and cookie authenticator into a
+// Session. New uses it after constructing both; it is also the seam for wiring
+// a pre-built authenticator (e.g. in tests) without a live OIDC flow.
+func NewSession(flow *browsersession.Flow, auth *browsersession.Authenticator) *Session {
+	return &Session{flow: flow, auth: auth}
+}
+
+// Flow returns the OIDC login flow, or nil when browser sessions are disabled
+// (a nil Session).
+func (s *Session) Flow() *browsersession.Flow {
+	if s == nil {
+		return nil
+	}
+	return s.flow
+}
+
+// Authenticator returns the cookie authenticator, or nil when browser sessions
+// are disabled (a nil Session).
+func (s *Session) Authenticator() *browsersession.Authenticator {
+	if s == nil {
+		return nil
+	}
+	return s.auth
+}

--- a/pkg/platform/browserauth/browserauth_test.go
+++ b/pkg/platform/browserauth/browserauth_test.go
@@ -1,0 +1,45 @@
+package browserauth_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/browsersession"
+	"github.com/txn2/mcp-data-platform/pkg/platform/browserauth"
+)
+
+func TestNewSession_Accessors(t *testing.T) {
+	auth := &browsersession.Authenticator{}
+	s := browserauth.NewSession(nil, auth)
+	assert.Nil(t, s.Flow(), "flow was not provided")
+	assert.Same(t, auth, s.Authenticator())
+}
+
+func TestNilSession_AccessorsAreSafe(t *testing.T) {
+	var s *browserauth.Session // browser sessions disabled
+	assert.Nil(t, s.Flow(), "nil Session must return a nil flow, not panic")
+	assert.Nil(t, s.Authenticator(), "nil Session must return a nil authenticator, not panic")
+}
+
+// TestNew_MapsConfigAndSurfacesFlowError exercises the cookie/flow config
+// mapping (including the SameSite=None cross-site warning branch) and the error
+// path: an empty Issuer makes browsersession.NewFlow fail, and New must wrap it.
+func TestNew_MapsConfigAndSurfacesFlowError(t *testing.T) {
+	_, err := browserauth.New(context.Background(), browserauth.Config{
+		CookieName: "sess",
+		SameSite:   "none", // triggers the cross-site cookie warning branch
+		Secure:     true,
+		SigningKey: []byte("0123456789abcdef0123456789abcdef"),
+		// Issuer omitted → NewFlow returns "issuer is required".
+		ClientID:    "client",
+		RedirectURI: "https://example/portal/auth/callback",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating OIDC flow")
+	assert.True(t, strings.Contains(err.Error(), "issuer"),
+		"the underlying validation error should be wrapped, got: %v", err)
+}

--- a/pkg/platform/init_browser_session_test.go
+++ b/pkg/platform/init_browser_session_test.go
@@ -1,0 +1,73 @@
+package platform
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeOIDCDiscovery serves the minimal OIDC discovery document browsersession's
+// NewFlow fetches at construction, so initBrowserSession can run end to end
+// without a real identity provider.
+func fakeOIDCDiscovery(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	var serverURL string
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"authorization_endpoint": serverURL + "/auth",
+			"token_endpoint":         serverURL + "/token",
+			"end_session_endpoint":   serverURL + "/logout",
+			"userinfo_endpoint":      serverURL + "/userinfo",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	serverURL = srv.URL
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestInitBrowserSession(t *testing.T) {
+	// 32 raw bytes → satisfies browsersession's minimum cookie key length.
+	key := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+
+	t.Run("enabled builds flow and authenticator", func(t *testing.T) {
+		srv := fakeOIDCDiscovery(t)
+		p := &Platform{config: &Config{
+			Auth: AuthConfig{
+				OIDC:           OIDCAuthConfig{Enabled: true, Issuer: srv.URL, ClientID: "c"},
+				BrowserSession: BrowserSessionConfig{Enabled: true, CookieName: "sess", SigningKey: key},
+			},
+			Portal: PortalConfig{PublicBaseURL: "https://portal.example"},
+		}}
+		require.NoError(t, p.initBrowserSession())
+		require.NotNil(t, p.BrowserSessionFlow(), "flow must be wired when enabled")
+		require.NotNil(t, p.BrowserSessionAuth(), "cookie authenticator must be wired when enabled")
+	})
+
+	t.Run("disabled is a no-op with nil accessors", func(t *testing.T) {
+		p := &Platform{config: &Config{}}
+		require.NoError(t, p.initBrowserSession())
+		require.Nil(t, p.BrowserSessionFlow())
+		require.Nil(t, p.BrowserSessionAuth())
+	})
+
+	t.Run("flow construction error is wrapped", func(t *testing.T) {
+		// Enabled with an empty issuer: NewFlow rejects it and the error must
+		// surface through initBrowserSession.
+		p := &Platform{config: &Config{
+			Auth: AuthConfig{
+				OIDC:           OIDCAuthConfig{Enabled: true, ClientID: "c"},
+				BrowserSession: BrowserSessionConfig{Enabled: true, SigningKey: key},
+			},
+		}}
+		err := p.initBrowserSession()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "browser session")
+	})
+}

--- a/pkg/platform/observability_browserauth_test.go
+++ b/pkg/platform/observability_browserauth_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/browsersession"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/platform/browserauth"
 )
 
 // errNoToken simulates token authentication failing, proving the decision
@@ -161,7 +162,7 @@ func TestObservabilityAuthMiddleware(t *testing.T) {
 
 	// A zero-value authenticator is non-nil; with no cookie it resolves
 	// nobody, so the request still passes through.
-	p := &Platform{browserSessionAuth: &browsersession.Authenticator{}}
+	p := &Platform{browserSession: browserauth.NewSession(nil, &browsersession.Authenticator{})}
 	if !serve(p.ObservabilityAuthMiddleware()) {
 		t.Fatal("non-nil browser-session path did not reach next handler")
 	}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -46,6 +46,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/oauth"
 	oauthpostgres "github.com/txn2/mcp-data-platform/pkg/oauth/postgres"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
+	"github.com/txn2/mcp-data-platform/pkg/platform/browserauth"
 	"github.com/txn2/mcp-data-platform/pkg/platform/dedup"
 	"github.com/txn2/mcp-data-platform/pkg/platform/exportadapters"
 	"github.com/txn2/mcp-data-platform/pkg/platform/fieldcrypt"
@@ -165,9 +166,8 @@ type Platform struct {
 	oauthSigningKey  []byte
 	oauthStoreCloser interface{ Close() error }
 
-	// Browser session (OIDC login flow + cookie-based auth)
-	browserSessionFlow *browsersession.Flow
-	browserSessionAuth *browsersession.Authenticator
+	// Browser session (OIDC login flow + cookie-based auth for the web UI)
+	browserSession *browserauth.Session
 
 	// Audit
 	auditLogger middleware.AuditLogger
@@ -1189,51 +1189,34 @@ func (p *Platform) initBrowserSession() error {
 		return fmt.Errorf("decoding browser session signing key: %w", err)
 	}
 
-	cookieCfg := browsersession.CookieConfig{
-		Name:     bsCfg.CookieName,
-		Domain:   bsCfg.Domain,
-		Secure:   bsCfg.IsSecure(),
-		TTL:      bsCfg.TTL,
-		Key:      keyBytes,
-		SameSite: browsersession.ParseSameSite(bsCfg.SameSite),
-	}
-
-	// SameSite=None disables the browser's built-in cross-site cookie defense,
-	// leaving the X-CSRF-Token check as the sole protection; warn on it.
-	if cookieCfg.IsCrossSiteCookieMode() {
-		slog.Warn("session cookie SameSite=None permits cross-site submission; " +
-			"the X-CSRF-Token header is the sole CSRF protection")
-	}
-
 	oidcCfg := p.config.Auth.OIDC
-
-	// Build redirect URI from portal public base URL.
 	redirectURI := p.config.Portal.PublicBaseURL + "/portal/auth/callback"
 
-	flowCfg := browsersession.FlowConfig{
+	bs, err := browserauth.New(context.Background(), browserauth.Config{
+		CookieName:         bsCfg.CookieName,
+		Domain:             bsCfg.Domain,
+		SameSite:           bsCfg.SameSite,
+		Secure:             bsCfg.IsSecure(),
+		TTL:                bsCfg.TTL,
+		SigningKey:         keyBytes,
 		Issuer:             oidcCfg.Issuer,
 		ClientID:           oidcCfg.ClientID,
 		ClientSecret:       oidcCfg.ClientSecret,
-		RedirectURI:        redirectURI,
 		Scopes:             oidcCfg.Scopes,
 		RoleClaim:          oidcCfg.RoleClaimPath,
 		RolePrefix:         oidcCfg.RolePrefix,
-		Cookie:             cookieCfg,
-		PostLoginRedirect:  browsersession.DefaultPortalPath,
+		RedirectURI:        redirectURI,
 		PostLogoutRedirect: p.config.Portal.PublicBaseURL + browsersession.DefaultPortalPath,
-		// Record portal/admin SPA users in the known-users directory (#614) at
-		// login. The token authenticator's ObservingAuthenticator wrapper never
-		// sees these users, since they authenticate via the session cookie.
+		// Portal/admin SPA users log in via the session cookie, so the token
+		// authenticator's ObservingAuthenticator never sees them; record them
+		// here at login instead (#614).
 		OnLogin: p.observeBrowserLogin,
-	}
-
-	flow, err := browsersession.NewFlow(context.Background(), flowCfg)
+	})
 	if err != nil {
-		return fmt.Errorf("creating OIDC flow: %w", err)
+		return fmt.Errorf("initializing browser session: %w", err)
 	}
 
-	p.browserSessionFlow = flow
-	p.browserSessionAuth = browsersession.NewAuthenticator(cookieCfg)
+	p.browserSession = bs
 
 	slog.Info("browser session enabled",
 		"issuer", oidcCfg.Issuer,
@@ -3489,12 +3472,12 @@ func (p *Platform) ResolveImplementorLogo() string {
 
 // BrowserSessionFlow returns the OIDC login flow, or nil if browser sessions are disabled.
 func (p *Platform) BrowserSessionFlow() *browsersession.Flow {
-	return p.browserSessionFlow
+	return p.browserSession.Flow()
 }
 
 // BrowserSessionAuth returns the cookie-based authenticator, or nil if browser sessions are disabled.
 func (p *Platform) BrowserSessionAuth() *browsersession.Authenticator {
-	return p.browserSessionAuth
+	return p.browserSession.Authenticator()
 }
 
 // ToolInfo describes a tool registered directly on the platform (not via a toolkit).

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -126,6 +126,7 @@ pkg/platform -> pkg/oauth/postgres
 pkg/platform -> pkg/observability
 pkg/platform -> pkg/observability/proxy
 pkg/platform -> pkg/persona
+pkg/platform -> pkg/platform/browserauth
 pkg/platform -> pkg/platform/connsource
 pkg/platform -> pkg/platform/dedup
 pkg/platform -> pkg/platform/exportadapters
@@ -174,6 +175,7 @@ pkg/platform -> pkg/toolkits/trino
 pkg/platform -> pkg/tuning
 pkg/platform -> pkg/urnbuild
 pkg/platform -> pkg/user
+pkg/platform/browserauth -> pkg/browsersession
 pkg/platform/dedup -> pkg/middleware
 pkg/platform/exportadapters -> pkg/portal
 pkg/platform/exportadapters -> pkg/toolkits/apigateway


### PR DESCRIPTION
## Summary

Third seam of the **Platform god-object decomposition** (#756), after iam (#828) and routepolicy (#830). Unlike those two — which isolated logic but left Platform's field/method counts unchanged — this seam **moves the god-object field budget**: it consolidates two Platform fields into a single owner handle, so the field ceiling ratchets **84 → 83**.

It also carries a **Go security bump** (its own commit) that was needed to get `make verify` green — see below.

## The package: `pkg/platform/browserauth`

```go
type Config struct { /* cookie + OIDC/flow settings, OnLogin callback */ }
type Session struct { /* flow, auth */ }
func New(ctx context.Context, cfg Config) (*Session, error)
func NewSession(flow *browsersession.Flow, auth *browsersession.Authenticator) *Session
func (s *Session) Flow() *browsersession.Flow                 // nil-safe on a nil Session
func (s *Session) Authenticator() *browsersession.Authenticator // nil-safe
```

`New` builds the portal/admin web-UI login stack — the OIDC login/callback flow and the cookie authenticator — from an explicit `Config`. The package imports only `pkg/browsersession`, not `pkg/platform`. `NewSession` wraps pre-built parts; it has a production caller (`New`) and is also the seam for injecting an authenticator in tests without a live OIDC flow.

## Field consolidation (the #756 win)

`Platform` previously held two fields:

```go
browserSessionFlow *browsersession.Flow
browserSessionAuth *browsersession.Authenticator
```

These become **one** handle:

```go
browserSession *browserauth.Session
```

`initBrowserSession` translates config into `browserauth.Config` and stores the handle (nil when browser sessions are disabled). `BrowserSessionFlow()` / `BrowserSessionAuth()` delegate to the handle's nil-safe accessors, so every `cmd/main.go` call site is unchanged. `godobject_budget_test.go`'s field ceiling is ratcheted **84 → 83** — a subsystem's N fields becoming one owner field is exactly the pattern that gate exists to reward.

## Behavioural equivalence

Behaviour-preserving. The enabled guard (`BrowserSession.Enabled && OIDC.Enabled`), base64 signing-key decode, cookie config (`Name/Domain/Secure=IsSecure()/TTL/Key/SameSite`), the `SameSite=None` cross-site warning, the flow config (`Issuer/ClientID/ClientSecret/RedirectURI/Scopes/RoleClaim=RoleClaimPath/RolePrefix/PostLoginRedirect=DefaultPortalPath/PostLogoutRedirect/OnLogin=observeBrowserLogin`), and the nil accessors when disabled all carry over. A high-effort adversarial review found **no findings**.

## Testing

- `browserauth` unit tests: nil-safe accessors, `NewSession` wiring, and `New`'s config mapping + error path (including the cross-site warning branch).
- A platform integration test (`TestInitBrowserSession`) stands up a fake OIDC discovery server and drives `initBrowserSession` through the enabled / disabled / flow-error paths — patch coverage **98.4%**.
- Import ratchet regenerated for `platform → browserauth` and `browserauth → browsersession`.
- `make verify` passes the full CI-equivalent suite.

## Included: Go 1.26.4 → 1.26.5 security bump (separate commit)

`make verify`'s security stage flagged **GO-2026-5856** (Encrypted Client Hello privacy leak in `crypto/tls@go1.26.4`), reached through the gateway toolkit's HTTP client. Commit `chore(security): bump Go toolchain to 1.26.5` bumps the `toolchain` directive in `go.mod` and the Go pin in every CI workflow (`ci`, `codeql`, `release`); `govulncheck` now reports **0 vulnerabilities**. It is a distinct commit; happy to split it into its own PR if preferred.

Not covered here: `Dockerfile.dev` still pins a 1.26.4-era `golang:1.26-alpine` digest (dev container only, not in the release/runtime or `make verify` path) — a follow-up.

Closes #832. Part of #756.