### PR TITLE
refactor(platform): batch-extract resource/user/brand seams; pin method ratchet (#851)

### DIFF
--- a/godobject_budget_test.go
+++ b/godobject_budget_test.go
@@ -54,15 +54,30 @@ const (
 	// 56 → 53. The search-federation extraction (#849) is a method-surface seam,
 	// not a field-cluster seam: it replaces the single knowledgeRouter field with
 	// one searchfed.Handle field (field-for-field), so the field ceiling holds
-	// flat at 53.
-	maxPlatformFields = 53
+	// flat at 53. The mechanical-cluster batch (#851) folded three clusters into
+	// three owner handles: resource (resourceStore, resourceS3Client → one
+	// resourcelayer.Handle), user (userStore, userDirectory → one userdir.Handle),
+	// and brand (resolvedBrandLogoSVG, resolvedBrandURL, resolvedImplementorLogo →
+	// one branding.Handle), ratcheting 53 → 49. The prompt cluster was split into
+	// its own follow-up seam (its ~40 methods across three files are not
+	// mechanical), so its four fields stay on Platform for now.
+	maxPlatformFields = 49
 
 	// maxPlatformMethods caps the number of methods with a *Platform receiver.
 	// Frozen at today's count; ratchet down as accessors move onto the
 	// subsystem owners they belong to. The search-federation extraction (#849)
 	// moved two provider-selection methods (storeSearchProviders,
-	// appendFederationSearchProviders) into searchfed, ratcheting 265 → 263.
-	maxPlatformMethods = 263
+	// appendFederationSearchProviders) into searchfed, ratcheting 265 → 263. The
+	// ceiling then carried 8 slack above the 255 actual — a ratchet with slack is
+	// not a ratchet, so it was pinned to the actual 255 (#851, Part 1) ahead of
+	// the mechanical-cluster extraction that re-tightens it further. That batch
+	// (#851, Part 2) then moved six methods off *Platform — resource's
+	// managedResourceURIScheme / managedResourceS3Connection / resolveDefaultS3Instance,
+	// user's observeAuthenticatedUser / observeBrowserLogin, and brand's
+	// injectPortalLogo — into their owner packages, ratcheting 255 → 249. The
+	// public accessors external callers use (ResourceStore, UserStore, BrandURL,
+	// …) stay as one-line delegators, so they still count.
+	maxPlatformMethods = 249
 )
 
 // TestPlatformGodObjectBudget fails when the Platform struct grows more fields

--- a/pkg/platform/branding/branding.go
+++ b/pkg/platform/branding/branding.go
@@ -1,0 +1,187 @@
+// Package branding owns the resolved-once brand assets behind one Handle: the
+// brand logo SVG, the brand URL, and the implementor logo SVG. Each is derived
+// from operator config (the portal logo, an mcpapps platform-info config map,
+// and the implementor logo URL) and cached so repeated reads — and repeated
+// fetches of a remote SVG — resolve only once.
+//
+// Construction takes the resolved config values (the portal logo URL and the
+// implementor logo URL) so the subsystem is constructible and testable without a
+// Platform. It imports only the standard library, never pkg/platform.
+//
+// InjectPortalLogo is the write seam the caller runs once while assembling the
+// platform-info MCP app: it caches the brand URL and logo SVG from the app
+// config, inlines the portal logo SVG (fetched from a URL) so it renders in
+// sandboxed MCP App iframes that block external resource loading, and returns
+// the possibly-augmented config map. The three accessors are the read seams the
+// caller surfaces to its portal/admin consumers. Every method is nil-safe, so a
+// caller that never built a Handle still reads empty brand assets.
+package branding
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// logoFetchTimeout is the maximum duration for fetching a brand or implementor
+// logo SVG.
+const logoFetchTimeout = 10 * time.Second
+
+// logoMaxBytes is the maximum size of fetched logo content (1 MB).
+const logoMaxBytes = 1 << 20
+
+// Config carries the resolved brand config values the owner caches from. The
+// caller translates its own config into this shape so this package stays free of
+// the platform's config types.
+type Config struct {
+	// PortalLogo is the portal.logo URL. When set and no explicit logo_svg /
+	// logo_url is present in the app config, InjectPortalLogo fetches and inlines
+	// it as logo_svg.
+	PortalLogo string
+	// ImplementorLogo is the portal.implementor.logo URL, fetched lazily by
+	// ResolveImplementorLogo.
+	ImplementorLogo string
+}
+
+// Handle owns the resolved brand assets: the portal / implementor logo URLs it
+// was configured with and the cached brand logo SVG, brand URL, and implementor
+// logo SVG. The read accessors expose the cached values to the caller's
+// portal/admin consumers; each resolves at most once.
+type Handle struct {
+	portalLogo      string
+	implementorLogo string
+
+	brandLogoSVG            string
+	brandURL                string
+	resolvedImplementorLogo string
+}
+
+// New builds a Handle from the resolved brand config. The cached assets start
+// empty; InjectPortalLogo and ResolveImplementorLogo populate them on first use.
+func New(cfg Config) *Handle {
+	return &Handle{
+		portalLogo:      cfg.PortalLogo,
+		implementorLogo: cfg.ImplementorLogo,
+	}
+}
+
+// InjectPortalLogo auto-populates the logo in the platform-info app config from
+// the configured portal logo when the operator hasn't set logo_svg or logo_url
+// explicitly. When the logo is an SVG URL, it is fetched and inlined as logo_svg
+// so the logo renders in sandboxed contexts (MCP App iframes) that block
+// external resource loading. It also caches brand_url from the app config for
+// use by BrandURL(). No-op passthrough on a nil Handle.
+func (h *Handle) InjectPortalLogo(cfg any) any {
+	m, ok := cfg.(map[string]any)
+	if !ok {
+		m = make(map[string]any)
+	}
+	if h == nil {
+		return m
+	}
+
+	// Cache brand_url from the platform-info config.
+	if brandURL, _ := m["brand_url"].(string); brandURL != "" {
+		h.brandURL = brandURL
+	}
+
+	if h.portalLogo == "" {
+		// Still cache logo_svg if present in the app config.
+		if svg, _ := m["logo_svg"].(string); svg != "" {
+			h.brandLogoSVG = svg
+		}
+		return m
+	}
+
+	if svg, _ := m["logo_svg"].(string); svg != "" {
+		h.brandLogoSVG = svg
+		return m
+	}
+	if m["logo_url"] != nil {
+		return m
+	}
+
+	// Fetch SVG content for inline rendering; fall back to URL on failure.
+	if svg, err := fetchLogoSVG(h.portalLogo); err == nil {
+		m["logo_svg"] = svg
+		h.brandLogoSVG = svg
+	} else {
+		slog.Debug("portal logo fetch failed, using URL", "url", h.portalLogo, "err", err)
+		m["logo_url"] = h.portalLogo
+	}
+	return m
+}
+
+// BrandLogoSVG returns the resolved brand logo SVG content (from the portal logo
+// or the mcpapps platform-info config), or "" if none is configured or on a nil
+// Handle.
+func (h *Handle) BrandLogoSVG() string {
+	if h == nil {
+		return ""
+	}
+	return h.brandLogoSVG
+}
+
+// BrandURL returns the resolved brand URL from the mcpapps platform-info config
+// (brand_url), or "" if not configured or on a nil Handle.
+func (h *Handle) BrandURL() string {
+	if h == nil {
+		return ""
+	}
+	return h.brandURL
+}
+
+// ResolveImplementorLogo fetches the implementor logo SVG from the configured
+// implementor logo URL. The result is cached so subsequent calls return the same
+// value without another HTTP request. Returns "" if no logo URL is configured,
+// the fetch fails, or the Handle is nil.
+func (h *Handle) ResolveImplementorLogo() string {
+	if h == nil || h.implementorLogo == "" {
+		return ""
+	}
+	if h.resolvedImplementorLogo != "" {
+		return h.resolvedImplementorLogo
+	}
+	svg, err := fetchLogoSVG(h.implementorLogo)
+	if err != nil {
+		slog.Debug("implementor logo fetch failed", "url", h.implementorLogo, "err", err)
+		return ""
+	}
+	h.resolvedImplementorLogo = svg
+	return svg
+}
+
+// fetchLogoSVG downloads an SVG from the given URL and returns its content.
+// Returns an error if the URL is unreachable, returns a non-SVG content type,
+// or exceeds the size limit.
+func fetchLogoSVG(url string) (string, error) {
+	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+		return "", fmt.Errorf("unsupported scheme")
+	}
+
+	client := &http.Client{Timeout: logoFetchTimeout}
+	resp, err := client.Get(url) //nolint:gosec,noctx // URL comes from operator config, not user input
+	if err != nil {
+		return "", fmt.Errorf("fetch: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("status %d", resp.StatusCode)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "svg") {
+		return "", fmt.Errorf("not SVG: %s", ct)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, logoMaxBytes))
+	if err != nil {
+		return "", fmt.Errorf("read: %w", err)
+	}
+
+	return string(body), nil
+}

