### PR TITLE
refactor(platform): extract memory layer into pkg/platform/memorylayer (#845)

### DIFF
--- a/godobject_budget_test.go
+++ b/godobject_budget_test.go
@@ -43,8 +43,11 @@ const (
 	// portalstore.Handle, ratcheting 71 → 64; the session / cross-replica-sync
 	// extraction (#843) folded six fields (sessionStore, sessionCache,
 	// broadcaster, reloadBroadcaster, reloadBus, reloadCancel) into one
-	// sessionsync.Handle, ratcheting 64 → 59.
-	maxPlatformFields = 59
+	// sessionsync.Handle, ratcheting 64 → 59; the memory-layer extraction (#845)
+	// folded four fields (memoryStore, memoryToolkit, stalenessWatcher,
+	// memoryAdapter) into one memorylayer.Handle — embeddingProv stays on
+	// Platform because it backs many other subsystems — ratcheting 59 → 56.
+	maxPlatformFields = 56
 
 	// maxPlatformMethods caps the number of methods with a *Platform receiver.
 	// Frozen at today's count; ratchet down as accessors move onto the

--- a/pkg/platform/apigateway_embed_jobs.go
+++ b/pkg/platform/apigateway_embed_jobs.go
@@ -81,7 +81,7 @@ func (p *Platform) WireAPIGatewayEmbedJobsFromDB() {
 		ToolEnumerator:    platformToolEnumerator{p: p},
 		DiscoveryToolName: platformFindToolsName,
 		Consumers: indexqueue.Consumers{
-			Memory:               p.memoryStore != nil,
+			Memory:               p.memory.MemoryStore() != nil,
 			Prompts:              p.promptStore != nil,
 			PortalAssets:         p.portalStore.AssetStore() != nil,
 			PortalCollections:    p.portalStore.CollectionStore() != nil,

--- a/pkg/platform/memorylayer/bridge.go
+++ b/pkg/platform/memorylayer/bridge.go
@@ -1,0 +1,43 @@
+package memorylayer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/txn2/mcp-data-platform/pkg/memory"
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
+)
+
+// middlewareBridge adapts memory.Store to middleware.MemoryProvider, converting
+// between memory.Snippet and middleware.MemorySnippet. It is the only
+// memory↔enrichment bridge; Platform injects it into the semantic-enrichment
+// middleware through Handle.MemoryProvider().
+type middlewareBridge struct {
+	store memory.Store
+}
+
+// RecallForEntities converts memory snippets to middleware format.
+func (b *middlewareBridge) RecallForEntities(ctx context.Context, urns []string, personaName string, limit int) ([]middleware.MemorySnippet, error) {
+	adapter := memory.NewMiddlewareAdapter(b.store)
+	memSnippets, err := adapter.RecallForEntities(ctx, urns, personaName, limit)
+	if err != nil {
+		return nil, fmt.Errorf("recalling memories for entities: %w", err)
+	}
+
+	snippets := make([]middleware.MemorySnippet, len(memSnippets))
+	for i, ms := range memSnippets {
+		snippets[i] = middleware.MemorySnippet{
+			ID: ms.ID,
+			// Canonical fetch handle (mcp:memory:<id>) so a summary-first
+			// rendering can point the agent at the full record (#761).
+			Reference:  knowledgepage.MemoryRef(ms.ID),
+			Content:    ms.Content,
+			Dimension:  ms.Dimension,
+			Category:   ms.Category,
+			Confidence: ms.Confidence,
+			CreatedAt:  ms.CreatedAt,
+		}
+	}
+	return snippets, nil
+}

--- a/pkg/platform/memorylayer/bridge_test.go
+++ b/pkg/platform/memorylayer/bridge_test.go
@@ -1,4 +1,4 @@
-package platform
+package memorylayer
 
 import (
 	"context"
@@ -30,7 +30,7 @@ func TestMemoryMiddlewareBridge_PopulatesReference(t *testing.T) {
 	store := &entityLookupStore{records: []memory.Record{
 		{ID: "mem-abc", Content: "Revenue includes deferred amounts", Dimension: "knowledge", Category: "business_context", Confidence: "high"},
 	}}
-	bridge := &memoryMiddlewareBridge{store: store}
+	bridge := &middlewareBridge{store: store}
 
 	snippets, err := bridge.RecallForEntities(
 		context.Background(),

--- a/pkg/platform/memorylayer/memory_dedup_realdb_integration_test.go
+++ b/pkg/platform/memorylayer/memory_dedup_realdb_integration_test.go
@@ -1,11 +1,11 @@
 //go:build integration
 
-package platform
+package memorylayer
 
 // Real-Postgres acceptance test for #762: rapid restatements of the same fact
 // must consolidate to a single active record, not accumulate active
 // near-duplicates. It wires the real capture pipeline (memory toolkit ->
-// memoryRecallChecker -> postgres store with pgvector) and captures the same
+// recallChecker -> postgres store with pgvector) and captures the same
 // content three times. Before the fix, the third capture's recall could match
 // the already-superseded first record (VectorSearch had no status scope),
 // re-supersede it, and leave two active duplicates standing — exactly the pair
@@ -48,7 +48,7 @@ func TestRealDB_MemoryCaptureDedup_ConsolidatesRestatements(t *testing.T) {
 
 	tk, err := memorykit.New("memory", store, fixedVecEmbedder{vec: vec})
 	require.NoError(t, err)
-	tk.SetRecallChecker(&memoryRecallChecker{store: store})
+	tk.SetRecallChecker(&recallChecker{store: store})
 
 	const owner = "dedup@example.com"
 	capture := func(content string) *memorykit.CaptureResult {

--- a/pkg/platform/memorylayer/memorylayer.go
+++ b/pkg/platform/memorylayer/memorylayer.go
@@ -1,0 +1,209 @@
+// Package memorylayer assembles the memory layer behind one Handle: the
+// Postgres-backed memory store, the embedding provider that powers vector
+// search, the memory_manage / memory_capture toolkit (with its recall-first
+// checker), the memory↔enrichment middleware adapter, and the background
+// staleness watcher.
+//
+// Construction takes explicit inputs — a *sql.DB, the shared semantic.Provider
+// (nil disables the staleness watcher), and the resolved memory / embedding /
+// staleness config values — so the subsystem is constructible and testable
+// without a Platform. It imports pkg/memory, pkg/toolkits/memory, pkg/embedding,
+// and pkg/middleware, never pkg/platform. The *sql.DB and the embedding provider
+// back many other subsystems, so they stay owned by Platform: the *sql.DB is
+// passed in, and the embedding provider is built here and handed back via
+// EmbeddingProvider for Platform to store and pass on to the other owners.
+//
+// Construction is two-phase: New builds the store + embedder + toolkit + adapter
+// and constructs (but does not start) the staleness watcher, and Start launches
+// the watcher goroutine. The split lets Platform register the toolkit between the
+// two — preserving the original order (register, then start the watcher) so a
+// registration failure leaves no detached goroutine running.
+//
+// Toolkit registration stays a Platform/registry concern: New builds the toolkit
+// and exposes it via Toolkit() for Platform to register into the shared toolkit
+// registry. The only background resource this package owns for shutdown is the
+// staleness watcher, stopped via Stop.
+package memorylayer
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
+	"github.com/txn2/mcp-data-platform/pkg/memory"
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/semantic"
+	memorykit "github.com/txn2/mcp-data-platform/pkg/toolkits/memory"
+)
+
+// providerOllama is the memory.embedding.provider value that selects the Ollama
+// embedder. Any other value (including the empty string) selects the noop
+// provider with a startup WARN.
+const providerOllama = "ollama"
+
+// Config carries the resolved memory / embedding / staleness values the owner
+// needs to assemble the layer. Platform translates its own config into this
+// shape (and resolves the toolkit instance name) so this package stays free of
+// the platform's config types and defaulting rules.
+type Config struct {
+	// ToolkitName is the memory toolkit instance name (the platform passes its
+	// default).
+	ToolkitName string
+	// EmbeddingProvider selects the embedding backend: "ollama" builds the
+	// Ollama provider from Ollama below; any other value selects the noop
+	// provider (with the startup WARN). Reported verbatim in the enabled log.
+	EmbeddingProvider string
+	// Ollama configures the Ollama embedder; used only when EmbeddingProvider
+	// is "ollama".
+	Ollama embedding.OllamaConfig
+	// StalenessEnabled gates the background staleness watcher; the watcher also
+	// requires a non-nil semantic provider (see New).
+	StalenessEnabled bool
+	// Staleness tunes the watcher's interval and batch size; ignored when the
+	// watcher is not started.
+	Staleness memory.StalenessConfig
+}
+
+// Handle owns the assembled memory layer: the memory store, the embedding
+// provider, the memory toolkit (and its recall-first checker), the
+// memory↔enrichment adapter, and the background staleness watcher (its
+// goroutine). The read accessors expose the store / embedder / toolkit / adapter
+// that Platform surfaces through its MemoryStore() / EmbeddingProvider()
+// accessors, registers into the shared toolkit registry, wires as the
+// thread-linker + reflexive-capture target, reads in the knowledge insight
+// adapter and search router, gates the indexqueue memory consumer on, and
+// injects into the enrichment middleware. Stop is the shutdown seam Platform
+// wires into stopBackgroundTrackers (the watcher must stop before Platform
+// closes its *sql.DB).
+type Handle struct {
+	store            memory.Store
+	embedder         embedding.Provider
+	toolkit          *memorykit.Toolkit
+	adapter          middleware.MemoryProvider
+	stalenessWatcher *memory.StalenessWatcher
+}
+
+// New assembles the memory store, embedder, toolkit (with its recall-first
+// checker), enrichment adapter, and — when StalenessEnabled and a non-nil
+// semantic provider is supplied — constructs the background staleness watcher.
+// It does NOT start the watcher goroutine: the caller registers the toolkit
+// first, then calls Start (so a registration failure leaves no goroutine
+// running). It returns (nil, nil) when db is nil: the memory layer is a no-op
+// without a database, matching the platform precondition, so a memory-disabled /
+// no-DB deployment still gets the nil handle (and downstream nil/noop embedder
+// behavior). It returns an error only when the memory toolkit fails to build.
+func New(db *sql.DB, semanticProvider semantic.Provider, cfg Config) (*Handle, error) {
+	if db == nil {
+		return nil, nil //nolint:nilnil // nil handle = memory layer disabled (no database)
+	}
+
+	store := memory.NewPostgresStore(db)
+	embedder := buildEmbedder(cfg)
+
+	tk, err := memorykit.New(cfg.ToolkitName, store, embedder)
+	if err != nil {
+		return nil, fmt.Errorf("memorylayer: creating memory toolkit: %w", err)
+	}
+	// Recall-first for memory_capture (#633): supersede a near-duplicate instead
+	// of appending. Uses a raw hybrid similarity over the caller's own memory
+	// (not the normalized search fusion, whose per-provider min-max scores are
+	// not thresholdable). Nil-safe: with no real embedder the check yields no
+	// match and capture simply appends.
+	tk.SetRecallChecker(&recallChecker{store: store})
+
+	h := &Handle{
+		store:    store,
+		embedder: embedder,
+		toolkit:  tk,
+		// Middleware adapter for cross-enrichment.
+		adapter: &middlewareBridge{store: store},
+	}
+
+	// Construct the staleness watcher only when enabled and a semantic provider
+	// is available to check entity state against. Start (below, called by the
+	// caller after registration) launches its goroutine.
+	if cfg.StalenessEnabled && semanticProvider != nil {
+		h.stalenessWatcher = memory.NewStalenessWatcher(store, semanticProvider, cfg.Staleness)
+	}
+	return h, nil
+}
+
+// Start launches the background staleness-watcher goroutine (idempotent, and a
+// no-op on a nil Handle or when the watcher was not constructed — staleness
+// disabled or no semantic provider). The caller invokes this after registering
+// the toolkit, so a failed registration never leaves a detached watcher running.
+func (h *Handle) Start() {
+	if h == nil || h.stalenessWatcher == nil {
+		return
+	}
+	h.stalenessWatcher.Start(context.Background())
+}
+
+// buildEmbedder selects the embedding provider from config. Ollama when
+// requested; otherwise the noop provider with a specific WARN — the operator's
+// only signal that semantic ranking is off. The platform still boots so Trino,
+// S3, DataHub, OAuth, audit, and every other non-embedding feature remains
+// available; semantic ranking degrades to the lexical fallback and memory writes
+// persist Embedding: nil (the toolkit guards see Kind() == KindNoop) (#429).
+func buildEmbedder(cfg Config) embedding.Provider {
+	if cfg.EmbeddingProvider == providerOllama {
+		return embedding.NewOllamaProvider(cfg.Ollama)
+	}
+	slog.Warn("memory.embedding.provider not configured; semantic ranking disabled (set memory.embedding.provider to 'ollama' to enable)",
+		"config_key", "memory.embedding.provider",
+		"current_value", cfg.EmbeddingProvider)
+	return embedding.NewNoopProvider(embedding.DefaultDimension)
+}
+
+// MemoryStore returns the memory store, or nil on a nil Handle (memory disabled
+// or no database).
+func (h *Handle) MemoryStore() memory.Store {
+	if h == nil {
+		return nil
+	}
+	return h.store
+}
+
+// EmbeddingProvider returns the embedding provider the layer built, or nil on a
+// nil Handle. Platform stores this as its own field and passes it to the other
+// subsystems (portalstore, indexqueue, api-gateway, search/knowledge) that share
+// the embedder.
+func (h *Handle) EmbeddingProvider() embedding.Provider {
+	if h == nil {
+		return nil
+	}
+	return h.embedder
+}
+
+// Toolkit returns the memory toolkit for Platform to register into the shared
+// toolkit registry and to wire as the thread-linker + reflexive-capture target,
+// or nil on a nil Handle.
+func (h *Handle) Toolkit() *memorykit.Toolkit {
+	if h == nil {
+		return nil
+	}
+	return h.toolkit
+}
+
+// MemoryProvider returns the memory↔enrichment adapter for Platform to inject
+// into the semantic-enrichment middleware config, or nil on a nil Handle.
+func (h *Handle) MemoryProvider() middleware.MemoryProvider {
+	if h == nil {
+		return nil
+	}
+	return h.adapter
+}
+
+// Stop stops the background staleness watcher and waits for its goroutine to
+// exit. No-op on a nil Handle or when the watcher was never started (staleness
+// disabled or no semantic provider). Platform calls this from
+// stopBackgroundTrackers, before it closes the shared *sql.DB.
+func (h *Handle) Stop() {
+	if h == nil || h.stalenessWatcher == nil {
+		return
+	}
+	slog.Debug("shutdown: stopping staleness watcher")
+	h.stalenessWatcher.Stop()
+}

--- a/pkg/platform/memorylayer/memorylayer_test.go
+++ b/pkg/platform/memorylayer/memorylayer_test.go
@@ -1,0 +1,115 @@
+package memorylayer
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/lib/pq"
+
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
+	"github.com/txn2/mcp-data-platform/pkg/memory"
+	"github.com/txn2/mcp-data-platform/pkg/semantic"
+)
+
+// dummyDB returns a non-connecting *sql.DB. New builds the store wrapper and the
+// toolkit without touching the database, so a real connection is never needed;
+// the staleness watcher (the only component that queries) is not started in
+// these tests unless explicitly gated on, and even then its first tick is far in
+// the future.
+func dummyDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("postgres", "postgres://localhost:5432/test?sslmode=disable")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// stubSemantic is a non-nil semantic.Provider used only to satisfy the staleness
+// watcher's precondition; its methods are never called because the watcher's
+// first tick is 15 minutes out and the test stops it immediately.
+type stubSemantic struct{ semantic.Provider }
+
+func TestNew_NilDBIsNoop(t *testing.T) {
+	h, err := New(nil, nil, Config{ToolkitName: "default"})
+	require.NoError(t, err)
+	assert.Nil(t, h, "no database → nil handle (memory disabled)")
+
+	// Every accessor is safe on the nil handle and returns the disabled zero.
+	assert.Nil(t, h.MemoryStore())
+	assert.Nil(t, h.EmbeddingProvider())
+	assert.Nil(t, h.Toolkit())
+	assert.Nil(t, h.MemoryProvider())
+	h.Start() // no panic
+	h.Stop()  // no panic
+}
+
+func TestNew_AssemblesLayer(t *testing.T) {
+	h, err := New(dummyDB(t), nil, Config{
+		ToolkitName:       "default",
+		EmbeddingProvider: providerOllama,
+		Ollama:            embedding.OllamaConfig{URL: "http://localhost:11434", Model: "nomic-embed-text"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, h)
+
+	assert.NotNil(t, h.MemoryStore(), "store built from the db")
+	assert.NotNil(t, h.Toolkit(), "toolkit exposed for registration")
+	assert.NotNil(t, h.MemoryProvider(), "enrichment adapter exposed")
+	require.NotNil(t, h.EmbeddingProvider())
+	assert.Equal(t, embedding.KindOllama, h.EmbeddingProvider().Kind(),
+		"provider 'ollama' selects the Ollama embedder")
+	assert.Nil(t, h.stalenessWatcher, "watcher stays off with no semantic provider")
+}
+
+func TestNew_EmbedderSelection(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		wantKind string
+	}{
+		{"ollama selected", providerOllama, embedding.KindOllama},
+		{"empty falls back to noop", "", embedding.KindNoop},
+		{"unknown falls back to noop", "openai", embedding.KindNoop},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h, err := New(dummyDB(t), nil, Config{ToolkitName: "default", EmbeddingProvider: tc.provider})
+			require.NoError(t, err)
+			require.NotNil(t, h.EmbeddingProvider())
+			assert.Equal(t, tc.wantKind, h.EmbeddingProvider().Kind())
+		})
+	}
+}
+
+func TestNew_StalenessWatcherGating(t *testing.T) {
+	t.Run("constructed when enabled and semantic provider present", func(t *testing.T) {
+		h, err := New(dummyDB(t), stubSemantic{}, Config{
+			ToolkitName:      "default",
+			StalenessEnabled: true,
+			Staleness:        memory.StalenessConfig{BatchSize: 10},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, h.stalenessWatcher, "watcher built when enabled + semantic provider")
+		// Two-phase: Start launches the goroutine, Stop winds it down without
+		// blocking (the first tick is far in the future).
+		h.Start()
+		h.Stop()
+	})
+
+	t.Run("disabled when staleness off", func(t *testing.T) {
+		h, err := New(dummyDB(t), stubSemantic{}, Config{ToolkitName: "default", StalenessEnabled: false})
+		require.NoError(t, err)
+		assert.Nil(t, h.stalenessWatcher)
+		h.Start() // no-op, no panic (no watcher constructed)
+		h.Stop()  // no-op, no panic
+	})
+
+	t.Run("disabled when no semantic provider even if enabled", func(t *testing.T) {
+		h, err := New(dummyDB(t), nil, Config{ToolkitName: "default", StalenessEnabled: true})
+		require.NoError(t, err)
+		assert.Nil(t, h.stalenessWatcher, "no semantic provider → no watcher")
+	})
+}

--- a/pkg/platform/memorylayer/recall_checker.go
+++ b/pkg/platform/memorylayer/recall_checker.go
@@ -1,0 +1,80 @@
+package memorylayer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/txn2/mcp-data-platform/pkg/memory"
+	memorykit "github.com/txn2/mcp-data-platform/pkg/toolkits/memory"
+)
+
+// recallCandidateK is how many nearest neighbors the recall-first check fetches
+// before applying the entity-URN gate. Small: a true restatement scores near the
+// top, so a handful of candidates is enough to find the right-entity match even
+// when an unrelated note about another table edges slightly higher on text alone.
+const recallCandidateK = 5
+
+// recallChecker implements memorykit.RecallChecker by running a raw cosine
+// (vector-only) similarity search over the caller's own memory and returning
+// every match clearing the threshold that also shares an entity URN with the
+// candidate (when it has any). It uses VectorSearch's raw cosine (not the search
+// router's min-max normalization, nor the fused hybrid score) so MinScore reads
+// as a true cosine. The candidate embedding is supplied by the caller
+// (memory_capture reuses the vector it already computed), so this type needs no
+// embedder of its own.
+type recallChecker struct {
+	store memory.Store
+}
+
+// Matches returns the caller's memories similar to the candidate, best first, or
+// nil when there is no precomputed embedding, no caller, or nothing clears
+// MinScore and the entity-URN gate. The caller (memory_capture) precomputes the
+// embedding and runs this BEFORE inserting the new row, so a capture never
+// matches itself. Superseded rows are excluded from the search: without that, a
+// superseded (near-identical) predecessor can outrank its active successor,
+// absorb the supersede, and leave two active duplicates standing (#762). Stale
+// rows remain matchable — a restatement is exactly how a stale record gets
+// corrected — and archived rows are excluded by the store's default.
+func (c *recallChecker) Matches(ctx context.Context, q memorykit.RecallQuery) ([]memorykit.RecallMatch, error) {
+	if q.CallerEmail == "" || c.store == nil || len(q.Embedding) == 0 {
+		return nil, nil
+	}
+	res, err := c.store.VectorSearch(ctx, memory.VectorQuery{
+		Embedding:       q.Embedding,
+		CreatedBy:       q.CallerEmail,
+		MinScore:        q.MinScore,
+		ExcludeStatuses: []string{memory.StatusSuperseded},
+		Limit:           recallCandidateK,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("recall-first similarity: %w", err)
+	}
+	// Results are sorted by descending similarity. Keep every one that clears the
+	// threshold and, when the candidate concerns specific entities, shares an
+	// entity URN — so knowledge about table A never supersedes knowledge about B.
+	var matches []memorykit.RecallMatch
+	for i := range res {
+		if res[i].Score < q.MinScore {
+			break
+		}
+		if len(q.EntityURNs) > 0 && !sharesAny(res[i].Record.EntityURNs, q.EntityURNs) {
+			continue
+		}
+		matches = append(matches, memorykit.RecallMatch{ID: res[i].Record.ID, Score: res[i].Score})
+	}
+	return matches, nil
+}
+
+// sharesAny reports whether a and b have at least one element in common.
+func sharesAny(a, b []string) bool {
+	set := make(map[string]struct{}, len(a))
+	for _, x := range a {
+		set[x] = struct{}{}
+	}
+	for _, y := range b {
+		if _, ok := set[y]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/platform/memorylayer/recall_checker_test.go
+++ b/pkg/platform/memorylayer/recall_checker_test.go
@@ -1,4 +1,4 @@
-package platform
+package memorylayer
 
 import (
 	"context"
@@ -63,7 +63,7 @@ func TestMemoryRecallChecker_Matches(t *testing.T) {
 
 	t.Run("no embedding skips search", func(t *testing.T) {
 		store := &recallFakeStore{results: []memory.ScoredRecord{scoredRec("x", 0.99)}}
-		c := &memoryRecallChecker{store: store}
+		c := &recallChecker{store: store}
 		matches, err := c.Matches(context.Background(), memorykit.RecallQuery{CallerEmail: "a@x.com", MinScore: 0.9})
 		require.NoError(t, err)
 		assert.Empty(t, matches)
@@ -72,7 +72,7 @@ func TestMemoryRecallChecker_Matches(t *testing.T) {
 
 	t.Run("no caller skips search", func(t *testing.T) {
 		store := &recallFakeStore{}
-		c := &memoryRecallChecker{store: store}
+		c := &recallChecker{store: store}
 		matches, err := c.Matches(context.Background(), memorykit.RecallQuery{Embedding: emb, MinScore: 0.9})
 		require.NoError(t, err)
 		assert.Empty(t, matches)
@@ -81,7 +81,7 @@ func TestMemoryRecallChecker_Matches(t *testing.T) {
 
 	t.Run("matches returned and query scoped to caller's active records", func(t *testing.T) {
 		store := &recallFakeStore{results: []memory.ScoredRecord{scoredRec("m1", 0.95), scoredRec("m2", 0.92)}}
-		c := &memoryRecallChecker{store: store}
+		c := &recallChecker{store: store}
 		matches, err := c.Matches(context.Background(), memorykit.RecallQuery{
 			Embedding: emb, CallerEmail: "a@x.com", MinScore: 0.9,
 		})
@@ -102,7 +102,7 @@ func TestMemoryRecallChecker_Matches(t *testing.T) {
 
 	t.Run("below threshold yields no match", func(t *testing.T) {
 		store := &recallFakeStore{results: []memory.ScoredRecord{scoredRec("m1", 0.5)}}
-		c := &memoryRecallChecker{store: store}
+		c := &recallChecker{store: store}
 		matches, err := c.Matches(context.Background(), memorykit.RecallQuery{
 			Embedding: emb, CallerEmail: "a@x.com", MinScore: 0.9,
 		})
@@ -116,7 +116,7 @@ func TestMemoryRecallChecker_Matches(t *testing.T) {
 			scoredRec("other-table", 0.97, "urn:li:dataset:B"),
 			scoredRec("same-table", 0.93, "urn:li:dataset:A"),
 		}}
-		c := &memoryRecallChecker{store: store}
+		c := &recallChecker{store: store}
 		matches, err := c.Matches(context.Background(), memorykit.RecallQuery{
 			Embedding: emb, CallerEmail: "a@x.com", MinScore: 0.9,
 			EntityURNs: []string{"urn:li:dataset:A"},
@@ -128,7 +128,7 @@ func TestMemoryRecallChecker_Matches(t *testing.T) {
 
 	t.Run("entity-URN gate with no overlap yields no match", func(t *testing.T) {
 		store := &recallFakeStore{results: []memory.ScoredRecord{scoredRec("other", 0.99, "urn:li:dataset:B")}}
-		c := &memoryRecallChecker{store: store}
+		c := &recallChecker{store: store}
 		matches, err := c.Matches(context.Background(), memorykit.RecallQuery{
 			Embedding: emb, CallerEmail: "a@x.com", MinScore: 0.9,
 			EntityURNs: []string{"urn:li:dataset:A"},
@@ -139,7 +139,7 @@ func TestMemoryRecallChecker_Matches(t *testing.T) {
 
 	t.Run("store error propagates", func(t *testing.T) {
 		store := &recallFakeStore{err: errors.New("boom")}
-		c := &memoryRecallChecker{store: store}
+		c := &recallChecker{store: store}
 		_, err := c.Matches(context.Background(), memorykit.RecallQuery{
 			Embedding: emb, CallerEmail: "a@x.com", MinScore: 0.9,
 		})

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -50,6 +50,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/platform/fieldcrypt"
 	"github.com/txn2/mcp-data-platform/pkg/platform/iam"
 	"github.com/txn2/mcp-data-platform/pkg/platform/indexqueue"
+	"github.com/txn2/mcp-data-platform/pkg/platform/memorylayer"
 	"github.com/txn2/mcp-data-platform/pkg/platform/mwchain"
 	"github.com/txn2/mcp-data-platform/pkg/platform/oauthserver"
 	"github.com/txn2/mcp-data-platform/pkg/platform/obs"
@@ -80,7 +81,6 @@ import (
 	gatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/gateway"
 	"github.com/txn2/mcp-data-platform/pkg/toolkits/gateway/enrichment"
 	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
-	memorykit "github.com/txn2/mcp-data-platform/pkg/toolkits/memory"
 	searchkit "github.com/txn2/mcp-data-platform/pkg/toolkits/search"
 	trinokit "github.com/txn2/mcp-data-platform/pkg/toolkits/trino"
 	"github.com/txn2/mcp-data-platform/pkg/tuning"
@@ -187,18 +187,21 @@ type Platform struct {
 	knowledgeInsightStore   knowledgekit.InsightStore
 	knowledgeChangesetStore knowledgekit.ChangesetStore
 	knowledgeToolkit        *knowledgekit.Toolkit
-	memoryToolkit           *memorykit.Toolkit
 	knowledgeDataHubWriter  knowledgekit.DataHubWriter
 	// knowledgeRouter is the unified search federation built in initSearch. It
 	// backs both the MCP search tool and the portal's GET /search REST endpoint;
 	// nil on a store-less deployment with no searchable source.
 	knowledgeRouter *knowledge.Router
 
-	// Memory layer
-	memoryStore      memory.Store
-	embeddingProv    embedding.Provider
-	stalenessWatcher *memory.StalenessWatcher
-	memoryAdapter    middleware.MemoryProvider
+	// Memory layer. The owner (pkg/platform/memorylayer) holds the memory store,
+	// memory toolkit (with its recall-first checker), enrichment adapter, and
+	// staleness watcher behind one Handle; the store / toolkit / adapter are read
+	// through its accessors. embeddingProv stays a Platform field (built by the
+	// memory owner, then handed back) because it backs many other subsystems
+	// (portalstore, indexqueue, api-gateway, search/knowledge); it is nil when
+	// memory is disabled or no database is configured.
+	memory        *memorylayer.Handle
+	embeddingProv embedding.Provider
 
 	// shared index-jobs embedding queue. The owner (pkg/platform/indexqueue)
 	// holds the store, registry, worker, reaper, reconciler, retention sweep,
@@ -367,8 +370,8 @@ func (p *Platform) initExtensions() error {
 	// same owns-or-edit access check as resolve_thread (the toolkit authorizes
 	// each thread before linking). Portal creates the toolkit, so this is wired
 	// after both init.
-	if p.memoryToolkit != nil && p.portalStore.Toolkit() != nil {
-		p.memoryToolkit.SetThreadLinker(p.portalStore.Toolkit())
+	if p.memory.Toolkit() != nil && p.portalStore.Toolkit() != nil {
+		p.memory.Toolkit().SetThreadLinker(p.portalStore.Toolkit())
 	}
 	// Unified knowledge read path (#632). Federates the stores initialized
 	// above (memory, insights, assets), so it must run after them.
@@ -381,104 +384,53 @@ func (p *Platform) initExtensions() error {
 	return p.initMCPApps()
 }
 
-// initMemory initializes the memory layer: store, embedder, toolkit, staleness watcher.
+// initMemory assembles the memory layer via the memorylayer owner: the store,
+// embedder, toolkit (with its recall-first checker), enrichment adapter, and
+// staleness watcher behind one Handle. It translates platform config into the
+// owner's Config and delegates assembly; toolkit registration stays here (a
+// registry concern), and embeddingProv is lifted back onto Platform because it
+// backs many other subsystems. No-op (nil handle, nil embedder) when memory is
+// explicitly disabled or no database is configured.
 func (p *Platform) initMemory() error {
 	if isExplicitlyDisabled(p.config.Memory.Enabled) || p.db == nil {
 		return nil
 	}
 
-	// 1. Create memory store.
-	p.memoryStore = memory.NewPostgresStore(p.db)
-
-	// 2. Create embedding provider.
-	switch p.config.Memory.Embedding.Provider {
-	case "ollama":
-		p.embeddingProv = embedding.NewOllamaProvider(embedding.OllamaConfig{
+	handle, err := memorylayer.New(p.db, p.semanticProvider, memorylayer.Config{
+		ToolkitName:       instanceDefault,
+		EmbeddingProvider: p.config.Memory.Embedding.Provider,
+		Ollama: embedding.OllamaConfig{
 			URL:           p.config.Memory.Embedding.Ollama.URL,
 			Model:         p.config.Memory.Embedding.Ollama.Model,
 			Timeout:       p.config.Memory.Embedding.Ollama.Timeout,
 			MaxInputBytes: p.config.Memory.Embedding.Ollama.MaxInputBytes,
-		})
-	default:
-		// No embedder configured. The platform still boots so Trino,
-		// S3, DataHub, OAuth, audit, and every other non-embedding
-		// feature remains available; semantic ranking degrades to the
-		// lexical fallback and memory writes persist Embedding: nil
-		// (the toolkit guards see Kind() == KindNoop). One WARN here
-		// is the operator's only signal that semantic features are
-		// off, so make it specific enough to act on (#429).
-		slog.Warn("memory.embedding.provider not configured; semantic ranking disabled (set memory.embedding.provider to 'ollama' to enable)",
-			"config_key", "memory.embedding.provider",
-			"current_value", p.config.Memory.Embedding.Provider)
-		p.embeddingProv = embedding.NewNoopProvider(embedding.DefaultDimension)
-	}
-
-	// 3. Create and register memory toolkit.
-	tk, err := memorykit.New(instanceDefault, p.memoryStore, p.embeddingProv)
+		},
+		StalenessEnabled: p.config.Memory.Staleness.Enabled,
+		Staleness: memory.StalenessConfig{
+			Interval:  p.config.Memory.Staleness.Interval,
+			BatchSize: p.config.Memory.Staleness.BatchSize,
+		},
+	})
 	if err != nil {
-		return fmt.Errorf("creating memory toolkit: %w", err)
+		return fmt.Errorf("creating memory layer: %w", err)
 	}
-	p.memoryToolkit = tk
-	// Recall-first for memory_capture (#633): supersede a near-duplicate instead
-	// of appending. Uses a raw hybrid similarity over the caller's own memory
-	// (not the normalized search fusion, whose per-provider min-max
-	// scores are not thresholdable). Nil-safe: with no real embedder the check
-	// yields no match and capture simply appends.
-	tk.SetRecallChecker(&memoryRecallChecker{store: p.memoryStore})
-	if err := p.toolkitRegistry.Register(tk); err != nil {
+	p.memory = handle
+	// embeddingProv stays a Platform field: it backs portalstore, indexqueue,
+	// the api-gateway, and the search/knowledge assembly (constraint 1).
+	p.embeddingProv = handle.EmbeddingProvider()
+
+	// Toolkit registration stays a Platform/registry concern. Register before
+	// starting the staleness watcher so a registration failure never leaves a
+	// detached watcher goroutine running (matching the original order).
+	if err := p.toolkitRegistry.Register(handle.Toolkit()); err != nil {
 		return fmt.Errorf("registering memory toolkit: %w", err)
 	}
-
-	// 4. Create middleware adapter for cross-enrichment.
-	p.memoryAdapter = &memoryMiddlewareBridge{store: p.memoryStore}
-
-	// 5. Start staleness watcher if configured.
-	if p.config.Memory.Staleness.Enabled && p.semanticProvider != nil {
-		p.stalenessWatcher = memory.NewStalenessWatcher(
-			p.memoryStore, p.semanticProvider,
-			memory.StalenessConfig{
-				Interval:  p.config.Memory.Staleness.Interval,
-				BatchSize: p.config.Memory.Staleness.BatchSize,
-			},
-		)
-		p.stalenessWatcher.Start(context.Background())
-	}
+	handle.Start()
 
 	slog.Info("memory layer enabled",
 		"embedding_provider", p.config.Memory.Embedding.Provider,
 		"staleness_enabled", p.config.Memory.Staleness.Enabled)
 	return nil
-}
-
-// memoryMiddlewareBridge adapts memory.Store to middleware.MemoryProvider,
-// converting between memory.Snippet and middleware.MemorySnippet.
-type memoryMiddlewareBridge struct {
-	store memory.Store
-}
-
-// RecallForEntities converts memory snippets to middleware format.
-func (b *memoryMiddlewareBridge) RecallForEntities(ctx context.Context, urns []string, personaName string, limit int) ([]middleware.MemorySnippet, error) {
-	adapter := memory.NewMiddlewareAdapter(b.store)
-	memSnippets, err := adapter.RecallForEntities(ctx, urns, personaName, limit)
-	if err != nil {
-		return nil, fmt.Errorf("recalling memories for entities: %w", err)
-	}
-
-	snippets := make([]middleware.MemorySnippet, len(memSnippets))
-	for i, ms := range memSnippets {
-		snippets[i] = middleware.MemorySnippet{
-			ID: ms.ID,
-			// Canonical fetch handle (mcp:memory:<id>) so a summary-first
-			// rendering can point the agent at the full record (#761).
-			Reference:  knowledgepage.MemoryRef(ms.ID),
-			Content:    ms.Content,
-			Dimension:  ms.Dimension,
-			Category:   ms.Category,
-			Confidence: ms.Confidence,
-			CreatedAt:  ms.CreatedAt,
-		}
-	}
-	return snippets, nil
 }
 
 // initDatabase initializes the database connection and runs migrations if configured.
@@ -1441,77 +1393,6 @@ func (p *Platform) initSessionGate() {
 	)
 }
 
-// recallCandidateK is how many nearest neighbors the recall-first check fetches
-// before applying the entity-URN gate. Small: a true restatement scores near the
-// top, so a handful of candidates is enough to find the right-entity match even
-// when an unrelated note about another table edges slightly higher on text alone.
-const recallCandidateK = 5
-
-// memoryRecallChecker implements memorykit.RecallChecker by running a raw cosine
-// (vector-only) similarity search over the caller's own memory and returning
-// every match clearing the threshold that also shares an entity URN with the
-// candidate (when it has any). It uses VectorSearch's raw cosine (not the
-// search router's min-max normalization, nor the fused hybrid score) so
-// MinScore reads as a true cosine. The candidate embedding is supplied by the
-// caller (memory_capture reuses the vector it already computed), so this type
-// needs no embedder of its own.
-type memoryRecallChecker struct {
-	store memory.Store
-}
-
-// Matches returns the caller's memories similar to the candidate, best first,
-// or nil when there is no precomputed embedding, no caller, or nothing clears
-// MinScore and the entity-URN gate. The caller (memory_capture) precomputes
-// the embedding and runs this BEFORE inserting the new row, so a capture never
-// matches itself. Superseded rows are excluded from the search: without that,
-// a superseded (near-identical) predecessor can outrank its active successor,
-// absorb the supersede, and leave two active duplicates standing (#762). Stale
-// rows remain matchable — a restatement is exactly how a stale record gets
-// corrected — and archived rows are excluded by the store's default.
-func (c *memoryRecallChecker) Matches(ctx context.Context, q memorykit.RecallQuery) ([]memorykit.RecallMatch, error) {
-	if q.CallerEmail == "" || c.store == nil || len(q.Embedding) == 0 {
-		return nil, nil
-	}
-	res, err := c.store.VectorSearch(ctx, memory.VectorQuery{
-		Embedding:       q.Embedding,
-		CreatedBy:       q.CallerEmail,
-		MinScore:        q.MinScore,
-		ExcludeStatuses: []string{memory.StatusSuperseded},
-		Limit:           recallCandidateK,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("recall-first similarity: %w", err)
-	}
-	// Results are sorted by descending similarity. Keep every one that clears
-	// the threshold and, when the candidate concerns specific entities, shares an
-	// entity URN — so knowledge about table A never supersedes knowledge about B.
-	var matches []memorykit.RecallMatch
-	for i := range res {
-		if res[i].Score < q.MinScore {
-			break
-		}
-		if len(q.EntityURNs) > 0 && !sharesAny(res[i].Record.EntityURNs, q.EntityURNs) {
-			continue
-		}
-		matches = append(matches, memorykit.RecallMatch{ID: res[i].Record.ID, Score: res[i].Score})
-	}
-	return matches, nil
-}
-
-// sharesAny reports whether a and b have at least one element in common.
-func sharesAny(a, b []string) bool {
-	set := make(map[string]struct{}, len(a))
-	for _, x := range a {
-		set[x] = struct{}{}
-	}
-	for _, y := range b {
-		if _, ok := set[y]; ok {
-			return true
-		}
-	}
-	return false
-}
-
 // initKnowledge initializes the knowledge capture toolkit if enabled.
 // Knowledge tools require database persistence — without a database the
 // toolkit is not registered and its tools won't appear in tools/list.
@@ -1523,8 +1404,8 @@ func (p *Platform) initKnowledge() error {
 	// Use memory-backed adapter when memory store is available (migration
 	// drops knowledge_insights in favor of memory_records).
 	var store knowledgekit.InsightStore
-	if p.memoryStore != nil {
-		store = knowledgekit.NewMemoryInsightAdapter(p.memoryStore)
+	if memStore := p.memory.MemoryStore(); memStore != nil {
+		store = knowledgekit.NewMemoryInsightAdapter(memStore)
 	} else {
 		store = knowledgekit.NewPostgresStore(p.db)
 	}
@@ -1597,11 +1478,11 @@ func (p *Platform) initSearch() error {
 func (p *Platform) storeSearchProviders() []knowledge.Provider {
 	var providers []knowledge.Provider
 
-	if p.memoryStore != nil {
+	if memStore := p.memory.MemoryStore(); memStore != nil {
 		// Lineage expansion of the entity path is the router's job (it runs once
 		// for every entity-keyed provider), so the memory provider takes the URN
 		// set as given.
-		providers = append(providers, knowledge.NewMemoryProvider(p.memoryStore))
+		providers = append(providers, knowledge.NewMemoryProvider(memStore))
 	}
 	// Insights are searchable only through the memory-backed adapter; the legacy
 	// SQL store and the noop store do not implement InsightSearcher (and so are
@@ -2326,9 +2207,9 @@ func (p *Platform) finalizeSetup() {
 // available. The tracker is retained so shutdown can Stop its cleanup loop.
 func (p *Platform) addReflexiveCaptureMiddleware() {
 	p.reflexiveErrors = reflexivecapture.Wire(reflexivecapture.Deps{
-		Enabled:           p.config.Knowledge.ReflexiveCapture.IsEnabled() && p.memoryToolkit != nil,
+		Enabled:           p.config.Knowledge.ReflexiveCapture.IsEnabled() && p.memory.Toolkit() != nil,
 		Server:            p.mcpServer,
-		Toolkit:           p.memoryToolkit,
+		Toolkit:           p.memory.Toolkit(),
 		ResolveURNMapping: p.reflexiveURNMapping,
 		PersonaAllowsTool: p.reflexivePersonaAllowsTool(),
 	})
@@ -2594,10 +2475,8 @@ func (p *Platform) addEnrichmentMiddleware() {
 
 	enrichCfg := p.buildEnrichmentConfig()
 	enrichCfg.WorkflowTracker = p.workflowTracker
-	var mp middleware.MemoryProvider
-	if p.memoryAdapter != nil {
-		mp = p.memoryAdapter
-	}
+	// Memory↔enrichment bridge, or a nil provider when memory is disabled.
+	mp := p.memory.MemoryProvider()
 	p.mcpServer.AddReceivingMiddleware(
 		middleware.MCPSemanticEnrichmentMiddleware(
 			p.semanticProvider,
@@ -3213,7 +3092,7 @@ func (p *Platform) FileDefaults() map[string]string {
 
 // MemoryStore returns the memory store, or nil if memory is disabled.
 func (p *Platform) MemoryStore() memory.Store {
-	return p.memoryStore
+	return p.memory.MemoryStore()
 }
 
 // KnowledgeInsightStore returns the insight store, or nil if knowledge is disabled.
@@ -3555,10 +3434,9 @@ func (p *Platform) stopBackgroundTrackers() {
 		slog.Debug("shutdown: stopping reflexive error tracker")
 		p.reflexiveErrors.Stop()
 	}
-	if p.stalenessWatcher != nil {
-		slog.Debug("shutdown: stopping staleness watcher")
-		p.stalenessWatcher.Stop()
-	}
+	// Stops the memory layer's staleness watcher (no-op when disabled). Runs
+	// before the DB closes, matching the prior teardown order.
+	p.memory.Stop()
 }
 
 // flushEnrichmentState persists enrichment dedup state from the session cache

--- a/pkg/platform/reflexive_capture_test.go
+++ b/pkg/platform/reflexive_capture_test.go
@@ -1,11 +1,14 @@
 package platform
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
-	memorykit "github.com/txn2/mcp-data-platform/pkg/toolkits/memory"
+	_ "github.com/lib/pq"
+
+	"github.com/txn2/mcp-data-platform/pkg/platform/memorylayer"
 )
 
 func TestReflexiveURNMapping(t *testing.T) {
@@ -49,9 +52,19 @@ func TestReflexivePersonaAllowsTool(t *testing.T) {
 
 func TestAddReflexiveCaptureMiddleware_Gating(t *testing.T) {
 	newP := func() *Platform {
-		tk, _ := memorykit.New("test", nil, nil)
+		// A non-connecting *sql.DB is enough: memorylayer.New builds the store
+		// wrapper and toolkit without touching the database, so Toolkit() is
+		// non-nil (the reflexive-capture gate's precondition).
+		db, err := sql.Open("postgres", "postgres://localhost:5432/test?sslmode=disable")
+		if err != nil {
+			t.Fatalf("open dummy db: %v", err)
+		}
+		h, err := memorylayer.New(db, nil, memorylayer.Config{ToolkitName: "test"})
+		if err != nil {
+			t.Fatalf("build memory handle: %v", err)
+		}
 		p := &Platform{config: &Config{}}
-		p.memoryToolkit = tk
+		p.memory = h
 		p.mcpServer = mcp.NewServer(&mcp.Implementation{Name: "t", Version: "v0"}, nil)
 		return p
 	}

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -133,6 +133,7 @@ pkg/platform -> pkg/platform/fieldcrypt
 pkg/platform -> pkg/platform/iam
 pkg/platform -> pkg/platform/indexqueue
 pkg/platform -> pkg/platform/instructions
+pkg/platform -> pkg/platform/memorylayer
 pkg/platform -> pkg/platform/mwchain
 pkg/platform -> pkg/platform/oauthserver
 pkg/platform -> pkg/platform/obs
@@ -165,7 +166,6 @@ pkg/platform -> pkg/toolkits/apigateway/catalogindex
 pkg/platform -> pkg/toolkits/gateway
 pkg/platform -> pkg/toolkits/gateway/enrichment
 pkg/platform -> pkg/toolkits/knowledge
-pkg/platform -> pkg/toolkits/memory
 pkg/platform -> pkg/toolkits/search
 pkg/platform -> pkg/toolkits/tools/toolsindex
 pkg/platform -> pkg/toolkits/trino
@@ -196,6 +196,12 @@ pkg/platform/indexqueue -> pkg/toolkits/apigateway/catalog
 pkg/platform/indexqueue -> pkg/toolkits/apigateway/catalogindex
 pkg/platform/indexqueue -> pkg/toolkits/tools/toolsindex
 pkg/platform/instructions -> pkg/persona
+pkg/platform/memorylayer -> pkg/embedding
+pkg/platform/memorylayer -> pkg/memory
+pkg/platform/memorylayer -> pkg/middleware
+pkg/platform/memorylayer -> pkg/portal/knowledgepage
+pkg/platform/memorylayer -> pkg/semantic
+pkg/platform/memorylayer -> pkg/toolkits/memory
 pkg/platform/oauthserver -> pkg/oauth
 pkg/platform/oauthserver -> pkg/oauth/postgres
 pkg/platform/oauthserver -> pkg/observability


### PR DESCRIPTION
## Summary

Ninth seam of the Platform decomposition (#756), continuing after iam (#828), api-gateway route policy (#830), browser-session auth (#832), the OAuth 2.1 server (#834), the index-jobs embedding queue (#836), the connection-OAuth token lifecycle (#838), the portal store layer (#841), and the session / cross-replica-sync layer (#843).

This advances the epic's **first goal** — extracting a per-subsystem assembly into a constructor that declares its dependencies as parameters — and consolidates the **memory layer** field cluster into one owner handle. It is the most self-contained of the remaining field groups: `initMemory` was a single, ordered assembly block whose only external inputs are shared primitives (`db`, the embedding provider, the semantic provider, and the toolkit registry).

**Result: Platform loses three fields (59 → 56); the field ceiling ratchets to 56.**

## What moved

A new owner package **`pkg/platform/memorylayer`** holds the subsystem behind one `Handle`:

| File | Contents |
| --- | --- |
| `memorylayer.go` | `New(db, semanticProvider, Config)` assembles the memory store, embedder, toolkit, enrichment adapter, and constructs the staleness watcher. Accessors `MemoryStore()`, `EmbeddingProvider()`, `Toolkit()`, `MemoryProvider()`; lifecycle `Start()` / `Stop()`. |
| `recall_checker.go` | The recall-first checker (`memorykit.RecallChecker`) + `sharesAny`, moved out of `platform.go`. |
| `bridge.go` | The memory↔enrichment adapter (`middleware.MemoryProvider`), moved out of `platform.go`. |

The owner imports `pkg/memory`, `pkg/toolkits/memory`, `pkg/embedding`, `pkg/middleware` (plus `pkg/semantic` for the staleness watcher and `pkg/portal/knowledgepage` for `MemoryRef`, the same dependency `portalstore` already carries) — **never `pkg/platform`**.

## Platform side

- The four memory fields (`memoryStore`, `memoryToolkit`, `stalenessWatcher`, `memoryAdapter`) collapse into one `memory *memorylayer.Handle`.
- `initMemory` collapses to config-translation + delegation.
- **`embeddingProv` stays a `Platform`-owned field** (constraint 1): it is built by the owner and handed back via `EmbeddingProvider()`, then stored on `Platform` and passed to the other subsystems that share it (`portalstore`, `indexqueue`, the api-gateway, and the search/knowledge assembly). Its memory-enabled gating is preserved (nil/noop downstream when memory is disabled or no DB is configured).
- Every read/inject/stop site now goes through the handle: `initKnowledge`'s insight adapter, `initSearch`'s router, the indexqueue memory-consumer gate, the `MemoryStore()` accessor, the thread-linker + reflexive-capture wiring, the enrichment-adapter injection, and `stopBackgroundTrackers`.
- `p.db` / `p.config` / `p.semanticProvider` / `p.toolkitRegistry` remain on `Platform` and are passed to the owner as explicit inputs.

## Ordering preserved (two-phase construction)

To keep the original teardown-safe order, construction is two-phase (mirroring `sessionsync`'s `New` + `StartCache`):

1. `New` builds the store + embedder + toolkit (with recall checker) + adapter and **constructs** the staleness watcher without starting its goroutine.
2. `Platform` registers the toolkit into the shared registry.
3. `Platform` calls `Handle.Start()` to launch the watcher goroutine, then logs `memory layer enabled`.

This preserves the pre-refactor order (register → start watcher → log), so a toolkit-registration failure leaves no detached watcher goroutine running and emits no misleading success log. `Stop()` (wired into `stopBackgroundTrackers`) winds the watcher down before `Platform` closes the shared `*sql.DB`.

## Behavior parity

All preconditions and behavior from the original `initMemory` are preserved:

- the memory-disabled / no-DB no-op (nil handle, nil embedder),
- the ollama-vs-noop embedder selection with the existing `#429` WARN,
- the recall-first checker (`#633`/`#762`),
- the staleness-watcher gating (`Memory.Staleness.Enabled && semanticProvider != nil`) + `Start`/`Stop`,
- toolkit registration into the shared registry.

## Testing

- New package assembled from explicit inputs and unit-tested **without a `Platform`**: db-nil no-op, embedder ollama/noop selection, staleness-watcher gating + `Start`/`Stop`, toolkit/adapter surface, and the recall/bridge tests relocated from `pkg/platform`. New package coverage **96.8%**.
- `TestPlatformGodObjectBudget` field ceiling lowered **59 → 56** (measured: 56 fields).
- Import ratchet (`testdata/allowed_internal_imports.txt`) regenerated: adds the seven `memorylayer` edges and drops the now-dead `pkg/platform -> pkg/toolkits/memory` edge (a real decoupling — Platform no longer imports the memory toolkit directly).
- `make verify` green (fmt, race tests, coverage ≥80% + patch coverage, patch + full lint, gosec, govulncheck, semgrep, CodeQL, dead-code, mutation ≥60%, GoReleaser dry-run, 44 e2e tests).

## Review

A high-effort adversarial review caught an ordering drift in the first draft (watcher started + "enabled" logged inside `New` before registration); fixed with the two-phase `New`/`Start` split described above and re-verified green.

Closes #845
Relates to #756
