### PR TITLE
refactor(platform): extract portal store layer into pkg/platform/portalstore (#841)

### DIFF
--- a/godobject_budget_test.go
+++ b/godobject_budget_test.go
@@ -36,8 +36,12 @@ const (
 	// indexqueue.Handle, ratcheting 82 → 74; the connection-OAuth token
 	// lifecycle extraction (#838) folded four fields (connOAuthStore,
 	// authEventStore, authEventWriter, connOAuthRefresher) into one
-	// connauth.Handle, ratcheting 74 → 71.
-	maxPlatformFields = 71
+	// connauth.Handle, ratcheting 74 → 71; the portal-store-layer extraction
+	// (#841) folded eight fields (portalAssetStore, portalShareStore,
+	// portalVersionStore, portalCollectionStore, portalThreadStore,
+	// portalKnowledgePageStore, portalToolkit, portalS3Client) into one
+	// portalstore.Handle, ratcheting 71 → 64.
+	maxPlatformFields = 64
 
 	// maxPlatformMethods caps the number of methods with a *Platform receiver.
 	// Frozen at today's count; ratchet down as accessors move onto the

--- a/pkg/platform/apigateway_embed_jobs.go
+++ b/pkg/platform/apigateway_embed_jobs.go
@@ -83,9 +83,9 @@ func (p *Platform) WireAPIGatewayEmbedJobsFromDB() {
 		Consumers: indexqueue.Consumers{
 			Memory:               p.memoryStore != nil,
 			Prompts:              p.promptStore != nil,
-			PortalAssets:         p.portalAssetStore != nil,
-			PortalCollections:    p.portalCollectionStore != nil,
-			PortalKnowledgePages: p.portalKnowledgePageStore != nil,
+			PortalAssets:         p.portalStore.AssetStore() != nil,
+			PortalCollections:    p.portalStore.CollectionStore() != nil,
+			PortalKnowledgePages: p.portalStore.KnowledgePageStore() != nil,
 		},
 	})
 	if handle == nil {

--- a/pkg/platform/connections_tool.go
+++ b/pkg/platform/connections_tool.go
@@ -40,8 +40,8 @@ func (p *Platform) handleListConnections(ctx context.Context, _ *mcp.CallToolReq
 		src = p.connectionSources
 	}
 	var pages connview.PageLookup
-	if p.portalKnowledgePageStore != nil {
-		pages = p.portalKnowledgePageStore
+	if kp := p.portalStore.KnowledgePageStore(); kp != nil {
+		pages = kp
 	}
 
 	out := connview.Build(ctx, p.toolkitRegistry.All(), src, pages)

--- a/pkg/platform/export_adapters_apigateway_test.go
+++ b/pkg/platform/export_adapters_apigateway_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/txn2/mcp-data-platform/pkg/portal"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
 )
@@ -37,7 +36,7 @@ func TestWireAPIGatewayExport_DisabledByConfig(_ *testing.T) {
 func TestWireAPIGatewayExport_NoPortalSkips(_ *testing.T) {
 	p := &Platform{
 		config: &Config{Portal: PortalConfig{Export: PortalExportConfig{}}},
-		// portalS3Client and portalAssetStore both nil.
+		// portalStore is nil — no S3 client and no asset store.
 	}
 	// Must not panic; toolkitRegistry stays nil because we never
 	// reach the GetByKind call.
@@ -71,11 +70,8 @@ func TestWireAPIGatewayExport_ToolAppearsInToolList(t *testing.T) {
 				PublicBaseURL: "https://platform.example.com",
 			},
 		},
-		portalAssetStore:   portal.NewNoopAssetStore(),
-		portalVersionStore: portal.NewNoopVersionStore(),
-		portalShareStore:   portal.NewNoopShareStore(),
-		portalS3Client:     &apiNoopS3Client{},
-		toolkitRegistry:    r,
+		portalStore:     newTestPortalHandle(&apiNoopS3Client{}),
+		toolkitRegistry: r,
 	}
 
 	p.wireAPIGatewayExport()

--- a/pkg/platform/export_adapters_test.go
+++ b/pkg/platform/export_adapters_test.go
@@ -10,10 +10,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/txn2/mcp-data-platform/pkg/platform/portalstore"
 	"github.com/txn2/mcp-data-platform/pkg/portal"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	trinokit "github.com/txn2/mcp-data-platform/pkg/toolkits/trino"
 )
+
+// newTestPortalHandle builds a portalstore.Handle over noop stores for the
+// export-wiring tests. wireTrinoExport / wireAPIGatewayExport only check that
+// the accessors are non-nil and hand them to the export adapters, so noop
+// stores are sufficient. s3 may be nil to exercise the database-only guard.
+func newTestPortalHandle(s3 portal.S3Client) *portalstore.Handle {
+	return portalstore.NewFromStores(portalstore.Stores{
+		Asset:    portal.NewNoopAssetStore(),
+		Version:  portal.NewNoopVersionStore(),
+		Share:    portal.NewNoopShareStore(),
+		S3Client: s3,
+	}, nil, portalstore.Config{})
+}
 
 // stubShareStore is consumed by prompt_shared_serving_test.go.
 type stubShareStore struct {
@@ -87,11 +101,8 @@ func TestWireTrinoExport_ToolAppearsInToolList(t *testing.T) {
 				S3Prefix: "exports",
 			},
 		},
-		portalAssetStore:   portal.NewNoopAssetStore(),
-		portalVersionStore: portal.NewNoopVersionStore(),
-		portalShareStore:   portal.NewNoopShareStore(),
-		portalS3Client:     &noopS3Client{},
-		toolkitRegistry:    newTestRegistry(tk),
+		portalStore:     newTestPortalHandle(&noopS3Client{}),
+		toolkitRegistry: newTestRegistry(tk),
 	}
 
 	p.wireTrinoExport()
@@ -148,11 +159,8 @@ func TestWireTrinoExport_WithMultiConnectionToolkit(t *testing.T) {
 				S3Prefix: "artifacts",
 			},
 		},
-		portalAssetStore:   portal.NewNoopAssetStore(),
-		portalVersionStore: portal.NewNoopVersionStore(),
-		portalShareStore:   portal.NewNoopShareStore(),
-		portalS3Client:     &noopS3Client{},
-		toolkitRegistry:    newTestRegistry(multiTk),
+		portalStore:     newTestPortalHandle(&noopS3Client{}),
+		toolkitRegistry: newTestRegistry(multiTk),
 	}
 
 	p.wireTrinoExport()
