### PR TITLE
refactor(platform): extract session / cross-replica-sync layer into pkg/platform/sessionsync (#843)

### DIFF
--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -455,8 +455,8 @@ func buildRootHandler(mcpServer *mcp.Server, p *platform.Platform, hcfg httpConf
 			TTL:         p.Config().Sessions.TTL,
 			Broadcaster: p.Broadcaster(),
 		})
-		// Platform.Broadcaster() is non-nil after New (initBroadcaster
-		// wires postgres or memory). The "+ broadcaster" tag is part
+		// Platform.Broadcaster() is non-nil after New (the sessionsync
+		// layer wires postgres or memory). The "+ broadcaster" tag is part
 		// of the log line so operators can grep deployments where the
 		// session-aware handler is wired with the SSE long-poll path.
 		log.Println("Session-aware handler enabled (external session store + broadcaster)")

--- a/godobject_budget_test.go
+++ b/godobject_budget_test.go
@@ -40,8 +40,11 @@ const (
 	// (#841) folded eight fields (portalAssetStore, portalShareStore,
 	// portalVersionStore, portalCollectionStore, portalThreadStore,
 	// portalKnowledgePageStore, portalToolkit, portalS3Client) into one
-	// portalstore.Handle, ratcheting 71 → 64.
-	maxPlatformFields = 64
+	// portalstore.Handle, ratcheting 71 → 64; the session / cross-replica-sync
+	// extraction (#843) folded six fields (sessionStore, sessionCache,
+	// broadcaster, reloadBroadcaster, reloadBus, reloadCancel) into one
+	// sessionsync.Handle, ratcheting 64 → 59.
+	maxPlatformFields = 59
 
 	// maxPlatformMethods caps the number of methods with a *Platform receiver.
 	// Frozen at today's count; ratchet down as accessors move onto the

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -1795,7 +1795,7 @@ func (c *Config) validateSessions(errs []string) []string {
 		errs = append(errs, "database.dsn is required when sessions.store is \"database\"")
 	}
 	// BroadcastChannel only takes effect for database-backed sessions
-	// (initBroadcaster only consults it on the postgres path). Skip
+	// (the sessionsync broadcasters consult it only on the postgres path). Skip
 	// validation entirely on memory-store deployments so an operator
 	// who set the field experimentally and switched back to memory
 	// doesn't get blocked at startup over a value the platform will

--- a/pkg/platform/info_tool.go
+++ b/pkg/platform/info_tool.go
@@ -341,14 +341,15 @@ func sessionThreadingInstruction(sessionID string) string {
 // nothing) when handles are disabled or no session store is configured, so the
 // caller can omit the fields for a byte-identical legacy response.
 func (p *Platform) mintSessionHandle(ctx context.Context, persona string) (id, expiresAt string) {
-	if !p.config.Sessions.Handles.IsEnabled() || p.sessionStore == nil {
+	store := p.sessions.SessionStore()
+	if !p.config.Sessions.Handles.IsEnabled() || store == nil {
 		return "", ""
 	}
 	userID := ""
 	if pc := middleware.GetPlatformContext(ctx); pc != nil {
 		userID = pc.UserID
 	}
-	sess, err := session.MintHandle(ctx, p.sessionStore, userID, persona, p.config.Sessions.Handles.HandleTTL())
+	sess, err := session.MintHandle(ctx, store, userID, persona, p.config.Sessions.Handles.HandleTTL())
 	if err != nil {
 		slog.Error("platform_info: failed to mint session handle", "error", err)
 		return "", ""

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -57,6 +57,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/platform/portalstore"
 	"github.com/txn2/mcp-data-platform/pkg/platform/reflexivecapture"
 	"github.com/txn2/mcp-data-platform/pkg/platform/routepolicy"
+	"github.com/txn2/mcp-data-platform/pkg/platform/sessionsync"
 	"github.com/txn2/mcp-data-platform/pkg/platform/toolkitcfg"
 	"github.com/txn2/mcp-data-platform/pkg/portal"
 	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
@@ -72,7 +73,6 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
 	datahubsemantic "github.com/txn2/mcp-data-platform/pkg/semantic/datahub"
 	"github.com/txn2/mcp-data-platform/pkg/session"
-	sessionpostgres "github.com/txn2/mcp-data-platform/pkg/session/postgres"
 	"github.com/txn2/mcp-data-platform/pkg/storage"
 	s3storage "github.com/txn2/mcp-data-platform/pkg/storage/s3"
 	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
@@ -171,23 +171,13 @@ type Platform struct {
 	// Audit
 	auditLogger middleware.AuditLogger
 
-	// Session management
-	sessionStore session.Store
-	sessionCache *middleware.SessionEnrichmentCache
-	// broadcaster delivers server-pushed MCP notifications (e.g.
-	// notifications/tools/list_changed) to SSE long-poll subscribers.
-	// Memory-backed for single-replica / no-DB deployments;
-	// postgres-LISTEN/NOTIFY-backed when the session store is
-	// database-backed so all replicas see every event.
-	broadcaster session.Broadcaster
-
-	// reloadBroadcaster carries server-side cross-replica reload events
-	// (connection/catalog/persona/apikey) on a dedicated channel,
-	// separate from the client-facing broadcaster, so admin config
-	// changes propagate to every replica's in-memory state (issue #501).
-	reloadBroadcaster session.Broadcaster
-	reloadBus         *reloadBus
-	reloadCancel      context.CancelFunc
+	// Session management: the externalized session store, the
+	// enrichment-dedup cache, the client-facing MCP notification
+	// broadcaster, and the dedicated cross-replica reload bus all live
+	// behind one owner handle (issue #843). Built from p.db + resolved
+	// config in initSessions; the reload re-materialization handlers
+	// (reload*Local) stay on Platform and are injected into the owner.
+	sessions *sessionsync.Handle
 
 	// Tuning
 	ruleEngine    *tuning.RuleEngine
@@ -689,7 +679,7 @@ func (p *Platform) WireGatewayTokenStore() {
 // and wires either a postgres LISTEN/NOTIFY broadcaster or an
 // in-memory one.
 func (p *Platform) Broadcaster() session.Broadcaster {
-	return p.broadcaster
+	return p.sessions.Broadcaster()
 }
 
 // gatewayListChangedNotifier adapts session.Broadcaster onto
@@ -852,10 +842,11 @@ func (p *Platform) WireAPIGatewayRoutePolicy() {
 // call before or after RegisterTools — gateway toolkits read the
 // notifier atomically per call, so wiring order does not matter.
 func (p *Platform) WireGatewayBroadcaster() {
-	if p.broadcaster == nil {
+	b := p.sessions.Broadcaster()
+	if b == nil {
 		return
 	}
-	notifier := gatewayListChangedNotifier{b: p.broadcaster}
+	notifier := gatewayListChangedNotifier{b: b}
 	for _, tk := range p.toolkitRegistry.All() {
 		if gw, ok := tk.(*gatewaykit.Toolkit); ok {
 			gw.SetToolListChangedNotifier(notifier)
@@ -1230,18 +1221,13 @@ func (p *Platform) initAudit(opts *Options) error {
 	return nil
 }
 
-// initSessions initializes the session store based on configuration.
+// initSessions assembles the session / cross-replica-sync layer (session
+// store, enrichment-dedup cache, client broadcaster, reload bus) behind the
+// sessionsync owner handle. It resolves the platform's config defaults and
+// injects the reload re-materialization handlers (which stay on Platform), then
+// applies the owner's stateless-forcing signal to the SDK's streamable config.
+// The cache is built later in buildEnrichmentConfig via the handle's StartCache.
 func (p *Platform) initSessions(opts *Options) error {
-	if opts.SessionStore != nil {
-		p.sessionStore = opts.SessionStore
-		// initBroadcaster runs even when an injected SessionStore is
-		// supplied so that Broadcaster() always returns a non-nil value
-		// after Start (matching the doc contract). The session store
-		// override doesn't override the broadcaster.
-		p.initBroadcaster()
-		return nil
-	}
-
 	ttl := p.config.Sessions.TTL
 	if ttl == 0 {
 		ttl = defaultSessionTimeout
@@ -1251,85 +1237,29 @@ func (p *Platform) initSessions(opts *Options) error {
 		cleanupInterval = defaultCleanupInterval
 	}
 
-	switch p.config.Sessions.Store {
-	case SessionStoreDatabase:
-		if p.db == nil {
-			return fmt.Errorf("sessions.store is \"database\" but no database configured")
-		}
-		store := sessionpostgres.New(p.db, sessionpostgres.Config{TTL: ttl})
-		store.StartCleanupRoutine(cleanupInterval)
-		p.sessionStore = store
-		// Force stateless mode so the SDK skips its built-in session map.
+	handle, err := sessionsync.New(p.db, sessionsync.Config{
+		Store:            p.config.Sessions.Store,
+		TTL:              ttl,
+		CleanupInterval:  cleanupInterval,
+		DSN:              p.config.Database.DSN,
+		BroadcastChannel: p.config.Sessions.BroadcastChannel,
+	}, opts.SessionStore, sessionsync.ReloadHandlers{
+		Connection: p.reloadConnectionLocal,
+		Catalog:    p.reloadCatalogLocal,
+		Persona:    p.reloadPersonaLocal,
+		APIKey:     p.reloadAPIKeyLocal,
+	})
+	if err != nil {
+		return fmt.Errorf("init sessions: %w", err)
+	}
+	p.sessions = handle
+
+	// The database store bypasses the SDK's built-in session map; the owner
+	// reports this so Platform (which owns the config) applies it.
+	if handle.StatelessForced() {
 		p.config.Server.Streamable.Stateless = true
-		slog.Info("session store: database (stateless mode enabled)",
-			"ttl", ttl, "cleanup_interval", cleanupInterval)
-	case SessionStoreMemory, "":
-		store := session.NewMemoryStore(ttl)
-		store.StartCleanupRoutine(cleanupInterval)
-		p.sessionStore = store
-		slog.Info("session store: memory",
-			"ttl", ttl, "cleanup_interval", cleanupInterval)
-	default:
-		return fmt.Errorf("unknown session store: %q", p.config.Sessions.Store)
 	}
-
-	p.initBroadcaster()
 	return nil
-}
-
-// initBroadcaster picks the right Broadcaster implementation based on
-// whether we have a database (postgres LISTEN/NOTIFY) or not (in-memory
-// fan-out for single-replica deployments). When postgres setup fails
-// we fall back to memory rather than failing platform startup —
-// tools/list_changed propagation is a UX feature, not a correctness
-// requirement, and the rest of the platform still works without it.
-func (p *Platform) initBroadcaster() {
-	wantPostgres := p.db != nil && p.config.Database.DSN != ""
-	if wantPostgres {
-		// Channel override lets operators isolate deployments that
-		// share a postgres instance — without it, both deployments
-		// would LISTEN on the same channel and cross-broadcast
-		// tools/list_changed to each other's downstream agents.
-		channel := p.config.Sessions.BroadcastChannel
-		if channel == "" {
-			channel = sessionpostgres.DefaultNotifyChannel
-			// Multiple deployments sharing a postgres instance with
-			// the default channel will cross-broadcast
-			// tools/list_changed events to each other's downstream
-			// agents. The doc tells operators to set the field per
-			// deployment when sharing a DB, but the most common
-			// operator error is forgetting to set it — surface a
-			// warning here so the misconfiguration is visible at
-			// startup rather than as a "tool list keeps changing
-			// on its own" mystery in production.
-			slog.Warn("broadcaster: using default channel; if multiple deployments share this postgres instance, set sessions.broadcast_channel per deployment to avoid cross-deployment fan-out",
-				"channel", channel)
-		}
-		b, err := sessionpostgres.NewBroadcaster(p.config.Database.DSN, p.db, channel, slog.Default())
-		if err == nil {
-			p.broadcaster = b
-			slog.Info("broadcaster: postgres LISTEN/NOTIFY",
-				"channel", channel)
-			p.initReloadBus()
-			return
-		}
-		// Fallback path: the operator configured postgres but
-		// NewBroadcaster failed (e.g., role lacks LISTEN privilege).
-		// Don't fail startup — tools/list_changed propagation is a
-		// UX feature, not a correctness requirement — but log
-		// distinguishably from the intentional single-replica path
-		// so log-grep operators can spot a degraded multi-replica
-		// deployment.
-		slog.Warn("broadcaster: postgres init failed — falling back to memory",
-			"error", err)
-	}
-	p.broadcaster = session.NewMemoryBroadcaster(slog.Default())
-	if wantPostgres {
-		slog.Info("broadcaster: memory (postgres unavailable, cross-replica fan-out disabled)")
-	} else {
-		slog.Info("broadcaster: memory (single-replica)")
-	}
-	p.initReloadBus()
 }
 
 // initOAuth initializes the OAuth server if enabled. It translates platform
@@ -2501,7 +2431,8 @@ func (p *Platform) addMCPAppsMiddleware() {
 // buildSessionResolver constructs the explicit session-handle resolver (#792),
 // or nil when handles are disabled (a valid no-op in MCPToolCallMiddleware).
 func (p *Platform) buildSessionResolver() *middleware.SessionResolver {
-	if !p.config.Sessions.Handles.IsEnabled() || p.sessionStore == nil {
+	store := p.sessions.SessionStore()
+	if !p.config.Sessions.Handles.IsEnabled() || store == nil {
 		return nil
 	}
 	metrics := p.obs.Metrics()
@@ -2510,7 +2441,7 @@ func (p *Platform) buildSessionResolver() *middleware.SessionResolver {
 	if p.config.SessionGate.Enabled {
 		exempt = p.config.SessionGate.ExemptTools
 	}
-	return middleware.NewSessionResolver(p.sessionStore, middleware.SessionResolverConfig{
+	return middleware.NewSessionResolver(store, middleware.SessionResolverConfig{
 		Enabled:     true,
 		Require:     p.config.Sessions.Handles.IsRequired(),
 		TTL:         p.config.Sessions.Handles.HandleTTL(),
@@ -2527,7 +2458,7 @@ func (p *Platform) buildSessionResolver() *middleware.SessionResolver {
 func (p *Platform) addSessionHandleSchemaMiddleware() {
 	// Same gate as buildSessionResolver: never advertise a session_id the platform
 	// neither issues nor validates.
-	if !p.config.Sessions.Handles.IsEnabled() || p.sessionStore == nil {
+	if !p.config.Sessions.Handles.IsEnabled() || p.sessions.SessionStore() == nil {
 		return
 	}
 	p.mcpServer.AddReceivingMiddleware(
@@ -2746,12 +2677,10 @@ func (p *Platform) buildEnrichmentConfig() middleware.EnrichmentConfig {
 	}
 
 	if p.config.Enrichment.SessionDedup.IsEnabled() {
-		p.sessionCache = middleware.NewSessionEnrichmentCache(
+		cfg.SessionCache = p.sessions.StartCache(
 			p.config.Enrichment.SessionDedup.EntryTTL,
 			p.config.Enrichment.SessionDedup.SessionTimeout,
 		)
-		p.sessionCache.StartCleanup(1 * time.Minute)
-		cfg.SessionCache = p.sessionCache
 		cfg.DedupMode = middleware.DedupMode(p.config.Enrichment.SessionDedup.EffectiveMode())
 
 		slog.Info("session metadata dedup enabled",
@@ -3086,7 +3015,7 @@ func (p *Platform) RuleEngine() *tuning.RuleEngine {
 
 // SessionStore returns the session store.
 func (p *Platform) SessionStore() session.Store {
-	return p.sessionStore
+	return p.sessions.SessionStore()
 }
 
 // OAuthServer returns the OAuth server, or nil if not enabled.
@@ -3560,25 +3489,13 @@ func (p *Platform) closeAuthEventStore(errs *[]error) {
 	closeResource(errs, p.connAuth)
 }
 
-// closeSessionLayer tears down the session cache, session store,
-// broadcaster, and OAuth store in that order. The broadcaster must
-// shut down before the database in Phase 4 because the postgres
-// broadcaster holds its own dedicated LISTEN connection.
+// closeSessionLayer tears down the session / cross-replica-sync layer and the
+// OAuth store in that order. The sessionsync handle closes the session cache,
+// session store, client broadcaster, and reload bus internally in the current
+// order; the broadcasters must shut down before the database in Phase 4 because
+// the postgres broadcasters hold their own dedicated LISTEN connections.
 func (p *Platform) closeSessionLayer(errs *[]error) {
-	if p.sessionCache != nil {
-		slog.Debug("shutdown: stopping session cache")
-		p.sessionCache.Stop()
-	}
-	if p.sessionStore != nil {
-		slog.Debug("shutdown: closing session store")
-		closeResource(errs, p.sessionStore)
-	}
-	if p.broadcaster != nil {
-		slog.Debug("shutdown: closing broadcaster")
-		closeResource(errs, p.broadcaster)
-	}
-	slog.Debug("shutdown: stopping reload bus")
-	p.stopReloadBus()
+	closeResource(errs, p.sessions)
 	if p.oauthHandle != nil {
 		slog.Debug("shutdown: closing OAuth server")
 		closeResource(errs, p.oauthHandle)
@@ -3647,11 +3564,13 @@ func (p *Platform) stopBackgroundTrackers() {
 // flushEnrichmentState persists enrichment dedup state from the session cache
 // to the session store for continuity across restarts.
 func (p *Platform) flushEnrichmentState() {
-	if p.sessionCache == nil || p.sessionStore == nil {
+	cache := p.sessions.SessionCache()
+	store := p.sessions.SessionStore()
+	if cache == nil || store == nil {
 		return
 	}
 
-	exported := p.sessionCache.ExportSessions()
+	exported := cache.ExportSessions()
 	if len(exported) == 0 {
 		return
 	}
@@ -3660,7 +3579,7 @@ func (p *Platform) flushEnrichmentState() {
 	flushed := 0
 	for sessionID, tables := range exported {
 		state := map[string]any{"enrichment_dedup": tables}
-		if err := p.sessionStore.UpdateState(ctx, sessionID, state); err != nil {
+		if err := store.UpdateState(ctx, sessionID, state); err != nil {
 			slog.Debug("shutdown: failed to flush enrichment state",
 				"session_id", sessionID, logKeyError, err)
 			continue
@@ -3673,12 +3592,14 @@ func (p *Platform) flushEnrichmentState() {
 // loadPersistedEnrichmentState restores enrichment dedup state from the
 // session store into the session cache on startup.
 func (p *Platform) loadPersistedEnrichmentState() {
-	if p.sessionCache == nil || p.sessionStore == nil {
+	cache := p.sessions.SessionCache()
+	store := p.sessions.SessionStore()
+	if cache == nil || store == nil {
 		return
 	}
 
 	ctx := context.Background()
-	sessions, err := p.sessionStore.List(ctx)
+	sessions, err := store.List(ctx)
 	if err != nil {
 		slog.Warn("failed to load persisted enrichment state", logKeyError, err)
 		return
@@ -3692,7 +3613,7 @@ func (p *Platform) loadPersistedEnrichmentState() {
 		}
 		tables := dedup.ParseState(dedupRaw)
 		if len(tables) > 0 {
-			p.sessionCache.LoadSession(sess.ID, tables)
+			cache.LoadSession(sess.ID, tables)
 			loaded++
 		}
 	}

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/platform/connauth"
 	"github.com/txn2/mcp-data-platform/pkg/platform/instructions"
 	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
+	"github.com/txn2/mcp-data-platform/pkg/platform/sessionsync"
 	"github.com/txn2/mcp-data-platform/pkg/platform/toolkitcfg"
 	"github.com/txn2/mcp-data-platform/pkg/query"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
@@ -2388,25 +2389,39 @@ func TestInitSessions_DatabaseWithoutDB(t *testing.T) {
 	}
 }
 
+// newTestSessions builds a sessionsync handle over an injected store with a
+// started enrichment cache, for the flush/load enrichment-state tests. The
+// returned cache is the same instance the handle exposes via SessionCache(), so
+// tests can populate it before exercising flushEnrichmentState. The handle is
+// closed via t.Cleanup (stopping its reload goroutine and closing the store).
+func newTestSessions(t *testing.T, store session.Store) (*sessionsync.Handle, *middleware.SessionEnrichmentCache) {
+	t.Helper()
+	h, err := sessionsync.New(nil, sessionsync.Config{}, store, sessionsync.ReloadHandlers{})
+	if err != nil {
+		t.Fatalf("sessionsync.New: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Close() })
+	cache := h.StartCache(5*time.Minute, 30*time.Minute)
+	return h, cache
+}
+
 func TestFlushEnrichmentState(t *testing.T) {
 	t.Run("nil cache or store is no-op", func(_ *testing.T) {
 		p := &Platform{}
 		p.flushEnrichmentState() // should not panic
 	})
 
-	t.Run("empty export is no-op", func(_ *testing.T) {
-		cache := middleware.NewSessionEnrichmentCache(5*time.Minute, 30*time.Minute)
+	t.Run("empty export is no-op", func(t *testing.T) {
 		store := session.NewMemoryStore(30 * time.Minute)
-		defer func() { _ = store.Close() }()
+		h, _ := newTestSessions(t, store)
 
-		p := &Platform{sessionCache: cache, sessionStore: store}
+		p := &Platform{sessions: h}
 		p.flushEnrichmentState() // nothing to flush
 	})
 
 	t.Run("flushes dedup state to store", func(t *testing.T) {
-		cache := middleware.NewSessionEnrichmentCache(5*time.Minute, 30*time.Minute)
 		store := session.NewMemoryStore(30 * time.Minute)
-		defer func() { _ = store.Close() }()
+		h, cache := newTestSessions(t, store)
 
 		// Create a session in the store
 		ctx := context.Background()
@@ -2422,7 +2437,7 @@ func TestFlushEnrichmentState(t *testing.T) {
 		// Mark table as sent in cache with token count
 		cache.MarkSent("flush-sess", "catalog.schema.users", 250)
 
-		p := &Platform{sessionCache: cache, sessionStore: store}
+		p := &Platform{sessions: h}
 		p.flushEnrichmentState()
 
 		// Verify state was persisted
@@ -2458,9 +2473,8 @@ func TestLoadPersistedEnrichmentState(t *testing.T) {
 	})
 
 	t.Run("loads dedup state from store", func(t *testing.T) {
-		cache := middleware.NewSessionEnrichmentCache(5*time.Minute, 30*time.Minute)
 		store := session.NewMemoryStore(30 * time.Minute)
-		defer func() { _ = store.Close() }()
+		h, cache := newTestSessions(t, store)
 
 		ctx := context.Background()
 		now := time.Now()
@@ -2477,7 +2491,7 @@ func TestLoadPersistedEnrichmentState(t *testing.T) {
 			t.Fatalf("create: %v", err)
 		}
 
-		p := &Platform{sessionCache: cache, sessionStore: store}
+		p := &Platform{sessions: h}
 		p.loadPersistedEnrichmentState()
 
 		// Verify cache was populated
@@ -2487,9 +2501,8 @@ func TestLoadPersistedEnrichmentState(t *testing.T) {
 	})
 
 	t.Run("skips sessions without dedup state", func(t *testing.T) {
-		cache := middleware.NewSessionEnrichmentCache(5*time.Minute, 30*time.Minute)
 		store := session.NewMemoryStore(30 * time.Minute)
-		defer func() { _ = store.Close() }()
+		h, cache := newTestSessions(t, store)
 
 		ctx := context.Background()
 		sess := &session.Session{
@@ -2501,7 +2514,7 @@ func TestLoadPersistedEnrichmentState(t *testing.T) {
 			t.Fatalf("create: %v", err)
 		}
 
-		p := &Platform{sessionCache: cache, sessionStore: store}
+		p := &Platform{sessions: h}
 		p.loadPersistedEnrichmentState()
 
 		if cache.SessionCount() != 0 {
@@ -2527,15 +2540,15 @@ func TestFlushLoadRoundTrip(t *testing.T) {
 	}
 
 	// Phase 1: populate cache and flush
-	cache1 := middleware.NewSessionEnrichmentCache(5*time.Minute, 30*time.Minute)
+	h1, cache1 := newTestSessions(t, store)
 	cache1.MarkSent("rt-sess", "catalog.schema.products", 350)
 
-	p1 := &Platform{sessionCache: cache1, sessionStore: store}
+	p1 := &Platform{sessions: h1}
 	p1.flushEnrichmentState()
 
 	// Phase 2: load into new cache
-	cache2 := middleware.NewSessionEnrichmentCache(5*time.Minute, 30*time.Minute)
-	p2 := &Platform{sessionCache: cache2, sessionStore: store}
+	h2, cache2 := newTestSessions(t, store)
+	p2 := &Platform{sessions: h2}
 	p2.loadPersistedEnrichmentState()
 
 	if !cache2.WasSentRecently("rt-sess", "catalog.schema.products") {
@@ -4657,8 +4670,8 @@ func (*noopResourceStore) Delete(_ context.Context, _ string) error             
 
 // TestBroadcaster_NonNilAfterNew proves Broadcaster() honors its
 // "always non-nil after New" contract — including the previously-buggy
-// path where opts.SessionStore was injected and initBroadcaster was
-// skipped, leaving the broadcaster nil.
+// path where opts.SessionStore was injected and the broadcaster wiring
+// was skipped, leaving the broadcaster nil.
 func TestBroadcaster_NonNilAfterNew(t *testing.T) {
 	cfg := &Config{
 		Server:   ServerConfig{Name: testServerName},
@@ -4677,8 +4690,8 @@ func TestBroadcaster_NonNilAfterNew(t *testing.T) {
 	}
 
 	// Inject a SessionStore and verify the broadcaster is still wired.
-	// Prior to the fix, this path early-returned in initSessions before
-	// initBroadcaster ran, leaving Broadcaster() nil.
+	// Prior to the fix, this path early-returned before the broadcaster
+	// was wired, leaving Broadcaster() nil.
 	p2, err := New(
 		WithConfig(cfg),
 		WithSessionStore(session.NewMemoryStore(time.Minute)),
@@ -4751,8 +4764,11 @@ func TestWireGatewayBroadcaster_NoBroadcaster(t *testing.T) {
 	}
 	defer func() { _ = p.Close() }()
 
-	// Force broadcaster nil to exercise the early-return.
-	p.broadcaster = nil
+	// Force the broadcaster nil (nil handle -> nil Broadcaster()) to
+	// exercise the early-return. Close the handle first so its reload and
+	// store-cleanup goroutines are torn down rather than orphaned by the nil.
+	_ = p.sessions.Close()
+	p.sessions = nil
 	p.WireGatewayBroadcaster() // must not panic
 }
 

--- a/pkg/platform/reload.go
+++ b/pkg/platform/reload.go
@@ -2,253 +2,21 @@ package platform
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"log/slog"
-	"os"
 
 	"github.com/txn2/mcp-data-platform/pkg/auth"
-	"github.com/txn2/mcp-data-platform/pkg/session"
-	sessionpostgres "github.com/txn2/mcp-data-platform/pkg/session/postgres"
 	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
 )
 
-// Reload event methods. These are internal control-plane signals carried
-// on a DEDICATED broadcaster channel, separate from the client-facing
-// tools/list_changed fan-out, so they are never written to an MCP
-// client's SSE stream. The "platform/reload/" prefix (not
-// "notifications/") makes the separation obvious in logs.
-const (
-	reloadMethodConnection = "platform/reload/connection"
-	reloadMethodCatalog    = "platform/reload/catalog" //nolint:gosec // event method name, not a credential
-	reloadMethodPersona    = "platform/reload/persona" //nolint:gosec // event method name, not a credential
-	reloadMethodAPIKey     = "platform/reload/apikey"  //nolint:gosec // event method name, not a credential
-)
-
-// reloadParamOrigin tags each reload event with the publishing replica's
-// instance id. The subscriber skips events whose origin matches its own
-// id: the replica that handled the admin write has already reloaded its
-// in-memory state synchronously, so re-applying its own broadcast would
-// be a redundant (though idempotent) rebuild.
-const reloadParamOrigin = "origin"
-
-// reloadHandlers carries the local re-materialization callbacks the
-// subscriber invokes when a peer replica announces a configuration
-// change. Any nil handler is treated as "this subsystem does not
-// participate in cross-replica reload yet" and the corresponding event
-// is ignored. Keeping the callbacks injected (rather than reaching into
-// Platform here) keeps the bus unit-testable in isolation.
-type reloadHandlers struct {
-	connection func(kind, name string)
-	catalog    func(catalogID string)
-	persona    func()
-	apiKey     func()
-}
-
-// reloadBus publishes and consumes cross-replica reload events over a
-// dedicated broadcaster channel. It is the server-side counterpart to
-// the client-facing notification path: when an operator changes
-// configuration through the admin API on one replica, that replica
-// reloads locally AND publishes a reload event here; every other replica
-// receives the event and re-materializes the affected in-memory state.
-//
-// Without this, a multi-replica deployment serves stale connection,
-// catalog, persona, and API-key state on every replica except the one
-// that handled the admin request (see issue #501).
-type reloadBus struct {
-	b        session.Broadcaster
-	origin   string
-	handlers reloadHandlers
-	logger   *slog.Logger
-}
-
-// newReloadBus builds a bus over b. origin is this replica's unique
-// instance id (used to skip self-published events). A nil logger falls
-// back to slog.Default().
-func newReloadBus(b session.Broadcaster, origin string, h reloadHandlers, logger *slog.Logger) *reloadBus {
-	if logger == nil {
-		logger = slog.Default()
-	}
-	return &reloadBus{b: b, origin: origin, handlers: h, logger: logger}
-}
-
-// publishConnection announces that the (kind, name) connection's stored
-// config changed and peers should rebuild it.
-func (rb *reloadBus) publishConnection(ctx context.Context, kind, name string) {
-	rb.publish(ctx, reloadMethodConnection, map[string]any{"kind": kind, "name": name})
-}
-
-// publishCatalog announces that an API catalog's specs changed and peers
-// should rebuild every connection that references it.
-func (rb *reloadBus) publishCatalog(ctx context.Context, catalogID string) {
-	rb.publish(ctx, reloadMethodCatalog, map[string]any{"catalog_id": catalogID})
-}
-
-// publishPersona announces that persona definitions changed and peers
-// should reconcile their persona registry from the store.
-func (rb *reloadBus) publishPersona(ctx context.Context) {
-	rb.publish(ctx, reloadMethodPersona, nil)
-}
-
-// publishAPIKey announces that API keys changed and peers should
-// re-sync their in-memory key set from the store.
-func (rb *reloadBus) publishAPIKey(ctx context.Context) {
-	rb.publish(ctx, reloadMethodAPIKey, nil)
-}
-
-func (rb *reloadBus) publish(ctx context.Context, method string, params map[string]any) {
-	if rb == nil || rb.b == nil {
-		return
-	}
-	if params == nil {
-		params = make(map[string]any, 1)
-	}
-	params[reloadParamOrigin] = rb.origin
-	if err := rb.b.Publish(ctx, session.Event{Method: method, Params: params}); err != nil {
-		// Best-effort: a failed publish means peers miss this one change
-		// until their next restart or a later successful publish. Log so
-		// a degraded reload channel is visible rather than silent.
-		rb.logger.Warn("reload-bus: publish failed", "method", method, "error", err)
-	}
-}
-
-// run subscribes to the reload channel and dispatches events until ctx is
-// canceled. Intended to be launched in its own goroutine at startup.
-func (rb *reloadBus) run(ctx context.Context) {
-	if rb == nil || rb.b == nil {
-		return
-	}
-	sub := rb.b.Subscribe(ctx, "reload-bus")
-	defer sub.Close()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case ev, ok := <-sub.Events():
-			if !ok {
-				return
-			}
-			rb.dispatch(ev)
-		}
-	}
-}
-
-// dispatch routes one reload event to the matching local handler. Events
-// published by this same replica are skipped (the handler already ran
-// synchronously on the write path).
-func (rb *reloadBus) dispatch(ev session.Event) {
-	if origin, _ := ev.Params[reloadParamOrigin].(string); origin == rb.origin {
-		return
-	}
-	switch ev.Method {
-	case reloadMethodConnection:
-		rb.dispatchConnection(ev)
-	case reloadMethodCatalog:
-		rb.dispatchCatalog(ev)
-	case reloadMethodPersona:
-		if rb.handlers.persona != nil {
-			rb.logger.Info("reload-bus: reloading personas from peer")
-			rb.handlers.persona()
-		}
-	case reloadMethodAPIKey:
-		if rb.handlers.apiKey != nil {
-			rb.logger.Info("reload-bus: reloading API keys from peer")
-			rb.handlers.apiKey()
-		}
-	default:
-		// Unknown method on the dedicated reload channel: ignore. This is
-		// the forward-compat path for a newer replica publishing a reload
-		// kind an older replica does not understand yet.
-	}
-}
-
-// dispatchConnection applies a peer's connection reload (kind/name).
-func (rb *reloadBus) dispatchConnection(ev session.Event) {
-	kind, _ := ev.Params["kind"].(string)
-	name, _ := ev.Params["name"].(string)
-	if rb.handlers.connection != nil && kind != "" && name != "" {
-		rb.logger.Info("reload-bus: reloading connection from peer", "kind", kind, "name", name)
-		rb.handlers.connection(kind, name)
-	}
-}
-
-// dispatchCatalog applies a peer's catalog reload (catalog_id).
-func (rb *reloadBus) dispatchCatalog(ev session.Event) {
-	id, _ := ev.Params["catalog_id"].(string)
-	if rb.handlers.catalog != nil && id != "" {
-		rb.logger.Info("reload-bus: reloading catalog connections from peer", "catalog_id", id)
-		rb.handlers.catalog(id)
-	}
-}
-
-// newReplicaOrigin returns a stable-per-process identifier used to tag
-// reload events so a replica skips its own broadcasts. Hostname plus a
-// random suffix keeps it unique even when two replicas share a hostname
-// (unlikely under k8s, but cheap insurance).
-func newReplicaOrigin() string {
-	host, _ := os.Hostname()
-	buf := make([]byte, 4)
-	_, _ = rand.Read(buf)
-	if host == "" {
-		host = "replica"
-	}
-	return host + "-" + hex.EncodeToString(buf)
-}
-
-// initReloadBus builds the dedicated cross-replica reload channel and
-// starts the subscriber. It uses a separate postgres LISTEN/NOTIFY
-// channel from the client-facing broadcaster (the configured channel
-// plus a "_reload" suffix) so internal control-plane events are never
-// written to an MCP client's SSE stream. On a single-replica or
-// db-less deployment it falls back to an in-memory broadcaster, where
-// publish/subscribe is a local no-op loop (harmless). Called at the end
-// of initBroadcaster so it shares the broadcaster lifecycle.
-func (p *Platform) initReloadBus() {
-	var b session.Broadcaster
-	if p.db != nil && p.config.Database.DSN != "" {
-		channel := p.config.Sessions.BroadcastChannel
-		if channel == "" {
-			channel = sessionpostgres.DefaultNotifyChannel
-		}
-		reloadChannel := channel + "_reload"
-		pb, err := sessionpostgres.NewBroadcaster(p.config.Database.DSN, p.db, reloadChannel, slog.Default())
-		if err == nil {
-			b = pb
-			slog.Info("reload-bus: postgres LISTEN/NOTIFY", "channel", reloadChannel)
-		} else {
-			// Degraded: cross-replica reload is disabled, but the platform
-			// still runs. Operators on a multi-replica deployment must
-			// restart pods after admin config changes until this is fixed.
-			slog.Warn("reload-bus: postgres init failed — cross-replica reload disabled, restart pods after admin changes",
-				"error", err)
-		}
-	}
-	if b == nil {
-		b = session.NewMemoryBroadcaster(slog.Default())
-	}
-	p.reloadBroadcaster = b
-	p.reloadBus = newReloadBus(b, newReplicaOrigin(), reloadHandlers{
-		connection: p.reloadConnectionLocal,
-		catalog:    p.reloadCatalogLocal,
-		persona:    p.reloadPersonaLocal,
-		apiKey:     p.reloadAPIKeyLocal,
-	}, slog.Default())
-
-	ctx, cancel := context.WithCancel(context.Background())
-	p.reloadCancel = cancel
-	go p.reloadBus.run(ctx)
-}
-
-// stopReloadBus cancels the subscriber and closes the reload broadcaster.
-func (p *Platform) stopReloadBus() {
-	if p.reloadCancel != nil {
-		p.reloadCancel()
-	}
-	if p.reloadBroadcaster != nil {
-		_ = p.reloadBroadcaster.Close()
-	}
-}
+// This file holds the reload re-materialization handlers and the public
+// reload-publish surface, both of which stay on Platform: the handlers reach
+// into Platform-owned state (connection store, toolkit registry, persona
+// registry, API-key store) and the Publish* methods are called by admin
+// handlers. The dedicated cross-replica reload BUS (its broadcaster channel and
+// the publish/subscribe machinery) lives in pkg/platform/sessionsync and is
+// reached through the sessions handle; the handlers are injected into it at
+// construction (issue #843).
 
 // reloadConnectionLocal re-materializes one connection on this replica
 // from the connection store. Used both by the reload subscriber (peer
@@ -313,31 +81,23 @@ func (p *Platform) reloadAPIKeyLocal() {
 }
 
 // PublishConnectionReload announces a connection config change to peer
-// replicas. Implements admin.ReloadNotifier. Safe when the bus is nil.
+// replicas. Implements admin.ReloadNotifier. Safe when the layer is nil.
 func (p *Platform) PublishConnectionReload(kind, name string) {
-	if p.reloadBus != nil {
-		p.reloadBus.publishConnection(context.Background(), kind, name)
-	}
+	p.sessions.PublishConnectionReload(context.Background(), kind, name)
 }
 
 // PublishPersonaReload announces a persona change to peer replicas.
 func (p *Platform) PublishPersonaReload() {
-	if p.reloadBus != nil {
-		p.reloadBus.publishPersona(context.Background())
-	}
+	p.sessions.PublishPersonaReload(context.Background())
 }
 
 // PublishAPIKeyReload announces an API-key change to peer replicas.
 func (p *Platform) PublishAPIKeyReload() {
-	if p.reloadBus != nil {
-		p.reloadBus.publishAPIKey(context.Background())
-	}
+	p.sessions.PublishAPIKeyReload(context.Background())
 }
 
 // PublishCatalogReload announces an API-catalog spec change to peer
-// replicas. Implements admin.ReloadNotifier. Safe when the bus is nil.
+// replicas. Implements admin.ReloadNotifier. Safe when the layer is nil.
 func (p *Platform) PublishCatalogReload(catalogID string) {
-	if p.reloadBus != nil {
-		p.reloadBus.publishCatalog(context.Background(), catalogID)
-	}
+	p.sessions.PublishCatalogReload(context.Background(), catalogID)
 }

--- a/pkg/platform/reload_test.go
+++ b/pkg/platform/reload_test.go
@@ -2,14 +2,11 @@ package platform
 
 import (
 	"context"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/txn2/mcp-data-platform/pkg/auth"
 	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
-	"github.com/txn2/mcp-data-platform/pkg/session"
 	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
 )
 
@@ -35,10 +32,11 @@ func (fakeAPIKeyStore) List(context.Context) ([]APIKeyDefinition, error) {
 func (fakeAPIKeyStore) Set(context.Context, APIKeyDefinition) error { return nil }
 func (fakeAPIKeyStore) Delete(context.Context, string) error        { return nil }
 
-// TestPlatform_ReloadWiring exercises the platform-level reload methods:
-// dedicated-bus init (memory fallback, no db), the connection/catalog
-// reloaders against a live api-gateway toolkit, the publish methods, and
-// shutdown. It is the coverage counterpart to the bus-core unit tests.
+// TestPlatform_ReloadWiring exercises the platform-level reload surface: the
+// sessions-handle assembly (memory fallback, no db) that carries the injected
+// reload handlers, the connection/catalog reloaders against a live api-gateway
+// toolkit, the publish delegators, and shutdown. The bus-core behavior (cross-
+// replica dispatch, self-origin skip) is covered in the sessionsync package.
 func TestPlatform_ReloadWiring(t *testing.T) {
 	reg := registry.NewRegistry()
 	apiTk := apigatewaykit.New("api")
@@ -54,9 +52,11 @@ func TestPlatform_ReloadWiring(t *testing.T) {
 		apiKeyAuth:      auth.NewAPIKeyAuthenticator(auth.APIKeyConfig{}),
 	}
 
-	p.initReloadBus() // no db -> in-memory broadcaster
-	if p.reloadBus == nil || p.reloadBroadcaster == nil {
-		t.Fatal("initReloadBus did not wire the bus")
+	if err := p.initSessions(&Options{}); err != nil { // no db -> in-memory store + broadcaster
+		t.Fatalf("initSessions: %v", err)
+	}
+	if p.sessions == nil || p.sessions.Broadcaster() == nil {
+		t.Fatal("initSessions did not assemble the session/reload layer")
 	}
 
 	// Reloaders against the live toolkit (rebuild from the fake store).
@@ -69,153 +69,16 @@ func TestPlatform_ReloadWiring(t *testing.T) {
 	p.reloadPersonaLocal()                    // reconcile personas from store
 	p.reloadAPIKeyLocal()                     // re-sync api keys from store
 
-	// Publish methods (memory bus; no subscriber needed for coverage).
+	// Publish delegators (memory bus; no subscriber needed for coverage).
 	p.PublishConnectionReload("api", "c1")
 	p.PublishCatalogReload("cat-1")
 	p.PublishPersonaReload()
 	p.PublishAPIKeyReload()
 
-	if origin := newReplicaOrigin(); !strings.Contains(origin, "-") {
-		t.Errorf("origin %q lacks the hostname-suffix shape", origin)
+	if err := p.sessions.Close(); err != nil { // cancel subscriber + close broadcaster/store
+		t.Fatalf("sessions close: %v", err)
 	}
 
-	p.stopReloadBus() // cancel subscriber + close broadcaster
-
-	// Publish after stop must be safe (broadcaster closed).
+	// Publish after close must be safe (broadcaster closed).
 	p.PublishConnectionReload("api", "c1")
-}
-
-// recordingHandlers captures reload-handler invocations on buffered
-// channels so tests can assert delivery (or non-delivery) with a timeout.
-type recordingHandlers struct {
-	conn    chan [2]string
-	catalog chan string
-	persona chan struct{}
-	apiKey  chan struct{}
-}
-
-func newRecordingHandlers() recordingHandlers {
-	return recordingHandlers{
-		conn:    make(chan [2]string, 4),
-		catalog: make(chan string, 4),
-		persona: make(chan struct{}, 4),
-		apiKey:  make(chan struct{}, 4),
-	}
-}
-
-func (r recordingHandlers) handlers() reloadHandlers {
-	return reloadHandlers{
-		connection: func(kind, name string) { r.conn <- [2]string{kind, name} },
-		catalog:    func(id string) { r.catalog <- id },
-		persona:    func() { r.persona <- struct{}{} },
-		apiKey:     func() { r.apiKey <- struct{}{} },
-	}
-}
-
-// TestReloadBus_CrossReplica proves the core #501 fix: a reload published
-// by one replica is applied by the OTHER replica, and the publishing
-// replica skips its own event (it reloaded synchronously on the write
-// path). Two buses share one in-memory broadcaster, which is exactly how
-// the postgres broadcaster re-publishes a received NOTIFY locally, so
-// this is a faithful cross-replica simulation.
-func TestReloadBus_CrossReplica(t *testing.T) {
-	b := session.NewMemoryBroadcaster(nil)
-	defer func() { _ = b.Close() }()
-
-	recA := newRecordingHandlers()
-	recB := newRecordingHandlers()
-	busA := newReloadBus(b, "replica-a", recA.handlers(), nil)
-	busB := newReloadBus(b, "replica-b", recB.handlers(), nil)
-
-	ctx := t.Context()
-	go busA.run(ctx)
-	go busB.run(ctx)
-	// Let both subscriptions register before publishing.
-	waitForSubscribers(t, b, 2)
-
-	// Replica A handled the admin write and publishes the reload.
-	busA.publishConnection(t.Context(), "api", "Test API")
-
-	// Replica B must apply it.
-	select {
-	case got := <-recB.conn:
-		if got != [2]string{"api", "Test API"} {
-			t.Fatalf("replica B reloaded %v, want [api Test API]", got)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("replica B never received the connection reload (the #501 bug)")
-	}
-
-	// Replica A must NOT re-apply its own event (origin skip).
-	select {
-	case got := <-recA.conn:
-		t.Fatalf("replica A re-applied its own publish %v; should skip self-origin", got)
-	case <-time.After(150 * time.Millisecond):
-		// expected: no self-reload
-	}
-}
-
-// TestReloadBus_DispatchRouting proves each method routes to its handler.
-func TestReloadBus_DispatchRouting(t *testing.T) {
-	rec := newRecordingHandlers()
-	rb := newReloadBus(session.NewMemoryBroadcaster(nil), "self", rec.handlers(), nil)
-
-	rb.dispatch(session.Event{Method: reloadMethodCatalog, Params: map[string]any{"catalog_id": "cat-1", reloadParamOrigin: "peer"}})
-	rb.dispatch(session.Event{Method: reloadMethodConnection, Params: map[string]any{"kind": "mcp", "name": "up", reloadParamOrigin: "peer"}})
-	rb.dispatch(session.Event{Method: reloadMethodPersona, Params: map[string]any{reloadParamOrigin: "peer"}})
-	rb.dispatch(session.Event{Method: reloadMethodAPIKey, Params: map[string]any{reloadParamOrigin: "peer"}})
-
-	if got := <-rec.catalog; got != "cat-1" {
-		t.Errorf("catalog reload id=%q, want cat-1", got)
-	}
-	if got := <-rec.conn; got != [2]string{"mcp", "up"} {
-		t.Errorf("connection reload=%v, want [mcp up]", got)
-	}
-	if _, ok := <-rec.persona; !ok {
-		t.Error("persona reload not dispatched")
-	}
-	if _, ok := <-rec.apiKey; !ok {
-		t.Error("apikey reload not dispatched")
-	}
-}
-
-// TestReloadBus_SkipsSelfOrigin proves self-published events are ignored.
-func TestReloadBus_SkipsSelfOrigin(t *testing.T) {
-	rec := newRecordingHandlers()
-	rb := newReloadBus(session.NewMemoryBroadcaster(nil), "self", rec.handlers(), nil)
-	rb.dispatch(session.Event{Method: reloadMethodCatalog, Params: map[string]any{"catalog_id": "x", reloadParamOrigin: "self"}})
-	select {
-	case <-rec.catalog:
-		t.Fatal("self-origin event must be skipped")
-	default:
-	}
-}
-
-// TestReloadBus_NilHandlerAndUnknownMethod proves a missing handler or an
-// unknown method is a safe no-op (forward compatibility).
-func TestReloadBus_NilHandlerAndUnknownMethod(_ *testing.T) {
-	rb := newReloadBus(session.NewMemoryBroadcaster(nil), "self", reloadHandlers{}, nil)
-	rb.dispatch(session.Event{Method: reloadMethodConnection, Params: map[string]any{"kind": "api", "name": "x", reloadParamOrigin: "peer"}})
-	rb.dispatch(session.Event{Method: "platform/reload/future", Params: map[string]any{reloadParamOrigin: "peer"}})
-	// Reaching here without panic is the assertion.
-}
-
-// TestReloadBus_NilBusPublishSafe proves a nil/disabled bus publish is a
-// no-op (single-replica deployments with no broadcaster).
-func TestReloadBus_NilBusPublishSafe(t *testing.T) {
-	var rb *reloadBus
-	rb.publishConnection(t.Context(), "api", "x") // must not panic
-	rb = newReloadBus(nil, "self", reloadHandlers{}, nil)
-	rb.publishCatalog(t.Context(), "x") // nil broadcaster: must not panic
-}
-
-func waitForSubscribers(t *testing.T, b *session.MemoryBroadcaster, n int) {
-	t.Helper()
-	for range 100 {
-		if b.SubscriberCount() >= n {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatalf("subscribers did not reach %d", n)
 }

--- a/pkg/platform/session_handle_mint_test.go
+++ b/pkg/platform/session_handle_mint_test.go
@@ -13,9 +13,22 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
+	"github.com/txn2/mcp-data-platform/pkg/platform/sessionsync"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/session"
 )
+
+// mintSessionsHandle wraps an injected session store in a sessionsync handle
+// (memory broadcaster, no db) for the mint tests, closing it via t.Cleanup.
+func mintSessionsHandle(t *testing.T, store session.Store) *sessionsync.Handle {
+	t.Helper()
+	h, err := sessionsync.New(nil, sessionsync.Config{}, store, sessionsync.ReloadHandlers{})
+	if err != nil {
+		t.Fatalf("sessionsync.New: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Close() })
+	return h
+}
 
 // mintTestPlatform builds a minimal Platform wired with a memory session store
 // and the given handles config, sufficient to exercise handleInfo minting.
@@ -29,7 +42,7 @@ func mintTestPlatform(t *testing.T, handles SessionHandlesConfig) (*Platform, *s
 		},
 		personaRegistry: persona.NewRegistry(),
 		toolkitRegistry: registry.NewRegistry(),
-		sessionStore:    store,
+		sessions:        mintSessionsHandle(t, store),
 	}
 	return p, store
 }
@@ -107,7 +120,7 @@ func (failCreateStore) Create(context.Context, *session.Session) error {
 // handle-less response rather than failing the whole platform_info call.
 func TestHandleInfo_MintCreateErrorOmitsHandle(t *testing.T) {
 	p, _ := mintTestPlatform(t, SessionHandlesConfig{})
-	p.sessionStore = failCreateStore{session.NewMemoryStore(time.Hour)}
+	p.sessions = mintSessionsHandle(t, failCreateStore{session.NewMemoryStore(time.Hour)})
 
 	result, _, err := p.handleInfo(ctxWithUser("u"), nil)
 	require.NoError(t, err, "a mint failure must not fail platform_info")

--- a/pkg/platform/sessionsync/reload.go
+++ b/pkg/platform/sessionsync/reload.go
@@ -1,0 +1,180 @@
+package sessionsync
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"os"
+
+	"github.com/txn2/mcp-data-platform/pkg/session"
+)
+
+// Reload event methods. These are internal control-plane signals carried
+// on a DEDICATED broadcaster channel, separate from the client-facing
+// tools/list_changed fan-out, so they are never written to an MCP
+// client's SSE stream. The "platform/reload/" prefix (not
+// "notifications/") makes the separation obvious in logs.
+const (
+	reloadMethodConnection = "platform/reload/connection"
+	reloadMethodCatalog    = "platform/reload/catalog" //nolint:gosec // event method name, not a credential
+	reloadMethodPersona    = "platform/reload/persona" //nolint:gosec // event method name, not a credential
+	reloadMethodAPIKey     = "platform/reload/apikey"  //nolint:gosec // event method name, not a credential
+)
+
+// reloadParamOrigin tags each reload event with the publishing replica's
+// instance id. The subscriber skips events whose origin matches its own
+// id: the replica that handled the admin write has already reloaded its
+// in-memory state synchronously, so re-applying its own broadcast would
+// be a redundant (though idempotent) rebuild.
+const reloadParamOrigin = "origin"
+
+// reloadBus publishes and consumes cross-replica reload events over a
+// dedicated broadcaster channel. It is the server-side counterpart to
+// the client-facing notification path: when an operator changes
+// configuration through the admin API on one replica, that replica
+// reloads locally AND publishes a reload event here; every other replica
+// receives the event and re-materializes the affected in-memory state.
+//
+// Without this, a multi-replica deployment serves stale connection,
+// catalog, persona, and API-key state on every replica except the one
+// that handled the admin request (see issue #501).
+type reloadBus struct {
+	b        session.Broadcaster
+	origin   string
+	handlers ReloadHandlers
+	logger   *slog.Logger
+}
+
+// newReloadBus builds a bus over b. origin is this replica's unique
+// instance id (used to skip self-published events). A nil logger falls
+// back to slog.Default().
+func newReloadBus(b session.Broadcaster, origin string, h ReloadHandlers, logger *slog.Logger) *reloadBus {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &reloadBus{b: b, origin: origin, handlers: h, logger: logger}
+}
+
+// publishConnection announces that the (kind, name) connection's stored
+// config changed and peers should rebuild it.
+func (rb *reloadBus) publishConnection(ctx context.Context, kind, name string) {
+	rb.publish(ctx, reloadMethodConnection, map[string]any{"kind": kind, "name": name})
+}
+
+// publishCatalog announces that an API catalog's specs changed and peers
+// should rebuild every connection that references it.
+func (rb *reloadBus) publishCatalog(ctx context.Context, catalogID string) {
+	rb.publish(ctx, reloadMethodCatalog, map[string]any{"catalog_id": catalogID})
+}
+
+// publishPersona announces that persona definitions changed and peers
+// should reconcile their persona registry from the store.
+func (rb *reloadBus) publishPersona(ctx context.Context) {
+	rb.publish(ctx, reloadMethodPersona, nil)
+}
+
+// publishAPIKey announces that API keys changed and peers should
+// re-sync their in-memory key set from the store.
+func (rb *reloadBus) publishAPIKey(ctx context.Context) {
+	rb.publish(ctx, reloadMethodAPIKey, nil)
+}
+
+func (rb *reloadBus) publish(ctx context.Context, method string, params map[string]any) {
+	if rb == nil || rb.b == nil {
+		return
+	}
+	if params == nil {
+		params = make(map[string]any, 1)
+	}
+	params[reloadParamOrigin] = rb.origin
+	if err := rb.b.Publish(ctx, session.Event{Method: method, Params: params}); err != nil {
+		// Best-effort: a failed publish means peers miss this one change
+		// until their next restart or a later successful publish. Log so
+		// a degraded reload channel is visible rather than silent.
+		rb.logger.Warn("reload-bus: publish failed", "method", method, "error", err)
+	}
+}
+
+// run subscribes to the reload channel and dispatches events until ctx is
+// canceled. Intended to be launched in its own goroutine at startup.
+func (rb *reloadBus) run(ctx context.Context) {
+	if rb == nil || rb.b == nil {
+		return
+	}
+	sub := rb.b.Subscribe(ctx, "reload-bus")
+	defer sub.Close()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-sub.Events():
+			if !ok {
+				return
+			}
+			rb.dispatch(ev)
+		}
+	}
+}
+
+// dispatch routes one reload event to the matching local handler. Events
+// published by this same replica are skipped (the handler already ran
+// synchronously on the write path).
+func (rb *reloadBus) dispatch(ev session.Event) {
+	if origin, _ := ev.Params[reloadParamOrigin].(string); origin == rb.origin {
+		return
+	}
+	switch ev.Method {
+	case reloadMethodConnection:
+		rb.dispatchConnection(ev)
+	case reloadMethodCatalog:
+		rb.dispatchCatalog(ev)
+	case reloadMethodPersona:
+		if rb.handlers.Persona != nil {
+			rb.logger.Info("reload-bus: reloading personas from peer")
+			rb.handlers.Persona()
+		}
+	case reloadMethodAPIKey:
+		if rb.handlers.APIKey != nil {
+			rb.logger.Info("reload-bus: reloading API keys from peer")
+			rb.handlers.APIKey()
+		}
+	default:
+		// Unknown method on the dedicated reload channel: ignore. This is
+		// the forward-compat path for a newer replica publishing a reload
+		// kind an older replica does not understand yet.
+	}
+}
+
+// dispatchConnection applies a peer's connection reload (kind/name).
+func (rb *reloadBus) dispatchConnection(ev session.Event) {
+	kind, _ := ev.Params["kind"].(string)
+	name, _ := ev.Params["name"].(string)
+	if rb.handlers.Connection != nil && kind != "" && name != "" {
+		rb.logger.Info("reload-bus: reloading connection from peer", "kind", kind, "name", name)
+		rb.handlers.Connection(kind, name)
+	}
+}
+
+// dispatchCatalog applies a peer's catalog reload (catalog_id).
+func (rb *reloadBus) dispatchCatalog(ev session.Event) {
+	id, _ := ev.Params["catalog_id"].(string)
+	if rb.handlers.Catalog != nil && id != "" {
+		rb.logger.Info("reload-bus: reloading catalog connections from peer", "catalog_id", id)
+		rb.handlers.Catalog(id)
+	}
+}
+
+// newReplicaOrigin returns a stable-per-process identifier used to tag
+// reload events so a replica skips its own broadcasts. Hostname plus a
+// random suffix keeps it unique even when two replicas share a hostname
+// (unlikely under k8s, but cheap insurance).
+func newReplicaOrigin() string {
+	host, _ := os.Hostname()
+	buf := make([]byte, 4)
+	_, _ = rand.Read(buf)
+	if host == "" {
+		host = "replica"
+	}
+	return host + "-" + hex.EncodeToString(buf)
+}

--- a/pkg/platform/sessionsync/sessionsync.go
+++ b/pkg/platform/sessionsync/sessionsync.go
@@ -1,0 +1,365 @@
+// Package sessionsync assembles the session / cross-replica-sync layer behind
+// one Handle: the externalized session store (memory or postgres), the
+// per-session enrichment-dedup cache, the client-facing MCP notification
+// broadcaster, and the dedicated cross-replica reload bus (its own broadcaster
+// channel plus the publish/subscribe machinery).
+//
+// Construction takes explicit inputs — a *sql.DB, the resolved session /
+// broadcast config values, an optional injected session store, and the reload
+// handlers Platform re-materializes local state through — so the subsystem is
+// constructible and testable without a Platform. It imports pkg/session,
+// pkg/session/postgres, and pkg/middleware, never pkg/platform. The *sql.DB and
+// the config values back many other subsystems, so they stay owned by Platform
+// and are passed in rather than owned here.
+//
+// Construction is two-phase: New builds the store + both broadcasters + reload
+// bus (owning their cleanup and subscriber goroutines), and StartCache builds
+// the enrichment-dedup cache during middleware assembly (gated by config on the
+// Platform side). The reload re-materialization handlers stay on Platform (they
+// reach into the connection store, toolkit registry, persona registry, and
+// API-key store — state this package does not own) and are injected as
+// callbacks. Close is the shutdown seam Platform wires into its own lifecycle.
+package sessionsync
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/session"
+	sessionpostgres "github.com/txn2/mcp-data-platform/pkg/session/postgres"
+)
+
+// storeKindDatabase / storeKindMemory name the two externalized session store
+// backends. The empty string selects memory (the zero-config default).
+const (
+	storeKindDatabase = "database"
+	storeKindMemory   = "memory"
+)
+
+// Config carries the resolved session / broadcast values the owner needs to
+// assemble the layer. Platform resolves defaults (TTL, cleanup interval) before
+// passing them so this package stays free of the platform's defaulting rules.
+type Config struct {
+	// Store selects the session store backend: "database", "memory", or ""
+	// (memory). Ignored when an injected store is supplied to New.
+	Store string
+	// TTL is the resolved session lifetime; CleanupInterval is how often the
+	// store's cleanup routine runs. Both are already defaulted by the caller.
+	TTL             time.Duration
+	CleanupInterval time.Duration
+	// DSN is the database connection string; empty disables the postgres
+	// broadcasters (memory fan-out only). BroadcastChannel overrides the
+	// postgres LISTEN/NOTIFY channel; empty uses the package default.
+	DSN              string
+	BroadcastChannel string
+}
+
+// ReloadHandlers carries the local re-materialization callbacks the reload
+// subscriber invokes when a peer replica announces a configuration change. They
+// stay on Platform (they reach into Platform-owned state) and are injected here
+// so the bus is unit-testable in isolation. Any nil handler means "this
+// subsystem does not participate in cross-replica reload"; the event is ignored.
+// This is also the reloadBus's handler type, so New passes it straight through.
+type ReloadHandlers struct {
+	Connection func(kind, name string)
+	Catalog    func(catalogID string)
+	Persona    func()
+	APIKey     func()
+}
+
+// Handle owns the assembled session / cross-replica-sync layer: the session
+// store (and its cleanup goroutine), the enrichment-dedup cache (and its
+// cleanup goroutine, started by StartCache), the client-facing broadcaster, and
+// the dedicated reload broadcaster + bus (and the subscriber goroutine). The
+// read accessors expose the store / broadcaster / cache that Platform surfaces
+// through its SessionStore() / Broadcaster() accessors, the HTTP session
+// resolver, session-handle minting, and the admin session export/restore; the
+// Publish*Reload delegators back the Platform wrappers admin handlers call.
+// Close is the shutdown seam Platform wires into its own lifecycle.
+type Handle struct {
+	store             session.Store
+	cache             *middleware.SessionEnrichmentCache
+	broadcaster       session.Broadcaster
+	reloadBroadcaster session.Broadcaster
+	reloadBus         *reloadBus
+	reloadCancel      context.CancelFunc
+
+	// forcedStateless records that the database store was selected, so the
+	// SDK's built-in session map must be bypassed. Platform reads this via
+	// StatelessForced and applies it to its own Server.Streamable config.
+	forcedStateless bool
+}
+
+// New assembles the session store, both broadcasters, and the reload bus from an
+// explicit *sql.DB, the resolved config, an optional injected store, and the
+// reload handlers. When injectedStore is non-nil it is used verbatim (the admin
+// SessionStore override path) — store selection, the cleanup routine, and
+// stateless forcing are all skipped, but the broadcasters and reload bus are
+// still wired so Broadcaster() is non-nil and cross-replica reload still works.
+//
+// It returns an error when Config.Store is "database" but db is nil, or when
+// Config.Store is an unknown value; otherwise the returned Handle is non-nil
+// and its Broadcaster is guaranteed non-nil (memory fallback).
+func New(db *sql.DB, cfg Config, injectedStore session.Store, handlers ReloadHandlers) (*Handle, error) {
+	store, forcedStateless, err := buildStore(db, cfg, injectedStore)
+	if err != nil {
+		return nil, err
+	}
+
+	h := &Handle{
+		store:           store,
+		forcedStateless: forcedStateless,
+	}
+	h.broadcaster = buildClientBroadcaster(db, cfg)
+	h.reloadBroadcaster = buildReloadBroadcaster(db, cfg)
+	h.reloadBus = newReloadBus(h.reloadBroadcaster, newReplicaOrigin(), handlers, slog.Default())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	h.reloadCancel = cancel
+	go h.reloadBus.run(ctx)
+
+	return h, nil
+}
+
+// buildStore selects the session store backend and starts its cleanup routine.
+// An injected store is used verbatim (no cleanup routine, no stateless forcing —
+// the caller owns that store's lifecycle). Otherwise the database store forces
+// stateless mode so the SDK skips its built-in session map.
+func buildStore(db *sql.DB, cfg Config, injectedStore session.Store) (session.Store, bool, error) {
+	if injectedStore != nil {
+		return injectedStore, false, nil
+	}
+
+	switch cfg.Store {
+	case storeKindDatabase:
+		if db == nil {
+			return nil, false, fmt.Errorf("sessions.store is \"database\" but no database configured")
+		}
+		store := sessionpostgres.New(db, sessionpostgres.Config{TTL: cfg.TTL})
+		store.StartCleanupRoutine(cfg.CleanupInterval)
+		slog.Info("session store: database (stateless mode enabled)",
+			"ttl", cfg.TTL, "cleanup_interval", cfg.CleanupInterval)
+		return store, true, nil
+	case storeKindMemory, "":
+		store := session.NewMemoryStore(cfg.TTL)
+		store.StartCleanupRoutine(cfg.CleanupInterval)
+		slog.Info("session store: memory",
+			"ttl", cfg.TTL, "cleanup_interval", cfg.CleanupInterval)
+		return store, false, nil
+	default:
+		return nil, false, fmt.Errorf("unknown session store: %q", cfg.Store)
+	}
+}
+
+// buildClientBroadcaster picks the client-facing broadcaster: postgres
+// LISTEN/NOTIFY when a database is configured, in-memory otherwise. A postgres
+// setup failure falls back to memory rather than failing startup —
+// tools/list_changed propagation is a UX feature, not a correctness
+// requirement — with a distinguishable log line.
+func buildClientBroadcaster(db *sql.DB, cfg Config) session.Broadcaster {
+	wantPostgres := db != nil && cfg.DSN != ""
+	if wantPostgres {
+		// Channel override lets operators isolate deployments that
+		// share a postgres instance — without it, both deployments
+		// would LISTEN on the same channel and cross-broadcast
+		// tools/list_changed to each other's downstream agents.
+		channel := cfg.BroadcastChannel
+		if channel == "" {
+			channel = sessionpostgres.DefaultNotifyChannel
+			// Multiple deployments sharing a postgres instance with
+			// the default channel will cross-broadcast
+			// tools/list_changed events to each other's downstream
+			// agents. The doc tells operators to set the field per
+			// deployment when sharing a DB, but the most common
+			// operator error is forgetting to set it — surface a
+			// warning here so the misconfiguration is visible at
+			// startup rather than as a "tool list keeps changing
+			// on its own" mystery in production.
+			slog.Warn("broadcaster: using default channel; if multiple deployments share this postgres instance, set sessions.broadcast_channel per deployment to avoid cross-deployment fan-out",
+				"channel", channel)
+		}
+		b, err := sessionpostgres.NewBroadcaster(cfg.DSN, db, channel, slog.Default())
+		if err == nil {
+			slog.Info("broadcaster: postgres LISTEN/NOTIFY",
+				"channel", channel)
+			return b
+		}
+		// Fallback path: the operator configured postgres but
+		// NewBroadcaster failed (e.g., role lacks LISTEN privilege).
+		// Don't fail startup — tools/list_changed propagation is a
+		// UX feature, not a correctness requirement — but log
+		// distinguishably from the intentional single-replica path
+		// so log-grep operators can spot a degraded multi-replica
+		// deployment.
+		slog.Warn("broadcaster: postgres init failed — falling back to memory",
+			"error", err)
+	}
+	b := session.NewMemoryBroadcaster(slog.Default())
+	if wantPostgres {
+		slog.Info("broadcaster: memory (postgres unavailable, cross-replica fan-out disabled)")
+	} else {
+		slog.Info("broadcaster: memory (single-replica)")
+	}
+	return b
+}
+
+// buildReloadBroadcaster picks the dedicated cross-replica reload channel. It
+// uses a separate postgres LISTEN/NOTIFY channel from the client-facing
+// broadcaster (the configured channel plus a "_reload" suffix) so internal
+// control-plane events are never written to an MCP client's SSE stream. On a
+// single-replica or db-less deployment it falls back to an in-memory
+// broadcaster (a local no-op loop, harmless).
+func buildReloadBroadcaster(db *sql.DB, cfg Config) session.Broadcaster {
+	if db != nil && cfg.DSN != "" {
+		channel := cfg.BroadcastChannel
+		if channel == "" {
+			channel = sessionpostgres.DefaultNotifyChannel
+		}
+		reloadChannel := channel + "_reload"
+		pb, err := sessionpostgres.NewBroadcaster(cfg.DSN, db, reloadChannel, slog.Default())
+		if err == nil {
+			slog.Info("reload-bus: postgres LISTEN/NOTIFY", "channel", reloadChannel)
+			return pb
+		}
+		// Degraded: cross-replica reload is disabled, but the platform
+		// still runs. Operators on a multi-replica deployment must
+		// restart pods after admin config changes until this is fixed.
+		slog.Warn("reload-bus: postgres init failed — cross-replica reload disabled, restart pods after admin changes",
+			"error", err)
+	}
+	return session.NewMemoryBroadcaster(slog.Default())
+}
+
+// StartCache builds the per-session enrichment-dedup cache and starts its
+// cleanup goroutine. Callers gate this on config (session_dedup enabled); when
+// not called the cache stays nil and SessionCache returns nil — the disabled
+// no-op. No-op on a nil Handle or a repeat call, so a second call cannot leak
+// the first cache's goroutine. Returns the cache for the caller to wire into
+// the enrichment middleware config.
+func (h *Handle) StartCache(entryTTL, sessionTimeout time.Duration) *middleware.SessionEnrichmentCache {
+	if h == nil {
+		return nil
+	}
+	if h.cache != nil {
+		return h.cache
+	}
+	h.cache = middleware.NewSessionEnrichmentCache(entryTTL, sessionTimeout)
+	h.cache.StartCleanup(1 * time.Minute)
+	return h.cache
+}
+
+// SessionStore returns the externalized session store, or nil on a nil Handle.
+func (h *Handle) SessionStore() session.Store {
+	if h == nil {
+		return nil
+	}
+	return h.store
+}
+
+// Broadcaster returns the client-facing MCP notification broadcaster. Non-nil
+// after a successful New (memory fallback guarantees it); nil only on a nil
+// Handle.
+func (h *Handle) Broadcaster() session.Broadcaster {
+	if h == nil {
+		return nil
+	}
+	return h.broadcaster
+}
+
+// SessionCache returns the enrichment-dedup cache, or nil on a nil Handle or
+// when StartCache was never called (session_dedup disabled).
+func (h *Handle) SessionCache() *middleware.SessionEnrichmentCache {
+	if h == nil {
+		return nil
+	}
+	return h.cache
+}
+
+// StatelessForced reports whether the database store was selected and the SDK's
+// built-in session map must therefore be bypassed. Platform applies this to its
+// Server.Streamable config after New.
+func (h *Handle) StatelessForced() bool {
+	return h != nil && h.forcedStateless
+}
+
+// PublishConnectionReload announces that the (kind, name) connection's stored
+// config changed so peers rebuild it. No-op on a nil Handle.
+func (h *Handle) PublishConnectionReload(ctx context.Context, kind, name string) {
+	if h == nil {
+		return
+	}
+	h.reloadBus.publishConnection(ctx, kind, name)
+}
+
+// PublishCatalogReload announces that an API catalog's specs changed so peers
+// rebuild every connection referencing it. No-op on a nil Handle.
+func (h *Handle) PublishCatalogReload(ctx context.Context, catalogID string) {
+	if h == nil {
+		return
+	}
+	h.reloadBus.publishCatalog(ctx, catalogID)
+}
+
+// PublishPersonaReload announces that persona definitions changed so peers
+// reconcile their persona registry. No-op on a nil Handle.
+func (h *Handle) PublishPersonaReload(ctx context.Context) {
+	if h == nil {
+		return
+	}
+	h.reloadBus.publishPersona(ctx)
+}
+
+// PublishAPIKeyReload announces that API keys changed so peers re-sync their
+// in-memory key set. No-op on a nil Handle.
+func (h *Handle) PublishAPIKeyReload(ctx context.Context) {
+	if h == nil {
+		return
+	}
+	h.reloadBus.publishAPIKey(ctx)
+}
+
+// Close tears down the layer in order: stop the enrichment cache, close the
+// session store, close the client broadcaster, then cancel the reload subscriber
+// and close the reload broadcaster. The broadcasters must close before Platform
+// closes its *sql.DB because the postgres broadcasters hold their own dedicated
+// LISTEN connections. Returns the joined store + client-broadcaster close errors;
+// the reload-broadcaster close error is best-effort (the reload channel is a
+// control-plane convenience, not a data path). No-op on a nil Handle.
+func (h *Handle) Close() error {
+	if h == nil {
+		return nil
+	}
+	var errs []error
+	if h.cache != nil {
+		slog.Debug("shutdown: stopping session cache")
+		h.cache.Stop()
+	}
+	if h.store != nil {
+		slog.Debug("shutdown: closing session store")
+		if err := h.store.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close session store: %w", err))
+		}
+	}
+	if h.broadcaster != nil {
+		slog.Debug("shutdown: closing broadcaster")
+		if err := h.broadcaster.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close broadcaster: %w", err))
+		}
+	}
+	slog.Debug("shutdown: stopping reload bus")
+	if h.reloadCancel != nil {
+		h.reloadCancel()
+	}
+	if h.reloadBroadcaster != nil {
+		_ = h.reloadBroadcaster.Close()
+	}
+	if err := errors.Join(errs...); err != nil {
+		return fmt.Errorf("sessionsync: close: %w", err)
+	}
+	return nil
+}

--- a/pkg/platform/sessionsync/sessionsync_test.go
+++ b/pkg/platform/sessionsync/sessionsync_test.go
@@ -1,0 +1,371 @@
+package sessionsync
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/txn2/mcp-data-platform/pkg/session"
+)
+
+// TestBuildStore_Database proves the database branch: a *sql.DB yields a
+// postgres store and forces stateless mode. The cleanup routine is stopped by
+// Close so no query ever fires against the mock.
+//
+// The postgres LISTEN-failure fallback in buildClientBroadcaster /
+// buildReloadBroadcaster is deliberately not unit-tested: pq.NewListener
+// retries a refused connection with backoff rather than failing fast, so an
+// unreachable DSN hangs instead of returning an error (the pkg/session/postgres
+// package documents the same limitation for its listener-driven goroutine). That
+// fallback is exercised only by the integration/live-DB path.
+func TestBuildStore_Database(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	store, forced, err := buildStore(db, Config{Store: storeKindDatabase, TTL: time.Minute, CleanupInterval: time.Minute}, nil)
+	if err != nil {
+		t.Fatalf("buildStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	if store == nil {
+		t.Fatal("database store not built")
+	}
+	if !forced {
+		t.Error("database store must force stateless mode")
+	}
+}
+
+// --- Assembly (New / StartCache / Close) tests -----------------------------
+
+// TestNew_MemoryStore proves the zero-config path: no database selects the
+// memory store (no stateless forcing) and a memory broadcaster (non-nil, so the
+// Broadcaster() contract holds), and wires the reload bus.
+func TestNew_MemoryStore(t *testing.T) {
+	h, err := New(nil, Config{Store: storeKindMemory, TTL: time.Minute, CleanupInterval: time.Minute}, nil, ReloadHandlers{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = h.Close() }()
+
+	if h.SessionStore() == nil {
+		t.Error("memory store not assembled")
+	}
+	if h.Broadcaster() == nil {
+		t.Error("broadcaster must be non-nil after New")
+	}
+	if h.StatelessForced() {
+		t.Error("memory store must not force stateless mode")
+	}
+	if h.SessionCache() != nil {
+		t.Error("cache must be nil until StartCache is called")
+	}
+}
+
+// TestNew_EmptyStoreDefaultsToMemory proves the "" store selects memory.
+func TestNew_EmptyStoreDefaultsToMemory(t *testing.T) {
+	h, err := New(nil, Config{TTL: time.Minute, CleanupInterval: time.Minute}, nil, ReloadHandlers{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = h.Close() }()
+	if h.SessionStore() == nil {
+		t.Error("empty store did not default to memory")
+	}
+}
+
+// TestNew_DatabaseStoreWithoutDBErrors proves the precondition: database store
+// selected but no *sql.DB is a construction error, not a silent fallback.
+func TestNew_DatabaseStoreWithoutDBErrors(t *testing.T) {
+	_, err := New(nil, Config{Store: storeKindDatabase}, nil, ReloadHandlers{})
+	if err == nil {
+		t.Fatal("expected error when database store selected without a db")
+	}
+	if !strings.Contains(err.Error(), "no database configured") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestNew_UnknownStoreErrors proves an unrecognized store value fails fast.
+func TestNew_UnknownStoreErrors(t *testing.T) {
+	_, err := New(nil, Config{Store: "bogus"}, nil, ReloadHandlers{})
+	if err == nil {
+		t.Fatal("expected error for unknown session store")
+	}
+	if !strings.Contains(err.Error(), "unknown session store") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestNew_InjectedStoreOverride proves the admin SessionStore override path:
+// the injected store is used verbatim (no stateless forcing) yet a broadcaster
+// and reload bus are still wired.
+func TestNew_InjectedStoreOverride(t *testing.T) {
+	injected := session.NewMemoryStore(time.Minute)
+	h, err := New(nil, Config{Store: storeKindDatabase}, injected, ReloadHandlers{})
+	if err != nil {
+		t.Fatalf("New with injected store must not error even for database store: %v", err)
+	}
+	defer func() { _ = h.Close() }()
+
+	if h.SessionStore() != injected {
+		t.Error("injected store was not used verbatim")
+	}
+	if h.StatelessForced() {
+		t.Error("injected store must not force stateless mode")
+	}
+	if h.Broadcaster() == nil {
+		t.Error("broadcaster must still be wired on the override path")
+	}
+}
+
+// TestStartCache proves the cache is built and returned, memoized across calls,
+// and exposed via SessionCache.
+func TestStartCache(t *testing.T) {
+	h, err := New(nil, Config{TTL: time.Minute, CleanupInterval: time.Minute}, nil, ReloadHandlers{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = h.Close() }()
+
+	cache := h.StartCache(time.Minute, 30*time.Minute)
+	if cache == nil {
+		t.Fatal("StartCache returned nil")
+	}
+	if h.SessionCache() != cache {
+		t.Error("SessionCache did not return the started cache")
+	}
+	if again := h.StartCache(time.Minute, 30*time.Minute); again != cache {
+		t.Error("StartCache must memoize (a second call must not leak a new cache goroutine)")
+	}
+}
+
+// TestClose_NilSafe proves Close and the accessors are nil-safe.
+func TestClose_NilSafe(t *testing.T) {
+	var h *Handle
+	if err := h.Close(); err != nil {
+		t.Errorf("nil Close: %v", err)
+	}
+	if h.SessionStore() != nil || h.Broadcaster() != nil || h.SessionCache() != nil {
+		t.Error("nil-handle accessors must return nil")
+	}
+	if h.StatelessForced() {
+		t.Error("nil-handle StatelessForced must be false")
+	}
+	// Publish delegators must be no-ops on a nil handle.
+	h.PublishConnectionReload(context.Background(), "api", "x")
+	h.PublishCatalogReload(context.Background(), "cat")
+	h.PublishPersonaReload(context.Background())
+	h.PublishAPIKeyReload(context.Background())
+}
+
+// recordingStore wraps a memory store and records Close so shutdown ordering
+// (cache stop -> store close -> broadcaster close) can be observed.
+type recordingStore struct {
+	session.Store
+	closed *bool
+}
+
+func (r recordingStore) Close() error {
+	*r.closed = true
+	if err := r.Store.Close(); err != nil {
+		return fmt.Errorf("recordingStore: %w", err)
+	}
+	return nil
+}
+
+// TestClose_TearsDownStoreAndCache proves Close stops the cache and closes the
+// session store (and is safe to call twice).
+func TestClose_TearsDownStoreAndCache(t *testing.T) {
+	closed := false
+	injected := recordingStore{Store: session.NewMemoryStore(time.Minute), closed: &closed}
+	h, err := New(nil, Config{}, injected, ReloadHandlers{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	h.StartCache(time.Minute, 30*time.Minute)
+
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !closed {
+		t.Error("Close did not close the session store")
+	}
+	if err := h.Close(); err != nil {
+		t.Errorf("second Close must be safe: %v", err)
+	}
+}
+
+// TestHandle_PublishDelegatorsSafe proves the handle's publish delegators route
+// through the reload bus without panicking (the cross-replica dispatch itself is
+// covered by the bus-core tests below).
+func TestHandle_PublishDelegatorsSafe(t *testing.T) {
+	h, err := New(nil, Config{TTL: time.Minute, CleanupInterval: time.Minute}, nil, ReloadHandlers{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = h.Close() }()
+	ctx := context.Background()
+	h.PublishConnectionReload(ctx, "api", "c1")
+	h.PublishCatalogReload(ctx, "cat-1")
+	h.PublishPersonaReload(ctx)
+	h.PublishAPIKeyReload(ctx)
+}
+
+// --- Reload bus core tests -------------------------------------------------
+
+// recordingHandlers captures reload-handler invocations on buffered
+// channels so tests can assert delivery (or non-delivery) with a timeout.
+type recordingHandlers struct {
+	conn    chan [2]string
+	catalog chan string
+	persona chan struct{}
+	apiKey  chan struct{}
+}
+
+func newRecordingHandlers() recordingHandlers {
+	return recordingHandlers{
+		conn:    make(chan [2]string, 4),
+		catalog: make(chan string, 4),
+		persona: make(chan struct{}, 4),
+		apiKey:  make(chan struct{}, 4),
+	}
+}
+
+func (r recordingHandlers) handlers() ReloadHandlers {
+	return ReloadHandlers{
+		Connection: func(kind, name string) { r.conn <- [2]string{kind, name} },
+		Catalog:    func(id string) { r.catalog <- id },
+		Persona:    func() { r.persona <- struct{}{} },
+		APIKey:     func() { r.apiKey <- struct{}{} },
+	}
+}
+
+// TestReloadBus_CrossReplica proves the core #501 fix: a reload published
+// by one replica is applied by the OTHER replica, and the publishing
+// replica skips its own event (it reloaded synchronously on the write
+// path). Two buses share one in-memory broadcaster, which is exactly how
+// the postgres broadcaster re-publishes a received NOTIFY locally, so
+// this is a faithful cross-replica simulation.
+func TestReloadBus_CrossReplica(t *testing.T) {
+	b := session.NewMemoryBroadcaster(nil)
+	defer func() { _ = b.Close() }()
+
+	recA := newRecordingHandlers()
+	recB := newRecordingHandlers()
+	busA := newReloadBus(b, "replica-a", recA.handlers(), nil)
+	busB := newReloadBus(b, "replica-b", recB.handlers(), nil)
+
+	ctx := t.Context()
+	go busA.run(ctx)
+	go busB.run(ctx)
+	// Let both subscriptions register before publishing.
+	waitForSubscribers(t, b, 2)
+
+	// Replica A handled the admin write and publishes the reload.
+	busA.publishConnection(t.Context(), "api", "Test API")
+
+	// Replica B must apply it.
+	select {
+	case got := <-recB.conn:
+		if got != [2]string{"api", "Test API"} {
+			t.Fatalf("replica B reloaded %v, want [api Test API]", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("replica B never received the connection reload (the #501 bug)")
+	}
+
+	// Replica A must NOT re-apply its own event (origin skip).
+	select {
+	case got := <-recA.conn:
+		t.Fatalf("replica A re-applied its own publish %v; should skip self-origin", got)
+	case <-time.After(150 * time.Millisecond):
+		// expected: no self-reload
+	}
+}
+
+// TestReloadBus_DispatchRouting proves each method routes to its handler.
+func TestReloadBus_DispatchRouting(t *testing.T) {
+	rec := newRecordingHandlers()
+	rb := newReloadBus(session.NewMemoryBroadcaster(nil), "self", rec.handlers(), nil)
+
+	rb.dispatch(session.Event{Method: reloadMethodCatalog, Params: map[string]any{"catalog_id": "cat-1", reloadParamOrigin: "peer"}})
+	rb.dispatch(session.Event{Method: reloadMethodConnection, Params: map[string]any{"kind": "mcp", "name": "up", reloadParamOrigin: "peer"}})
+	rb.dispatch(session.Event{Method: reloadMethodPersona, Params: map[string]any{reloadParamOrigin: "peer"}})
+	rb.dispatch(session.Event{Method: reloadMethodAPIKey, Params: map[string]any{reloadParamOrigin: "peer"}})
+
+	if got := <-rec.catalog; got != "cat-1" {
+		t.Errorf("catalog reload id=%q, want cat-1", got)
+	}
+	if got := <-rec.conn; got != [2]string{"mcp", "up"} {
+		t.Errorf("connection reload=%v, want [mcp up]", got)
+	}
+	if _, ok := <-rec.persona; !ok {
+		t.Error("persona reload not dispatched")
+	}
+	if _, ok := <-rec.apiKey; !ok {
+		t.Error("apikey reload not dispatched")
+	}
+}
+
+// TestReloadBus_SkipsSelfOrigin proves self-published events are ignored.
+func TestReloadBus_SkipsSelfOrigin(t *testing.T) {
+	rec := newRecordingHandlers()
+	rb := newReloadBus(session.NewMemoryBroadcaster(nil), "self", rec.handlers(), nil)
+	rb.dispatch(session.Event{Method: reloadMethodCatalog, Params: map[string]any{"catalog_id": "x", reloadParamOrigin: "self"}})
+	select {
+	case <-rec.catalog:
+		t.Fatal("self-origin event must be skipped")
+	default:
+	}
+}
+
+// TestReloadBus_NilHandlerAndUnknownMethod proves a missing handler or an
+// unknown method is a safe no-op (forward compatibility).
+func TestReloadBus_NilHandlerAndUnknownMethod(_ *testing.T) {
+	rb := newReloadBus(session.NewMemoryBroadcaster(nil), "self", ReloadHandlers{}, nil)
+	rb.dispatch(session.Event{Method: reloadMethodConnection, Params: map[string]any{"kind": "api", "name": "x", reloadParamOrigin: "peer"}})
+	rb.dispatch(session.Event{Method: "platform/reload/future", Params: map[string]any{reloadParamOrigin: "peer"}})
+	// Reaching here without panic is the assertion.
+}
+
+// TestReloadBus_NilBusPublishSafe proves a nil/disabled bus publish is a
+// no-op (single-replica deployments with no broadcaster).
+func TestReloadBus_NilBusPublishSafe(t *testing.T) {
+	var rb *reloadBus
+	rb.publishConnection(t.Context(), "api", "x") // must not panic
+	rb = newReloadBus(nil, "self", ReloadHandlers{}, nil)
+	rb.publishCatalog(t.Context(), "x") // nil broadcaster: must not panic
+	rb.publishPersona(t.Context())
+	rb.publishAPIKey(t.Context())
+}
+
+// TestNewReplicaOrigin proves the origin id carries a hostname-suffix shape so
+// two replicas sharing a hostname still differ.
+func TestNewReplicaOrigin(t *testing.T) {
+	o1 := newReplicaOrigin()
+	o2 := newReplicaOrigin()
+	if !strings.Contains(o1, "-") {
+		t.Errorf("origin %q lacks the hostname-suffix shape", o1)
+	}
+	if o1 == o2 {
+		t.Errorf("two origins collided: %q", o1)
+	}
+}
+
+func waitForSubscribers(t *testing.T, b *session.MemoryBroadcaster, n int) {
+	t.Helper()
+	for range 100 {
+		if b.SubscriberCount() >= n {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("subscribers did not reach %d", n)
+}

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -140,6 +140,7 @@ pkg/platform -> pkg/platform/personastore
 pkg/platform -> pkg/platform/portalstore
 pkg/platform -> pkg/platform/reflexivecapture
 pkg/platform -> pkg/platform/routepolicy
+pkg/platform -> pkg/platform/sessionsync
 pkg/platform -> pkg/platform/toolkitcfg
 pkg/platform -> pkg/portal
 pkg/platform -> pkg/portal/knowledgepage
@@ -155,7 +156,6 @@ pkg/platform -> pkg/searchgate/postgres
 pkg/platform -> pkg/semantic
 pkg/platform -> pkg/semantic/datahub
 pkg/platform -> pkg/session
-pkg/platform -> pkg/session/postgres
 pkg/platform -> pkg/storage
 pkg/platform -> pkg/storage/s3
 pkg/platform -> pkg/toolkit
@@ -211,6 +211,9 @@ pkg/platform/reflexivecapture -> pkg/toolkits/memory
 pkg/platform/reflexivecapture -> pkg/urnbuild
 pkg/platform/routepolicy -> pkg/middleware
 pkg/platform/routepolicy -> pkg/persona
+pkg/platform/sessionsync -> pkg/middleware
+pkg/platform/sessionsync -> pkg/session
+pkg/platform/sessionsync -> pkg/session/postgres
 pkg/platform/toolkitcfg -> pkg/platform/cfgmap
 pkg/platform/toolkitcfg -> pkg/platform/fieldcrypt
 pkg/portal -> internal/contentviewer


### PR DESCRIPTION
## Summary

Eighth seam of the Platform decomposition (#756). This extracts the **session / cross-replica-sync** lifecycle cluster — the largest remaining field group on `Platform` after portal — into a new owner package, `pkg/platform/sessionsync`, and folds **six** `Platform` fields into **one** handle.

Closes #843. Relates to #756.

## What moved

The subsystem previously spanned six `Platform` fields, three init methods (`initSessions` / `initBroadcaster` / `initReloadBus`), two teardown methods (`closeSessionLayer` / `stopReloadBus`), and the whole reload-bus type in `reload.go`. It now lives behind one `sessionsync.Handle`:

| Before (six `Platform` fields) | After |
| --- | --- |
| `sessionStore session.Store` | `sessions *sessionsync.Handle` |
| `sessionCache *middleware.SessionEnrichmentCache` | ↑ |
| `broadcaster session.Broadcaster` | ↑ |
| `reloadBroadcaster session.Broadcaster` | ↑ |
| `reloadBus *reloadBus` | ↑ |
| `reloadCancel context.CancelFunc` | ↑ |

**God-object field ceiling ratcheted 64 → 59** (`godobject_budget_test.go`).

## The new package: `pkg/platform/sessionsync`

- **`sessionsync.go`** — `Handle`, `Config`, `ReloadHandlers`, the two-phase constructor, the read accessors, the reload-publish delegators, and `Close`.
- **`reload.go`** — the `reloadBus` type + its publish/run/dispatch machinery + `newReplicaOrigin`, moved out of `pkg/platform`.
- **`sessionsync_test.go`** — assembly + bus-core unit tests (**83.4%** package coverage).

Imports `pkg/session`, `pkg/session/postgres`, and `pkg/middleware` — **never** `pkg/platform`. The package is constructible and testable without a `Platform`.

### Construction is two-phase

- `New(db, cfg, injectedStore, handlers)` builds the session store + client broadcaster + reload broadcaster + reload bus, owning their cleanup and subscriber goroutines. It returns an error for the two precondition failures (`store == "database"` with no db; unknown store value); otherwise the returned `Handle`'s `Broadcaster()` is guaranteed non-nil (memory fallback).
- `StartCache(entryTTL, sessionTimeout)` builds the enrichment-dedup cache during middleware assembly, gated on `enrichment.session_dedup` by `Platform`.

This mirrors the `New` + deferred-second-phase split already used by `connauth` and `portalstore`.

## What stays on `Platform` (by design)

Per the issue's scoping constraints:

- **The reload *handlers*** (`reloadConnectionLocal` / `reloadCatalogLocal` / `reloadPersonaLocal` / `reloadAPIKeyLocal`) re-materialize state by reaching into the connection store, toolkit registry, persona registry, and API-key store — Platform state this seam does not own. They stay on `Platform` and are injected into the bus as `ReloadHandlers` callbacks.
- **The public reload-publish surface** (`PublishConnectionReload` / `PublishCatalogReload` / `PublishPersonaReload` / `PublishAPIKeyReload`, which satisfy `admin.ReloadNotifier`) stays on `Platform` and delegates through the handle. The interface signatures are unchanged.
- **Broadcaster read paths + gateway wiring** (`WireGatewayBroadcaster`, `gatewayListChangedNotifier`) and the **admin session export/restore** (`flushEnrichmentState` / `loadPersistedEnrichmentState`) stay on `Platform` and read through the handle.
- **`p.db` and `p.config`** remain Platform-owned and are passed to `New` as explicit inputs (`*sql.DB` + resolved config values), mirroring how `portalstore` took the `*sql.DB` + `Config`.

`initSessions` collapses to config-translation + delegation; `initBroadcaster` / `initReloadBus` / `stopReloadBus` are removed. `closeSessionLayer` delegates to `Handle.Close()` and retains the separate OAuth-store close.

## Behavior preserved

- Memory vs database store selection, including forcing `Streamable.Stateless` for the DB store (the owner reports this via `StatelessForced()`; `Platform` applies it to its own config).
- The postgres-broadcaster-fails-to-memory fallback on **both** the client and reload channels, without failing startup, with the existing distinguishable log lines.
- The `session_dedup`-disabled cache no-op.
- The injected-`SessionStore` override path (still wires a broadcaster + reload bus; no stateless forcing).
- Shutdown ordering: cache `Stop` → store close → client-broadcaster close → reload cancel + reload-broadcaster close — before the DB closes, because the postgres broadcasters hold their own dedicated LISTEN connections.

## Import graph

The ratchet (`testdata/allowed_internal_imports.txt`) is a net decoupling — `pkg/platform` no longer imports `pkg/session/postgres` directly:

```
- pkg/platform -> pkg/session/postgres
+ pkg/platform -> pkg/platform/sessionsync
+ pkg/platform/sessionsync -> pkg/middleware
+ pkg/platform/sessionsync -> pkg/session
+ pkg/platform/sessionsync -> pkg/session/postgres
```

## Tests

- **New unit tests** (`sessionsync_test.go`): memory vs database store selection, the database-without-db and unknown-store precondition errors, the injected-store override path, `StartCache` memoization, `Close` teardown + nil-safety, publish-delegator safety, and the reload-bus cross-replica dispatch / self-origin skip / nil-handler forward-compat cases.
- The platform-level flush/load enrichment-state, mint, and reload-wiring tests were rewired to assemble the layer through a real `sessionsync.Handle` rather than setting the removed fields directly.
- The postgres LISTEN-failure fallback is documented as integration-only: `pq.NewListener` retries a refused connection with backoff rather than failing fast (the `pkg/session/postgres` package documents the same limitation for its listener goroutine), so an unreachable DSN hangs instead of erroring.

## Verification

`make verify` green — the full CI-equivalent suite: tools-check parity gate, gofmt, race tests (incl. `TestPlatformGodObjectBudget` at the new 59 ceiling and `TestPackageImportRatchet`), total + patch coverage (≥80%), patch-scoped lint, gosec, govulncheck, semgrep, CodeQL, doc-check, dead-code, mutation (≥60%), and the GoReleaser dry-run.

## Acceptance criteria

- [x] New owner package assembles the layer from explicit inputs; imports `pkg/session`, `pkg/session/postgres`, `pkg/middleware`, not `pkg/platform`.
- [x] Constructible/testable without a `Platform`.
- [x] Six fields replaced by one handle; behavior preserved (store selection + stateless forcing, postgres→memory fallback on both channels with the existing log lines, `session_dedup`-disabled no-op, injected-store override, shutdown ordering).
- [x] Reload handlers, `Publish*Reload`, `WireGatewayBroadcaster` / `gatewayListChangedNotifier`, and admin session export/restore stay on `Platform` and read/inject through the handle.
- [x] `p.db` / `p.config` remain on `Platform`, passed to the owner as explicit inputs.
- [x] Owner exposes `Close` for shutdown; does not reach into `p.lifecycle` or the shutdown error-list helpers.
- [x] `TestPlatformGodObjectBudget` field ceiling lowered 64 → 59.
- [x] Unit tests for the assembly; construction testable without a `Platform`.
- [x] Import ratchet regenerated; `make verify` green.
