### PR TITLE
fix(apigateway): default api_list_endpoints ranking to hybrid when embeddings available

### DIFF
--- a/pkg/toolkits/apigateway/persisted_embeddings_test.go
+++ b/pkg/toolkits/apigateway/persisted_embeddings_test.go
@@ -284,6 +284,186 @@ func TestRanking_LexicalFallbackOnNoVectors(t *testing.T) {
 	}
 }
 
+// TestListEndpoints_DefaultOnHybridWhenEmbeddingsAvailable covers #858:
+// an omitted ranking must default to hybrid whenever the connection
+// has an embedding index, so a multi-intent query that the lexical
+// AND filter would drop to an empty set is instead ranked and
+// returned. An explicit ranking="lexical" is preserved as the
+// opt-out (the switch is offered, not the default).
+func TestListEndpoints_DefaultOnHybridWhenEmbeddingsAvailable(t *testing.T) {
+	t.Parallel()
+	tk := New("test")
+	emb := newTrackingEmbedder()
+	tk.SetEmbeddingProvider(emb)
+	store := catalog.NewMemoryStore()
+	tk.SetCatalogStore(store)
+	seedCatalogWithEmbeddings(t, store, emb, "shared", "default")
+	if err := tk.AddConnection("api", map[string]any{
+		"base_url":   "https://api.example.com",
+		"catalog_id": "shared",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	ctx := context.Background()
+
+	// "alpha bravo" has no single operation containing BOTH tokens, so
+	// the lexical AND filter matches nothing. With embeddings present
+	// the omitted ranking must resolve to hybrid and return both ops.
+	res, payload, _ := tk.handleListEndpoints(ctx, nil, ListEndpointsInput{
+		Connection: "api", Query: "alpha bravo",
+	})
+	if res == nil || res.IsError {
+		t.Fatalf("default ranking should not error: %v", res)
+	}
+	out, _ := payload.(ListEndpointsOutput)
+	if len(out.Operations) == 0 {
+		t.Fatal("omitted ranking with embeddings must default to hybrid and return ranked ops, not an empty lexical-AND result")
+	}
+	if out.Note != "" {
+		t.Errorf("hybrid default with vectors present should have no fallback Note; got %q", out.Note)
+	}
+
+	// Explicit lexical is the opt-out: the same multi-token query
+	// still AND-narrows to empty.
+	_, lexPayload, _ := tk.handleListEndpoints(ctx, nil, ListEndpointsInput{
+		Connection: "api", Query: "alpha bravo", Ranking: "lexical",
+	})
+	lexOut, _ := lexPayload.(ListEndpointsOutput)
+	if len(lexOut.Operations) != 0 {
+		t.Errorf("explicit lexical must preserve AND semantics; got %d ops", len(lexOut.Operations))
+	}
+}
+
+// TestListEndpoints_DefaultStaysLexicalWithoutEmbeddings covers the
+// other side of #858's gate: with no embedding index the omitted
+// ranking must stay on the lexical floor rather than attempting a
+// semantic path, so behavior is unchanged for un-indexed connections.
+func TestListEndpoints_DefaultStaysLexicalWithoutEmbeddings(t *testing.T) {
+	t.Parallel()
+	tk := New("test")
+	// No embedder wired -> embeddingsAvailable is false.
+	store := catalog.NewMemoryStore()
+	tk.SetCatalogStore(store)
+	ctx := context.Background()
+	_ = store.CreateCatalog(ctx, catalog.Catalog{ID: "c", Name: "c", DisplayName: "c"})
+	_ = store.UpsertSpec(ctx, "c", catalog.SpecEntry{
+		SpecName: "default", Content: persistedEmbedTestSpec, SourceKind: catalog.SourceInline,
+	})
+	if err := tk.AddConnection("api", map[string]any{
+		"base_url":   "https://api.example.com",
+		"catalog_id": "c",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	res, payload, _ := tk.handleListEndpoints(ctx, nil, ListEndpointsInput{
+		Connection: "api", Query: "alpha bravo",
+	})
+	if res == nil || res.IsError {
+		t.Fatalf("lexical default should not error: %v", res)
+	}
+	out, _ := payload.(ListEndpointsOutput)
+	if len(out.Operations) != 0 {
+		t.Errorf("without embeddings the omitted ranking stays lexical AND -> empty; got %d ops", len(out.Operations))
+	}
+}
+
+// TestListEndpoints_DefaultStaysLexicalWhenWiredButUnindexed covers
+// the middle branch of embeddingsAvailable (#858): an embedding
+// provider IS wired, but the connection has no persisted vectors, so
+// the omitted ranking must stay on the lexical floor rather than
+// upgrading to hybrid and surfacing a fallback Note on every call.
+func TestListEndpoints_DefaultStaysLexicalWhenWiredButUnindexed(t *testing.T) {
+	t.Parallel()
+	tk := New("test")
+	tk.SetEmbeddingProvider(newFakeEmbedder(32)) // embedder wired...
+	store := catalog.NewMemoryStore()
+	tk.SetCatalogStore(store)
+	ctx := context.Background()
+	_ = store.CreateCatalog(ctx, catalog.Catalog{ID: "c", Name: "c", DisplayName: "c"})
+	_ = store.UpsertSpec(ctx, "c", catalog.SpecEntry{
+		SpecName: "default", Content: persistedEmbedTestSpec, SourceKind: catalog.SourceInline,
+	})
+	// ...but no UpsertOperationEmbeddings, so the connection has no vectors.
+	if err := tk.AddConnection("api", map[string]any{
+		"base_url":   "https://api.example.com",
+		"catalog_id": "c",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	// embeddingsAvailable must be false (wired but unindexed), so the
+	// omitted ranking stays lexical and the multi-token AND query
+	// returns empty rather than a hybrid-ranked catalog, with no
+	// fallback Note (the lexical floor never attempted a semantic path).
+	res, payload, _ := tk.handleListEndpoints(ctx, nil, ListEndpointsInput{
+		Connection: "api", Query: "alpha bravo",
+	})
+	if res == nil || res.IsError {
+		t.Fatalf("unindexed default should not error: %v", res)
+	}
+	out, _ := payload.(ListEndpointsOutput)
+	if len(out.Operations) != 0 {
+		t.Errorf("wired-but-unindexed connection must stay lexical (AND -> empty); got %d ops", len(out.Operations))
+	}
+	if out.Note != "" {
+		t.Errorf("lexical floor should emit no fallback Note; got %q", out.Note)
+	}
+}
+
+// TestListEndpoints_DefaultedFallbackNoteDoesNotClaimHybrid covers
+// #858 fix for the misleading Note: when an omitted ranking is
+// auto-upgraded to hybrid and the query embed then fails at rank
+// time, the fallback Note must attribute the cause to the default
+// semantic path being unavailable, NOT to a "hybrid" mode the caller
+// never selected.
+func TestListEndpoints_DefaultedFallbackNoteDoesNotClaimHybrid(t *testing.T) {
+	t.Parallel()
+	tk := New("test")
+	emb := newFakeEmbedder(32)
+	tk.SetEmbeddingProvider(emb)
+	store := catalog.NewMemoryStore()
+	tk.SetCatalogStore(store)
+	ctx := context.Background()
+	if err := store.CreateCatalog(ctx, catalog.Catalog{ID: "shared", Name: "shared", DisplayName: "shared"}); err != nil {
+		t.Fatalf("CreateCatalog: %v", err)
+	}
+	if err := store.UpsertSpec(ctx, "shared", catalog.SpecEntry{
+		SpecName: "default", Content: persistedEmbedTestSpec, SourceKind: catalog.SourceInline,
+	}); err != nil {
+		t.Fatalf("UpsertSpec: %v", err)
+	}
+	// Seed vectors with the batch path working so the connection loads
+	// them (embeddingsAvailable -> true, omitted ranking upgrades to
+	// hybrid).
+	rows := computeEmbeddingsForTest(t, emb, persistedEmbedTestSpec, "default")
+	if err := store.UpsertOperationEmbeddings(ctx, "shared", "default", rows); err != nil {
+		t.Fatalf("UpsertOperationEmbeddings: %v", err)
+	}
+	if err := tk.AddConnection("api", map[string]any{
+		"base_url":   "https://api.example.com",
+		"catalog_id": "shared",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	// Force the query-time embed to fail so hybrid falls back to lexical.
+	emb.failEmbed.Store(true)
+	res, payload, _ := tk.handleListEndpoints(ctx, nil, ListEndpointsInput{
+		Connection: "api", Query: "alpha",
+	})
+	if res == nil || res.IsError {
+		t.Fatalf("defaulted fallback should not error: %v", res)
+	}
+	out, _ := payload.(ListEndpointsOutput)
+	if out.Note == "" {
+		t.Fatal("a fallback at rank time should surface a Note")
+	}
+	if strings.Contains(out.Note, "hybrid") {
+		t.Errorf("defaulted fallback Note must not claim the caller requested hybrid; got %q", out.Note)
+	}
+	if !strings.Contains(out.Note, "default semantic ranking unavailable") {
+		t.Errorf("defaulted fallback Note should name the default-semantic cause; got %q", out.Note)
+	}
+}
+
 // failingEmbeddingsStore is a wrapper around catalog.MemoryStore
 // that injects an error on ListOperationEmbeddings so the toolkit's
 // addParsedConnection logs and continues without halting the

--- a/pkg/toolkits/apigateway/ranking.go
+++ b/pkg/toolkits/apigateway/ranking.go
@@ -54,8 +54,10 @@ var (
 // RankingMode selects the algorithm api_list_endpoints uses to score
 // candidate operations against the model's query.
 //
-// Lexical (default) is the substring-match filter that v1 shipped:
-// fast, deterministic, no embedding-provider dependency. Misses on
+// Lexical is the substring-match filter that v1 shipped: fast,
+// deterministic, no embedding-provider dependency. It is the floor
+// when no embedding index is available, and the explicit opt-out
+// when a caller wants to bypass semantic ranking. Misses on
 // natural-language queries when the model's phrasing doesn't share
 // vocabulary with the spec author's (e.g. query "create order" vs
 // summary "Place a new order").
@@ -75,7 +77,9 @@ type RankingMode string
 
 // RankingMode values exposed on the api_list_endpoints schema.
 const (
-	// RankingLexical is the v1 substring-match filter (default).
+	// RankingLexical is the v1 substring-match filter. It is the
+	// floor when no embedding index is available; with embeddings
+	// present, an omitted ranking defaults to hybrid (#858).
 	RankingLexical RankingMode = "lexical"
 	// RankingSemantic ranks by embedding cosine similarity only.
 	RankingSemantic RankingMode = "semantic"
@@ -286,6 +290,25 @@ func (t *Toolkit) queryVectorFor(ctx context.Context, c *conn, query string) ([]
 		return nil, errEmbeddingsZeroVector
 	}
 	return vec, nil
+}
+
+// embeddingsAvailable reports whether this connection can be ranked
+// semantically right now: an embedding provider is wired on the
+// toolkit AND the connection has persisted operation vectors loaded.
+// It is the gate for the default-ON hybrid upgrade in
+// handleListEndpoints — when true, an omitted ranking resolves to
+// hybrid rather than lexical, so the semantic path is the default
+// whenever its requirement is met (#858). Snapshots t.embedder under
+// the read lock, mirroring queryVectorFor, so a concurrent
+// SetEmbeddingProvider cannot race the nil check.
+func (t *Toolkit) embeddingsAvailable(c *conn) bool {
+	t.mu.RLock()
+	embedder := t.embedder
+	t.mu.RUnlock()
+	if embedder == nil {
+		return false
+	}
+	return checkEmbeddingsReady(c) == nil
 }
 
 // checkEmbeddingsReady reports whether persisted operation

--- a/pkg/toolkits/apigateway/schemas.go
+++ b/pkg/toolkits/apigateway/schemas.go
@@ -30,7 +30,7 @@ var listEndpointsSchema = json.RawMessage(`{
     "ranking": {
       "type": "string",
       "enum": ["lexical", "semantic", "hybrid"],
-      "description": "Optional ranking algorithm. \"lexical\" (default) is per-token case-insensitive substring match: fast, deterministic, but misses when your phrasing differs from the spec author's. \"semantic\" ranks by embedding cosine similarity, which finds endpoints by intent (\"create order\" finds POST /v1/orders) even when no words overlap. \"hybrid\" blends both: best for free-form intent queries that may also share path/tag vocabulary. semantic and hybrid require an embedding provider; if unavailable they fall back to lexical and a note explains the reason."
+      "description": "Optional ranking algorithm. Defaults to \"hybrid\" whenever this connection has an embedding index available (the platform default), otherwise \"lexical\". \"hybrid\" blends embedding cosine similarity with per-token substring match: best for free-form intent queries that may also share path/tag vocabulary, and the recommended choice. \"semantic\" ranks by embedding cosine similarity only, which finds endpoints by intent (\"create order\" finds POST /v1/orders) even when no words overlap. \"lexical\" is a fast, deterministic per-token substring match with no embedding dependency; pass it explicitly to opt out of semantic ranking. semantic and hybrid require an embedding provider; if unavailable they fall back to lexical and a note explains the reason."
     }
   }
 }`)

--- a/pkg/toolkits/apigateway/toolkit.go
+++ b/pkg/toolkits/apigateway/toolkit.go
@@ -611,13 +611,25 @@ func (t *Toolkit) handleListEndpoints(ctx context.Context, _ *mcp.CallToolReques
 	if modeErr != nil {
 		return errorResult(modeErr.Error()), nil, nil
 	}
+	// Default-ON semantic ranking: when the caller does not pin a
+	// ranking, resolve an omitted value to hybrid whenever this
+	// connection has an embedding index available, so intent queries
+	// ("whoami echo status") are ranked instead of failing the
+	// lexical AND filter closed to an empty set. The lexical mode is
+	// an opt-out we offer, not the default — an explicit
+	// ranking="lexical" is preserved. Skipped for an empty query,
+	// which rankWithMode serves from the lexical "return all" path
+	// regardless of mode, so the readiness gate would be wasted work.
+	// See #858.
+	rankingDefaulted := in.Query != "" && in.Ranking == "" && t.embeddingsAvailable(c)
+	if rankingDefaulted {
+		mode = RankingHybrid
+	}
 	ranked, fallbackReason := rankWithMode(ctx, rankRequest{
 		tk: t, conn: c, ops: visible, query: in.Query, limit: limit, mode: mode,
 	})
 	out := ListEndpointsOutput{Operations: ranked}
-	if fallbackReason != "" {
-		out.Note = fmt.Sprintf("ranking %q fell back to lexical: %s", mode, fallbackReason)
-	}
+	out.Note = rankingFallbackNote(rankingDefaulted, mode, fallbackReason)
 	return jsonResult(out), out, nil
 }
 
@@ -685,11 +697,29 @@ func filterBySpec(ops []OperationSummary, spec string) []OperationSummary {
 	return out
 }
 
+// rankingFallbackNote builds the response Note when ranking fell
+// back to lexical. An empty reason yields an empty Note. When the
+// hybrid mode was auto-selected because the caller omitted ranking
+// (defaulted), the note must not attribute "hybrid" to the caller —
+// it phrases the cause as the default semantic path being
+// unavailable, so an operator is never told they requested a mode
+// they never passed (#858).
+func rankingFallbackNote(defaulted bool, mode RankingMode, reason string) string {
+	if reason == "" {
+		return ""
+	}
+	if defaulted {
+		return fmt.Sprintf("default semantic ranking unavailable, used lexical: %s", reason)
+	}
+	return fmt.Sprintf("ranking %q fell back to lexical: %s", mode, reason)
+}
+
 // parseRankingMode maps the input string to a RankingMode. Empty
-// (omitted from the call) defaults to lexical for backward
-// compatibility — adding semantic ranking to the toolkit must not
-// silently change behavior for callers that don't pass the new
-// field.
+// (omitted from the call) parses to lexical as the safe floor; the
+// list-endpoints handler then upgrades an omitted ranking to hybrid
+// when the connection has an embedding index available, so the
+// semantic path is ON by default whenever its requirement is met
+// (#858). An explicit "lexical" is preserved as an opt-out.
 func parseRankingMode(raw string) (RankingMode, error) {
 	switch raw {
 	case "", string(RankingLexical):


### PR DESCRIPTION
## Summary

`api_list_endpoints` returned an empty result (`{"operations":[]}`) for a legitimate multi-intent query, with no explanation. An agent asking "are there endpoints for whoami, echo, and status?" got zero rows and reasonably concluded the API had none of them — when all three exist.

Root cause: the tool's **default** ranking was `lexical`, and lexical mode is a hard **AND** filter across whitespace tokens. No single operation contains all of `whoami` AND `echo` AND `status`, so the AND filter matched nothing. Meanwhile the semantic-embedding ranking path (shipped in #371 / #419) already returns the correct results — but it was opt-in via `ranking:"semantic"`/`"hybrid"`, which a model has no reason to pass. The invested embedding pipeline was dark by default, and the default path failed silently.

This PR makes semantic ranking the default whenever its requirement (an embedding index) is met, per the platform's default-ON principle: a capability is ON by default when its requirement is satisfied; the ability to turn it off is something we offer, not the default state.

Fixes #858.

## Change

`api_list_endpoints` now resolves an omitted `ranking` to `hybrid` whenever the connection has an embedding index available. An explicit `ranking:"lexical"` is preserved as the opt-out. Connections without an embedding index continue to use the lexical filter (the floor).

- **`toolkit.go`** — the list handler upgrades an omitted, non-empty-query ranking to hybrid via a new `embeddingsAvailable(conn)` gate. A new `rankingFallbackNote` helper phrases the fallback Note so a defaulted upgrade never attributes `"hybrid"` to a caller who did not select it.
- **`ranking.go`** — `embeddingsAvailable` helper (snapshots the embedder under the read lock, mirroring `queryVectorFor`). `RankingLexical` doc no longer claims to be the unconditional default.
- **`schemas.go`** — the `ranking` field description documents hybrid-when-available as the default and lexical as the explicit opt-out.

## Behavior (Test API fixture, 34 operations)

| `query` | `ranking` | Before | After |
|---|---|---|---|
| `whoami echo status` | (omitted) | `[]` | whoami, echo ops, status ranked to the top |
| `whoami echo status` | `lexical` | `[]` | `[]` (opt-out preserved) |
| `echo post` | (omitted) | echo_post, method_post | precise matches still ranked first |

Every token matched on its own before; the empty result was purely the default AND filter. `ranking:"semantic"` and `ranking:"hybrid"` already returned the intended endpoints, confirming the embeddings are indexed and the ranking works — the fix is the default, not the ranker.

## Tests

Four table-free tests in `persisted_embeddings_test.go`:

- **Default-on hybrid** — an omitted ranking with embeddings present returns ranked ops for a multi-token query (`"alpha bravo"`) that the lexical AND filter drops to empty, and no fallback Note.
- **Lexical opt-out** — an explicit `ranking:"lexical"` still AND-narrows the same query to empty.
- **Wired-but-unindexed** — an embedder is wired but the connection has no vectors, so the omitted ranking stays on the lexical floor (covers the middle branch of `embeddingsAvailable`).
- **Defaulted fallback Note** — a defaulted hybrid upgrade whose query embed then fails surfaces a Note that names the default-semantic cause and does not claim the caller requested hybrid.

## Verification

Backend `make verify` gate, all green locally:

- `tools-check` (local `golangci-lint 2.11.4` / `gosec 2.27.1` match the Makefile pins)
- `gofmt` clean; `go test -race ./...` pass
- `test-realdb` and `migrate-check` pass against real Postgres
- `lint` (patch-scoped, mirrors CI `only-new-issues`) — 0 issues
- `security` (gosec + govulncheck) — 0 in our code; `semgrep` clean
- **patch-coverage 100%** (31/31 changed executable lines); total coverage 89.8%
- `doc-check`, `emdash-check`, `swagger-check`, `embed-clean`, `dead-code` clean

Not run locally (unaffected by this backend-only diff / heavy env): `frontend-test`, `frontend-lint`, `frontend-e2e`, `codeql`, `release-check` — left to CI.

## Review notes (from an adversarial code review of this diff)

Three verified findings were fixed in this PR: the misleading fallback Note (now attributes the cause to the default path, not a caller-selected mode), a wasted readiness-gate evaluation on empty (browse-all) queries (now guarded by `in.Query != ""`), and the previously untested wired-but-unindexed branch.

## Known tradeoffs and follow-up

Making the default a ranker rather than a filter is intentional and is what "hybrid when available" means, but it has two inherent consequences worth noting:

1. A precise single-concept query (e.g. `"delete"`) now returns the ranked catalog up to `limit` rather than only the operations containing the token.
2. Each default call makes one `embedder.Embed` round-trip for the query vector (operation vectors remain pre-computed).

A follow-up refinement — **lexical-filter-first, hybrid only when the lexical filter returns nothing** — would preserve filter precision and skip the embed call for queries that match lexically, while still eliminating the silent-empty. Tracked as a follow-up; not included here to keep this change focused on the default-ON correction. The no-embedder lexical path could similarly move from hard-AND to OR-with-rank so un-indexed deployments also never return a silent empty (also follow-up, noted in #858).

## References

- Closes #858
- #371 — semantic search ranking for `api_list_endpoints` (shipped)
- #419 — persist operation embeddings in pgvector (shipped)