@@ -174,11 +182,8 @@ func TestWireTrinoExport_SkipsWhenExplicitlyDisabled(t *testing.T) {
 				S3Bucket: "b",
 			},
 		},
-		portalAssetStore:   portal.NewNoopAssetStore(),
-		portalVersionStore: portal.NewNoopVersionStore(),
-		portalShareStore:   portal.NewNoopShareStore(),
-		portalS3Client:     &noopS3Client{},
-		toolkitRegistry:    newTestRegistry(tk),
+		portalStore:     newTestPortalHandle(&noopS3Client{}),
+		toolkitRegistry: newTestRegistry(tk),
 	}
 
 	p.wireTrinoExport()
@@ -191,9 +196,9 @@ func TestWireTrinoExport_SkipsWhenNoPortalS3(t *testing.T) {
 	defer tk.Close() //nolint:errcheck // test cleanup
 
 	p := &Platform{
-		config:           &Config{},
-		portalAssetStore: portal.NewNoopAssetStore(),
-		// portalS3Client is nil — no S3 configured
+		config: &Config{},
+		// S3 client is nil — no S3 configured; the asset store is still present.
+		portalStore:     newTestPortalHandle(nil),
 		toolkitRegistry: newTestRegistry(tk),
 	}
 
@@ -205,12 +210,9 @@ func TestWireTrinoExport_SkipsWhenNoPortalS3(t *testing.T) {
 
 func TestWireTrinoExport_SkipsWhenNoTrino(_ *testing.T) {
 	p := &Platform{
-		config:             &Config{Portal: PortalConfig{S3Bucket: "b"}},
-		portalAssetStore:   portal.NewNoopAssetStore(),
-		portalVersionStore: portal.NewNoopVersionStore(),
-		portalShareStore:   portal.NewNoopShareStore(),
-		portalS3Client:     &noopS3Client{},
-		toolkitRegistry:    registry.NewRegistry(), // empty — no trino
+		config:          &Config{Portal: PortalConfig{S3Bucket: "b"}},
+		portalStore:     newTestPortalHandle(&noopS3Client{}),
+		toolkitRegistry: registry.NewRegistry(), // empty — no trino
 	}
 
 	p.wireTrinoExport()

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -54,6 +54,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/platform/oauthserver"
 	"github.com/txn2/mcp-data-platform/pkg/platform/obs"
 	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
+	"github.com/txn2/mcp-data-platform/pkg/platform/portalstore"
 	"github.com/txn2/mcp-data-platform/pkg/platform/reflexivecapture"
 	"github.com/txn2/mcp-data-platform/pkg/platform/routepolicy"
 	"github.com/txn2/mcp-data-platform/pkg/platform/toolkitcfg"
@@ -80,7 +81,6 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/toolkits/gateway/enrichment"
 	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
 	memorykit "github.com/txn2/mcp-data-platform/pkg/toolkits/memory"
-	portalkit "github.com/txn2/mcp-data-platform/pkg/toolkits/portal"
 	searchkit "github.com/txn2/mcp-data-platform/pkg/toolkits/search"
 	trinokit "github.com/txn2/mcp-data-platform/pkg/toolkits/trino"
 	"github.com/txn2/mcp-data-platform/pkg/tuning"
@@ -218,19 +218,17 @@ type Platform struct {
 	// both a database connection and a configured embedding provider.
 	indexQueue *indexqueue.Handle
 
-	// Portal stores (exposed for REST API in Phase 3)
-	portalAssetStore         portal.AssetStore
-	portalShareStore         portal.ShareStore
-	portalVersionStore       portal.VersionStore
-	portalCollectionStore    portal.CollectionStore
-	portalThreadStore        portal.ThreadStore
-	portalKnowledgePageStore knowledgepage.Store
-	portalToolkit            *portalkit.Toolkit
-	portalS3Client           portal.S3Client
-	provenanceTracker        *middleware.ProvenanceTracker
-	resolvedBrandLogoSVG     string // cached SVG from portal.logo or mcpapps config
-	resolvedBrandURL         string // cached brand_url from mcpapps platform-info config
-	resolvedImplementorLogo  string // cached SVG fetched from portal.implementor.logo
+	// portalStore owns the asset-portal store layer: the five Postgres stores
+	// (asset, share, version, collection, thread), the knowledge-page store, the
+	// S3 blob backend, and the save/manage-artifact toolkit. nil until initPortal
+	// runs, which requires the portal enabled and a database connection. Read
+	// through its accessors by the Portal* accessors (admin/portal REST wiring),
+	// the trino/api export wiring, and the search/enrichment provider assembly.
+	portalStore             *portalstore.Handle
+	provenanceTracker       *middleware.ProvenanceTracker
+	resolvedBrandLogoSVG    string // cached SVG from portal.logo or mcpapps config
+	resolvedBrandURL        string // cached brand_url from mcpapps platform-info config
+	resolvedImplementorLogo string // cached SVG fetched from portal.implementor.logo
 
 	// Workflow gating
 	workflowTracker *middleware.SessionWorkflowTracker
@@ -379,8 +377,8 @@ func (p *Platform) initExtensions() error {
 	// same owns-or-edit access check as resolve_thread (the toolkit authorizes
 	// each thread before linking). Portal creates the toolkit, so this is wired
 	// after both init.
-	if p.memoryToolkit != nil && p.portalToolkit != nil {
-		p.memoryToolkit.SetThreadLinker(p.portalToolkit)
+	if p.memoryToolkit != nil && p.portalStore.Toolkit() != nil {
+		p.memoryToolkit.SetThreadLinker(p.portalStore.Toolkit())
 	}
 	// Unified knowledge read path (#632). Federates the stores initialized
 	// above (memory, insights, assets), so it must run after them.
@@ -1693,7 +1691,7 @@ func (p *Platform) storeSearchProviders() []knowledge.Provider {
 	}
 	// Canonical knowledge pages (the internal-knowledge home for business
 	// ontology) are shared and searchable over their full content.
-	if s, ok := p.portalKnowledgePageStore.(knowledge.PageSearcher); ok {
+	if s, ok := p.portalStore.KnowledgePageStore().(knowledge.PageSearcher); ok {
 		providers = append(providers, knowledge.NewKnowledgePagesProvider(s))
 	}
 	// Prompts are searchable and fetchable through the postgres prompt store
@@ -1702,12 +1700,12 @@ func (p *Platform) storeSearchProviders() []knowledge.Provider {
 		providers = append(providers, knowledge.NewPromptsProvider(s))
 	}
 	// Assets are searchable and fetchable only through the postgres asset store.
-	if s, ok := p.portalAssetStore.(knowledge.AssetSearcher); ok {
+	if s, ok := p.portalStore.AssetStore().(knowledge.AssetSearcher); ok {
 		providers = append(providers, knowledge.NewAssetsProvider(s))
 	}
 	// Feedback threads complete the search corpus (#686): a caller's own feedback
 	// becomes discoverable knowledge. Lexical and per-user (threads carry no embedding).
-	if s, ok := p.portalThreadStore.(knowledge.ThreadSearcher); ok {
+	if s, ok := p.portalStore.ThreadStore().(knowledge.ThreadSearcher); ok {
 		providers = append(providers, knowledge.NewThreadsProvider(s))
 	}
 	return providers
@@ -1756,9 +1754,9 @@ func (p *Platform) configureKnowledgeApply(tk *knowledgekit.Toolkit) error {
 
 	// #633 Goal 3: let apply promote business_knowledge/operational_rule captures
 	// to canonical knowledge pages. Built directly from the DB (not
-	// p.portalKnowledgePageStore) because initKnowledge runs before initPortal, so
-	// that field is not yet set here; apply requires the DB the changeset store
-	// already uses.
+	// p.portalStore.KnowledgePageStore()) because initKnowledge runs before
+	// initPortal, so the portal handle is not yet set here; apply requires the DB
+	// the changeset store already uses.
 	if p.db != nil {
 		tk.SetPageWriter(knowledgepage.NewPostgresStoreSearcher(p.db))
 	}
@@ -1803,15 +1801,9 @@ func (p *Platform) initPortal() error {
 		return nil
 	}
 
-	// Create stores
-	p.portalAssetStore = portal.NewPostgresAssetStore(p.db)
-	p.portalShareStore = portal.NewPostgresShareStore(p.db)
-	p.portalVersionStore = portal.NewPostgresVersionStore(p.db)
-	p.portalCollectionStore = portal.NewPostgresCollectionStore(p.db)
-	p.portalThreadStore = portal.NewPostgresThreadStore(p.db)
-	p.portalKnowledgePageStore = knowledgepage.NewPostgresStore(p.db)
-
-	// Create S3 client from referenced S3 connection
+	// Create S3 client from referenced S3 connection. Built here (Platform owns
+	// the toolkit config lookup) and passed into the owner; nil in database-only
+	// mode when no s3_connection is configured.
 	var s3Client portal.S3Client
 	if p.config.Portal.S3Connection != "" {
 		var clientErr error
@@ -1819,32 +1811,27 @@ func (p *Platform) initPortal() error {
 		if clientErr != nil {
 			return fmt.Errorf("creating portal S3 client: %w", clientErr)
 		}
-		p.portalS3Client = s3Client
 	} else {
 		slog.Warn("portal: no s3_connection configured; artifacts will be saved to database only")
 	}
 
-	// Create provenance tracker
+	// Assemble the portal store layer (six stores + S3 client + artifact
+	// toolkit) behind one handle from p.db + the resolved S3 client +
+	// embeddingProv (both stay owned by Platform).
+	p.portalStore = portalstore.New(p.db, s3Client, p.embeddingProv, portalstore.Config{
+		Name:           instanceDefault,
+		S3Bucket:       p.config.Portal.S3Bucket,
+		S3Prefix:       p.config.Portal.S3Prefix,
+		BaseURL:        p.config.Portal.PublicBaseURL,
+		MaxContentSize: p.config.Portal.MaxContentSize,
+	})
+
+	// provenanceTracker is a middleware primitive wired into the middleware
+	// chain, not a portal store; it stays on Platform.
 	p.provenanceTracker = middleware.NewProvenanceTracker()
 
-	// Create and register toolkit
-	tk := portalkit.New(portalkit.Config{
-		Name:            instanceDefault,
-		AssetStore:      p.portalAssetStore,
-		ShareStore:      p.portalShareStore,
-		VersionStore:    p.portalVersionStore,
-		CollectionStore: p.portalCollectionStore,
-		ThreadStore:     p.portalThreadStore,
-		S3Client:        s3Client,
-		S3Bucket:        p.config.Portal.S3Bucket,
-		S3Prefix:        p.config.Portal.S3Prefix,
-		BaseURL:         p.config.Portal.PublicBaseURL,
-		MaxContentSize:  p.config.Portal.MaxContentSize,
-		Embedder:        p.embeddingProv,
-	})
-	p.portalToolkit = tk
-
-	if err := p.toolkitRegistry.Register(tk); err != nil {
+	// Registration stays a Platform/registry concern.
+	if err := p.toolkitRegistry.Register(p.portalStore.Toolkit()); err != nil {
 		return fmt.Errorf("registering portal toolkit: %w", err)
 	}
 
@@ -1895,7 +1882,7 @@ func (p *Platform) wireTrinoExport() {
 		slog.Debug("trino_export: disabled by config")
 		return
 	}
-	if p.portalS3Client == nil || p.portalAssetStore == nil {
+	if p.portalStore.S3Client() == nil || p.portalStore.AssetStore() == nil {
 		slog.Debug("trino_export: portal S3 or asset store not configured, skipping")
 		return
 	}
@@ -1909,7 +1896,7 @@ func (p *Platform) wireTrinoExport() {
 	exportCfg := p.parseExportConfig()
 
 	trinoExporter := exportadapters.NewTrinoExporter(
-		p.portalAssetStore, p.portalVersionStore, p.portalShareStore, p.config.Portal.PublicBaseURL,
+		p.portalStore.AssetStore(), p.portalStore.VersionStore(), p.portalStore.ShareStore(), p.config.Portal.PublicBaseURL,
 	)
 
 	for _, tk := range trinoToolkits {
@@ -1920,7 +1907,7 @@ func (p *Platform) wireTrinoExport() {
 		trinoTk.SetExportDeps(trinokit.ExportDeps{
 			AssetStore:   trinoExporter,
 			VersionStore: trinoExporter,
-			S3Client:     p.portalS3Client,
+			S3Client:     p.portalStore.S3Client(),
 			ShareCreator: trinoExporter,
 			S3Bucket:     p.config.Portal.S3Bucket,
 			S3Prefix:     p.config.Portal.S3Prefix,
@@ -2493,7 +2480,7 @@ func (p *Platform) hasTrinoExport() bool {
 	if isExplicitlyDisabled(p.config.Portal.Export.Enabled) {
 		return false
 	}
-	if p.portalS3Client == nil || p.portalAssetStore == nil {
+	if p.portalStore.S3Client() == nil || p.portalStore.AssetStore() == nil {
 		return false
 	}
 	trinoToolkits := p.toolkitRegistry.GetByKind("trino")
@@ -2687,7 +2674,7 @@ func (p *Platform) addEnrichmentMiddleware() {
 			p.storageProvider,
 			enrichCfg,
 			mp,
-			knowledgePageProviders(p.portalKnowledgePageStore)...,
+			knowledgePageProviders(p.portalStore.KnowledgePageStore())...,
 		),
 	)
 }
@@ -3317,38 +3304,38 @@ func (p *Platform) KnowledgeDataHubWriter() knowledgekit.DataHubWriter {
 
 // PortalAssetStore returns the portal asset store, or nil if portal is disabled.
 func (p *Platform) PortalAssetStore() portal.AssetStore {
-	return p.portalAssetStore
+	return p.portalStore.AssetStore()
 }
 
 // PortalShareStore returns the portal share store, or nil if portal is disabled.
 func (p *Platform) PortalShareStore() portal.ShareStore {
-	return p.portalShareStore
+	return p.portalStore.ShareStore()
 }
 
 // PortalVersionStore returns the portal version store, or nil if portal is disabled.
 func (p *Platform) PortalVersionStore() portal.VersionStore {
-	return p.portalVersionStore
+	return p.portalStore.VersionStore()
 }
 
 // PortalCollectionStore returns the portal collection store, or nil if portal is disabled.
 func (p *Platform) PortalCollectionStore() portal.CollectionStore {
-	return p.portalCollectionStore
+	return p.portalStore.CollectionStore()
 }
 
 // PortalThreadStore returns the portal feedback thread store, or nil if portal is disabled.
 func (p *Platform) PortalThreadStore() portal.ThreadStore {
-	return p.portalThreadStore
+	return p.portalStore.ThreadStore()
 }
 
 // PortalKnowledgePageStore returns the canonical knowledge-page store, or nil
 // when the portal is disabled.
 func (p *Platform) PortalKnowledgePageStore() knowledgepage.Store {
-	return p.portalKnowledgePageStore
+	return p.portalStore.KnowledgePageStore()
 }
 
 // PortalS3Client returns the portal S3 client, or nil if portal is disabled.
 func (p *Platform) PortalS3Client() portal.S3Client {
-	return p.portalS3Client
+	return p.portalStore.S3Client()
 }
 
 // KnowledgeRouter returns the unified search federation, or nil when no
@@ -3620,10 +3607,7 @@ func (p *Platform) closeProvidersAndRegistry(errs *[]error) {
 	closeResource(errs, p.semanticProvider)
 	closeResource(errs, p.queryProvider)
 	closeResource(errs, p.storageProvider)
-	if p.portalS3Client != nil {
-		slog.Debug("shutdown: closing portal S3 client")
-		closeResource(errs, p.portalS3Client)
-	}
+	closeResource(errs, p.portalStore)
 	closeResource(errs, p.toolkitRegistry)
 }
 
@@ -3757,7 +3741,7 @@ func (p *Platform) wireAPIGatewayExport() {
 		slog.Debug("api_export: disabled by portal.export.enabled")
 		return
 	}
-	if p.portalS3Client == nil || p.portalAssetStore == nil {
+	if p.portalStore.S3Client() == nil || p.portalStore.AssetStore() == nil {
 		slog.Debug("api_export: portal S3 or asset store not configured, skipping")
 		return
 	}
@@ -3778,7 +3762,7 @@ func (p *Platform) wireAPIGatewayExport() {
 	}
 
 	apiExporter := exportadapters.NewAPIExporter(
-		p.portalAssetStore, p.portalVersionStore, p.portalShareStore, p.config.Portal.PublicBaseURL,
+		p.portalStore.AssetStore(), p.portalStore.VersionStore(), p.portalStore.ShareStore(), p.config.Portal.PublicBaseURL,
 	)
 
 	for _, tk := range apiToolkits {
@@ -3789,7 +3773,7 @@ func (p *Platform) wireAPIGatewayExport() {
 		apiTk.SetExportDeps(apigatewaykit.ExportDeps{
 			AssetStore:   apiExporter,
 			VersionStore: apiExporter,
-			S3Client:     p.portalS3Client,
+			S3Client:     p.portalStore.S3Client(),
 			ShareCreator: apiExporter,
 			S3Bucket:     p.config.Portal.S3Bucket,
 			S3Prefix:     p.config.Portal.S3Prefix,

--- a/pkg/platform/portalstore/portalstore.go
+++ b/pkg/platform/portalstore/portalstore.go
@@ -1,0 +1,212 @@
+// Package portalstore assembles the asset-portal store layer behind one Handle:
+// the five Postgres stores (asset, share, version, collection, thread), the
+// knowledge-page store, the S3 blob backend, and the save/manage-artifact
+// toolkit built on top of them.
+//
+// Construction takes explicit inputs — a *sql.DB, the resolved portal.S3Client
+// (or nil for database-only mode), the embedding.Provider that powers ranked
+// artifact search, and the toolkit's Config knobs — so the subsystem is
+// constructible and testable without a Platform. It imports pkg/portal,
+// pkg/portal/knowledgepage, and pkg/toolkits/portal, never pkg/platform. The
+// *sql.DB and embedding.Provider back many other subsystems, so they stay owned
+// by Platform and are passed in rather than owned here.
+//
+// Toolkit registration stays a Platform/registry concern: New builds the
+// toolkit and exposes it via Toolkit() for Platform to register into the shared
+// toolkit registry. The only resource this package owns for shutdown is the S3
+// client, closed via Close.
+package portalstore
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
+	"github.com/txn2/mcp-data-platform/pkg/portal"
+	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
+	portalkit "github.com/txn2/mcp-data-platform/pkg/toolkits/portal"
+)
+
+// Config carries the portal-toolkit knobs the owner needs to build the
+// save/manage-artifact toolkit. The stores themselves need only the *sql.DB;
+// these values shape the toolkit's blob addressing and artifact limits.
+type Config struct {
+	// Name is the toolkit instance name (the platform passes its default).
+	Name string
+	// S3Bucket / S3Prefix address the portal's blob backend; empty in
+	// database-only mode (no S3 client).
+	S3Bucket string
+	S3Prefix string
+	// BaseURL is the portal's public base URL used to render share links.
+	BaseURL string
+	// MaxContentSize caps artifact content size in bytes (0 = no limit).
+	MaxContentSize int
+}
+
+// Handle owns the assembled portal store layer: the six stores, the S3 blob
+// backend, and the artifact toolkit. The read accessors expose the stores +
+// S3 client that Platform surfaces through its Portal* accessors (the admin
+// REST handler and portal REST wiring) and that the cross-toolkit export wiring
+// and search/enrichment provider assembly consume; Toolkit() exposes the
+// artifact toolkit for registration and as the memory thread linker. Close is
+// the shutdown seam Platform wires into its own lifecycle (only the S3 client
+// needs closing — the stores share Platform's *sql.DB, which Platform closes).
+type Handle struct {
+	assetStore         portal.AssetStore
+	shareStore         portal.ShareStore
+	versionStore       portal.VersionStore
+	collectionStore    portal.CollectionStore
+	threadStore        portal.ThreadStore
+	knowledgePageStore knowledgepage.Store
+	s3Client           portal.S3Client
+	toolkit            *portalkit.Toolkit
+}
+
+// Stores bundles the six store implementations and the S3 blob client the
+// Handle owns. New builds these from a *sql.DB; NewFromStores assembles a Handle
+// from already-built implementations — the path New itself delegates to after
+// constructing the Postgres stores, and the seam that lets callers (and tests)
+// inject their own store implementations without a database.
+type Stores struct {
+	Asset         portal.AssetStore
+	Share         portal.ShareStore
+	Version       portal.VersionStore
+	Collection    portal.CollectionStore
+	Thread        portal.ThreadStore
+	KnowledgePage knowledgepage.Store
+	S3Client      portal.S3Client
+}
+
+// New assembles the six Postgres-backed stores and the artifact toolkit from an
+// explicit *sql.DB, the resolved S3 client (nil for database-only mode), the
+// embedding provider, and the toolkit Config. It returns nil when db is nil:
+// the portal is a no-op without a database, matching the platform precondition.
+func New(db *sql.DB, s3Client portal.S3Client, embedder embedding.Provider, cfg Config) *Handle {
+	if db == nil {
+		return nil
+	}
+	return NewFromStores(Stores{
+		Asset:         portal.NewPostgresAssetStore(db),
+		Share:         portal.NewPostgresShareStore(db),
+		Version:       portal.NewPostgresVersionStore(db),
+		Collection:    portal.NewPostgresCollectionStore(db),
+		Thread:        portal.NewPostgresThreadStore(db),
+		KnowledgePage: knowledgepage.NewPostgresStore(db),
+		S3Client:      s3Client,
+	}, embedder, cfg)
+}
+
+// NewFromStores assembles the Handle and its artifact toolkit from already-built
+// store implementations. New delegates here after constructing the Postgres
+// stores; it is also the entry point for assembling a Handle over injected store
+// implementations (fakes or alternative backends) without a *sql.DB.
+func NewFromStores(s Stores, embedder embedding.Provider, cfg Config) *Handle {
+	h := &Handle{
+		assetStore:         s.Asset,
+		shareStore:         s.Share,
+		versionStore:       s.Version,
+		collectionStore:    s.Collection,
+		threadStore:        s.Thread,
+		knowledgePageStore: s.KnowledgePage,
+		s3Client:           s.S3Client,
+	}
+	h.toolkit = portalkit.New(portalkit.Config{
+		Name:            cfg.Name,
+		AssetStore:      h.assetStore,
+		ShareStore:      h.shareStore,
+		VersionStore:    h.versionStore,
+		CollectionStore: h.collectionStore,
+		ThreadStore:     h.threadStore,
+		S3Client:        h.s3Client,
+		S3Bucket:        cfg.S3Bucket,
+		S3Prefix:        cfg.S3Prefix,
+		BaseURL:         cfg.BaseURL,
+		MaxContentSize:  cfg.MaxContentSize,
+		Embedder:        embedder,
+	})
+	return h
+}
+
+// AssetStore returns the portal asset store, or nil on a nil Handle (portal
+// disabled or no database).
+func (h *Handle) AssetStore() portal.AssetStore {
+	if h == nil {
+		return nil
+	}
+	return h.assetStore
+}
+
+// ShareStore returns the portal share store, or nil on a nil Handle.
+func (h *Handle) ShareStore() portal.ShareStore {
+	if h == nil {
+		return nil
+	}
+	return h.shareStore
+}
+
+// VersionStore returns the portal version store, or nil on a nil Handle.
+func (h *Handle) VersionStore() portal.VersionStore {
+	if h == nil {
+		return nil
+	}
+	return h.versionStore
+}
+
+// CollectionStore returns the portal collection store, or nil on a nil Handle.
+func (h *Handle) CollectionStore() portal.CollectionStore {
+	if h == nil {
+		return nil
+	}
+	return h.collectionStore
+}
+
+// ThreadStore returns the portal feedback-thread store, or nil on a nil Handle.
+func (h *Handle) ThreadStore() portal.ThreadStore {
+	if h == nil {
+		return nil
+	}
+	return h.threadStore
+}
+
+// KnowledgePageStore returns the canonical knowledge-page store, or nil on a
+// nil Handle.
+func (h *Handle) KnowledgePageStore() knowledgepage.Store {
+	if h == nil {
+		return nil
+	}
+	return h.knowledgePageStore
+}
+
+// S3Client returns the portal S3 blob backend, or nil on a nil Handle or in
+// database-only mode (no s3_connection configured).
+func (h *Handle) S3Client() portal.S3Client {
+	if h == nil {
+		return nil
+	}
+	return h.s3Client
+}
+
+// Toolkit returns the save/manage-artifact toolkit for Platform to register
+// into the shared toolkit registry and to wire as the memory thread linker, or
+// nil on a nil Handle.
+func (h *Handle) Toolkit() *portalkit.Toolkit {
+	if h == nil {
+		return nil
+	}
+	return h.toolkit
+}
+
+// Close closes the S3 blob backend. No-op on a nil Handle or in database-only
+// mode (no S3 client). The stores share Platform's *sql.DB, which Platform
+// closes, so they are not closed here.
+func (h *Handle) Close() error {
+	if h == nil || h.s3Client == nil {
+		return nil
+	}
+	slog.Debug("portalstore: closing portal S3 client")
+	if err := h.s3Client.Close(); err != nil {
+		return fmt.Errorf("portalstore: close S3 client: %w", err)
+	}
+	return nil
+}

--- a/pkg/platform/portalstore/portalstore_test.go
+++ b/pkg/platform/portalstore/portalstore_test.go
@@ -1,0 +1,218 @@
+package portalstore
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/txn2/mcp-data-platform/pkg/portal"
+)
+
+// fakeS3Client satisfies portal.S3Client and records whether Close was called
+// (and returns a configurable error) so the shutdown seam can be asserted.
+type fakeS3Client struct {
+	closed   bool
+	closeErr error
+}
+
+func (*fakeS3Client) PutObject(_ context.Context, _, _ string, _ []byte, _ string) error {
+	return nil
+}
+
+func (*fakeS3Client) PutObjectStream(_ context.Context, _, _ string, _ io.Reader, _ string) (int64, error) {
+	return 0, nil
+}
+
+func (*fakeS3Client) GetObject(_ context.Context, _, _ string) (data []byte, contentType string, err error) { //nolint:gocritic // named for clarity
+	return nil, "", nil
+}
+func (*fakeS3Client) DeleteObject(_ context.Context, _, _ string) error { return nil }
+
+func (f *fakeS3Client) Close() error {
+	f.closed = true
+	return f.closeErr
+}
+
+func TestNew_NilDBReturnsNil(t *testing.T) {
+	t.Parallel()
+	if h := New(nil, nil, nil, Config{}); h != nil {
+		t.Fatalf("New(nil db) = %v, want nil (no-op without a database)", h)
+	}
+}
+
+func TestNew_S3BackedWiresEveryStoreAndToolkit(t *testing.T) {
+	t.Parallel()
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	s3 := &fakeS3Client{}
+	h := New(db, s3, nil, Config{Name: "default", S3Bucket: "b", S3Prefix: "p", BaseURL: "https://x"})
+	if h == nil {
+		t.Fatal("New with a db must return a non-nil handle")
+	}
+	if h.AssetStore() == nil {
+		t.Error("AssetStore() = nil, want the postgres asset store")
+	}
+	if h.ShareStore() == nil {
+		t.Error("ShareStore() = nil, want the postgres share store")
+	}
+	if h.VersionStore() == nil {
+		t.Error("VersionStore() = nil, want the postgres version store")
+	}
+	if h.CollectionStore() == nil {
+		t.Error("CollectionStore() = nil, want the postgres collection store")
+	}
+	if h.ThreadStore() == nil {
+		t.Error("ThreadStore() = nil, want the postgres thread store")
+	}
+	if h.KnowledgePageStore() == nil {
+		t.Error("KnowledgePageStore() = nil, want the postgres knowledge-page store")
+	}
+	if h.S3Client() != portal.S3Client(s3) {
+		t.Error("S3Client() did not return the injected S3 client")
+	}
+	if h.Toolkit() == nil {
+		t.Error("Toolkit() = nil, want the assembled artifact toolkit for registration")
+	}
+	if got := h.Toolkit().Kind(); got != "portal" {
+		t.Errorf("Toolkit().Kind() = %q, want %q", got, "portal")
+	}
+}
+
+func TestNew_DatabaseOnlyLeavesS3Nil(t *testing.T) {
+	t.Parallel()
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// No S3 client (database-only mode): the stores must still be wired and the
+	// toolkit assembled, but S3Client() reports nil.
+	h := New(db, nil, nil, Config{Name: "default"})
+	if h == nil {
+		t.Fatal("New with a db must return a non-nil handle in database-only mode")
+	}
+	if h.AssetStore() == nil {
+		t.Error("AssetStore() = nil in database-only mode, want the postgres store")
+	}
+	if h.S3Client() != nil {
+		t.Error("S3Client() = non-nil in database-only mode, want nil")
+	}
+	if h.Toolkit() == nil {
+		t.Error("Toolkit() = nil in database-only mode, want the assembled toolkit")
+	}
+}
+
+func TestNewFromStores_AccessorsReturnInjectedStores(t *testing.T) {
+	t.Parallel()
+	asset := portal.NewNoopAssetStore()
+	share := portal.NewNoopShareStore()
+	version := portal.NewNoopVersionStore()
+	collection := portal.NewNoopCollectionStore()
+	// portal has no noop thread store; the postgres constructor just wraps the
+	// (here nil) *sql.DB and gives a distinct value to assert the accessor
+	// returns exactly what was injected. It is never queried in this test.
+	thread := portal.NewPostgresThreadStore(nil)
+	s3 := &fakeS3Client{}
+
+	h := NewFromStores(Stores{
+		Asset:      asset,
+		Share:      share,
+		Version:    version,
+		Collection: collection,
+		Thread:     thread,
+		S3Client:   s3,
+	}, nil, Config{Name: "default"})
+
+	if h.AssetStore() != asset {
+		t.Error("AssetStore() did not return the injected asset store")
+	}
+	if h.ShareStore() != share {
+		t.Error("ShareStore() did not return the injected share store")
+	}
+	if h.VersionStore() != version {
+		t.Error("VersionStore() did not return the injected version store")
+	}
+	if h.CollectionStore() != collection {
+		t.Error("CollectionStore() did not return the injected collection store")
+	}
+	if h.ThreadStore() != thread {
+		t.Error("ThreadStore() did not return the injected thread store")
+	}
+	if h.S3Client() != portal.S3Client(s3) {
+		t.Error("S3Client() did not return the injected S3 client")
+	}
+	if h.Toolkit() == nil {
+		t.Error("Toolkit() = nil, want the assembled toolkit")
+	}
+}
+
+func TestClose_ClosesS3Client(t *testing.T) {
+	t.Parallel()
+	s3 := &fakeS3Client{}
+	h := NewFromStores(Stores{S3Client: s3}, nil, Config{})
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close() = %v, want nil", err)
+	}
+	if !s3.closed {
+		t.Error("Close() did not close the S3 client")
+	}
+}
+
+func TestClose_PropagatesS3Error(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("boom")
+	s3 := &fakeS3Client{closeErr: wantErr}
+	h := NewFromStores(Stores{S3Client: s3}, nil, Config{})
+	if err := h.Close(); !errors.Is(err, wantErr) {
+		t.Errorf("Close() = %v, want it to wrap %v", err, wantErr)
+	}
+}
+
+func TestClose_DatabaseOnlyIsNoOp(t *testing.T) {
+	t.Parallel()
+	// No S3 client: Close has nothing to close and must not error.
+	h := NewFromStores(Stores{}, nil, Config{})
+	if err := h.Close(); err != nil {
+		t.Errorf("Close() with no S3 client = %v, want nil", err)
+	}
+}
+
+func TestNilHandle_AccessorsAndCloseAreSafe(t *testing.T) {
+	t.Parallel()
+	var h *Handle
+	if h.AssetStore() != nil {
+		t.Error("nil Handle AssetStore() != nil")
+	}
+	if h.ShareStore() != nil {
+		t.Error("nil Handle ShareStore() != nil")
+	}
+	if h.VersionStore() != nil {
+		t.Error("nil Handle VersionStore() != nil")
+	}
+	if h.CollectionStore() != nil {
+		t.Error("nil Handle CollectionStore() != nil")
+	}
+	if h.ThreadStore() != nil {
+		t.Error("nil Handle ThreadStore() != nil")
+	}
+	if h.KnowledgePageStore() != nil {
+		t.Error("nil Handle KnowledgePageStore() != nil")
+	}
+	if h.S3Client() != nil {
+		t.Error("nil Handle S3Client() != nil")
+	}
+	if h.Toolkit() != nil {
+		t.Error("nil Handle Toolkit() != nil")
+	}
+	if err := h.Close(); err != nil {
+		t.Errorf("nil Handle Close() = %v, want nil", err)
+	}
+}

--- a/pkg/platform/prompt_shared_serving_test.go
+++ b/pkg/platform/prompt_shared_serving_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/txn2/mcp-data-platform/pkg/platform/portalstore"
 	"github.com/txn2/mcp-data-platform/pkg/portal"
 	"github.com/txn2/mcp-data-platform/pkg/prompt"
 )
@@ -20,9 +21,11 @@ func TestSharedPrompt_VisibleAndRunnable(t *testing.T) {
 		ID: "p1", Name: "report", Scope: prompt.ScopePersonal,
 		OwnerEmail: "sarah@example.com", Content: "shared report {x}", Enabled: true,
 	}
-	p.portalShareStore = &stubShareStore{promptRefs: []portal.SharedPromptRef{
-		{PromptID: "p1", ShareID: "s1", SharedBy: "sarah@example.com", Permission: portal.PermissionViewer},
-	}}
+	p.portalStore = portalstore.NewFromStores(portalstore.Stores{
+		Share: &stubShareStore{promptRefs: []portal.SharedPromptRef{
+			{PromptID: "p1", ShareID: "s1", SharedBy: "sarah@example.com", Permission: portal.PermissionViewer},
+		}},
+	}, nil, portalstore.Config{})
 
 	ctx := context.Background()
 	// Bob (the recipient) sees it as shared-report.
@@ -52,9 +55,11 @@ func TestSharedPrompt_PromotedNotDoubleServed(t *testing.T) {
 		ID: "p1", Name: "report", Scope: prompt.ScopeGlobal, // promoted away from personal
 		OwnerEmail: "sarah@example.com", Content: "x", Enabled: true,
 	}
-	p.portalShareStore = &stubShareStore{promptRefs: []portal.SharedPromptRef{
-		{PromptID: "p1", ShareID: "s1", SharedBy: "sarah@example.com", Permission: portal.PermissionViewer},
-	}}
+	p.portalStore = portalstore.NewFromStores(portalstore.Stores{
+		Share: &stubShareStore{promptRefs: []portal.SharedPromptRef{
+			{PromptID: "p1", ShareID: "s1", SharedBy: "sarah@example.com", Permission: portal.PermissionViewer},
+		}},
+	}, nil, portalstore.Config{})
 
 	ctx := context.Background()
 	out := p.listVisiblePrompts(ctx, "bob@example.com", nil)

--- a/pkg/platform/prompts.go
+++ b/pkg/platform/prompts.go
@@ -497,10 +497,11 @@ func (p *Platform) listVisiblePrompts(ctx context.Context, email string, persona
 // shared prompts collide on bare name, the first (most recent share) wins so the
 // list and getDynamicPrompt agree.
 func (p *Platform) listSharedDescriptors(ctx context.Context, email string) []*mcp.Prompt {
-	if p.portalShareStore == nil {
+	share := p.portalStore.ShareStore()
+	if share == nil {
 		return nil
 	}
-	refs, err := p.portalShareStore.ListSharedPromptsWithUser(ctx, "", email)
+	refs, err := share.ListSharedPromptsWithUser(ctx, "", email)
 	if err != nil {
 		slog.Warn("failed to list shared prompts", logKeyError, err)
 		return nil
@@ -607,10 +608,11 @@ func (p *Platform) getDynamicPrompt(ctx context.Context, email string, personas 
 // bare name. The first matching active share wins (consistent with the dedup in
 // listSharedDescriptors).
 func (p *Platform) getSharedPrompt(ctx context.Context, email, bare string, args map[string]string) (*mcp.GetPromptResult, bool) {
-	if email == "" || p.portalShareStore == nil {
+	share := p.portalStore.ShareStore()
+	if email == "" || share == nil {
 		return nil, false
 	}
-	refs, err := p.portalShareStore.ListSharedPromptsWithUser(ctx, "", email)
+	refs, err := share.ListSharedPromptsWithUser(ctx, "", email)
 	if err != nil {
 		return nil, false
 	}

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -137,6 +137,7 @@ pkg/platform -> pkg/platform/mwchain
 pkg/platform -> pkg/platform/oauthserver
 pkg/platform -> pkg/platform/obs
 pkg/platform -> pkg/platform/personastore
+pkg/platform -> pkg/platform/portalstore
 pkg/platform -> pkg/platform/reflexivecapture
 pkg/platform -> pkg/platform/routepolicy
 pkg/platform -> pkg/platform/toolkitcfg
@@ -165,7 +166,6 @@ pkg/platform -> pkg/toolkits/gateway
 pkg/platform -> pkg/toolkits/gateway/enrichment
 pkg/platform -> pkg/toolkits/knowledge
 pkg/platform -> pkg/toolkits/memory
-pkg/platform -> pkg/toolkits/portal
 pkg/platform -> pkg/toolkits/search
 pkg/platform -> pkg/toolkits/tools/toolsindex
 pkg/platform -> pkg/toolkits/trino
@@ -201,6 +201,10 @@ pkg/platform/oauthserver -> pkg/oauth/postgres
 pkg/platform/oauthserver -> pkg/observability
 pkg/platform/obs -> pkg/observability
 pkg/platform/personastore -> pkg/persona
+pkg/platform/portalstore -> pkg/embedding
+pkg/platform/portalstore -> pkg/portal
+pkg/platform/portalstore -> pkg/portal/knowledgepage
+pkg/platform/portalstore -> pkg/toolkits/portal
 pkg/platform/reflexivecapture -> pkg/memory
 pkg/platform/reflexivecapture -> pkg/middleware
 pkg/platform/reflexivecapture -> pkg/toolkits/memory


### PR DESCRIPTION
## Summary

Seventh seam of the Platform decomposition (#756), continuing after iam (#828), api-gateway route policy (#830), browser-session auth (#832), the OAuth 2.1 server (#834), the index-jobs embedding queue (#836), and the connection-OAuth token lifecycle (#838).

This seam folds the **eight** portal-store-layer fields on `Platform` into one `portalstore.Handle` and moves the store / S3-client / toolkit assembly into a lifecycle-owning package. It is the largest remaining field cluster on `Platform`, and advances the epic's first goal: a per-subsystem assembly behind a constructor that declares its dependencies as parameters.

Closes #841.

## What moved

**New package `pkg/platform/portalstore`** assembles the portal store layer from explicit inputs and hides it behind one handle:

- `New(db *sql.DB, s3Client portal.S3Client, embedder embedding.Provider, cfg Config) *Handle` builds the five Postgres stores (asset, share, version, collection, thread), the knowledge-page store, and the save/manage-artifact toolkit. Returns `nil` when `db` is `nil` (the portal is a no-op without a database).
- `New` delegates to `NewFromStores(Stores, embedder, cfg)` — the assembly primitive that builds the toolkit over already-constructed store implementations. This is the path `New` uses after constructing the Postgres stores, and the seam that lets callers (and tests) inject their own store implementations without a `*sql.DB`, so the owner is **constructible/testable without a `Platform`**.
- Read accessors: `AssetStore()`, `ShareStore()`, `VersionStore()`, `CollectionStore()`, `ThreadStore()`, `KnowledgePageStore()`, `S3Client()`, `Toolkit()` — all nil-safe on a nil handle (portal disabled).
- `Close()` is the shutdown seam `Platform` wires into its lifecycle; it closes **only** the S3 client (the stores share `Platform`'s `*sql.DB`, which `Platform` closes). The portal toolkit's own `Close()` is a no-op, so this preserves the pre-existing single close of the S3 client.

The package imports `pkg/portal`, `pkg/portal/knowledgepage`, `pkg/toolkits/portal`, and `pkg/embedding` — **not** `pkg/platform`.

## Platform changes

- Eight fields (`portalAssetStore`, `portalShareStore`, `portalVersionStore`, `portalCollectionStore`, `portalThreadStore`, `portalKnowledgePageStore`, `portalToolkit`, `portalS3Client`) replaced by one `portalStore *portalstore.Handle`.
- The seven `Portal*Store` / `PortalS3Client` accessors, the `trino_export` / `api_export` wiring, the search/enrichment provider assembly, the `memory` thread-linker wiring, toolkit registration, and the shutdown S3-client close all read through the handle.
- `initPortal` keeps only what the issue scopes to `Platform`: it builds the S3 client (via `createPortalS3Client`, which stays on `Platform` because it owns the toolkit-config lookup), delegates store/toolkit assembly to the owner, constructs `provenanceTracker`, registers the toolkit into the shared `toolkitRegistry`, and runs `wireTrinoExport` / `wireAPIGatewayExport`.

## Stays on Platform (per issue scope)

- `provenanceTracker` — a middleware primitive wired into `MCPProvenanceMiddleware`, not a portal store.
- `resolvedBrandLogoSVG` / `resolvedBrandURL` / `resolvedImplementorLogo` — branding-resolution cache, a separate concern.
- `wireTrinoExport` / `wireAPIGatewayExport` — cross-toolkit wiring that reads the registry and mutates the trino / api-gateway toolkits; they read the portal stores through the handle.
- `p.db` and `p.embeddingProv` — shared primitives that back many subsystems; passed to the owner as explicit inputs, not owned by it.

## Behaviour preserved

- No-op when portal is explicitly disabled or no database is present (nil handle -> nil-safe accessors).
- Database-only mode when `portal.s3_connection` is unset (S3 client stays nil, existing startup warning retained).
- The `portalS3Client` shutdown close, the seven read accessors, the internal toolkit reads, and toolkit registration are unchanged.

## Tests

- New `portalstore` package unit tests (100% statement coverage): precondition no-op (nil db), S3-backed vs database-only construction, accessor wiring, toolkit assembly/registration, S3-client close (success + error propagation + database-only no-op), and nil-handle safety.
- Existing platform-side export-wiring and shared-prompt-serving tests migrated to build the handle via `NewFromStores` (injecting noop / stub stores) instead of setting fields directly.

## Ratchets

- `TestPlatformGodObjectBudget` field ceiling lowered **71 -> 64** (verified exact count 64).
- Import ratchet (`testdata/allowed_internal_imports.txt`) regenerated: adds `pkg/platform -> pkg/platform/portalstore` and the owner's four edges; drops the now-unused `pkg/platform -> pkg/toolkits/portal`.

## Verification

`make verify` green (gofmt, race tests, coverage >=80%, patch coverage, lint parity via `--new-from-rev`, gosec/govulncheck, semgrep, CodeQL, dead-code, mutation >=60%, GoReleaser dry-run).

Relates to #756.