--- a/pkg/platform/branding/branding_test.go
+++ b/pkg/platform/branding/branding_test.go
@@ -1,0 +1,271 @@
+package branding
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func mustMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", v)
+	}
+	return m
+}
+
+func TestInjectPortalLogo(t *testing.T) {
+	svgContent := `<svg viewBox="0 0 40 40"><circle cx="20" cy="20" r="10"/></svg>`
+
+	t.Run("fetches SVG and injects as logo_svg", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "image/svg+xml")
+			_, _ = w.Write([]byte(svgContent))
+		}))
+		defer srv.Close()
+
+		h := New(Config{PortalLogo: srv.URL + "/logo.svg"})
+		m := mustMap(t, h.InjectPortalLogo(map[string]any{"brand_name": "Test"}))
+		if m["logo_svg"] != svgContent {
+			t.Errorf("logo_svg = %v, want %q", m["logo_svg"], svgContent)
+		}
+		if m["logo_url"] != nil {
+			t.Error("logo_url should be nil when SVG was fetched")
+		}
+		if h.BrandLogoSVG() != svgContent {
+			t.Errorf("BrandLogoSVG() = %q, want %q", h.BrandLogoSVG(), svgContent)
+		}
+	})
+
+	t.Run("falls back to logo_url on non-SVG content type", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte("not-svg"))
+		}))
+		defer srv.Close()
+
+		h := New(Config{PortalLogo: srv.URL + "/logo.png"})
+		m := mustMap(t, h.InjectPortalLogo(map[string]any{"brand_name": "Test"}))
+		if m["logo_url"] != srv.URL+"/logo.png" {
+			t.Errorf("logo_url = %v, want %q", m["logo_url"], srv.URL+"/logo.png")
+		}
+		if m["logo_svg"] != nil {
+			t.Error("logo_svg should be nil for non-SVG")
+		}
+	})
+
+	t.Run("falls back to logo_url on fetch error", func(t *testing.T) {
+		h := New(Config{PortalLogo: "http://127.0.0.1:1/unreachable.svg"})
+		m := mustMap(t, h.InjectPortalLogo(map[string]any{"brand_name": "Test"}))
+		if m["logo_url"] != "http://127.0.0.1:1/unreachable.svg" {
+			t.Errorf("logo_url = %v, want unreachable URL", m["logo_url"])
+		}
+	})
+
+	t.Run("does not overwrite explicit logo_svg", func(t *testing.T) {
+		h := New(Config{PortalLogo: "https://example.com/logo.svg"})
+		m := mustMap(t, h.InjectPortalLogo(map[string]any{"logo_svg": "<svg>custom</svg>"}))
+		if m["logo_svg"] != "<svg>custom</svg>" {
+			t.Errorf("logo_svg was overwritten: %v", m["logo_svg"])
+		}
+	})
+
+	t.Run("does not overwrite explicit logo_url", func(t *testing.T) {
+		h := New(Config{PortalLogo: "https://example.com/logo.svg"})
+		m := mustMap(t, h.InjectPortalLogo(map[string]any{"logo_url": "https://other.com/logo.png"}))
+		if m["logo_url"] != "https://other.com/logo.png" {
+			t.Errorf("logo_url = %v, want %q", m["logo_url"], "https://other.com/logo.png")
+		}
+	})
+
+	t.Run("no-op when portal logo is empty", func(t *testing.T) {
+		h := New(Config{})
+		m := mustMap(t, h.InjectPortalLogo(map[string]any{"brand_name": "Test"}))
+		if m["logo_url"] != nil {
+			t.Errorf("logo_url should be nil when portal logo is empty, got %v", m["logo_url"])
+		}
+	})
+
+	t.Run("creates map when config is nil", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "image/svg+xml")
+			_, _ = w.Write([]byte(svgContent))
+		}))
+		defer srv.Close()
+
+		h := New(Config{PortalLogo: srv.URL + "/logo.svg"})
+		m := mustMap(t, h.InjectPortalLogo(nil))
+		if m["logo_svg"] != svgContent {
+			t.Errorf("logo_svg = %v, want %q", m["logo_svg"], svgContent)
+		}
+	})
+
+	t.Run("nil handle returns the map unchanged", func(t *testing.T) {
+		var h *Handle
+		m := mustMap(t, h.InjectPortalLogo(map[string]any{"brand_url": "https://x"}))
+		if m["brand_url"] != "https://x" {
+			t.Errorf("nil handle should pass the map through: %v", m)
+		}
+	})
+}
+
+func TestFetchLogoSVG(t *testing.T) {
+	svgContent := `<svg viewBox="0 0 40 40"><circle cx="20" cy="20" r="10"/></svg>`
+
+	t.Run("returns SVG content", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "image/svg+xml")
+			_, _ = w.Write([]byte(svgContent))
+		}))
+		defer srv.Close()
+
+		got, err := fetchLogoSVG(srv.URL + "/logo.svg")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != svgContent {
+			t.Errorf("got %q, want %q", got, svgContent)
+		}
+	})
+
+	t.Run("rejects non-SVG content type", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write([]byte("PNG"))
+		}))
+		defer srv.Close()
+
+		if _, err := fetchLogoSVG(srv.URL + "/logo.png"); err == nil {
+			t.Fatal("expected error for non-SVG content type")
+		}
+	})
+
+	t.Run("rejects non-200 status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		if _, err := fetchLogoSVG(srv.URL + "/missing.svg"); err == nil {
+			t.Fatal("expected error for 404")
+		}
+	})
+
+	t.Run("rejects non-HTTP scheme", func(t *testing.T) {
+		if _, err := fetchLogoSVG("ftp://example.com/logo.svg"); err == nil {
+			t.Fatal("expected error for non-HTTP scheme")
+		}
+	})
+
+	t.Run("handles SVG with charset in content type", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "image/svg+xml; charset=utf-8")
+			_, _ = w.Write([]byte(svgContent))
+		}))
+		defer srv.Close()
+
+		got, err := fetchLogoSVG(srv.URL + "/logo.svg")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != svgContent {
+			t.Errorf("got %q, want %q", got, svgContent)
+		}
+	})
+}
+
+func TestBrandURL(t *testing.T) {
+	t.Run("returns empty when not set", func(t *testing.T) {
+		if got := New(Config{}).BrandURL(); got != "" {
+			t.Errorf("BrandURL() = %q, want empty", got)
+		}
+	})
+
+	t.Run("returns cached value from InjectPortalLogo", func(t *testing.T) {
+		h := New(Config{})
+		_ = h.InjectPortalLogo(map[string]any{"brand_url": "https://example.com"})
+		if got := h.BrandURL(); got != "https://example.com" {
+			t.Errorf("BrandURL() = %q, want %q", got, "https://example.com")
+		}
+	})
+
+	t.Run("nil handle returns empty", func(t *testing.T) {
+		var h *Handle
+		if got := h.BrandURL(); got != "" {
+			t.Errorf("nil BrandURL() = %q, want empty", got)
+		}
+	})
+}
+
+func TestInjectPortalLogoCachesBrandURL(t *testing.T) {
+	t.Run("caches brand_url from config", func(t *testing.T) {
+		h := New(Config{})
+		_ = h.InjectPortalLogo(map[string]any{"brand_url": "https://platform.io"})
+		if got := h.BrandURL(); got != "https://platform.io" {
+			t.Errorf("BrandURL() = %q, want %q", got, "https://platform.io")
+		}
+	})
+
+	t.Run("caches brand_url and logo_svg even without portal logo", func(t *testing.T) {
+		h := New(Config{}) // no PortalLogo
+		_ = h.InjectPortalLogo(map[string]any{"brand_url": "https://noportallogo.io", "logo_svg": "<svg/>"})
+		if got := h.BrandURL(); got != "https://noportallogo.io" {
+			t.Errorf("BrandURL() = %q, want %q", got, "https://noportallogo.io")
+		}
+		if got := h.BrandLogoSVG(); got != "<svg/>" {
+			t.Errorf("BrandLogoSVG() = %q, want %q", got, "<svg/>")
+		}
+	})
+
+	t.Run("does not set brand_url when absent", func(t *testing.T) {
+		h := New(Config{})
+		_ = h.InjectPortalLogo(map[string]any{"brand_name": "Test"})
+		if got := h.BrandURL(); got != "" {
+			t.Errorf("BrandURL() = %q, want empty", got)
+		}
+	})
+}
+
+func TestResolveImplementorLogo(t *testing.T) {
+	svgContent := `<svg viewBox="0 0 32 32"><rect width="32" height="32"/></svg>`
+
+	t.Run("fetches and caches SVG", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "image/svg+xml")
+			_, _ = w.Write([]byte(svgContent))
+		}))
+		defer srv.Close()
+
+		h := New(Config{ImplementorLogo: srv.URL + "/impl.svg"})
+		if got := h.ResolveImplementorLogo(); got != svgContent {
+			t.Errorf("ResolveImplementorLogo() = %q, want %q", got, svgContent)
+		}
+
+		// Second call must return the cached value even after the server stops.
+		srv.Close()
+		if got := h.ResolveImplementorLogo(); got != svgContent {
+			t.Errorf("cached ResolveImplementorLogo() = %q, want %q", got, svgContent)
+		}
+	})
+
+	t.Run("returns empty when logo URL is empty", func(t *testing.T) {
+		if got := New(Config{}).ResolveImplementorLogo(); got != "" {
+			t.Errorf("ResolveImplementorLogo() = %q, want empty", got)
+		}
+	})
+
+	t.Run("returns empty on fetch failure", func(t *testing.T) {
+		h := New(Config{ImplementorLogo: "http://127.0.0.1:1/unreachable.svg"})
+		if got := h.ResolveImplementorLogo(); got != "" {
+			t.Errorf("ResolveImplementorLogo() = %q, want empty on fetch failure", got)
+		}
+	})
+
+	t.Run("nil handle returns empty", func(t *testing.T) {
+		var h *Handle
+		if got := h.ResolveImplementorLogo(); got != "" {
+			t.Errorf("nil ResolveImplementorLogo() = %q, want empty", got)
+		}
+	})
+}

--- a/pkg/platform/info_tool.go
+++ b/pkg/platform/info_tool.go
@@ -111,7 +111,7 @@ func (p *Platform) buildFeatures(ctx context.Context, accessibleTools []string) 
 		StorageEnrichment: p.storageProvider != nil && p.config.Enrichment.IsDataHubStorageEnrichmentEnabled(),
 		AuditLogging:      !isExplicitlyDisabled(p.config.Audit.Enabled),
 		KnowledgeCapture:  canReach(toolMemoryCapture) && !isExplicitlyDisabled(p.config.Knowledge.Enabled),
