### PR TITLE
refactor(platform): extract search-federation layer into pkg/platform/searchfed (#849)

### DIFF
--- a/godobject_budget_test.go
+++ b/godobject_budget_test.go
@@ -51,13 +51,18 @@ const (
 	// (knowledgeInsightStore, knowledgeChangesetStore, knowledgeToolkit,
 	// knowledgeDataHubWriter) into one knowledgelayer.Handle — knowledgeRouter
 	// (search federation) stays on Platform as a separate later seam — ratcheting
-	// 56 → 53.
+	// 56 → 53. The search-federation extraction (#849) is a method-surface seam,
+	// not a field-cluster seam: it replaces the single knowledgeRouter field with
+	// one searchfed.Handle field (field-for-field), so the field ceiling holds
+	// flat at 53.
 	maxPlatformFields = 53
 
 	// maxPlatformMethods caps the number of methods with a *Platform receiver.
 	// Frozen at today's count; ratchet down as accessors move onto the
-	// subsystem owners they belong to.
-	maxPlatformMethods = 265
+	// subsystem owners they belong to. The search-federation extraction (#849)
+	// moved two provider-selection methods (storeSearchProviders,
+	// appendFederationSearchProviders) into searchfed, ratcheting 265 → 263.
+	maxPlatformMethods = 263
 )
 
 // TestPlatformGodObjectBudget fails when the Platform struct grows more fields

--- a/pkg/platform/knowledge_router_accessor_test.go
+++ b/pkg/platform/knowledge_router_accessor_test.go
@@ -3,17 +3,29 @@ package platform
 import (
 	"testing"
 
-	"github.com/txn2/mcp-data-platform/pkg/knowledge"
+	"github.com/txn2/mcp-data-platform/pkg/memory"
+	"github.com/txn2/mcp-data-platform/pkg/platform/searchfed"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
 )
 
 func TestKnowledgeRouter_Accessor(t *testing.T) {
 	p := &Platform{}
 	if p.KnowledgeRouter() != nil {
-		t.Fatal("KnowledgeRouter should be nil before initSearch wires it")
+		t.Fatal("KnowledgeRouter should be nil before initSearch wires the handle")
 	}
-	router := knowledge.NewRouter(nil, nil)
-	p.knowledgeRouter = router
-	if p.KnowledgeRouter() != router {
-		t.Fatal("KnowledgeRouter should return the wired router")
+
+	// A non-nil memory store yields a searchable source, so New builds a handle
+	// whose Router() the accessor must return unchanged.
+	h := searchfed.New(searchfed.Config{
+		ToolkitName: "default",
+		MemoryStore: memory.NewNoopStore(),
+		Registry:    registry.NewRegistry(),
+	})
+	if h == nil || h.Router() == nil {
+		t.Fatal("searchfed.New with a memory store should build a router")
+	}
+	p.searchFed = h
+	if p.KnowledgeRouter() != h.Router() {
+		t.Fatal("KnowledgeRouter should return the router the handle owns")
 	}
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -36,7 +36,6 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/database/migrate"
 	"github.com/txn2/mcp-data-platform/pkg/embedding"
 	"github.com/txn2/mcp-data-platform/pkg/knowledge"
-	"github.com/txn2/mcp-data-platform/pkg/knowledge/federation"
 	"github.com/txn2/mcp-data-platform/pkg/mcpapps"
 	"github.com/txn2/mcp-data-platform/pkg/memory"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
@@ -58,6 +57,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/platform/portalstore"
 	"github.com/txn2/mcp-data-platform/pkg/platform/reflexivecapture"
 	"github.com/txn2/mcp-data-platform/pkg/platform/routepolicy"
+	"github.com/txn2/mcp-data-platform/pkg/platform/searchfed"
 	"github.com/txn2/mcp-data-platform/pkg/platform/sessionsync"
 	"github.com/txn2/mcp-data-platform/pkg/platform/toolkitcfg"
 	"github.com/txn2/mcp-data-platform/pkg/portal"
@@ -81,7 +81,6 @@ import (
 	gatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/gateway"
 	"github.com/txn2/mcp-data-platform/pkg/toolkits/gateway/enrichment"
 	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
-	searchkit "github.com/txn2/mcp-data-platform/pkg/toolkits/search"
 	trinokit "github.com/txn2/mcp-data-platform/pkg/toolkits/trino"
 	"github.com/txn2/mcp-data-platform/pkg/tuning"
 	"github.com/txn2/mcp-data-platform/pkg/user"
@@ -191,10 +190,12 @@ type Platform struct {
 	// surfaced by the three admin accessors below. nil when knowledge is disabled
 	// or no database is configured.
 	knowledge *knowledgelayer.Handle
-	// knowledgeRouter is the unified search federation built in initSearch. It
-	// backs both the MCP search tool and the portal's GET /search REST endpoint;
-	// nil on a store-less deployment with no searchable source.
-	knowledgeRouter *knowledge.Router
+	// Search-federation layer. The owner (pkg/platform/searchfed) holds the
+	// unified search router and the search toolkit behind one Handle; the router
+	// is read through its accessor and backs both the MCP search tool and the
+	// portal's GET /search REST endpoint. nil on a store-less deployment with no
+	// searchable source, so no search tool is registered.
+	searchFed *searchfed.Handle
 
 	// Memory layer. The owner (pkg/platform/memorylayer) holds the memory store,
 	// memory toolkit (with its recall-first checker), enrichment adapter, and
@@ -1471,106 +1472,36 @@ func (p *Platform) resolveKnowledgeDataHubConfig(connName string, applyEnabled b
 // at least one source is available and is skipped entirely on a store-less
 // (no-database) deployment with no catalog, endpoints, or connections.
 func (p *Platform) initSearch() error {
-	providers := p.storeSearchProviders()
-	providers = p.appendFederationSearchProviders(providers)
+	// Assemble the search federation behind one handle from the searchable source
+	// handles/stores + the shared semantic provider / registry / embedding
+	// provider (all stay owned by Platform). New returns nil when no source is
+	// searchable, so a store-less deployment with no catalog, endpoints, or
+	// connections registers no search tool.
+	p.searchFed = searchfed.New(searchfed.Config{
+		ToolkitName:        instanceDefault,
+		ProviderTimeout:    p.config.Knowledge.SearchProviderTimeout, // 0 keeps the default
+		EmbedTimeout:       p.config.Knowledge.SearchEmbedTimeout,    // 0 keeps the default
+		CatalogEnabled:     p.config.Semantic.Provider == kindDataHub,
+		SemanticProvider:   p.semanticProvider,
+		MemoryStore:        p.memory.MemoryStore(),
+		InsightStore:       p.knowledge.InsightStore(),
+		KnowledgePageStore: p.portalStore.KnowledgePageStore(),
+		AssetStore:         p.portalStore.AssetStore(),
+		ThreadStore:        p.portalStore.ThreadStore(),
+		PromptStore:        p.promptStore,
+		Registry:           p.toolkitRegistry,
+		Embedding:          p.embeddingProv,
+	})
 
-	if len(providers) == 0 {
+	if p.searchFed == nil {
 		return nil
 	}
 
-	// The lineage expander widens the entity path along DataHub lineage (the old
-	// memory_recall graph strategy) once per search, shared across every
-	// entity-keyed provider; nil when no real catalog is configured, leaving a
-	// plain entity lookup.
-	var lineage knowledge.LineageExpander
-	if p.config.Semantic.Provider == kindDataHub && p.semanticProvider != nil {
-		lineage = knowledge.NewLineageExpander(p.semanticProvider)
-	}
-
-	router := knowledge.NewRouter(p.embeddingProv, lineage, providers...)
-	router.SetProviderTimeout(p.config.Knowledge.SearchProviderTimeout) // 0 keeps the 5s default
-	router.SetEmbedTimeout(p.config.Knowledge.SearchEmbedTimeout)       // 0 keeps the 5s default
-	p.knowledgeRouter = router
-	tk := searchkit.New(instanceDefault, router)
-	if err := p.toolkitRegistry.Register(tk); err != nil {
+	// Toolkit registration stays a Platform/registry concern.
+	if err := p.toolkitRegistry.Register(p.searchFed.Toolkit()); err != nil {
 		return fmt.Errorf("registering search toolkit: %w", err)
 	}
-
-	slog.Info("search enabled", "providers", len(providers))
 	return nil
-}
-
-// storeSearchProviders builds the store-backed search providers (memory,
-// insights, technical catalog, prompts, assets), each registered only when its
-// backing store exists so the no-database deployment adds none of them.
-func (p *Platform) storeSearchProviders() []knowledge.Provider {
-	var providers []knowledge.Provider
-
-	if memStore := p.memory.MemoryStore(); memStore != nil {
-		// Lineage expansion of the entity path is the router's job (it runs once
-		// for every entity-keyed provider), so the memory provider takes the URN
-		// set as given.
-		providers = append(providers, knowledge.NewMemoryProvider(memStore))
-	}
-	// Insights are searchable only through the memory-backed adapter; the legacy
-	// SQL store and the noop store do not implement InsightSearcher (and so are
-	// not SearchableInsightStores).
-	if s, ok := p.knowledge.InsightStore().(knowledgekit.SearchableInsightStore); ok {
-		providers = append(providers, knowledge.NewInsightsProvider(s))
-	}
-	// The technical catalog is a knowledge sink only when a real DataHub
-	// semantic provider is configured (the noop fallback would add an
-	// always-empty provider).
-	if p.config.Semantic.Provider == kindDataHub && p.semanticProvider != nil {
-		providers = append(providers, knowledge.NewCatalogProvider(p.semanticProvider))
-		// Context documents: a distinct search source (#692), present only when the real catalog exposes document search.
-		if ds, ok := semantic.DocumentSearcherFrom(p.semanticProvider); ok {
-			providers = append(providers, knowledge.NewContextDocumentsProvider(ds))
-		}
-	}
-	// Canonical knowledge pages (the internal-knowledge home for business
-	// ontology) are shared and searchable over their full content.
-	if s, ok := p.portalStore.KnowledgePageStore().(knowledge.PageSearcher); ok {
-		providers = append(providers, knowledge.NewKnowledgePagesProvider(s))
-	}
-	// Prompts are searchable and fetchable through the postgres prompt store
-	// (search + read-by-id, the two halves of search/fetch).
-	if s, ok := p.promptStore.(knowledge.PromptSearcher); ok {
-		providers = append(providers, knowledge.NewPromptsProvider(s))
-	}
-	// Assets are searchable and fetchable only through the postgres asset store.
-	if s, ok := p.portalStore.AssetStore().(knowledge.AssetSearcher); ok {
-		providers = append(providers, knowledge.NewAssetsProvider(s))
-	}
-	// Feedback threads complete the search corpus (#686): a caller's own feedback
-	// becomes discoverable knowledge. Lexical and per-user (threads carry no embedding).
-	if s, ok := p.portalStore.ThreadStore().(knowledge.ThreadSearcher); ok {
-		providers = append(providers, knowledge.NewThreadsProvider(s))
-	}
-	return providers
-}
-
-// appendFederationSearchProviders adds the registry-federated search sources
-// (API endpoints and connections) to the store-backed providers. Both are in
-// the default corpus (#645): an agent should discover a relevant endpoint or
-// connection from one query without first knowing a gateway exists.
-func (p *Platform) appendFederationSearchProviders(providers []knowledge.Provider) []knowledge.Provider {
-	// API endpoints aggregate the per-connection semantic ranking of every API
-	// gateway toolkit.
-	if searchers := federation.EndpointSearchers(p.toolkitRegistry); len(searchers) > 0 {
-		providers = append(providers, knowledge.NewEndpointsProvider(searchers...))
-	}
-	// Connections are the same set list_connections enumerates, surfaced by
-	// relevance. Added whenever search will exist at all — when any other source
-	// is present, or when at least one connection exists at startup — but never on
-	// its own on a bare deployment with no other source and no connection, so such
-	// a deployment still registers no search tool. The lister stays live, so once
-	// registered, connections added later through the admin API are searchable.
-	connLister := federation.NewConnectionLister(p.toolkitRegistry)
-	if len(providers) > 0 || len(connLister.Connections()) > 0 {
-		providers = append(providers, knowledge.NewConnectionsProvider(connLister))
-	}
-	return providers
 }
 
 // initPortal initializes the asset portal toolkit if enabled.
@@ -3119,7 +3050,7 @@ func (p *Platform) PortalS3Client() portal.S3Client {
 // endpoint wraps it so the browser surfaces the same grouped, scope-enforced
 // results as the MCP search tool.
 func (p *Platform) KnowledgeRouter() *knowledge.Router {
-	return p.knowledgeRouter
+	return p.searchFed.Router()
 }
 
 // BrandLogoSVG returns the resolved brand logo SVG content (from portal.logo

--- a/pkg/platform/searchfed/searchfed.go
+++ b/pkg/platform/searchfed/searchfed.go
@@ -1,0 +1,226 @@
+// Package searchfed assembles the universal, topology-free search federation
+// behind one Handle: the knowledge.Router that federates every searchable
+// source a caller can access, and the search toolkit that exposes it as the one
+// discovery entry point (#645).
+//
+// Unlike the store-owning layers, this layer is a reader/aggregator: it owns no
+// store. Its constructor takes explicit inputs — the searchable source
+// handles/stores (memory store, knowledge insight store, portal
+// knowledge-page/asset/thread stores, prompt store), the semantic.Provider plus
+// a catalog-enabled flag, the *registry.Registry, the shared embedding.Provider,
+// the resolved search-timeout values, and the toolkit instance name — performs
+// the per-source provider selection (each source gated on existing and
+// implementing the relevant searcher interface), builds the DataHub
+// LineageExpander and the knowledge.Router, and constructs the search toolkit.
+// It imports pkg/knowledge, pkg/knowledge/federation, pkg/toolkits/search,
+// pkg/toolkits/knowledge, pkg/semantic, pkg/memory, pkg/portal,
+// pkg/portal/knowledgepage, pkg/prompt, pkg/registry, and pkg/embedding — never
+// pkg/platform. Every federated store is owned by another subsystem and is
+// passed in; the registry, embedding provider, and semantic provider are shared
+// foundations passed in the same way.
+//
+// The provider count governs registration: with zero providers New returns a
+// nil Handle, so the caller registers no search toolkit and a store-less
+// deployment with no catalog, endpoints, or connections gets no search tool. The
+// layer owns no background goroutine, so it needs no Stop/Close. Toolkit
+// registration stays a caller/registry concern: New builds the toolkit and
+// exposes it via Toolkit() for the caller to register into the shared toolkit
+// registry; consumers read the router through Router().
+package searchfed
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
+	"github.com/txn2/mcp-data-platform/pkg/knowledge"
+	"github.com/txn2/mcp-data-platform/pkg/knowledge/federation"
+	"github.com/txn2/mcp-data-platform/pkg/memory"
+	"github.com/txn2/mcp-data-platform/pkg/portal"
+	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
+	"github.com/txn2/mcp-data-platform/pkg/prompt"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/semantic"
+	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
+	searchkit "github.com/txn2/mcp-data-platform/pkg/toolkits/search"
+)
+
+// Config carries the resolved inputs the owner needs to assemble the search
+// federation. The caller translates its own config and source handles into this
+// shape so this package stays free of the platform's config types.
+type Config struct {
+	// ToolkitName is the search toolkit instance name (the caller passes its
+	// default).
+	ToolkitName string
+
+	// ProviderTimeout / EmbedTimeout are passed through to the router; 0 keeps
+	// the router's built-in defaults.
+	ProviderTimeout time.Duration
+	EmbedTimeout    time.Duration
+
+	// CatalogEnabled gates the DataHub-backed catalog, context-documents, and
+	// lineage-expander sources: they are added only when the configured semantic
+	// provider is DataHub (a noop fallback would add an always-empty provider).
+	// Combined with a non-nil SemanticProvider.
+	CatalogEnabled bool
+	// SemanticProvider backs the catalog / context-documents providers and the
+	// lineage expander; nil when no real catalog is configured, leaving a plain
+	// entity lookup.
+	SemanticProvider semantic.Provider
+
+	// Source stores federated into the corpus. Each is gated on being non-nil and
+	// implementing the relevant searcher interface, so a source that is absent (or
+	// whose implementation is not searchable) contributes no provider.
+	MemoryStore        memory.Store
+	InsightStore       knowledgekit.InsightStore
+	KnowledgePageStore knowledgepage.Store
+	AssetStore         portal.AssetStore
+	ThreadStore        portal.ThreadStore
+	PromptStore        prompt.Store
+
+	// Registry backs the registry-federated sources (API endpoints +
+	// connections). Required: New walks it for endpoint searchers and connections
+	// even when no store-backed source is present.
+	Registry *registry.Registry
+	// Embedding powers the router's intent embedding.
+	Embedding embedding.Provider
+}
+
+// Handle owns the assembled search federation: the knowledge.Router and the
+// search toolkit that exposes it. Router() backs both the search tool and any
+// REST consumer; Toolkit() is registered by the caller into the shared toolkit
+// registry. Both are nil on a nil Handle, which New returns when no source is
+// searchable — so a store-less deployment registers no search tool. The layer
+// owns no background goroutine, so there is no Stop/Close.
+type Handle struct {
+	router  *knowledge.Router
+	toolkit *searchkit.Toolkit
+}
+
+// New assembles the router over every searchable source in cfg and builds the
+// search toolkit. It returns nil when no provider is available: with zero
+// providers there is no router and no toolkit to register, preserving the
+// store-less no-op. Otherwise it wires the two search timeouts and logs "search
+// enabled" with the provider count.
+func New(cfg Config) *Handle {
+	providers := storeProviders(cfg)
+	providers = appendFederationProviders(cfg, providers)
+
+	if len(providers) == 0 {
+		return nil
+	}
+
+	// The lineage expander widens the entity path along DataHub lineage (the old
+	// memory_recall graph strategy) once per search, shared across every
+	// entity-keyed provider; nil when no real catalog is configured, leaving a
+	// plain entity lookup.
+	var lineage knowledge.LineageExpander
+	if cfg.CatalogEnabled && cfg.SemanticProvider != nil {
+		lineage = knowledge.NewLineageExpander(cfg.SemanticProvider)
+	}
+
+	router := knowledge.NewRouter(cfg.Embedding, lineage, providers...)
+	router.SetProviderTimeout(cfg.ProviderTimeout) // 0 keeps the default
+	router.SetEmbedTimeout(cfg.EmbedTimeout)       // 0 keeps the default
+
+	h := &Handle{router: router, toolkit: searchkit.New(cfg.ToolkitName, router)}
+	slog.Info("search enabled", "providers", len(providers))
+	return h
+}
+
+// storeProviders builds the store-backed search providers (memory, insights,
+// technical catalog, context documents, knowledge pages, prompts, assets, and
+// feedback threads), each added only when its backing source exists and
+// implements the relevant searcher interface, so a no-database deployment adds
+// none of them.
+func storeProviders(cfg Config) []knowledge.Provider {
+	var providers []knowledge.Provider
+
+	if cfg.MemoryStore != nil {
+		// Lineage expansion of the entity path is the router's job (it runs once
+		// for every entity-keyed provider), so the memory provider takes the URN
+		// set as given.
+		providers = append(providers, knowledge.NewMemoryProvider(cfg.MemoryStore))
+	}
+	// Insights are searchable only through the memory-backed adapter; the legacy
+	// SQL store and the noop store do not implement InsightSearcher (and so are
+	// not SearchableInsightStores).
+	if s, ok := cfg.InsightStore.(knowledgekit.SearchableInsightStore); ok {
+		providers = append(providers, knowledge.NewInsightsProvider(s))
+	}
+	// The technical catalog is a knowledge sink only when a real DataHub semantic
+	// provider is configured (the noop fallback would add an always-empty
+	// provider).
+	if cfg.CatalogEnabled && cfg.SemanticProvider != nil {
+		providers = append(providers, knowledge.NewCatalogProvider(cfg.SemanticProvider))
+		// Context documents: a distinct search source (#692), present only when the
+		// real catalog exposes document search.
+		if ds, ok := semantic.DocumentSearcherFrom(cfg.SemanticProvider); ok {
+			providers = append(providers, knowledge.NewContextDocumentsProvider(ds))
+		}
+	}
+	// Canonical knowledge pages (the internal-knowledge home for business
+	// ontology) are shared and searchable over their full content.
+	if s, ok := cfg.KnowledgePageStore.(knowledge.PageSearcher); ok {
+		providers = append(providers, knowledge.NewKnowledgePagesProvider(s))
+	}
+	// Prompts are searchable and fetchable through the postgres prompt store
+	// (search + read-by-id, the two halves of search/fetch).
+	if s, ok := cfg.PromptStore.(knowledge.PromptSearcher); ok {
+		providers = append(providers, knowledge.NewPromptsProvider(s))
+	}
+	// Assets are searchable and fetchable only through the postgres asset store.
+	if s, ok := cfg.AssetStore.(knowledge.AssetSearcher); ok {
+		providers = append(providers, knowledge.NewAssetsProvider(s))
+	}
+	// Feedback threads complete the search corpus (#686): a caller's own feedback
+	// becomes discoverable knowledge. Lexical and per-user (threads carry no
+	// embedding).
+	if s, ok := cfg.ThreadStore.(knowledge.ThreadSearcher); ok {
+		providers = append(providers, knowledge.NewThreadsProvider(s))
+	}
+	return providers
+}
+
+// appendFederationProviders adds the registry-federated search sources (API
+// endpoints and connections) to the store-backed providers. Both are in the
+// default corpus (#645): an agent should discover a relevant endpoint or
+// connection from one query without first knowing a gateway exists.
+func appendFederationProviders(cfg Config, providers []knowledge.Provider) []knowledge.Provider {
+	// API endpoints aggregate the per-connection semantic ranking of every API
+	// gateway toolkit.
+	if searchers := federation.EndpointSearchers(cfg.Registry); len(searchers) > 0 {
+		providers = append(providers, knowledge.NewEndpointsProvider(searchers...))
+	}
+	// Connections are the same set list_connections enumerates, surfaced by
+	// relevance. Added whenever search will exist at all — when any other source
+	// is present, or when at least one connection exists at startup — but never on
+	// its own on a bare deployment with no other source and no connection, so such
+	// a deployment still registers no search tool. The lister stays live, so once
+	// registered, connections added later through the admin API are searchable.
+	connLister := federation.NewConnectionLister(cfg.Registry)
+	if len(providers) > 0 || len(connLister.Connections()) > 0 {
+		providers = append(providers, knowledge.NewConnectionsProvider(connLister))
+	}
+	return providers
+}
+
+// Router returns the unified search federation router, or nil on a nil Handle
+// (no searchable source configured). Consumers read it to serve the same
+// grouped, scope-enforced results as the search tool.
+func (h *Handle) Router() *knowledge.Router {
+	if h == nil {
+		return nil
+	}
+	return h.router
+}
+
+// Toolkit returns the search toolkit for the caller to register into the shared
+// toolkit registry, or nil on a nil Handle (no searchable source → no search
+// tool).
+func (h *Handle) Toolkit() *searchkit.Toolkit {
+	if h == nil {
+		return nil
+	}
+	return h.toolkit
+}

--- a/pkg/platform/searchfed/searchfed_test.go
+++ b/pkg/platform/searchfed/searchfed_test.go
@@ -1,0 +1,209 @@
+package searchfed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/knowledge"
+	"github.com/txn2/mcp-data-platform/pkg/memory"
+	"github.com/txn2/mcp-data-platform/pkg/portal"
+	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
+	"github.com/txn2/mcp-data-platform/pkg/portal/threads"
+	"github.com/txn2/mcp-data-platform/pkg/prompt"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/semantic"
+	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
+)
+
+// searchableInsight embeds the noop insight store (for the InsightStore methods)
+// and adds Search, so it satisfies knowledgekit.SearchableInsightStore — the
+// capability the plain noop store lacks.
+type searchableInsight struct {
+	knowledgekit.InsightStore
+}
+
+func (searchableInsight) Search(context.Context, knowledgekit.InsightSearchQuery) ([]knowledgekit.ScoredInsight, error) {
+	return nil, nil
+}
+
+// stubThreadStore embeds portal.ThreadStore (a nil interface, for the store
+// methods that are never called) and overrides SearchThreads so it also
+// satisfies knowledge.ThreadSearcher — the capability searchfed casts for.
+type stubThreadStore struct {
+	portal.ThreadStore
+}
+
+func (stubThreadStore) SearchThreads(context.Context, string, string, int) ([]threads.Thread, error) {
+	return nil, nil
+}
+
+// stubPageStore embeds knowledgepage.Store (nil) and adds Search — the one
+// method PageSearcher needs beyond the Store method set — so it satisfies
+// knowledge.PageSearcher.
+type stubPageStore struct {
+	knowledgepage.Store
+}
+
+func (stubPageStore) Search(context.Context, knowledgepage.SearchQuery) ([]knowledgepage.ScoredPage, error) {
+	return nil, nil
+}
+
+// stubPromptStore embeds prompt.Store (nil) and adds Search, so it satisfies
+// knowledge.PromptSearcher (GetByID is promoted from prompt.Store).
+type stubPromptStore struct {
+	prompt.Store
+}
+
+func (stubPromptStore) Search(context.Context, prompt.SearchQuery) ([]prompt.ScoredPrompt, error) {
+	return nil, nil
+}
+
+// stubAssetStore embeds portal.AssetStore (nil) and adds SearchAssets, so it
+// satisfies knowledge.AssetSearcher (Get is promoted from portal.AssetStore).
+type stubAssetStore struct {
+	portal.AssetStore
+}
+
+func (stubAssetStore) SearchAssets(context.Context, portal.AssetSearchQuery) ([]portal.ScoredAsset, error) {
+	return nil, nil
+}
+
+// providerNames returns the Name() of every provider the handle's router holds.
+func providerNames(t *testing.T, h *Handle) []string {
+	t.Helper()
+	require.NotNil(t, h)
+	require.NotNil(t, h.Router())
+	provs := h.Router().Providers()
+	names := make([]string, 0, len(provs))
+	for _, p := range provs {
+		names = append(names, p.Name())
+	}
+	return names
+}
+
+func TestNew_ZeroProvidersIsNoop(t *testing.T) {
+	// No store-backed source, catalog disabled, and an empty registry (no
+	// endpoints, no connections) → no provider at all → nil handle, so the caller
+	// registers no search tool.
+	h := New(Config{ToolkitName: "default", Registry: registry.NewRegistry()})
+	assert.Nil(t, h, "zero providers must yield a nil handle")
+
+	// Every accessor is nil-safe on the nil handle.
+	assert.Nil(t, h.Router())
+	assert.Nil(t, h.Toolkit())
+}
+
+func TestNew_MemoryStoreProducesHandleAndToolkit(t *testing.T) {
+	h := New(Config{
+		ToolkitName: "default",
+		MemoryStore: memory.NewNoopStore(),
+		Registry:    registry.NewRegistry(),
+	})
+	require.NotNil(t, h)
+	require.NotNil(t, h.Router())
+	require.NotNil(t, h.Toolkit())
+	assert.Equal(t, "default", h.Toolkit().Name())
+
+	// A present store-backed source makes providers non-empty, so the live
+	// connection lister is added even on an empty registry (federation rule).
+	assert.Equal(t, []string{knowledge.SourceMemory, knowledge.SourceConnections}, providerNames(t, h))
+}
+
+func TestNew_InsightGating(t *testing.T) {
+	t.Run("searchable insight store adds the insights provider", func(t *testing.T) {
+		h := New(Config{
+			ToolkitName:  "default",
+			InsightStore: searchableInsight{InsightStore: knowledgekit.NewNoopStore()},
+			Registry:     registry.NewRegistry(),
+		})
+		assert.Contains(t, providerNames(t, h), knowledge.SourceInsights)
+	})
+
+	t.Run("non-searchable insight store adds no insights provider", func(t *testing.T) {
+		// The plain noop store implements InsightStore but not InsightSearcher, so
+		// it is not a SearchableInsightStore and contributes no provider. With no
+		// other source and an empty registry, that leaves zero providers.
+		h := New(Config{
+			ToolkitName:  "default",
+			InsightStore: knowledgekit.NewNoopStore(),
+			Registry:     registry.NewRegistry(),
+		})
+		assert.Nil(t, h, "an unsearchable insight store is the only would-be source → nil handle")
+	})
+}
+
+func TestNew_CatalogGating(t *testing.T) {
+	t.Run("datahub provider enabled adds the catalog provider", func(t *testing.T) {
+		h := New(Config{
+			ToolkitName:      "default",
+			CatalogEnabled:   true,
+			SemanticProvider: semantic.NewNoopProvider(),
+			Registry:         registry.NewRegistry(),
+		})
+		assert.Contains(t, providerNames(t, h), knowledge.SourceCatalog)
+	})
+
+	t.Run("catalog disabled adds no catalog provider even with a provider", func(t *testing.T) {
+		h := New(Config{
+			ToolkitName:      "default",
+			CatalogEnabled:   false,
+			SemanticProvider: semantic.NewNoopProvider(),
+			Registry:         registry.NewRegistry(),
+		})
+		assert.Nil(t, h, "catalog gated off and no other source → nil handle")
+	})
+
+	t.Run("catalog enabled but nil provider adds no catalog provider", func(t *testing.T) {
+		h := New(Config{
+			ToolkitName:      "default",
+			CatalogEnabled:   true,
+			SemanticProvider: nil,
+			Registry:         registry.NewRegistry(),
+		})
+		assert.Nil(t, h, "catalog enabled with no provider and no other source → nil handle")
+	})
+}
+
+func TestNew_ThreadSearcherProvider(t *testing.T) {
+	h := New(Config{
+		ToolkitName: "default",
+		ThreadStore: stubThreadStore{},
+		Registry:    registry.NewRegistry(),
+	})
+	assert.Contains(t, providerNames(t, h), knowledge.SourceFeedback)
+}
+
+func TestNew_PortalAndPromptStoreProviders(t *testing.T) {
+	// The knowledge-page, prompt, and asset stores each contribute a provider
+	// when their store implements the relevant searcher interface.
+	h := New(Config{
+		ToolkitName:        "default",
+		KnowledgePageStore: stubPageStore{},
+		PromptStore:        stubPromptStore{},
+		AssetStore:         stubAssetStore{},
+		Registry:           registry.NewRegistry(),
+	})
+	names := providerNames(t, h)
+	assert.Contains(t, names, knowledge.SourceKnowledgePages)
+	assert.Contains(t, names, knowledge.SourcePrompts)
+	assert.Contains(t, names, knowledge.SourceAssets)
+}
+
+func TestNew_ConnectionsFederationRule(t *testing.T) {
+	// The connection lister is added only when another provider already exists (or
+	// a connection is configured). With an empty registry and no store source,
+	// connections alone never register a tool.
+	empty := New(Config{ToolkitName: "default", Registry: registry.NewRegistry()})
+	assert.Nil(t, empty, "no other source + no connection → no connections provider → nil handle")
+
+	// With a store source present, the connections provider is appended.
+	withStore := New(Config{
+		ToolkitName: "default",
+		MemoryStore: memory.NewNoopStore(),
+		Registry:    registry.NewRegistry(),
+	})
+	assert.Contains(t, providerNames(t, withStore), knowledge.SourceConnections)
+}

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -116,7 +116,6 @@ pkg/platform -> pkg/database/migrate
 pkg/platform -> pkg/embedding
 pkg/platform -> pkg/indexjobs
 pkg/platform -> pkg/knowledge
-pkg/platform -> pkg/knowledge/federation
 pkg/platform -> pkg/mcpapps
 pkg/platform -> pkg/memory
 pkg/platform -> pkg/middleware
@@ -142,6 +141,7 @@ pkg/platform -> pkg/platform/personastore
 pkg/platform -> pkg/platform/portalstore
 pkg/platform -> pkg/platform/reflexivecapture
 pkg/platform -> pkg/platform/routepolicy
+pkg/platform -> pkg/platform/searchfed
 pkg/platform -> pkg/platform/sessionsync
 pkg/platform -> pkg/platform/toolkitcfg
 pkg/platform -> pkg/portal
@@ -167,7 +167,6 @@ pkg/platform -> pkg/toolkits/apigateway/catalogindex
 pkg/platform -> pkg/toolkits/gateway
 pkg/platform -> pkg/toolkits/gateway/enrichment
 pkg/platform -> pkg/toolkits/knowledge
-pkg/platform -> pkg/toolkits/search
 pkg/platform -> pkg/toolkits/tools/toolsindex
 pkg/platform -> pkg/toolkits/trino
 pkg/platform -> pkg/tuning
@@ -222,6 +221,17 @@ pkg/platform/reflexivecapture -> pkg/toolkits/memory
 pkg/platform/reflexivecapture -> pkg/urnbuild
 pkg/platform/routepolicy -> pkg/middleware
 pkg/platform/routepolicy -> pkg/persona
+pkg/platform/searchfed -> pkg/embedding
+pkg/platform/searchfed -> pkg/knowledge
+pkg/platform/searchfed -> pkg/knowledge/federation
+pkg/platform/searchfed -> pkg/memory
+pkg/platform/searchfed -> pkg/portal
+pkg/platform/searchfed -> pkg/portal/knowledgepage
+pkg/platform/searchfed -> pkg/prompt
+pkg/platform/searchfed -> pkg/registry
+pkg/platform/searchfed -> pkg/semantic
+pkg/platform/searchfed -> pkg/toolkits/knowledge
+pkg/platform/searchfed -> pkg/toolkits/search
 pkg/platform/sessionsync -> pkg/middleware
 pkg/platform/sessionsync -> pkg/session
 pkg/platform/sessionsync -> pkg/session/postgres


### PR DESCRIPTION
## Summary

Eleventh seam of the **Platform decomposition** (#756), continuing after iam (#828), api-gateway route policy (#830), browser-session auth (#832), the OAuth 2.1 server (#834), the index-jobs embedding queue (#836), the connection-OAuth token lifecycle (#838), the portal store layer (#841), the session / cross-replica-sync layer (#843), the memory layer (#845), and the knowledge-capture layer (#847). The knowledge-capture seam explicitly deferred the unified search federation (`knowledgeRouter`) as a distinct concern for a later seam — this PR is that seam.

Unlike the prior ten seams, search federation is a **reader/aggregator**, not a store-owner: it held a single `Platform` field but federated across nearly every other owner. So this seam advances the epic's first goal (extract a per-subsystem assembly into a constructor that declares its dependencies as parameters) and ratchets the **method** ceiling rather than the field ceiling.

Pure refactor — no intended behavior change.

## New package: `pkg/platform/searchfed`

A reader/aggregator that owns no store. `New(Config) *Handle` takes explicit inputs and assembles the whole search federation:

- **Inputs** — the searchable source stores (memory, insight, knowledge-page, asset, thread, prompt), the `semantic.Provider` + a `CatalogEnabled` flag, the `*registry.Registry`, the shared `embedding.Provider`, the two resolved search timeouts, and the toolkit instance name.
- **Work** — performs the per-source provider selection + interface casts (`SearchableInsightStore`, `PageSearcher`, `AssetSearcher`, `ThreadSearcher`, `PromptSearcher`, `DocumentSearcher`), builds the DataHub `LineageExpander` and `knowledge.Router`, sets the two timeouts, and constructs the `searchkit` toolkit.
- **Zero-providers no-op** — returns `nil` when no source is searchable, so a store-less deployment with no catalog, endpoints, or connections registers no `search` tool.
- **Surface** — `Router()` and `Toolkit()`, both nil-safe. The layer owns no background goroutine, so no `Stop`/`Close`.
- **Imports** `pkg/knowledge`, `pkg/knowledge/federation`, `pkg/toolkits/search`, `pkg/toolkits/knowledge`, `pkg/semantic`, `pkg/memory`, `pkg/portal`, `pkg/portal/knowledgepage`, `pkg/prompt`, `pkg/registry`, and `pkg/embedding` — **not** `pkg/platform`.

## `Platform` changes

- The `knowledgeRouter *knowledge.Router` field is replaced **field-for-field** by `searchFed *searchfed.Handle`.
- `initSearch` collapses from ~35 lines of assembly to config-translation + delegation + registration.
- `storeSearchProviders` and `appendFederationSearchProviders` are deleted (moved into the owner).
- `KnowledgeRouter()` keeps its signature and now reads `p.searchFed.Router()`, so `cmd/mcp-data-platform/main.go`'s portal `GET /search` wiring is unchanged.
- Platform drops its direct imports of `pkg/knowledge/federation` and `pkg/toolkits/search` (they move to `searchfed`).

## Behavior preserved

- `initMemory` / `initKnowledge` / `initPortal` before `initSearch` ordering.
- Per-source provider gating (each provider present only when its backing source exists and implements the searcher interface).
- DataHub-only catalog / context-documents / lineage gating.
- Endpoints/connections federation rules — the connection lister is added iff any other provider exists or a connection is configured, and stays live so connections added later via the admin API become searchable.
- The two search-timeout config passthroughs and the `search enabled` log with provider count.

## God-object budget & ratchets

- **Method ceiling** ratcheted `265 → 263` (the two moved provider-selection methods).
- **Field ceiling** held flat at `53` — this is a method-surface seam, not a field-cluster seam (one field swapped for one handle).
- Import ratchet (`testdata/allowed_internal_imports.txt`) regenerated to match the new coupling.

## Tests

- New `searchfed_test.go` — construction is testable without a `Platform`: zero-providers no-op, memory provider, insight gating (searchable adapter vs non-searchable noop store), DataHub-only catalog gating (enabled / disabled / nil-provider), portal + prompt store casts, thread searcher, connections-federation rule, and the nil-handle surface. Package coverage 95.3%.
- `knowledge_router_accessor_test.go` updated to exercise the accessor through the handle rather than the removed field.

## Verification

- `make verify` green — patch coverage **95.7%** (90/94 changed executable lines).
- Workflow-backed high-effort code review: no findings survived verification.

Closes #849
Relates to #756