### PR TITLE
refactor(platform): extract the prompt seam into pkg/platform/promptlayer (#853)

### DIFF
--- a/godobject_budget_test.go
+++ b/godobject_budget_test.go
@@ -58,10 +58,10 @@ const (
 	// three owner handles: resource (resourceStore, resourceS3Client → one
 	// resourcelayer.Handle), user (userStore, userDirectory → one userdir.Handle),
 	// and brand (resolvedBrandLogoSVG, resolvedBrandURL, resolvedImplementorLogo →
-	// one branding.Handle), ratcheting 53 → 49. The prompt cluster was split into
-	// its own follow-up seam (its ~40 methods across three files are not
-	// mechanical), so its four fields stay on Platform for now.
-	maxPlatformFields = 49
+	// one branding.Handle), ratcheting 53 → 49. The prompt-seam extraction (#853)
+	// folded four fields (promptManager, promptStore, promptInfosMu, promptInfos)
+	// into one promptlayer.Handle, ratcheting 49 → 46.
+	maxPlatformFields = 46
 
 	// maxPlatformMethods caps the number of methods with a *Platform receiver.
 	// Frozen at today's count; ratchet down as accessors move onto the
@@ -76,8 +76,16 @@ const (
 	// user's observeAuthenticatedUser / observeBrowserLogin, and brand's
 	// injectPortalLogo — into their owner packages, ratcheting 255 → 249. The
 	// public accessors external callers use (ResourceStore, UserStore, BrandURL,
-	// …) stay as one-line delegators, so they still count.
-	maxPlatformMethods = 249
+	// …) stay as one-line delegators, so they still count. The prompt-seam
+	// extraction (#853) moved the ~40-method prompt cluster (static/workflow/
+	// database registration, dynamic serving, the manage_prompt tool) onto
+	// promptlayer.Handle, ratcheting 249 → 212; the four accessors external
+	// callers use (PromptStore, AllPromptInfos, RegisterRuntimePrompt,
+	// UnregisterRuntimePrompt) stay as one-line delegators, and the
+	// middleware-chain wiring (addPromptVisibilityMiddleware) plus the
+	// late-collaborator binding (bindPromptCollaborators) stay on Platform, so
+	// they still count.
+	maxPlatformMethods = 212
 )
 
 // TestPlatformGodObjectBudget fails when the Platform struct grows more fields

--- a/pkg/platform/apigateway_embed_jobs.go
+++ b/pkg/platform/apigateway_embed_jobs.go
@@ -82,7 +82,7 @@ func (p *Platform) WireAPIGatewayEmbedJobsFromDB() {
 		DiscoveryToolName: platformFindToolsName,
 		Consumers: indexqueue.Consumers{
 			Memory:               p.memory.MemoryStore() != nil,
-			Prompts:              p.promptStore != nil,
+			Prompts:              p.prompts.Store() != nil,
 			PortalAssets:         p.portalStore.AssetStore() != nil,
 			PortalCollections:    p.portalStore.CollectionStore() != nil,
 			PortalKnowledgePages: p.portalStore.KnowledgePageStore() != nil,

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -39,6 +39,14 @@ const (
 	// kindPlatform identifies tools provided directly by the platform
 	// (not a toolkit), e.g. platform_info, list_connections.
 	kindPlatform = "platform"
+	// Toolkit kind identifiers used across the platform for connection-source
+	// mapping, semantic-provider selection, and auto-enable defaulting. The
+	// prompt layer keeps its own copy for capability bullets and workflow gating.
+	kindDataHub = "datahub"
+	kindTrino   = "trino"
+	kindS3      = "s3"
+	kindMCP     = "mcp"
+	kindAPI     = "api"
 	// toolListConns is the unified platform-provided list-connections
 	// tool name.
 	toolListConns = "list_connections"

--- a/pkg/platform/find_tools_tool_test.go
+++ b/pkg/platform/find_tools_tool_test.go
@@ -196,3 +196,16 @@ func TestHandleFindTools_Semantic(t *testing.T) {
 		t.Errorf("semantic result wrong: err=%v text=%s", res.IsError, resultText(res))
 	}
 }
+
+// resultText extracts the first text-content string from a tool result, or ""
+// when the result is nil or carries no text content.
+func resultText(r *mcp.CallToolResult) string {
+	if r == nil || len(r.Content) == 0 {
+		return ""
+	}
+	tc, ok := r.Content[0].(*mcp.TextContent)
+	if !ok {
+		return ""
+	}
+	return tc.Text
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -13,7 +13,6 @@ import (
 	"maps"
 	"os"
 	"slices"
-	"sync"
 	"time"
 
 	// PostgreSQL driver for database/sql.
@@ -53,6 +52,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/platform/obs"
 	"github.com/txn2/mcp-data-platform/pkg/platform/personastore"
 	"github.com/txn2/mcp-data-platform/pkg/platform/portalstore"
+	"github.com/txn2/mcp-data-platform/pkg/platform/promptlayer"
 	"github.com/txn2/mcp-data-platform/pkg/platform/reflexivecapture"
 	"github.com/txn2/mcp-data-platform/pkg/platform/resourcelayer"
 	"github.com/txn2/mcp-data-platform/pkg/platform/routepolicy"
@@ -64,7 +64,6 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
 	"github.com/txn2/mcp-data-platform/pkg/portal/s3adapter"
 	"github.com/txn2/mcp-data-platform/pkg/prompt"
-	promptpostgres "github.com/txn2/mcp-data-platform/pkg/prompt/postgres"
 	"github.com/txn2/mcp-data-platform/pkg/query"
 	trinoquery "github.com/txn2/mcp-data-platform/pkg/query/trino"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
@@ -178,8 +177,17 @@ type Platform struct {
 	sessions *sessionsync.Handle
 
 	// Tuning
-	ruleEngine    *tuning.RuleEngine
-	promptManager *tuning.PromptManager
+	ruleEngine *tuning.RuleEngine
+
+	// Prompt layer. The owner (pkg/platform/promptlayer) holds the prompt store,
+	// the file-based tuning prompt manager, and the name-keyed prompt-metadata
+	// list behind one Handle, along with the static/workflow/database registration
+	// path, the per-viewer dynamic-serving callbacks, and the manage_prompt tool.
+	// The store is read through Store() and surfaced by PromptStore(); the
+	// registration/serving entry points take the *mcp.Server per call. Never nil
+	// (prompts register and serve without a database); the store is nil on a
+	// no-DB deployment.
+	prompts *promptlayer.Handle
 
 	// Knowledge-capture layer. The owner (pkg/platform/knowledgelayer) holds the
 	// insight store (the memory-backed adapter over memory_records, else the
@@ -255,11 +263,6 @@ type Platform struct {
 	// free-typed email sharing.
 	users *userdir.Handle
 
-	// Prompt store + metadata collected during registration
-	promptStore   prompt.Store
-	promptInfosMu sync.RWMutex
-	promptInfos   []registry.PromptInfo
-
 	// MCP Apps
 	mcpAppsRegistry *mcpapps.Registry
 
@@ -320,6 +323,10 @@ func (p *Platform) initializeComponents(opts *Options) error {
 	if err := p.initRegistries(opts); err != nil {
 		return err
 	}
+	// Prompt layer: assembled after the toolkit registry exists (it reads the
+	// registry for capability bullets and workflow gating) and before
+	// initExtensions, whose knowledge/search wiring reads the prompt store.
+	p.initPromptStore()
 	// Parse OAuth signing key early so auth can use it
 	if err := p.initOAuthSigningKey(); err != nil {
 		return err
@@ -359,7 +366,6 @@ func (p *Platform) initDataInfra(opts *Options) error {
 	}
 	p.initPersonaStore()
 	p.initAPIKeyStore()
-	p.initPromptStore()
 	p.initUserStore()
 	return p.initConfigStore()
 }
@@ -848,12 +854,47 @@ func (p *Platform) initAPIKeyStore() {
 	}
 }
 
-// initPromptStore initializes the prompt definition store.
+// initPromptStore assembles the prompt layer via the promptlayer owner: the
+// prompt store, the file-based tuning prompt manager, and the name-keyed
+// prompt-metadata list behind one Handle. It translates platform config into the
+// owner's Config and delegates assembly. The owner is never nil (prompts
+// register and serve without a database); the store is nil when no database is
+// configured. The embedding provider and portal share lister are bound later
+// (finalizeSetup), once those subsystems exist.
 func (p *Platform) initPromptStore() {
-	if p.db != nil {
-		p.promptStore = promptpostgres.New(p.db)
-		slog.Info("prompt store: postgres")
+	p.prompts = promptlayer.New(promptlayer.Config{
+		DB:                p.db,
+		PromptsDir:        p.config.Tuning.PromptsDir,
+		ServerName:        p.config.Server.Name,
+		ServerDescription: p.config.Server.Description,
+		AdminPersona:      p.config.Admin.Persona,
+		OperatorPrompts:   promptSpecsFromConfig(p.config.Server.Prompts),
+		BuiltinPrompts:    p.config.Server.BuiltinPrompts,
+		Registry:          p.toolkitRegistry,
+	})
+}
+
+// promptSpecsFromConfig translates operator-configured prompts into the owner's
+// caller-neutral PromptSpec shape, keeping the platform config types out of the
+// promptlayer package.
+func promptSpecsFromConfig(cfgs []PromptConfig) []promptlayer.PromptSpec {
+	specs := make([]promptlayer.PromptSpec, 0, len(cfgs))
+	for _, c := range cfgs {
+		spec := promptlayer.PromptSpec{
+			Name:        c.Name,
+			Description: c.Description,
+			Content:     c.Content,
+		}
+		for _, a := range c.Arguments {
+			spec.Arguments = append(spec.Arguments, promptlayer.PromptArgSpec{
+				Name:        a.Name,
+				Description: a.Description,
+				Required:    a.Required,
+			})
+		}
+		specs = append(specs, spec)
 	}
+	return specs
 }
 
 // buildFieldEncryptor creates a FieldEncryptor from the ENCRYPTION_KEY env var.
@@ -1306,7 +1347,9 @@ func (p *Platform) parseOrGenerateSigningKey() ([]byte, error) {
 	return key, nil
 }
 
-// initTuning initializes tuning components.
+// initTuning initializes tuning components. The file-based prompt manager is
+// owned by the prompt layer (assembled in initPromptStore), so only the rule
+// engine is built here.
 func (p *Platform) initTuning(opts *Options) {
 	if opts.RuleEngine != nil {
 		p.ruleEngine = opts.RuleEngine
@@ -1316,10 +1359,6 @@ func (p *Platform) initTuning(opts *Options) {
 		}
 		p.ruleEngine = tuning.NewRuleEngine(rules)
 	}
-
-	p.promptManager = tuning.NewPromptManager(tuning.PromptConfig{
-		PromptsDir: p.config.Tuning.PromptsDir,
-	})
 }
 
 // initWorkflow initializes the session workflow tracker for the search-first
@@ -1437,11 +1476,12 @@ func (p *Platform) initKnowledge() error {
 	}
 	p.knowledge = handle
 
-	// Wire prompt creator for add_prompt change type. This reaches back into
-	// Platform (the prompt store + a *Platform), so it stays here and is applied
-	// through the handle's toolkit.
-	if p.promptStore != nil {
-		handle.Toolkit().SetPromptCreator(&platformPromptCreator{store: p.promptStore, platform: p})
+	// Wire prompt creator for add_prompt change type through the prompt layer's
+	// adapter. Toolkit registration stays a Platform/registry concern, so this is
+	// applied here through the handle's toolkit. The adapter is nil on a no-DB
+	// deployment (no store to create into).
+	if pc := p.prompts.PromptCreator(); pc != nil {
+		handle.Toolkit().SetPromptCreator(pc)
 	}
 
 	// Toolkit registration stays a Platform/registry concern.
@@ -1496,7 +1536,7 @@ func (p *Platform) initSearch() error {
 		KnowledgePageStore: p.portalStore.KnowledgePageStore(),
 		AssetStore:         p.portalStore.AssetStore(),
 		ThreadStore:        p.portalStore.ThreadStore(),
-		PromptStore:        p.promptStore,
+		PromptStore:        p.prompts.Store(),
 		Registry:           p.toolkitRegistry,
 		Embedding:          p.embeddingProv,
 	})
@@ -1888,6 +1928,11 @@ func convertCSP(cfg *CSPAppConfig) *mcpapps.CSPConfig {
 
 // finalizeSetup completes platform initialization.
 func (p *Platform) finalizeSetup() {
+	// Bind the prompt layer's late collaborators before the middleware chain and
+	// tool are registered below, now that the subsystems that build them have
+	// initialized.
+	p.bindPromptCollaborators()
+
 	p.mcpServer = mcp.NewServer(&mcp.Implementation{
 		Name:    p.config.Server.Name,
 		Version: p.config.Server.Version,
@@ -1918,6 +1963,19 @@ func (p *Platform) finalizeSetup() {
 	// (innermost first) to realize that execution order.
 	for i := len(specs) - 1; i >= 0; i-- {
 		specs[i].Register()
+	}
+}
+
+// bindPromptCollaborators injects the prompt layer's two late collaborators, now
+// that the subsystems that build them have initialized: the embedding provider
+// (manage_prompt semantic ranking; nil falls back to lexical) and the portal
+// share lister (shared-prompt serving; nil when portal is disabled). Both feed
+// the prompts/list visibility middleware and manage_prompt tool wired later in
+// finalizeSetup, so this must run before that wiring.
+func (p *Platform) bindPromptCollaborators() {
+	p.prompts.SetEmbedder(p.embeddingProv)
+	if p.portalStore != nil {
+		p.prompts.SetShareStore(p.portalStore.ShareStore())
 	}
 }
 
@@ -2096,8 +2154,8 @@ func (p *Platform) addToolVisibilityMiddleware() {
 func (p *Platform) addPromptVisibilityMiddleware() {
 	cfg := middleware.PromptVisibilityConfig{
 		Authenticator: p.authenticator,
-		ListVisible:   p.listVisiblePrompts,
-		GetByName:     p.getDynamicPrompt,
+		ListVisible:   p.prompts.ListVisible,
+		GetByName:     p.prompts.GetByName,
 	}
 	if p.personaRegistry != nil {
 		cfg.PersonasForRoles = personasForRolesFunc(p.personaRegistry)
@@ -2526,7 +2584,7 @@ func (p *Platform) loadDBAPIKeys() {
 // Start starts the platform.
 func (p *Platform) Start(ctx context.Context) error {
 	// Load prompts from prompts_dir
-	if err := p.promptManager.LoadPrompts(); err != nil {
+	if err := p.prompts.LoadPrompts(); err != nil {
 		return fmt.Errorf("loading prompts: %w", err)
 	}
 
@@ -2542,10 +2600,10 @@ func (p *Platform) Start(ctx context.Context) error {
 	p.registerInfoTool()
 	p.registerConnectionsTool()
 	p.registerFindToolsTool()
-	p.registerPromptTool()
+	p.prompts.RegisterTool(p.mcpServer)
 
 	// Register platform-level prompts from config
-	p.registerPlatformPrompts()
+	p.prompts.RegisterPlatformPrompts(p.mcpServer)
 
 	// Register user-defined custom resources from config
 	p.registerCustomResources()
@@ -2652,8 +2710,28 @@ func (p *Platform) APIKeyStore() APIKeyStore {
 }
 
 // PromptStore returns the prompt definition store, or nil if not initialized.
+// Delegates to the prompt layer owner.
 func (p *Platform) PromptStore() prompt.Store {
-	return p.promptStore
+	return p.prompts.Store()
+}
+
+// AllPromptInfos returns all prompt metadata (platform + toolkit). Delegates to
+// the prompt layer owner; read by the admin and portal prompt REST handlers.
+func (p *Platform) AllPromptInfos() []registry.PromptInfo {
+	return p.prompts.AllPromptInfos()
+}
+
+// RegisterRuntimePrompt records a prompt's metadata at runtime after a
+// create/update. Delegates to the prompt layer owner; called by the admin and
+// portal prompt REST handlers.
+func (p *Platform) RegisterRuntimePrompt(pr *prompt.Prompt) {
+	p.prompts.RegisterRuntimePrompt(pr)
+}
+
+// UnregisterRuntimePrompt drops a database prompt's tracked metadata. Delegates
+// to the prompt layer owner; called by the admin and portal prompt REST handlers.
+func (p *Platform) UnregisterRuntimePrompt(name string) {
+	p.prompts.UnregisterRuntimePrompt(name)
 }
 
 // ConnectionStore returns the connection instance store, or nil if not initialized.
@@ -2916,7 +2994,7 @@ func (p *Platform) PlatformTools() []ToolInfo {
 		{Name: defaultInitTool, Kind: kindPlatform},
 		{Name: toolListConns, Kind: kindPlatform},
 	}
-	if p.promptStore != nil {
+	if p.prompts.Store() != nil {
 		tools = append(tools, ToolInfo{Name: "manage_prompt", Kind: kindPlatform})
 	}
 	return tools

--- a/pkg/platform/prompt_wiring_test.go
+++ b/pkg/platform/prompt_wiring_test.go
@@ -1,0 +1,261 @@
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/platform/portalstore"
+	"github.com/txn2/mcp-data-platform/pkg/platform/promptlayer"
+	"github.com/txn2/mcp-data-platform/pkg/portal"
+	"github.com/txn2/mcp-data-platform/pkg/prompt"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+)
+
+// wiringPromptStore is a minimal in-memory prompt.Store + prompt.Searcher for the
+// finalizeSetup wiring test. Search always succeeds (returning no rows), so the
+// manage_prompt ranking reflects only whether an embedder is wired.
+type wiringPromptStore struct {
+	prompts map[string]*prompt.Prompt
+}
+
+func newWiringPromptStore() *wiringPromptStore {
+	return &wiringPromptStore{prompts: make(map[string]*prompt.Prompt)}
+}
+
+func (m *wiringPromptStore) Create(_ context.Context, p *prompt.Prompt) error {
+	m.prompts[p.Name] = p
+	return nil
+}
+
+func (m *wiringPromptStore) Get(_ context.Context, name string) (*prompt.Prompt, error) {
+	return m.prompts[name], nil //nolint:nilnil // interface contract
+}
+
+func (m *wiringPromptStore) GetPersonal(_ context.Context, ownerEmail, name string) (*prompt.Prompt, error) {
+	for _, p := range m.prompts {
+		if p.Scope == prompt.ScopePersonal && p.OwnerEmail == ownerEmail && p.Name == name {
+			return p, nil
+		}
+	}
+	return nil, nil //nolint:nilnil // interface contract
+}
+
+func (m *wiringPromptStore) GetByID(_ context.Context, id string) (*prompt.Prompt, error) {
+	for _, p := range m.prompts {
+		if p.ID == id {
+			return p, nil
+		}
+	}
+	return nil, nil //nolint:nilnil // interface contract
+}
+
+func (m *wiringPromptStore) Update(_ context.Context, p *prompt.Prompt) error {
+	m.prompts[p.Name] = p
+	return nil
+}
+
+func (m *wiringPromptStore) Delete(_ context.Context, name string) error {
+	delete(m.prompts, name)
+	return nil
+}
+
+func (m *wiringPromptStore) DeleteByID(_ context.Context, id string) error {
+	for name, p := range m.prompts {
+		if p.ID == id {
+			delete(m.prompts, name)
+		}
+	}
+	return nil
+}
+
+func (m *wiringPromptStore) List(_ context.Context, f prompt.ListFilter) ([]prompt.Prompt, error) { //nolint:revive // interface impl
+	var out []prompt.Prompt
+	for _, p := range m.prompts {
+		if f.Scope != "" && p.Scope != f.Scope {
+			continue
+		}
+		if f.OwnerEmail != "" && p.OwnerEmail != f.OwnerEmail {
+			continue
+		}
+		out = append(out, *p)
+	}
+	return out, nil
+}
+
+func (m *wiringPromptStore) Count(_ context.Context, _ prompt.ListFilter) (int, error) {
+	return len(m.prompts), nil
+}
+
+func (*wiringPromptStore) Search(_ context.Context, _ prompt.SearchQuery) ([]prompt.ScoredPrompt, error) {
+	return nil, nil
+}
+
+var (
+	_ prompt.Store    = (*wiringPromptStore)(nil)
+	_ prompt.Searcher = (*wiringPromptStore)(nil)
+)
+
+// wiringEmbedder is a configured (non-noop) embedder that returns a fixed
+// non-zero vector, so EmbedForSearch produces a query vector and manage_prompt
+// search reports "hybrid" ranking whenever the embedder is actually wired.
+type wiringEmbedder struct{}
+
+func (*wiringEmbedder) Embed(context.Context, string) ([]float32, error) {
+	return []float32{1, 0, 0, 0}, nil
+}
+
+func (*wiringEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = []float32{1, 0, 0, 0}
+	}
+	return out, nil
+}
+
+func (*wiringEmbedder) Dimension() int { return 4 }
+func (*wiringEmbedder) Kind() string   { return "stub" }
+
+// TestBindPromptCollaborators_WiresEmbedderAndShareStore is the assembled-system
+// proof (CLAUDE.md rule 5) that finalizeSetup's binding actually connects the
+// Platform's embedding provider and portal share store into the prompt layer:
+// the collaborators are observed reaching the layer through its own public
+// serving surfaces, not asserted on a hand-built Handle. It exercises the real
+// production wiring method (bindPromptCollaborators), so a future edit that drops
+// a SetEmbedder/SetShareStore call or the portalStore nil-guard fails here.
+func TestBindPromptCollaborators_WiresEmbedderAndShareStore(t *testing.T) {
+	ctx := context.Background()
+
+	store := newWiringPromptStore()
+	// A personal prompt owned by sarah, shared with bob via the portal share store.
+	store.prompts["report"] = &prompt.Prompt{
+		ID: "p1", Name: "report", Scope: prompt.ScopePersonal,
+		OwnerEmail: "sarah@example.com", Content: "shared {x}", Enabled: true,
+	}
+
+	p := &Platform{
+		config:        &Config{Admin: AdminConfig{Persona: "admin"}},
+		prompts:       promptlayer.New(promptlayer.Config{Store: store, AdminPersona: "admin", Registry: registry.NewRegistry()}),
+		embeddingProv: &wiringEmbedder{},
+		portalStore: portalstore.NewFromStores(portalstore.Stores{
+			Share: &stubShareStore{promptRefs: []portal.SharedPromptRef{
+				{PromptID: "p1", ShareID: "s1", SharedBy: "sarah@example.com", Permission: portal.PermissionViewer},
+			}},
+		}, nil, portalstore.Config{}),
+	}
+
+	// Before binding, neither collaborator has reached the prompt layer: bob sees
+	// no shared prompt, and search ranking would be lexical.
+	require.Empty(t, p.prompts.ListVisible(ctx, "bob@example.com", nil),
+		"no shared prompt is served before finalizeSetup binds the share store")
+
+	// The real production wiring.
+	p.bindPromptCollaborators()
+
+	// Share store wired: bob now sees the shared prompt as shared-<name>.
+	names := map[string]bool{}
+	for _, pr := range p.prompts.ListVisible(ctx, "bob@example.com", nil) {
+		names[pr.Name] = true
+	}
+	assert.True(t, names["shared-report"],
+		"finalizeSetup must wire the portal share store into the prompt layer")
+
+	// Embedder wired: manage_prompt search reports hybrid ranking, observed
+	// through the assembled tool + server (the only surface that reads the
+	// embedder).
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil)
+	p.prompts.RegisterTool(server)
+	session, cleanup := connectTestClientForWiring(t, server)
+	defer cleanup()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "manage_prompt",
+		Arguments: map[string]any{"command": "list", "query": "sales"},
+	})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var parsed struct {
+		Ranking string `json:"ranking"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(res)), &parsed))
+	assert.Equal(t, "hybrid", parsed.Ranking,
+		"finalizeSetup must wire the embedding provider into the prompt layer")
+}
+
+// TestPromptSpecsFromConfig verifies the config-translation that initPromptStore
+// feeds the prompt layer: operator PromptConfig entries map field-for-field to
+// the owner's caller-neutral PromptSpec shape.
+func TestPromptSpecsFromConfig(t *testing.T) {
+	specs := promptSpecsFromConfig([]PromptConfig{
+		{
+			Name:        "a",
+			Description: "da",
+			Content:     "ca",
+			Arguments:   []PromptArgumentConfig{{Name: "x", Description: "dx", Required: true}},
+		},
+		{Name: "b", Content: "cb"},
+	})
+
+	require.Len(t, specs, 2)
+	assert.Equal(t, "a", specs[0].Name)
+	assert.Equal(t, "da", specs[0].Description)
+	assert.Equal(t, "ca", specs[0].Content)
+	require.Len(t, specs[0].Arguments, 1)
+	assert.Equal(t, "x", specs[0].Arguments[0].Name)
+	assert.Equal(t, "dx", specs[0].Arguments[0].Description)
+	assert.True(t, specs[0].Arguments[0].Required)
+	assert.Equal(t, "b", specs[1].Name)
+	assert.Empty(t, specs[1].Arguments)
+}
+
+// TestPromptDelegators verifies the four public Platform accessors external
+// callers use forward to the prompt layer owner.
+func TestPromptDelegators(t *testing.T) {
+	store := newWiringPromptStore()
+	p := &Platform{
+		prompts: promptlayer.New(promptlayer.Config{
+			Store: store, AdminPersona: "admin", Registry: registry.NewRegistry(),
+		}),
+	}
+
+	assert.Same(t, store, p.PromptStore(), "PromptStore delegates to the owner's Store()")
+
+	tracked := func() map[string]bool {
+		m := map[string]bool{}
+		for _, i := range p.AllPromptInfos() {
+			m[i.Name] = true
+		}
+		return m
+	}
+
+	p.RegisterRuntimePrompt(&prompt.Prompt{Name: "g", Scope: prompt.ScopeGlobal})
+	assert.True(t, tracked()["g"], "RegisterRuntimePrompt delegates and AllPromptInfos reflects it")
+
+	p.UnregisterRuntimePrompt("g")
+	assert.False(t, tracked()["g"], "UnregisterRuntimePrompt delegates")
+}
+
+// connectTestClientForWiring connects an in-memory MCP client to a server for the
+// wiring test and returns the session; the caller must call cleanup().
+func connectTestClientForWiring(t *testing.T, server *mcp.Server) (session *mcp.ClientSession, cleanup func()) {
+	t.Helper()
+	ctx := context.Background()
+	t1, t2 := mcp.NewInMemoryTransports()
+
+	serverSession, err := server.Connect(ctx, t1, nil)
+	require.NoError(t, err)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0"}, nil)
+	clientSession, err := client.Connect(ctx, t2, nil)
+	require.NoError(t, err)
+
+	return clientSession, func() {
+		_ = clientSession.Close()
+		_ = serverSession.Close()
+	}
+}

--- a/pkg/platform/promptlayer/construct_test.go
+++ b/pkg/platform/promptlayer/construct_test.go
@@ -1,0 +1,121 @@
+package promptlayer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/prompt"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+)
+
+func TestNew_StoreSelection(t *testing.T) {
+	t.Run("explicit store is used", func(t *testing.T) {
+		store := newMockPromptStore()
+		h := New(Config{Store: store, Registry: registry.NewRegistry()})
+		require.NotNil(t, h)
+		assert.Same(t, store, h.Store())
+	})
+
+	t.Run("no store and no db leaves store nil", func(t *testing.T) {
+		h := New(Config{Registry: registry.NewRegistry()})
+		require.NotNil(t, h, "handle is always non-nil so static prompts still register")
+		assert.Nil(t, h.Store())
+	})
+}
+
+func TestNew_LoadPrompts(t *testing.T) {
+	// An empty prompts directory loads nothing and does not error.
+	h := New(Config{PromptsDir: t.TempDir(), Registry: registry.NewRegistry()})
+	assert.NoError(t, h.LoadPrompts())
+}
+
+func TestSetEmbedderAndShareStore(t *testing.T) {
+	h := New(Config{Store: newMockPromptStore(), Registry: registry.NewRegistry()})
+
+	// Before binding, a shared-prompt lookup finds no share lister.
+	share := &stubShareLister{}
+	h.SetShareStore(share)
+	assert.Same(t, share, h.shareStore)
+
+	emb := &stubEmbedder{}
+	h.SetEmbedder(emb)
+	assert.Same(t, emb, h.embedder)
+}
+
+func TestStore_NilHandle(t *testing.T) {
+	var h *Handle
+	assert.Nil(t, h.Store())
+}
+
+func TestPromptCreator(t *testing.T) {
+	t.Run("nil when no store", func(t *testing.T) {
+		h := New(Config{Registry: registry.NewRegistry()})
+		assert.Nil(t, h.PromptCreator())
+	})
+
+	t.Run("adapter creates and registers", func(t *testing.T) {
+		store := newMockPromptStore()
+		h := New(Config{Store: store, Registry: registry.NewRegistry()})
+		pc := h.PromptCreator()
+		require.NotNil(t, pc)
+
+		pr := &prompt.Prompt{Name: "new-prompt", Scope: prompt.ScopeGlobal, Content: "c"}
+		require.NoError(t, pc.Create(context.Background(), pr))
+		assert.Contains(t, store.prompts, "new-prompt", "Create persisted through the store")
+
+		pc.RegisterRuntimePrompt(pr)
+		infos := h.AllPromptInfos()
+		found := false
+		for _, i := range infos {
+			if i.Name == "new-prompt" {
+				found = true
+			}
+		}
+		assert.True(t, found, "RegisterRuntimePrompt tracked the prompt metadata")
+	})
+
+	t.Run("adapter surfaces store create error", func(t *testing.T) {
+		store := newMockPromptStore()
+		store.createErr = assert.AnError
+		h := New(Config{Store: store, Registry: registry.NewRegistry()})
+		err := h.PromptCreator().Create(context.Background(), &prompt.Prompt{Name: "x"})
+		assert.Error(t, err)
+	})
+}
+
+// A nil Handle degrades every entry point to a safe no-op / zero value, matching
+// the documented contract, so a caller that never built the layer never panics.
+func TestNilHandle_IsSafe(t *testing.T) {
+	var h *Handle
+	ctx := context.Background()
+
+	assert.Nil(t, h.Store())
+	assert.Nil(t, h.PromptCreator())
+	assert.Nil(t, h.AllPromptInfos())
+	assert.Nil(t, h.ListVisible(ctx, "a@x", nil))
+	_, ok := h.GetByName(ctx, "a@x", nil, "global-x", nil)
+	assert.False(t, ok)
+
+	// Mutators and registration are no-ops (must not panic).
+	assert.NotPanics(t, func() {
+		h.RegisterRuntimePrompt(&prompt.Prompt{Name: "g", Scope: prompt.ScopeGlobal})
+		h.UnregisterRuntimePrompt("g")
+		server := mcp.NewServer(&mcp.Implementation{Name: "t", Version: "0"}, nil)
+		h.RegisterTool(server)
+		h.RegisterPlatformPrompts(server)
+	})
+}
+
+// stubEmbedder is a minimal non-noop embedding provider for setter coverage.
+type stubEmbedder struct{}
+
+func (*stubEmbedder) Embed(context.Context, string) ([]float32, error) { return []float32{1}, nil }
+func (*stubEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float32, error) {
+	return make([][]float32, len(texts)), nil
+}
+func (*stubEmbedder) Dimension() int { return 1 }
+func (*stubEmbedder) Kind() string   { return "stub" }

--- a/pkg/platform/promptlayer/dynamic_serving_test.go
+++ b/pkg/platform/promptlayer/dynamic_serving_test.go
@@ -1,4 +1,4 @@
-package platform
+package promptlayer
 
 import (
 	"context"
@@ -12,14 +12,14 @@ import (
 )
 
 func TestListVisiblePrompts_ScopePrefixesAndScoping(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["g1"] = &prompt.Prompt{Name: "g1", Scope: prompt.ScopeGlobal, Enabled: true}
 	store.prompts["pa"] = &prompt.Prompt{Name: "pa", Scope: prompt.ScopePersona, Personas: []string{"analyst"}, Enabled: true}
 	store.prompts["pe"] = &prompt.Prompt{Name: "pe", Scope: prompt.ScopePersona, Personas: []string{"engineer"}, Enabled: true}
 	store.prompts["mine"] = &prompt.Prompt{Name: "mine", Scope: prompt.ScopePersonal, OwnerEmail: "sarah@example.com", Enabled: true}
 	store.prompts["bob"] = &prompt.Prompt{Name: "bob", Scope: prompt.ScopePersonal, OwnerEmail: "bob@example.com", Enabled: true}
 
-	out := p.listVisiblePrompts(context.Background(), "sarah@example.com", []string{"analyst"})
+	out := h.ListVisible(context.Background(), "sarah@example.com", []string{"analyst"})
 	names := map[string]bool{}
 	for _, pr := range out {
 		names[pr.Name] = true
@@ -37,11 +37,11 @@ func TestListVisiblePrompts_ScopePrefixesAndScoping(t *testing.T) {
 func TestListVisiblePrompts_ExcludesSystemRows(t *testing.T) {
 	// Ingested static prompts (source=system) are served under their bare name
 	// via AddPrompt; they must not also appear as a global- prefixed entry.
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["g1"] = &prompt.Prompt{Name: "g1", Scope: prompt.ScopeGlobal, Source: prompt.SourceOperator, Enabled: true}
 	store.prompts["sys"] = &prompt.Prompt{Name: "sys", Scope: prompt.ScopeGlobal, Source: prompt.SourceSystem, Enabled: true}
 
-	out := p.listVisiblePrompts(context.Background(), "", nil)
+	out := h.ListVisible(context.Background(), "", nil)
 	names := map[string]bool{}
 	for _, pr := range out {
 		names[pr.Name] = true
@@ -51,18 +51,18 @@ func TestListVisiblePrompts_ExcludesSystemRows(t *testing.T) {
 }
 
 func TestRegisterDatabasePrompts_SkipsSystemRows(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["op"] = &prompt.Prompt{Name: "op", Scope: prompt.ScopeGlobal, Source: prompt.SourceOperator, Enabled: true}
 	store.prompts["sys"] = &prompt.Prompt{Name: "sys", Scope: prompt.ScopeGlobal, Source: prompt.SourceSystem, Enabled: true}
 
-	p.registerDatabasePrompts()
+	h.registerDatabasePrompts()
 
 	infos := map[string]bool{}
-	p.promptInfosMu.RLock()
-	for _, i := range p.promptInfos {
+	h.promptInfosMu.RLock()
+	for _, i := range h.promptInfos {
 		infos[i.Name] = true
 	}
-	p.promptInfosMu.RUnlock()
+	h.promptInfosMu.RUnlock()
 	assert.True(t, infos["op"], "operator database prompt registered for admin listing")
 	assert.False(t, infos["sys"], "system row must be skipped (already served via AddPrompt)")
 }
@@ -70,12 +70,12 @@ func TestRegisterDatabasePrompts_SkipsSystemRows(t *testing.T) {
 func TestPromptServing_AnonymousIsFailClosed(t *testing.T) {
 	// An anonymous caller (empty email, no personas) sees only globals and can
 	// fetch only globals, never personal or persona prompts.
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["g"] = &prompt.Prompt{Name: "g", Scope: prompt.ScopeGlobal, Enabled: true}
 	store.prompts["pa"] = &prompt.Prompt{Name: "pa", Scope: prompt.ScopePersona, Personas: []string{"analyst"}, Enabled: true}
 	store.prompts["mine"] = &prompt.Prompt{Name: "mine", Scope: prompt.ScopePersonal, OwnerEmail: "sarah@example.com", Enabled: true}
 
-	out := p.listVisiblePrompts(context.Background(), "", nil)
+	out := h.ListVisible(context.Background(), "", nil)
 	names := map[string]bool{}
 	for _, pr := range out {
 		names[pr.Name] = true
@@ -85,16 +85,16 @@ func TestPromptServing_AnonymousIsFailClosed(t *testing.T) {
 	assert.False(t, names["personal-mine"], "anonymous must not see personal prompts")
 	assert.Len(t, out, 1, "anonymous list contains only the global prompt")
 
-	_, ok := p.getDynamicPrompt(context.Background(), "", nil, "personal-mine", nil)
+	_, ok := h.GetByName(context.Background(), "", nil, "personal-mine", nil)
 	assert.False(t, ok, "anonymous cannot fetch a personal prompt")
-	_, ok = p.getDynamicPrompt(context.Background(), "", nil, "analyst-pa", nil)
+	_, ok = h.GetByName(context.Background(), "", nil, "analyst-pa", nil)
 	assert.False(t, ok, "anonymous cannot fetch a persona prompt")
-	_, ok = p.getDynamicPrompt(context.Background(), "", nil, "global-g", nil)
+	_, ok = h.GetByName(context.Background(), "", nil, "global-g", nil)
 	assert.True(t, ok, "anonymous can fetch a global prompt")
 }
 
 func TestGetDynamicPrompt_ResolvesByPrefix(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["g1"] = &prompt.Prompt{Name: "g1", Scope: prompt.ScopeGlobal, Content: "global {x}", Enabled: true}
 	store.prompts["pa"] = &prompt.Prompt{Name: "pa", Scope: prompt.ScopePersona, Personas: []string{"analyst"}, Content: "persona", Enabled: true}
 	store.prompts["mine"] = &prompt.Prompt{Name: "mine", Scope: prompt.ScopePersonal, OwnerEmail: "sarah@example.com", Content: "personal", Enabled: true}
@@ -102,34 +102,34 @@ func TestGetDynamicPrompt_ResolvesByPrefix(t *testing.T) {
 	ctx := context.Background()
 	analyst := []string{"analyst"}
 
-	_, ok := p.getDynamicPrompt(ctx, "sarah@example.com", analyst, "personal-mine", nil)
+	_, ok := h.GetByName(ctx, "sarah@example.com", analyst, "personal-mine", nil)
 	assert.True(t, ok, "own personal prompt resolves via personal- prefix")
 
-	res, ok := p.getDynamicPrompt(ctx, "sarah@example.com", analyst, "global-g1", map[string]string{"x": "Y"})
+	res, ok := h.GetByName(ctx, "sarah@example.com", analyst, "global-g1", map[string]string{"x": "Y"})
 	require.True(t, ok, "global prompt resolves via global- prefix")
 	require.NotNil(t, res)
 
-	_, ok = p.getDynamicPrompt(ctx, "sarah@example.com", analyst, "analyst-pa", nil)
+	_, ok = h.GetByName(ctx, "sarah@example.com", analyst, "analyst-pa", nil)
 	assert.True(t, ok, "persona prompt resolves for a member via <persona>- prefix")
 
-	_, ok = p.getDynamicPrompt(ctx, "sarah@example.com", []string{"engineer"}, "analyst-pa", nil)
+	_, ok = h.GetByName(ctx, "sarah@example.com", []string{"engineer"}, "analyst-pa", nil)
 	assert.False(t, ok, "a non-member cannot resolve a persona prompt by its prefix")
 
-	_, ok = p.getDynamicPrompt(ctx, "bob@example.com", nil, "personal-mine", nil)
+	_, ok = h.GetByName(ctx, "bob@example.com", nil, "personal-mine", nil)
 	assert.False(t, ok, "another user cannot resolve someone else's personal prompt")
 
-	_, ok = p.getDynamicPrompt(ctx, "sarah@example.com", analyst, "personal-g1", nil)
+	_, ok = h.GetByName(ctx, "sarah@example.com", analyst, "personal-g1", nil)
 	assert.False(t, ok, "a global prompt is not reachable under the personal- prefix")
 
-	_, ok = p.getDynamicPrompt(ctx, "sarah@example.com", analyst, "global-nope", nil)
+	_, ok = h.GetByName(ctx, "sarah@example.com", analyst, "global-nope", nil)
 	assert.False(t, ok, "an unknown name resolves to nothing")
 }
 
 // A persona may literally be named "global" or "personal". The reserved-prefix
-// branches of getDynamicPrompt must fall through to persona resolution so such a
+// branches of GetByName must fall through to persona resolution so such a
 // persona's prompts remain fetchable.
 func TestGetDynamicPrompt_ReservedPrefixPersonaName(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["report"] = &prompt.Prompt{
 		Name: "report", Scope: prompt.ScopePersona, Personas: []string{"global"},
 		Content: "persona-global report", Enabled: true,
@@ -140,9 +140,9 @@ func TestGetDynamicPrompt_ReservedPrefixPersonaName(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	_, ok := p.getDynamicPrompt(ctx, "u@example.com", []string{"global"}, "global-report", nil)
+	_, ok := h.GetByName(ctx, "u@example.com", []string{"global"}, "global-report", nil)
 	assert.True(t, ok, "a persona named 'global' resolves its prompt via fall-through")
-	_, ok = p.getDynamicPrompt(ctx, "u@example.com", []string{"personal"}, "personal-runbook", nil)
+	_, ok = h.GetByName(ctx, "u@example.com", []string{"personal"}, "personal-runbook", nil)
 	assert.True(t, ok, "a persona named 'personal' resolves its prompt via fall-through")
 }
 
@@ -150,15 +150,15 @@ func TestGetDynamicPrompt_ReservedPrefixPersonaName(t *testing.T) {
 // names collide across owners), and unregistering by name must not drop an
 // unrelated shared entry of the same name.
 func TestRuntimePromptMetadata_ExcludesPersonal(t *testing.T) {
-	p, _ := newTestPlatformWithPromptStore()
-	p.RegisterRuntimePrompt(&prompt.Prompt{Name: "g", Scope: prompt.ScopeGlobal})
-	p.RegisterRuntimePrompt(&prompt.Prompt{Name: "mine", Scope: prompt.ScopePersonal, OwnerEmail: "a@x"})
+	h, _ := newTestHandle()
+	h.RegisterRuntimePrompt(&prompt.Prompt{Name: "g", Scope: prompt.ScopeGlobal})
+	h.RegisterRuntimePrompt(&prompt.Prompt{Name: "mine", Scope: prompt.ScopePersonal, OwnerEmail: "a@x"})
 
 	tracked := func() map[string]bool {
 		names := map[string]bool{}
-		p.promptInfosMu.RLock()
-		defer p.promptInfosMu.RUnlock()
-		for _, i := range p.promptInfos {
+		h.promptInfosMu.RLock()
+		defer h.promptInfosMu.RUnlock()
+		for _, i := range h.promptInfos {
 			names[i.Name] = true
 		}
 		return names
@@ -168,8 +168,8 @@ func TestRuntimePromptMetadata_ExcludesPersonal(t *testing.T) {
 	assert.True(t, names["g"], "global prompt is tracked")
 	assert.False(t, names["mine"], "personal prompt is not tracked")
 
-	p.RegisterRuntimePrompt(&prompt.Prompt{Name: "shared", Scope: prompt.ScopeGlobal})
-	p.UnregisterRuntimePrompt("g")
+	h.RegisterRuntimePrompt(&prompt.Prompt{Name: "shared", Scope: prompt.ScopeGlobal})
+	h.UnregisterRuntimePrompt("g")
 	after := tracked()
 	assert.False(t, after["g"], "unregister drops the named global entry")
 	assert.True(t, after["shared"], "unrelated shared entries are retained")
@@ -179,7 +179,7 @@ func TestRuntimePromptMetadata_ExcludesPersonal(t *testing.T) {
 // more than one way; the most specific (longest) persona prefix must win
 // deterministically.
 func TestGetPersonaPrompt_LongestPrefixWins(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["engineer-report"] = &prompt.Prompt{
 		Name: "engineer-report", Scope: prompt.ScopePersona, Personas: []string{"data"},
 		Content: "data persona", Enabled: true,
@@ -189,7 +189,7 @@ func TestGetPersonaPrompt_LongestPrefixWins(t *testing.T) {
 		Content: "data-engineer persona", Enabled: true,
 	}
 
-	res, ok := p.getDynamicPrompt(context.Background(), "u@example.com",
+	res, ok := h.GetByName(context.Background(), "u@example.com",
 		[]string{"data", "data-engineer"}, "data-engineer-report", nil)
 	require.True(t, ok)
 	require.Len(t, res.Messages, 1)

--- a/pkg/platform/promptlayer/ingest.go
+++ b/pkg/platform/promptlayer/ingest.go
@@ -1,4 +1,4 @@
-package platform
+package promptlayer
 
 import (
 	"context"
@@ -8,10 +8,10 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 )
 
-// ingestStaticPrompts mirrors the platform's statically-registered prompts
-// (operator config + built-in workflow + toolkit prompts) into the prompt store
-// as read-only, system-sourced rows so the existing embedding indexer and
-// manage_prompt search cover them, exactly like database-authored prompts.
+// ingestStaticPrompts mirrors the statically-registered prompts (operator config
+// + built-in workflow + toolkit prompts) into the prompt store as read-only,
+// system-sourced rows so the existing embedding indexer and manage_prompt search
+// cover them, exactly like database-authored prompts.
 //
 // Static prompts are otherwise served only as MCP protocol prompts (AddPrompt)
 // and never reach the store, so on a deployment whose prompts are all static the
@@ -24,12 +24,12 @@ import (
 // Must run after all static prompts are registered into promptInfos and before
 // registerDatabasePrompts (which would otherwise add database prompts to
 // promptInfos and cause them to be re-ingested as system rows).
-func (p *Platform) ingestStaticPrompts(ctx context.Context) {
-	if p.promptStore == nil {
+func (h *Handle) ingestStaticPrompts(ctx context.Context) {
+	if h.store == nil {
 		return
 	}
 
-	infos := p.staticPromptInfos()
+	infos := h.staticPromptInfos()
 	wanted := make(map[string]bool, len(infos))
 
 	for _, info := range infos {
@@ -37,10 +37,10 @@ func (p *Platform) ingestStaticPrompts(ctx context.Context) {
 			continue
 		}
 		wanted[info.Name] = true
-		p.upsertSystemPrompt(ctx, info)
+		h.upsertSystemPrompt(ctx, info)
 	}
 
-	p.pruneStaleSystemPrompts(ctx, wanted)
+	h.pruneStaleSystemPrompts(ctx, wanted)
 
 	if len(wanted) > 0 {
 		slog.Info("ingested static prompts for indexing and search", "count", len(wanted))
@@ -50,22 +50,22 @@ func (p *Platform) ingestStaticPrompts(ctx context.Context) {
 // upsertSystemPrompt creates or refreshes the system row for one static prompt.
 // A name already owned by a non-system prompt is left untouched so ingestion
 // never clobbers user/admin-authored prompts.
-func (p *Platform) upsertSystemPrompt(ctx context.Context, info registry.PromptInfo) {
+func (h *Handle) upsertSystemPrompt(ctx context.Context, info registry.PromptInfo) {
 	desired := systemPromptFromInfo(info)
 
-	existing, err := p.promptStore.Get(ctx, info.Name)
+	existing, err := h.store.Get(ctx, info.Name)
 	if err != nil {
 		slog.Warn("ingest static prompt: lookup failed", promptLogKey, info.Name, logKeyError, err)
 		return
 	}
 	switch {
 	case existing == nil:
-		if err := p.promptStore.Create(ctx, desired); err != nil {
+		if err := h.store.Create(ctx, desired); err != nil {
 			slog.Warn("ingest static prompt: create failed", promptLogKey, info.Name, logKeyError, err)
 		}
 	case existing.Source == prompt.SourceSystem:
 		desired.ID = existing.ID
-		if err := p.promptStore.Update(ctx, desired); err != nil {
+		if err := h.store.Update(ctx, desired); err != nil {
 			slog.Warn("ingest static prompt: update failed", promptLogKey, info.Name, logKeyError, err)
 		}
 	default:
@@ -77,12 +77,12 @@ func (p *Platform) upsertSystemPrompt(ctx context.Context, info registry.PromptI
 // staticPromptInfos is the set of statically-registered prompts (operator config
 // + workflow, held in promptInfos) plus toolkit-described prompts. It must be
 // read before registerDatabasePrompts pollutes promptInfos with database prompts.
-func (p *Platform) staticPromptInfos() []registry.PromptInfo {
-	toolkit := p.collectToolkitPromptInfos()
-	p.promptInfosMu.RLock()
-	infos := make([]registry.PromptInfo, 0, len(p.promptInfos)+len(toolkit))
-	infos = append(infos, p.promptInfos...)
-	p.promptInfosMu.RUnlock()
+func (h *Handle) staticPromptInfos() []registry.PromptInfo {
+	toolkit := h.collectToolkitPromptInfos()
+	h.promptInfosMu.RLock()
+	infos := make([]registry.PromptInfo, 0, len(h.promptInfos)+len(toolkit))
+	infos = append(infos, h.promptInfos...)
+	h.promptInfosMu.RUnlock()
 	return append(infos, toolkit...)
 }
 
@@ -110,8 +110,8 @@ func systemPromptFromInfo(info registry.PromptInfo) *prompt.Prompt {
 // pruneStaleSystemPrompts deletes system-sourced prompt rows whose name is no
 // longer in the registered static set, so removing a prompt from config or the
 // build reconciles the store on the next startup.
-func (p *Platform) pruneStaleSystemPrompts(ctx context.Context, wanted map[string]bool) {
-	rows, err := p.promptStore.List(ctx, prompt.ListFilter{Source: prompt.SourceSystem})
+func (h *Handle) pruneStaleSystemPrompts(ctx context.Context, wanted map[string]bool) {
+	rows, err := h.store.List(ctx, prompt.ListFilter{Source: prompt.SourceSystem})
 	if err != nil {
 		slog.Warn("ingest static prompt: list system prompts failed", logKeyError, err)
 		return
@@ -120,7 +120,7 @@ func (p *Platform) pruneStaleSystemPrompts(ctx context.Context, wanted map[strin
 		if wanted[rows[i].Name] {
 			continue
 		}
-		if err := p.promptStore.DeleteByID(ctx, rows[i].ID); err != nil {
+		if err := h.store.DeleteByID(ctx, rows[i].ID); err != nil {
 			slog.Warn("ingest static prompt: prune failed", "name", rows[i].Name, logKeyError, err)
 		}
 	}

--- a/pkg/platform/promptlayer/ingest_realdb_integration_test.go
+++ b/pkg/platform/promptlayer/ingest_realdb_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package platform
+package promptlayer
 
 // Real-Postgres proof for #593: the assembled ingestion path writes the
 // platform's static prompts into the store and they become searchable, exactly
@@ -25,16 +25,16 @@ func TestIngestStaticPrompts_RealDB_Searchable(t *testing.T) {
 	store := pgstore.New(testdb.New(t))
 	ctx := context.Background()
 
-	p := &Platform{
-		promptStore:     store,
-		toolkitRegistry: registry.NewRegistry(),
+	h := &Handle{
+		store:    store,
+		registry: registry.NewRegistry(),
 		promptInfos: []registry.PromptInfo{
 			{Name: "explore-available-data", Description: "Discover what datasets are available in the catalog", Content: "Explore data about {topic}."},
 			{Name: "create-interactive-dashboard", Description: "Build a dashboard and save it", Content: "Create a dashboard about {topic}."},
 		},
 	}
 
-	p.ingestStaticPrompts(ctx)
+	h.ingestStaticPrompts(ctx)
 
 	// Stored as read-only, approved, global system rows.
 	got, err := store.Get(ctx, "explore-available-data")
@@ -57,7 +57,7 @@ func TestIngestStaticPrompts_RealDB_Searchable(t *testing.T) {
 	assert.True(t, found, "ingested static prompt is returned by the real store search")
 
 	// Re-running ingest is idempotent (no duplicate system rows).
-	p.ingestStaticPrompts(ctx)
+	h.ingestStaticPrompts(ctx)
 	system, err := store.List(ctx, prompt.ListFilter{Source: prompt.SourceSystem})
 	require.NoError(t, err)
 	assert.Len(t, system, 2, "re-ingest does not duplicate system rows")

--- a/pkg/platform/promptlayer/ingest_test.go
+++ b/pkg/platform/promptlayer/ingest_test.go
@@ -1,34 +1,32 @@
-package platform
+package promptlayer
 
 import (
 	"context"
 	"testing"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/txn2/mcp-data-platform/pkg/prompt"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 )
 
-// newIngestTestPlatform builds a platform with an in-memory prompt store, a
-// toolkit registry carrying one PromptDescriber toolkit, and the given
-// platform-level static prompt infos already collected into promptInfos.
-func newIngestTestPlatform(platformInfos, toolkitInfos []registry.PromptInfo) (*Platform, *mockPlatformPromptStore) {
-	store := newMockPlatformPromptStore()
+// newIngestTestHandle builds a Handle with an in-memory prompt store, a toolkit
+// registry carrying one PromptDescriber toolkit, and the given platform-level
+// static prompt infos already collected into promptInfos.
+func newIngestTestHandle(platformInfos, toolkitInfos []registry.PromptInfo) (*Handle, *mockPromptStore) {
+	store := newMockPromptStore()
 	reg := registry.NewRegistry()
 	_ = reg.Register(&mockToolkitWithPrompts{
 		mockToolkit: mockToolkit{kind: "knowledge", name: "primary"},
 		prompts:     toolkitInfos,
 	})
-	p := &Platform{
-		config:          &Config{Admin: AdminConfig{Persona: "admin"}},
-		mcpServer:       mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil),
-		promptStore:     store,
-		toolkitRegistry: reg,
-		promptInfos:     platformInfos,
+	h := &Handle{
+		store:        store,
+		adminPersona: "admin",
+		registry:     reg,
+		promptInfos:  platformInfos,
 	}
-	return p, store
+	return h, store
 }
 
 func TestIngestStaticPrompts(t *testing.T) {
@@ -38,9 +36,9 @@ func TestIngestStaticPrompts(t *testing.T) {
 	toolkitInfos := []registry.PromptInfo{
 		{Name: "capture-knowledge", Description: "Record insights", Content: "Capture", Category: "toolkit"},
 	}
-	p, store := newIngestTestPlatform(platformInfos, toolkitInfos)
+	h, store := newIngestTestHandle(platformInfos, toolkitInfos)
 
-	p.ingestStaticPrompts(context.Background())
+	h.ingestStaticPrompts(context.Background())
 
 	// Both the platform and toolkit static prompts are ingested as read-only,
 	// approved, global system rows ready for indexing.
@@ -64,7 +62,7 @@ func TestIngestStaticPrompts(t *testing.T) {
 	}
 
 	// Idempotent: a second run does not duplicate rows.
-	p.ingestStaticPrompts(context.Background())
+	h.ingestStaticPrompts(context.Background())
 	all, _ := store.List(context.Background(), prompt.ListFilter{Source: prompt.SourceSystem})
 	if len(all) != 2 {
 		t.Errorf("after re-ingest, system rows = %d, want 2", len(all))
@@ -73,7 +71,7 @@ func TestIngestStaticPrompts(t *testing.T) {
 
 func TestIngestStaticPrompts_SkipsNonSystemName(t *testing.T) {
 	infos := []registry.PromptInfo{{Name: "shared-name", Description: "from config", Content: "x"}}
-	p, store := newIngestTestPlatform(infos, nil)
+	h, store := newIngestTestHandle(infos, nil)
 
 	// A user/admin already owns this global name (non-system).
 	store.prompts["shared-name"] = &prompt.Prompt{
@@ -81,7 +79,7 @@ func TestIngestStaticPrompts_SkipsNonSystemName(t *testing.T) {
 		Source: prompt.SourceOperator, Description: "user owned", Content: "user content",
 	}
 
-	p.ingestStaticPrompts(context.Background())
+	h.ingestStaticPrompts(context.Background())
 
 	got, _ := store.Get(context.Background(), "shared-name")
 	if got.Source != prompt.SourceOperator || got.Description != "user owned" {
@@ -91,14 +89,14 @@ func TestIngestStaticPrompts_SkipsNonSystemName(t *testing.T) {
 
 func TestIngestStaticPrompts_PrunesStaleSystemRows(t *testing.T) {
 	infos := []registry.PromptInfo{{Name: "current", Description: "d", Content: "c"}}
-	p, store := newIngestTestPlatform(infos, nil)
+	h, store := newIngestTestHandle(infos, nil)
 
 	// A system row from a prior build that is no longer registered.
 	store.prompts["removed"] = &prompt.Prompt{
 		ID: "sys-removed", Name: "removed", Scope: prompt.ScopeGlobal, Source: prompt.SourceSystem,
 	}
 
-	p.ingestStaticPrompts(context.Background())
+	h.ingestStaticPrompts(context.Background())
 
 	if got, _ := store.Get(context.Background(), "removed"); got != nil {
 		t.Errorf("stale system prompt %q was not pruned", "removed")
@@ -115,53 +113,53 @@ func TestIngestStaticPrompts_StoreErrorsAreNonFatal(t *testing.T) {
 	}}
 
 	// Create failure: ingest logs and continues; nothing is stored.
-	p, store := newIngestTestPlatform(infos, nil)
+	h, store := newIngestTestHandle(infos, nil)
 	store.createErr = assert.AnError
-	p.ingestStaticPrompts(context.Background())
+	h.ingestStaticPrompts(context.Background())
 	if got, _ := store.Get(context.Background(), "p1"); got != nil {
 		t.Error("nothing should be stored when create fails")
 	}
 
 	// Lookup failure: ingest logs and continues without panicking.
-	p2, store2 := newIngestTestPlatform(infos, nil)
+	h2, store2 := newIngestTestHandle(infos, nil)
 	store2.getErr = assert.AnError
-	p2.ingestStaticPrompts(context.Background())
+	h2.ingestStaticPrompts(context.Background())
 
 	// Prune list failure: the upsert still creates the row.
-	p3, store3 := newIngestTestPlatform(infos, nil)
+	h3, store3 := newIngestTestHandle(infos, nil)
 	store3.listErr = assert.AnError
-	p3.ingestStaticPrompts(context.Background())
+	h3.ingestStaticPrompts(context.Background())
 	if got, _ := store3.Get(context.Background(), "p1"); got == nil {
 		t.Error("p1 should be created even when the prune list fails")
 	}
 
 	// Prune delete failure: ingest logs and continues.
-	p4, store4 := newIngestTestPlatform(infos, nil)
+	h4, store4 := newIngestTestHandle(infos, nil)
 	store4.prompts["stale"] = &prompt.Prompt{
 		ID: "x", Name: "stale", Scope: prompt.ScopeGlobal, Source: prompt.SourceSystem,
 	}
 	store4.deleteErr = assert.AnError
-	p4.ingestStaticPrompts(context.Background())
+	h4.ingestStaticPrompts(context.Background())
 }
 
 func TestHandlePromptUpdate_SystemRowReadOnly(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["sys-prompt"] = &prompt.Prompt{
 		ID: "s1", Name: "sys-prompt", Scope: prompt.ScopeGlobal,
 		Source: prompt.SourceSystem, Status: prompt.StatusApproved, Enabled: true,
 	}
-	r, _, _ := p.handlePromptUpdate(adminCtx(), managePromptInput{Name: "sys-prompt", Description: "hacked"})
+	r, _, _ := h.handlePromptUpdate(adminCtx(), managePromptInput{Name: "sys-prompt", Description: "hacked"})
 	assert.True(t, r.IsError)
 	assert.Contains(t, resultText(r), "read-only")
 	assert.Equal(t, "", store.prompts["sys-prompt"].Description, "system row must be unchanged")
 }
 
 func TestHandlePromptDelete_SystemRowReadOnly(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["sys-prompt"] = &prompt.Prompt{
 		ID: "s1", Name: "sys-prompt", Scope: prompt.ScopeGlobal, Source: prompt.SourceSystem,
 	}
-	r, _, _ := p.handlePromptDelete(adminCtx(), managePromptInput{Name: "sys-prompt"})
+	r, _, _ := h.handlePromptDelete(adminCtx(), managePromptInput{Name: "sys-prompt"})
 	assert.True(t, r.IsError)
 	assert.Contains(t, resultText(r), "read-only")
 	assert.Contains(t, store.prompts, "sys-prompt", "system row must not be deleted")

--- a/pkg/platform/promptlayer/lifecycle_test.go
+++ b/pkg/platform/promptlayer/lifecycle_test.go
@@ -1,4 +1,4 @@
-package platform
+package promptlayer
 
 import (
 	"testing"

--- a/pkg/platform/promptlayer/promptlayer.go
+++ b/pkg/platform/promptlayer/promptlayer.go
@@ -1,0 +1,207 @@
+// Package promptlayer assembles the prompt subsystem behind one Handle: the
+// Postgres-backed prompt store, the file-based tuning prompt manager, the
+// name-keyed prompt-metadata registry (promptInfos), and every behavior that
+// registers, serves, and manages prompts — the static/workflow/database
+// registration path, the per-viewer dynamic-serving path behind the
+// prompts/list visibility middleware, and the manage_prompt tool.
+//
+// Construction takes explicit inputs — an optional *sql.DB (nil leaves the store
+// nil; static and workflow prompts still register), the resolved prompts
+// directory, the server name/description, the admin persona, the operator prompt
+// specs, the built-in-prompt disable map, and the toolkit registry — so the
+// subsystem is constructible and testable without a caller assembling it. It
+// imports pkg/prompt, pkg/tuning, pkg/registry, pkg/embedding, pkg/middleware,
+// pkg/portal, and the MCP SDK, never the platform package.
+//
+// The MCP server is NOT captured at construction: the store and metadata must
+// exist early (other subsystems read the store before the server is created),
+// but the AddPrompt/AddTool registration happens later, so RegisterPlatformPrompts
+// and RegisterTool take the *mcp.Server per call. Two collaborators are bound
+// after construction because they are assembled later than the prompt store: the
+// embedding provider (SetEmbedder — powers manage_prompt semantic ranking; nil
+// falls back to lexical) and the portal share lister (SetShareStore — resolves
+// prompts shared directly with a caller; nil serves no shared prompts). Both
+// serving paths nil-check their collaborator, so a Handle with neither set still
+// serves global/persona/personal prompts.
+package promptlayer
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/txn2/mcp-data-platform/pkg/embedding"
+	"github.com/txn2/mcp-data-platform/pkg/portal"
+	"github.com/txn2/mcp-data-platform/pkg/prompt"
+	promptpostgres "github.com/txn2/mcp-data-platform/pkg/prompt/postgres"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/tuning"
+)
+
+// logKeyError is the slog key for error values in log messages.
+const logKeyError = "error"
+
+// ToolkitRegistry is the read-only slice of the toolkit registry the prompt
+// layer needs: enabled-kind checks for capability bullets and workflow gating,
+// and the full toolkit list to collect prompt metadata from PromptDescriber
+// toolkits. The concrete *registry.Registry satisfies it.
+type ToolkitRegistry interface {
+	GetByKind(kind string) []registry.Toolkit
+	All() []registry.Toolkit
+}
+
+// ShareLister looks up the prompts shared directly with a caller. The portal
+// share store satisfies it; it is bound via SetShareStore once the portal layer
+// exists. A nil lister disables shared-prompt serving.
+type ShareLister interface {
+	ListSharedPromptsWithUser(ctx context.Context, userID, email string) ([]portal.SharedPromptRef, error)
+}
+
+// Config carries the resolved values the owner needs to assemble the prompt
+// layer. The caller translates its own config into this shape so this package
+// stays free of the platform's config types.
+type Config struct {
+	// DB backs the prompt store; nil leaves the store nil (static and workflow
+	// prompts still register, but database prompts and manage_prompt are off).
+	// Ignored when Store is set.
+	DB *sql.DB
+	// Store, when non-nil, is used as the prompt store directly instead of
+	// building a Postgres store from DB. Lets a caller (or a test) supply an
+	// already-assembled store; production passes DB and leaves this nil.
+	Store prompt.Store
+	// PromptsDir is the directory the tuning prompt manager loads file prompts
+	// from (empty is valid: the manager loads nothing).
+	PromptsDir string
+	// ServerName / ServerDescription title and seed the auto-generated
+	// platform-overview prompt (an empty description skips it).
+	ServerName        string
+	ServerDescription string
+	// AdminPersona is the persona name that grants admin authority over prompts
+	// at every scope; matched against the caller's persona in each command.
+	AdminPersona string
+	// OperatorPrompts are the operator-configured static prompts to register.
+	OperatorPrompts []PromptSpec
+	// BuiltinPrompts disables named built-in workflow prompts (name → enabled);
+	// a name mapped to false is skipped. Nil enables every built-in.
+	BuiltinPrompts map[string]bool
+	// Registry is the toolkit registry read for capability bullets, workflow
+	// gating, and toolkit prompt metadata.
+	Registry ToolkitRegistry
+}
+
+// Handle owns the assembled prompt layer: the prompt store, the tuning prompt
+// manager, and the name-keyed prompt-metadata list, plus the registration,
+// dynamic-serving, and manage_prompt behaviors. Store exposes the backing store
+// the caller surfaces and hands to the search federation; RegisterPlatformPrompts
+// and RegisterTool take the *mcp.Server per call; ListVisible / GetByName are the
+// prompts/list visibility callbacks the caller wires into the middleware chain;
+// AllPromptInfos / RegisterRuntimePrompt / UnregisterRuntimePrompt back the admin
+// and portal prompt REST handlers. All accessors are nil-safe.
+type Handle struct {
+	store         prompt.Store
+	promptManager *tuning.PromptManager
+	registry      ToolkitRegistry
+
+	serverName        string
+	serverDescription string
+	adminPersona      string
+	operatorPrompts   []PromptSpec
+	builtinPrompts    map[string]bool
+
+	// Bound after construction (assembled later than the prompt store).
+	embedder   embedding.Provider
+	shareStore ShareLister
+
+	promptInfosMu sync.RWMutex
+	promptInfos   []registry.PromptInfo
+}
+
+// New assembles the prompt layer. It always returns a non-nil Handle: prompts
+// are a first-class feature even without a database (static and workflow prompts
+// register and serve), so a no-DB deployment gets a Handle with a nil store and
+// every store-backed path (database prompts, manage_prompt, search) degrades to
+// a no-op. The tuning prompt manager is built here from the configured prompts
+// directory; the caller starts it with LoadPrompts.
+func New(cfg Config) *Handle {
+	h := &Handle{
+		promptManager:     tuning.NewPromptManager(tuning.PromptConfig{PromptsDir: cfg.PromptsDir}),
+		registry:          cfg.Registry,
+		serverName:        cfg.ServerName,
+		serverDescription: cfg.ServerDescription,
+		adminPersona:      cfg.AdminPersona,
+		operatorPrompts:   cfg.OperatorPrompts,
+		builtinPrompts:    cfg.BuiltinPrompts,
+	}
+	switch {
+	case cfg.Store != nil:
+		h.store = cfg.Store
+	case cfg.DB != nil:
+		h.store = promptpostgres.New(cfg.DB)
+		slog.Info("prompt store: postgres")
+	}
+	return h
+}
+
+// SetEmbedder binds the embedding provider that powers manage_prompt semantic
+// ranking. Called once the provider is assembled; a nil provider (or never
+// calling this) leaves ranking on the lexical fallback.
+func (h *Handle) SetEmbedder(e embedding.Provider) {
+	h.embedder = e
+}
+
+// SetShareStore binds the portal share lister used to resolve prompts shared
+// directly with a caller. Called once the portal layer exists; a nil lister (or
+// never calling this) serves no shared prompts.
+func (h *Handle) SetShareStore(s ShareLister) {
+	h.shareStore = s
+}
+
+// Store returns the backing prompt store, or nil on a nil Handle or a no-DB
+// deployment. The caller surfaces it and hands it to the search federation.
+func (h *Handle) Store() prompt.Store {
+	if h == nil {
+		return nil
+	}
+	return h.store
+}
+
+// LoadPrompts loads the file-based tuning prompts from the configured directory.
+// Called once at startup.
+func (h *Handle) LoadPrompts() error {
+	if err := h.promptManager.LoadPrompts(); err != nil {
+		return fmt.Errorf("promptlayer: loading file prompts: %w", err)
+	}
+	return nil
+}
+
+// PromptCreatorAdapter adapts the Handle to the knowledge toolkit's PromptCreator
+// interface (Create + RegisterRuntimePrompt) for the add_prompt change type,
+// without this package importing the knowledge toolkit.
+type PromptCreatorAdapter struct {
+	h *Handle
+}
+
+// PromptCreator returns an adapter satisfying the knowledge toolkit's
+// PromptCreator interface over this handle, or nil on a no-DB deployment (no
+// store to create into).
+func (h *Handle) PromptCreator() *PromptCreatorAdapter {
+	if h == nil || h.store == nil {
+		return nil
+	}
+	return &PromptCreatorAdapter{h: h}
+}
+
+// Create persists a new prompt through the backing store.
+func (c *PromptCreatorAdapter) Create(ctx context.Context, p *prompt.Prompt) error {
+	if err := c.h.store.Create(ctx, p); err != nil {
+		return fmt.Errorf("prompt store create: %w", err)
+	}
+	return nil
+}
+
+// RegisterRuntimePrompt records the prompt's metadata for admin listing.
+func (c *PromptCreatorAdapter) RegisterRuntimePrompt(p *prompt.Prompt) {
+	c.h.RegisterRuntimePrompt(p)
+}

--- a/pkg/platform/promptlayer/promptlayer_test.go
+++ b/pkg/platform/promptlayer/promptlayer_test.go
@@ -1,0 +1,204 @@
+package promptlayer
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/portal"
+	"github.com/txn2/mcp-data-platform/pkg/prompt"
+	"github.com/txn2/mcp-data-platform/pkg/query"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/semantic"
+)
+
+// --- mock prompt store ---
+
+type mockPromptStore struct {
+	prompts   map[string]*prompt.Prompt
+	createErr error
+	getErr    error
+	updateErr error
+	deleteErr error
+	listErr   error
+}
+
+func newMockPromptStore() *mockPromptStore {
+	return &mockPromptStore{prompts: make(map[string]*prompt.Prompt)}
+}
+
+func (m *mockPromptStore) Create(_ context.Context, p *prompt.Prompt) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	p.ID = "gen-" + p.Name
+	m.prompts[p.Name] = p
+	return nil
+}
+
+func (m *mockPromptStore) Get(_ context.Context, name string) (*prompt.Prompt, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	p := m.prompts[name]
+	return p, nil //nolint:nilnil // interface contract
+}
+
+func (m *mockPromptStore) GetPersonal(_ context.Context, ownerEmail, name string) (*prompt.Prompt, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	for _, p := range m.prompts {
+		if p.Scope == prompt.ScopePersonal && p.OwnerEmail == ownerEmail && p.Name == name {
+			return p, nil
+		}
+	}
+	return nil, nil //nolint:nilnil // interface contract
+}
+
+func (m *mockPromptStore) GetByID(_ context.Context, id string) (*prompt.Prompt, error) {
+	for _, p := range m.prompts {
+		if p.ID == id {
+			return p, nil
+		}
+	}
+	return nil, nil //nolint:nilnil // interface contract
+}
+
+func (m *mockPromptStore) Update(_ context.Context, p *prompt.Prompt) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.prompts[p.Name] = p
+	return nil
+}
+
+func (m *mockPromptStore) Delete(_ context.Context, name string) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	delete(m.prompts, name)
+	return nil
+}
+
+func (m *mockPromptStore) DeleteByID(_ context.Context, id string) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	for name, p := range m.prompts {
+		if p.ID == id {
+			delete(m.prompts, name)
+			return nil
+		}
+	}
+	return nil
+}
+
+func (m *mockPromptStore) List(_ context.Context, f prompt.ListFilter) ([]prompt.Prompt, error) { //nolint:revive // interface impl
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	var result []prompt.Prompt
+	for _, p := range m.prompts {
+		if f.Scope != "" && p.Scope != f.Scope {
+			continue
+		}
+		if f.OwnerEmail != "" && p.OwnerEmail != f.OwnerEmail {
+			continue
+		}
+		if f.Source != "" && p.Source != f.Source {
+			continue
+		}
+		if f.ExcludeSource != "" && p.Source == f.ExcludeSource {
+			continue
+		}
+		result = append(result, *p)
+	}
+	return result, nil
+}
+
+func (m *mockPromptStore) Count(_ context.Context, _ prompt.ListFilter) (int, error) {
+	return len(m.prompts), nil
+}
+
+var _ prompt.Store = (*mockPromptStore)(nil)
+
+// --- mock toolkit ---
+
+type mockToolkit struct {
+	kind string
+	name string
+}
+
+func (m *mockToolkit) Kind() string                          { return m.kind }
+func (m *mockToolkit) Name() string                          { return m.name }
+func (*mockToolkit) Connection() string                      { return "" }
+func (*mockToolkit) RegisterTools(_ *mcp.Server)             {}
+func (*mockToolkit) Tools() []string                         { return nil }
+func (*mockToolkit) SetSemanticProvider(_ semantic.Provider) {}
+func (*mockToolkit) SetQueryProvider(_ query.Provider)       {}
+func (*mockToolkit) Close() error                            { return nil }
+
+// mockToolkitWithPrompts adds PromptDescriber to mockToolkit.
+type mockToolkitWithPrompts struct {
+	mockToolkit
+	prompts []registry.PromptInfo
+}
+
+func (m *mockToolkitWithPrompts) PromptInfos() []registry.PromptInfo {
+	return m.prompts
+}
+
+// --- stub share lister ---
+
+type stubShareLister struct {
+	promptRefs []portal.SharedPromptRef
+	err        error
+}
+
+func (s *stubShareLister) ListSharedPromptsWithUser(_ context.Context, _, _ string) ([]portal.SharedPromptRef, error) {
+	return s.promptRefs, s.err
+}
+
+var _ ShareLister = (*stubShareLister)(nil)
+
+// --- context + handle helpers ---
+
+// newTestHandle builds a Handle backed by an in-memory prompt store with the
+// admin persona set to "admin". The registry is empty; tests that exercise the
+// registration path set their own.
+func newTestHandle() (*Handle, *mockPromptStore) {
+	store := newMockPromptStore()
+	h := &Handle{
+		store:        store,
+		adminPersona: "admin",
+		registry:     registry.NewRegistry(),
+	}
+	return h, store
+}
+
+func adminCtx() context.Context {
+	pc := middleware.NewPlatformContext("")
+	pc.PersonaName = "admin"
+	pc.UserEmail = "admin@example.com"
+	return middleware.WithPlatformContext(context.Background(), pc)
+}
+
+func userCtx(email, persona string) context.Context {
+	pc := middleware.NewPlatformContext("")
+	pc.PersonaName = persona
+	pc.UserEmail = email
+	return middleware.WithPlatformContext(context.Background(), pc)
+}
+
+func resultText(r *mcp.CallToolResult) string {
+	if r == nil || len(r.Content) == 0 {
+		return ""
+	}
+	tc, ok := r.Content[0].(*mcp.TextContent)
+	if !ok {
+		return ""
+	}
+	return tc.Text
+}

--- a/pkg/platform/promptlayer/register.go
+++ b/pkg/platform/promptlayer/register.go
@@ -1,5 +1,4 @@
-// Package platform provides the main platform orchestration.
-package platform
+package promptlayer
 
 import (
 	"context"
@@ -23,8 +22,6 @@ const (
 	kindPortal     = "portal"
 	kindKnowledge  = "knowledge"
 	kindMemory     = "memory"
-	kindMCP        = "mcp"
-	kindAPI        = "api"
 	// promptArgTopic is the argument name shared across workflow prompts
 	// that take a free-form subject ("explore", "create-dashboard", etc.).
 	promptArgTopic = "topic"
@@ -33,45 +30,67 @@ const (
 	promptRoleUser = "user"
 )
 
-// registerPlatformPrompts registers platform-level prompts from config.
-// It first registers the auto-generated platform overview prompt (if applicable),
-// then registers operator-configured prompts, then workflow prompts,
-// then database-stored prompts.
-func (p *Platform) registerPlatformPrompts() {
-	p.registerAutoPrompt()
-	for _, promptCfg := range p.config.Server.Prompts {
-		p.registerPromptWithCategory(promptCfg, "custom")
+// PromptArgSpec is one argument of an operator- or workflow-defined prompt in
+// the caller-neutral shape this package registers from. The caller translates
+// its own config type into this.
+type PromptArgSpec struct {
+	Name        string
+	Description string
+	Required    bool
+}
+
+// PromptSpec is an operator- or workflow-defined prompt in the caller-neutral
+// shape this package registers from, decoupling the layer from the caller's
+// config types and defaulting rules.
+type PromptSpec struct {
+	Name        string
+	Description string
+	Content     string
+	Arguments   []PromptArgSpec
+}
+
+// RegisterPlatformPrompts registers platform-level prompts with the given MCP
+// server. It first registers the auto-generated platform overview prompt (if
+// applicable), then operator-configured prompts, then workflow prompts, then
+// database-stored prompts. No-op on a nil Handle.
+func (h *Handle) RegisterPlatformPrompts(server *mcp.Server) {
+	if h == nil {
+		return
 	}
-	p.registerWorkflowPrompts()
+	h.registerAutoPrompt(server)
+	for _, spec := range h.operatorPrompts {
+		h.registerPromptWithCategory(server, spec, "custom")
+	}
+	h.registerWorkflowPrompts(server)
 	// Mirror the static prompts registered above into the store (as read-only
 	// system rows) so they are embedded and searchable (#593). Must run before
 	// registerDatabasePrompts so database prompts are not added to promptInfos
 	// and re-ingested as system rows.
-	p.ingestStaticPrompts(context.Background())
-	p.registerDatabasePrompts()
+	h.ingestStaticPrompts(context.Background())
+	h.registerDatabasePrompts()
 }
 
 // registerAutoPrompt registers the auto-generated "platform-overview" prompt when
-// server.description is non-empty. It is skipped if an operator-configured prompt
-// already uses the name "platform-overview".
+// the server description is non-empty. It is skipped if an operator-configured
+// prompt already uses the name "platform-overview".
 //
 // The content is built dynamically based on enabled toolkits, listing what the
 // user can do with this platform.
-func (p *Platform) registerAutoPrompt() {
-	if p.config.Server.Description == "" {
+func (h *Handle) registerAutoPrompt(server *mcp.Server) {
+	if h.serverDescription == "" {
 		return
 	}
 
 	// Skip if operator has already defined a prompt with this name.
-	if p.isOperatorPrompt(autoPromptName) {
+	if h.isOperatorPrompt(autoPromptName) {
 		return
 	}
 
-	content := p.buildDynamicOverviewContent()
+	content := h.buildDynamicOverviewContent()
 
-	p.mcpServer.AddPrompt(&mcp.Prompt{
+	server.AddPrompt(&mcp.Prompt{
 		Name:        autoPromptName,
-		Title:       p.config.Server.Name,
+		Title:       h.serverName,
 		Description: "Overview of this data platform — what it covers and how to use it",
 	}, func(_ context.Context, _ *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 		return buildPromptResult(content), nil
@@ -83,12 +102,12 @@ func (p *Platform) registerAutoPrompt() {
 
 // buildDynamicOverviewContent builds the platform overview content dynamically
 // based on the server description and enabled toolkits.
-func (p *Platform) buildDynamicOverviewContent() string {
+func (h *Handle) buildDynamicOverviewContent() string {
 	var b strings.Builder
-	b.WriteString(p.config.Server.Description)
+	b.WriteString(h.serverDescription)
 	b.WriteString("\n\n")
 
-	capabilities := p.collectCapabilityBullets()
+	capabilities := h.collectCapabilityBullets()
 	if len(capabilities) > 0 {
 		b.WriteString("With this platform you can:\n")
 		for _, bullet := range capabilities {
@@ -127,14 +146,14 @@ func capabilityTable() []capabilityEntry {
 
 // collectCapabilityBullets returns human-readable capability descriptions
 // based on which toolkits are enabled.
-func (p *Platform) collectCapabilityBullets() []string {
+func (h *Handle) collectCapabilityBullets() []string {
 	has := map[string]bool{
-		kindDataHub:   len(p.toolkitRegistry.GetByKind(kindDataHub)) > 0,
-		kindTrino:     len(p.toolkitRegistry.GetByKind(kindTrino)) > 0,
-		kindS3:        len(p.toolkitRegistry.GetByKind(kindS3)) > 0,
-		kindPortal:    len(p.toolkitRegistry.GetByKind(kindPortal)) > 0,
-		kindKnowledge: len(p.toolkitRegistry.GetByKind(kindKnowledge)) > 0,
-		kindMemory:    len(p.toolkitRegistry.GetByKind(kindMemory)) > 0,
+		kindDataHub:   len(h.registry.GetByKind(kindDataHub)) > 0,
+		kindTrino:     len(h.registry.GetByKind(kindTrino)) > 0,
+		kindS3:        len(h.registry.GetByKind(kindS3)) > 0,
+		kindPortal:    len(h.registry.GetByKind(kindPortal)) > 0,
+		kindKnowledge: len(h.registry.GetByKind(kindKnowledge)) > 0,
+		kindMemory:    len(h.registry.GetByKind(kindMemory)) > 0,
 	}
 
 	var caps []string
@@ -149,12 +168,12 @@ func (p *Platform) collectCapabilityBullets() []string {
 // registerPromptWithCategory registers a single prompt with the MCP server,
 // supporting argument substitution in content. The category is stored in
 // prompt metadata for frontend grouping (e.g., "workflow", "custom", "toolkit").
-func (p *Platform) registerPromptWithCategory(cfg PromptConfig, category string) {
-	promptContent := cfg.Content
+func (h *Handle) registerPromptWithCategory(server *mcp.Server, spec PromptSpec, category string) {
+	promptContent := spec.Content
 
 	// Build MCP prompt arguments
-	mcpArgs := make([]*mcp.PromptArgument, 0, len(cfg.Arguments))
-	for _, arg := range cfg.Arguments {
+	mcpArgs := make([]*mcp.PromptArgument, 0, len(spec.Arguments))
+	for _, arg := range spec.Arguments {
 		mcpArgs = append(mcpArgs, &mcp.PromptArgument{
 			Name:        arg.Name,
 			Description: arg.Description,
@@ -162,9 +181,9 @@ func (p *Platform) registerPromptWithCategory(cfg PromptConfig, category string)
 		})
 	}
 
-	p.mcpServer.AddPrompt(&mcp.Prompt{
-		Name:        cfg.Name,
-		Description: cfg.Description,
+	server.AddPrompt(&mcp.Prompt{
+		Name:        spec.Name,
+		Description: spec.Description,
 		Arguments:   mcpArgs,
 	}, func(_ context.Context, req *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 		resolved := substituteArgs(promptContent, req.Params.Arguments)
@@ -173,29 +192,27 @@ func (p *Platform) registerPromptWithCategory(cfg PromptConfig, category string)
 
 	// Collect metadata
 	info := registry.PromptInfo{
-		Name:        cfg.Name,
-		Description: cfg.Description,
+		Name:        spec.Name,
+		Description: spec.Description,
 		Category:    category,
-		Content:     cfg.Content,
+		Content:     spec.Content,
 	}
-	for _, arg := range cfg.Arguments {
+	for _, arg := range spec.Arguments {
 		info.Arguments = append(info.Arguments, registry.PromptArgumentInfo{
 			Name:        arg.Name,
 			Description: arg.Description,
 			Required:    arg.Required,
 		})
 	}
-	p.promptInfosMu.Lock()
-	p.promptInfos = append(p.promptInfos, info)
-	p.promptInfosMu.Unlock()
+	h.promptInfosMu.Lock()
+	h.promptInfos = append(h.promptInfos, info)
+	h.promptInfosMu.Unlock()
 }
 
-// substituteArgs replaces {arg_name} placeholders in content with values from
-// the arguments map. Unresolved placeholders are left as-is. Keys are sorted
-// to ensure deterministic output when values contain other argument placeholders.
 // substituteArgs replaces both {name} and {{name}} placeholders with values
 // from args. Double-brace is processed first so that a {{name}} placeholder
-// is not accidentally consumed by a {name} replacement of a substring.
+// is not accidentally consumed by a {name} replacement of a substring. Keys are
+// sorted so output is deterministic when values contain other placeholders.
 func substituteArgs(content string, args map[string]string) string {
 	if len(args) == 0 {
 		return content
@@ -216,20 +233,19 @@ func substituteArgs(content string, args map[string]string) string {
 
 // workflowPrompt defines a platform-level workflow prompt with its required toolkits.
 type workflowPrompt struct {
-	config        PromptConfig
+	spec          PromptSpec
 	requiredKinds []string
 }
 
 // promptExploreAvailableData is the canonical name of the data-exploration
-// workflow prompt. Used by the prompt registration code and referenced by
-// the disable-prompt allowlist in tests.
+// workflow prompt.
 const promptExploreAvailableData = "explore-available-data"
 
 // workflowPrompts returns the set of platform-level workflow prompts.
 func workflowPrompts() []workflowPrompt {
 	return []workflowPrompt{
 		{
-			config: PromptConfig{
+			spec: PromptSpec{
 				Name:        promptExploreAvailableData,
 				Description: "Discover what data is available about a topic",
 				Content: `Explore what data is available about {topic}.
@@ -238,14 +254,14 @@ func workflowPrompts() []workflowPrompt {
 2. Present relevant datasets with descriptions, ownership, and quality scores
 3. Highlight data products that group related datasets
 4. Note any data quality concerns or deprecation warnings`,
-				Arguments: []PromptArgumentConfig{
+				Arguments: []PromptArgSpec{
 					{Name: promptArgTopic, Description: "What topic or subject area?", Required: true},
 				},
 			},
 			requiredKinds: []string{kindDataHub},
 		},
 		{
-			config: PromptConfig{
+			spec: PromptSpec{
 				Name:        "create-interactive-dashboard",
 				Description: "Discover data, build a visualization, and save it as a shareable asset",
 				Content: `Create an interactive dashboard about {topic}.
@@ -254,14 +270,14 @@ func workflowPrompts() []workflowPrompt {
 2. Query the most relevant datasets
 3. Build an interactive visualization with key metrics and trends
 4. Save it as an artifact I can view and share`,
-				Arguments: []PromptArgumentConfig{
+				Arguments: []PromptArgSpec{
 					{Name: promptArgTopic, Description: "What should the dashboard visualize?", Required: true},
 				},
 			},
 			requiredKinds: []string{kindDataHub, kindTrino, kindPortal},
 		},
 		{
-			config: PromptConfig{
+			spec: PromptSpec{
 				Name:        "create-a-report",
 				Description: "Analyze data and produce a structured Markdown report",
 				Content: `Generate a comprehensive report about {topic}.
@@ -270,14 +286,14 @@ func workflowPrompts() []workflowPrompt {
 2. Query and analyze the data for key findings
 3. Produce a well-structured Markdown report with tables, metrics, and insights
 4. Summarize the key takeaways`,
-				Arguments: []PromptArgumentConfig{
+				Arguments: []PromptArgSpec{
 					{Name: promptArgTopic, Description: "What should the report cover?", Required: true},
 				},
 			},
 			requiredKinds: []string{kindDataHub, kindTrino},
 		},
 		{
-			config: PromptConfig{
+			spec: PromptSpec{
 				Name:        "trace-data-lineage",
 				Description: "Trace where data comes from and what depends on it",
 				Content: `Trace the data lineage for {dataset}.
@@ -286,7 +302,7 @@ func workflowPrompts() []workflowPrompt {
 2. Map the downstream consumers that depend on it
 3. Show column-level lineage where available
 4. Highlight any transformation steps in the pipeline`,
-				Arguments: []PromptArgumentConfig{
+				Arguments: []PromptArgSpec{
 					{Name: "dataset", Description: "Which dataset or column to trace?", Required: true},
 				},
 			},
@@ -298,43 +314,42 @@ func workflowPrompts() []workflowPrompt {
 // registerWorkflowPrompts registers platform-level workflow prompts
 // conditional on the required toolkits being available.
 // Skips any prompt whose name matches an operator-configured prompt or that
-// has been explicitly disabled via server.builtin_prompts config.
-func (p *Platform) registerWorkflowPrompts() {
+// has been explicitly disabled via the built-in-prompt disable map.
+func (h *Handle) registerWorkflowPrompts(server *mcp.Server) {
 	for _, wp := range workflowPrompts() {
 		// Skip if explicitly disabled in config
-		if p.isBuiltinDisabled(wp.config.Name) {
+		if h.isBuiltinDisabled(wp.spec.Name) {
 			continue
 		}
 
 		// Skip if operator already defined this prompt
-		if p.isOperatorPrompt(wp.config.Name) {
+		if h.isOperatorPrompt(wp.spec.Name) {
 			continue
 		}
 
 		// Check all required toolkit kinds are present
-		if !p.hasAllToolkitKinds(wp.requiredKinds) {
+		if !h.hasAllToolkitKinds(wp.requiredKinds) {
 			continue
 		}
 
-		p.registerPromptWithCategory(wp.config, "workflow")
+		h.registerPromptWithCategory(server, wp.spec, "workflow")
 	}
 }
 
-// isBuiltinDisabled checks if a built-in prompt has been explicitly disabled
-// via server.builtin_prompts config. If the map is nil or the key is absent,
-// the prompt is enabled by default.
-func (p *Platform) isBuiltinDisabled(name string) bool {
-	if p.config.Server.BuiltinPrompts == nil {
+// isBuiltinDisabled checks if a built-in prompt has been explicitly disabled.
+// If the map is nil or the key is absent, the prompt is enabled by default.
+func (h *Handle) isBuiltinDisabled(name string) bool {
+	if h.builtinPrompts == nil {
 		return false
 	}
-	enabled, exists := p.config.Server.BuiltinPrompts[name]
+	enabled, exists := h.builtinPrompts[name]
 	return exists && !enabled
 }
 
 // isOperatorPrompt checks if a prompt name is already defined in operator config.
-func (p *Platform) isOperatorPrompt(name string) bool {
-	for _, cfg := range p.config.Server.Prompts {
-		if cfg.Name == name {
+func (h *Handle) isOperatorPrompt(name string) bool {
+	for _, spec := range h.operatorPrompts {
+		if spec.Name == name {
 			return true
 		}
 	}
@@ -342,9 +357,9 @@ func (p *Platform) isOperatorPrompt(name string) bool {
 }
 
 // hasAllToolkitKinds checks that every kind in the list has at least one registered toolkit.
-func (p *Platform) hasAllToolkitKinds(kinds []string) bool {
+func (h *Handle) hasAllToolkitKinds(kinds []string) bool {
 	for _, kind := range kinds {
-		if len(p.toolkitRegistry.GetByKind(kind)) == 0 {
+		if len(h.registry.GetByKind(kind)) == 0 {
 			return false
 		}
 	}
@@ -352,9 +367,9 @@ func (p *Platform) hasAllToolkitKinds(kinds []string) bool {
 }
 
 // collectToolkitPromptInfos gathers prompt metadata from toolkits that implement PromptDescriber.
-func (p *Platform) collectToolkitPromptInfos() []registry.PromptInfo {
+func (h *Handle) collectToolkitPromptInfos() []registry.PromptInfo {
 	var infos []registry.PromptInfo
-	for _, tk := range p.toolkitRegistry.All() {
+	for _, tk := range h.registry.All() {
 		if pd, ok := tk.(registry.PromptDescriber); ok {
 			infos = append(infos, pd.PromptInfos()...)
 		}
@@ -362,27 +377,31 @@ func (p *Platform) collectToolkitPromptInfos() []registry.PromptInfo {
 	return infos
 }
 
-// AllPromptInfos returns all prompt metadata (platform + toolkit).
-// Exported for the admin API to surface system prompts.
-func (p *Platform) AllPromptInfos() []registry.PromptInfo {
-	tkInfos := p.collectToolkitPromptInfos()
-	p.promptInfosMu.RLock()
-	all := make([]registry.PromptInfo, 0, len(p.promptInfos)+len(tkInfos))
-	all = append(all, p.promptInfos...)
-	p.promptInfosMu.RUnlock()
+// AllPromptInfos returns all prompt metadata (platform + toolkit), or nil on a
+// nil Handle. Read by the admin and portal prompt REST handlers to surface
+// system prompts.
+func (h *Handle) AllPromptInfos() []registry.PromptInfo {
+	if h == nil {
+		return nil
+	}
+	tkInfos := h.collectToolkitPromptInfos()
+	h.promptInfosMu.RLock()
+	all := make([]registry.PromptInfo, 0, len(h.promptInfos)+len(tkInfos))
+	all = append(all, h.promptInfos...)
+	h.promptInfosMu.RUnlock()
 	all = append(all, tkInfos...)
 	return all
 }
 
 // registerDatabasePrompts loads enabled prompts from the database and registers
-// them with the MCP server. Called during startup after the prompt store is initialized.
-func (p *Platform) registerDatabasePrompts() {
-	if p.promptStore == nil {
+// their metadata. Called during startup after the prompt store is initialized.
+func (h *Handle) registerDatabasePrompts() {
+	if h.store == nil {
 		return
 	}
 
 	enabled := true
-	prompts, err := p.promptStore.List(context.Background(), prompt.ListFilter{Enabled: &enabled})
+	prompts, err := h.store.List(context.Background(), prompt.ListFilter{Enabled: &enabled})
 	if err != nil {
 		slog.Warn("failed to load prompts from database", logKeyError, err)
 		return
@@ -396,7 +415,7 @@ func (p *Platform) registerDatabasePrompts() {
 		if prompts[i].Source == prompt.SourceSystem {
 			continue
 		}
-		p.registerDatabasePrompt(&prompts[i])
+		h.registerDatabasePrompt(&prompts[i])
 		registered++
 	}
 	if registered > 0 {
@@ -418,7 +437,7 @@ func (p *Platform) registerDatabasePrompts() {
 // create colliding entries and expose one user's personal prompts in
 // platform-wide metadata (platform_info). They are still served per-caller from
 // the store. Only globally-unique scopes (global, persona) are tracked.
-func (p *Platform) registerDatabasePrompt(pr *prompt.Prompt) {
+func (h *Handle) registerDatabasePrompt(pr *prompt.Prompt) {
 	if pr.Scope == prompt.ScopePersonal {
 		return
 	}
@@ -435,9 +454,9 @@ func (p *Platform) registerDatabasePrompt(pr *prompt.Prompt) {
 			Required:    arg.Required,
 		})
 	}
-	p.promptInfosMu.Lock()
-	p.promptInfos = append(p.promptInfos, info)
-	p.promptInfosMu.Unlock()
+	h.promptInfosMu.Lock()
+	h.promptInfos = append(h.promptInfos, info)
+	h.promptInfosMu.Unlock()
 }
 
 // toMCPPromptArgs maps prompt arguments to their MCP descriptors.
@@ -473,20 +492,20 @@ func promptDescriptor(presentedName string, pr *prompt.Prompt) *mcp.Prompt {
 	}
 }
 
-// listVisiblePrompts returns the caller's visible database prompts as MCP
-// descriptors with their scope prefix: global-<name> for globals,
-// <persona>-<name> for each persona the caller belongs to, and personal-<name>
-// for the caller's own. A persona prompt shared with several personas appears
-// once per persona the caller is in.
-func (p *Platform) listVisiblePrompts(ctx context.Context, email string, personas []string) []*mcp.Prompt {
-	if p.promptStore == nil {
+// ListVisible returns the caller's visible database prompts as MCP descriptors
+// with their scope prefix: global-<name> for globals, <persona>-<name> for each
+// persona the caller belongs to, and personal-<name> for the caller's own. A
+// persona prompt shared with several personas appears once per persona the
+// caller is in. Wired as the prompts/list visibility callback.
+func (h *Handle) ListVisible(ctx context.Context, email string, personas []string) []*mcp.Prompt {
+	if h == nil || h.store == nil {
 		return nil
 	}
-	out := p.listScopedDescriptors(ctx, prompt.ListFilter{Scope: prompt.ScopeGlobal}, promptPrefixGlobal)
-	out = append(out, p.listPersonaDescriptors(ctx, personas)...)
+	out := h.listScopedDescriptors(ctx, prompt.ListFilter{Scope: prompt.ScopeGlobal}, promptPrefixGlobal)
+	out = append(out, h.listPersonaDescriptors(ctx, personas)...)
 	if email != "" {
-		out = append(out, p.listScopedDescriptors(ctx, prompt.ListFilter{Scope: prompt.ScopePersonal, OwnerEmail: email}, promptPrefixPersonal)...)
-		out = append(out, p.listSharedDescriptors(ctx, email)...)
+		out = append(out, h.listScopedDescriptors(ctx, prompt.ListFilter{Scope: prompt.ScopePersonal, OwnerEmail: email}, promptPrefixPersonal)...)
+		out = append(out, h.listSharedDescriptors(ctx, email)...)
 	}
 	return out
 }
@@ -495,13 +514,12 @@ func (p *Platform) listVisiblePrompts(ctx context.Context, email string, persona
 // another user), presenting each as shared-<name>. Shares are looked up via the
 // portal share store and the prompt bodies fetched from the prompt store. If two
 // shared prompts collide on bare name, the first (most recent share) wins so the
-// list and getDynamicPrompt agree.
-func (p *Platform) listSharedDescriptors(ctx context.Context, email string) []*mcp.Prompt {
-	share := p.portalStore.ShareStore()
-	if share == nil {
+// list and GetByName agree.
+func (h *Handle) listSharedDescriptors(ctx context.Context, email string) []*mcp.Prompt {
+	if h.shareStore == nil {
 		return nil
 	}
-	refs, err := share.ListSharedPromptsWithUser(ctx, "", email)
+	refs, err := h.shareStore.ListSharedPromptsWithUser(ctx, "", email)
 	if err != nil {
 		slog.Warn("failed to list shared prompts", logKeyError, err)
 		return nil
@@ -509,7 +527,7 @@ func (p *Platform) listSharedDescriptors(ctx context.Context, email string) []*m
 	var out []*mcp.Prompt
 	seen := make(map[string]bool, len(refs))
 	for _, ref := range refs {
-		pr, err := p.promptStore.GetByID(ctx, ref.PromptID)
+		pr, err := h.store.GetByID(ctx, ref.PromptID)
 		// Only personal prompts are served via the shared- alias. A prompt that
 		// was promoted to a shared scope after being shared is already served
 		// under its global-/persona- prefix; serving it again as shared- would
@@ -525,10 +543,10 @@ func (p *Platform) listSharedDescriptors(ctx context.Context, email string) []*m
 
 // listScopedDescriptors lists enabled prompts matching the filter and presents
 // each under a fixed scope prefix (for global and personal scopes).
-func (p *Platform) listScopedDescriptors(ctx context.Context, filter prompt.ListFilter, prefix string) []*mcp.Prompt {
+func (h *Handle) listScopedDescriptors(ctx context.Context, filter prompt.ListFilter, prefix string) []*mcp.Prompt {
 	enabled := true
 	filter.Enabled = &enabled
-	prompts, err := p.promptStore.List(ctx, filter)
+	prompts, err := h.store.List(ctx, filter)
 	if err != nil {
 		slog.Warn("failed to list prompts", logKeyError, err, "scope", filter.Scope)
 		return nil
@@ -548,12 +566,12 @@ func (p *Platform) listScopedDescriptors(ctx context.Context, filter prompt.List
 
 // listPersonaDescriptors lists the caller's persona prompts, presenting each
 // once per persona the caller belongs to (the prefix is the persona name).
-func (p *Platform) listPersonaDescriptors(ctx context.Context, personas []string) []*mcp.Prompt {
+func (h *Handle) listPersonaDescriptors(ctx context.Context, personas []string) []*mcp.Prompt {
 	if len(personas) == 0 {
 		return nil
 	}
 	enabled := true
-	personaPrompts, err := p.promptStore.List(ctx, prompt.ListFilter{
+	personaPrompts, err := h.store.List(ctx, prompt.ListFilter{
 		Scope: prompt.ScopePersona, Personas: personas, Enabled: &enabled,
 	})
 	if err != nil {
@@ -571,84 +589,83 @@ func (p *Platform) listPersonaDescriptors(ctx context.Context, personas []string
 	return out
 }
 
-// getDynamicPrompt resolves a prefixed prompt name to the caller's visible
-// database prompt and renders it for prompts/get. It strips the scope prefix to
-// the bare stored name: personal-/global- are reserved tokens; a persona prefix
-// must be one of the caller's personas, and the target prompt must actually be
-// shared with that persona. Returns (nil, false) when no such visible prompt
-// exists.
+// GetByName resolves a prefixed prompt name to the caller's visible database
+// prompt and renders it for prompts/get. It strips the scope prefix to the bare
+// stored name: personal-/global- are reserved tokens; a persona prefix must be
+// one of the caller's personas, and the target prompt must actually be shared
+// with that persona. Returns (nil, false) when no such visible prompt exists.
+// Wired as the prompts/get visibility callback.
 //
 // The reserved-prefix branches fall through to persona resolution on a miss:
 // persona names are operator-defined and may literally be "personal" or
 // "global", so a name like "global-report" must still resolve a persona prompt
 // when no global prompt by that bare name exists.
-func (p *Platform) getDynamicPrompt(ctx context.Context, email string, personas []string, name string, args map[string]string) (*mcp.GetPromptResult, bool) {
-	if p.promptStore == nil {
+func (h *Handle) GetByName(ctx context.Context, email string, personas []string, name string, args map[string]string) (*mcp.GetPromptResult, bool) {
+	if h == nil || h.store == nil {
 		return nil, false
 	}
 	if bare, ok := strings.CutPrefix(name, promptPrefixPersonal); ok {
-		if res, found := p.getOwnedPersonalPrompt(ctx, email, bare, args); found {
+		if res, found := h.getOwnedPersonalPrompt(ctx, email, bare, args); found {
 			return res, true
 		}
 	}
 	if bare, ok := strings.CutPrefix(name, promptPrefixGlobal); ok {
-		if res, found := p.getGlobalPrompt(ctx, bare, args); found {
+		if res, found := h.getGlobalPrompt(ctx, bare, args); found {
 			return res, true
 		}
 	}
 	if bare, ok := strings.CutPrefix(name, promptPrefixShared); ok {
-		if res, found := p.getSharedPrompt(ctx, email, bare, args); found {
+		if res, found := h.getSharedPrompt(ctx, email, bare, args); found {
 			return res, true
 		}
 	}
-	return p.getPersonaPrompt(ctx, personas, name, args)
+	return h.getPersonaPrompt(ctx, personas, name, args)
 }
 
 // getSharedPrompt renders a prompt shared directly with the caller, matched by
 // bare name. The first matching active share wins (consistent with the dedup in
 // listSharedDescriptors).
-func (p *Platform) getSharedPrompt(ctx context.Context, email, bare string, args map[string]string) (*mcp.GetPromptResult, bool) {
-	share := p.portalStore.ShareStore()
-	if email == "" || share == nil {
+func (h *Handle) getSharedPrompt(ctx context.Context, email, bare string, args map[string]string) (*mcp.GetPromptResult, bool) {
+	if email == "" || h.shareStore == nil {
 		return nil, false
 	}
-	refs, err := share.ListSharedPromptsWithUser(ctx, "", email)
+	refs, err := h.shareStore.ListSharedPromptsWithUser(ctx, "", email)
 	if err != nil {
 		return nil, false
 	}
 	for _, ref := range refs {
-		pr, err := p.promptStore.GetByID(ctx, ref.PromptID)
+		pr, err := h.store.GetByID(ctx, ref.PromptID)
 		if err != nil || pr == nil || !pr.Enabled || pr.Scope != prompt.ScopePersonal {
 			continue
 		}
 		if pr.Name == bare {
-			return p.renderPrompt(pr, args)
+			return renderPrompt(pr, args)
 		}
 	}
 	return nil, false
 }
 
 // getOwnedPersonalPrompt renders the caller's own personal prompt of the bare name.
-func (p *Platform) getOwnedPersonalPrompt(ctx context.Context, email, bare string, args map[string]string) (*mcp.GetPromptResult, bool) {
+func (h *Handle) getOwnedPersonalPrompt(ctx context.Context, email, bare string, args map[string]string) (*mcp.GetPromptResult, bool) {
 	if email == "" {
 		return nil, false
 	}
-	pr, err := p.promptStore.GetPersonal(ctx, email, bare)
+	pr, err := h.store.GetPersonal(ctx, email, bare)
 	if err != nil || pr == nil || !pr.Enabled {
 		return nil, false
 	}
-	return p.renderPrompt(pr, args)
+	return renderPrompt(pr, args)
 }
 
 // getGlobalPrompt renders the global prompt of the bare name.
-func (p *Platform) getGlobalPrompt(ctx context.Context, bare string, args map[string]string) (*mcp.GetPromptResult, bool) {
-	pr, err := p.promptStore.Get(ctx, bare)
+func (h *Handle) getGlobalPrompt(ctx context.Context, bare string, args map[string]string) (*mcp.GetPromptResult, bool) {
+	pr, err := h.store.Get(ctx, bare)
 	// System rows are ingested static prompts already served under their bare
 	// name via AddPrompt; do not also serve them under the global- prefix.
 	if err != nil || pr == nil || !pr.Enabled || pr.Scope != prompt.ScopeGlobal || pr.Source == prompt.SourceSystem {
 		return nil, false
 	}
-	return p.renderPrompt(pr, args)
+	return renderPrompt(pr, args)
 }
 
 // getPersonaPrompt resolves a <persona>-<name> prompt for a caller who belongs
@@ -657,7 +674,7 @@ func (p *Platform) getGlobalPrompt(ctx context.Context, bare string, args map[st
 // way (persona "data" + "engineer-x" vs persona "data-engineer" + "x"); personas
 // are tried longest-name-first so the most specific persona prefix wins
 // deterministically.
-func (p *Platform) getPersonaPrompt(ctx context.Context, personas []string, name string, args map[string]string) (*mcp.GetPromptResult, bool) {
+func (h *Handle) getPersonaPrompt(ctx context.Context, personas []string, name string, args map[string]string) (*mcp.GetPromptResult, bool) {
 	ordered := append([]string(nil), personas...)
 	slices.SortStableFunc(ordered, func(a, b string) int { return len(b) - len(a) })
 	for _, persona := range ordered {
@@ -665,9 +682,9 @@ func (p *Platform) getPersonaPrompt(ctx context.Context, personas []string, name
 		if !ok {
 			continue
 		}
-		if pr, err := p.promptStore.Get(ctx, bare); err == nil && pr != nil && pr.Enabled &&
+		if pr, err := h.store.Get(ctx, bare); err == nil && pr != nil && pr.Enabled &&
 			pr.Scope == prompt.ScopePersona && slices.Contains(pr.Personas, persona) {
-			return p.renderPrompt(pr, args)
+			return renderPrompt(pr, args)
 		}
 	}
 	return nil, false
@@ -676,31 +693,37 @@ func (p *Platform) getPersonaPrompt(ctx context.Context, personas []string, name
 // renderPrompt substitutes the request arguments into a prompt's content.
 // Shared by every serving path so personal and global/persona prompts render
 // identically.
-func (*Platform) renderPrompt(pr *prompt.Prompt, args map[string]string) (*mcp.GetPromptResult, bool) {
+func renderPrompt(pr *prompt.Prompt, args map[string]string) (*mcp.GetPromptResult, bool) {
 	return buildPromptResult(substituteArgs(pr.Content, args)), true
 }
 
-// RegisterRuntimePrompt registers a prompt with the live MCP server at runtime.
-// Called after create/update operations on the prompt store.
-func (p *Platform) RegisterRuntimePrompt(pr *prompt.Prompt) {
-	p.registerDatabasePrompt(pr)
+// RegisterRuntimePrompt records a prompt's metadata at runtime. Called after
+// create/update operations on the prompt store. No-op on a nil Handle.
+func (h *Handle) RegisterRuntimePrompt(pr *prompt.Prompt) {
+	if h == nil {
+		return
+	}
+	h.registerDatabasePrompt(pr)
 }
 
 // UnregisterRuntimePrompt removes a database prompt's tracked metadata. It does
-// NOT call mcpServer.RemovePrompts: database prompts are never placed in the
-// static MCP registry (see registerDatabasePrompt), so removing by bare name
-// there could only ever delete an unrelated built-in/operator/toolkit prompt of
-// the same name. Only the name-keyed metadata entry (global/persona scope) is
-// dropped.
-func (p *Platform) UnregisterRuntimePrompt(name string) {
-	p.promptInfosMu.Lock()
-	for i, info := range p.promptInfos {
+// NOT remove the prompt from the static MCP registry: database prompts are never
+// placed there (see registerDatabasePrompt), so removing by bare name could only
+// ever delete an unrelated built-in/operator/toolkit prompt of the same name.
+// Only the name-keyed metadata entry (global/persona scope) is dropped. No-op
+// on a nil Handle.
+func (h *Handle) UnregisterRuntimePrompt(name string) {
+	if h == nil {
+		return
+	}
+	h.promptInfosMu.Lock()
+	for i, info := range h.promptInfos {
 		if info.Name == name {
-			p.promptInfos = append(p.promptInfos[:i], p.promptInfos[i+1:]...)
+			h.promptInfos = append(h.promptInfos[:i], h.promptInfos[i+1:]...)
 			break
 		}
 	}
-	p.promptInfosMu.Unlock()
+	h.promptInfosMu.Unlock()
 }
 
 // buildPromptResult creates a GetPromptResult with the given content.

--- a/pkg/platform/promptlayer/register_test.go
+++ b/pkg/platform/promptlayer/register_test.go
@@ -1,4 +1,4 @@
-package platform
+package promptlayer
 
 import (
 	"context"
@@ -13,8 +13,23 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 )
 
-// connectTestClient connects an in-memory MCP client to a server and returns the session.
-// The caller must call cleanup() when done.
+// newRegisterHandle builds a Handle for the static/workflow registration path:
+// no store, the given toolkit registry, server name/description, and operator
+// prompt specs.
+func newRegisterHandle(serverName, serverDesc string, operator []PromptSpec, reg ToolkitRegistry) *Handle {
+	if reg == nil {
+		reg = registry.NewRegistry()
+	}
+	return &Handle{
+		registry:          reg,
+		serverName:        serverName,
+		serverDescription: serverDesc,
+		operatorPrompts:   operator,
+	}
+}
+
+// connectTestClient connects an in-memory MCP client to a server and returns the
+// session. The caller must call cleanup() when done.
 func connectTestClient(t *testing.T, server *mcp.Server) (session *mcp.ClientSession, cleanup func()) {
 	t.Helper()
 	ctx := context.Background()
@@ -113,100 +128,59 @@ func TestSubstituteArgs(t *testing.T) {
 
 func TestRegisterPlatformPrompts(t *testing.T) {
 	tests := []struct {
-		name        string
-		prompts     []PromptConfig
-		wantPrompts int
+		name         string
+		prompts      []PromptSpec
+		wantMetadata int
 	}{
-		{
-			name:        "no prompts configured",
-			prompts:     nil,
-			wantPrompts: 0,
-		},
-		{
-			name:        "empty prompts list",
-			prompts:     []PromptConfig{},
-			wantPrompts: 0,
-		},
+		{name: "no prompts configured", prompts: nil, wantMetadata: 0},
+		{name: "empty prompts list", prompts: []PromptSpec{}, wantMetadata: 0},
 		{
 			name: "single prompt",
-			prompts: []PromptConfig{
-				{
-					Name:        "routing_rules",
-					Description: "How to route queries between systems",
-					Content:     "Route queries based on data type.",
-				},
+			prompts: []PromptSpec{
+				{Name: "routing_rules", Description: "How to route queries between systems", Content: "Route queries based on data type."},
 			},
-			wantPrompts: 1,
+			wantMetadata: 1,
 		},
 		{
 			name: "multiple prompts",
-			prompts: []PromptConfig{
-				{
-					Name:        "routing_rules",
-					Description: "How to route queries",
-					Content:     "Route queries based on data type.",
-				},
-				{
-					Name:        "data_dictionary",
-					Description: "Key business terms",
-					Content:     "ARR: Annual Recurring Revenue",
-				},
+			prompts: []PromptSpec{
+				{Name: "routing_rules", Description: "How to route queries", Content: "Route queries based on data type."},
+				{Name: "data_dictionary", Description: "Key business terms", Content: "ARR: Annual Recurring Revenue"},
 			},
-			wantPrompts: 2,
+			wantMetadata: 2,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mcpServer := mcp.NewServer(&mcp.Implementation{
-				Name:    "test-server",
-				Version: "1.0.0",
-			}, nil)
+			mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+			h := newRegisterHandle("", "", tt.prompts, nil)
 
-			p := &Platform{
-				mcpServer:       mcpServer,
-				toolkitRegistry: registry.NewRegistry(),
-				config: &Config{
-					Server: ServerConfig{
-						Prompts: tt.prompts,
-					},
-				},
-			}
+			h.RegisterPlatformPrompts(mcpServer)
 
-			// Should not panic
-			p.registerPlatformPrompts()
-
-			assert.NotNil(t, p.mcpServer)
+			// With no toolkits registered, workflow prompts are gated out and
+			// database prompts need a store, so only the operator prompts land in
+			// the name-keyed metadata.
+			assert.Len(t, h.AllPromptInfos(), tt.wantMetadata)
 		})
 	}
 }
 
 func TestRegisterPromptWithArguments(t *testing.T) {
-	mcpServer := mcp.NewServer(&mcp.Implementation{
-		Name:    "test-server",
-		Version: "1.0.0",
-	}, nil)
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
 
-	p := &Platform{
-		mcpServer:       mcpServer,
-		toolkitRegistry: registry.NewRegistry(),
-		config: &Config{
-			Server: ServerConfig{
-				Prompts: []PromptConfig{
-					{
-						Name:        "explore-data",
-						Description: "Explore data about a topic",
-						Content:     "Explore {topic} and find insights.",
-						Arguments: []PromptArgumentConfig{
-							{Name: "topic", Description: "The topic to explore", Required: true},
-						},
-					},
-				},
+	h := newRegisterHandle("", "", []PromptSpec{
+		{
+			Name:        "explore-data",
+			Description: "Explore data about a topic",
+			Content:     "Explore {topic} and find insights.",
+			Arguments: []PromptArgSpec{
+				{Name: "topic", Description: "The topic to explore", Required: true},
 			},
 		},
-	}
+	}, nil)
 
-	p.registerPlatformPrompts()
+	h.RegisterPlatformPrompts(mcpServer)
 
 	session, cleanup := connectTestClient(t, mcpServer)
 	defer cleanup()
@@ -237,7 +211,7 @@ func TestRegisterAutoPrompt(t *testing.T) {
 		name            string
 		serverName      string
 		serverDesc      string
-		operatorPrompts []PromptConfig
+		operatorPrompts []PromptSpec
 		wantRegistered  bool
 		wantTitle       string
 	}{
@@ -258,7 +232,7 @@ func TestRegisterAutoPrompt(t *testing.T) {
 			name:       "skipped when operator already has platform-overview",
 			serverName: "My Platform",
 			serverDesc: "Covers all analytics data.",
-			operatorPrompts: []PromptConfig{
+			operatorPrompts: []PromptSpec{
 				{Name: autoPromptName, Description: "custom", Content: "custom content"},
 			},
 			wantRegistered: false,
@@ -267,7 +241,7 @@ func TestRegisterAutoPrompt(t *testing.T) {
 			name:       "registers alongside other operator prompts",
 			serverName: "My Platform",
 			serverDesc: "Covers analytics.",
-			operatorPrompts: []PromptConfig{
+			operatorPrompts: []PromptSpec{
 				{Name: "routing-guide", Description: "routing", Content: "route here"},
 			},
 			wantRegistered: true,
@@ -277,24 +251,10 @@ func TestRegisterAutoPrompt(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mcpServer := mcp.NewServer(&mcp.Implementation{
-				Name:    "test-server",
-				Version: "1.0.0",
-			}, nil)
+			mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+			h := newRegisterHandle(tt.serverName, tt.serverDesc, tt.operatorPrompts, nil)
 
-			p := &Platform{
-				mcpServer:       mcpServer,
-				toolkitRegistry: registry.NewRegistry(),
-				config: &Config{
-					Server: ServerConfig{
-						Name:        tt.serverName,
-						Description: tt.serverDesc,
-						Prompts:     tt.operatorPrompts,
-					},
-				},
-			}
-
-			p.registerAutoPrompt()
+			h.registerAutoPrompt(mcpServer)
 
 			session, cleanup := connectTestClient(t, mcpServer)
 			defer cleanup()
@@ -319,30 +279,16 @@ func TestRegisterAutoPrompt(t *testing.T) {
 
 func TestAutoPromptContent(t *testing.T) {
 	const desc = "Covers all ACME Corp data."
-	mcpServer := mcp.NewServer(&mcp.Implementation{
-		Name:    "test-server",
-		Version: "1.0.0",
-	}, nil)
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
 
-	p := &Platform{
-		mcpServer:       mcpServer,
-		toolkitRegistry: registry.NewRegistry(),
-		config: &Config{
-			Server: ServerConfig{
-				Name:        "ACME Data Platform",
-				Description: desc,
-			},
-		},
-	}
+	h := newRegisterHandle("ACME Data Platform", desc, nil, nil)
 
-	p.registerAutoPrompt()
+	h.registerAutoPrompt(mcpServer)
 
 	session, cleanup := connectTestClient(t, mcpServer)
 	defer cleanup()
 
-	resp, err := session.GetPrompt(context.Background(), &mcp.GetPromptParams{
-		Name: autoPromptName,
-	})
+	resp, err := session.GetPrompt(context.Background(), &mcp.GetPromptParams{Name: autoPromptName})
 	require.NoError(t, err)
 	require.Len(t, resp.Messages, 1)
 
@@ -358,23 +304,9 @@ func TestDynamicOverviewContentWithToolkits(t *testing.T) {
 	_ = reg.Register(&mockToolkit{kind: "datahub", name: "primary"})
 	_ = reg.Register(&mockToolkit{kind: "trino", name: "default"})
 
-	mcpServer := mcp.NewServer(&mcp.Implementation{
-		Name:    "test-server",
-		Version: "1.0.0",
-	}, nil)
+	h := newRegisterHandle("Test Platform", "Test platform for analytics.", nil, reg)
 
-	p := &Platform{
-		mcpServer:       mcpServer,
-		toolkitRegistry: reg,
-		config: &Config{
-			Server: ServerConfig{
-				Name:        "Test Platform",
-				Description: "Test platform for analytics.",
-			},
-		},
-	}
-
-	content := p.buildDynamicOverviewContent()
+	content := h.buildDynamicOverviewContent()
 
 	assert.Contains(t, content, "Test platform for analytics.")
 	assert.Contains(t, content, "Explore available data")
@@ -390,22 +322,10 @@ func TestWorkflowPromptsConditionalRegistration(t *testing.T) {
 		reg := registry.NewRegistry()
 		_ = reg.Register(&mockToolkit{kind: "datahub", name: "primary"})
 
-		mcpServer := mcp.NewServer(&mcp.Implementation{
-			Name:    "test-server",
-			Version: "1.0.0",
-		}, nil)
+		mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+		h := newRegisterHandle("", "Test platform.", nil, reg)
 
-		p := &Platform{
-			mcpServer:       mcpServer,
-			toolkitRegistry: reg,
-			config: &Config{
-				Server: ServerConfig{
-					Description: "Test platform.",
-				},
-			},
-		}
-
-		p.registerPlatformPrompts()
+		h.RegisterPlatformPrompts(mcpServer)
 
 		session, cleanup := connectTestClient(t, mcpServer)
 		defer cleanup()
@@ -426,18 +346,10 @@ func TestWorkflowPromptsConditionalRegistration(t *testing.T) {
 		reg := registry.NewRegistry()
 		// Only trino, no datahub
 
-		mcpServer := mcp.NewServer(&mcp.Implementation{
-			Name:    "test-server",
-			Version: "1.0.0",
-		}, nil)
+		mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+		h := newRegisterHandle("", "", nil, reg)
 
-		p := &Platform{
-			mcpServer:       mcpServer,
-			toolkitRegistry: reg,
-			config:          &Config{},
-		}
-
-		p.registerWorkflowPrompts()
+		h.registerWorkflowPrompts(mcpServer)
 
 		session, cleanup := connectTestClient(t, mcpServer)
 		defer cleanup()
@@ -452,24 +364,12 @@ func TestWorkflowPromptsConditionalRegistration(t *testing.T) {
 		reg := registry.NewRegistry()
 		_ = reg.Register(&mockToolkit{kind: "datahub", name: "primary"})
 
-		mcpServer := mcp.NewServer(&mcp.Implementation{
-			Name:    "test-server",
-			Version: "1.0.0",
-		}, nil)
+		mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+		h := newRegisterHandle("", "", []PromptSpec{
+			{Name: "explore-available-data", Description: "Custom", Content: "Custom content."},
+		}, reg)
 
-		p := &Platform{
-			mcpServer:       mcpServer,
-			toolkitRegistry: reg,
-			config: &Config{
-				Server: ServerConfig{
-					Prompts: []PromptConfig{
-						{Name: "explore-available-data", Description: "Custom", Content: "Custom content."},
-					},
-				},
-			},
-		}
-
-		p.registerWorkflowPrompts()
+		h.registerWorkflowPrompts(mcpServer)
 
 		session, cleanup := connectTestClient(t, mcpServer)
 		defer cleanup()
@@ -490,18 +390,10 @@ func TestWorkflowPromptsConditionalRegistration(t *testing.T) {
 		_ = reg.Register(&mockToolkit{kind: "trino", name: "default"})
 		_ = reg.Register(&mockToolkit{kind: "portal", name: "default"})
 
-		mcpServer := mcp.NewServer(&mcp.Implementation{
-			Name:    "test-server",
-			Version: "1.0.0",
-		}, nil)
+		mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+		h := newRegisterHandle("", "", nil, reg)
 
-		p := &Platform{
-			mcpServer:       mcpServer,
-			toolkitRegistry: reg,
-			config:          &Config{},
-		}
-
-		p.registerWorkflowPrompts()
+		h.registerWorkflowPrompts(mcpServer)
 
 		session, cleanup := connectTestClient(t, mcpServer)
 		defer cleanup()
@@ -521,34 +413,21 @@ func TestPromptMetadataCollection(t *testing.T) {
 	reg := registry.NewRegistry()
 	_ = reg.Register(&mockToolkit{kind: "datahub", name: "primary"})
 
-	mcpServer := mcp.NewServer(&mcp.Implementation{
-		Name:    "test-server",
-		Version: "1.0.0",
-	}, nil)
-
-	p := &Platform{
-		mcpServer:       mcpServer,
-		toolkitRegistry: reg,
-		config: &Config{
-			Server: ServerConfig{
-				Description: "Test platform.",
-				Prompts: []PromptConfig{
-					{
-						Name:        "custom-prompt",
-						Description: "A custom prompt",
-						Content:     "Do {thing}.",
-						Arguments: []PromptArgumentConfig{
-							{Name: "thing", Description: "What to do", Required: true},
-						},
-					},
-				},
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+	h := newRegisterHandle("", "Test platform.", []PromptSpec{
+		{
+			Name:        "custom-prompt",
+			Description: "A custom prompt",
+			Content:     "Do {thing}.",
+			Arguments: []PromptArgSpec{
+				{Name: "thing", Description: "What to do", Required: true},
 			},
 		},
-	}
+	}, reg)
 
-	p.registerPlatformPrompts()
+	h.RegisterPlatformPrompts(mcpServer)
 
-	infos := p.AllPromptInfos()
+	infos := h.AllPromptInfos()
 	assert.True(t, len(infos) > 0, "should have collected prompt infos")
 
 	// Find custom-prompt
@@ -582,34 +461,21 @@ func TestPromptContentInJSON(t *testing.T) {
 	reg := registry.NewRegistry()
 	_ = reg.Register(&mockToolkit{kind: "datahub", name: "primary"})
 
-	mcpServer := mcp.NewServer(&mcp.Implementation{
-		Name:    "test-server",
-		Version: "1.0.0",
-	}, nil)
-
-	p := &Platform{
-		mcpServer:       mcpServer,
-		toolkitRegistry: reg,
-		config: &Config{
-			Server: ServerConfig{
-				Description: "Test.",
-				Prompts: []PromptConfig{
-					{
-						Name:        "my-prompt",
-						Description: "My prompt",
-						Content:     "Do the thing about {topic}.",
-						Arguments: []PromptArgumentConfig{
-							{Name: "topic", Description: "The topic", Required: true},
-						},
-					},
-				},
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+	h := newRegisterHandle("", "Test.", []PromptSpec{
+		{
+			Name:        "my-prompt",
+			Description: "My prompt",
+			Content:     "Do the thing about {topic}.",
+			Arguments: []PromptArgSpec{
+				{Name: "topic", Description: "The topic", Required: true},
 			},
 		},
-	}
+	}, reg)
 
-	p.registerPlatformPrompts()
+	h.RegisterPlatformPrompts(mcpServer)
 
-	infos := p.AllPromptInfos()
+	infos := h.AllPromptInfos()
 
 	data, err := json.Marshal(infos)
 	require.NoError(t, err)
@@ -635,28 +501,18 @@ func TestCollectToolkitPromptInfos(t *testing.T) {
 		},
 	})
 
-	p := &Platform{
-		toolkitRegistry: reg,
-	}
+	h := &Handle{registry: reg}
 
-	infos := p.collectToolkitPromptInfos()
+	infos := h.collectToolkitPromptInfos()
 	require.Len(t, infos, 1)
 	assert.Equal(t, "save-this-as-an-asset", infos[0].Name)
 }
 
 func TestIsOperatorPrompt(t *testing.T) {
-	p := &Platform{
-		config: &Config{
-			Server: ServerConfig{
-				Prompts: []PromptConfig{
-					{Name: "my-prompt"},
-				},
-			},
-		},
-	}
+	h := &Handle{operatorPrompts: []PromptSpec{{Name: "my-prompt"}}}
 
-	assert.True(t, p.isOperatorPrompt("my-prompt"))
-	assert.False(t, p.isOperatorPrompt("nonexistent"))
+	assert.True(t, h.isOperatorPrompt("my-prompt"))
+	assert.False(t, h.isOperatorPrompt("nonexistent"))
 }
 
 func TestHasAllToolkitKinds(t *testing.T) {
@@ -664,12 +520,12 @@ func TestHasAllToolkitKinds(t *testing.T) {
 	_ = reg.Register(&mockToolkit{kind: "datahub", name: "primary"})
 	_ = reg.Register(&mockToolkit{kind: "trino", name: "default"})
 
-	p := &Platform{toolkitRegistry: reg}
+	h := &Handle{registry: reg}
 
-	assert.True(t, p.hasAllToolkitKinds([]string{"datahub"}))
-	assert.True(t, p.hasAllToolkitKinds([]string{"datahub", "trino"}))
-	assert.False(t, p.hasAllToolkitKinds([]string{"datahub", "portal"}))
-	assert.True(t, p.hasAllToolkitKinds([]string{}))
+	assert.True(t, h.hasAllToolkitKinds([]string{"datahub"}))
+	assert.True(t, h.hasAllToolkitKinds([]string{"datahub", "trino"}))
+	assert.False(t, h.hasAllToolkitKinds([]string{"datahub", "portal"}))
+	assert.True(t, h.hasAllToolkitKinds([]string{}))
 }
 
 func TestBuildPromptResult(t *testing.T) {
@@ -677,22 +533,10 @@ func TestBuildPromptResult(t *testing.T) {
 		name    string
 		content string
 	}{
-		{
-			name:    "simple content",
-			content: "This is a simple prompt.",
-		},
-		{
-			name:    "multiline content",
-			content: "Line 1\nLine 2\nLine 3",
-		},
-		{
-			name:    "empty content",
-			content: "",
-		},
-		{
-			name:    "content with special characters",
-			content: "Use `code` and **bold** formatting.",
-		},
+		{name: "simple content", content: "This is a simple prompt."},
+		{name: "multiline content", content: "Line 1\nLine 2\nLine 3"},
+		{name: "empty content", content: ""},
+		{name: "content with special characters", content: "Use `code` and **bold** formatting."},
 	}
 
 	for _, tt := range tests {
@@ -714,14 +558,14 @@ func TestWorkflowPromptArguments(t *testing.T) {
 	// Verify each workflow prompt has the expected argument
 	prompts := workflowPrompts()
 	for _, wp := range prompts {
-		t.Run(wp.config.Name, func(t *testing.T) {
-			require.NotEmpty(t, wp.config.Arguments, "workflow prompt should have arguments")
+		t.Run(wp.spec.Name, func(t *testing.T) {
+			require.NotEmpty(t, wp.spec.Arguments, "workflow prompt should have arguments")
 			require.NotEmpty(t, wp.requiredKinds, "workflow prompt should require toolkits")
-			assert.NotEmpty(t, wp.config.Description)
-			assert.NotEmpty(t, wp.config.Content)
+			assert.NotEmpty(t, wp.spec.Description)
+			assert.NotEmpty(t, wp.spec.Content)
 			// Verify the argument placeholder exists in the content
-			for _, arg := range wp.config.Arguments {
-				assert.Contains(t, wp.config.Content, "{"+arg.Name+"}",
+			for _, arg := range wp.spec.Arguments {
+				assert.Contains(t, wp.spec.Content, "{"+arg.Name+"}",
 					"content should contain placeholder for argument %q", arg.Name)
 			}
 		})
@@ -736,14 +580,4 @@ func promptNames(prompts []*mcp.Prompt) []string {
 		names = append(names, p.Name)
 	}
 	return names
-}
-
-// mockToolkitWithPrompts adds PromptDescriber to mockToolkit.
-type mockToolkitWithPrompts struct {
-	mockToolkit
-	prompts []registry.PromptInfo
-}
-
-func (m *mockToolkitWithPrompts) PromptInfos() []registry.PromptInfo {
-	return m.prompts
 }

--- a/pkg/platform/promptlayer/search_test.go
+++ b/pkg/platform/promptlayer/search_test.go
@@ -1,4 +1,4 @@
-package platform
+package promptlayer
 
 import (
 	"context"
@@ -11,41 +11,40 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/prompt"
 )
 
-// searchablePlatformStore adds prompt.Searcher to the platform mock store.
-type searchablePlatformStore struct {
-	*mockPlatformPromptStore
+// searchableStore adds prompt.Searcher to the mock prompt store.
+type searchableStore struct {
+	*mockPromptStore
 	gotQuery prompt.SearchQuery
 	result   []prompt.ScoredPrompt
 	err      error
 }
 
-func (s *searchablePlatformStore) Search(_ context.Context, q prompt.SearchQuery) ([]prompt.ScoredPrompt, error) {
+func (s *searchableStore) Search(_ context.Context, q prompt.SearchQuery) ([]prompt.ScoredPrompt, error) {
 	s.gotQuery = q
 	return s.result, s.err
 }
 
-var _ prompt.Searcher = (*searchablePlatformStore)(nil)
+var _ prompt.Searcher = (*searchableStore)(nil)
 
 func TestHandlePromptSearch_Unavailable(t *testing.T) {
 	// Plain mock store does not implement prompt.Searcher.
-	p, _ := newTestPlatformWithPromptStore()
-	r, _, _ := p.handleManagePrompt(adminCtx(), managePromptInput{Command: cmdList, Query: "sales"})
+	h, _ := newTestHandle()
+	r, _, _ := h.handleManagePrompt(adminCtx(), managePromptInput{Command: cmdList, Query: "sales"})
 	assert.True(t, r.IsError)
 	assert.Contains(t, resultText(r), "unavailable")
 }
 
 func TestHandlePromptSearch_Success(t *testing.T) {
-	base := newMockPlatformPromptStore()
-	store := &searchablePlatformStore{
-		mockPlatformPromptStore: base,
+	store := &searchableStore{
+		mockPromptStore: newMockPromptStore(),
 		result: []prompt.ScoredPrompt{
 			{Prompt: prompt.Prompt{ID: "p-1", Name: "daily-sales"}, Score: 0.9},
 		},
 	}
-	p, _ := newTestPlatformWithPromptStore()
-	p.promptStore = store
+	h, _ := newTestHandle()
+	h.store = store
 
-	r, _, _ := p.handleManagePrompt(userCtx("alice@example.com", "analyst"),
+	r, _, _ := h.handleManagePrompt(userCtx("alice@example.com", "analyst"),
 		managePromptInput{Command: cmdList, Query: "sales report", Limit: 3})
 	require.False(t, r.IsError)
 
@@ -58,7 +57,7 @@ func TestHandlePromptSearch_Success(t *testing.T) {
 	require.Len(t, out.Prompts, 1)
 	assert.Equal(t, "daily-sales", out.Prompts[0].Prompt.Name)
 	assert.Equal(t, 1, out.Count)
-	// No embedding provider configured in the test platform, so ranking degrades
+	// No embedding provider configured in the test handle, so ranking degrades
 	// to lexical.
 	assert.Equal(t, "lexical", out.Ranking)
 
@@ -70,21 +69,21 @@ func TestHandlePromptSearch_Success(t *testing.T) {
 }
 
 func TestHandlePromptSearch_AdminFlag(t *testing.T) {
-	store := &searchablePlatformStore{mockPlatformPromptStore: newMockPlatformPromptStore()}
-	p, _ := newTestPlatformWithPromptStore()
-	p.promptStore = store
+	store := &searchableStore{mockPromptStore: newMockPromptStore()}
+	h, _ := newTestHandle()
+	h.store = store
 
-	r, _, _ := p.handleManagePrompt(adminCtx(), managePromptInput{Command: cmdList, Query: "x"})
+	r, _, _ := h.handleManagePrompt(adminCtx(), managePromptInput{Command: cmdList, Query: "x"})
 	require.False(t, r.IsError)
 	assert.True(t, store.gotQuery.IsAdmin)
 }
 
 func TestHandlePromptSearch_StoreError(t *testing.T) {
-	store := &searchablePlatformStore{mockPlatformPromptStore: newMockPlatformPromptStore(), err: assert.AnError}
-	p, _ := newTestPlatformWithPromptStore()
-	p.promptStore = store
+	store := &searchableStore{mockPromptStore: newMockPromptStore(), err: assert.AnError}
+	h, _ := newTestHandle()
+	h.store = store
 
-	r, _, _ := p.handleManagePrompt(adminCtx(), managePromptInput{Command: cmdList, Query: "x"})
+	r, _, _ := h.handleManagePrompt(adminCtx(), managePromptInput{Command: cmdList, Query: "x"})
 	assert.True(t, r.IsError)
 	assert.Contains(t, resultText(r), "failed to search prompts")
 }

--- a/pkg/platform/promptlayer/shared_serving_test.go
+++ b/pkg/platform/promptlayer/shared_serving_test.go
@@ -1,4 +1,4 @@
-package platform
+package promptlayer
 
 import (
 	"context"
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/txn2/mcp-data-platform/pkg/platform/portalstore"
 	"github.com/txn2/mcp-data-platform/pkg/portal"
 	"github.com/txn2/mcp-data-platform/pkg/prompt"
 )
@@ -15,21 +14,19 @@ import (
 // A prompt shared with the caller is visible as shared-<name> and renders for
 // prompts/get, making it a real runnable prompt for the recipient.
 func TestSharedPrompt_VisibleAndRunnable(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	// Sarah owns a personal prompt; it is shared with bob.
 	store.prompts["report"] = &prompt.Prompt{
 		ID: "p1", Name: "report", Scope: prompt.ScopePersonal,
 		OwnerEmail: "sarah@example.com", Content: "shared report {x}", Enabled: true,
 	}
-	p.portalStore = portalstore.NewFromStores(portalstore.Stores{
-		Share: &stubShareStore{promptRefs: []portal.SharedPromptRef{
-			{PromptID: "p1", ShareID: "s1", SharedBy: "sarah@example.com", Permission: portal.PermissionViewer},
-		}},
-	}, nil, portalstore.Config{})
+	h.shareStore = &stubShareLister{promptRefs: []portal.SharedPromptRef{
+		{PromptID: "p1", ShareID: "s1", SharedBy: "sarah@example.com", Permission: portal.PermissionViewer},
+	}}
 
 	ctx := context.Background()
 	// Bob (the recipient) sees it as shared-report.
-	out := p.listVisiblePrompts(ctx, "bob@example.com", nil)
+	out := h.ListVisible(ctx, "bob@example.com", nil)
 	names := map[string]bool{}
 	for _, pr := range out {
 		names[pr.Name] = true
@@ -37,12 +34,12 @@ func TestSharedPrompt_VisibleAndRunnable(t *testing.T) {
 	assert.True(t, names["shared-report"], "shared prompt visible to recipient as shared-<name>")
 
 	// And it resolves for prompts/get.
-	res, ok := p.getDynamicPrompt(ctx, "bob@example.com", nil, "shared-report", map[string]string{"x": "Y"})
+	res, ok := h.GetByName(ctx, "bob@example.com", nil, "shared-report", map[string]string{"x": "Y"})
 	require.True(t, ok, "shared prompt resolves for the recipient")
 	require.NotNil(t, res)
 
 	// An anonymous caller cannot fetch it.
-	_, ok = p.getDynamicPrompt(ctx, "", nil, "shared-report", nil)
+	_, ok = h.GetByName(ctx, "", nil, "shared-report", nil)
 	assert.False(t, ok, "anonymous caller cannot resolve a shared prompt")
 }
 
@@ -50,22 +47,20 @@ func TestSharedPrompt_VisibleAndRunnable(t *testing.T) {
 // is no longer served via the shared- alias (it is served under global-/persona-),
 // avoiding a duplicate.
 func TestSharedPrompt_PromotedNotDoubleServed(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["report"] = &prompt.Prompt{
 		ID: "p1", Name: "report", Scope: prompt.ScopeGlobal, // promoted away from personal
 		OwnerEmail: "sarah@example.com", Content: "x", Enabled: true,
 	}
-	p.portalStore = portalstore.NewFromStores(portalstore.Stores{
-		Share: &stubShareStore{promptRefs: []portal.SharedPromptRef{
-			{PromptID: "p1", ShareID: "s1", SharedBy: "sarah@example.com", Permission: portal.PermissionViewer},
-		}},
-	}, nil, portalstore.Config{})
+	h.shareStore = &stubShareLister{promptRefs: []portal.SharedPromptRef{
+		{PromptID: "p1", ShareID: "s1", SharedBy: "sarah@example.com", Permission: portal.PermissionViewer},
+	}}
 
 	ctx := context.Background()
-	out := p.listVisiblePrompts(ctx, "bob@example.com", nil)
+	out := h.ListVisible(ctx, "bob@example.com", nil)
 	for _, pr := range out {
 		assert.NotEqual(t, "shared-report", pr.Name, "promoted prompt must not be served via shared- alias")
 	}
-	_, ok := p.getSharedPrompt(ctx, "bob@example.com", "report", nil)
+	_, ok := h.getSharedPrompt(ctx, "bob@example.com", "report", nil)
 	assert.False(t, ok, "promoted prompt not resolvable via shared- prefix")
 }

--- a/pkg/platform/promptlayer/tool.go
+++ b/pkg/platform/promptlayer/tool.go
@@ -1,4 +1,4 @@
-package platform
+package promptlayer
 
 import (
 	"context"
@@ -20,7 +20,7 @@ const (
 	promptLogKey    = "name"
 	promptLogKeyErr = "error"
 
-	// Command names for the manage_prompt tool.
+	// Command name for the manage_prompt list command.
 	cmdList = "list"
 
 	// JSON field names used in result and schema maps. These share the
@@ -32,26 +32,6 @@ const (
 	// ("created", "updated", "deleted") returned by manage_prompt.
 	fieldStatus = "status"
 )
-
-// platformPromptCreator adapts the prompt store and platform for the
-// knowledge toolkit's PromptCreator interface.
-type platformPromptCreator struct {
-	store    prompt.Store
-	platform *Platform
-}
-
-// Create delegates prompt creation to the backing store.
-func (c *platformPromptCreator) Create(ctx context.Context, p *prompt.Prompt) error {
-	if err := c.store.Create(ctx, p); err != nil {
-		return fmt.Errorf("prompt store create: %w", err)
-	}
-	return nil
-}
-
-// RegisterRuntimePrompt delegates runtime registration to the platform.
-func (c *platformPromptCreator) RegisterRuntimePrompt(p *prompt.Prompt) {
-	c.platform.RegisterRuntimePrompt(p)
-}
 
 // managePromptInput is the input schema for the manage_prompt tool.
 type managePromptInput struct {
@@ -81,13 +61,14 @@ type managePromptInput struct {
 	RequestedPersonas []string `json:"requested_personas,omitempty"`
 }
 
-// registerPromptTool registers the manage_prompt tool with the MCP server.
-func (p *Platform) registerPromptTool() {
-	if p.promptStore == nil {
+// RegisterTool registers the manage_prompt tool with the given MCP server. No-op
+// on a nil Handle or a no-DB deployment (no store to manage prompts in).
+func (h *Handle) RegisterTool(server *mcp.Server) {
+	if h == nil || h.store == nil {
 		return
 	}
 
-	mcp.AddTool(p.mcpServer, &mcp.Tool{
+	mcp.AddTool(server, &mcp.Tool{
 		Name:  "manage_prompt",
 		Title: "Manage Prompts",
 		Description: "Create, update, delete, list, or get prompts. " +
@@ -97,30 +78,30 @@ func (p *Platform) registerPromptTool() {
 			"configuration are not listed or editable here.",
 		InputSchema: managePromptSchema(),
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, input managePromptInput) (*mcp.CallToolResult, any, error) {
-		return p.handleManagePrompt(ctx, input)
+		return h.handleManagePrompt(ctx, input)
 	})
 }
 
 // handleManagePrompt dispatches manage_prompt commands.
-func (p *Platform) handleManagePrompt(ctx context.Context, input managePromptInput) (*mcp.CallToolResult, any, error) {
+func (h *Handle) handleManagePrompt(ctx context.Context, input managePromptInput) (*mcp.CallToolResult, any, error) {
 	switch input.Command {
 	case "create":
-		return p.handlePromptCreate(ctx, input)
+		return h.handlePromptCreate(ctx, input)
 	case "update":
-		return p.handlePromptUpdate(ctx, input)
+		return h.handlePromptUpdate(ctx, input)
 	case "delete":
-		return p.handlePromptDelete(ctx, input)
+		return h.handlePromptDelete(ctx, input)
 	case cmdList:
-		return p.handlePromptList(ctx, input)
+		return h.handlePromptList(ctx, input)
 	case "get":
-		return p.handlePromptGet(ctx, input)
+		return h.handlePromptGet(ctx, input)
 	default:
 		return promptErrorResult(fmt.Sprintf("unknown command: %s", input.Command)), nil, nil
 	}
 }
 
 // handlePromptCreate creates a new prompt.
-func (p *Platform) handlePromptCreate(ctx context.Context, input managePromptInput) (*mcp.CallToolResult, any, error) {
+func (h *Handle) handlePromptCreate(ctx context.Context, input managePromptInput) (*mcp.CallToolResult, any, error) {
 	if err := prompt.ValidateName(input.Name); err != nil {
 		return promptErrorResult(err.Error()), nil, nil
 	}
@@ -140,7 +121,7 @@ func (p *Platform) handlePromptCreate(ctx context.Context, input managePromptInp
 	}
 
 	email := resolveEmail(ctx)
-	if !p.isAdminPersona(ctx) && scope != prompt.ScopePersonal {
+	if !h.isAdminPersona(ctx) && scope != prompt.ScopePersonal {
 		return promptErrorResult("only admins can create global or persona-scoped prompts"), nil, nil
 	}
 
@@ -164,12 +145,12 @@ func (p *Platform) handlePromptCreate(ctx context.Context, input managePromptInp
 		Enabled:     true,
 	}
 
-	if err := p.promptStore.Create(ctx, pr); err != nil {
+	if err := h.store.Create(ctx, pr); err != nil {
 		slog.Error("failed to create prompt", promptLogKey, input.Name, promptLogKeyErr, err)
-		return p.promptErrorDetail(ctx, "failed to create prompt", err), nil, nil
+		return h.promptErrorDetail(ctx, "failed to create prompt", err), nil, nil
 	}
 
-	p.RegisterRuntimePrompt(pr)
+	h.RegisterRuntimePrompt(pr)
 
 	return promptJSONResult(map[string]any{
 		fieldStatus: "created",
@@ -179,15 +160,15 @@ func (p *Platform) handlePromptCreate(ctx context.Context, input managePromptInp
 }
 
 // handlePromptUpdate updates an existing prompt.
-func (p *Platform) handlePromptUpdate(ctx context.Context, input managePromptInput) (*mcp.CallToolResult, any, error) {
+func (h *Handle) handlePromptUpdate(ctx context.Context, input managePromptInput) (*mcp.CallToolResult, any, error) {
 	if input.Name == "" {
 		return promptErrorResult("name is required"), nil, nil
 	}
 
-	existing, err := p.resolveManagedPrompt(ctx, input.Name, resolveEmail(ctx), input.Scope)
+	existing, err := h.resolveManagedPrompt(ctx, input.Name, resolveEmail(ctx), input.Scope)
 	if err != nil {
 		slog.Error(promptErrGet, promptLogKey, input.Name, promptLogKeyErr, err)
-		return p.promptErrorDetail(ctx, promptErrGet, err), nil, nil
+		return h.promptErrorDetail(ctx, promptErrGet, err), nil, nil
 	}
 	if existing == nil {
 		return promptErrorResult(fmt.Sprintf("prompt %q not found", input.Name)), nil, nil
@@ -197,44 +178,27 @@ func (p *Platform) handlePromptUpdate(ctx context.Context, input managePromptInp
 	}
 
 	email := resolveEmail(ctx)
-	if !p.isAdminPersona(ctx) {
-		if existing.Scope != prompt.ScopePersonal {
-			return promptErrorResult("non-admins can only manage personal prompts"), nil, nil
-		}
-		if existing.OwnerEmail != email {
-			return promptErrorResult("you can only update your own prompts"), nil, nil
-		}
+	if msg := authorizePromptMutation(existing, email, "update", h.isAdminPersona(ctx)); msg != "" {
+		return promptErrorResult(msg), nil, nil
 	}
 
 	oldScope := existing.Scope
-	if errMsg := applyPromptUpdates(existing, input, p.isAdminPersona(ctx)); errMsg != "" {
+	if errMsg := applyPromptUpdates(existing, input, h.isAdminPersona(ctx)); errMsg != "" {
 		return promptErrorResult(errMsg), nil, nil
 	}
-	if errMsg := applyStatusTransition(existing, input.Status, input.SupersededBy, email, p.isAdminPersona(ctx)); errMsg != "" {
+	if errMsg := applyStatusTransition(existing, input.Status, input.SupersededBy, email, h.isAdminPersona(ctx)); errMsg != "" {
 		return promptErrorResult(errMsg), nil, nil
 	}
-	// Promoting a personal prompt into the shared (global/persona) namespace
-	// requires a name that is free there; the shared names are globally unique.
-	if oldScope == prompt.ScopePersonal && existing.Scope != prompt.ScopePersonal {
-		if dup, _ := p.promptStore.Get(ctx, existing.Name); dup != nil && dup.ID != existing.ID {
-			return promptErrorResult(fmt.Sprintf(
-				"the name %q is already used by a %s prompt; rename before promoting", existing.Name, dup.Scope)), nil, nil
-		}
+	if errMsg := h.checkPromotionNameFree(ctx, existing, oldScope); errMsg != "" {
+		return promptErrorResult(errMsg), nil, nil
 	}
 
-	if err := p.promptStore.Update(ctx, existing); err != nil {
+	if err := h.store.Update(ctx, existing); err != nil {
 		slog.Error("failed to update prompt", promptLogKey, input.Name, promptLogKeyErr, err)
-		return p.promptErrorDetail(ctx, "failed to update prompt", err), nil, nil
+		return h.promptErrorDetail(ctx, "failed to update prompt", err), nil, nil
 	}
 
-	// Re-register the name-keyed metadata. Personal prompts are not tracked
-	// there (names collide across owners), so only (un)register shared scopes;
-	// RegisterRuntimePrompt self-skips personal, and unregistering the old name
-	// is gated on the old scope to avoid dropping an unrelated shared entry.
-	if oldScope != prompt.ScopePersonal {
-		p.UnregisterRuntimePrompt(existing.Name)
-	}
-	p.RegisterRuntimePrompt(existing)
+	h.reregisterAfterUpdate(existing, oldScope)
 
 	return promptJSONResult(map[string]any{
 		fieldStatus: "updated",
@@ -242,9 +206,63 @@ func (p *Platform) handlePromptUpdate(ctx context.Context, input managePromptInp
 	})
 }
 
-// applyPromptUpdates applies non-empty fields from input to existing.
-// Returns a non-empty error message if a scope check fails.
+// checkPromotionNameFree guards a personal-to-shared promotion: the shared
+// (global/persona) namespace is globally unique, so promoting requires the name
+// to be free there. Returns a non-empty user-facing error message when a
+// different prompt already owns the name, or "" when the update is not a
+// promotion or the name is free.
+func (h *Handle) checkPromotionNameFree(ctx context.Context, existing *prompt.Prompt, oldScope string) string {
+	if oldScope != prompt.ScopePersonal || existing.Scope == prompt.ScopePersonal {
+		return ""
+	}
+	dup, _ := h.store.Get(ctx, existing.Name)
+	if dup != nil && dup.ID != existing.ID {
+		return fmt.Sprintf("the name %q is already used by a %s prompt; rename before promoting", existing.Name, dup.Scope)
+	}
+	return ""
+}
+
+// reregisterAfterUpdate refreshes the name-keyed metadata after an update.
+// Personal prompts are not tracked there (names collide across owners), so only
+// (un)register shared scopes; RegisterRuntimePrompt self-skips personal, and
+// unregistering the old name is gated on the old scope to avoid dropping an
+// unrelated shared entry.
+func (h *Handle) reregisterAfterUpdate(existing *prompt.Prompt, oldScope string) {
+	if oldScope != prompt.ScopePersonal {
+		h.UnregisterRuntimePrompt(existing.Name)
+	}
+	h.RegisterRuntimePrompt(existing)
+}
+
+// authorizePromptMutation checks whether the caller may update or delete the
+// target prompt. Admins may act on any prompt; a non-admin may only act on their
+// own personal prompts. Returns a non-empty user-facing error message when the
+// action is not permitted, or "" when it is. verb ("update"/"delete") is spliced
+// into the ownership-denial message.
+func authorizePromptMutation(existing *prompt.Prompt, email, verb string, isAdmin bool) string {
+	if isAdmin {
+		return ""
+	}
+	if existing.Scope != prompt.ScopePersonal {
+		return "non-admins can only manage personal prompts"
+	}
+	if existing.OwnerEmail != email {
+		return "you can only " + verb + " your own prompts"
+	}
+	return ""
+}
+
+// applyPromptUpdates applies non-empty fields from input to existing. Returns a
+// non-empty error message when a validated field (scope, tags, promotion request)
+// fails its check; the plain fields are always applied first.
 func applyPromptUpdates(existing *prompt.Prompt, input managePromptInput, isAdmin bool) string {
+	applyPlainPromptFields(existing, input)
+	return applyValidatedPromptFields(existing, input, isAdmin)
+}
+
+// applyPlainPromptFields copies the input fields that need no validation onto
+// existing, leaving an unset (empty/nil) input field untouched.
+func applyPlainPromptFields(existing *prompt.Prompt, input managePromptInput) {
 	if input.DisplayName != "" {
 		existing.DisplayName = input.DisplayName
 	}
@@ -260,14 +278,20 @@ func applyPromptUpdates(existing *prompt.Prompt, input managePromptInput, isAdmi
 	if input.Category != "" {
 		existing.Category = input.Category
 	}
+	if input.Personas != nil {
+		existing.Personas = input.Personas
+	}
+}
+
+// applyValidatedPromptFields applies the input fields that carry authorization or
+// validation rules: scope (admin-only for shared scopes), tags (format), and a
+// promotion request. Returns a non-empty error message on the first failing check.
+func applyValidatedPromptFields(existing *prompt.Prompt, input managePromptInput, isAdmin bool) string {
 	if input.Scope != "" {
 		if !isAdmin && input.Scope != prompt.ScopePersonal {
 			return "only admins can set global or persona scope"
 		}
 		existing.Scope = input.Scope
-	}
-	if input.Personas != nil {
-		existing.Personas = input.Personas
 	}
 	if input.Tags != nil {
 		if err := prompt.ValidateTags(input.Tags); err != nil {
@@ -294,15 +318,15 @@ func applyStatusTransition(existing *prompt.Prompt, newStatus, supersededBy, act
 }
 
 // handlePromptDelete deletes a prompt.
-func (p *Platform) handlePromptDelete(ctx context.Context, input managePromptInput) (*mcp.CallToolResult, any, error) {
+func (h *Handle) handlePromptDelete(ctx context.Context, input managePromptInput) (*mcp.CallToolResult, any, error) {
 	if input.Name == "" {
 		return promptErrorResult("name is required"), nil, nil
 	}
 
-	existing, err := p.resolveManagedPrompt(ctx, input.Name, resolveEmail(ctx), input.Scope)
+	existing, err := h.resolveManagedPrompt(ctx, input.Name, resolveEmail(ctx), input.Scope)
 	if err != nil {
 		slog.Error(promptErrGet, promptLogKey, input.Name, promptLogKeyErr, err)
-		return p.promptErrorDetail(ctx, promptErrGet, err), nil, nil
+		return h.promptErrorDetail(ctx, promptErrGet, err), nil, nil
 	}
 	if existing == nil {
 		return promptErrorResult(fmt.Sprintf("prompt %q not found", input.Name)), nil, nil
@@ -312,24 +336,19 @@ func (p *Platform) handlePromptDelete(ctx context.Context, input managePromptInp
 	}
 
 	email := resolveEmail(ctx)
-	if !p.isAdminPersona(ctx) {
-		if existing.Scope != prompt.ScopePersonal {
-			return promptErrorResult("non-admins can only manage personal prompts"), nil, nil
-		}
-		if existing.OwnerEmail != email {
-			return promptErrorResult("you can only delete your own prompts"), nil, nil
-		}
+	if msg := authorizePromptMutation(existing, email, "delete", h.isAdminPersona(ctx)); msg != "" {
+		return promptErrorResult(msg), nil, nil
 	}
 
-	if err := p.promptStore.DeleteByID(ctx, existing.ID); err != nil {
+	if err := h.store.DeleteByID(ctx, existing.ID); err != nil {
 		slog.Error("failed to delete prompt", promptLogKey, input.Name, promptLogKeyErr, err)
-		return p.promptErrorDetail(ctx, "failed to delete prompt", err), nil, nil
+		return h.promptErrorDetail(ctx, "failed to delete prompt", err), nil, nil
 	}
 
 	// Personal prompts are not tracked in the name-keyed metadata; unregistering
 	// by name would drop an unrelated shared entry of the same name.
 	if existing.Scope != prompt.ScopePersonal {
-		p.UnregisterRuntimePrompt(existing.Name)
+		h.UnregisterRuntimePrompt(existing.Name)
 	}
 
 	return promptJSONResult(map[string]any{
@@ -341,9 +360,9 @@ func (p *Platform) handlePromptDelete(ctx context.Context, input managePromptInp
 // handlePromptList lists prompts visible to the current user. When a free-text
 // query is supplied it ranks visible approved prompts by relevance; otherwise
 // it returns the visible set filtered by the substring Search and scope.
-func (p *Platform) handlePromptList(ctx context.Context, input managePromptInput) (*mcp.CallToolResult, any, error) {
+func (h *Handle) handlePromptList(ctx context.Context, input managePromptInput) (*mcp.CallToolResult, any, error) {
 	if strings.TrimSpace(input.Query) != "" {
-		return p.handlePromptSearch(ctx, input)
+		return h.handlePromptSearch(ctx, input)
 	}
 
 	filter := prompt.ListFilter{
@@ -351,7 +370,7 @@ func (p *Platform) handlePromptList(ctx context.Context, input managePromptInput
 		Search: input.Search,
 	}
 
-	isAdmin := p.isAdminPersona(ctx)
+	isAdmin := h.isAdminPersona(ctx)
 	enabled := true
 	filter.Enabled = &enabled
 
@@ -366,15 +385,15 @@ func (p *Platform) handlePromptList(ctx context.Context, input managePromptInput
 		}
 	}
 
-	prompts, err := p.promptStore.List(ctx, filter)
+	prompts, err := h.store.List(ctx, filter)
 	if err != nil {
 		slog.Error("failed to list prompts", promptLogKeyErr, err)
-		return p.promptErrorDetail(ctx, "failed to list prompts", err), nil, nil
+		return h.promptErrorDetail(ctx, "failed to list prompts", err), nil, nil
 	}
 
 	// For non-admins without an explicit scope, also include global and persona-scoped prompts.
 	if !isAdmin && input.Scope == "" {
-		prompts = p.mergeExtraScopes(ctx, prompts, &enabled)
+		prompts = h.mergeExtraScopes(ctx, prompts, &enabled)
 	}
 
 	return promptJSONResult(map[string]any{
@@ -384,8 +403,8 @@ func (p *Platform) handlePromptList(ctx context.Context, input managePromptInput
 }
 
 // mergeExtraScopes appends global and persona-scoped prompts for non-admin users.
-func (p *Platform) mergeExtraScopes(ctx context.Context, prompts []prompt.Prompt, enabled *bool) []prompt.Prompt {
-	globalPrompts, globalErr := p.promptStore.List(ctx, prompt.ListFilter{
+func (h *Handle) mergeExtraScopes(ctx context.Context, prompts []prompt.Prompt, enabled *bool) []prompt.Prompt {
+	globalPrompts, globalErr := h.store.List(ctx, prompt.ListFilter{
 		Scope:   prompt.ScopeGlobal,
 		Enabled: enabled,
 	})
@@ -397,7 +416,7 @@ func (p *Platform) mergeExtraScopes(ctx context.Context, prompts []prompt.Prompt
 
 	pc := middleware.GetPlatformContext(ctx)
 	if pc != nil && pc.PersonaName != "" {
-		personaPrompts, personaErr := p.promptStore.List(ctx, prompt.ListFilter{
+		personaPrompts, personaErr := h.store.List(ctx, prompt.ListFilter{
 			Scope:    prompt.ScopePersona,
 			Personas: []string{pc.PersonaName},
 			Enabled:  enabled,
@@ -417,8 +436,8 @@ func (p *Platform) mergeExtraScopes(ctx context.Context, prompts []prompt.Prompt
 // over all approved prompts. Ranking is hybrid (semantic + lexical) when an
 // embedding provider is configured and lexical-only otherwise, reported as the
 // "ranking" field so the caller knows which path produced the results.
-func (p *Platform) handlePromptSearch(ctx context.Context, input managePromptInput) (*mcp.CallToolResult, any, error) {
-	searcher, ok := p.promptStore.(prompt.Searcher)
+func (h *Handle) handlePromptSearch(ctx context.Context, input managePromptInput) (*mcp.CallToolResult, any, error) {
+	searcher, ok := h.store.(prompt.Searcher)
 	if !ok {
 		return promptErrorResult("prompt search is unavailable: semantic discovery is not enabled"), nil, nil
 	}
@@ -429,7 +448,7 @@ func (p *Platform) handlePromptSearch(ctx context.Context, input managePromptInp
 		persona = pc.PersonaName
 	}
 
-	emb := embedding.EmbedForSearch(ctx, p.embeddingProv, query)
+	emb := embedding.EmbedForSearch(ctx, h.embedder, query)
 	ranking := "lexical"
 	if len(emb) > 0 {
 		ranking = "hybrid"
@@ -440,13 +459,13 @@ func (p *Platform) handlePromptSearch(ctx context.Context, input managePromptInp
 		QueryText:  query,
 		OwnerEmail: resolveEmail(ctx),
 		Persona:    persona,
-		IsAdmin:    p.isAdminPersona(ctx),
+		IsAdmin:    h.isAdminPersona(ctx),
 		Scope:      input.Scope,
 		Limit:      input.Limit,
 	})
 	if err != nil {
 		slog.Error("failed to search prompts", promptLogKeyErr, err)
-		return p.promptErrorDetail(ctx, "failed to search prompts", err), nil, nil
+		return h.promptErrorDetail(ctx, "failed to search prompts", err), nil, nil
 	}
 
 	return promptJSONResult(map[string]any{
@@ -457,22 +476,22 @@ func (p *Platform) handlePromptSearch(ctx context.Context, input managePromptInp
 }
 
 // handlePromptGet retrieves a single prompt by name.
-func (p *Platform) handlePromptGet(ctx context.Context, input managePromptInput) (*mcp.CallToolResult, any, error) {
+func (h *Handle) handlePromptGet(ctx context.Context, input managePromptInput) (*mcp.CallToolResult, any, error) {
 	if input.Name == "" {
 		return promptErrorResult("name is required"), nil, nil
 	}
 
-	pr, err := p.resolveManagedPrompt(ctx, input.Name, resolveEmail(ctx), input.Scope)
+	pr, err := h.resolveManagedPrompt(ctx, input.Name, resolveEmail(ctx), input.Scope)
 	if err != nil {
 		slog.Error(promptErrGet, promptLogKey, input.Name, promptLogKeyErr, err)
-		return p.promptErrorDetail(ctx, promptErrGet, err), nil, nil
+		return h.promptErrorDetail(ctx, promptErrGet, err), nil, nil
 	}
 	if pr == nil {
 		return promptErrorResult(fmt.Sprintf("prompt %q not found", input.Name)), nil, nil
 	}
 
 	// Non-admins can only see their own personal prompts or global/persona prompts
-	if !p.isAdminPersona(ctx) {
+	if !h.isAdminPersona(ctx) {
 		email := resolveEmail(ctx)
 		if pr.Scope == prompt.ScopePersonal && pr.OwnerEmail != email {
 			return promptErrorResult("you can only view your own personal prompts"), nil, nil
@@ -488,10 +507,10 @@ func (p *Platform) handlePromptGet(ctx context.Context, input managePromptInput)
 // prompt is returned. An explicit shared scope (global/persona) skips the
 // personal lookup so a caller who owns a same-named personal prompt can still
 // target the shared one.
-func (p *Platform) resolveManagedPrompt(ctx context.Context, name, email, scope string) (*prompt.Prompt, error) {
+func (h *Handle) resolveManagedPrompt(ctx context.Context, name, email, scope string) (*prompt.Prompt, error) {
 	sharedOnly := scope == prompt.ScopeGlobal || scope == prompt.ScopePersona
 	if email != "" && !sharedOnly {
-		personal, err := p.promptStore.GetPersonal(ctx, email, name)
+		personal, err := h.store.GetPersonal(ctx, email, name)
 		if err != nil {
 			return nil, fmt.Errorf("resolving personal prompt: %w", err)
 		}
@@ -499,7 +518,7 @@ func (p *Platform) resolveManagedPrompt(ctx context.Context, name, email, scope 
 			return personal, nil
 		}
 	}
-	shared, err := p.promptStore.Get(ctx, name)
+	shared, err := h.store.Get(ctx, name)
 	if err != nil {
 		return nil, fmt.Errorf("resolving shared prompt: %w", err)
 	}
@@ -516,12 +535,12 @@ func resolveEmail(ctx context.Context) string {
 }
 
 // isAdminPersona checks if the current user has the admin persona.
-func (p *Platform) isAdminPersona(ctx context.Context) bool {
+func (h *Handle) isAdminPersona(ctx context.Context) bool {
 	pc := middleware.GetPlatformContext(ctx)
 	if pc == nil {
 		return false
 	}
-	return pc.PersonaName == p.config.Admin.Persona
+	return pc.PersonaName == h.adminPersona
 }
 
 // promptErrorDetail builds a tool error for a failed store or internal
@@ -530,8 +549,8 @@ func (p *Platform) isAdminPersona(ctx context.Context) bool {
 // get only a request-id breadcrumb so an operator can correlate the failure in
 // the logs. Raw errors (which may carry SQL or schema detail) are never shown to
 // non-admins. The full error is always written to the server log by the caller.
-func (p *Platform) promptErrorDetail(ctx context.Context, public string, err error) *mcp.CallToolResult {
-	if p.isAdminPersona(ctx) {
+func (h *Handle) promptErrorDetail(ctx context.Context, public string, err error) *mcp.CallToolResult {
+	if h.isAdminPersona(ctx) {
 		return promptErrorResult(fmt.Sprintf("%s: %v", public, err))
 	}
 	if pc := middleware.GetPlatformContext(ctx); pc != nil && pc.RequestID != "" {

--- a/pkg/platform/promptlayer/tool_test.go
+++ b/pkg/platform/promptlayer/tool_test.go
@@ -1,4 +1,4 @@
-package platform
+package promptlayer
 
 import (
 	"context"
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -14,160 +13,11 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/prompt"
 )
 
-// --- mock prompt store for platform tests ---
-
-type mockPlatformPromptStore struct {
-	prompts   map[string]*prompt.Prompt
-	createErr error
-	getErr    error
-	updateErr error
-	deleteErr error
-	listErr   error
-}
-
-func newMockPlatformPromptStore() *mockPlatformPromptStore {
-	return &mockPlatformPromptStore{prompts: make(map[string]*prompt.Prompt)}
-}
-
-func (m *mockPlatformPromptStore) Create(_ context.Context, p *prompt.Prompt) error {
-	if m.createErr != nil {
-		return m.createErr
-	}
-	p.ID = "gen-" + p.Name
-	m.prompts[p.Name] = p
-	return nil
-}
-
-func (m *mockPlatformPromptStore) Get(_ context.Context, name string) (*prompt.Prompt, error) {
-	if m.getErr != nil {
-		return nil, m.getErr
-	}
-	p := m.prompts[name]
-	return p, nil //nolint:nilnil // interface contract
-}
-
-func (m *mockPlatformPromptStore) GetPersonal(_ context.Context, ownerEmail, name string) (*prompt.Prompt, error) {
-	if m.getErr != nil {
-		return nil, m.getErr
-	}
-	for _, p := range m.prompts {
-		if p.Scope == prompt.ScopePersonal && p.OwnerEmail == ownerEmail && p.Name == name {
-			return p, nil
-		}
-	}
-	return nil, nil //nolint:nilnil // interface contract
-}
-
-func (m *mockPlatformPromptStore) GetByID(_ context.Context, id string) (*prompt.Prompt, error) {
-	for _, p := range m.prompts {
-		if p.ID == id {
-			return p, nil
-		}
-	}
-	return nil, nil //nolint:nilnil // interface contract
-}
-
-func (m *mockPlatformPromptStore) Update(_ context.Context, p *prompt.Prompt) error {
-	if m.updateErr != nil {
-		return m.updateErr
-	}
-	m.prompts[p.Name] = p
-	return nil
-}
-
-func (m *mockPlatformPromptStore) Delete(_ context.Context, name string) error {
-	if m.deleteErr != nil {
-		return m.deleteErr
-	}
-	delete(m.prompts, name)
-	return nil
-}
-
-func (m *mockPlatformPromptStore) DeleteByID(_ context.Context, id string) error {
-	if m.deleteErr != nil {
-		return m.deleteErr
-	}
-	for name, p := range m.prompts {
-		if p.ID == id {
-			delete(m.prompts, name)
-			return nil
-		}
-	}
-	return nil
-}
-
-func (m *mockPlatformPromptStore) List(_ context.Context, f prompt.ListFilter) ([]prompt.Prompt, error) { //nolint:revive // interface impl
-	if m.listErr != nil {
-		return nil, m.listErr
-	}
-	var result []prompt.Prompt
-	for _, p := range m.prompts {
-		if f.Scope != "" && p.Scope != f.Scope {
-			continue
-		}
-		if f.OwnerEmail != "" && p.OwnerEmail != f.OwnerEmail {
-			continue
-		}
-		if f.Source != "" && p.Source != f.Source {
-			continue
-		}
-		if f.ExcludeSource != "" && p.Source == f.ExcludeSource {
-			continue
-		}
-		result = append(result, *p)
-	}
-	return result, nil
-}
-
-func (m *mockPlatformPromptStore) Count(_ context.Context, _ prompt.ListFilter) (int, error) {
-	return len(m.prompts), nil
-}
-
-var _ prompt.Store = (*mockPlatformPromptStore)(nil)
-
-// --- helpers ---
-
-func newTestPlatformWithPromptStore() (*Platform, *mockPlatformPromptStore) {
-	store := newMockPlatformPromptStore()
-	srv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil)
-	p := &Platform{
-		config:      &Config{Admin: AdminConfig{Persona: "admin"}},
-		mcpServer:   srv,
-		promptStore: store,
-	}
-	return p, store
-}
-
-func adminCtx() context.Context {
-	pc := middleware.NewPlatformContext("")
-	pc.PersonaName = "admin"
-	pc.UserEmail = "admin@example.com"
-	return middleware.WithPlatformContext(context.Background(), pc)
-}
-
-func userCtx(email, persona string) context.Context {
-	pc := middleware.NewPlatformContext("")
-	pc.PersonaName = persona
-	pc.UserEmail = email
-	return middleware.WithPlatformContext(context.Background(), pc)
-}
-
-func resultText(r *mcp.CallToolResult) string {
-	if r == nil || len(r.Content) == 0 {
-		return ""
-	}
-	tc, ok := r.Content[0].(*mcp.TextContent)
-	if !ok {
-		return ""
-	}
-	return tc.Text
-}
-
 // --- handleManagePrompt dispatch ---
 
 func TestHandleManagePrompt_UnknownCommand(t *testing.T) {
-	p, _ := newTestPlatformWithPromptStore()
-	r, _, _ := p.handleManagePrompt(context.Background(), managePromptInput{Command: "bogus"})
+	h, _ := newTestHandle()
+	r, _, _ := h.handleManagePrompt(context.Background(), managePromptInput{Command: "bogus"})
 	assert.True(t, r.IsError)
 	assert.Contains(t, resultText(r), "unknown command")
 }
@@ -175,8 +25,8 @@ func TestHandleManagePrompt_UnknownCommand(t *testing.T) {
 // --- handlePromptCreate ---
 
 func TestHandlePromptCreate_Success(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
-	r, _, _ := p.handlePromptCreate(adminCtx(), managePromptInput{
+	h, store := newTestHandle()
+	r, _, _ := h.handlePromptCreate(adminCtx(), managePromptInput{
 		Name: "my-prompt", Content: "hello {topic}", Scope: "global",
 	})
 	assert.False(t, r.IsError)
@@ -185,23 +35,23 @@ func TestHandlePromptCreate_Success(t *testing.T) {
 }
 
 func TestHandlePromptCreate_InvalidName(t *testing.T) {
-	p, _ := newTestPlatformWithPromptStore()
-	r, _, _ := p.handlePromptCreate(adminCtx(), managePromptInput{
+	h, _ := newTestHandle()
+	r, _, _ := h.handlePromptCreate(adminCtx(), managePromptInput{
 		Name: "INVALID NAME!", Content: "content",
 	})
 	assert.True(t, r.IsError)
 }
 
 func TestHandlePromptCreate_MissingContent(t *testing.T) {
-	p, _ := newTestPlatformWithPromptStore()
-	r, _, _ := p.handlePromptCreate(adminCtx(), managePromptInput{Name: "test"})
+	h, _ := newTestHandle()
+	r, _, _ := h.handlePromptCreate(adminCtx(), managePromptInput{Name: "test"})
 	assert.True(t, r.IsError)
 	assert.Contains(t, resultText(r), "content is required")
 }
 
 func TestHandlePromptCreate_InvalidScope(t *testing.T) {
-	p, _ := newTestPlatformWithPromptStore()
-	r, _, _ := p.handlePromptCreate(adminCtx(), managePromptInput{
+	h, _ := newTestHandle()
+	r, _, _ := h.handlePromptCreate(adminCtx(), managePromptInput{
 		Name: "test", Content: "c", Scope: "invalid",
 	})
 	assert.True(t, r.IsError)
@@ -209,8 +59,8 @@ func TestHandlePromptCreate_InvalidScope(t *testing.T) {
 }
 
 func TestHandlePromptCreate_NonAdminDeniedGlobalScope(t *testing.T) {
-	p, _ := newTestPlatformWithPromptStore()
-	r, _, _ := p.handlePromptCreate(userCtx("user@example.com", "analyst"), managePromptInput{
+	h, _ := newTestHandle()
+	r, _, _ := h.handlePromptCreate(userCtx("user@example.com", "analyst"), managePromptInput{
 		Name: "test", Content: "c", Scope: "global",
 	})
 	assert.True(t, r.IsError)
@@ -218,8 +68,8 @@ func TestHandlePromptCreate_NonAdminDeniedGlobalScope(t *testing.T) {
 }
 
 func TestHandlePromptCreate_NonAdminPersonalOK(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
-	r, _, _ := p.handlePromptCreate(userCtx("user@example.com", "analyst"), managePromptInput{
+	h, store := newTestHandle()
+	r, _, _ := h.handlePromptCreate(userCtx("user@example.com", "analyst"), managePromptInput{
 		Name: "my-personal", Content: "content",
 	})
 	assert.False(t, r.IsError)
@@ -228,8 +78,8 @@ func TestHandlePromptCreate_NonAdminPersonalOK(t *testing.T) {
 }
 
 func TestHandlePromptCreate_NilPersonasDefaultsToEmpty(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
-	r, _, _ := p.handlePromptCreate(adminCtx(), managePromptInput{
+	h, store := newTestHandle()
+	r, _, _ := h.handlePromptCreate(adminCtx(), managePromptInput{
 		Name: "no-personas", Content: "content", Scope: "personal",
 		// Personas intentionally omitted (nil)
 	})
@@ -238,11 +88,11 @@ func TestHandlePromptCreate_NilPersonasDefaultsToEmpty(t *testing.T) {
 }
 
 func TestHandlePromptCreate_StoreErrorDoesNotLeakToNonAdmin(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.createErr = fmt.Errorf("pq: null value in column \"personas\" violates not-null constraint (23502)")
 	// A non-admin creating a personal prompt reaches the store; the raw DB error
 	// (which carries SQL/schema detail) must not leak to a non-admin caller.
-	r, _, _ := p.handlePromptCreate(userCtx("user@example.com", "analyst"), managePromptInput{
+	r, _, _ := h.handlePromptCreate(userCtx("user@example.com", "analyst"), managePromptInput{
 		Name: "test", Content: "content",
 	})
 	assert.True(t, r.IsError)
@@ -253,11 +103,11 @@ func TestHandlePromptCreate_StoreErrorDoesNotLeakToNonAdmin(t *testing.T) {
 }
 
 func TestHandlePromptCreate_StoreErrorAdminSeesDetail(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.createErr = fmt.Errorf("pq: null value in column \"personas\" violates not-null constraint (23502)")
 	// Admins are platform operators: they get the underlying error to diagnose
 	// failures (admin-gated, per the self-describing error contract).
-	r, _, _ := p.handlePromptCreate(adminCtx(), managePromptInput{
+	r, _, _ := h.handlePromptCreate(adminCtx(), managePromptInput{
 		Name: "test", Content: "content",
 	})
 	assert.True(t, r.IsError)
@@ -268,9 +118,9 @@ func TestHandlePromptCreate_StoreErrorAdminSeesDetail(t *testing.T) {
 }
 
 func TestHandlePromptCreate_StoreError(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.createErr = fmt.Errorf("db down")
-	r, _, _ := p.handlePromptCreate(adminCtx(), managePromptInput{
+	r, _, _ := h.handlePromptCreate(adminCtx(), managePromptInput{
 		Name: "test", Content: "content",
 	})
 	assert.True(t, r.IsError)
@@ -280,12 +130,12 @@ func TestHandlePromptCreate_StoreError(t *testing.T) {
 // --- handlePromptUpdate ---
 
 func TestHandlePromptUpdate_Success(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["old"] = &prompt.Prompt{
 		ID: "id-1", Name: "old", Content: "old-content",
 		Scope: prompt.ScopePersonal, OwnerEmail: "user@example.com", Enabled: true,
 	}
-	r, _, _ := p.handlePromptUpdate(userCtx("user@example.com", "analyst"), managePromptInput{
+	r, _, _ := h.handlePromptUpdate(userCtx("user@example.com", "analyst"), managePromptInput{
 		Name: "old", Content: "new-content",
 	})
 	assert.False(t, r.IsError)
@@ -293,18 +143,18 @@ func TestHandlePromptUpdate_Success(t *testing.T) {
 }
 
 func TestHandlePromptUpdate_NotFound(t *testing.T) {
-	p, _ := newTestPlatformWithPromptStore()
-	r, _, _ := p.handlePromptUpdate(adminCtx(), managePromptInput{Name: "missing"})
+	h, _ := newTestHandle()
+	r, _, _ := h.handlePromptUpdate(adminCtx(), managePromptInput{Name: "missing"})
 	assert.True(t, r.IsError)
 	assert.Contains(t, resultText(r), "not found")
 }
 
 func TestHandlePromptUpdate_NonAdminDeniedNonPersonal(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["global"] = &prompt.Prompt{
 		ID: "id-1", Name: "global", Scope: prompt.ScopeGlobal,
 	}
-	r, _, _ := p.handlePromptUpdate(userCtx("user@example.com", "analyst"), managePromptInput{
+	r, _, _ := h.handlePromptUpdate(userCtx("user@example.com", "analyst"), managePromptInput{
 		Name: "global", Content: "hacked",
 	})
 	assert.True(t, r.IsError)
@@ -312,11 +162,11 @@ func TestHandlePromptUpdate_NonAdminDeniedNonPersonal(t *testing.T) {
 }
 
 func TestHandlePromptUpdate_NonAdminDeniedOtherUser(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["other"] = &prompt.Prompt{
 		ID: "id-1", Name: "other", Scope: prompt.ScopePersonal, OwnerEmail: "bob@example.com",
 	}
-	r, _, _ := p.handlePromptUpdate(userCtx("alice@example.com", "analyst"), managePromptInput{
+	r, _, _ := h.handlePromptUpdate(userCtx("alice@example.com", "analyst"), managePromptInput{
 		Name: "other", Content: "hacked",
 	})
 	assert.True(t, r.IsError)
@@ -324,11 +174,11 @@ func TestHandlePromptUpdate_NonAdminDeniedOtherUser(t *testing.T) {
 }
 
 func TestHandlePromptUpdate_ScopeChangeByNonAdmin(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["mine"] = &prompt.Prompt{
 		ID: "id-1", Name: "mine", Scope: prompt.ScopePersonal, OwnerEmail: "user@example.com",
 	}
-	r, _, _ := p.handlePromptUpdate(userCtx("user@example.com", "analyst"), managePromptInput{
+	r, _, _ := h.handlePromptUpdate(userCtx("user@example.com", "analyst"), managePromptInput{
 		Name: "mine", Scope: "global",
 	})
 	assert.True(t, r.IsError)
@@ -336,9 +186,9 @@ func TestHandlePromptUpdate_ScopeChangeByNonAdmin(t *testing.T) {
 }
 
 func TestHandlePromptUpdate_StoreGetError(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.getErr = fmt.Errorf("pq: connection refused")
-	r, _, _ := p.handlePromptUpdate(adminCtx(), managePromptInput{Name: "test", Content: "c"})
+	r, _, _ := h.handlePromptUpdate(adminCtx(), managePromptInput{Name: "test", Content: "c"})
 	assert.True(t, r.IsError)
 	text := resultText(r)
 	assert.Contains(t, text, "failed to get prompt")
@@ -346,12 +196,12 @@ func TestHandlePromptUpdate_StoreGetError(t *testing.T) {
 }
 
 func TestHandlePromptUpdate_StoreUpdateError(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["test"] = &prompt.Prompt{
 		ID: "id-1", Name: "test", Scope: prompt.ScopeGlobal,
 	}
 	store.updateErr = fmt.Errorf("pq: disk full")
-	r, _, _ := p.handlePromptUpdate(adminCtx(), managePromptInput{Name: "test", Content: "c"})
+	r, _, _ := h.handlePromptUpdate(adminCtx(), managePromptInput{Name: "test", Content: "c"})
 	assert.True(t, r.IsError)
 	text := resultText(r)
 	assert.Contains(t, text, "failed to update prompt")
@@ -361,36 +211,36 @@ func TestHandlePromptUpdate_StoreUpdateError(t *testing.T) {
 // --- handlePromptDelete ---
 
 func TestHandlePromptDelete_Success(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["del"] = &prompt.Prompt{
 		ID: "id-1", Name: "del", Scope: prompt.ScopePersonal, OwnerEmail: "user@example.com",
 	}
-	r, _, _ := p.handlePromptDelete(userCtx("user@example.com", "analyst"), managePromptInput{Name: "del"})
+	r, _, _ := h.handlePromptDelete(userCtx("user@example.com", "analyst"), managePromptInput{Name: "del"})
 	assert.False(t, r.IsError)
 	assert.NotContains(t, store.prompts, "del")
 }
 
 func TestHandlePromptDelete_NotFound(t *testing.T) {
-	p, _ := newTestPlatformWithPromptStore()
-	r, _, _ := p.handlePromptDelete(adminCtx(), managePromptInput{Name: "missing"})
+	h, _ := newTestHandle()
+	r, _, _ := h.handlePromptDelete(adminCtx(), managePromptInput{Name: "missing"})
 	assert.True(t, r.IsError)
 	assert.Contains(t, resultText(r), "not found")
 }
 
 func TestHandlePromptDelete_NonAdminDeniedNonPersonal(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["global"] = &prompt.Prompt{
 		ID: "id-1", Name: "global", Scope: prompt.ScopeGlobal,
 	}
-	r, _, _ := p.handlePromptDelete(userCtx("user@example.com", "analyst"), managePromptInput{Name: "global"})
+	r, _, _ := h.handlePromptDelete(userCtx("user@example.com", "analyst"), managePromptInput{Name: "global"})
 	assert.True(t, r.IsError)
 	assert.Contains(t, resultText(r), "non-admins")
 }
 
 func TestHandlePromptDelete_StoreGetError(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.getErr = fmt.Errorf("pq: timeout")
-	r, _, _ := p.handlePromptDelete(adminCtx(), managePromptInput{Name: "test"})
+	r, _, _ := h.handlePromptDelete(adminCtx(), managePromptInput{Name: "test"})
 	assert.True(t, r.IsError)
 	text := resultText(r)
 	assert.Contains(t, text, "failed to get prompt")
@@ -398,12 +248,12 @@ func TestHandlePromptDelete_StoreGetError(t *testing.T) {
 }
 
 func TestHandlePromptDelete_StoreDeleteError(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["test"] = &prompt.Prompt{
 		ID: "id-1", Name: "test", Scope: prompt.ScopeGlobal,
 	}
 	store.deleteErr = fmt.Errorf("pq: constraint violation")
-	r, _, _ := p.handlePromptDelete(adminCtx(), managePromptInput{Name: "test"})
+	r, _, _ := h.handlePromptDelete(adminCtx(), managePromptInput{Name: "test"})
 	assert.True(t, r.IsError)
 	text := resultText(r)
 	assert.Contains(t, text, "failed to delete prompt")
@@ -413,10 +263,10 @@ func TestHandlePromptDelete_StoreDeleteError(t *testing.T) {
 // --- handlePromptList ---
 
 func TestHandlePromptList_Admin(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["a"] = &prompt.Prompt{ID: "1", Name: "a", Scope: prompt.ScopeGlobal, Enabled: true}
 	store.prompts["b"] = &prompt.Prompt{ID: "2", Name: "b", Scope: prompt.ScopePersonal, Enabled: true, OwnerEmail: "u@x.com"}
-	r, _, _ := p.handlePromptList(adminCtx(), managePromptInput{Command: "list"})
+	r, _, _ := h.handlePromptList(adminCtx(), managePromptInput{Command: "list"})
 	assert.False(t, r.IsError)
 
 	var resp map[string]any
@@ -427,14 +277,14 @@ func TestHandlePromptList_Admin(t *testing.T) {
 }
 
 func TestHandlePromptList_NonAdminNoScope(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["personal"] = &prompt.Prompt{
 		ID: "1", Name: "personal", Scope: prompt.ScopePersonal, Enabled: true, OwnerEmail: "user@example.com",
 	}
 	store.prompts["global"] = &prompt.Prompt{
 		ID: "2", Name: "global", Scope: prompt.ScopeGlobal, Enabled: true,
 	}
-	r, _, _ := p.handlePromptList(userCtx("user@example.com", "analyst"), managePromptInput{Command: "list"})
+	r, _, _ := h.handlePromptList(userCtx("user@example.com", "analyst"), managePromptInput{Command: "list"})
 	assert.False(t, r.IsError)
 
 	var resp map[string]any
@@ -445,10 +295,10 @@ func TestHandlePromptList_NonAdminNoScope(t *testing.T) {
 }
 
 func TestHandlePromptList_NonAdminWithScope(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["g1"] = &prompt.Prompt{ID: "1", Name: "g1", Scope: prompt.ScopeGlobal, Enabled: true}
 	store.prompts["p1"] = &prompt.Prompt{ID: "2", Name: "p1", Scope: prompt.ScopePersonal, Enabled: true, OwnerEmail: "user@example.com"}
-	r, _, _ := p.handlePromptList(userCtx("user@example.com", "analyst"), managePromptInput{
+	r, _, _ := h.handlePromptList(userCtx("user@example.com", "analyst"), managePromptInput{
 		Command: "list", Scope: "global",
 	})
 	assert.False(t, r.IsError)
@@ -461,9 +311,9 @@ func TestHandlePromptList_NonAdminWithScope(t *testing.T) {
 }
 
 func TestHandlePromptList_StoreError(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.listErr = fmt.Errorf("pq: too many connections")
-	r, _, _ := p.handlePromptList(adminCtx(), managePromptInput{Command: "list"})
+	r, _, _ := h.handlePromptList(adminCtx(), managePromptInput{Command: "list"})
 	assert.True(t, r.IsError)
 	text := resultText(r)
 	assert.Contains(t, text, "failed to list prompts")
@@ -471,11 +321,11 @@ func TestHandlePromptList_StoreError(t *testing.T) {
 }
 
 func TestPromptErrorDetail(t *testing.T) {
-	p := &Platform{config: &Config{Admin: AdminConfig{Persona: "admin"}}}
+	h := &Handle{adminPersona: "admin"}
 	cause := fmt.Errorf("pq: null value in column \"tags\" (23502)")
 
 	t.Run("admin sees underlying detail", func(t *testing.T) {
-		r := p.promptErrorDetail(adminCtx(), "failed to create prompt", cause)
+		r := h.promptErrorDetail(adminCtx(), "failed to create prompt", cause)
 		assert.True(t, r.IsError)
 		text := resultText(r)
 		assert.Contains(t, text, "failed to create prompt")
@@ -488,7 +338,7 @@ func TestPromptErrorDetail(t *testing.T) {
 		pc.PersonaName = "analyst"
 		pc.UserEmail = "user@example.com"
 		ctx := middleware.WithPlatformContext(context.Background(), pc)
-		r := p.promptErrorDetail(ctx, "failed to create prompt", cause)
+		r := h.promptErrorDetail(ctx, "failed to create prompt", cause)
 		text := resultText(r)
 		assert.Contains(t, text, "failed to create prompt")
 		assert.Contains(t, text, "req-xyz")
@@ -497,7 +347,7 @@ func TestPromptErrorDetail(t *testing.T) {
 	})
 
 	t.Run("non-admin without request id gets generic message", func(t *testing.T) {
-		r := p.promptErrorDetail(userCtx("user@example.com", "analyst"), "failed to create prompt", cause)
+		r := h.promptErrorDetail(userCtx("user@example.com", "analyst"), "failed to create prompt", cause)
 		text := resultText(r)
 		assert.Equal(t, "failed to create prompt", text)
 		assert.NotContains(t, text, "pq:")
@@ -507,36 +357,36 @@ func TestPromptErrorDetail(t *testing.T) {
 // --- handlePromptGet ---
 
 func TestHandlePromptGet_Found(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["test"] = &prompt.Prompt{
 		ID: "id-1", Name: "test", Content: "content", Scope: prompt.ScopeGlobal,
 	}
-	r, _, _ := p.handlePromptGet(adminCtx(), managePromptInput{Name: "test"})
+	r, _, _ := h.handlePromptGet(adminCtx(), managePromptInput{Name: "test"})
 	assert.False(t, r.IsError)
 	assert.Contains(t, resultText(r), "test")
 }
 
 func TestHandlePromptGet_NotFound(t *testing.T) {
-	p, _ := newTestPlatformWithPromptStore()
-	r, _, _ := p.handlePromptGet(adminCtx(), managePromptInput{Name: "missing"})
+	h, _ := newTestHandle()
+	r, _, _ := h.handlePromptGet(adminCtx(), managePromptInput{Name: "missing"})
 	assert.True(t, r.IsError)
 	assert.Contains(t, resultText(r), "not found")
 }
 
 func TestHandlePromptGet_NonAdminDeniedOtherPersonal(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["secret"] = &prompt.Prompt{
 		ID: "id-1", Name: "secret", Scope: prompt.ScopePersonal, OwnerEmail: "bob@example.com",
 	}
-	r, _, _ := p.handlePromptGet(userCtx("alice@example.com", "engineer"), managePromptInput{Name: "secret"})
+	r, _, _ := h.handlePromptGet(userCtx("alice@example.com", "engineer"), managePromptInput{Name: "secret"})
 	assert.True(t, r.IsError)
 	assert.Contains(t, resultText(r), "your own")
 }
 
 func TestHandlePromptGet_StoreError(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.getErr = fmt.Errorf("pq: connection reset")
-	r, _, _ := p.handlePromptGet(adminCtx(), managePromptInput{Name: "test"})
+	r, _, _ := h.handlePromptGet(adminCtx(), managePromptInput{Name: "test"})
 	assert.True(t, r.IsError)
 	text := resultText(r)
 	assert.Contains(t, text, "failed to get prompt")
@@ -613,13 +463,13 @@ func TestResolveEmail_FromContext(t *testing.T) {
 }
 
 func TestIsAdminPersona_NoContext(t *testing.T) {
-	p := &Platform{config: &Config{Admin: AdminConfig{Persona: "admin"}}}
-	assert.False(t, p.isAdminPersona(t.Context()))
+	h := &Handle{adminPersona: "admin"}
+	assert.False(t, h.isAdminPersona(t.Context()))
 }
 
 func TestIsAdminPersona_AdminContext(t *testing.T) {
-	p := &Platform{config: &Config{Admin: AdminConfig{Persona: "admin"}}}
-	assert.True(t, p.isAdminPersona(adminCtx()))
+	h := &Handle{adminPersona: "admin"}
+	assert.True(t, h.isAdminPersona(adminCtx()))
 }
 
 func TestIsBuiltinDisabled(t *testing.T) {
@@ -637,16 +487,39 @@ func TestIsBuiltinDisabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Platform{config: &Config{Server: ServerConfig{BuiltinPrompts: tt.config}}}
-			assert.Equal(t, tt.expected, p.isBuiltinDisabled(tt.prompt))
+			h := &Handle{builtinPrompts: tt.config}
+			assert.Equal(t, tt.expected, h.isBuiltinDisabled(tt.prompt))
 		})
 	}
+}
+
+func TestCheckPromotionNameFree(t *testing.T) {
+	h, store := newTestHandle()
+	ctx := context.Background()
+
+	// Not a promotion: old scope is not personal.
+	assert.Empty(t, h.checkPromotionNameFree(ctx,
+		&prompt.Prompt{ID: "g", Name: "x", Scope: prompt.ScopeGlobal}, prompt.ScopeGlobal))
+
+	// Not a promotion: still personal.
+	assert.Empty(t, h.checkPromotionNameFree(ctx,
+		&prompt.Prompt{ID: "p", Name: "x", Scope: prompt.ScopePersonal}, prompt.ScopePersonal))
+
+	// Promotion, name free in the shared namespace.
+	assert.Empty(t, h.checkPromotionNameFree(ctx,
+		&prompt.Prompt{ID: "p1", Name: "free", Scope: prompt.ScopeGlobal}, prompt.ScopePersonal))
+
+	// Promotion, name already owned by a different shared prompt.
+	store.prompts["taken"] = &prompt.Prompt{ID: "g1", Name: "taken", Scope: prompt.ScopeGlobal}
+	msg := h.checkPromotionNameFree(ctx,
+		&prompt.Prompt{ID: "p1", Name: "taken", Scope: prompt.ScopeGlobal}, prompt.ScopePersonal)
+	assert.Contains(t, msg, "already used")
 }
 
 // resolveManagedPrompt prefers the caller's personal prompt by default, but an
 // explicit shared scope targets the global/persona prompt of the same name.
 func TestResolveManagedPrompt_ScopePreference(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["report"] = &prompt.Prompt{ID: "g", Name: "report", Scope: prompt.ScopeGlobal, Content: "global"}
 	store.prompts["personal:report"] = &prompt.Prompt{
 		ID: "p", Name: "report", Scope: prompt.ScopePersonal, OwnerEmail: "admin@x", Content: "personal",
@@ -654,12 +527,12 @@ func TestResolveManagedPrompt_ScopePreference(t *testing.T) {
 
 	ctx := context.Background()
 
-	got, err := p.resolveManagedPrompt(ctx, "report", "admin@x", "")
+	got, err := h.resolveManagedPrompt(ctx, "report", "admin@x", "")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "p", got.ID, "default resolution prefers the caller's personal prompt")
 
-	got, err = p.resolveManagedPrompt(ctx, "report", "admin@x", prompt.ScopeGlobal)
+	got, err = h.resolveManagedPrompt(ctx, "report", "admin@x", prompt.ScopeGlobal)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "g", got.ID, "explicit global scope targets the shared prompt")
@@ -668,14 +541,14 @@ func TestResolveManagedPrompt_ScopePreference(t *testing.T) {
 // manage_prompt update with requested_scope flags the owner's personal prompt
 // for the admin promotion queue without changing its scope.
 func TestManagePrompt_RequestPromotion(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["report"] = &prompt.Prompt{
 		ID: "id1", Name: "report", Scope: prompt.ScopePersonal,
 		OwnerEmail: "u@x", Content: "x", Enabled: true,
 	}
 
 	ctx := userCtx("u@x", "analyst")
-	_, _, err := p.handleManagePrompt(ctx, managePromptInput{
+	_, _, err := h.handleManagePrompt(ctx, managePromptInput{
 		Command: "update", Name: "report",
 		RequestedScope: prompt.ScopePersona, RequestedPersonas: []string{"analyst"},
 	})
@@ -690,12 +563,12 @@ func TestManagePrompt_RequestPromotion(t *testing.T) {
 
 // A non-personal prompt cannot be flagged for promotion.
 func TestManagePrompt_RequestPromotion_RejectsNonPersonal(t *testing.T) {
-	p, store := newTestPlatformWithPromptStore()
+	h, store := newTestHandle()
 	store.prompts["report"] = &prompt.Prompt{
 		ID: "id1", Name: "report", Scope: prompt.ScopeGlobal, Content: "x", Enabled: true,
 	}
 
-	res, _, err := p.handleManagePrompt(adminCtx(), managePromptInput{
+	res, _, err := h.handleManagePrompt(adminCtx(), managePromptInput{
 		Command: "update", Name: "report", RequestedScope: prompt.ScopePersona, RequestedPersonas: []string{"analyst"},
 	})
 	require.NoError(t, err)

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -140,6 +140,7 @@ pkg/platform -> pkg/platform/oauthserver
 pkg/platform -> pkg/platform/obs
 pkg/platform -> pkg/platform/personastore
 pkg/platform -> pkg/platform/portalstore
+pkg/platform -> pkg/platform/promptlayer
 pkg/platform -> pkg/platform/reflexivecapture
 pkg/platform -> pkg/platform/resourcelayer
 pkg/platform -> pkg/platform/routepolicy
@@ -151,7 +152,6 @@ pkg/platform -> pkg/portal
 pkg/platform -> pkg/portal/knowledgepage
 pkg/platform -> pkg/portal/s3adapter
 pkg/platform -> pkg/prompt
-pkg/platform -> pkg/prompt/postgres
 pkg/platform -> pkg/query
 pkg/platform -> pkg/query/trino
 pkg/platform -> pkg/registry
@@ -218,6 +218,13 @@ pkg/platform/portalstore -> pkg/embedding
 pkg/platform/portalstore -> pkg/portal
 pkg/platform/portalstore -> pkg/portal/knowledgepage
 pkg/platform/portalstore -> pkg/toolkits/portal
+pkg/platform/promptlayer -> pkg/embedding
+pkg/platform/promptlayer -> pkg/middleware
+pkg/platform/promptlayer -> pkg/portal
+pkg/platform/promptlayer -> pkg/prompt
+pkg/platform/promptlayer -> pkg/prompt/postgres
+pkg/platform/promptlayer -> pkg/registry
+pkg/platform/promptlayer -> pkg/tuning
 pkg/platform/reflexivecapture -> pkg/memory
 pkg/platform/reflexivecapture -> pkg/middleware
 pkg/platform/reflexivecapture -> pkg/toolkits/memory


### PR DESCRIPTION
Closes #853. Relates to #756.

## Summary

Follow-on to the Platform decomposition (#756). The mechanical-cluster batch (#851) deliberately **split the prompt cluster into this dedicated seam** because it is not mechanical: ~1520 lines and ~40 `*Platform` methods across three files that reach into personas, the toolkit registry, the MCP server, the semantic/embedding providers, the portal share store, and searchfed.

This PR folds the prompt subsystem behind one owner `Handle` in a new package, `pkg/platform/promptlayer`.

## What moved

A new package `pkg/platform/promptlayer` owns the prompt subsystem behind one `Handle`:

- **Prompt store** (`prompt.Store`), the file-based **tuning prompt manager**, and the name-keyed **prompt-metadata list** (`promptInfos` + its mutex).
- The **static / workflow / database registration path** (`RegisterPlatformPrompts`, the auto `platform-overview` prompt, workflow-prompt gating, capability bullets, static-prompt ingestion for search — #593).
- The **per-viewer dynamic-serving callbacks** wired into the prompts/list visibility middleware (`ListVisible` / `GetByName`, with global-/persona-/personal-/shared- scoping).
- The **`manage_prompt` tool** (create/update/delete/list/get, semantic ranking, promotion requests).

The owner imports its domain packages (`pkg/prompt`, `pkg/tuning`, `pkg/registry`, `pkg/embedding`, `pkg/middleware`, `pkg/portal`) and **never** `pkg/platform`; its constructor takes explicit inputs, so it is constructible and testable without a `Platform`.

## Platform changes

- **Four fields removed** from `Platform` (`promptManager`, `promptStore`, `promptInfosMu`, `promptInfos`) → one `prompts *promptlayer.Handle`.
- `initPromptStore()` collapses to config-translation plus delegation (mirroring `initMemory` / `initManagedResources`) and now runs after `initRegistries`, since the layer reads the toolkit registry for capability bullets and workflow gating.
- **`addPromptVisibilityMiddleware()` stays on `Platform`** (middleware-chain wiring that reaches back into Platform), same pattern as `addManagedResourceMiddleware` / `memorylayer` / `knowledgelayer`.
- The public accessors external callers use — `PromptStore()`, `AllPromptInfos()`, `RegisterRuntimePrompt()`, `UnregisterRuntimePrompt()` — stay on `Platform` as **nil-safe one-line delegators** (consumed by `pkg/admin`, `pkg/portal`, `cmd/`).
- Late collaborators (the embedding provider and the portal share store) are bound in `finalizeSetup` via a new `bindPromptCollaborators()`; the MCP server is passed per-call to `RegisterPlatformPrompts` / `RegisterTool` (never snapshot — it does not exist at `initPromptStore` time).
- The prompt search provider stays federated via searchfed's `PromptSearcher` cast — that edge is unchanged.

## Ratchets

- **God-object field ceiling 49 → 46**, method ceiling **249 → 212** (re-pinned to the actual, with ratchet comments). The `bindPromptCollaborators` binding seam stays on Platform, mirroring `addPromptVisibilityMiddleware`.
- Import ratchet golden (`testdata/allowed_internal_imports.txt`) regenerated for the new package edges.

## Tests

- All behavioral prompt tests migrated into the owner package (ingest, register, tool, search, dynamic-serving, shared-serving, lifecycle) and rewritten against `Handle` rather than a hand-built `Platform`.
- Added owner unit tests for construction, accessors, the `PromptCreator` adapter, and nil-handle safety.
- Added an **assembled-system test** (`TestBindPromptCollaborators_WiresEmbedderAndShareStore`) that runs the real `bindPromptCollaborators()` and observes both collaborators reaching the layer through its public surfaces — the portal share store via `ListVisible` returning a shared prompt, and the embedding provider via `manage_prompt` search reporting `hybrid` ranking.

## Verification

`make verify` green end-to-end: fmt, race tests, total + patch coverage (patch 94.3%), lint (`golangci-lint` full + `--new-from-patch`), gosec/govulncheck, semgrep, CodeQL, dead-code, mutation, and the GoReleaser dry-run.