-		ManagedResources:  p.resourceStore != nil,
+		ManagedResources:  p.resources.Store() != nil,
 	}
 
 	if p.config.Knowledge.Apply.IsEnabled() && canReach(toolApplyKnowledge) {
@@ -255,7 +255,7 @@ func (p *Platform) handleInfo(ctx context.Context, _ *mcp.CallToolRequest) (*mcp
 	// tools this caller may reach) beneath the admin business context, with the
 	// resources nudge appended as a runtime note when managed resources exist.
 	var notes []string
-	if p.resourceStore != nil {
+	if p.resources.Store() != nil {
 		notes = append(notes, resourcesDiscoverabilityNote)
 	}
 	// The tools this caller's persona may reach gate both the instruction baseline

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -8,14 +8,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/fs"
 	"log/slog"
 	"maps"
-	"net/http"
 	"os"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
@@ -41,6 +38,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/oauth"
 	"github.com/txn2/mcp-data-platform/pkg/persona"
+	"github.com/txn2/mcp-data-platform/pkg/platform/branding"
 	"github.com/txn2/mcp-data-platform/pkg/platform/browserauth"
 	"github.com/txn2/mcp-data-platform/pkg/platform/connauth"
 	"github.com/txn2/mcp-data-platform/pkg/platform/dedup"
@@ -56,10 +54,12 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
 	"github.com/txn2/mcp-data-platform/pkg/platform/portalstore"
 	"github.com/txn2/mcp-data-platform/pkg/platform/reflexivecapture"
+	"github.com/txn2/mcp-data-platform/pkg/platform/resourcelayer"
 	"github.com/txn2/mcp-data-platform/pkg/platform/routepolicy"
 	"github.com/txn2/mcp-data-platform/pkg/platform/searchfed"
 	"github.com/txn2/mcp-data-platform/pkg/platform/sessionsync"
 	"github.com/txn2/mcp-data-platform/pkg/platform/toolkitcfg"
+	"github.com/txn2/mcp-data-platform/pkg/platform/userdir"
 	"github.com/txn2/mcp-data-platform/pkg/portal"
 	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
 	"github.com/txn2/mcp-data-platform/pkg/portal/s3adapter"
@@ -83,7 +83,6 @@ import (
 	knowledgekit "github.com/txn2/mcp-data-platform/pkg/toolkits/knowledge"
 	trinokit "github.com/txn2/mcp-data-platform/pkg/toolkits/trino"
 	"github.com/txn2/mcp-data-platform/pkg/tuning"
-	"github.com/txn2/mcp-data-platform/pkg/user"
 )
 
 // providerNoop is the provider name for no-op (disabled) providers.
@@ -221,11 +220,14 @@ type Platform struct {
 	// runs, which requires the portal enabled and a database connection. Read
 	// through its accessors by the Portal* accessors (admin/portal REST wiring),
 	// the trino/api export wiring, and the search/enrichment provider assembly.
-	portalStore             *portalstore.Handle
-	provenanceTracker       *middleware.ProvenanceTracker
-	resolvedBrandLogoSVG    string // cached SVG from portal.logo or mcpapps config
-	resolvedBrandURL        string // cached brand_url from mcpapps platform-info config
-	resolvedImplementorLogo string // cached SVG fetched from portal.implementor.logo
+	portalStore       *portalstore.Handle
+	provenanceTracker *middleware.ProvenanceTracker
+	// Brand assets (logo SVG, brand URL, implementor logo). The owner
+	// (pkg/platform/branding) resolves each once from config and caches it behind
+	// one Handle; the caller injects the portal logo into the platform-info app
+	// config and reads the cached values through BrandLogoSVG() / BrandURL() /
+	// ResolveImplementorLogo(). Built in initMCPApps.
+	branding *branding.Handle
 
 	// Workflow gating
 	workflowTracker *middleware.SessionWorkflowTracker
@@ -238,14 +240,20 @@ type Platform struct {
 	// Session gate
 	sessionGate *middleware.SessionGate
 
-	// Resource store (managed resources)
-	resourceStore    resource.Store
-	resourceS3Client resource.S3Client
+	// Managed-resources layer. The owner (pkg/platform/resourcelayer) holds the
+	// Postgres resource store, the S3 blob client, and the MCP-server
+	// registration behind one Handle; the store / client are read through its
+	// accessors and surfaced by ResourceStore() / ResourceS3Client(). nil when
+	// managed resources are disabled or no database is configured.
+	resources *resourcelayer.Handle
 
-	// Known-users directory (#614). userStore is nil without a database;
-	// userDirectory wraps it with throttled async upserts on authentication.
-	userStore     user.Store
-	userDirectory *user.Directory
+	// Known-users directory (#614). The owner (pkg/platform/userdir) holds the
+	// user store and the throttled-async directory behind one Handle; the store
+	// is read through UserStore(), and the owner's Observe methods are wired as
+	// the authenticator's UserObserver and the browser-session login callback.
+	// nil without a database, in which case every consumer degrades cleanly to
+	// free-typed email sharing.
+	users *userdir.Handle
 
 	// Prompt store + metadata collected during registration
 	promptStore   prompt.Store
@@ -1035,8 +1043,8 @@ func (p *Platform) initAuth(opts *Options) error {
 	// Wrapping the authenticator catches all auth paths (MCP, portal, admin)
 	// at their single Authenticate() chokepoint. The observer is best-effort
 	// and asynchronous, so it never blocks or fails authentication.
-	if p.userDirectory != nil {
-		p.authenticator = auth.NewObservingAuthenticator(p.authenticator, p.observeAuthenticatedUser)
+	if p.users.Directory() != nil {
+		p.authenticator = auth.NewObservingAuthenticator(p.authenticator, p.users.ObserveAuthenticated)
 	}
 
 	if opts.Authorizer != nil {
@@ -1129,7 +1137,7 @@ func (p *Platform) initBrowserSession() error {
 		// Portal/admin SPA users log in via the session cookie, so the token
 		// authenticator's ObservingAuthenticator never sees them; record them
 		// here at login instead (#614).
-		OnLogin: p.observeBrowserLogin,
+		OnLogin: p.users.ObserveBrowserLogin,
 	})
 	if err != nil {
 		return fmt.Errorf("initializing browser session: %w", err)
@@ -1674,176 +1682,72 @@ func (p *Platform) parseExportConfig() trinokit.ExportConfig {
 	return cfg
 }
 
-// initManagedResources initializes the managed resources subsystem (human-uploaded
-// reference material stored in S3 with metadata in PostgreSQL).
+// initManagedResources assembles the managed-resources layer via the
+// resourcelayer owner: the Postgres resource store, the S3 blob client, and the
+// MCP-server registration behind one Handle. It translates platform config into
+// the owner's Config and delegates assembly. No-op (nil handle) when managed
+// resources are explicitly disabled or no database is configured. The
+// resources/read middleware wiring stays on Platform (addManagedResourceMiddleware).
 func (p *Platform) initManagedResources() error {
 	if isExplicitlyDisabled(p.config.Resources.Managed.Enabled) || p.db == nil {
 		return nil
 	}
 
-	p.resourceStore = resource.NewPostgresStore(p.db)
-
-	// Create S3 client from referenced or default S3 connection.
-	if connName := p.managedResourceS3Connection(); connName != "" {
-		s3Cfg := toolkitcfg.S3Config(p.config.Toolkits, connName)
-		if s3Cfg == nil {
-			return fmt.Errorf("resource s3 connection %q not found in toolkits config", connName)
-		}
-
-		clientCfg := &s3client.Config{
-			Region:          s3Cfg.Region,
-			Endpoint:        s3Cfg.Endpoint,
-			AccessKeyID:     s3Cfg.AccessKeyID,
-			SecretAccessKey: s3Cfg.SecretKey,
-			Name:            s3Cfg.ConnectionName,
-			UsePathStyle:    s3Cfg.UsePathStyle,
-		}
-
-		c, err := s3client.New(context.Background(), clientCfg)
-		if err != nil {
-			return fmt.Errorf("creating resource s3 client for connection %q: %w", connName, err)
-		}
-
-		p.resourceS3Client = s3adapter.New(c)
-	} else {
-		slog.Warn("managed resources: no s3_connection configured; blob storage disabled")
+	handle, err := resourcelayer.New(p.db, resourcelayer.Config{
+		S3Connection: p.config.Resources.Managed.S3Connection,
+		S3Bucket:     p.config.Resources.Managed.S3Bucket,
+		URIScheme:    p.config.Resources.Managed.URIScheme,
+		Toolkits:     p.config.Toolkits,
+	})
+	if err != nil {
+		return fmt.Errorf("creating managed-resources layer: %w", err)
 	}
-
-	slog.Info("managed resources enabled",
-		"s3_connection", p.managedResourceS3Connection(),
-		"s3_bucket", p.config.Resources.Managed.S3Bucket,
-		"uri_scheme", p.managedResourceURIScheme(),
-	)
+	p.resources = handle
 	return nil
-}
-
-// managedResourceURIScheme returns the configured URI scheme or the default.
-func (p *Platform) managedResourceURIScheme() string {
-	if s := p.config.Resources.Managed.URIScheme; s != "" {
-		return s
-	}
-	return resource.DefaultURIScheme
-}
-
-// managedResourceS3Connection returns the S3 connection name for managed
-// resources. Returns the explicit config value if set, otherwise falls back
-// to the default/first S3 toolkit instance.
-func (p *Platform) managedResourceS3Connection() string {
-	name := p.config.Resources.Managed.S3Connection
-	if name != "" {
-		return name
-	}
-	// No explicit s3_connection — resolve the default S3 toolkit instance
-	// so managed resources automatically use an available S3 backend.
-	resolved := p.resolveDefaultS3Instance()
-	if resolved == "" {
-		slog.Debug("managed resources: no S3 toolkit available for default resolution")
-		return ""
-	}
-	slog.Debug("managed resources: using default S3 connection", "s3_connection", resolved)
-	return resolved
-}
-
-// resolveDefaultS3Instance returns the name of the default/first S3 toolkit
-// instance, or "" if no S3 toolkit is configured.
-func (p *Platform) resolveDefaultS3Instance() string {
-	toolkitsCfg, ok := p.config.Toolkits["s3"]
-	if !ok {
-		return ""
-	}
-	kindCfg, ok := toolkitsCfg.(map[string]any)
-	if !ok {
-		return ""
-	}
-	instances, ok := kindCfg[cfgKeyInstances].(map[string]any)
-	if !ok {
-		return ""
-	}
-	return toolkitcfg.ResolveDefaultInstance(kindCfg, instances)
 }
 
 // ResourceStore returns the managed resource store (nil if not enabled).
 func (p *Platform) ResourceStore() resource.Store {
-	return p.resourceStore
+	return p.resources.Store()
 }
 
 // ResourceS3Client returns the S3 client for managed resources (nil if not configured).
 func (p *Platform) ResourceS3Client() resource.S3Client {
-	return p.resourceS3Client
+	return p.resources.S3Client()
 }
 
-// RegisterManagedResource registers a managed resource with the MCP server
-// so it appears in the SDK's native resource list. The handler is a no-op —
-// the middleware handles the actual resources/read with auth and S3 fetch.
-// This also triggers notifications/resources/list_changed for connected clients.
+// RegisterManagedResource registers a managed resource with the MCP server so it
+// appears in the SDK's native resource list. Delegates to the resourcelayer
+// owner, passing the live p.mcpServer (created after the resource layer is
+// built); wired as the create callback of the REST resources API.
 func (p *Platform) RegisterManagedResource(res *resource.Resource) {
-	if p.mcpServer == nil || res == nil {
-		slog.Debug("RegisterManagedResource: skipping", "server_nil", p.mcpServer == nil, "res_nil", res == nil)
-		return
-	}
-	slog.Debug("RegisterManagedResource: registering with SDK", "uri", res.URI, "name", res.DisplayName)
-	p.mcpServer.AddResource(&mcp.Resource{
-		URI:         res.URI,
-		Name:        res.DisplayName,
-		Description: res.Description,
-		MIMEType:    res.MIMEType,
-	}, func(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
-		// Fallback handler — the middleware normally intercepts resources/read
-		// before this runs. If we get here, the middleware fell through (auth
-		// failure or config issue). Return a placeholder instead of nil to
-		// avoid the SDK's "nil information" error.
-		slog.Warn("managed resource: SDK fallback handler called (middleware did not intercept)", "uri", req.Params.URI)
-		return &mcp.ReadResourceResult{
-			Contents: []*mcp.ResourceContents{{
-				URI:      req.Params.URI,
-				MIMEType: res.MIMEType,
-				Text:     "(resource content unavailable — authentication required)",
-			}},
-		}, nil
-	})
+	p.resources.Register(p.mcpServer, res)
 }
 
 // UnregisterManagedResource removes a managed resource from the MCP server's
-// resource list. This also triggers notifications/resources/list_changed.
+// resource list. Delegates to the resourcelayer owner; wired as the delete
+// callback of the REST resources API.
 func (p *Platform) UnregisterManagedResource(uri string) {
-	if p.mcpServer == nil {
-		slog.Debug("UnregisterManagedResource: skipping, no server")
-		return
-	}
-	slog.Debug("UnregisterManagedResource: removing from SDK", "uri", uri)
-	p.mcpServer.RemoveResources(uri)
+	p.resources.Unregister(p.mcpServer, uri)
 }
 
-// LoadManagedResources registers all existing managed resources from the
-// database with the MCP server so they're visible on the first resources/list
-// call. Called during platform initialization.
+// LoadManagedResources registers all existing managed resources with the MCP
+// server so they're visible on the first resources/list call. Delegates to the
+// resourcelayer owner, passing the live p.mcpServer; called during platform
+// initialization after finalizeSetup has created the server.
 func (p *Platform) LoadManagedResources() {
-	if p.resourceStore == nil {
-		slog.Debug("LoadManagedResources: no resource store, skipping")
-		return
-	}
-	if p.mcpServer == nil {
-		slog.Debug("LoadManagedResources: no MCP server, skipping")
-		return
-	}
-	resources, _, err := p.resourceStore.List(context.Background(), resource.Filter{
-		Scopes: []resource.ScopeFilter{{Scope: resource.ScopeGlobal}},
-		Limit:  1000,
-	})
-	if err != nil {
-		slog.Warn("managed resources: failed to load existing resources", "error", err)
-		return
-	}
-	for i := range resources {
-		p.RegisterManagedResource(&resources[i])
-	}
-	if len(resources) > 0 {
-		slog.Info("managed resources: registered existing resources", logKeyCount, len(resources))
-	}
+	p.resources.LoadAll(p.mcpServer)
 }
 
-// initMCPApps initializes MCP Apps support.
+// initMCPApps initializes MCP Apps support. The branding owner is built first
+// (regardless of whether MCP Apps are enabled) so BrandLogoSVG() / BrandURL() /
+// ResolveImplementorLogo() resolve from config for every consumer.
 func (p *Platform) initMCPApps() error {
+	p.branding = branding.New(branding.Config{
+		PortalLogo:      p.config.Portal.Logo,
+		ImplementorLogo: p.config.Portal.Implementor.Logo,
+	})
+
 	if !p.config.MCPApps.IsEnabled() {
 		return nil
 	}
@@ -1905,7 +1809,7 @@ func (p *Platform) registerBuiltinPlatformInfo() error {
 	}
 
 	// Auto-inject portal logo when the operator hasn't set one explicitly.
-	app.Config = p.injectPortalLogo(app.Config)
+	app.Config = p.branding.InjectPortalLogo(app.Config)
 
 	if app.AssetsPath != "" {
 		if err := app.ValidateAssets(); err != nil {
@@ -1919,90 +1823,6 @@ func (p *Platform) registerBuiltinPlatformInfo() error {
 
 	slog.Info("registered MCP app", "app", builtinPlatformInfoName, "resource_uri", app.ResourceURI)
 	return nil
-}
-
-// injectPortalLogo auto-populates the logo in the platform-info app config
-// from portal.logo when the operator hasn't set logo_svg or logo_url
-// explicitly. When the logo is an SVG URL, it is fetched and inlined as
-// logo_svg so the logo renders in sandboxed contexts (MCP App iframes)
-// that block external resource loading.
-//
-// Also caches brand_url from the app config for use by BrandURL().
-func (p *Platform) injectPortalLogo(cfg any) any {
-	m, ok := cfg.(map[string]any)
-	if !ok {
-		m = make(map[string]any)
-	}
-
-	// Cache brand_url from the mcpapps platform-info config.
-	if brandURL, _ := m["brand_url"].(string); brandURL != "" {
-		p.resolvedBrandURL = brandURL
-	}
-
-	portalLogo := p.config.Portal.Logo
-	if portalLogo == "" {
-		// Still cache logo_svg if present in the app config.
-		if svg, _ := m["logo_svg"].(string); svg != "" {
-			p.resolvedBrandLogoSVG = svg
-		}
-		return m
-	}
-
-	if svg, _ := m["logo_svg"].(string); svg != "" {
-		p.resolvedBrandLogoSVG = svg
-		return m
-	}
-	if m["logo_url"] != nil {
-		return m
-	}
-
-	// Fetch SVG content for inline rendering; fall back to URL on failure.
-	if svg, err := fetchLogoSVG(portalLogo); err == nil {
-		m["logo_svg"] = svg
-		p.resolvedBrandLogoSVG = svg
-	} else {
-		slog.Debug("portal logo fetch failed, using URL", "url", portalLogo, "err", err)
-		m["logo_url"] = portalLogo
-	}
-	return m
-}
-
-// logoFetchTimeout is the maximum duration for fetching a portal logo SVG.
-const logoFetchTimeout = 10 * time.Second
-
-// logoMaxBytes is the maximum size of fetched logo content (1 MB).
-const logoMaxBytes = 1 << 20
-
-// fetchLogoSVG downloads an SVG from the given URL and returns its content.
-// Returns an error if the URL is unreachable, returns a non-SVG content type,
-// or exceeds the size limit.
-func fetchLogoSVG(url string) (string, error) {
-	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
-		return "", fmt.Errorf("unsupported scheme")
-	}
-
-	client := &http.Client{Timeout: logoFetchTimeout}
-	resp, err := client.Get(url) //nolint:gosec,noctx // URL comes from operator config, not user input
-	if err != nil {
-		return "", fmt.Errorf("fetch: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("status %d", resp.StatusCode)
-	}
-
-	ct := resp.Header.Get("Content-Type")
-	if !strings.Contains(ct, "svg") {
-		return "", fmt.Errorf("not SVG: %s", ct)
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, logoMaxBytes))
-	if err != nil {
-		return "", fmt.Errorf("read: %w", err)
-	}
-
-	return string(body), nil
 }
 
 // registerMCPApp creates, validates, and registers a single MCP app.
@@ -2137,14 +1957,14 @@ func (p *Platform) reflexivePersonaAllowsTool() reflexivecapture.PersonaToolChec
 
 // addManagedResourceMiddleware registers managed resources middleware when enabled.
 func (p *Platform) addManagedResourceMiddleware() {
-	if p.resourceStore == nil {
+	if p.resources.Store() == nil {
 		return
 	}
 	cfg := middleware.ManagedResourceConfig{
-		Store:         p.resourceStore,
-		S3Client:      p.resourceS3Client,
+		Store:         p.resources.Store(),
+		S3Client:      p.resources.S3Client(),
 		S3Bucket:      p.config.Resources.Managed.S3Bucket,
-		URIScheme:     p.managedResourceURIScheme(),
+		URIScheme:     p.resources.URIScheme(),
 		Authenticator: p.authenticator,
 		AdminPersona:  p.config.Admin.Persona,
 	}
@@ -2349,7 +2169,7 @@ func (p *Platform) buildServerCapabilities() *mcp.ServerCapabilities {
 	}
 
 	// Resources are available when templates or managed resources are enabled.
-	if p.config.Resources.IsEnabled() || p.resourceStore != nil || len(p.config.Resources.Custom) > 0 {
+	if p.config.Resources.IsEnabled() || p.resources.Store() != nil || len(p.config.Resources.Custom) > 0 {
 		caps.Resources = &mcp.ResourceCapabilities{ListChanged: true}
 	}
 
@@ -3055,35 +2875,23 @@ func (p *Platform) KnowledgeRouter() *knowledge.Router {
 
 // BrandLogoSVG returns the resolved brand logo SVG content (from portal.logo
 // or mcpapps platform-info config), or empty string if none is configured.
+// Delegates to the branding owner.
 func (p *Platform) BrandLogoSVG() string {
-	return p.resolvedBrandLogoSVG
+	return p.branding.BrandLogoSVG()
 }
 
 // BrandURL returns the resolved brand URL from the mcpapps platform-info
-// config (brand_url), or empty string if not configured.
+// config (brand_url), or empty string if not configured. Delegates to the
+// branding owner.
 func (p *Platform) BrandURL() string {
-	return p.resolvedBrandURL
+	return p.branding.BrandURL()
 }
 
-// ResolveImplementorLogo fetches the implementor logo SVG from the URL
-// configured in portal.implementor.logo. The result is cached so subsequent
-// calls return the same value without another HTTP request. Returns empty
-// string if no logo URL is configured or the fetch fails.
+// ResolveImplementorLogo fetches (once, then caches) the implementor logo SVG
+// from portal.implementor.logo, or empty string if no logo URL is configured or
+// the fetch fails. Delegates to the branding owner.
 func (p *Platform) ResolveImplementorLogo() string {
-	logoURL := p.config.Portal.Implementor.Logo
-	if logoURL == "" {
-		return ""
-	}
-	if p.resolvedImplementorLogo != "" {
-		return p.resolvedImplementorLogo
-	}
-	svg, err := fetchLogoSVG(logoURL)
-	if err != nil {
-		slog.Debug("implementor logo fetch failed", "url", logoURL, "err", err)
-		return ""
-	}
-	p.resolvedImplementorLogo = svg
-	return svg
+	return p.branding.ResolveImplementorLogo()
 }
 
 // BrowserSessionFlow returns the OIDC login flow, or nil if browser sessions are disabled.

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -6,8 +6,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"log/slog"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -3458,276 +3456,34 @@ func TestNew_WorkflowGatingEnabled(t *testing.T) {
 	}
 }
 
-func mustMap(t *testing.T, v any) map[string]any {
-	t.Helper()
-	m, ok := v.(map[string]any)
-	if !ok {
-		t.Fatalf("expected map[string]any, got %T", v)
-	}
-	return m
-}
-
-func TestInjectPortalLogo(t *testing.T) {
-	svgContent := `<svg viewBox="0 0 40 40"><circle cx="20" cy="20" r="10"/></svg>`
-
-	t.Run("fetches SVG and injects as logo_svg", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "image/svg+xml")
-			_, _ = w.Write([]byte(svgContent))
-		}))
-		defer srv.Close()
-
-		p := &Platform{config: &Config{
-			Portal: PortalConfig{Logo: srv.URL + "/logo.svg"},
-		}}
-		cfg := map[string]any{"brand_name": "Test"}
-		m := mustMap(t, p.injectPortalLogo(cfg))
-		if m["logo_svg"] != svgContent {
-			t.Errorf("logo_svg = %v, want %q", m["logo_svg"], svgContent)
+// TestBrandingAccessorsDelegate proves the Platform brand accessors read through
+// the branding owner built in initMCPApps (behavioral coverage of the resolve /
+// cache / fetch logic lives in pkg/platform/branding).
+func TestBrandingAccessorsDelegate(t *testing.T) {
+	t.Run("nil handle yields empty brand assets", func(t *testing.T) {
+		p := &Platform{}
+		if got := p.BrandLogoSVG(); got != "" {
+			t.Errorf("BrandLogoSVG() = %q, want empty", got)
 		}
-		if m["logo_url"] != nil {
-			t.Error("logo_url should be nil when SVG was fetched")
-		}
-	})
-
-	t.Run("falls back to logo_url on non-SVG content type", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "image/png")
-			_, _ = w.Write([]byte("not-svg"))
-		}))
-		defer srv.Close()
-
-		p := &Platform{config: &Config{
-			Portal: PortalConfig{Logo: srv.URL + "/logo.png"},
-		}}
-		cfg := map[string]any{"brand_name": "Test"}
-		m := mustMap(t, p.injectPortalLogo(cfg))
-		if m["logo_url"] != srv.URL+"/logo.png" {
-			t.Errorf("logo_url = %v, want %q", m["logo_url"], srv.URL+"/logo.png")
-		}
-		if m["logo_svg"] != nil {
-			t.Error("logo_svg should be nil for non-SVG")
-		}
-	})
-
-	t.Run("falls back to logo_url on fetch error", func(t *testing.T) {
-		p := &Platform{config: &Config{
-			Portal: PortalConfig{Logo: "http://127.0.0.1:1/unreachable.svg"},
-		}}
-		cfg := map[string]any{"brand_name": "Test"}
-		m := mustMap(t, p.injectPortalLogo(cfg))
-		if m["logo_url"] != "http://127.0.0.1:1/unreachable.svg" {
-			t.Errorf("logo_url = %v, want unreachable URL", m["logo_url"])
-		}
-	})
-
-	t.Run("does not overwrite explicit logo_svg", func(t *testing.T) {
-		p := &Platform{config: &Config{
-			Portal: PortalConfig{Logo: "https://example.com/logo.svg"},
-		}}
-		cfg := map[string]any{"logo_svg": "<svg>custom</svg>"}
-		m := mustMap(t, p.injectPortalLogo(cfg))
-		if m["logo_svg"] != "<svg>custom</svg>" {
-			t.Errorf("logo_svg was overwritten: %v", m["logo_svg"])
-		}
-	})
-
-	t.Run("does not overwrite explicit logo_url", func(t *testing.T) {
-		p := &Platform{config: &Config{
-			Portal: PortalConfig{Logo: "https://example.com/logo.svg"},
-		}}
-		cfg := map[string]any{"logo_url": "https://other.com/logo.png"}
-		m := mustMap(t, p.injectPortalLogo(cfg))
-		if m["logo_url"] != "https://other.com/logo.png" {
-			t.Errorf("logo_url = %v, want %q", m["logo_url"], "https://other.com/logo.png")
-		}
-	})
-
-	t.Run("no-op when portal logo is empty", func(t *testing.T) {
-		p := &Platform{config: &Config{}}
-		cfg := map[string]any{"brand_name": "Test"}
-		m := mustMap(t, p.injectPortalLogo(cfg))
-		if m["logo_url"] != nil {
-			t.Errorf("logo_url should be nil when portal logo is empty, got %v", m["logo_url"])
-		}
-	})
-
-	t.Run("creates map when config is nil", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "image/svg+xml")
-			_, _ = w.Write([]byte(svgContent))
-		}))
-		defer srv.Close()
-
-		p := &Platform{config: &Config{
-			Portal: PortalConfig{Logo: srv.URL + "/logo.svg"},
-		}}
-		m := mustMap(t, p.injectPortalLogo(nil))
-		if m["logo_svg"] != svgContent {
-			t.Errorf("logo_svg = %v, want %q", m["logo_svg"], svgContent)
-		}
-	})
-}
-
-func TestFetchLogoSVG(t *testing.T) {
-	svgContent := `<svg viewBox="0 0 40 40"><circle cx="20" cy="20" r="10"/></svg>`
-
-	t.Run("returns SVG content", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "image/svg+xml")
-			_, _ = w.Write([]byte(svgContent))
-		}))
-		defer srv.Close()
-
-		got, err := fetchLogoSVG(srv.URL + "/logo.svg")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got != svgContent {
-			t.Errorf("got %q, want %q", got, svgContent)
-		}
-	})
-
-	t.Run("rejects non-SVG content type", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "image/png")
-			_, _ = w.Write([]byte("PNG"))
-		}))
-		defer srv.Close()
-
-		_, err := fetchLogoSVG(srv.URL + "/logo.png")
-		if err == nil {
-			t.Fatal("expected error for non-SVG content type")
-		}
-	})
-
-	t.Run("rejects non-200 status", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
-		}))
-		defer srv.Close()
-
-		_, err := fetchLogoSVG(srv.URL + "/missing.svg")
-		if err == nil {
-			t.Fatal("expected error for 404")
-		}
-	})
-
-	t.Run("rejects non-HTTP scheme", func(t *testing.T) {
-		_, err := fetchLogoSVG("ftp://example.com/logo.svg")
-		if err == nil {
-			t.Fatal("expected error for non-HTTP scheme")
-		}
-	})
-
-	t.Run("handles SVG with charset in content type", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "image/svg+xml; charset=utf-8")
-			_, _ = w.Write([]byte(svgContent))
-		}))
-		defer srv.Close()
-
-		got, err := fetchLogoSVG(srv.URL + "/logo.svg")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got != svgContent {
-			t.Errorf("got %q, want %q", got, svgContent)
-		}
-	})
-}
-
-func TestBrandURL(t *testing.T) {
-	t.Run("returns empty when not set", func(t *testing.T) {
-		p := &Platform{config: &Config{}}
 		if got := p.BrandURL(); got != "" {
 			t.Errorf("BrandURL() = %q, want empty", got)
 		}
-	})
-
-	t.Run("returns cached value from injectPortalLogo", func(t *testing.T) {
-		p := &Platform{config: &Config{}}
-		cfg := map[string]any{"brand_url": "https://example.com"}
-		_ = p.injectPortalLogo(cfg)
-		if got := p.BrandURL(); got != "https://example.com" {
-			t.Errorf("BrandURL() = %q, want %q", got, "https://example.com")
-		}
-	})
-}
-
-func TestInjectPortalLogo_CachesBrandURL(t *testing.T) {
-	t.Run("caches brand_url from config", func(t *testing.T) {
-		p := &Platform{config: &Config{}}
-		cfg := map[string]any{"brand_url": "https://platform.io"}
-		_ = p.injectPortalLogo(cfg)
-		if p.resolvedBrandURL != "https://platform.io" {
-			t.Errorf("resolvedBrandURL = %q, want %q", p.resolvedBrandURL, "https://platform.io")
-		}
-	})
-
-	t.Run("caches brand_url even without portal logo", func(t *testing.T) {
-		p := &Platform{config: &Config{}} // no Portal.Logo
-		cfg := map[string]any{"brand_url": "https://noportallogo.io", "logo_svg": "<svg/>"}
-		_ = p.injectPortalLogo(cfg)
-		if p.resolvedBrandURL != "https://noportallogo.io" {
-			t.Errorf("resolvedBrandURL = %q, want %q", p.resolvedBrandURL, "https://noportallogo.io")
-		}
-		// Also verify logo_svg was cached even without portal.Logo
-		if p.resolvedBrandLogoSVG != "<svg/>" {
-			t.Errorf("resolvedBrandLogoSVG = %q, want %q", p.resolvedBrandLogoSVG, "<svg/>")
-		}
-	})
-
-	t.Run("does not set brand_url when absent", func(t *testing.T) {
-		p := &Platform{config: &Config{}}
-		cfg := map[string]any{"brand_name": "Test"}
-		_ = p.injectPortalLogo(cfg)
-		if p.resolvedBrandURL != "" {
-			t.Errorf("resolvedBrandURL = %q, want empty", p.resolvedBrandURL)
-		}
-	})
-}
-
-func TestResolveImplementorLogo(t *testing.T) {
-	svgContent := `<svg viewBox="0 0 32 32"><rect width="32" height="32"/></svg>`
-
-	t.Run("fetches and caches SVG", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "image/svg+xml")
-			_, _ = w.Write([]byte(svgContent))
-		}))
-		defer srv.Close()
-
-		p := &Platform{config: &Config{
-			Portal: PortalConfig{Implementor: ImplementorConfig{Logo: srv.URL + "/impl.svg"}},
-		}}
-
-		got := p.ResolveImplementorLogo()
-		if got != svgContent {
-			t.Errorf("ResolveImplementorLogo() = %q, want %q", got, svgContent)
-		}
-
-		// Second call should return cached value (no HTTP request)
-		srv.Close()
-		got2 := p.ResolveImplementorLogo()
-		if got2 != svgContent {
-			t.Errorf("cached ResolveImplementorLogo() = %q, want %q", got2, svgContent)
-		}
-	})
-
-	t.Run("returns empty when logo URL is empty", func(t *testing.T) {
-		p := &Platform{config: &Config{}}
 		if got := p.ResolveImplementorLogo(); got != "" {
 			t.Errorf("ResolveImplementorLogo() = %q, want empty", got)
 		}
 	})
 
