### PR TITLE
refactor(platform): extract knowledge-capture layer into pkg/platform/knowledgelayer (#847)

### DIFF
--- a/godobject_budget_test.go
+++ b/godobject_budget_test.go
@@ -46,8 +46,13 @@ const (
 	// sessionsync.Handle, ratcheting 64 → 59; the memory-layer extraction (#845)
 	// folded four fields (memoryStore, memoryToolkit, stalenessWatcher,
 	// memoryAdapter) into one memorylayer.Handle — embeddingProv stays on
-	// Platform because it backs many other subsystems — ratcheting 59 → 56.
-	maxPlatformFields = 56
+	// Platform because it backs many other subsystems — ratcheting 59 → 56; the
+	// knowledge-capture-layer extraction (#847) folded four fields
+	// (knowledgeInsightStore, knowledgeChangesetStore, knowledgeToolkit,
+	// knowledgeDataHubWriter) into one knowledgelayer.Handle — knowledgeRouter
+	// (search federation) stays on Platform as a separate later seam — ratcheting
+	// 56 → 53.
+	maxPlatformFields = 53
 
 	// maxPlatformMethods caps the number of methods with a *Platform receiver.
 	// Frozen at today's count; ratchet down as accessors move onto the

--- a/pkg/platform/info_tool.go
+++ b/pkg/platform/info_tool.go
@@ -131,13 +131,14 @@ func (p *Platform) buildFeatures(ctx context.Context, accessibleTools []string) 
 // the queue is empty; a failed lookup must not fail orientation, so the error is
 // logged and swallowed rather than propagated.
 func (p *Platform) reviewQueueInfo(ctx context.Context) *ReviewQueueInfo {
-	if p.knowledgeInsightStore == nil {
+	store := p.knowledge.InsightStore()
+	if store == nil {
 		return nil
 	}
 	// Prefer the store's cheap pending-count + staleness path over the full Stats
 	// fan-out: platform_info runs once per session and needs only the review-debt
 	// nudge, not the category/confidence group-bys (#764).
-	review, err := knowledgekit.PendingReviewOf(ctx, p.knowledgeInsightStore)
+	review, err := knowledgekit.PendingReviewOf(ctx, store)
 	if err != nil {
 		slog.WarnContext(ctx, "platform_info: pending review queue stats unavailable", "error", err)
 		return nil

--- a/pkg/platform/info_tool_test.go
+++ b/pkg/platform/info_tool_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
+	"github.com/txn2/mcp-data-platform/pkg/platform/knowledgelayer"
 	"github.com/txn2/mcp-data-platform/pkg/query"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
@@ -65,7 +66,11 @@ func TestReviewQueueInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Platform{knowledgeInsightStore: tt.store}
+			// Build the layer handle over the injected insight store; the
+			// db/embedding inputs are unused with apply disabled.
+			handle, err := knowledgelayer.NewFromInsightStore(nil, tt.store, nil, knowledgelayer.Config{ToolkitName: instanceDefault})
+			require.NoError(t, err)
+			p := &Platform{knowledge: handle}
 			got := p.reviewQueueInfo(context.Background())
 			if tt.want == nil {
 				assert.Nil(t, got)

--- a/pkg/platform/knowledgelayer/knowledgelayer.go
+++ b/pkg/platform/knowledgelayer/knowledgelayer.go
@@ -1,0 +1,236 @@
+// Package knowledgelayer assembles the knowledge-capture layer behind one
+// Handle: the insight store (the memory-backed adapter over memory_records when
+// a memory store is present, else the legacy Postgres store), the changeset
+// store and DataHub writer that back apply_knowledge, and the capture_insight /
+// apply_knowledge toolkit itself.
+//
+// Construction takes explicit inputs — a *sql.DB, the memory.Store for the
+// insight adapter (nil selects the Postgres store), the shared
+// embedding.Provider that powers the knowledge-page write-guard dedup probe, and
+// the resolved knowledge / apply / page-guard / DataHub-connection config values
+// — so the subsystem is constructible and testable without a Platform. It
+// imports pkg/toolkits/knowledge, pkg/memory, pkg/embedding, and
+// pkg/portal/knowledgepage, never pkg/platform. The *sql.DB, the memory store,
+// and the embedding provider back many other subsystems, so they stay owned by
+// Platform and are passed in.
+//
+// The layer owns no background goroutine, so it needs no Stop/Close (unlike the
+// memory layer's staleness watcher). Toolkit registration and the prompt-creator
+// wiring stay Platform/registry concerns: New builds the toolkit and exposes it
+// via Toolkit() for Platform to register into the shared toolkit registry and to
+// wire the prompt creator onto (that wiring reaches back into Platform, so it
+// cannot move here).
+package knowledgelayer
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"time"
+
+	dhclient "github.com/txn2/mcp-datahub/pkg/client"
+
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
+	"github.com/txn2/mcp-data-platform/pkg/memory"
+	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
+	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
+)
+
+// DataHubConfig carries the resolved DataHub connection values the owner needs
+// to build the real client-backed apply writer. Platform resolves its own
+// toolkit config (keeping its toolkitcfg coupling out of this package) and
+// passes a non-nil value when the apply datahub_connection is configured, or nil
+// to select the noop writer (with the startup WARN).
+type DataHubConfig struct {
+	URL     string
+	Token   string
+	Timeout time.Duration
+	Debug   bool
+}
+
+// Config carries the resolved knowledge / apply / page-guard values the owner
+// needs to assemble the layer. Platform translates its own config into this
+// shape so this package stays free of the platform's config types.
+type Config struct {
+	// ToolkitName is the knowledge toolkit instance name (the platform passes its
+	// default).
+	ToolkitName string
+	// ApplyEnabled gates the apply_knowledge dependencies: the changeset store,
+	// the DataHub writer, the knowledge-page writer, and the page guards.
+	ApplyEnabled bool
+	// ApplyDataHubConnection is the connection name apply writes to; reported in
+	// the enabled log and the noop-writer WARN.
+	ApplyDataHubConnection string
+	// ApplyRequireConfirmation is passed through to the toolkit's ApplyConfig.
+	ApplyRequireConfirmation bool
+	// PageGuards are the resolved knowledge-page write-guard thresholds (#705),
+	// applied only when apply is enabled.
+	PageGuards knowledgepage.PageGuards
+	// DataHub is the resolved DataHub connection for the apply writer; nil selects
+	// the noop writer with a startup WARN. Used only when ApplyEnabled.
+	DataHub *DataHubConfig
+}
+
+// Handle owns the assembled knowledge-capture layer: the insight store, the
+// changeset store and DataHub writer for apply_knowledge, and the knowledge
+// toolkit. The read accessors expose the pieces Platform surfaces through its
+// KnowledgeInsightStore() / KnowledgeChangesetStore() / KnowledgeDataHubWriter()
+// admin accessors, reads for platform_info's pending-review count and the search
+// router's insights provider, registers into the shared toolkit registry, and
+// wires the prompt creator + guarded backfill onto. The layer owns no background
+// goroutine, so there is no Stop/Close.
+type Handle struct {
+	insightStore   knowledgekit.InsightStore
+	changesetStore knowledgekit.ChangesetStore
+	toolkit        *knowledgekit.Toolkit
+	dataHubWriter  knowledgekit.DataHubWriter
+}
+
+// New assembles the insight store (the memory-backed adapter when memStore is
+// non-nil, else the legacy Postgres store), the knowledge toolkit, and — when
+// cfg.ApplyEnabled — the changeset store, DataHub writer, knowledge-page writer,
+// and page guards for apply_knowledge. It returns (nil, nil) when db is nil: the
+// knowledge layer is a no-op without a database, matching the platform
+// precondition. It returns an error only when the toolkit or the DataHub client
+// fails to build.
+func New(db *sql.DB, memStore memory.Store, embeddingProv embedding.Provider, cfg Config) (*Handle, error) {
+	if db == nil {
+		return nil, nil //nolint:nilnil // nil handle = knowledge layer disabled (no database)
+	}
+
+	// Use the memory-backed adapter when a memory store is available (the
+	// migration drops knowledge_insights in favor of memory_records); otherwise
+	// fall back to the legacy Postgres store.
+	var store knowledgekit.InsightStore
+	if memStore != nil {
+		store = knowledgekit.NewMemoryInsightAdapter(memStore)
+	} else {
+		store = knowledgekit.NewPostgresStore(db)
+	}
+	return NewFromInsightStore(db, store, embeddingProv, cfg)
+}
+
+// NewFromInsightStore assembles the Handle and its toolkit from an already-built
+// insight store. New delegates here after selecting the adapter-vs-postgres
+// store; it is also the seam that lets callers (and tests) inject their own
+// insight store implementation. When cfg.ApplyEnabled it configures the
+// apply_knowledge dependencies from db / embeddingProv / cfg — which requires a
+// non-nil db (the changeset and page stores are Postgres-backed), so enabling
+// apply with a nil db is a construction error rather than a query-time failure.
+func NewFromInsightStore(db *sql.DB, store knowledgekit.InsightStore, embeddingProv embedding.Provider, cfg Config) (*Handle, error) {
+	tk, err := knowledgekit.New(cfg.ToolkitName, store)
+	if err != nil {
+		return nil, fmt.Errorf("knowledgelayer: creating knowledge toolkit: %w", err)
+	}
+
+	h := &Handle{insightStore: store, toolkit: tk}
+
+	if cfg.ApplyEnabled {
+		if db == nil {
+			return nil, fmt.Errorf("knowledgelayer: apply enabled requires a non-nil database")
+		}
+		if err := h.configureApply(db, embeddingProv, cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	slog.Info("knowledge capture enabled")
+	return h, nil
+}
+
+// configureApply wires the apply_knowledge tool dependencies: the Postgres
+// changeset store, the DataHub writer (real or noop), the knowledge-page writer,
+// and the page guards. Called only when cfg.ApplyEnabled.
+func (h *Handle) configureApply(db *sql.DB, embeddingProv embedding.Provider, cfg Config) error {
+	csStore := knowledgekit.NewPostgresChangesetStore(db)
+	h.changesetStore = csStore
+
+	writer, err := buildDataHubWriter(cfg.ApplyDataHubConnection, cfg.DataHub)
+	if err != nil {
+		return fmt.Errorf("knowledgelayer: creating datahub writer: %w", err)
+	}
+	h.dataHubWriter = writer
+
+	h.toolkit.SetApplyConfig(knowledgekit.ApplyConfig{
+		Enabled:             true,
+		DataHubConnection:   cfg.ApplyDataHubConnection,
+		RequireConfirmation: cfg.ApplyRequireConfirmation,
+	}, csStore, writer)
+
+	// #633 Goal 3: let apply promote business_knowledge/operational_rule captures
+	// to canonical knowledge pages. Built directly from the DB (the portal handle
+	// is not yet available when knowledge initializes) because apply requires the
+	// same DB the changeset store already uses.
+	h.toolkit.SetPageWriter(knowledgepage.NewPostgresStoreSearcher(db))
+	// Knowledge-page write guards (#705); the embedding provider powers the dedup
+	// probe and is inactive under a noop provider.
+	h.toolkit.SetPageGuards(cfg.PageGuards, embeddingProv)
+
+	slog.Info("knowledge apply enabled",
+		"datahub_connection", cfg.ApplyDataHubConnection,
+		"require_confirmation", cfg.ApplyRequireConfirmation)
+	return nil
+}
+
+// buildDataHubWriter creates a DataHubWriter backed by a real DataHub client
+// when a connection is configured (dhCfg non-nil), or falls back to a noop
+// writer with a WARN — the operator's only signal that apply cannot write to
+// DataHub. connName is reported in both the WARN and the real-writer log.
+func buildDataHubWriter(connName string, dhCfg *DataHubConfig) (knowledgekit.DataHubWriter, error) {
+	if dhCfg == nil {
+		slog.Warn("knowledge apply: datahub connection not found, using noop writer",
+			"connection", connName)
+		return &knowledgekit.NoopDataHubWriter{}, nil
+	}
+
+	clientCfg := dhclient.DefaultConfig()
+	clientCfg.URL = dhCfg.URL
+	clientCfg.Token = dhCfg.Token
+	clientCfg.Timeout = dhCfg.Timeout
+	clientCfg.Debug = dhCfg.Debug
+
+	c, err := dhclient.New(clientCfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating datahub client for connection %q: %w", connName, err)
+	}
+
+	slog.Info("knowledge apply: using datahub writer", "connection", connName)
+	return knowledgekit.NewDataHubClientWriter(c), nil
+}
+
+// InsightStore returns the insight store, or nil on a nil Handle (knowledge
+// disabled or no database).
+func (h *Handle) InsightStore() knowledgekit.InsightStore {
+	if h == nil {
+		return nil
+	}
+	return h.insightStore
+}
+
+// ChangesetStore returns the apply_knowledge changeset store, or nil on a nil
+// Handle or when apply is disabled.
+func (h *Handle) ChangesetStore() knowledgekit.ChangesetStore {
+	if h == nil {
+		return nil
+	}
+	return h.changesetStore
+}
+
+// Toolkit returns the knowledge toolkit for Platform to register into the shared
+// toolkit registry, wire the prompt creator onto, and run the guarded backfill
+// against, or nil on a nil Handle.
+func (h *Handle) Toolkit() *knowledgekit.Toolkit {
+	if h == nil {
+		return nil
+	}
+	return h.toolkit
+}
+
+// DataHubWriter returns the apply_knowledge DataHub writer, or nil on a nil
+// Handle or when apply is disabled.
+func (h *Handle) DataHubWriter() knowledgekit.DataHubWriter {
+	if h == nil {
+		return nil
+	}
+	return h.dataHubWriter
+}

--- a/pkg/platform/knowledgelayer/knowledgelayer_test.go
+++ b/pkg/platform/knowledgelayer/knowledgelayer_test.go
@@ -1,0 +1,148 @@
+package knowledgelayer
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/lib/pq"
+
+	"github.com/txn2/mcp-data-platform/pkg/memory"
+	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
+)
+
+// dummyDB returns a non-connecting *sql.DB. New builds the store wrappers and
+// toolkit without touching the database, so a real connection is never needed.
+func dummyDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("postgres", "postgres://localhost:5432/test?sslmode=disable")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// stubMemoryStore is a non-nil memory.Store used only to select the
+// memory-backed insight adapter; its methods are never called in these tests.
+type stubMemoryStore struct{ memory.Store }
+
+func TestNew_NilDBIsNoop(t *testing.T) {
+	h, err := New(nil, nil, nil, Config{ToolkitName: "default"})
+	require.NoError(t, err)
+	assert.Nil(t, h, "no database → nil handle (knowledge disabled)")
+
+	// Every accessor is safe on the nil handle and returns the disabled zero.
+	assert.Nil(t, h.InsightStore())
+	assert.Nil(t, h.ChangesetStore())
+	assert.Nil(t, h.Toolkit())
+	assert.Nil(t, h.DataHubWriter())
+}
+
+func TestNew_InsightStoreSelection(t *testing.T) {
+	t.Run("memory store selects the searchable adapter", func(t *testing.T) {
+		h, err := New(dummyDB(t), stubMemoryStore{}, nil, Config{ToolkitName: "default"})
+		require.NoError(t, err)
+		require.NotNil(t, h)
+		require.NotNil(t, h.InsightStore())
+		_, ok := h.InsightStore().(knowledgekit.SearchableInsightStore)
+		assert.True(t, ok, "memory-backed adapter is a SearchableInsightStore")
+	})
+
+	t.Run("no memory store falls back to the postgres store", func(t *testing.T) {
+		h, err := New(dummyDB(t), nil, nil, Config{ToolkitName: "default"})
+		require.NoError(t, err)
+		require.NotNil(t, h)
+		require.NotNil(t, h.InsightStore())
+		_, ok := h.InsightStore().(knowledgekit.SearchableInsightStore)
+		assert.False(t, ok, "the legacy postgres store is not searchable")
+	})
+}
+
+func TestNew_ApplyGating(t *testing.T) {
+	t.Run("apply disabled leaves changeset store and writer nil", func(t *testing.T) {
+		h, err := New(dummyDB(t), nil, nil, Config{ToolkitName: "default", ApplyEnabled: false})
+		require.NoError(t, err)
+		require.NotNil(t, h)
+		assert.NotNil(t, h.Toolkit(), "toolkit is always built")
+		assert.Nil(t, h.ChangesetStore(), "no changeset store when apply is disabled")
+		assert.Nil(t, h.DataHubWriter(), "no writer when apply is disabled")
+	})
+
+	t.Run("apply enabled builds changeset store and noop writer without a connection", func(t *testing.T) {
+		h, err := New(dummyDB(t), nil, nil, Config{ToolkitName: "default", ApplyEnabled: true})
+		require.NoError(t, err)
+		require.NotNil(t, h)
+		assert.NotNil(t, h.ChangesetStore(), "changeset store built when apply is enabled")
+		require.NotNil(t, h.DataHubWriter())
+		_, ok := h.DataHubWriter().(*knowledgekit.NoopDataHubWriter)
+		assert.True(t, ok, "nil DataHub config selects the noop writer")
+	})
+
+	t.Run("apply enabled with an invalid connection fails construction", func(t *testing.T) {
+		_, err := New(dummyDB(t), nil, nil, Config{
+			ToolkitName:            "default",
+			ApplyEnabled:           true,
+			ApplyDataHubConnection: "primary",
+			DataHub:                &DataHubConfig{URL: "", Token: ""},
+		})
+		require.Error(t, err, "an unbuildable DataHub client propagates as an error")
+	})
+
+	t.Run("apply enabled with a connection builds the real writer", func(t *testing.T) {
+		h, err := New(dummyDB(t), nil, nil, Config{
+			ToolkitName:            "default",
+			ApplyEnabled:           true,
+			ApplyDataHubConnection: "primary",
+			DataHub:                &DataHubConfig{URL: "http://datahub:8080", Token: "test-token"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, h)
+		require.NotNil(t, h.DataHubWriter())
+		_, ok := h.DataHubWriter().(*knowledgekit.DataHubClientWriter)
+		assert.True(t, ok, "a resolved DataHub config selects the real client writer")
+	})
+}
+
+func TestBuildDataHubWriter(t *testing.T) {
+	t.Run("nil config yields the noop writer", func(t *testing.T) {
+		w, err := buildDataHubWriter("nonexistent", nil)
+		require.NoError(t, err)
+		_, ok := w.(*knowledgekit.NoopDataHubWriter)
+		assert.True(t, ok, "expected NoopDataHubWriter when connection not found")
+	})
+
+	t.Run("valid config yields the client writer", func(t *testing.T) {
+		w, err := buildDataHubWriter("primary", &DataHubConfig{URL: "http://datahub:8080", Token: "test-token"})
+		require.NoError(t, err)
+		_, ok := w.(*knowledgekit.DataHubClientWriter)
+		assert.True(t, ok, "expected DataHubClientWriter for a valid connection")
+	})
+
+	t.Run("empty url yields an error", func(t *testing.T) {
+		_, err := buildDataHubWriter("primary", &DataHubConfig{URL: "", Token: ""})
+		require.Error(t, err, "expected error for invalid datahub config")
+	})
+}
+
+func TestNewFromInsightStore_InjectedStore(t *testing.T) {
+	// The seam that lets callers inject their own insight store without a
+	// database (apply disabled, so db/embedding are unused).
+	store := knowledgekit.NewNoopStore()
+	h, err := NewFromInsightStore(nil, store, nil, Config{ToolkitName: "default"})
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.Equal(t, store, h.InsightStore(), "the injected store is exposed verbatim")
+	assert.NotNil(t, h.Toolkit())
+}
+
+func TestNewFromInsightStore_ApplyRequiresDB(t *testing.T) {
+	// Enabling apply without a database is a construction error: the changeset
+	// and page stores are Postgres-backed, so a nil db would otherwise build
+	// stores that only fail at query time.
+	_, err := NewFromInsightStore(nil, knowledgekit.NewNoopStore(), nil, Config{
+		ToolkitName:  "default",
+		ApplyEnabled: true,
+	})
+	require.Error(t, err, "apply enabled with a nil db must fail construction")
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -22,7 +22,6 @@ import (
 	// PostgreSQL driver for database/sql.
 	_ "github.com/lib/pq"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	dhclient "github.com/txn2/mcp-datahub/pkg/client"
 	s3client "github.com/txn2/mcp-s3/pkg/client"
 
 	"github.com/txn2/mcp-data-platform/apps"
@@ -50,6 +49,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/platform/fieldcrypt"
 	"github.com/txn2/mcp-data-platform/pkg/platform/iam"
 	"github.com/txn2/mcp-data-platform/pkg/platform/indexqueue"
+	"github.com/txn2/mcp-data-platform/pkg/platform/knowledgelayer"
 	"github.com/txn2/mcp-data-platform/pkg/platform/memorylayer"
 	"github.com/txn2/mcp-data-platform/pkg/platform/mwchain"
 	"github.com/txn2/mcp-data-platform/pkg/platform/oauthserver"
@@ -183,11 +183,14 @@ type Platform struct {
 	ruleEngine    *tuning.RuleEngine
 	promptManager *tuning.PromptManager
 
-	// Knowledge stores (exposed for admin API)
-	knowledgeInsightStore   knowledgekit.InsightStore
-	knowledgeChangesetStore knowledgekit.ChangesetStore
-	knowledgeToolkit        *knowledgekit.Toolkit
-	knowledgeDataHubWriter  knowledgekit.DataHubWriter
+	// Knowledge-capture layer. The owner (pkg/platform/knowledgelayer) holds the
+	// insight store (the memory-backed adapter over memory_records, else the
+	// legacy Postgres store), the changeset store + DataHub writer for
+	// apply_knowledge, and the capture_insight / apply_knowledge toolkit behind
+	// one Handle; the stores / writer / toolkit are read through its accessors and
+	// surfaced by the three admin accessors below. nil when knowledge is disabled
+	// or no database is configured.
+	knowledge *knowledgelayer.Handle
 	// knowledgeRouter is the unified search federation built in initSearch. It
 	// backs both the MCP search tool and the portal's GET /search REST endpoint;
 	// nil on a store-less deployment with no searchable source.
@@ -1393,46 +1396,71 @@ func (p *Platform) initSessionGate() {
 	)
 }
 
-// initKnowledge initializes the knowledge capture toolkit if enabled.
-// Knowledge tools require database persistence — without a database the
-// toolkit is not registered and its tools won't appear in tools/list.
+// initKnowledge assembles the knowledge-capture layer via the knowledgelayer
+// owner: the insight store (the memory-backed adapter over memory_records when
+// the memory store is present, else the legacy Postgres store), the changeset
+// store + DataHub writer for apply_knowledge, and the capture_insight /
+// apply_knowledge toolkit behind one Handle. It translates platform config into
+// the owner's Config (resolving the DataHub connection through toolkitcfg so the
+// owner stays free of that coupling), delegates assembly, then keeps the
+// prompt-creator wiring and toolkit registration here (both reach back into
+// Platform / the shared registry). Knowledge tools require database persistence —
+// without a database the toolkit is not registered and its tools won't appear in
+// tools/list. Must run after initMemory so the memory store is available for the
+// insight adapter.
 func (p *Platform) initKnowledge() error {
 	if isExplicitlyDisabled(p.config.Knowledge.Enabled) || p.db == nil {
 		return nil
 	}
 
-	// Use memory-backed adapter when memory store is available (migration
-	// drops knowledge_insights in favor of memory_records).
-	var store knowledgekit.InsightStore
-	if memStore := p.memory.MemoryStore(); memStore != nil {
-		store = knowledgekit.NewMemoryInsightAdapter(memStore)
-	} else {
-		store = knowledgekit.NewPostgresStore(p.db)
-	}
-	p.knowledgeInsightStore = store
-
-	tk, err := knowledgekit.New(instanceDefault, store)
+	apply := p.config.Knowledge.Apply
+	applyEnabled := apply.IsEnabled()
+	handle, err := knowledgelayer.New(p.db, p.memory.MemoryStore(), p.embeddingProv, knowledgelayer.Config{
+		ToolkitName:              instanceDefault,
+		ApplyEnabled:             applyEnabled,
+		ApplyDataHubConnection:   apply.DataHubConnection,
+		ApplyRequireConfirmation: apply.RequireConfirmation,
+		PageGuards:               p.config.Knowledge.Pages.Resolve(),
+		DataHub:                  p.resolveKnowledgeDataHubConfig(apply.DataHubConnection, applyEnabled),
+	})
 	if err != nil {
-		return fmt.Errorf("creating knowledge toolkit: %w", err)
+		return fmt.Errorf("creating knowledge layer: %w", err)
 	}
-	p.knowledgeToolkit = tk
+	p.knowledge = handle
 
-	// Configure apply_knowledge tool if enabled.
-	if err := p.configureKnowledgeApply(tk); err != nil {
-		return err
-	}
-
-	// Wire prompt creator for add_prompt change type
+	// Wire prompt creator for add_prompt change type. This reaches back into
+	// Platform (the prompt store + a *Platform), so it stays here and is applied
+	// through the handle's toolkit.
 	if p.promptStore != nil {
-		tk.SetPromptCreator(&platformPromptCreator{store: p.promptStore, platform: p})
+		handle.Toolkit().SetPromptCreator(&platformPromptCreator{store: p.promptStore, platform: p})
 	}
 
-	if err := p.toolkitRegistry.Register(tk); err != nil {
+	// Toolkit registration stays a Platform/registry concern.
+	if err := p.toolkitRegistry.Register(handle.Toolkit()); err != nil {
 		return fmt.Errorf("registering knowledge toolkit: %w", err)
 	}
-
-	slog.Info("knowledge capture enabled")
 	return nil
+}
+
+// resolveKnowledgeDataHubConfig resolves the apply_knowledge DataHub connection
+// into the owner's config shape, keeping Platform's toolkitcfg coupling out of
+// the knowledgelayer package. It returns nil when apply is disabled or the
+// connection is not configured (the owner then selects the noop writer with a
+// WARN).
+func (p *Platform) resolveKnowledgeDataHubConfig(connName string, applyEnabled bool) *knowledgelayer.DataHubConfig {
+	if !applyEnabled {
+		return nil
+	}
+	dhCfg := toolkitcfg.DataHubConfig(p.config.Toolkits, connName)
+	if dhCfg == nil {
+		return nil
+	}
+	return &knowledgelayer.DataHubConfig{
+		URL:     dhCfg.URL,
+		Token:   dhCfg.Token,
+		Timeout: dhCfg.Timeout,
+		Debug:   dhCfg.Debug,
+	}
 }
 
 // initSearch wires the universal, topology-free discovery entry point (#645):
@@ -1487,7 +1515,7 @@ func (p *Platform) storeSearchProviders() []knowledge.Provider {
 	// Insights are searchable only through the memory-backed adapter; the legacy
 	// SQL store and the noop store do not implement InsightSearcher (and so are
 	// not SearchableInsightStores).
-	if s, ok := p.knowledgeInsightStore.(knowledgekit.SearchableInsightStore); ok {
+	if s, ok := p.knowledge.InsightStore().(knowledgekit.SearchableInsightStore); ok {
 		providers = append(providers, knowledge.NewInsightsProvider(s))
 	}
 	// The technical catalog is a knowledge sink only when a real DataHub
@@ -1543,66 +1571,6 @@ func (p *Platform) appendFederationSearchProviders(providers []knowledge.Provide
 		providers = append(providers, knowledge.NewConnectionsProvider(connLister))
 	}
 	return providers
-}
-
-// configureKnowledgeApply sets up the apply_knowledge tool dependencies if enabled.
-func (p *Platform) configureKnowledgeApply(tk *knowledgekit.Toolkit) error {
-	if !p.config.Knowledge.Apply.IsEnabled() {
-		return nil
-	}
-
-	csStore := knowledgekit.NewPostgresChangesetStore(p.db)
-	p.knowledgeChangesetStore = csStore
-
-	writer, err := p.createDataHubWriter()
-	if err != nil {
-		return fmt.Errorf("creating datahub writer: %w", err)
-	}
-	p.knowledgeDataHubWriter = writer
-
-	apply := p.config.Knowledge.Apply
-	tk.SetApplyConfig(knowledgekit.ApplyConfig{Enabled: true, DataHubConnection: apply.DataHubConnection, RequireConfirmation: apply.RequireConfirmation}, csStore, writer)
-
-	// #633 Goal 3: let apply promote business_knowledge/operational_rule captures
-	// to canonical knowledge pages. Built directly from the DB (not
-	// p.portalStore.KnowledgePageStore()) because initKnowledge runs before
-	// initPortal, so the portal handle is not yet set here; apply requires the DB
-	// the changeset store already uses.
-	if p.db != nil {
-		tk.SetPageWriter(knowledgepage.NewPostgresStoreSearcher(p.db))
-	}
-	// Knowledge-page write guards (#705); embeddingProv (from initMemory, which runs
-	// first) powers the dedup probe and is inactive under a noop provider.
-	tk.SetPageGuards(p.config.Knowledge.Pages.Resolve(), p.embeddingProv)
-
-	slog.Info("knowledge apply enabled", "datahub_connection", p.config.Knowledge.Apply.DataHubConnection, "require_confirmation", p.config.Knowledge.Apply.RequireConfirmation)
-	return nil
-}
-
-// createDataHubWriter creates a DataHubWriter backed by a real DataHub client
-// when a datahub_connection is configured, or falls back to a noop writer.
-func (p *Platform) createDataHubWriter() (knowledgekit.DataHubWriter, error) {
-	connName := p.config.Knowledge.Apply.DataHubConnection
-	dhCfg := toolkitcfg.DataHubConfig(p.config.Toolkits, connName)
-	if dhCfg == nil {
-		slog.Warn("knowledge apply: datahub connection not found, using noop writer",
-			"connection", connName)
-		return &knowledgekit.NoopDataHubWriter{}, nil
-	}
-
-	clientCfg := dhclient.DefaultConfig()
-	clientCfg.URL = dhCfg.URL
-	clientCfg.Token = dhCfg.Token
-	clientCfg.Timeout = dhCfg.Timeout
-	clientCfg.Debug = dhCfg.Debug
-
-	c, err := dhclient.New(clientCfg)
-	if err != nil {
-		return nil, fmt.Errorf("creating datahub client for connection %q: %w", connName, err)
-	}
-
-	slog.Info("knowledge apply: using datahub writer", "connection", connName)
-	return knowledgekit.NewDataHubClientWriter(c), nil
 }
 
 // initPortal initializes the asset portal toolkit if enabled.
@@ -2839,8 +2807,8 @@ func (p *Platform) Start(ctx context.Context) error {
 
 	// One-time knowledge-page reference backfill (#664 Phase 5), guarded by a
 	// sentinel and run in the background so it never delays startup.
-	if p.db != nil && p.knowledgeToolkit != nil {
-		go p.knowledgeToolkit.RunGuardedBackfill(ctx, p.db, knowledgepage.NewPostgresStore(p.db))
+	if p.db != nil && p.knowledge.Toolkit() != nil {
+		go p.knowledge.Toolkit().RunGuardedBackfill(ctx, p.db, knowledgepage.NewPostgresStore(p.db))
 	}
 
 	// Start lifecycle
@@ -3097,17 +3065,17 @@ func (p *Platform) MemoryStore() memory.Store {
 
 // KnowledgeInsightStore returns the insight store, or nil if knowledge is disabled.
 func (p *Platform) KnowledgeInsightStore() knowledgekit.InsightStore {
-	return p.knowledgeInsightStore
+	return p.knowledge.InsightStore()
 }
 
 // KnowledgeChangesetStore returns the changeset store, or nil if knowledge apply is disabled.
 func (p *Platform) KnowledgeChangesetStore() knowledgekit.ChangesetStore {
-	return p.knowledgeChangesetStore
+	return p.knowledge.ChangesetStore()
 }
 
 // KnowledgeDataHubWriter returns the DataHub writer, or nil if knowledge apply is disabled.
 func (p *Platform) KnowledgeDataHubWriter() knowledgekit.DataHubWriter {
-	return p.knowledgeDataHubWriter
+	return p.knowledge.DataHubWriter()
 }
 
 // PortalAssetStore returns the portal asset store, or nil if portal is disabled.

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/session"
 	"github.com/txn2/mcp-data-platform/pkg/storage"
 	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
-	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
 	"github.com/txn2/mcp-data-platform/pkg/tuning"
 )
 
@@ -2688,84 +2687,48 @@ func TestInitKnowledge_ApplyWithDataHubConnection(t *testing.T) {
 	}
 }
 
-func TestCreateDataHubWriter_NoConnection(t *testing.T) {
-	p := &Platform{
-		config: &Config{
-			Knowledge: KnowledgeConfig{
-				Apply: KnowledgeApplyConfig{
-					DataHubConnection: "nonexistent",
-				},
-			},
-			Toolkits: map[string]any{},
-		},
-	}
+// TestResolveKnowledgeDataHubConfig covers the connection-resolution seam that
+// translates platform toolkit config into the knowledgelayer owner's
+// DataHubConfig (the owner then selects the real vs noop writer). The writer
+// build itself is exercised in the knowledgelayer package.
+func TestResolveKnowledgeDataHubConfig(t *testing.T) {
+	t.Run("nil when apply disabled", func(t *testing.T) {
+		p := &Platform{config: &Config{Toolkits: map[string]any{}}}
+		if cfg := p.resolveKnowledgeDataHubConfig(testInstanceDefault, false); cfg != nil {
+			t.Errorf("expected nil when apply disabled, got %+v", cfg)
+		}
+	})
 
-	writer, err := p.createDataHubWriter()
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
+	t.Run("nil when connection not found", func(t *testing.T) {
+		p := &Platform{config: &Config{Toolkits: map[string]any{}}}
+		if cfg := p.resolveKnowledgeDataHubConfig("nonexistent", true); cfg != nil {
+			t.Errorf("expected nil when connection not found, got %+v", cfg)
+		}
+	})
 
-	if _, ok := writer.(*knowledgekit.NoopDataHubWriter); !ok {
-		t.Error("expected NoopDataHubWriter when connection not found")
-	}
-}
-
-func TestCreateDataHubWriter_WithConnection(t *testing.T) {
-	p := &Platform{
-		config: &Config{
-			Knowledge: KnowledgeConfig{
-				Apply: KnowledgeApplyConfig{
-					DataHubConnection: testInstanceDefault,
-				},
-			},
-			Toolkits: map[string]any{
-				testToolkitKeyDatahub: map[string]any{
-					testInstancesKey: map[string]any{
-						testInstanceDefault: map[string]any{
-							testCfgKeyURL:   "http://datahub:8080",
-							testCfgKeyToken: "test-token",
+	t.Run("populated when connection configured", func(t *testing.T) {
+		p := &Platform{
+			config: &Config{
+				Toolkits: map[string]any{
+					testToolkitKeyDatahub: map[string]any{
+						testInstancesKey: map[string]any{
+							testInstanceDefault: map[string]any{
+								testCfgKeyURL:   "http://datahub:8080",
+								testCfgKeyToken: "test-token",
+							},
 						},
 					},
 				},
 			},
-		},
-	}
-
-	writer, err := p.createDataHubWriter()
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-
-	if _, ok := writer.(*knowledgekit.DataHubClientWriter); !ok {
-		t.Errorf("expected DataHubClientWriter, got %T", writer)
-	}
-}
-
-func TestCreateDataHubWriter_InvalidConfig(t *testing.T) {
-	p := &Platform{
-		config: &Config{
-			Knowledge: KnowledgeConfig{
-				Apply: KnowledgeApplyConfig{
-					DataHubConnection: testInstanceDefault,
-				},
-			},
-			Toolkits: map[string]any{
-				testToolkitKeyDatahub: map[string]any{
-					testInstancesKey: map[string]any{
-						testInstanceDefault: map[string]any{
-							testCfgKeyURL:   "",
-							testCfgKeyToken: "",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	_, err := p.createDataHubWriter()
-	if err == nil {
-		t.Error("expected error for invalid datahub config")
-	}
+		}
+		cfg := p.resolveKnowledgeDataHubConfig(testInstanceDefault, true)
+		if cfg == nil {
+			t.Fatal("expected non-nil config when connection configured")
+		}
+		if cfg.URL != "http://datahub:8080" || cfg.Token != "test-token" {
+			t.Errorf("unexpected resolved config: %+v", cfg)
+		}
+	})
 }
 
 func TestAuditStore_Accessor(t *testing.T) {

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -133,6 +133,7 @@ pkg/platform -> pkg/platform/fieldcrypt
 pkg/platform -> pkg/platform/iam
 pkg/platform -> pkg/platform/indexqueue
 pkg/platform -> pkg/platform/instructions
+pkg/platform -> pkg/platform/knowledgelayer
 pkg/platform -> pkg/platform/memorylayer
 pkg/platform -> pkg/platform/mwchain
 pkg/platform -> pkg/platform/oauthserver
@@ -196,6 +197,10 @@ pkg/platform/indexqueue -> pkg/toolkits/apigateway/catalog
 pkg/platform/indexqueue -> pkg/toolkits/apigateway/catalogindex
 pkg/platform/indexqueue -> pkg/toolkits/tools/toolsindex
 pkg/platform/instructions -> pkg/persona
+pkg/platform/knowledgelayer -> pkg/embedding
+pkg/platform/knowledgelayer -> pkg/memory
+pkg/platform/knowledgelayer -> pkg/portal/knowledgepage
+pkg/platform/knowledgelayer -> pkg/toolkits/knowledge
 pkg/platform/memorylayer -> pkg/embedding
 pkg/platform/memorylayer -> pkg/memory
 pkg/platform/memorylayer -> pkg/middleware


### PR DESCRIPTION
## Summary

Tenth seam of the Platform decomposition (#756). Consolidates the **knowledge-capture layer** field cluster into one owner handle behind a constructor that declares its dependencies as parameters — the natural sibling of the memory seam (#845), since the knowledge insight store is the memory-backed adapter over `memory_records`.

Closes #847.

## What moved

A new package **`pkg/platform/knowledgelayer`** owns the knowledge-capture subsystem behind one `Handle`:

- the **insight store** — the memory-backed adapter (`knowledgekit.NewMemoryInsightAdapter`) when a memory store is present, else the legacy Postgres store;
- the **changeset store** + **DataHub writer** for `apply_knowledge` (built only when apply is enabled);
- the **`capture_insight` / `apply_knowledge` toolkit**.

Construction takes explicit inputs — the `*sql.DB`, the `memory.Store` for the insight adapter, the `embedding.Provider` for the knowledge-page write-guard dedup probe, and the resolved knowledge / apply / page-guard / DataHub-connection config — so the subsystem is constructible and testable without a `Platform`. It imports `pkg/toolkits/knowledge`, `pkg/memory`, `pkg/embedding`, and `pkg/portal/knowledgepage`, **not** `pkg/platform`.

Two constructors: `New` selects the adapter-vs-postgres insight store and delegates to `NewFromInsightStore`, the injection seam that also lets callers (and tests) supply their own insight store — mirroring `portalstore.NewFromStores`. The layer owns no background goroutine, so it needs no `Stop`/`Close` (unlike #845's staleness watcher).

## Platform changes

`Platform` replaces **four fields** (`knowledgeInsightStore`, `knowledgeChangesetStore`, `knowledgeToolkit`, `knowledgeDataHubWriter`) with one `knowledge *knowledgelayer.Handle`:

- `initKnowledge` collapses to config-translation + delegation; `configureKnowledgeApply` and `createDataHubWriter` are **deleted** (folded into the owner).
- DataHub connection resolution stays on `Platform` via a small new `resolveKnowledgeDataHubConfig` helper, so `Platform`'s `toolkitcfg` coupling never leaks into the owner's imports (the `dhclient` import moves out of `platform.go`).
- The read paths (`info_tool` pending-review count, `initSearch`'s `SearchableInsightStore` insights provider, `RunGuardedBackfill`, and the three admin accessors `KnowledgeInsightStore()` / `KnowledgeChangesetStore()` / `KnowledgeDataHubWriter()`), toolkit registration, and the prompt-creator wiring stay on `Platform` and read/wire through the handle.
- `embeddingProv` stays a `Platform`-owned shared field and is passed to the owner for the page guards; `p.db` / `p.config` / `p.toolkitRegistry` stay on `Platform` and are passed as explicit inputs. The `initMemory`-before-`initKnowledge` order is preserved.
- **`knowledgeRouter` (search federation) stays a `Platform` field** — explicitly out of scope for this seam (a candidate for a separate later seam), reading the insight store through the new handle.

## Behavior preserved

- knowledge-disabled / no-DB no-op (`initKnowledge` early-return);
- insight-store adapter-vs-postgres selection;
- apply-enabled gating of the changeset store + DataHub writer + page writer + page guards;
- the real-vs-noop DataHub writer selection with its existing WARN;
- toolkit registration into the shared registry, and the `knowledge capture enabled` / `knowledge apply enabled` log lines.

One deliberate hardening: enabling apply through the new public `NewFromInsightStore` seam with a nil `db` is now an explicit construction error rather than a query-time failure (the changeset/page stores are Postgres-backed). No production path is affected — `Platform` only reaches apply via `New`, which returns early on a nil `db`.

## God-object budget

Platform loses three fields (56 → 53); `TestPlatformGodObjectBudget`'s field ceiling ratchets **56 → 53**.

## Testing

- New owner unit tests cover: nil-db no-op, insight-store adapter/postgres selection, apply-enabled gating, real/noop DataHub writer selection, the `buildDataHubWriter` build/error paths, and the injection seam + its apply-requires-db guard. Owner package coverage **98.1%**.
- Existing `Platform` tests updated to read through the handle; the deleted `createDataHubWriter` tests are re-expressed as `resolveKnowledgeDataHubConfig` (resolution) + owner `buildDataHubWriter` (build) tests.
- Adversarial `/code-review` (high) run before verify; its two findings (a gofmt violation and the `NewFromInsightStore` nil-db footgun) are fixed in this PR.
- Import ratchet regenerated (`testdata/allowed_internal_imports.txt`).
- `make verify` green (formatting, race tests, coverage ≥80%, patch coverage, lint, gosec/govulncheck, semgrep, CodeQL, dead-code, mutation ≥60%, GoReleaser dry-run), including the real-DB round-trip gate.

Relates to #756.
