### PR TITLE
fix(portal): resolve asset access via collection cascade in getAsset (#839)

### DIFF
--- a/pkg/portal/handler.go
+++ b/pkg/portal/handler.go
@@ -486,7 +486,11 @@ func (h *Handler) getAsset(w http.ResponseWriter, r *http.Request) {
 	resp := assetResponse{Asset: *asset, IsOwner: asset.OwnerID == user.UserID}
 
 	if !resp.IsOwner {
-		perm, permErr := h.sharePermissionForUser(r, id, user)
+		// Resolve the highest permission across a direct share and the collection
+		// cascade, so a user who holds only a collection share can open the
+		// individual asset (issue #839) and a collection editor is reported as
+		// editor even when a lesser direct share also exists.
+		perm, permErr := h.resolveAssetPermission(r, id, user)
 		if permErr != nil {
 			writeError(w, http.StatusInternalServerError, "failed to check share access")
 			return
@@ -2179,11 +2183,51 @@ func (h *Handler) sharePermissionForUser(r *http.Request, assetID string, user *
 	return best, nil
 }
 
+// permissionRank orders share permissions so the highest grant wins when a user
+// holds access through more than one path (editor > viewer > none).
+func permissionRank(p SharePermission) int {
+	switch p {
+	case PermissionEditor:
+		return 2
+	case PermissionViewer:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// resolveAssetPermission returns the highest permission a non-owner user holds for
+// an asset, combining a direct share (sharePermissionForUser) with a collection
+// share (GetUserAssetPermissionViaCollection). A direct editor short-circuits the
+// collection lookup because editor is the ceiling. The returned error is the
+// direct-share store error (nil on success); a collection-lookup error is treated
+// as no collection access, matching the best-effort cascade the access helpers use.
+// Owner access must be checked by the caller, which treats a non-nil error as 500.
+//
+// This is for callers that need the effective permission value (getAsset reports it
+// as SharePermission; canEditAsset compares it to editor). The bool view helpers
+// (canViewAsset/userCanViewAsset) deliberately do not use it: they only need "any
+// grant" and short-circuit on a direct share to avoid a collection query per asset.
+func (h *Handler) resolveAssetPermission(r *http.Request, assetID string, user *User) (SharePermission, error) {
+	direct, err := h.sharePermissionForUser(r, assetID, user)
+	if err == nil && direct == PermissionEditor {
+		return direct, nil // editor is the ceiling; no need to consult the cascade
+	}
+	collPerm, _ := h.deps.ShareStore.GetUserAssetPermissionViaCollection(r.Context(), assetID, user.UserID, user.Email)
+	best := direct
+	if permissionRank(collPerm) > permissionRank(best) {
+		best = collPerm
+	}
+	return best, err
+}
+
 // canViewAsset checks owner or any share access, writing an HTTP error on failure.
 func (h *Handler) canViewAsset(w http.ResponseWriter, r *http.Request, assetID string, asset *Asset, user *User) bool {
 	if asset.OwnerID == user.UserID {
 		return true
 	}
+	// A view only needs any grant, so short-circuit on a direct share before the
+	// collection lookup — this runs per-asset in loops (e.g. knowledge-page refs).
 	perm, err := h.sharePermissionForUser(r, assetID, user)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to check share access")
@@ -2202,8 +2246,9 @@ func (h *Handler) canViewAsset(w http.ResponseWriter, r *http.Request, assetID s
 
 // userCanViewAsset reports whether the user may view the asset (owner, a direct
 // share, or a collection share) without writing an HTTP response — the pure form
-// of canViewAsset, for callers that resolve many entities in a loop. A share-store
-// error is treated as no access.
+// of canViewAsset, for callers that resolve many entities in a loop. A direct-share
+// store error is tolerated: a collection grant still allows access. Like canViewAsset
+// it short-circuits on a direct grant to avoid a collection query on the hot path.
 func (h *Handler) userCanViewAsset(r *http.Request, assetID string, asset *Asset, user *User) bool {
 	if asset.OwnerID == user.UserID {
 		return true
@@ -2220,16 +2265,12 @@ func (h *Handler) canEditAsset(w http.ResponseWriter, r *http.Request, assetID s
 	if asset.OwnerID == user.UserID {
 		return true
 	}
-	perm, err := h.sharePermissionForUser(r, assetID, user)
+	perm, err := h.resolveAssetPermission(r, assetID, user)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to check share access")
 		return false
 	}
 	if perm == PermissionEditor {
-		return true
-	}
-	collPerm, _ := h.deps.ShareStore.GetUserAssetPermissionViaCollection(r.Context(), assetID, user.UserID, user.Email)
-	if collPerm == PermissionEditor {
 		return true
 	}
 	writeError(w, http.StatusForbidden, "only the owner or an editor can update this asset")

--- a/pkg/portal/handler_test.go
+++ b/pkg/portal/handler_test.go
@@ -85,6 +85,7 @@ type mockShareStore struct {
 	summariesErr   error
 	collAssetPerm  SharePermission
 	collAssetPermE error
+	collAssetCalls int // number of GetUserAssetPermissionViaCollection invocations
 	inserted       *Share
 	promptRefs     []SharedPromptRef
 	promptRefsErr  error
@@ -143,6 +144,7 @@ func (*mockShareStore) ListSharedCollectionsWithUser(_ context.Context, _, _ str
 }
 
 func (m *mockShareStore) GetUserAssetPermissionViaCollection(_ context.Context, _, _, _ string) (SharePermission, error) {
+	m.collAssetCalls++
 	if m.collAssetPerm != "" {
 		return m.collAssetPerm, nil
 	}
@@ -570,6 +572,177 @@ func TestGetAssetSharedWithUser(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.False(t, resp.IsOwner)
 	assert.Equal(t, PermissionViewer, resp.SharePermission)
+}
+
+// TestGetAssetSharedViaCollection reproduces issue #839: a user who holds only a
+// collection share (no direct per-asset share row) must be able to open the
+// individual-asset metadata endpoint, resolving the permission via the collection
+// cascade rather than getting 403.
+func TestGetAssetSharedViaCollection(t *testing.T) {
+	now := time.Now()
+	asset := &Asset{ID: "a1", OwnerID: "other-user", Tags: []string{}, CreatedAt: now, UpdatedAt: now}
+	h := newTestHandler(
+		&mockAssetStore{getAsset: asset},
+		&mockShareStore{listByAsset: []Share{}, collAssetPerm: PermissionViewer}, // no direct share, collection viewer
+		&mockS3Client{},
+		&User{UserID: "u1"},
+	)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/api/v1/portal/assets/a1", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp assetResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.False(t, resp.IsOwner)
+	assert.Equal(t, PermissionViewer, resp.SharePermission)
+}
+
+// TestGetAssetSharedViaCollectionEditor verifies an editor-level collection share
+// surfaces as editor on the individual-asset endpoint.
+func TestGetAssetSharedViaCollectionEditor(t *testing.T) {
+	now := time.Now()
+	asset := &Asset{ID: "a1", OwnerID: "other-user", Tags: []string{}, CreatedAt: now, UpdatedAt: now}
+	h := newTestHandler(
+		&mockAssetStore{getAsset: asset},
+		&mockShareStore{listByAsset: []Share{}, collAssetPerm: PermissionEditor},
+		&mockS3Client{},
+		&User{UserID: "u1"},
+	)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/api/v1/portal/assets/a1", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp assetResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, PermissionEditor, resp.SharePermission)
+}
+
+// TestGetAssetCollectionEditorBeatsDirectViewer verifies getAsset reports the
+// highest permission across both paths: a user holding a direct viewer share AND
+// an editor-level collection share is reported as editor, so the UI does not hide
+// edit controls the backend (canEditAsset) actually permits.
+func TestGetAssetCollectionEditorBeatsDirectViewer(t *testing.T) {
+	now := time.Now()
+	asset := &Asset{ID: "a1", OwnerID: "other-user", Tags: []string{}, CreatedAt: now, UpdatedAt: now}
+	h := newTestHandler(
+		&mockAssetStore{getAsset: asset},
+		&mockShareStore{
+			listByAsset:   []Share{{ID: "s1", SharedWithUserID: "u1", Permission: PermissionViewer}},
+			collAssetPerm: PermissionEditor,
+		},
+		&mockS3Client{},
+		&User{UserID: "u1"},
+	)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/api/v1/portal/assets/a1", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp assetResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, PermissionEditor, resp.SharePermission)
+}
+
+// TestGetAssetForbiddenNoDirectOrCollectionShare verifies a non-owner with neither
+// a direct nor a collection share is still denied.
+func TestGetAssetForbiddenNoDirectOrCollectionShare(t *testing.T) {
+	asset := &Asset{ID: "a1", OwnerID: "other-user"}
+	h := newTestHandler(
+		&mockAssetStore{getAsset: asset},
+		&mockShareStore{listByAsset: []Share{}}, // no direct share; mock returns no collection share
+		&mockS3Client{},
+		&User{UserID: "u1"},
+	)
+
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/api/v1/portal/assets/a1", http.NoBody)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// TestResolveAssetPermission covers the resolver's cross-path and error semantics.
+func TestResolveAssetPermission(t *testing.T) {
+	user := &User{UserID: "u1", Email: "u1@example.com"}
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/", http.NoBody)
+
+	t.Run("collection editor beats direct viewer", func(t *testing.T) {
+		h := newTestHandler(&mockAssetStore{}, &mockShareStore{
+			listByAsset:   []Share{{ID: "s1", SharedWithUserID: "u1", Permission: PermissionViewer}},
+			collAssetPerm: PermissionEditor,
+		}, &mockS3Client{}, user)
+		perm, err := h.resolveAssetPermission(req, "a1", user)
+		require.NoError(t, err)
+		assert.Equal(t, PermissionEditor, perm)
+	})
+
+	t.Run("direct editor short-circuits, no collection needed", func(t *testing.T) {
+		shares := &mockShareStore{
+			listByAsset: []Share{{ID: "s1", SharedWithUserID: "u1", Permission: PermissionEditor}},
+		}
+		h := newTestHandler(&mockAssetStore{}, shares, &mockS3Client{}, user)
+		perm, err := h.resolveAssetPermission(req, "a1", user)
+		require.NoError(t, err)
+		assert.Equal(t, PermissionEditor, perm)
+		// A direct editor is the ceiling: the collection cascade must not be queried.
+		assert.Equal(t, 0, shares.collAssetCalls)
+	})
+
+	t.Run("direct-share error surfaces when neither path grants", func(t *testing.T) {
+		h := newTestHandler(&mockAssetStore{}, &mockShareStore{listByAssetE: fmt.Errorf("boom")}, &mockS3Client{}, user)
+		perm, err := h.resolveAssetPermission(req, "a1", user)
+		require.Error(t, err)
+		assert.Equal(t, SharePermission(""), perm)
+	})
+
+	// Tolerant path: a transient direct-share error must not hide a
+	// collection-reachable asset — the returned permission still reflects the
+	// collection grant so userCanViewAsset (which ignores the error) allows access.
+	t.Run("collection grant survives a direct-share error", func(t *testing.T) {
+		h := newTestHandler(&mockAssetStore{}, &mockShareStore{
+			listByAssetE:  fmt.Errorf("boom"),
+			collAssetPerm: PermissionViewer,
+		}, &mockS3Client{}, user)
+		perm, err := h.resolveAssetPermission(req, "a1", user)
+		require.Error(t, err) // direct error still surfaces for HTTP callers (500)
+		assert.Equal(t, PermissionViewer, perm)
+
+		// userCanViewAsset ignores the error and grants via the collection perm.
+		asset := &Asset{ID: "a1", OwnerID: "other"}
+		assert.True(t, h.userCanViewAsset(req, "a1", asset, user))
+	})
+}
+
+// TestViewHelpersShortCircuitOnDirectShare guards the hot path: canViewAsset and
+// userCanViewAsset must not issue a collection-cascade query when a direct share
+// already grants view access (these run per-asset in the knowledge-page-ref loop).
+func TestViewHelpersShortCircuitOnDirectShare(t *testing.T) {
+	asset := &Asset{ID: "a1", OwnerID: "other"}
+	user := &User{UserID: "u1"}
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/", http.NoBody)
+	directViewer := []Share{{ID: "s1", SharedWithUserID: "u1", Permission: PermissionViewer}}
+
+	t.Run("userCanViewAsset", func(t *testing.T) {
+		shares := &mockShareStore{listByAsset: directViewer}
+		h := newTestHandler(&mockAssetStore{}, shares, &mockS3Client{}, user)
+		assert.True(t, h.userCanViewAsset(req, "a1", asset, user))
+		assert.Equal(t, 0, shares.collAssetCalls)
+	})
+
+	t.Run("canViewAsset", func(t *testing.T) {
+		shares := &mockShareStore{listByAsset: directViewer}
+		h := newTestHandler(&mockAssetStore{}, shares, &mockS3Client{}, user)
+		assert.True(t, h.canViewAsset(httptest.NewRecorder(), req, "a1", asset, user))
+		assert.Equal(t, 0, shares.collAssetCalls)
+	})
 }
 
 func TestGetAssetNoUser(t *testing.T) {


### PR DESCRIPTION
## Summary

Sharing a collection with a user gave them the collection and thumbnails but **not** the individual assets — opening any asset returned `403 access denied`, forcing the reporter to share each asset one by one.

The collection→asset access cascade was already implemented (`ShareStore.GetUserAssetPermissionViaCollection`, wired into `canViewAsset`/`userCanViewAsset`/`canEditAsset`), so content download, version listing, thread targets, and sign-off already honored a collection share. The one gap: **`getAsset` (`GET /api/v1/portal/assets/{id}`, the individual-asset metadata endpoint) never consulted the cascade** — it checked only direct per-asset shares. The web app hits that endpoint the moment a user opens an asset, so a collection-only user was denied there.

Closes #839

## The fix

`getAsset` now resolves access across **both** a direct share and the collection cascade, the same access the other read paths already honor.

The change is centered on a new `resolveAssetPermission` helper that returns the **highest** permission across both paths:

- **Collection-only viewer** → `getAsset` returns `200` instead of `403` (the reported bug).
- **Collection editor + lesser direct viewer share** → reported as `editor`, not `viewer`. Previously `getAsset` short-circuited on the direct viewer share and under-reported, so the UI hid edit controls that `canEditAsset` would actually allow. This was a pre-existing correctness bug in the same endpoint, now fixed.

`canEditAsset` is routed through the same helper (behavior unchanged — it already honored collection editors). A direct **editor** short-circuits the collection lookup since editor is the ceiling.

### Hot-path preservation

The bool view helpers (`canViewAsset` / `userCanViewAsset`) **keep their direct-share short-circuit** and do **not** use the max-resolver. They only need "any grant," so a direct share returns early with no collection query — important because `userCanViewAsset` runs per-referenced-asset inside the knowledge-page-ref resolve loop. Value-callers that need the effective permission (`getAsset`, `canEditAsset`) use the resolver; bool view-callers stay on the efficient path.

## Error semantics (unchanged from prior behavior)

The existing split is preserved exactly:

- HTTP callers (`getAsset`, `canViewAsset`, `canEditAsset`) surface a direct-share store error as `500`.
- The silent `userCanViewAsset` tolerates a direct-share error and still honors a collection grant.
- Collection-lookup errors are treated as "no collection access" — the established best-effort cascade pattern used throughout the access helpers.

## Testing

- `make verify` green — all checks passed, patch coverage **100% (25/25 changed lines)**.
- Every new/changed function at **100%** unit coverage (`getAsset`, `resolveAssetPermission`, `permissionRank`, `canViewAsset`, `userCanViewAsset`, `canEditAsset`).
- New tests:
  - collection-only viewer / editor can open an individual asset (the #839 repro)
  - collection editor beats a lesser direct viewer share in the reported permission
  - resolver cross-path + error semantics (max permission, direct-editor short-circuit with the collection lookup asserted **not** called, direct-share error surfacing, collection grant surviving a direct-share error)
  - view helpers issue **no** collection query when a direct share already grants access (hot-path guard)

## Deliberately out of scope (follow-ups)

1. **Thread-moderation consistency.** A collection-editor can now view/edit an asset but still cannot moderate its discussion threads — `canEditAssetSilent` (backing `canModerateThread`) requires a direct editor share. This inconsistency is *inherent* to fixing #839 (any fix that lets a collection-editor reach the asset exposes it). Making moderation collection-aware is a policy decision (should collection-editors delete others' feedback threads?) and would also need the MCP toolkit twin (`pkg/toolkits/portal/thread_actions.go`) updated to match. Left for a separate, scoped change.
2. **Transient-error uniformity.** Surfacing collection-lookup errors as retryable `500`s (rather than the current best-effort swallow → `403`) would require the share store to distinguish `sql.ErrNoRows` from real errors — a store-contract change beyond this view-access fix.