-	t.Run("returns empty on fetch failure", func(t *testing.T) {
+	t.Run("initMCPApps builds the branding owner from config", func(t *testing.T) {
+		mcpAppsDisabled := false
 		p := &Platform{config: &Config{
-			Portal: PortalConfig{Implementor: ImplementorConfig{Logo: "http://127.0.0.1:1/unreachable.svg"}},
+			Portal:  PortalConfig{Logo: "https://example.com/logo.svg"},
+			MCPApps: MCPAppsConfig{Enabled: &mcpAppsDisabled},
 		}}
-		if got := p.ResolveImplementorLogo(); got != "" {
-			t.Errorf("ResolveImplementorLogo() = %q, want empty on fetch failure", got)
+		if err := p.initMCPApps(); err != nil {
+			t.Fatalf("initMCPApps: %v", err)
+		}
+		if p.branding == nil {
+			t.Fatal("expected branding owner to be built even when MCP Apps are disabled")
 		}
 	})
 }
@@ -4464,99 +4220,6 @@ func TestAPIKeyStoreAccessor(t *testing.T) {
 	}
 }
 
-func TestResolvedResourceS3Connection(t *testing.T) {
-	t.Run("explicit connection returned", func(t *testing.T) {
-		p := &Platform{config: &Config{
-			Resources: ResourcesConfig{
-				Managed: ManagedResourcesCfg{S3Connection: "my-s3"},
-			},
-		}}
-		if got := p.managedResourceS3Connection(); got != "my-s3" {
-			t.Errorf("got %q, want my-s3", got)
-		}
-	})
-
-	t.Run("falls back to default S3 instance", func(t *testing.T) {
-		p := &Platform{config: &Config{
-			Toolkits: map[string]any{
-				"s3": map[string]any{
-					"instances": map[string]any{
-						"acme": map[string]any{
-							"endpoint":      "http://localhost:9000",
-							"access_key_id": "key",
-							"secret_key":    "secret",
-						},
-					},
-				},
-			},
-		}}
-		if got := p.managedResourceS3Connection(); got != "acme" {
-			t.Errorf("got %q, want acme", got)
-		}
-	})
-
-	t.Run("empty when no S3 toolkit", func(t *testing.T) {
-		p := &Platform{config: &Config{}}
-		if got := p.managedResourceS3Connection(); got != "" {
-			t.Errorf("got %q, want empty", got)
-		}
-	})
-}
-
-func TestResolveDefaultS3Instance(t *testing.T) {
-	t.Run("returns instance name", func(t *testing.T) {
-		p := &Platform{config: &Config{
-			Toolkits: map[string]any{
-				"s3": map[string]any{
-					"instances": map[string]any{
-						"mys3": map[string]any{"endpoint": "http://localhost:9000"},
-					},
-				},
-			},
-		}}
-		if got := p.resolveDefaultS3Instance(); got != "mys3" {
-			t.Errorf("got %q, want mys3", got)
-		}
-	})
-
-	t.Run("returns configured default", func(t *testing.T) {
-		p := &Platform{config: &Config{
-			Toolkits: map[string]any{
-				"s3": map[string]any{
-					"default": "second",
-					"instances": map[string]any{
-						"first":  map[string]any{"endpoint": "http://a:9000"},
-						"second": map[string]any{"endpoint": "http://b:9000"},
-					},
-				},
-			},
-		}}
-		if got := p.resolveDefaultS3Instance(); got != "second" {
-			t.Errorf("got %q, want second", got)
-		}
-	})
-
-	t.Run("empty when no S3 toolkit", func(t *testing.T) {
-		p := &Platform{config: &Config{}}
-		if got := p.resolveDefaultS3Instance(); got != "" {
-			t.Errorf("got %q, want empty", got)
-		}
-	})
-
-	t.Run("empty when instances not a map", func(t *testing.T) {
-		p := &Platform{config: &Config{
-			Toolkits: map[string]any{
-				"s3": map[string]any{
-					"instances": "invalid",
-				},
-			},
-		}}
-		if got := p.resolveDefaultS3Instance(); got != "" {
-			t.Errorf("got %q, want empty", got)
-		}
-	})
-}
-
 func TestRegisterManagedResource(t *testing.T) {
 	t.Run("nil server does not panic", func(_ *testing.T) {
 		p := &Platform{}
@@ -4598,38 +4261,11 @@ func TestUnregisterManagedResource(t *testing.T) {
 }
 
 func TestLoadManagedResources(t *testing.T) {
-	t.Run("nil store does not panic", func(_ *testing.T) {
+	t.Run("nil handle does not panic", func(_ *testing.T) {
 		p := newTestPlatform(t)
-		p.LoadManagedResources() // no store, should be no-op
-	})
-
-	t.Run("store without server does not panic", func(_ *testing.T) {
-		p := &Platform{
-			resourceStore: &noopResourceStore{},
-		}
-		p.LoadManagedResources() // store set but no server
+		p.LoadManagedResources() // no resources handle, should be no-op
 	})
 }
-
-// noopResourceStore satisfies resource.Store for guard-clause tests.
-type noopResourceStore struct{}
-
-func (*noopResourceStore) Insert(_ context.Context, _ resource.Resource) error { return nil }
-
-func (*noopResourceStore) Get(_ context.Context, _ string) (*resource.Resource, error) {
-	return &resource.Resource{}, nil
-}
-
-func (*noopResourceStore) GetByURI(_ context.Context, _ string) (*resource.Resource, error) {
-	return &resource.Resource{}, nil
-}
-
-func (*noopResourceStore) List(_ context.Context, _ resource.Filter) ([]resource.Resource, int, error) {
-	return nil, 0, nil
-}
-
-func (*noopResourceStore) Update(_ context.Context, _ string, _ resource.Update) error { return nil }
-func (*noopResourceStore) Delete(_ context.Context, _ string) error                    { return nil }
 
 // TestBroadcaster_NonNilAfterNew proves Broadcaster() honors its
 // "always non-nil after New" contract — including the previously-buggy

--- a/pkg/platform/resourcelayer/resourcelayer.go
+++ b/pkg/platform/resourcelayer/resourcelayer.go
@@ -1,0 +1,271 @@
+// Package resourcelayer assembles the managed-resources layer behind one Handle:
+// the Postgres-backed resource store for human-uploaded reference material, the
+// S3 blob client that holds the file bytes, and the MCP-server registration that
+// makes each resource visible in the SDK's native resources/list.
+//
+// Construction takes explicit inputs — a *sql.DB and the resolved
+// managed-resources config (the S3 connection name, bucket, URI scheme, and the
+// toolkits config map used to resolve a default S3 instance) — so the subsystem
+// is constructible and testable without a Platform. It imports pkg/resource,
+// pkg/platform/toolkitcfg, the mcp-s3 client + its resource adapter, and the MCP
+// SDK, never pkg/platform. The *sql.DB is a shared foundation owned by the
+// caller and passed in.
+//
+// The MCP server is NOT captured at construction: the store must exist before
+// the caller wires the resources/read middleware, but the server is created
+// later in the caller's setup, so Register / Unregister / LoadAll take the
+// *mcp.Server per call (the caller passes the server it owns at the moment it
+// registers, after the server exists). A snapshot at construction would freeze a
+// nil server and silently skip every registration.
+//
+// New returns (nil, nil) when db is nil: managed resources need a database, so a
+// no-DB deployment gets the nil Handle and every accessor and mutation degrades
+// to a no-op. Otherwise it builds the store and — when an S3 connection resolves
+// — the blob client, returning an error only when the referenced connection is
+// missing or its client fails to build. The layer owns no background goroutine,
+// so it needs no Stop/Close; the caller closes the shared *sql.DB.
+package resourcelayer
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	s3client "github.com/txn2/mcp-s3/pkg/client"
+
+	"github.com/txn2/mcp-data-platform/pkg/platform/toolkitcfg"
+	"github.com/txn2/mcp-data-platform/pkg/portal/s3adapter"
+	"github.com/txn2/mcp-data-platform/pkg/resource"
+)
+
+// cfgKeyInstances is the config map key for toolkit instances, matched when
+// resolving the default S3 instance for blob storage.
+const cfgKeyInstances = "instances"
+
+// logKeyCount is the slog key for item counts in log messages.
+const logKeyCount = "count"
+
+// Config carries the resolved managed-resources values the owner needs to
+// assemble the layer. The caller translates its own config into this shape so
+// this package stays free of the platform's config types and defaulting rules.
+type Config struct {
+	// S3Connection is the explicit S3 toolkit instance name for blob storage.
+	// Empty falls back to the default/first S3 instance resolved from Toolkits.
+	S3Connection string
+	// S3Bucket is the bucket managed resources are stored in (logged at startup).
+	S3Bucket string
+	// URIScheme is the URI prefix for resource URIs; empty selects the resource
+	// package default.
+	URIScheme string
+	// Toolkits is the raw toolkits config map, walked to resolve a default S3
+	// instance when S3Connection is empty.
+	Toolkits map[string]any
+}
+
+// Handle owns the assembled managed-resources layer: the resource store and the
+// S3 blob client. Store and S3Client expose the two backends the caller hands to
+// its REST resources API; Register / Unregister / LoadAll take the *mcp.Server
+// per call (the caller owns it and passes it once the server exists) and are the
+// SDK-registration seams wired as the create/delete callbacks and called once at
+// startup. All methods are nil-safe, so a no-DB deployment (nil Handle) degrades
+// cleanly.
+type Handle struct {
+	store     resource.Store
+	s3Client  resource.S3Client
+	uriScheme string
+}
+
+// New assembles the resource store and — when an S3 connection resolves — the S3
+// blob client. It returns (nil, nil) when db is nil (managed resources are a
+// no-op without a database). It returns an error when a referenced S3 connection
+// is missing from the toolkits config or its client fails to build. When no S3
+// connection resolves, blob storage is disabled with a WARN but the store-only
+// layer is still returned so metadata operations work. The "managed resources
+// enabled" INFO is emitted in both cases (with an empty s3_connection when blob
+// storage is off) so the startup log always confirms the feature is active.
+func New(db *sql.DB, cfg Config) (*Handle, error) {
+	if db == nil {
+		return nil, nil //nolint:nilnil // nil handle = managed resources disabled (no database)
+	}
+
+	h := &Handle{
+		store:     resource.NewPostgresStore(db),
+		uriScheme: uriScheme(cfg),
+	}
+
+	connName := s3Connection(cfg)
+	if connName != "" {
+		s3Cfg := toolkitcfg.S3Config(cfg.Toolkits, connName)
+		if s3Cfg == nil {
+			return nil, fmt.Errorf("resource s3 connection %q not found in toolkits config", connName)
+		}
+
+		c, err := s3client.New(context.Background(), &s3client.Config{
+			Region:          s3Cfg.Region,
+			Endpoint:        s3Cfg.Endpoint,
+			AccessKeyID:     s3Cfg.AccessKeyID,
+			SecretAccessKey: s3Cfg.SecretKey,
+			Name:            s3Cfg.ConnectionName,
+			UsePathStyle:    s3Cfg.UsePathStyle,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("creating resource s3 client for connection %q: %w", connName, err)
+		}
+		h.s3Client = s3adapter.New(c)
+	} else {
+		slog.Warn("managed resources: no s3_connection configured; blob storage disabled")
+	}
+
+	slog.Info("managed resources enabled",
+		"s3_connection", connName,
+		"s3_bucket", cfg.S3Bucket,
+		"uri_scheme", h.uriScheme,
+	)
+	return h, nil
+}
+
+// uriScheme returns the configured URI scheme or the resource package default.
+func uriScheme(cfg Config) string {
+	if cfg.URIScheme != "" {
+		return cfg.URIScheme
+	}
+	return resource.DefaultURIScheme
+}
+
+// s3Connection returns the S3 connection name for managed resources: the
+// explicit config value if set, otherwise the default/first S3 toolkit instance
+// resolved from the toolkits config (so managed resources automatically use an
+// available S3 backend).
+func s3Connection(cfg Config) string {
+	if cfg.S3Connection != "" {
+		return cfg.S3Connection
+	}
+	resolved := resolveDefaultS3Instance(cfg.Toolkits)
+	if resolved == "" {
+		slog.Debug("managed resources: no S3 toolkit available for default resolution")
+		return ""
+	}
+	slog.Debug("managed resources: using default S3 connection", "s3_connection", resolved)
+	return resolved
+}
+
+// resolveDefaultS3Instance returns the name of the default/first S3 toolkit
+// instance in the toolkits config, or "" when no S3 toolkit is configured.
+func resolveDefaultS3Instance(toolkits map[string]any) string {
+	toolkitsCfg, ok := toolkits["s3"]
+	if !ok {
+		return ""
+	}
+	kindCfg, ok := toolkitsCfg.(map[string]any)
+	if !ok {
+		return ""
+	}
+	instances, ok := kindCfg[cfgKeyInstances].(map[string]any)
+	if !ok {
+		return ""
+	}
+	return toolkitcfg.ResolveDefaultInstance(kindCfg, instances)
+}
+
+// Store returns the managed resource store, or nil on a nil Handle (managed
+// resources disabled or no database).
+func (h *Handle) Store() resource.Store {
+	if h == nil {
+		return nil
+	}
+	return h.store
+}
+
+// S3Client returns the S3 blob client for managed resources, or nil on a nil
+// Handle or when no S3 connection was configured.
+func (h *Handle) S3Client() resource.S3Client {
+	if h == nil {
+		return nil
+	}
+	return h.s3Client
+}
+
+// URIScheme returns the resolved resource URI scheme (the configured value or
+// the resource package default), or "" on a nil Handle. The caller reads it to
+// configure the resources/read middleware.
+func (h *Handle) URIScheme() string {
+	if h == nil {
+		return ""
+	}
+	return h.uriScheme
+}
+
+// Register registers a managed resource with the given MCP server so it appears
+// in the SDK's native resource list and triggers notifications/resources/list_changed.
+// The SDK handler is a fallback only — the resources middleware normally
+// intercepts resources/read with auth and the S3 fetch before it runs. No-op on
+// a nil Handle, a nil server, or a nil resource.
+func (h *Handle) Register(server *mcp.Server, res *resource.Resource) {
+	if h == nil || server == nil || res == nil {
+		slog.Debug("resourcelayer.Register: skipping",
+			"handle_nil", h == nil, "server_nil", server == nil, "res_nil", res == nil)
+		return
+	}
+	slog.Debug("resourcelayer.Register: registering with SDK", "uri", res.URI, "name", res.DisplayName)
+	server.AddResource(&mcp.Resource{
+		URI:         res.URI,
+		Name:        res.DisplayName,
+		Description: res.Description,
+		MIMEType:    res.MIMEType,
+	}, func(_ context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		// Fallback handler — the middleware normally intercepts resources/read
+		// before this runs. If we get here, the middleware fell through (auth
+		// failure or config issue). Return a placeholder instead of nil to
+		// avoid the SDK's "nil information" error.
+		slog.Warn("managed resource: SDK fallback handler called (middleware did not intercept)", "uri", req.Params.URI)
+		return &mcp.ReadResourceResult{
+			Contents: []*mcp.ResourceContents{{
+				URI:      req.Params.URI,
+				MIMEType: res.MIMEType,
+				Text:     "(resource content unavailable — authentication required)",
+			}},
+		}, nil
+	})
+}
+
+// Unregister removes a managed resource from the given MCP server's resource
+// list, triggering notifications/resources/list_changed. No-op on a nil Handle
+// or a nil server.
+func (h *Handle) Unregister(server *mcp.Server, uri string) {
+	if h == nil || server == nil {
+		slog.Debug("resourcelayer.Unregister: skipping, no server")
+		return
+	}
+	slog.Debug("resourcelayer.Unregister: removing from SDK", "uri", uri)
+	server.RemoveResources(uri)
+}
+
+// LoadAll registers every existing global managed resource from the store with
+// the given MCP server so they are visible on the first resources/list call.
+// Called once at startup. No-op on a nil Handle, a nil store, or a nil server.
+func (h *Handle) LoadAll(server *mcp.Server) {
+	if h == nil || h.store == nil {
+		slog.Debug("resourcelayer.LoadAll: no resource store, skipping")
+		return
+	}
+	if server == nil {
+		slog.Debug("resourcelayer.LoadAll: no MCP server, skipping")
+		return
+	}
+	resources, _, err := h.store.List(context.Background(), resource.Filter{
+		Scopes: []resource.ScopeFilter{{Scope: resource.ScopeGlobal}},
+		Limit:  1000,
+	})
+	if err != nil {
+		slog.Warn("managed resources: failed to load existing resources", "error", err)
+		return
+	}
+	for i := range resources {
+		h.Register(server, &resources[i])
+	}
+	if len(resources) > 0 {
+		slog.Info("managed resources: registered existing resources", logKeyCount, len(resources))
+	}
+}

--- a/pkg/platform/resourcelayer/resourcelayer_test.go
+++ b/pkg/platform/resourcelayer/resourcelayer_test.go
@@ -1,0 +1,285 @@
+package resourcelayer
+
+import (
+	"context"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/resource"
+)
+
+func TestNewNilDB(t *testing.T) {
+	h, err := New(nil, Config{})
+	if err != nil {
+		t.Fatalf("New(nil db) error = %v, want nil", err)
+	}
+	if h != nil {
+		t.Fatalf("New(nil db) handle = %v, want nil", h)
+	}
+	// A nil handle must be safe for every accessor and mutation.
+	if h.Store() != nil {
+		t.Error("nil handle Store() should be nil")
+	}
+	if h.S3Client() != nil {
+		t.Error("nil handle S3Client() should be nil")
+	}
+	if h.URIScheme() != "" {
+		t.Error("nil handle URIScheme() should be empty")
+	}
+	server := mcp.NewServer(&mcp.Implementation{Name: "t", Version: "1"}, nil)
+	h.Register(server, &resource.Resource{URI: "mcp://x"}) // no panic
+	h.Unregister(server, "mcp://x")                        // no panic
+	h.LoadAll(server)                                      // no panic
+}
+
+func TestNewWithDB(t *testing.T) {
+	t.Run("store-only when no S3 connection resolves", func(t *testing.T) {
+		db, _, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = db.Close() }()
+
+		h, err := New(db, Config{URIScheme: "res"})
+		if err != nil {
+			t.Fatalf("New = %v, want nil error", err)
+		}
+		if h == nil || h.Store() == nil {
+			t.Fatal("expected a store-backed handle")
+		}
+		if h.S3Client() != nil {
+			t.Error("S3Client should be nil when no connection resolves")
+		}
+		if h.URIScheme() != "res" {
+			t.Errorf("URIScheme() = %q, want res", h.URIScheme())
+		}
+	})
+
+	t.Run("builds the S3 client when a connection resolves", func(t *testing.T) {
+		db, _, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = db.Close() }()
+
+		h, err := New(db, Config{
+			S3Bucket: "resources",
+			Toolkits: map[string]any{
+				"s3": map[string]any{
+					"instances": map[string]any{
+						"acme": map[string]any{
+							"endpoint":      "http://localhost:9000",
+							"access_key_id": "key",
+							"secret_key":    "secret",
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("New = %v, want nil error", err)
+		}
+		if h == nil || h.S3Client() == nil {
+			t.Fatal("expected an S3-backed handle")
+		}
+	})
+
+	t.Run("errors when the referenced S3 connection is missing", func(t *testing.T) {
+		db, _, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = db.Close() }()
+
+		_, err = New(db, Config{S3Connection: "ghost"})
+		if err == nil {
+			t.Fatal("expected an error for a missing S3 connection")
+		}
+	})
+}
+
+func TestAccessors(t *testing.T) {
+	h := &Handle{
+		store:     &countingStore{},
+		uriScheme: "mcp",
+	}
+	if h.Store() == nil {
+		t.Error("Store() should be non-nil")
+	}
+	if h.S3Client() != nil {
+		t.Error("S3Client() should be nil when unset")
+	}
+	if h.URIScheme() != "mcp" {
+		t.Errorf("URIScheme() = %q, want mcp", h.URIScheme())
+	}
+}
+
+func TestS3Connection(t *testing.T) {
+	t.Run("explicit connection returned", func(t *testing.T) {
+		got := s3Connection(Config{S3Connection: "my-s3"})
+		if got != "my-s3" {
+			t.Errorf("got %q, want my-s3", got)
+		}
+	})
+
+	t.Run("falls back to default S3 instance", func(t *testing.T) {
+		got := s3Connection(Config{Toolkits: map[string]any{
+			"s3": map[string]any{
+				"instances": map[string]any{
+					"acme": map[string]any{
+						"endpoint":      "http://localhost:9000",
+						"access_key_id": "key",
+						"secret_key":    "secret",
+					},
+				},
+			},
+		}})
+		if got != "acme" {
+			t.Errorf("got %q, want acme", got)
+		}
+	})
+
+	t.Run("empty when no S3 toolkit", func(t *testing.T) {
+		if got := s3Connection(Config{}); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+func TestResolveDefaultS3Instance(t *testing.T) {
+	t.Run("returns instance name", func(t *testing.T) {
+		got := resolveDefaultS3Instance(map[string]any{
+			"s3": map[string]any{
+				"instances": map[string]any{
+					"mys3": map[string]any{"endpoint": "http://localhost:9000"},
+				},
+			},
+		})
+		if got != "mys3" {
+			t.Errorf("got %q, want mys3", got)
+		}
+	})
+
+	t.Run("returns configured default", func(t *testing.T) {
+		got := resolveDefaultS3Instance(map[string]any{
+			"s3": map[string]any{
+				"default": "second",
+				"instances": map[string]any{
+					"first":  map[string]any{"endpoint": "http://a:9000"},
+					"second": map[string]any{"endpoint": "http://b:9000"},
+				},
+			},
+		})
+		if got != "second" {
+			t.Errorf("got %q, want second", got)
+		}
+	})
+
+	t.Run("empty when no S3 toolkit", func(t *testing.T) {
+		if got := resolveDefaultS3Instance(map[string]any{}); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("empty when instances not a map", func(t *testing.T) {
+		got := resolveDefaultS3Instance(map[string]any{
+			"s3": map[string]any{"instances": "invalid"},
+		})
+		if got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("empty when kind config not a map", func(t *testing.T) {
+		got := resolveDefaultS3Instance(map[string]any{"s3": "invalid"})
+		if got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+func TestURIScheme(t *testing.T) {
+	if got := uriScheme(Config{URIScheme: "custom"}); got != "custom" {
+		t.Errorf("got %q, want custom", got)
+	}
+	if got := uriScheme(Config{}); got != resource.DefaultURIScheme {
+		t.Errorf("got %q, want default %q", got, resource.DefaultURIScheme)
+	}
+}
+
+// newTestHandle builds a store-only handle without a database, so registration
+// behavior can be exercised in isolation. The MCP server is passed per call.
+func newTestHandle(store resource.Store) *Handle {
+	return &Handle{store: store, uriScheme: resource.DefaultURIScheme}
+}
+
+func TestRegisterUnregister(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
+	h := newTestHandle(&countingStore{})
+
+	t.Run("nil resource is a no-op", func(_ *testing.T) {
+		h.Register(server, nil) // no panic
+	})
+
+	t.Run("registers and unregisters with the server", func(_ *testing.T) {
+		h.Register(server, &resource.Resource{
+			URI:         "mcp://global/test/file.txt",
+			DisplayName: "Test File",
+			Description: "A test resource",
+			MIMEType:    "text/plain",
+		})
+		h.Unregister(server, "mcp://global/test/file.txt")
+	})
+
+	t.Run("nil server is a no-op", func(_ *testing.T) {
+		h.Register(nil, &resource.Resource{URI: "mcp://x"})
+		h.Unregister(nil, "mcp://x")
+	})
+}
+
+func TestLoadAll(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "t", Version: "1"}, nil)
+
+	t.Run("no store is a no-op", func(_ *testing.T) {
+		(&Handle{}).LoadAll(server)
+	})
+
+	t.Run("nil server is a no-op", func(_ *testing.T) {
+		newTestHandle(&countingStore{}).LoadAll(nil)
+	})
+
+	t.Run("registers each global resource from the store", func(t *testing.T) {
+		store := &countingStore{list: []resource.Resource{
+			{URI: "mcp://global/a.txt", DisplayName: "A"},
+			{URI: "mcp://global/b.txt", DisplayName: "B"},
+		}}
+		newTestHandle(store).LoadAll(server)
+		if store.listCalls != 1 {
+			t.Errorf("List called %d times, want 1", store.listCalls)
+		}
+	})
+}
+
+// countingStore is a resource.Store that records List calls and returns a fixed
+// slice, enough to exercise LoadAll without a database.
+type countingStore struct {
+	list      []resource.Resource
+	listCalls int
+}
+
+func (s *countingStore) List(_ context.Context, _ resource.Filter) ([]resource.Resource, int, error) {
+	s.listCalls++
+	return s.list, len(s.list), nil
+}
+func (*countingStore) Insert(_ context.Context, _ resource.Resource) error { return nil }
+func (*countingStore) Get(_ context.Context, _ string) (*resource.Resource, error) {
+	return &resource.Resource{}, nil
+}
+
+func (*countingStore) GetByURI(_ context.Context, _ string) (*resource.Resource, error) {
+	return &resource.Resource{}, nil
+}
+func (*countingStore) Update(_ context.Context, _ string, _ resource.Update) error { return nil }
+func (*countingStore) Delete(_ context.Context, _ string) error                    { return nil }

--- a/pkg/platform/user_directory.go
+++ b/pkg/platform/user_directory.go
@@ -1,66 +1,19 @@
 package platform
 
 import (
-	"log/slog"
-
-	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/platform/userdir"
 	"github.com/txn2/mcp-data-platform/pkg/user"
 )
 
-// Auth-type labels that represent a real person (as opposed to an API key or
-// anonymous session). Only these populate the known-users directory.
-const (
-	authTypeLabelOIDC  = "oidc"
-	authTypeLabelOAuth = "oauth"
-)
-
-// initUserStore initializes the known-users directory (#614). The directory
-// requires a database; without one the feature is disabled (nil store) and
-// every consumer degrades cleanly to free-typed email sharing.
+// initUserStore assembles the known-users directory (#614) via the userdir
+// owner. The directory requires a database; without one the feature is disabled
+// (nil handle) and every consumer degrades cleanly to free-typed email sharing.
 func (p *Platform) initUserStore() {
-	if p.db == nil {
-		return
-	}
-	p.userStore = user.NewPostgresStore(p.db)
-	p.userDirectory = user.NewDirectory(p.userStore)
-	slog.Info("user directory enabled")
+	p.users = userdir.New(p.db)
 }
 
 // UserStore returns the known-users directory store (nil when no database is
-// configured).
+// configured). Delegates to the userdir owner.
 func (p *Platform) UserStore() user.Store {
-	return p.userStore
-}
-
-// observeAuthenticatedUser records an authenticated person in the directory.
-// It is wired as the UserObserver on the authenticator, so it runs on every
-// successful authentication. Only real people (OIDC/OAuth) are recorded; API
-// keys and anonymous sessions are not persons to share with. The directory
-// itself throttles and writes asynchronously, so this is cheap.
-func (p *Platform) observeAuthenticatedUser(info *middleware.UserInfo) {
-	if p.userDirectory == nil || info == nil {
-		return
-	}
-	if info.AuthType != authTypeLabelOIDC && info.AuthType != authTypeLabelOAuth {
-		return
-	}
-	first, last := deriveUserName(info)
-	p.userDirectory.Observe(info.Email, first, last)
-}
-
-// observeBrowserLogin records a portal/admin SPA user in the directory at
-// login. The browser-session flow already supplies a split first/last name
-// from the id_token, so this routes straight to the directory (which sanitizes,
-// throttles, and writes asynchronously). No-op when no database is configured.
-func (p *Platform) observeBrowserLogin(email, firstName, lastName string) {
-	if p.userDirectory == nil {
-		return
-	}
-	p.userDirectory.Observe(email, firstName, lastName)
-}
-
-// deriveUserName extracts a first and last name from a UserInfo, delegating to
-// the shared pkg/user derivation so the token and browser-session paths agree.
-func deriveUserName(info *middleware.UserInfo) (first, last string) {
-	return user.NameFromClaims(info.Claims, info.Name)
+	return p.users.Store()
 }

--- a/pkg/platform/user_directory_test.go
+++ b/pkg/platform/user_directory_test.go
@@ -1,15 +1,9 @@
 package platform
 
 import (
-	"context"
-	"sync"
 	"testing"
-	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
-
-	"github.com/txn2/mcp-data-platform/pkg/middleware"
-	"github.com/txn2/mcp-data-platform/pkg/user"
 )
 
 func TestInitUserStore(t *testing.T) {
@@ -19,7 +13,7 @@ func TestInitUserStore(t *testing.T) {
 		if p.UserStore() != nil {
 			t.Error("expected nil user store without a database")
 		}
-		if p.userDirectory != nil {
+		if p.users.Directory() != nil {
 			t.Error("expected nil directory without a database")
 		}
 	})
@@ -36,133 +30,8 @@ func TestInitUserStore(t *testing.T) {
 		if p.UserStore() == nil {
 			t.Error("expected a user store when a database is present")
 		}
-		if p.userDirectory == nil {
+		if p.users.Directory() == nil {
 			t.Error("expected a directory when a database is present")
 		}
-	})
-}
-
-func TestDeriveUserName(t *testing.T) {
-	t.Run("prefers given/family claims", func(t *testing.T) {
-		info := &middleware.UserInfo{
-			Name:   "Ignore Me",
-			Claims: map[string]any{"given_name": "Marcus", "family_name": "Johnson"},
-		}
-		first, last := deriveUserName(info)
-		if first != "Marcus" || last != "Johnson" {
-			t.Errorf("got (%q,%q)", first, last)
-		}
-	})
-	t.Run("falls back to full name", func(t *testing.T) {
-		info := &middleware.UserInfo{Name: "Dana Lee"}
-		first, last := deriveUserName(info)
-		if first != "Dana" || last != "Lee" {
-			t.Errorf("got (%q,%q)", first, last)
-		}
-	})
-	t.Run("empty claims and name", func(t *testing.T) {
-		first, last := deriveUserName(&middleware.UserInfo{})
-		if first != "" || last != "" {
-			t.Errorf("got (%q,%q)", first, last)
-		}
-	})
-}
-
-// fakeUserStore captures Observe calls for the wiring test.
-type fakeUserStore struct {
-	mu     sync.Mutex
-	last   [3]string
-	signal chan struct{}
-}
-
-func newFakeUserStore() *fakeUserStore {
-	return &fakeUserStore{signal: make(chan struct{}, 8)}
-}
-
-func (f *fakeUserStore) Observe(_ context.Context, email, first, last string) error {
-	f.mu.Lock()
-	f.last = [3]string{email, first, last}
-	f.mu.Unlock()
-	f.signal <- struct{}{}
-	return nil
-}
-
-func (*fakeUserStore) Insert(context.Context, user.User) error         { return nil }
-func (*fakeUserStore) Get(context.Context, string) (*user.User, error) { return nil, user.ErrNotFound }
-func (*fakeUserStore) List(context.Context, user.Filter) ([]user.User, int, error) {
-	return nil, 0, nil
-}
-func (*fakeUserStore) Update(context.Context, string, user.Update) error { return nil }
-func (*fakeUserStore) Delete(context.Context, string) error              { return nil }
-
-// TestObserveAuthenticatedUser proves the full wiring: a UserInfo flowing
-// through observeAuthenticatedUser is name-derived and lands in the directory
-// store — but only for real-person auth types.
-func TestObserveAuthenticatedUser(t *testing.T) {
-	t.Run("records an OIDC user with derived name", func(t *testing.T) {
-		fake := newFakeUserStore()
-		p := &Platform{userDirectory: user.NewDirectory(fake)}
-
-		p.observeAuthenticatedUser(&middleware.UserInfo{
-			Email:    "Marcus.Johnson@Example.com",
-			AuthType: "oidc",
-			Claims:   map[string]any{"given_name": "Marcus", "family_name": "Johnson"},
-		})
-
-		select {
-		case <-fake.signal:
-		case <-time.After(2 * time.Second):
-			t.Fatal("expected a directory write")
-		}
-		fake.mu.Lock()
-		defer fake.mu.Unlock()
-		if fake.last != [3]string{"marcus.johnson@example.com", "Marcus", "Johnson"} {
-			t.Errorf("unexpected write: %v", fake.last)
-		}
-	})
-
-	t.Run("ignores API key and anonymous auth", func(t *testing.T) {
-		for _, at := range []string{"apikey", "noop", ""} {
-			fake := newFakeUserStore()
-			p := &Platform{userDirectory: user.NewDirectory(fake)}
-			p.observeAuthenticatedUser(&middleware.UserInfo{
-				Email: "ci@apikey.local", AuthType: at,
-			})
-			select {
-			case <-fake.signal:
-				t.Fatalf("auth type %q must not be recorded", at)
-			case <-time.After(100 * time.Millisecond):
-			}
-		}
-	})
-
-	t.Run("nil directory is safe", func(_ *testing.T) {
-		p := &Platform{}
-		p.observeAuthenticatedUser(&middleware.UserInfo{AuthType: "oidc", Email: "a@b.io"})
-	})
-}
-
-func TestObserveBrowserLogin(t *testing.T) {
-	t.Run("records the browser-session user", func(t *testing.T) {
-		fake := newFakeUserStore()
-		p := &Platform{userDirectory: user.NewDirectory(fake)}
-
-		p.observeBrowserLogin("Dana@Example.com", "Dana", "Lee")
-
-		select {
-		case <-fake.signal:
-		case <-time.After(2 * time.Second):
-			t.Fatal("expected a directory write")
-		}
-		fake.mu.Lock()
-		defer fake.mu.Unlock()
-		if fake.last != [3]string{"dana@example.com", "Dana", "Lee"} {
-			t.Errorf("unexpected write: %v", fake.last)
-		}
-	})
-
-	t.Run("nil directory is safe", func(_ *testing.T) {
-		p := &Platform{}
-		p.observeBrowserLogin("a@b.io", "A", "B")
 	})
 }

--- a/pkg/platform/userdir/userdir.go
+++ b/pkg/platform/userdir/userdir.go
@@ -1,0 +1,99 @@
+// Package userdir assembles the known-users directory (#614) behind one Handle:
+// the Postgres-backed user store and the *user.Directory that wraps it with
+// throttled, asynchronous upserts of authenticated people.
+//
+// Construction takes a single explicit input — a *sql.DB — so the subsystem is
+// constructible and testable without a Platform. It imports pkg/user and
+// pkg/middleware (for the authenticated-user shape), never pkg/platform. The
+// *sql.DB is a shared foundation owned by the caller and passed in.
+//
+// New returns nil when db is nil: the directory needs a database, so a no-DB
+// deployment gets the nil Handle and every accessor and observer degrades to a
+// no-op (consumers fall back to free-typed email sharing). The two Observe
+// methods are the seams the caller wires as the authenticator's UserObserver and
+// the browser-session login callback; the directory itself sanitizes, throttles,
+// and writes asynchronously, so both are cheap. The layer owns no background
+// goroutine of its own, so it needs no Stop/Close.
+package userdir
+
+import (
+	"database/sql"
+	"log/slog"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/user"
+)
+
+// Auth-type labels that represent a real person (as opposed to an API key or
+// anonymous session). Only these populate the known-users directory.
+const (
+	authTypeLabelOIDC  = "oidc"
+	authTypeLabelOAuth = "oauth"
+)
+
+// Handle owns the assembled known-users directory: the user store and the
+// *user.Directory. Store() backs the callers that surface the directory (the
+// find-tools / portal directory endpoints); Directory() is read to decide
+// whether to wrap the authenticator. Both are nil on a nil Handle (no database),
+// and the Observe methods are no-ops there, so every consumer degrades cleanly.
+type Handle struct {
+	store     user.Store
+	directory *user.Directory
+}
+
+// New builds the user store and directory from db. It returns nil when db is nil
+// (the directory is a no-op without a database), so the caller holds a nil Handle
+// that every accessor and observer treats as disabled.
+func New(db *sql.DB) *Handle {
+	if db == nil {
+		return nil
+	}
+	store := user.NewPostgresStore(db)
+	slog.Info("user directory enabled")
+	return &Handle{store: store, directory: user.NewDirectory(store)}
+}
+
+// Store returns the known-users directory store, or nil on a nil Handle (no
+// database configured).
+func (h *Handle) Store() user.Store {
+	if h == nil {
+		return nil
+	}
+	return h.store
+}
+
+// Directory returns the throttled async directory, or nil on a nil Handle. The
+// caller reads it to decide whether to wrap the authenticator with the observer.
+func (h *Handle) Directory() *user.Directory {
+	if h == nil {
+		return nil
+	}
+	return h.directory
+}
+
+// ObserveAuthenticated records an authenticated person in the directory. It is
+// wired as the UserObserver on the authenticator, so it runs on every successful
+// authentication. Only real people (OIDC/OAuth) are recorded; API keys and
+// anonymous sessions are not persons to share with. No-op on a nil Handle, a nil
+// directory, or a nil info.
+func (h *Handle) ObserveAuthenticated(info *middleware.UserInfo) {
+	if h == nil || h.directory == nil || info == nil {
+		return
+	}
+	if info.AuthType != authTypeLabelOIDC && info.AuthType != authTypeLabelOAuth {
+		return
+	}
+	first, last := user.NameFromClaims(info.Claims, info.Name)
+	h.directory.Observe(info.Email, first, last)
+}
+
+// ObserveBrowserLogin records a portal/admin SPA user in the directory at login.
+// The browser-session flow already supplies a split first/last name from the
+// id_token, so this routes straight to the directory (which sanitizes, throttles,
+// and writes asynchronously). No-op on a nil Handle or a nil directory.
+func (h *Handle) ObserveBrowserLogin(email, firstName, lastName string) {
+	if h == nil || h.directory == nil {
+		return
+	}
+	h.directory.Observe(email, firstName, lastName)
+}

--- a/pkg/platform/userdir/userdir_test.go
+++ b/pkg/platform/userdir/userdir_test.go
@@ -1,0 +1,169 @@
+package userdir
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/user"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("nil database returns a nil handle", func(t *testing.T) {
+		h := New(nil)
+		if h != nil {
+			t.Fatalf("New(nil) = %v, want nil", h)
+		}
+		// Every accessor and observer must be nil-safe on the nil handle.
+		if h.Store() != nil {
+			t.Error("nil handle Store() should be nil")
+		}
+		if h.Directory() != nil {
+			t.Error("nil handle Directory() should be nil")
+		}
+		h.ObserveAuthenticated(&middleware.UserInfo{AuthType: "oidc", Email: "a@b.io"}) // no panic
+		h.ObserveBrowserLogin("a@b.io", "A", "B")                                       // no panic
+	})
+
+	t.Run("database builds store and directory", func(t *testing.T) {
+		db, _, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = db.Close() }()
+
+		h := New(db)
+		if h == nil {
+			t.Fatal("New(db) = nil, want a handle")
+		}
+		if h.Store() == nil {
+			t.Error("Store() should be non-nil with a database")
+		}
+		if h.Directory() == nil {
+			t.Error("Directory() should be non-nil with a database")
+		}
+	})
+}
+
+// fakeUserStore captures Observe calls for the wiring tests.
+type fakeUserStore struct {
+	mu     sync.Mutex
+	last   [3]string
+	signal chan struct{}
+}
+
+func newFakeUserStore() *fakeUserStore {
+	return &fakeUserStore{signal: make(chan struct{}, 8)}
+}
+
+func (f *fakeUserStore) Observe(_ context.Context, email, first, last string) error {
+	f.mu.Lock()
+	f.last = [3]string{email, first, last}
+	f.mu.Unlock()
+	f.signal <- struct{}{}
+	return nil
+}
+
+func (*fakeUserStore) Insert(context.Context, user.User) error         { return nil }
+func (*fakeUserStore) Get(context.Context, string) (*user.User, error) { return nil, user.ErrNotFound }
+func (*fakeUserStore) List(context.Context, user.Filter) ([]user.User, int, error) {
+	return nil, 0, nil
+}
+func (*fakeUserStore) Update(context.Context, string, user.Update) error { return nil }
+func (*fakeUserStore) Delete(context.Context, string) error              { return nil }
+
+// handleWith builds a Handle over a directory backed by store, bypassing New so
+// the Observe behavior can be exercised without a real database.
+func handleWith(store user.Store) *Handle {
+	return &Handle{store: store, directory: user.NewDirectory(store)}
+}
+
+// TestObserveAuthenticated proves the full wiring: a UserInfo flowing through
+// ObserveAuthenticated is name-derived and lands in the directory store — but
+// only for real-person auth types.
+func TestObserveAuthenticated(t *testing.T) {
+	t.Run("records an OIDC user with derived name", func(t *testing.T) {
+		fake := newFakeUserStore()
+		h := handleWith(fake)
+
+		h.ObserveAuthenticated(&middleware.UserInfo{
+			Email:    "Marcus.Johnson@Example.com",
+			AuthType: "oidc",
+			Claims:   map[string]any{"given_name": "Marcus", "family_name": "Johnson"},
+		})
+
+		select {
+		case <-fake.signal:
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected a directory write")
+		}
+		fake.mu.Lock()
+		defer fake.mu.Unlock()
+		if fake.last != [3]string{"marcus.johnson@example.com", "Marcus", "Johnson"} {
+			t.Errorf("unexpected write: %v", fake.last)
+		}
+	})
+
+	t.Run("records an OAuth user", func(t *testing.T) {
+		fake := newFakeUserStore()
+		h := handleWith(fake)
+
+		h.ObserveAuthenticated(&middleware.UserInfo{
+			Email: "Dana@Example.com", AuthType: "oauth", Name: "Dana Lee",
+		})
+
+		select {
+		case <-fake.signal:
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected a directory write")
+		}
+	})
+
+	t.Run("ignores API key and anonymous auth", func(t *testing.T) {
+		for _, at := range []string{"apikey", "noop", ""} {
+			fake := newFakeUserStore()
+			h := handleWith(fake)
+			h.ObserveAuthenticated(&middleware.UserInfo{
+				Email: "ci@apikey.local", AuthType: at,
+			})
+			select {
+			case <-fake.signal:
+				t.Fatalf("auth type %q must not be recorded", at)
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+	})
+
+	t.Run("nil info and nil directory are safe", func(_ *testing.T) {
+		handleWith(newFakeUserStore()).ObserveAuthenticated(nil)
+		(&Handle{}).ObserveAuthenticated(&middleware.UserInfo{AuthType: "oidc", Email: "a@b.io"})
+	})
+}
+
+func TestObserveBrowserLogin(t *testing.T) {
+	t.Run("records the browser-session user", func(t *testing.T) {
+		fake := newFakeUserStore()
+		h := handleWith(fake)
+
+		h.ObserveBrowserLogin("Dana@Example.com", "Dana", "Lee")
+
+		select {
+		case <-fake.signal:
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected a directory write")
+		}
+		fake.mu.Lock()
+		defer fake.mu.Unlock()
+		if fake.last != [3]string{"dana@example.com", "Dana", "Lee"} {
+			t.Errorf("unexpected write: %v", fake.last)
+		}
+	})
+
+	t.Run("nil directory is safe", func(_ *testing.T) {
+		(&Handle{}).ObserveBrowserLogin("a@b.io", "A", "B")
+	})
+}

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -123,6 +123,7 @@ pkg/platform -> pkg/oauth
 pkg/platform -> pkg/observability
 pkg/platform -> pkg/observability/proxy
 pkg/platform -> pkg/persona
+pkg/platform -> pkg/platform/branding
 pkg/platform -> pkg/platform/browserauth
 pkg/platform -> pkg/platform/connauth
 pkg/platform -> pkg/platform/connsource
@@ -140,10 +141,12 @@ pkg/platform -> pkg/platform/obs
 pkg/platform -> pkg/platform/personastore
 pkg/platform -> pkg/platform/portalstore
 pkg/platform -> pkg/platform/reflexivecapture
+pkg/platform -> pkg/platform/resourcelayer
 pkg/platform -> pkg/platform/routepolicy
 pkg/platform -> pkg/platform/searchfed
 pkg/platform -> pkg/platform/sessionsync
 pkg/platform -> pkg/platform/toolkitcfg
+pkg/platform -> pkg/platform/userdir
 pkg/platform -> pkg/portal
 pkg/platform -> pkg/portal/knowledgepage
 pkg/platform -> pkg/portal/s3adapter
@@ -219,6 +222,9 @@ pkg/platform/reflexivecapture -> pkg/memory
 pkg/platform/reflexivecapture -> pkg/middleware
 pkg/platform/reflexivecapture -> pkg/toolkits/memory
 pkg/platform/reflexivecapture -> pkg/urnbuild
+pkg/platform/resourcelayer -> pkg/platform/toolkitcfg
+pkg/platform/resourcelayer -> pkg/portal/s3adapter
+pkg/platform/resourcelayer -> pkg/resource
 pkg/platform/routepolicy -> pkg/middleware
 pkg/platform/routepolicy -> pkg/persona
 pkg/platform/searchfed -> pkg/embedding
@@ -237,6 +243,8 @@ pkg/platform/sessionsync -> pkg/session
 pkg/platform/sessionsync -> pkg/session/postgres
 pkg/platform/toolkitcfg -> pkg/platform/cfgmap
 pkg/platform/toolkitcfg -> pkg/platform/fieldcrypt
+pkg/platform/userdir -> pkg/middleware
+pkg/platform/userdir -> pkg/user
 pkg/portal -> internal/contentviewer
 pkg/portal -> pkg/audit
 pkg/portal -> pkg/browsersession


### PR DESCRIPTION
## Summary

Twelfth batch of the Platform decomposition (#756), following the search-federation seam (#849 / #850). The remaining extractable state is small and clustered, so **three mechanical clusters land together in this one PR**; the heavier prompt cluster is **split into its own follow-up seam** (see decision below). Also fixes a loose ratchet introduced along the way.

Pure refactor — behavior preserved, `make verify` green.

Closes #851.

## Part 1 — pin the method ceiling to actual (standalone-safe, done first)

`TestPlatformGodObjectBudget`'s method ceiling was `263` while the actual count was `255` — **8 slack**. A ratchet with slack is not a ratchet: it silently permits 8 new `*Platform` methods to re-accumulate with no gate. Pinned `maxPlatformMethods` `263 → 255` ahead of the extraction, then re-tightened after (below).

## Part 2 — batch-extract three clusters into owner packages

Each owner holds the raw fields behind one `Handle`, is constructible and testable **without** a `Platform`, imports only its domain packages (**never `pkg/platform`**), documents its own contract (refers to the caller abstractly), and ships its own unit tests.

| Cluster | New package | Fields folded → one handle |
|---|---|---|
| resource | `pkg/platform/resourcelayer` | `resourceStore`, `resourceS3Client` |
| user | `pkg/platform/userdir` | `userStore`, `userDirectory` |
| brand | `pkg/platform/branding` | `resolvedBrandLogoSVG`, `resolvedBrandURL`, `resolvedImplementorLogo` |

**resourcelayer** — the Postgres managed-resources store, the S3 blob client, and the MCP-server registration that makes each resource visible in `resources/list`. `New` builds the store and (when an S3 connection resolves) the blob client; returns `(nil, nil)` on no-DB. The private S3-resolution helpers (`managedResourceURIScheme`, `managedResourceS3Connection`, `resolveDefaultS3Instance`) moved onto the owner.

**userdir** — the known-users directory (#614). `New(db)` builds the store + `*user.Directory`; `ObserveAuthenticated` / `ObserveBrowserLogin` are the seams wired as the authenticator's `UserObserver` and the browser-session login callback (moved off `Platform`).

**branding** — resolve-once brand logo SVG / brand URL / implementor logo. `InjectPortalLogo` caches and inlines the portal logo into the platform-info MCP app config; the three accessors are the read seams. `injectPortalLogo` + `fetchLogoSVG` moved off `Platform`.

`Platform` keeps the **public accessors external callers use** (`ResourceStore`, `ResourceS3Client`, `RegisterManagedResource`, `UnregisterManagedResource`, `LoadManagedResources`, `UserStore`, `BrandLogoSVG`, `BrandURL`, `ResolveImplementorLogo`) as one-line delegators so `cmd/main.go` is unchanged. `addManagedResourceMiddleware` stays on `Platform` (chain wiring that reaches back into `Platform`, mirroring how `memorylayer` / `knowledgelayer` leave chain wiring behind).

### Server passed per-call, not snapshotted

`resourcelayer.Register` / `Unregister` / `LoadAll` take the `*mcp.Server` **per call**, not at construction. `initManagedResources` runs inside `initExtensions`, **before** `finalizeSetup()` creates `p.mcpServer` — a construction-time snapshot would freeze a `nil` server and silently skip every registration (managed resources would never appear in `resources/list`). `Platform` passes the live `p.mcpServer` at call time, matching the original lazy-server semantics. This was caught by adversarial review on the first pass and fixed; a clean re-review confirmed no findings survived.

## Prompt cluster — split decision (as the issue permits)

The prompt cluster is **not mechanical**: ~1520 lines / ~40 methods across `prompt_ingest.go`, `prompts.go`, `prompt_tool.go`, deeply coupled to personas, the toolkit registry, `mcpServer`, the semantic provider, and searchfed. Extracting an owner that doesn't import `pkg/platform` is its own multi-day seam. Per the issue's explicit guidance ("do **not** let it drag the mechanical three into a multi-day change"), it is **deferred to a follow-up**. Its four fields (`promptManager`, `promptStore`, `promptInfosMu`, `promptInfos`) stay on `Platform` for now; a prompt seam would ratchet fields `49 → 46`.

## God-object budget

| Metric | Before | After |
|---|---|---|
| Fields | 53 | **49** (−4: resource −1, user −1, brand −2) |
| Methods | 255 | **249** (−6 private/wiring methods moved to owners) |

Both ceilings re-pinned tight against the new actual with ratchet comments (`godobject_budget_test.go`). Import ratchet regenerated (`testdata/allowed_internal_imports.txt`) — `Platform` picks up the three new owner edges; the owners pick up their domain imports.

## Testing

`make verify` green (fmt, `go test -race`, coverage ≥80% total **and** patch, patch-scoped lint mirroring CI `only-new-issues`, gosec + govulncheck, semgrep, CodeQL, dead-code, mutation ≥60%, GoReleaser dry-run).

New owner package coverage: `userdir` 100%, `branding` 96.4%, `resourcelayer` 93.0%. Behavioral tests for the moved logic migrated into each owner package; `Platform`-level delegator tests verify the accessors read through the handles.

Relates to #756.
