### PR TITLE
refactor(platform): extract connection-OAuth token lifecycle into pkg/platform/connauth (#838)

### DIFF
--- a/godobject_budget_test.go
+++ b/godobject_budget_test.go
@@ -33,8 +33,11 @@ const (
 	// Frozen at today's count; ratchet down as subsystems are grouped into
 	// owner structs (a subsystem's N fields become one owner field). The
 	// index-jobs queue extraction (#836) folded nine fields into one
-	// indexqueue.Handle, ratcheting 82 → 74.
-	maxPlatformFields = 74
+	// indexqueue.Handle, ratcheting 82 → 74; the connection-OAuth token
+	// lifecycle extraction (#838) folded four fields (connOAuthStore,
+	// authEventStore, authEventWriter, connOAuthRefresher) into one
+	// connauth.Handle, ratcheting 74 → 71.
+	maxPlatformFields = 71
 
 	// maxPlatformMethods caps the number of methods with a *Platform receiver.
 	// Frozen at today's count; ratchet down as accessors move onto the

--- a/pkg/platform/connauth/connauth.go
+++ b/pkg/platform/connauth/connauth.go
@@ -1,0 +1,157 @@
+// Package connauth assembles the connection-OAuth token lifecycle behind one
+// Handle: the unified connection_oauth_tokens store (pkg/connoauth), the durable
+// connection_auth_events store together with its nil-safe writer and daily
+// 90-day prune routine (pkg/authevents), and the background token-refresh loop.
+//
+// Construction is two-phase. New takes explicit inputs (a *sql.DB and the
+// platform's *fieldcrypt.RestFieldEncryptor) and returns the assembled store +
+// writer + auth-event store, starting the prune routine. StartRefresher builds
+// and starts the refresh loop from an injected ConfigResolver and AdvisoryLocker:
+// the resolver is only constructible after the per-kind OAuth handlers are wired,
+// and the caller owns the single- vs multi-replica locker choice, so this package
+// stays free of *sql.DB / replica config for the refresher and never imports
+// pkg/platform.
+package connauth
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/txn2/mcp-data-platform/pkg/authevents"
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
+	"github.com/txn2/mcp-data-platform/pkg/platform/fieldcrypt"
+)
+
+// authEventsRetention is the retention window for connection_auth_events. 90
+// days matches the contract in #395: operators can always answer "what happened
+// to this connection's tokens in the last quarter" from the History panel.
+const authEventsRetention = 90 * 24 * time.Hour
+
+// pruneInterval is the cadence of the auth-event prune routine. Daily is plenty
+// for a table that grows at most a few events per connection per day; the first
+// prune fires after one interval so a freshly-started replica does not
+// immediately churn the DB.
+const pruneInterval = 24 * time.Hour
+
+// Handle owns the connection-OAuth token lifecycle and the goroutines behind it
+// (the auth-event prune routine, started by New, and the background refresh
+// loop, started by StartRefresher). The read accessors expose the token store,
+// auth-event store, and nil-safe writer that the platform's read paths and the
+// gateway / api-gateway toolkit wiring consume; Stop and Close are the shutdown
+// seam the platform wires into its own lifecycle.
+type Handle struct {
+	store      connoauth.Store
+	authEvents *authevents.PostgresStore
+	authWriter *authevents.Writer
+	refresher  *connoauth.Refresher
+}
+
+// New assembles the token store, the durable auth-event store and its nil-safe
+// writer, and starts the daily 90-day prune routine. It returns nil when db is
+// nil: the whole subsystem is a no-op without a database, matching the platform
+// precondition (the platform falls back to the legacy per-kind in-memory stores
+// in that case). enc may be nil (at-rest encryption disabled, dev-only) — it is
+// passed through only when non-nil so a typed-nil interface never reaches the
+// store's encryptor.
+func New(db *sql.DB, enc *fieldcrypt.RestFieldEncryptor) *Handle {
+	if db == nil {
+		return nil
+	}
+	// Guard the typed-nil-in-interface trap: connoauth.NewPostgresStore checks
+	// its FieldEncryptor argument against nil to select the noop fallback, so a
+	// nil *RestFieldEncryptor must arrive as an untyped nil, not an interface
+	// wrapping a nil pointer.
+	var fe connoauth.FieldEncryptor
+	if enc != nil {
+		fe = enc
+	}
+	authStore := authevents.NewPostgresStore(db)
+	authStore.StartPruneRoutine(pruneInterval, authEventsRetention)
+	return &Handle{
+		store:      connoauth.NewPostgresStore(db, fe),
+		authEvents: authStore,
+		authWriter: authevents.NewWriter(authStore, nil),
+	}
+}
+
+// StartRefresher builds and starts the background token-refresh loop. The caller
+// supplies the ConfigResolver (which depends on the per-kind OAuth handlers
+// wired after the store exists) and the AdvisoryLocker it has selected
+// (NoopLocker single-replica, PostgresLocker multi-replica), so this package
+// stays free of the replica-mode decision. No-op on a nil Handle, a nil
+// resolver, or a repeat call — the refresher is built once, so a second call
+// cannot leak the first loop's goroutine.
+func (h *Handle) StartRefresher(resolver connoauth.ConfigResolver, locker connoauth.AdvisoryLocker) {
+	if h == nil || h.store == nil || resolver == nil {
+		return
+	}
+	if h.refresher != nil {
+		return
+	}
+	h.refresher = connoauth.NewRefresher(
+		h.store, resolver, h.authWriter, locker,
+		connoauth.RefresherConfig{},
+	)
+	h.refresher.Start()
+}
+
+// Store returns the unified OAuth-token store backing connection_oauth_tokens,
+// or nil on a nil Handle (no database configured). Read by the admin unified
+// OAuth handler and, via toolkit OAuthKindHandlers, by per-kind Authenticators.
+func (h *Handle) Store() connoauth.Store {
+	if h == nil {
+		return nil
+	}
+	return h.store
+}
+
+// AuthEventStore returns the read-side handle for connection lifecycle events
+// (the admin OAuth History panel), or nil on a nil Handle. Returned as the
+// interface so callers stay off the concrete type.
+func (h *Handle) AuthEventStore() authevents.Store {
+	if h == nil || h.authEvents == nil {
+		return nil
+	}
+	return h.authEvents
+}
+
+// AuthEventWriter returns the writer wrapping the auth-event store. nil-safe by
+// contract: the Writer's methods short-circuit on a nil receiver, so every call
+// site can pass the result straight to a component without a nil-check.
+func (h *Handle) AuthEventWriter() *authevents.Writer {
+	if h == nil {
+		return nil
+	}
+	return h.authWriter
+}
+
+// Stop stops the background refresh loop, waiting up to ctx's deadline for an
+// in-flight refresh to settle before returning. No-op on a nil Handle or when
+// StartRefresher was never called. The caller owns the deadline (the platform
+// bounds it to fit the K8s termination grace period).
+func (h *Handle) Stop(ctx context.Context) error {
+	if h == nil || h.refresher == nil {
+		return nil
+	}
+	slog.Debug("connauth: stopping refresher")
+	if err := h.refresher.Stop(ctx); err != nil {
+		return fmt.Errorf("connauth: stop refresher: %w", err)
+	}
+	return nil
+}
+
+// Close stops the auth-event store's daily prune goroutine and waits for it.
+// No-op on a nil Handle or when no auth-event store was wired. Idempotent: the
+// underlying store's Close no-ops after the first call.
+func (h *Handle) Close() error {
+	if h == nil || h.authEvents == nil {
+		return nil
+	}
+	if err := h.authEvents.Close(); err != nil {
+		return fmt.Errorf("connauth: close auth-event store: %w", err)
+	}
+	return nil
+}

--- a/pkg/platform/connauth/connauth_test.go
+++ b/pkg/platform/connauth/connauth_test.go
@@ -1,0 +1,216 @@
+package connauth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"go.uber.org/goleak"
+
+	"github.com/txn2/mcp-data-platform/pkg/authevents"
+	"github.com/txn2/mcp-data-platform/pkg/connoauth"
+	"github.com/txn2/mcp-data-platform/pkg/platform/fieldcrypt"
+)
+
+// TestMain fails the package if any test leaks a goroutine. New starts the
+// auth-event prune routine and StartRefresher starts the refresh loop, so this
+// guards the shutdown contract: every Handle a test constructs must be Closed
+// and every started refresher Stopped.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+// stubResolver satisfies connoauth.ConfigResolver. ResolveConfig always returns
+// ErrConfigNotResolvable so the refresher's per-row processing is a no-op — the
+// Start/Stop scaffolding is exercised without a real IdP.
+type stubResolver struct{}
+
+func (stubResolver) ResolveConfig(_ context.Context, _ connoauth.Key) (connoauth.Config, error) {
+	return connoauth.Config{}, connoauth.ErrConfigNotResolvable
+}
+
+func (stubResolver) MaxLifetime(_ context.Context, _ connoauth.Key) time.Duration {
+	return 0
+}
+
+// newHandle builds a Handle over a sqlmock-backed *sql.DB and registers cleanup
+// that closes both the handle (reaping the prune goroutine) and the mock db.
+// The prune routine's first tick is 24h out, so the mock is never queried by it.
+func newHandle(t *testing.T) *Handle {
+	t.Helper()
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	h := New(db, nil)
+	t.Cleanup(func() {
+		_ = h.Close()
+		_ = db.Close()
+	})
+	return h
+}
+
+func TestNew_NilDBReturnsNil(t *testing.T) {
+	t.Parallel()
+	if h := New(nil, nil); h != nil {
+		t.Fatalf("New(nil db) = %v, want nil (no-op without a database)", h)
+	}
+}
+
+func TestNew_WiresStoreWriterAndAuthEventStore(t *testing.T) {
+	t.Parallel()
+	h := newHandle(t)
+	if h == nil {
+		t.Fatal("New with a db must return a non-nil handle")
+	}
+	if h.Store() == nil {
+		t.Error("Store() = nil, want the connection_oauth_tokens store")
+	}
+	if h.AuthEventStore() == nil {
+		t.Error("AuthEventStore() = nil, want the auth-event store")
+	}
+	if h.AuthEventWriter() == nil {
+		t.Error("AuthEventWriter() = nil, want a writer over the auth-event store")
+	}
+}
+
+func TestNew_WithEncryptorWiresStore(t *testing.T) {
+	t.Parallel()
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	// A non-nil encryptor exercises the pass-through branch (the store
+	// receives the platform's at-rest encryptor rather than the noop
+	// fallback). NewRestFieldEncryptor(nil) is a non-nil *RestFieldEncryptor.
+	h := New(db, fieldcrypt.NewRestFieldEncryptor(nil))
+	t.Cleanup(func() {
+		_ = h.Close()
+		_ = db.Close()
+	})
+	if h.Store() == nil {
+		t.Error("Store() = nil, want the encrypted-store handle")
+	}
+}
+
+func TestNilHandleAccessorsAreSafe(t *testing.T) {
+	t.Parallel()
+	var h *Handle
+	if h.Store() != nil {
+		t.Error("nil handle Store() must be nil")
+	}
+	if h.AuthEventStore() != nil {
+		t.Error("nil handle AuthEventStore() must be nil")
+	}
+	if h.AuthEventWriter() != nil {
+		t.Error("nil handle AuthEventWriter() must be nil")
+	}
+	// The nil-safe contract: even the nil writer's methods short-circuit.
+	h.AuthEventWriter().TokenDeletedAdmin(context.Background(), "k", "n", "actor")
+	// Stop / Close / StartRefresher must all no-op on a nil handle.
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("nil handle Stop() = %v, want nil", err)
+	}
+	if err := h.Close(); err != nil {
+		t.Errorf("nil handle Close() = %v, want nil", err)
+	}
+	h.StartRefresher(stubResolver{}, connoauth.NoopLocker{}) // must not panic
+}
+
+func TestAuthEventWriterIsNilSafe(t *testing.T) {
+	t.Parallel()
+	// Explicit nil *authevents.Writer confirms the platform contract that a
+	// writer returned from the handle can be used without nil-checks.
+	var w *authevents.Writer
+	w.TokenDeletedAdmin(context.Background(), "k", "n", "actor") // must not panic
+}
+
+func TestStartRefresher_NilResolverNoop(t *testing.T) {
+	t.Parallel()
+	h := newHandle(t)
+	h.StartRefresher(nil, connoauth.NoopLocker{})
+	if h.refresher != nil {
+		t.Error("nil resolver must not build a refresher")
+	}
+}
+
+func TestStartRefresher_StartStopRoundTrip(t *testing.T) {
+	t.Parallel()
+	h := newHandle(t)
+	h.StartRefresher(stubResolver{}, connoauth.NoopLocker{})
+	if h.refresher == nil {
+		t.Fatal("StartRefresher must build the refresh loop")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := h.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}
+
+func TestStartRefresher_IdempotentDoesNotLeak(t *testing.T) {
+	t.Parallel()
+	h := newHandle(t)
+	h.StartRefresher(stubResolver{}, connoauth.NoopLocker{})
+	first := h.refresher
+	// A second call must be a no-op: the refresher is built once, so the
+	// first loop's goroutine is not orphaned. goleak (TestMain) enforces this.
+	h.StartRefresher(stubResolver{}, connoauth.NoopLocker{})
+	if h.refresher != first {
+		t.Error("StartRefresher rebuilt the refresher on a repeat call")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := h.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}
+
+func TestStop_WrapsErrorWhenContextAlreadyDone(t *testing.T) {
+	// Not parallel: the refresher loop goroutine is left to wind down on its
+	// own (Stop canceled its context but returned before the loop closed done);
+	// TestMain's goleak check retries long enough for it to exit.
+	h := newHandle(t)
+	h.StartRefresher(stubResolver{}, connoauth.NoopLocker{})
+	// A pre-canceled wait context: Stop calls cancel() on the loop and then
+	// selects between the loop's done channel and ctx.Done(). done cannot have
+	// closed yet (the loop goroutine has not been scheduled), so the already-done
+	// ctx wins and Stop returns the wrapped error rather than a clean nil.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := h.Stop(ctx)
+	if err == nil {
+		t.Fatal("Stop with an already-canceled context must return the wrapped error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Stop error = %v, want a wrapped context.Canceled", err)
+	}
+}
+
+func TestStop_NoopWhenNeverStarted(t *testing.T) {
+	t.Parallel()
+	h := newHandle(t)
+	if err := h.Stop(context.Background()); err != nil {
+		t.Errorf("Stop with no refresher started = %v, want nil", err)
+	}
+}
+
+func TestClose_StopsPruneRoutineIdempotently(t *testing.T) {
+	t.Parallel()
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	h := New(db, nil)
+	// First Close reaps the prune goroutine; a second is a safe no-op.
+	if err := h.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := h.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}

--- a/pkg/platform/connoauth_lifecycle_test.go
+++ b/pkg/platform/connoauth_lifecycle_test.go
@@ -2,19 +2,21 @@ package platform
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
-	"github.com/txn2/mcp-data-platform/pkg/authevents"
+	"github.com/DATA-DOG/go-sqlmock"
+
 	"github.com/txn2/mcp-data-platform/pkg/connoauth"
 )
 
 // stubConfigResolver satisfies connoauth.ConfigResolver for the
-// lifecycle smoke tests below. ResolveConfig always returns
-// ErrConfigNotResolvable so the refresher's per-row processing is a
-// no-op and we exercise the Start/Stop scaffolding without needing a
-// real IdP.
+// platform-level delegation smoke tests below. ResolveConfig always
+// returns ErrConfigNotResolvable so the refresher's per-row processing
+// is a no-op and we exercise the Start/Stop scaffolding without needing
+// a real IdP. The connauth package owns the deeper refresher/prune
+// lifecycle tests; these assert only that the Platform methods delegate
+// through the connauth.Handle correctly.
 type stubConfigResolver struct{}
 
 func (stubConfigResolver) ResolveConfig(_ context.Context, _ connoauth.Key) (connoauth.Config, error) {
@@ -25,40 +27,70 @@ func (stubConfigResolver) MaxLifetime(_ context.Context, _ connoauth.Key) time.D
 	return 0
 }
 
-func TestStartConnOAuthRefresherNilStoreIsNoop(t *testing.T) {
+func TestStartConnOAuthRefresherNilHandleIsNoop(t *testing.T) {
 	t.Parallel()
+	// No connAuth handle (no DB) → StartConnOAuthRefresher must be a
+	// safe no-op and StopConnOAuthRefresher must report nothing to stop.
 	p := &Platform{}
 	p.StartConnOAuthRefresher(stubConfigResolver{}, false)
-	if p.connOAuthRefresher != nil {
-		t.Error("expected nil refresher when connOAuthStore is nil")
+	if err := p.StopConnOAuthRefresher(context.Background()); err != nil {
+		t.Errorf("Stop after no-op start = %v, want nil", err)
 	}
 }
 
 func TestStartConnOAuthRefresherNilResolverIsNoop(t *testing.T) {
 	t.Parallel()
-	p := &Platform{
-		connOAuthStore: connoauth.NewMemoryStore(),
-	}
+	p := &Platform{connAuth: newTestConnAuth(t)}
 	p.StartConnOAuthRefresher(nil, false)
-	if p.connOAuthRefresher != nil {
-		t.Error("expected nil refresher when resolver is nil")
+	// Nothing started; Stop is a clean no-op.
+	if err := p.StopConnOAuthRefresher(context.Background()); err != nil {
+		t.Errorf("Stop after nil-resolver start = %v, want nil", err)
 	}
 }
 
-func TestStartConnOAuthRefresherSucceeds(t *testing.T) {
+func TestStartConnOAuthRefresherSingleReplicaRoundTrip(t *testing.T) {
 	t.Parallel()
-	p := &Platform{
-		connOAuthStore:  connoauth.NewMemoryStore(),
-		authEventWriter: authevents.NewWriter(authevents.NewMemoryStore(), nil),
-	}
+	p := &Platform{connAuth: newTestConnAuth(t)}
 	p.StartConnOAuthRefresher(stubConfigResolver{}, false)
-	if p.connOAuthRefresher == nil {
-		t.Fatal("expected non-nil refresher")
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	if err := p.StopConnOAuthRefresher(ctx); err != nil {
 		t.Fatalf("StopConnOAuthRefresher: %v", err)
+	}
+}
+
+func TestStartConnOAuthRefresherMultiReplicaSelectsPostgresLocker(t *testing.T) {
+	t.Parallel()
+	// With multiReplica=true and a non-nil p.db, the platform selects the
+	// PostgresLocker branch (vs the NoopLocker default). We can't observe
+	// the locker from outside connauth, so this test exercises the branch
+	// for coverage and asserts the start/stop round-trip still succeeds.
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	p := &Platform{db: db, connAuth: newTestConnAuth(t)}
+	p.StartConnOAuthRefresher(stubConfigResolver{}, true)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := p.StopConnOAuthRefresher(ctx); err != nil {
+		t.Fatalf("StopConnOAuthRefresher: %v", err)
+	}
+}
+
+func TestStopConnOAuthRefresherSurfacesErrorOnCanceledContext(t *testing.T) {
+	t.Parallel()
+	// A started refresher plus an already-canceled context drives the error
+	// path: StopConnOAuthRefresher delegates to connAuth.Stop, whose wait races
+	// the (already-done) context against the loop's not-yet-closed done channel,
+	// so the wrapped ctx error propagates back through the exported method.
+	p := &Platform{connAuth: newTestConnAuth(t)}
+	p.StartConnOAuthRefresher(stubConfigResolver{}, false)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := p.StopConnOAuthRefresher(ctx); err == nil {
+		t.Error("StopConnOAuthRefresher with a canceled context must surface the error")
 	}
 }
 
@@ -80,37 +112,22 @@ func TestStopConnOAuthRefresherDuringShutdownNoopWhenNil(t *testing.T) {
 	}
 }
 
-func TestStopConnOAuthRefresherDuringShutdownReportsStopError(t *testing.T) {
+func TestStopConnOAuthRefresherDuringShutdownStopsStartedRefresher(t *testing.T) {
 	t.Parallel()
-	// Set up a refresher then immediately wrap with a context that
-	// expires so the Stop call surfaces a non-nil error path.
-	p := &Platform{
-		connOAuthStore:  connoauth.NewMemoryStore(),
-		authEventWriter: authevents.NewWriter(authevents.NewMemoryStore(), nil),
-	}
+	p := &Platform{connAuth: newTestConnAuth(t)}
 	p.StartConnOAuthRefresher(stubConfigResolver{}, false)
-	// Force Stop into ctx-cancel path by stopping a goroutine that
-	// the loop's defer hasn't drained yet — easier: use a fast
-	// timeout that should still succeed since the refresher loop
-	// exits quickly with the stub resolver. Just exercise the path.
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
 	var errs []error
-	// We don't strictly assert on the error here because the loop
-	// often exits within the timeout. The point of the test is to
-	// exercise the function's both branches in coverage.
-	_ = p.StopConnOAuthRefresher(ctx)
 	p.stopConnOAuthRefresherDuringShutdown(&errs)
-	// errs may or may not be populated depending on timing — either
-	// branch is legitimate platform behavior.
-	_ = errs
+	if len(errs) != 0 {
+		t.Errorf("expected clean shutdown, got %v", errs)
+	}
 }
 
-func TestAuthEventStoreNil(t *testing.T) {
+func TestAuthEventStoreNilWhenNoHandle(t *testing.T) {
 	t.Parallel()
 	p := &Platform{}
 	if got := p.AuthEventStore(); got != nil {
-		t.Errorf("AuthEventStore() with nil store = %v, want nil", got)
+		t.Errorf("AuthEventStore() with nil handle = %v, want nil", got)
 	}
 }
 
@@ -124,41 +141,14 @@ func TestCloseAuthEventStoreNoopWhenNil(t *testing.T) {
 	}
 }
 
-func TestAuthEventWriterNilSafe(t *testing.T) {
+func TestAuthEventWriterNilSafeWhenNoHandle(t *testing.T) {
 	t.Parallel()
 	p := &Platform{}
 	// Writer is nil — but the Writer's methods are nil-safe, so the
-	// nil return is still usable downstream.
-	if got := p.AuthEventWriter(); got != nil {
-		t.Errorf("AuthEventWriter() with no init = %v, want nil", got)
+	// nil return is still usable downstream without a nil-check.
+	w := p.AuthEventWriter()
+	if w != nil {
+		t.Errorf("AuthEventWriter() with no handle = %v, want nil", w)
 	}
-}
-
-func TestStartConnOAuthRefresherErrConfigNotResolvableDoesntPanic(t *testing.T) {
-	t.Parallel()
-	// Defensive: even if the resolver returns a wrapped sentinel,
-	// the Start path must not panic. The actual coverage of the
-	// processRow loop body comes from a tick, which we don't drive
-	// here.
-	p := &Platform{
-		connOAuthStore:  connoauth.NewMemoryStore(),
-		authEventWriter: authevents.NewWriter(authevents.NewMemoryStore(), nil),
-	}
-	resolver := wrappedResolver{}
-	p.StartConnOAuthRefresher(resolver, false)
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	if err := p.StopConnOAuthRefresher(ctx); err != nil {
-		t.Fatalf("Stop: %v", err)
-	}
-}
-
-type wrappedResolver struct{}
-
-func (wrappedResolver) ResolveConfig(_ context.Context, _ connoauth.Key) (connoauth.Config, error) {
-	return connoauth.Config{}, errors.New("wrapping ErrConfigNotResolvable was forgotten")
-}
-
-func (wrappedResolver) MaxLifetime(_ context.Context, _ connoauth.Key) time.Duration {
-	return 0
+	w.TokenDeletedAdmin(context.Background(), "k", "n", "actor") // must not panic
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -44,6 +44,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/oauth"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/platform/browserauth"
+	"github.com/txn2/mcp-data-platform/pkg/platform/connauth"
 	"github.com/txn2/mcp-data-platform/pkg/platform/dedup"
 	"github.com/txn2/mcp-data-platform/pkg/platform/exportadapters"
 	"github.com/txn2/mcp-data-platform/pkg/platform/fieldcrypt"
@@ -130,18 +131,20 @@ type Platform struct {
 	auditStore *auditpostgres.Store
 
 	// Config store
-	configStore        configstore.Store
-	fileDefaults       map[string]string
-	connectionStore    ConnectionStore
-	connectionSources  *ConnectionSourceMap
-	enrichmentStore    enrichment.Store
-	connOAuthStore     connoauth.Store
-	authEventStore     *authevents.PostgresStore
-	authEventWriter    *authevents.Writer
-	connOAuthRefresher *connoauth.Refresher
-	restEncryptor      *fieldcrypt.RestFieldEncryptor
-	personaStore       personastore.Store
-	apiKeyStore        APIKeyStore
+	configStore       configstore.Store
+	fileDefaults      map[string]string
+	connectionStore   ConnectionStore
+	connectionSources *ConnectionSourceMap
+	enrichmentStore   enrichment.Store
+	// connAuth owns the connection-OAuth token lifecycle (the unified
+	// connection_oauth_tokens store, the durable connection_auth_events store +
+	// nil-safe writer with its daily 90-day prune routine, and the background
+	// token-refresh loop) behind one handle. nil when no database is configured;
+	// the read accessors and shutdown helpers are all nil-safe.
+	connAuth      *connauth.Handle
+	restEncryptor *fieldcrypt.RestFieldEncryptor
+	personaStore  personastore.Store
+	apiKeyStore   APIKeyStore
 
 	// Providers
 	semanticProvider semantic.Provider
@@ -551,24 +554,13 @@ func (p *Platform) initConnectionStore(opts *Options) error {
 	p.restEncryptor = fieldcrypt.NewRestFieldEncryptor(encryptor)
 	p.connectionStore = NewPostgresConnectionStore(p.db, encryptor)
 	p.enrichmentStore = enrichment.NewPostgresStore(p.db)
-	p.connOAuthStore = connoauth.NewPostgresStore(p.db, p.restEncryptor)
-	// AuthEvents store + writer are wired alongside the connoauth
-	// store so every refresh / revocation / admin-deletion path can
-	// emit lifecycle events to the same database the tokens live in.
-	// The 90-day prune routine is started here too — daily cadence
-	// is plenty for a table that grows at most a few events per
-	// connection per day.
-	p.authEventStore = authevents.NewPostgresStore(p.db)
-	p.authEventWriter = authevents.NewWriter(p.authEventStore, nil)
-	p.authEventStore.StartPruneRoutine(24*time.Hour, authEventsRetention)
+	// The connection-OAuth token lifecycle (unified token store, durable
+	// auth-event store + writer, and its 90-day prune routine) is owned by
+	// connauth.Handle, assembled from the same *sql.DB and at-rest encryptor.
+	// The background refresher is started post-init via StartConnOAuthRefresher.
+	p.connAuth = connauth.New(p.db, p.restEncryptor)
 	return nil
 }
-
-// authEventsRetention is the retention window for connection_auth_events.
-// 90 days matches the documented contract in issue #395: operators can
-// always answer "what happened to this connection's tokens in the last
-// quarter" by reading the History panel.
-const authEventsRetention = 90 * 24 * time.Hour
 
 // ConnOAuthStore returns the unified OAuth-token store backing the
 // connection_oauth_tokens table. Used by the admin layer's unified
@@ -576,17 +568,14 @@ const authEventsRetention = 90 * 24 * time.Hour
 // Authenticators. Nil when no database is configured — the platform
 // falls back to the legacy per-kind in-memory stores in that case.
 func (p *Platform) ConnOAuthStore() connoauth.Store {
-	return p.connOAuthStore
+	return p.connAuth.Store()
 }
 
 // AuthEventStore returns the read-side handle for connection
 // lifecycle events. Used by the admin layer to render the OAuth
 // History panel. Nil when no database is configured.
 func (p *Platform) AuthEventStore() authevents.Store {
-	if p.authEventStore == nil {
-		return nil
-	}
-	return p.authEventStore
+	return p.connAuth.AuthEventStore()
 }
 
 // AuthEventWriter returns the writer wrapping AuthEventStore. nil-safe
@@ -594,7 +583,7 @@ func (p *Platform) AuthEventStore() authevents.Store {
 // nil-checks; the Writer methods short-circuit when the receiver is
 // nil. Wired into the admin handler and the toolkit auth paths.
 func (p *Platform) AuthEventWriter() *authevents.Writer {
-	return p.authEventWriter
+	return p.connAuth.AuthEventWriter()
 }
 
 // StartConnOAuthRefresher launches the background refresh loop with
@@ -607,28 +596,24 @@ func (p *Platform) AuthEventWriter() *authevents.Writer {
 // single-replica, PostgresLocker for multi-replica) keeps races out
 // of the IdP side.
 func (p *Platform) StartConnOAuthRefresher(resolver connoauth.ConfigResolver, multiReplica bool) {
-	if p.connOAuthStore == nil || resolver == nil {
+	if p.connAuth == nil || resolver == nil {
 		return
 	}
+	// The locker selection stays here because it depends on p.db and the
+	// replica mode; connauth takes the chosen locker so it stays free of that
+	// decision. NoopLocker for single-replica, PostgresLocker for multi-replica.
 	var locker connoauth.AdvisoryLocker = connoauth.NoopLocker{}
 	if multiReplica && p.db != nil {
 		locker = connoauth.NewPostgresLocker(p.db)
 	}
-	p.connOAuthRefresher = connoauth.NewRefresher(
-		p.connOAuthStore, resolver, p.authEventWriter, locker,
-		connoauth.RefresherConfig{},
-	)
-	p.connOAuthRefresher.Start()
+	p.connAuth.StartRefresher(resolver, locker)
 }
 
 // StopConnOAuthRefresher cancels the refresher loop. Called by the
 // lifecycle shutdown path so an in-flight refresh has up to ctx's
 // deadline to settle before the process exits.
 func (p *Platform) StopConnOAuthRefresher(ctx context.Context) error {
-	if p.connOAuthRefresher == nil {
-		return nil
-	}
-	if err := p.connOAuthRefresher.Stop(ctx); err != nil {
+	if err := p.connAuth.Stop(ctx); err != nil {
 		return fmt.Errorf("stop connoauth refresher: %w", err)
 	}
 	return nil
@@ -685,7 +670,8 @@ func (p *Platform) WireGatewayIntegrations() {
 // admin action. This is what makes auto-enabled gateway toolkits work
 // on a fresh boot.
 func (p *Platform) WireGatewayTokenStore() {
-	if p.connOAuthStore == nil {
+	store := p.connAuth.Store()
+	if store == nil {
 		return
 	}
 	for _, tk := range p.toolkitRegistry.All() {
@@ -694,8 +680,8 @@ func (p *Platform) WireGatewayTokenStore() {
 			// retry path's discoverFor builds Sources with the events
 			// writer already in place. The writer is nil-safe; events
 			// short-circuit when the writer is nil (dev with no DB).
-			gw.SetAuthEvents(p.authEventWriter)
-			gw.SetConnOAuthStore(p.connOAuthStore)
+			gw.SetAuthEvents(p.connAuth.AuthEventWriter())
+			gw.SetConnOAuthStore(store)
 		}
 	}
 }
@@ -742,15 +728,16 @@ func (n gatewayListChangedNotifier) NotifyToolsListChanged(ctx context.Context) 
 // toolkit's SetConnOAuthStore re-threads any already-materialized
 // authorization_code Authenticators.
 func (p *Platform) WireAPIGatewayTokenStore() {
-	if p.connOAuthStore == nil {
+	store := p.connAuth.Store()
+	if store == nil {
 		return
 	}
 	for _, tk := range p.toolkitRegistry.All() {
 		if api, ok := tk.(*apigatewaykit.Toolkit); ok {
 			// Audit writer FIRST so any subsequent refresh through the
 			// Authenticator emits lifecycle events.
-			api.SetAuthEvents(p.authEventWriter)
-			api.SetConnOAuthStore(p.connOAuthStore)
+			api.SetAuthEvents(p.connAuth.AuthEventWriter())
+			api.SetConnOAuthStore(store)
 		}
 	}
 }
@@ -3562,25 +3549,28 @@ func (p *Platform) closeMetricsLayer(errs *[]error) {
 // the exported StopConnOAuthRefresher so revive's confusing-naming
 // rule doesn't flag the differ-only-by-casing pair.
 func (p *Platform) stopConnOAuthRefresherDuringShutdown(errs *[]error) {
-	if p.connOAuthRefresher == nil {
+	if p.connAuth == nil {
 		return
 	}
+	// connauth.Stop is a no-op (and logs nothing) when no refresher was ever
+	// started, so this bounded stop stays silent unless there is a live loop to
+	// wind down.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	slog.Debug("shutdown: stopping connoauth refresher")
-	if err := p.connOAuthRefresher.Stop(ctx); err != nil {
-		*errs = append(*errs, fmt.Errorf("stop connoauth refresher: %w", err))
+	if err := p.connAuth.Stop(ctx); err != nil {
+		*errs = append(*errs, err)
 	}
 }
 
-// closeAuthEventStore stops the daily prune goroutine. Safe to call
-// when no AuthEventStore was wired (e.g., dev with no DB).
+// closeAuthEventStore stops the connection-auth prune goroutine via the
+// connauth handle's Close. Safe to call when no handle was wired (e.g.,
+// dev with no DB).
 func (p *Platform) closeAuthEventStore(errs *[]error) {
-	if p.authEventStore == nil {
+	if p.connAuth == nil {
 		return
 	}
 	slog.Debug("shutdown: closing auth event store")
-	closeResource(errs, p.authEventStore)
+	closeResource(errs, p.connAuth)
 }
 
 // closeSessionLayer tears down the session cache, session store,

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -18,11 +18,11 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/txn2/mcp-data-platform/pkg/auth"
-	"github.com/txn2/mcp-data-platform/pkg/connoauth"
 	"github.com/txn2/mcp-data-platform/pkg/embedding"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/platform/cfgmap"
+	"github.com/txn2/mcp-data-platform/pkg/platform/connauth"
 	"github.com/txn2/mcp-data-platform/pkg/platform/instructions"
 	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
 	"github.com/txn2/mcp-data-platform/pkg/platform/toolkitcfg"
@@ -2073,6 +2073,24 @@ func TestNew_NilToolkitsConfig(t *testing.T) {
 // (database-backed mode). The token-store retry semantics on
 // placeholders are owned by the gateway package's own tests
 // (TestSetTokenStore_RetriesAuthorizationCodePlaceholders).
+// newTestConnAuth builds a connauth.Handle over a sqlmock-backed *sql.DB so the
+// token-store wiring paths can be exercised without a live database. The prune
+// routine's first tick is 24h out, so the mock is never queried; cleanup closes
+// the handle (reaping the prune goroutine) and the mock db.
+func newTestConnAuth(t *testing.T) *connauth.Handle {
+	t.Helper()
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	h := connauth.New(db, nil)
+	t.Cleanup(func() {
+		_ = h.Close()
+		_ = db.Close()
+	})
+	return h
+}
+
 func TestPlatform_AutoEnabledGatewayReceivesTokenStore(t *testing.T) {
 	cfg := &Config{
 		Server:   ServerConfig{Name: testServerName},
@@ -2106,8 +2124,8 @@ func TestPlatform_AutoEnabledGatewayReceivesTokenStore(t *testing.T) {
 	// (b) WireGatewayTokenStore must be safe to call when the platform
 	// has no DB-backed connoauth store (stateless mode). Must not
 	// panic, must not error, must not crash on the nil store reference.
-	if p.connOAuthStore != nil {
-		t.Fatalf("expected nil connOAuthStore in test (no DB), got %T", p.connOAuthStore)
+	if p.connAuth != nil {
+		t.Fatalf("expected nil connAuth in test (no DB), got %v", p.connAuth)
 	}
 	p.WireGatewayTokenStore() // no-op path
 
@@ -2116,7 +2134,7 @@ func TestPlatform_AutoEnabledGatewayReceivesTokenStore(t *testing.T) {
 	// SetConnOAuthStore implementation is what handles placeholder
 	// retry — here we only assert the platform-level wiring delivers
 	// the store.
-	p.connOAuthStore = connoauth.NewMemoryStore()
+	p.connAuth = newTestConnAuth(t)
 	p.WireGatewayTokenStore() // wired path
 }
 
@@ -4904,18 +4922,17 @@ func TestWireAPIGatewayTokenStore(t *testing.T) {
 
 	// Pre-condition: no DB → connOAuthStore is nil → wire must be a
 	// safe no-op and leave the toolkit's store unset.
-	if p.connOAuthStore != nil {
-		t.Fatalf("expected nil connOAuthStore in test (no DB), got %T", p.connOAuthStore)
+	if p.connAuth != nil {
+		t.Fatalf("expected nil connAuth in test (no DB), got %v", p.connAuth)
 	}
 	p.WireAPIGatewayTokenStore()
 	if tk.ConnOAuthStore() != nil {
 		t.Error("WireAPIGatewayTokenStore set a store when platform store is nil")
 	}
 
-	// Now simulate the DB-backed mode: install a memory connoauth
-	// store and re-wire. Every api gateway toolkit must observe it.
-	want := connoauth.NewMemoryStore()
-	p.connOAuthStore = want
+	// Now simulate the DB-backed mode: install a connauth handle and
+	// re-wire. Every api gateway toolkit must observe its token store.
+	p.connAuth = newTestConnAuth(t)
 	p.WireAPIGatewayTokenStore()
 	if got := tk.ConnOAuthStore(); got == nil {
 		t.Fatal("WireAPIGatewayTokenStore did not deliver the store to the toolkit")
@@ -5031,7 +5048,7 @@ func TestWireAPIGatewayTokenStore_NoToolkit_NoOp(t *testing.T) {
 	}
 	defer func() { _ = p.Close() }()
 
-	p.connOAuthStore = connoauth.NewMemoryStore()
+	p.connAuth = newTestConnAuth(t)
 	p.WireAPIGatewayTokenStore() // no api toolkit registered → must not panic
 }
 

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -125,6 +125,7 @@ pkg/platform -> pkg/observability
 pkg/platform -> pkg/observability/proxy
 pkg/platform -> pkg/persona
 pkg/platform -> pkg/platform/browserauth
+pkg/platform -> pkg/platform/connauth
 pkg/platform -> pkg/platform/connsource
 pkg/platform -> pkg/platform/dedup
 pkg/platform -> pkg/platform/exportadapters
@@ -172,6 +173,9 @@ pkg/platform -> pkg/tuning
 pkg/platform -> pkg/urnbuild
 pkg/platform -> pkg/user
 pkg/platform/browserauth -> pkg/browsersession
+pkg/platform/connauth -> pkg/authevents
+pkg/platform/connauth -> pkg/connoauth
+pkg/platform/connauth -> pkg/platform/fieldcrypt
 pkg/platform/dedup -> pkg/middleware
 pkg/platform/exportadapters -> pkg/portal
 pkg/platform/exportadapters -> pkg/toolkits/apigateway


### PR DESCRIPTION
## Summary

Sixth seam of the Platform decomposition (#756), continuing after iam (#828), api-gateway route policy (#830), browser-session auth (#832), the OAuth 2.1 server (#834), and the index-jobs embedding queue (#836). Like #834 and #836, it advances the epic's **second goal** — folding a two-phase `Wire`/`Start`/`Stop` sequence into a lifecycle-owning package — and consolidates the **four** connection-OAuth token-lifecycle fields into one owner handle.

Fixes #838.

## What moved

A new `pkg/platform/connauth` package owns the connection-OAuth token lifecycle behind one `Handle`:

- **`New(db, enc)`** assembles the unified `connection_oauth_tokens` store (`pkg/connoauth`), the durable `connection_auth_events` store + its nil-safe `Writer` (`pkg/authevents`), and starts the daily 90-day prune routine. Returns `nil` when `db` is nil — the whole subsystem is a no-op without a database, matching the platform precondition.
- **`StartRefresher(resolver, locker)`** builds and starts the background token-refresh loop. Construction stays **two-phase** because the `connoauth.ConfigResolver` is only constructible after `main.go` wires the per-kind OAuth handlers.
- Read accessors **`Store()`**, **`AuthEventStore()`**, **`AuthEventWriter()`** plus a **`Stop`/`Close`** shutdown seam — all nil-safe.

The package imports `pkg/connoauth`, `pkg/authevents`, and `pkg/platform/fieldcrypt` — **not** `pkg/platform` (enforced by the regenerated import ratchet).

## Platform changes

`Platform` replaces four fields — `connOAuthStore`, `authEventStore`, `authEventWriter`, `connOAuthRefresher` — with one `connAuth *connauth.Handle`:

- `ConnOAuthStore()`, `AuthEventStore()`, `AuthEventWriter()`, `StartConnOAuthRefresher`, `StopConnOAuthRefresher`, `WireGatewayTokenStore`, `WireAPIGatewayTokenStore`, and the two shutdown helpers (`stopConnOAuthRefresherDuringShutdown`, `closeAuthEventStore`) now read through the handle.
- `StartConnOAuthRefresher` keeps the single- vs multi-replica locker selection (it depends on `p.db`), passing the chosen `connoauth.AdvisoryLocker` to the owner so the package stays free of that decision.
- `restEncryptor`, `connectionStore`, and `enrichmentStore` stay on `Platform`; `initConnectionStore` retains their assembly.

## Behaviour preserved

- No-op without a database (nil handle → nil-safe accessors and shutdown helpers).
- 90-day prune routine (`authEventsRetention`) still starts at construction.
- Nil-safe `AuthEventWriter()` contract (Writer methods short-circuit on a nil receiver).
- Multi-replica advisory-locker selection (`NoopLocker` single-replica, `PostgresLocker` multi-replica).
- Bounded (10s) refresher shutdown; prune-routine `Close`.
- Gateway / api-gateway `SetConnOAuthStore` + `SetAuthEvents` read paths.

## God-object budget

Platform loses three net fields: **74 → 71**. `TestPlatformGodObjectBudget` field ceiling ratcheted to 71.

## Testing

- New `pkg/platform/connauth` unit tests (goleak-guarded, 93.9% statement coverage): nil-db precondition, prune-routine start + idempotent `Close`, nil-safe accessors, refresher start/stop, `StartRefresher` idempotency (no orphaned goroutine), and a deterministic `Stop` error path via a pre-canceled context.
- Platform-level delegation tests updated to drive the handle (locker-selection boundary, shutdown, nil-safe writer, error propagation).
- Import ratchet regenerated.
- `make verify` green (tests + race, coverage ≥80%, patch coverage, lint, gosec, mutation, GoReleaser dry-run).

## Review

Ran a high-effort adversarial code review before committing: **no correctness bugs**. Three cleanup findings addressed — restored deterministic coverage of the shutdown error branch, moved the shutdown debug log into `connauth.Stop` so it no longer fires when no refresher was started, and rewrote a package-doc comment to state the contract rather than narrate the extraction.

Relates to #756.
