### PR TITLE
refactor(platform): extract OAuth 2.1 server assembly into pkg/platform/oauthserver (#834)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0

--- a/godobject_budget_test.go
+++ b/godobject_budget_test.go
@@ -32,7 +32,7 @@ const (
 	// maxPlatformFields caps the number of fields on the Platform struct.
 	// Frozen at today's count; ratchet down as subsystems are grouped into
 	// owner structs (a subsystem's N fields become one owner field).
-	maxPlatformFields = 83
+	maxPlatformFields = 82
 
 	// maxPlatformMethods caps the number of methods with a *Platform receiver.
 	// Frozen at today's count; ratchet down as accessors move onto the

--- a/pkg/platform/oauthserver/oauthserver.go
+++ b/pkg/platform/oauthserver/oauthserver.go
@@ -1,0 +1,269 @@
+// Package oauthserver assembles the OAuth 2.1 authorization server and its
+// storage behind one Handle: storage selection (Postgres when a database is
+// present, else in-memory), bcrypt-hashed pre-registration of configured
+// clients, the server itself, its authorization-state cleanup, and metrics
+// wiring.
+//
+// New takes an explicit Config so the server can be built and tested on its
+// own; the package imports pkg/oauth (+ pkg/oauth/postgres) and
+// pkg/observability, never pkg/platform. Callers translate their own config
+// into Config at the boundary.
+package oauthserver
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/txn2/mcp-data-platform/pkg/oauth"
+	oauthpostgres "github.com/txn2/mcp-data-platform/pkg/oauth/postgres"
+	"github.com/txn2/mcp-data-platform/pkg/observability"
+)
+
+// Client is a pre-registered OAuth client. Its Secret is the plaintext secret;
+// New bcrypt-hashes it before persisting.
+type Client struct {
+	ID           string
+	Secret       string
+	RedirectURIs []string
+}
+
+// DCR carries the Dynamic Client Registration policy.
+type DCR struct {
+	Enabled                 bool
+	AllowedRedirectPatterns []string
+	AllowAllRedirectURIs    bool
+}
+
+// Upstream identifies the upstream identity provider used for the
+// authorization-code flow, when one is configured.
+type Upstream struct {
+	Issuer       string
+	ClientID     string
+	ClientSecret string
+	RedirectURI  string
+}
+
+// Config carries the values New needs to assemble the OAuth server. Callers
+// build it from their own config so this package stays free of platform config
+// types.
+type Config struct {
+	Issuer         string
+	AccessTokenTTL time.Duration
+	SigningKey     []byte
+	Clients        []Client
+	DCR            DCR
+	Upstream       *Upstream
+
+	// DB selects Postgres-backed storage when non-nil; otherwise in-memory
+	// storage is used. Ignored when Storage is set. Only the DB path yields a
+	// shared (multi-replica) authorization-state store; see New.
+	DB *sql.DB
+	// Storage overrides storage selection with a pre-chosen backend. When set,
+	// DB is ignored and no store-closer is owned by the Handle. An injected
+	// Storage backs client/code/token persistence only: the server still uses
+	// the in-memory authorization-state store (multi-replica state sharing
+	// requires DB). Primarily a test seam.
+	Storage oauth.Storage
+
+	// Metrics records token issuance/refresh outcomes; may be nil.
+	Metrics *observability.Metrics
+}
+
+// Handle owns the assembled OAuth server together with the resources that must
+// be torn down at shutdown: the Postgres store's closer (database path) and the
+// in-memory state-store cleanup routine's cancellation (single-replica path).
+//
+// The two torn-down resources belong to different shutdown phases, mirroring the
+// original platform wiring: the store-closer is released by Close (the resource
+// teardown phase), while the in-memory cleanup cancel is returned by
+// StateStoreCleanup for the caller to wire into its lifecycle stop phase.
+type Handle struct {
+	server       *oauth.Server
+	storeCloser  interface{ Close() error }
+	stateCleanup context.CancelFunc
+}
+
+// Server returns the assembled OAuth server, or nil when the Handle is nil
+// (OAuth disabled).
+func (h *Handle) Server() *oauth.Server {
+	if h == nil {
+		return nil
+	}
+	return h.server
+}
+
+// StateStoreCleanup returns the cancel for the in-memory authorization-state
+// cleanup routine (single-replica path), or nil on the database path or a nil
+// Handle. The caller wires it into its lifecycle stop so the ticker goroutine is
+// canceled when the platform stops, without this package importing the caller's
+// lifecycle.
+func (h *Handle) StateStoreCleanup() context.CancelFunc {
+	if h == nil {
+		return nil
+	}
+	return h.stateCleanup
+}
+
+// Close closes the Postgres store (database path); it is nil-safe and a no-op on
+// the in-memory path, whose cleanup routine is canceled via StateStoreCleanup.
+func (h *Handle) Close() error {
+	if h == nil || h.storeCloser == nil {
+		return nil
+	}
+	if err := h.storeCloser.Close(); err != nil {
+		return fmt.Errorf("closing oauth store: %w", err)
+	}
+	return nil
+}
+
+// resolveStorage picks the storage backend. It returns the storage plus the
+// typed Postgres store when the database path is chosen (nil otherwise), so the
+// caller can wire it as the shared state store and close it at shutdown.
+func (c Config) resolveStorage() (oauth.Storage, *oauthpostgres.Store) {
+	if c.Storage != nil {
+		return c.Storage, nil
+	}
+	if c.DB != nil {
+		pg := oauthpostgres.New(c.DB)
+		return pg, pg
+	}
+	return oauth.NewMemoryStorage(), nil
+}
+
+// New assembles the OAuth server from cfg: it selects storage, pre-registers
+// configured clients with bcrypt-hashed secrets, builds the server, wires the
+// authorization-state store (shared Postgres store, or an in-memory cleanup
+// routine whose cancel is returned by StateStoreCleanup), and attaches metrics.
+//
+// The Postgres store's cleanup ticker starts before the failure-prone assembly
+// steps, so the returned Handle owns its closer immediately: on any error after
+// that point, New closes the Handle before returning so the store and its
+// goroutine never outlive a failed construction.
+func New(ctx context.Context, cfg Config) (*Handle, error) {
+	storage, pgStore := cfg.resolveStorage()
+
+	h := &Handle{}
+	if pgStore != nil {
+		pgStore.StartCleanupRoutine(time.Minute)
+		h.storeCloser = pgStore
+		slog.Info("OAuth storage: database")
+	} else {
+		slog.Info("OAuth storage: memory")
+	}
+
+	// If assembly fails after a cleanup ticker has started, tear the Handle back
+	// down so no goroutine outlives the failed construction. The Handle is never
+	// returned on error, so the caller cannot wire StateStoreCleanup itself;
+	// cancel both cleanups here regardless of which path started one.
+	ok := false
+	defer func() {
+		if !ok {
+			if h.stateCleanup != nil {
+				h.stateCleanup()
+			}
+			_ = h.Close()
+		}
+	}()
+
+	if err := preRegisterClients(ctx, storage, cfg.Clients); err != nil {
+		return nil, err
+	}
+
+	serverConfig := oauth.ServerConfig{
+		Issuer:         cfg.Issuer,
+		AccessTokenTTL: cfg.AccessTokenTTL,
+		SigningKey:     cfg.SigningKey,
+		DCR: oauth.DCRConfig{
+			Enabled:                 cfg.DCR.Enabled,
+			AllowedRedirectPatterns: cfg.DCR.AllowedRedirectPatterns,
+			AllowAllRedirectURIs:    cfg.DCR.AllowAllRedirectURIs,
+			RequirePKCE:             true,
+		},
+	}
+	if cfg.Upstream != nil {
+		serverConfig.Upstream = &oauth.UpstreamConfig{
+			Issuer:       cfg.Upstream.Issuer,
+			ClientID:     cfg.Upstream.ClientID,
+			ClientSecret: cfg.Upstream.ClientSecret,
+			RedirectURI:  cfg.Upstream.RedirectURI,
+		}
+	}
+
+	server, err := oauth.NewServer(serverConfig, storage)
+	if err != nil {
+		return nil, fmt.Errorf("creating OAuth server: %w", err)
+	}
+	h.server = server
+
+	warnOnDefaultDenyDCR(cfg.DCR)
+
+	// In multi-replica deployments the upstream IdP callback can land on a
+	// different replica than the one that started the flow, so in-flight
+	// authorization state must live in the shared database when one is
+	// configured. The Postgres store's cleanup routine sweeps it; the memory
+	// path sweeps via the server's own cleanup routine, whose cancel the caller
+	// wires into its lifecycle stop so repeated start/stop cycles do not leak
+	// ticker goroutines.
+	if pgStore != nil {
+		server.SetStateStore(pgStore)
+		slog.Info("OAuth state store: database")
+	} else {
+		// cancelCleanup escapes via h.stateCleanup: the caller invokes it at
+		// lifecycle stop (StateStoreCleanup), and the error defer invokes it on a
+		// failed construction, so it is never dropped.
+		cleanupCtx, cancelCleanup := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel is retained on the Handle and invoked by the caller / error defer, not leaked.
+		server.StartCleanupRoutine(cleanupCtx, time.Minute)
+		h.stateCleanup = cancelCleanup
+		slog.Info("OAuth state store: memory (single-replica)")
+	}
+
+	server.SetMetrics(cfg.Metrics)
+	ok = true
+	return h, nil
+}
+
+// preRegisterClients bcrypt-hashes each configured client's secret and persists
+// it. The registration endpoint stores hashed secrets, so pre-registered
+// clients must match that shape.
+func preRegisterClients(ctx context.Context, storage oauth.Storage, clients []Client) error {
+	for _, clientCfg := range clients {
+		hashedSecret, err := bcrypt.GenerateFromPassword([]byte(clientCfg.Secret), bcrypt.DefaultCost)
+		if err != nil {
+			return fmt.Errorf("hashing client secret for %s: %w", clientCfg.ID, err)
+		}
+
+		client := &oauth.Client{
+			ID:           clientCfg.ID,
+			ClientID:     clientCfg.ID,
+			ClientSecret: string(hashedSecret),
+			Name:         clientCfg.ID,
+			RedirectURIs: clientCfg.RedirectURIs,
+			GrantTypes:   []string{"authorization_code", "refresh_token"},
+			RequirePKCE:  true,
+			CreatedAt:    time.Now(),
+			Active:       true,
+		}
+
+		if err := storage.CreateClient(ctx, client); err != nil {
+			return fmt.Errorf("creating client %s: %w", clientCfg.ID, err)
+		}
+	}
+	return nil
+}
+
+// warnOnDefaultDenyDCR surfaces the DCR default-deny at boot: a deployment that
+// enabled DCR without patterns previously accepted any redirect URI and now
+// denies all registrations. The request-time error repeats the guidance, but
+// the operator should learn about it from the startup log, not from the first
+// failing client.
+func warnOnDefaultDenyDCR(dcr DCR) {
+	if dcr.Enabled && len(dcr.AllowedRedirectPatterns) == 0 && !dcr.AllowAllRedirectURIs {
+		slog.Warn("OAuth DCR is enabled without allowed_redirect_patterns: all client registrations will be denied. " +
+			"Set oauth.dcr.allowed_redirect_patterns, or oauth.dcr.allow_all_redirect_uris: true to explicitly accept any redirect URI.")
+	}
+}

--- a/pkg/platform/oauthserver/oauthserver_test.go
+++ b/pkg/platform/oauthserver/oauthserver_test.go
@@ -1,0 +1,250 @@
+package oauthserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/txn2/mcp-data-platform/pkg/oauth"
+	oauthpostgres "github.com/txn2/mcp-data-platform/pkg/oauth/postgres"
+)
+
+const testSigningKey = "0123456789abcdef0123456789abcdef" // 32 bytes, satisfies HMAC minimum.
+
+// TestMain fails the package if any test leaks a goroutine. The OAuth server and
+// Postgres store both run cleanup tickers, so this guards the shutdown contract:
+// every Handle a test builds must be fully torn down (see stop).
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+// stop fully tears down a Handle in tests: it closes the store (database path)
+// and cancels the in-memory cleanup routine (single-replica path), mirroring how
+// platform wires Close and StateStoreCleanup into shutdown. Without both, the
+// ticker goroutines outlive the test and TestMain's goleak check fails.
+func stop(t *testing.T, h *Handle) {
+	t.Helper()
+	assert.NoError(t, h.Close())
+	if cancel := h.StateStoreCleanup(); cancel != nil {
+		cancel()
+	}
+}
+
+// failingStorage wraps a real storage but forces CreateClient to fail, exercising
+// the client pre-registration error path without a live database.
+type failingStorage struct {
+	oauth.Storage
+}
+
+func (failingStorage) CreateClient(context.Context, *oauth.Client) error {
+	return errors.New("create client boom")
+}
+
+func TestResolveStorage_Memory(t *testing.T) {
+	storage, pg := Config{}.resolveStorage()
+	assert.Nil(t, pg, "no database → no Postgres store")
+	_, ok := storage.(*oauth.MemoryStorage)
+	assert.True(t, ok, "no database → in-memory storage, got %T", storage)
+}
+
+func TestResolveStorage_Database(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // sqlmock close error is inconsequential in tests.
+
+	storage, pg := Config{DB: db}.resolveStorage()
+	require.NotNil(t, pg, "database present → Postgres store selected")
+	// The Postgres store is both the storage and the returned typed handle.
+	got, ok := storage.(*oauthpostgres.Store)
+	require.True(t, ok, "database path returns a *oauthpostgres.Store, got %T", storage)
+	assert.Same(t, pg, got)
+}
+
+func TestResolveStorage_InjectedOverridesDB(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // sqlmock close error is inconsequential in tests.
+
+	injected := oauth.NewMemoryStorage()
+	storage, pg := Config{DB: db, Storage: injected}.resolveStorage()
+	assert.Nil(t, pg, "injected storage → no Postgres store owned")
+	assert.Same(t, injected, storage, "injected storage used verbatim")
+}
+
+func TestNew_MemoryPath_StartsCleanupRoutine(t *testing.T) {
+	handle, err := New(context.Background(), Config{
+		Issuer:     "https://auth.example.com",
+		SigningKey: []byte(testSigningKey),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, handle)
+
+	// Memory path exposes a cleanup cancel (for the caller's lifecycle) and owns
+	// no store-closer.
+	assert.NotNil(t, handle.StateStoreCleanup(), "memory state store starts a cancelable cleanup routine")
+	assert.Nil(t, handle.storeCloser, "memory path owns no store-closer")
+	require.NotNil(t, handle.Server())
+
+	// Close is a no-op on the memory path; the cleanup routine is canceled via
+	// StateStoreCleanup.
+	stop(t, handle)
+}
+
+func TestNew_PreRegistersClientWithBcryptHash(t *testing.T) {
+	// Inject a storage we hold a reference to so we can read the client back;
+	// the server exposes no storage accessor.
+	storage := oauth.NewMemoryStorage()
+	handle, err := New(context.Background(), Config{
+		Issuer:     "https://auth.example.com",
+		SigningKey: []byte(testSigningKey),
+		Storage:    storage,
+		Clients: []Client{{
+			ID:           "acme-client",
+			Secret:       "s3cr3t",
+			RedirectURIs: []string{"https://acme.example.com/callback"},
+		}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, handle.Server())
+
+	// The pre-registered client's secret must be stored as a bcrypt hash, not
+	// plaintext, so it matches the shape the token endpoint verifies against.
+	client, err := storage.GetClient(context.Background(), "acme-client")
+	require.NoError(t, err)
+	assert.NotEqual(t, "s3cr3t", client.ClientSecret)
+	assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(client.ClientSecret), []byte("s3cr3t")))
+	assert.True(t, client.RequirePKCE)
+	assert.Equal(t, []string{"authorization_code", "refresh_token"}, client.GrantTypes)
+	assert.Equal(t, []string{"https://acme.example.com/callback"}, client.RedirectURIs)
+
+	stop(t, handle)
+}
+
+func TestNew_DatabasePath_OwnsStoreCloser(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // sqlmock close error is inconsequential in tests.
+
+	handle, err := New(context.Background(), Config{
+		Issuer:     "https://auth.example.com",
+		SigningKey: []byte(testSigningKey),
+		DB:         db,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, handle)
+
+	// Database path owns a store-closer and uses the shared store for state,
+	// so no in-memory cleanup routine is started.
+	assert.NotNil(t, handle.storeCloser, "database path owns the Postgres store-closer")
+	assert.Nil(t, handle.StateStoreCleanup(), "database path uses the shared store, no memory cleanup")
+
+	// Close delegates to the Postgres store's Close (stops its cleanup routine).
+	assert.NoError(t, handle.Close())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestNew_UpstreamConfigured(t *testing.T) {
+	handle, err := New(context.Background(), Config{
+		Issuer:     "https://auth.example.com",
+		SigningKey: []byte(testSigningKey),
+		Upstream: &Upstream{
+			Issuer:       "https://keycloak.example.com",
+			ClientID:     "mcp",
+			ClientSecret: "kc-secret",
+			RedirectURI:  "https://auth.example.com/oauth/callback",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, handle.Server())
+	stop(t, handle)
+}
+
+func TestNew_ClientHashingError(t *testing.T) {
+	// A secret longer than bcrypt's 72-byte input limit forces a hashing error,
+	// exercising the pre-registration failure path.
+	longSecret := make([]byte, 100)
+	for i := range longSecret {
+		longSecret[i] = 'a'
+	}
+	_, err := New(context.Background(), Config{
+		Issuer:     "https://auth.example.com",
+		SigningKey: []byte(testSigningKey),
+		Clients:    []Client{{ID: "big", Secret: string(longSecret)}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hashing client secret for big")
+}
+
+func TestNew_ClientCreateError(t *testing.T) {
+	_, err := New(context.Background(), Config{
+		Issuer:     "https://auth.example.com",
+		SigningKey: []byte(testSigningKey),
+		Storage:    failingStorage{oauth.NewMemoryStorage()},
+		Clients:    []Client{{ID: "acme", Secret: "s3cr3t"}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating client acme")
+}
+
+func TestNew_ServerConstructionError(t *testing.T) {
+	// DCR enabled with an invalid regex pattern fails NewServer's DCR service.
+	_, err := New(context.Background(), Config{
+		Issuer:     "https://auth.example.com",
+		SigningKey: []byte(testSigningKey),
+		DCR: DCR{
+			Enabled:                 true,
+			AllowedRedirectPatterns: []string{"("},
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating OAuth server")
+}
+
+func TestNew_DatabasePath_ClosesStoreOnError(t *testing.T) {
+	// The Postgres store's cleanup ticker starts before the failure-prone
+	// assembly steps. When assembly fails, New must close the store so its
+	// goroutine does not outlive the failed construction. goleak asserts no
+	// goroutine leaks past the failed New.
+	defer goleak.VerifyNone(t)
+
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck // sqlmock close error is inconsequential in tests.
+
+	// Invalid DCR regex fails NewServer, which runs after pgStore's cleanup
+	// routine has already started.
+	handle, err := New(context.Background(), Config{
+		Issuer:     "https://auth.example.com",
+		SigningKey: []byte(testSigningKey),
+		DB:         db,
+		DCR:        DCR{Enabled: true, AllowedRedirectPatterns: []string{"("}},
+	})
+	require.Error(t, err)
+	assert.Nil(t, handle, "failed construction returns no handle")
+}
+
+func TestNew_DCRDefaultDenyStillConstructs(t *testing.T) {
+	// DCR enabled without patterns and without allow-all is valid but denies all
+	// registrations; New must still construct the server (and warn at boot).
+	handle, err := New(context.Background(), Config{
+		Issuer:     "https://auth.example.com",
+		SigningKey: []byte(testSigningKey),
+		DCR:        DCR{Enabled: true},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, handle.Server())
+	stop(t, handle)
+}
+
+func TestHandle_NilSafe(t *testing.T) {
+	var h *Handle
+	assert.Nil(t, h.Server())
+	assert.Nil(t, h.StateStoreCleanup())
+	assert.NoError(t, h.Close())
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -24,7 +24,6 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	dhclient "github.com/txn2/mcp-datahub/pkg/client"
 	s3client "github.com/txn2/mcp-s3/pkg/client"
-	"golang.org/x/crypto/bcrypt"
 
 	"github.com/txn2/mcp-data-platform/apps"
 	auditpostgres "github.com/txn2/mcp-data-platform/pkg/audit/postgres"
@@ -44,7 +43,6 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/memory"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/oauth"
-	oauthpostgres "github.com/txn2/mcp-data-platform/pkg/oauth/postgres"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/platform/browserauth"
 	"github.com/txn2/mcp-data-platform/pkg/platform/dedup"
@@ -52,6 +50,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/platform/fieldcrypt"
 	"github.com/txn2/mcp-data-platform/pkg/platform/iam"
 	"github.com/txn2/mcp-data-platform/pkg/platform/mwchain"
+	"github.com/txn2/mcp-data-platform/pkg/platform/oauthserver"
 	"github.com/txn2/mcp-data-platform/pkg/platform/obs"
 	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
 	"github.com/txn2/mcp-data-platform/pkg/platform/reflexivecapture"
@@ -162,9 +161,8 @@ type Platform struct {
 	apiKeyAuth    *auth.APIKeyAuthenticator
 
 	// OAuth
-	oauthServer      *oauth.Server
-	oauthSigningKey  []byte
-	oauthStoreCloser interface{ Close() error }
+	oauthHandle     *oauthserver.Handle
+	oauthSigningKey []byte
 
 	// Browser session (OIDC login flow + cookie-based auth for the web UI)
 	browserSession *browserauth.Session
@@ -1360,66 +1358,37 @@ func (p *Platform) initBroadcaster() {
 	p.initReloadBus()
 }
 
-// initOAuth initializes the OAuth server if enabled.
+// initOAuth initializes the OAuth server if enabled. It translates platform
+// config into oauthserver.Config and delegates assembly to the owner package;
+// the returned Handle owns the server plus its store-closer/cleanup, closed at
+// platform shutdown.
 func (p *Platform) initOAuth() error {
 	if !p.config.OAuth.Enabled {
 		return nil
 	}
 
-	// Create storage: use PostgreSQL if database is available, otherwise in-memory.
-	var oauthStorage oauth.Storage
-	var pgStore *oauthpostgres.Store
-	if p.db != nil {
-		pgStore = oauthpostgres.New(p.db)
-		pgStore.StartCleanupRoutine(time.Minute)
-		p.oauthStoreCloser = pgStore
-		oauthStorage = pgStore
-		slog.Info("OAuth storage: database")
-	} else {
-		oauthStorage = oauth.NewMemoryStorage()
-		slog.Info("OAuth storage: memory")
-	}
-
-	// Pre-register clients from config
-	for _, clientCfg := range p.config.OAuth.Clients {
-		hashedSecret, err := bcrypt.GenerateFromPassword([]byte(clientCfg.Secret), bcrypt.DefaultCost)
-		if err != nil {
-			return fmt.Errorf("hashing client secret for %s: %w", clientCfg.ID, err)
-		}
-
-		client := &oauth.Client{
-			ID:           clientCfg.ID,
-			ClientID:     clientCfg.ID,
-			ClientSecret: string(hashedSecret),
-			Name:         clientCfg.ID,
-			RedirectURIs: clientCfg.RedirectURIs,
-			GrantTypes:   []string{"authorization_code", "refresh_token"},
-			RequirePKCE:  true,
-			CreatedAt:    time.Now(),
-			Active:       true,
-		}
-
-		if err := oauthStorage.CreateClient(context.Background(), client); err != nil {
-			return fmt.Errorf("creating client %s: %w", clientCfg.ID, err)
-		}
-	}
-
-	// Build OAuth server config
-	serverConfig := oauth.ServerConfig{
+	cfg := oauthserver.Config{
 		Issuer:         p.config.OAuth.Issuer,
 		AccessTokenTTL: 1 * time.Hour,
 		SigningKey:     p.oauthSigningKey,
-		DCR: oauth.DCRConfig{
+		Clients:        make([]oauthserver.Client, 0, len(p.config.OAuth.Clients)),
+		DCR: oauthserver.DCR{
 			Enabled:                 p.config.OAuth.DCR.Enabled,
 			AllowedRedirectPatterns: p.config.OAuth.DCR.AllowedRedirectPatterns,
 			AllowAllRedirectURIs:    p.config.OAuth.DCR.AllowAllRedirectURIs,
-			RequirePKCE:             true,
 		},
+		DB:      p.db,
+		Metrics: p.obs.Metrics(),
 	}
-
-	// Configure upstream IdP if present
+	for _, clientCfg := range p.config.OAuth.Clients {
+		cfg.Clients = append(cfg.Clients, oauthserver.Client{
+			ID:           clientCfg.ID,
+			Secret:       clientCfg.Secret,
+			RedirectURIs: clientCfg.RedirectURIs,
+		})
+	}
 	if p.config.OAuth.Upstream != nil {
-		serverConfig.Upstream = &oauth.UpstreamConfig{
+		cfg.Upstream = &oauthserver.Upstream{
 			Issuer:       p.config.OAuth.Upstream.Issuer,
 			ClientID:     p.config.OAuth.Upstream.ClientID,
 			ClientSecret: p.config.OAuth.Upstream.ClientSecret,
@@ -1427,45 +1396,22 @@ func (p *Platform) initOAuth() error {
 		}
 	}
 
-	// Create OAuth server
-	server, err := oauth.NewServer(serverConfig, oauthStorage)
+	handle, err := oauthserver.New(context.Background(), cfg)
 	if err != nil {
-		return fmt.Errorf("creating OAuth server: %w", err)
+		return fmt.Errorf("initializing OAuth server: %w", err)
 	}
+	p.oauthHandle = handle
 
-	// Surface the DCR default-deny at boot: a deployment that enabled DCR
-	// without patterns previously accepted any redirect URI and now denies
-	// all registrations. The request-time error repeats the guidance, but
-	// the operator should learn about it from the startup log, not from
-	// the first failing client.
-	if p.config.OAuth.DCR.Enabled && len(p.config.OAuth.DCR.AllowedRedirectPatterns) == 0 &&
-		!p.config.OAuth.DCR.AllowAllRedirectURIs {
-		slog.Warn("OAuth DCR is enabled without allowed_redirect_patterns: all client registrations will be denied. " +
-			"Set oauth.dcr.allowed_redirect_patterns, or oauth.dcr.allow_all_redirect_uris: true to explicitly accept any redirect URI.")
-	}
-
-	// In multi-replica deployments the upstream IdP callback can land on a
-	// different replica than the one that started the flow, so in-flight
-	// authorization state must live in the shared database when one is
-	// configured. The Postgres store's cleanup routine sweeps it; the
-	// memory path sweeps via the server's own cleanup routine, canceled
-	// at platform shutdown so repeated start/stop cycles do not leak
-	// ticker goroutines.
-	if pgStore != nil {
-		server.SetStateStore(pgStore)
-		slog.Info("OAuth state store: database")
-	} else {
-		cleanupCtx, cancelCleanup := context.WithCancel(context.Background())
-		server.StartCleanupRoutine(cleanupCtx, time.Minute)
+	// The in-memory (single-replica) state-store path runs a cleanup ticker that
+	// must be canceled when the lifecycle stops so repeated start/stop cycles do
+	// not leak the goroutine. The database path returns a nil cancel (its store
+	// sweeps itself and is closed at platform Close).
+	if cancel := handle.StateStoreCleanup(); cancel != nil {
 		p.lifecycle.OnStop(func(context.Context) error {
-			cancelCleanup()
+			cancel()
 			return nil
 		})
-		slog.Info("OAuth state store: memory (single-replica)")
 	}
-
-	server.SetMetrics(p.obs.Metrics())
-	p.oauthServer = server
 	return nil
 }
 
@@ -3182,7 +3128,7 @@ func (p *Platform) SessionStore() session.Store {
 
 // OAuthServer returns the OAuth server, or nil if not enabled.
 func (p *Platform) OAuthServer() *oauth.Server {
-	return p.oauthServer
+	return p.oauthHandle.Server()
 }
 
 // AuditStore returns the PostgreSQL audit store, or nil if audit is disabled.
@@ -3667,9 +3613,9 @@ func (p *Platform) closeSessionLayer(errs *[]error) {
 	}
 	slog.Debug("shutdown: stopping reload bus")
 	p.stopReloadBus()
-	if p.oauthStoreCloser != nil {
-		slog.Debug("shutdown: closing OAuth store")
-		closeResource(errs, p.oauthStoreCloser)
+	if p.oauthHandle != nil {
+		slog.Debug("shutdown: closing OAuth server")
+		closeResource(errs, p.oauthHandle)
 	}
 }
 

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -122,7 +122,6 @@ pkg/platform -> pkg/memory
 pkg/platform -> pkg/memory/memoryindex
 pkg/platform -> pkg/middleware
 pkg/platform -> pkg/oauth
-pkg/platform -> pkg/oauth/postgres
 pkg/platform -> pkg/observability
 pkg/platform -> pkg/observability/proxy
 pkg/platform -> pkg/persona
@@ -134,6 +133,7 @@ pkg/platform -> pkg/platform/fieldcrypt
 pkg/platform -> pkg/platform/iam
 pkg/platform -> pkg/platform/instructions
 pkg/platform -> pkg/platform/mwchain
+pkg/platform -> pkg/platform/oauthserver
 pkg/platform -> pkg/platform/obs
 pkg/platform -> pkg/platform/personastore
 pkg/platform -> pkg/platform/reflexivecapture
@@ -184,6 +184,9 @@ pkg/platform/iam -> pkg/auth
 pkg/platform/iam -> pkg/middleware
 pkg/platform/iam -> pkg/persona
 pkg/platform/instructions -> pkg/persona
+pkg/platform/oauthserver -> pkg/oauth
+pkg/platform/oauthserver -> pkg/oauth/postgres
+pkg/platform/oauthserver -> pkg/observability
 pkg/platform/obs -> pkg/observability
 pkg/platform/personastore -> pkg/persona
 pkg/platform/reflexivecapture -> pkg/memory


### PR DESCRIPTION
## Summary

Fourth seam of the Platform decomposition (#756), continuing the auth-subsystem extraction after iam (#828), api-gateway route policy (#830), and browser-session auth (#832). It moves the OAuth 2.1 authorization server's construction out of `Platform` and into a new self-contained owner package, consolidating two Platform fields into one owner handle.

`initOAuth` previously assembled the server and stored it across three fields — `oauthServer`, `oauthStoreCloser`, and `oauthSigningKey`. This PR extracts the assembly into **`pkg/platform/oauthserver`** and collapses the first two fields into a single `oauthHandle`. `oauthSigningKey` stays a Platform field because it is shared with iam's OAuth JWT authenticator (`platform.go` reads it both as the server's signing key and as the authenticator's verification key).

Result: **Platform loses one field (83 → 82); the god-object field ceiling ratchets to 82.**

## What the new package does

`pkg/platform/oauthserver` imports `pkg/oauth` (+ `pkg/oauth/postgres`) and `pkg/observability`, **never** `pkg/platform`. Callers translate their config into `oauthserver.Config` at the boundary.

`New(ctx, Config) (*Handle, error)`:
- **Storage selection** — Postgres store when a `*sql.DB` is present, else in-memory. A `Config.Storage` override seam accepts a pre-chosen `oauth.Storage` (primarily for tests).
- **Client pre-registration** — bcrypt-hashes each configured client secret and persists it.
- **Server construction** — builds `oauth.ServerConfig` (issuer, TTL, signing key, DCR, upstream IdP) and calls `oauth.NewServer`.
- **DCR default-deny warning** — surfaces at boot when DCR is enabled without allowed redirect patterns.
- **Auth-state store** — shared Postgres store on the DB path; an in-memory cleanup routine on the single-replica path, whose cancel is returned to the caller.
- **Metrics** — attaches the observability recorder.

`Handle` exposes `Server()`, `Close()`, and `StateStoreCleanup()`, all nil-safe.

## Platform integration

- `oauthServer` + `oauthStoreCloser` → one `oauthHandle *oauthserver.Handle`.
- `initOAuth` becomes config-translation + delegation to `oauthserver.New`.
- `OAuthServer()` returns `p.oauthHandle.Server()`; the shutdown path closes the handle.
- The memory-path cleanup cancel is returned via `StateStoreCleanup()` and wired into `lifecycle.OnStop` by `Platform` — so the owner never reaches into `p.lifecycle`, and `Stop()`-time cancellation is preserved.

## Behavior preserved

Postgres-vs-memory storage selection, bcrypt client pre-registration, DCR default-deny warning, auth-state cleanup + lifecycle cancellation, metrics wiring, the `OAuthServer()` accessor, and `Close()` semantics are all unchanged. `oauthSigningKey` is untouched.

## Adversarial review — three lifecycle regressions found and fixed

A high-effort multi-agent review of the extraction surfaced three resource/goroutine-lifecycle regressions, all fixed in this PR:

1. **DB-path resource leak on `New` error** (confirmed). The Postgres cleanup ticker starts before the failure-prone assembly steps, but the closer was only attached to the returned handle at the end — so an error (bad client secret, invalid DCR regex, `CreateClient` failure) left the store and its goroutine leaking. Fixed: the handle owns the closer immediately, and a `defer` tears the handle down on any error so nothing outlives a failed construction.
2. **`Stop()`-without-`Close()` leaked the memory cleanup goroutine.** The initial extraction moved the cancel from `lifecycle.OnStop` (fires on `Stop()`) into `Handle.Close()` (fires on `Close()`). Restored the original semantics: the cancel is returned via `StateStoreCleanup()` and `Platform` re-wires it into `lifecycle.OnStop`.
3. **Injected `Storage` state-sharing ambiguity.** Sharpened the `Config.Storage` doc — an arbitrary `oauth.Storage` backs client/token persistence only; multi-replica auth-state sharing requires the `DB` path.

A package-level `TestMain` + `goleak.VerifyTestMain` now enforces the shutdown contract: every `Handle` a test builds must be fully torn down, or the package fails.

## Testing

- New package unit tests cover storage selection (memory / database / injected), bcrypt client pre-registration, upstream config, both cleanup paths, nil-safety, and every error path (client hashing, client create, server construction, DB-path error cleanup verified with `goleak`). **100% statement coverage.**
- `TestPlatformGodObjectBudget` field ceiling lowered 83 → 82 (test logs `82 fields`).
- Import ratchet (`testdata/allowed_internal_imports.txt`) regenerated: drops `pkg/platform → pkg/oauth/postgres`, adds `pkg/platform → pkg/platform/oauthserver` and the new package's edges to `pkg/oauth`, `pkg/oauth/postgres`, `pkg/observability`.
- `go.uber.org/goleak` promoted to a direct dependency.
- `make verify` green (tests + race, patch-scoped lint, gosec, mutation, dead-code, doc-check, GoReleaser dry-run).

Closes #834. Relates to #756.
