### PR TITLE
security(oauth): hash refresh tokens and authorization codes at rest

### DIFF
--- a/docs/auth/oauth-server.md
+++ b/docs/auth/oauth-server.md
@@ -204,6 +204,24 @@ stored in PostgreSQL. This matters behind a load balancer: the callback can
 land on a different replica than the one that started the flow, and browser
 login would fail if the state lived only in one replica's memory.
 
+Refresh tokens and authorization codes are stored only as hex-encoded
+SHA-256 digests (both in PostgreSQL and in the in-memory store); the server
+hashes the presented value on lookup. A database read, backup, or replica
+therefore never yields a usable bearer credential.
+
+## Upgrade Note: Hashed Refresh Tokens
+
+Migration `000078` converts pre-existing plaintext refresh tokens and
+authorization codes to digests in place, so live sessions stay valid across
+the upgrade. During a multi-replica rolling upgrade, replicas still running
+the previous binary cannot validate the hashed rows, and any refresh token
+such a replica issues after the migration ran is invalid under the new
+binary; affected clients recover with one interactive re-authorization.
+Complete the rollout promptly to minimize that window. Rolling this
+migration back deletes all outstanding refresh tokens and authorization
+codes (hashing is one-way), which forces every client through a full
+interactive re-authorization.
+
 ## Upgrade Note: Access Token Audience
 
 Access tokens mint `aud` as the issuer URL (the platform is both the
@@ -261,6 +279,7 @@ Response:
 | **JWT Access Tokens** | Self-validating signed JWTs containing user claims and roles |
 | **PKCE Required** | All clients must use PKCE with S256 |
 | **Bcrypt Secrets** | Client secrets stored as bcrypt hashes |
+| **Hashed Credentials at Rest** | Refresh tokens and authorization codes stored only as SHA-256 digests |
 | **State Validation** | CSRF protection via state parameter |
 | **Token Expiration** | Access tokens expire after 1 hour |
 | **Refresh Token Rotation** | New refresh token issued on each use |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -756,6 +756,8 @@ Dynamic Client Registration (`oauth.dcr`) is off by default. Enabling it require
 
 When a database is configured, in-flight authorization state (linking `/oauth/authorize` to the upstream IdP callback) is stored in PostgreSQL so multi-replica deployments work behind a load balancer: the callback can land on a different replica than the one that started the flow.
 
+Refresh tokens and authorization codes are stored only as hex-encoded SHA-256 digests (in both the PostgreSQL and in-memory stores); the server hashes the presented value on lookup, so a database read, backup, or replica never yields a usable bearer credential. Migration 000078 converts pre-existing plaintext rows in place so live sessions survive the upgrade; rolling it back deletes all outstanding refresh tokens and authorization codes, forcing interactive re-authorization.
+
 ## Browser Sessions (OIDC Login for Portal UI)
 
 When `auth.oidc` and `auth.browser_session` are both enabled, the portal UI offers SSO login. The flow uses OIDC authorization code with PKCE. Sessions are stored as HMAC-SHA256 signed JWT cookies (stateless, no server-side store).

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -39,7 +39,7 @@ mcp-data-platform is the orchestration layer for the txn2 MCP ecosystem. DataHub
 - [Auth Overview](https://mcp-data-platform.txn2.com/auth/overview/): Fail-closed security model, stdio vs HTTP authentication
 - [OIDC](https://mcp-data-platform.txn2.com/auth/oidc/): Keycloak, Auth0, Okta, Azure AD setup with required claims
 - [API Keys](https://mcp-data-platform.txn2.com/auth/api-keys/): Service account authentication
-- [OAuth Server](https://mcp-data-platform.txn2.com/auth/oauth-server/): Built-in OAuth 2.1 authorization server for Claude Desktop and other MCP clients, with PKCE, Dynamic Client Registration, and upstream IdP integration
+- [OAuth Server](https://mcp-data-platform.txn2.com/auth/oauth-server/): Built-in OAuth 2.1 authorization server for Claude Desktop and other MCP clients, with PKCE, Dynamic Client Registration, upstream IdP integration, and refresh tokens hashed at rest
 - [OAuth to Upstream MCPs](https://mcp-data-platform.txn2.com/auth/oauth-gateway/): Outbound OAuth to gateway upstreams: client_credentials and authorization_code + PKCE grants, encrypted refresh tokens that survive restarts, background refresh, and a full auth-event history
 
 ## Personas

--- a/pkg/database/migrate/migrate_realpg_test.go
+++ b/pkg/database/migrate/migrate_realpg_test.go
@@ -14,7 +14,7 @@ import (
 
 // expectedFinalVersion is the highest migration the embedded set defines. Bump
 // this when adding a migration so the gate asserts the full set applied.
-const expectedFinalVersion = 77
+const expectedFinalVersion = 78
 
 // TestMigrationsAgainstRealPostgres applies the embedded migrations to a real
 // PostgreSQL (pgvector) instance and exercises the full lifecycle: up, seed,

--- a/pkg/database/migrate/migrate_unit_test.go
+++ b/pkg/database/migrate/migrate_unit_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	migrateTestFileCount    = 154
+	migrateTestFileCount    = 156
 	migrateTestSuccess      = "success"
 	migrateTestFactoryError = "factory error"
 )

--- a/pkg/database/migrate/migrations/000078_hash_oauth_tokens.down.sql
+++ b/pkg/database/migrate/migrations/000078_hash_oauth_tokens.down.sql
@@ -1,0 +1,7 @@
+-- Hashing is one-way: the plaintext token and code values cannot be
+-- restored, so rolling back to a plaintext-lookup binary requires
+-- invalidating all outstanding credentials. This is user-visible: every
+-- client's next refresh grant fails with invalid_grant, forcing a full
+-- interactive re-authorization (browser sign-in), not a silent refresh.
+DELETE FROM oauth_refresh_tokens;
+DELETE FROM oauth_authorization_codes;

--- a/pkg/database/migrate/migrations/000078_hash_oauth_tokens.up.sql
+++ b/pkg/database/migrate/migrations/000078_hash_oauth_tokens.up.sql
@@ -1,0 +1,29 @@
+-- Hash opaque bearer credentials at rest. Refresh tokens and authorization
+-- codes were previously stored as plaintext, so anyone with read access to
+-- the database (backup, replica, operator) held live credentials. The store
+-- now persists only the hex-encoded SHA-256 digest and hashes the presented
+-- value on lookup; converting existing rows in place keeps live sessions
+-- valid across the upgrade. Column names are unchanged: only the value
+-- representation changes.
+--
+-- convert_to(.., 'UTF8') is the byte-exact counterpart of Go's
+-- sha256([]byte(value)); a plain ::bytea cast would run the text through
+-- bytea's input parser, which mis-parses or rejects backslashes.
+--
+-- The WHERE guard skips values that are already 64-char lowercase hex, so
+-- re-running the statement (e.g. dirty-migration recovery, or an operator
+-- sweeping up stragglers) never double-hashes a digest. Issued raw
+-- credentials are 43-char base64url strings and can never match the guard.
+--
+-- Deployment note for multi-replica rolling upgrades: replicas still running
+-- the previous binary compare raw values against the now-hashed rows, so
+-- refresh grants they serve fail until the rollout completes, and any token
+-- such a replica issues after this migration ran is stored plaintext and is
+-- invalid under the new binary. Affected clients recover with one interactive
+-- re-authorization. Complete the rollout promptly to minimize the window.
+UPDATE oauth_refresh_tokens
+SET token = encode(sha256(convert_to(token, 'UTF8')), 'hex')
+WHERE token !~ '^[0-9a-f]{64}$';
+UPDATE oauth_authorization_codes
+SET code = encode(sha256(convert_to(code, 'UTF8')), 'hex')
+WHERE code !~ '^[0-9a-f]{64}$';

--- a/pkg/oauth/memory.go
+++ b/pkg/oauth/memory.go
@@ -84,46 +84,52 @@ func (m *MemoryStorage) ListClients(_ context.Context) ([]*Client, error) {
 	return clients, nil
 }
 
-// SaveAuthorizationCode stores an authorization code.
+// SaveAuthorizationCode stores an authorization code. Only the SHA-256
+// digest of the code value is retained; the caller's struct is not
+// mutated, so the raw value it holds stays usable for issuance.
 func (m *MemoryStorage) SaveAuthorizationCode(_ context.Context, code *AuthorizationCode) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.codes[code.Code] = code
+	stored := *code
+	stored.Code = HashToken(code.Code)
+	m.codes[stored.Code] = &stored
 	return nil
 }
 
-// GetAuthorizationCode retrieves an authorization code.
+// GetAuthorizationCode retrieves an authorization code by its raw value.
 func (m *MemoryStorage) GetAuthorizationCode(_ context.Context, code string) (*AuthorizationCode, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	authCode, ok := m.codes[code]
+	authCode, ok := m.codes[HashToken(code)]
 	if !ok {
 		return nil, errors.New("authorization code not found")
 	}
 	return authCode, nil
 }
 
-// DeleteAuthorizationCode deletes an authorization code.
+// DeleteAuthorizationCode deletes an authorization code by its raw value.
 func (m *MemoryStorage) DeleteAuthorizationCode(_ context.Context, code string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	delete(m.codes, code)
+	delete(m.codes, HashToken(code))
 	return nil
 }
 
-// ConsumeAuthorizationCode atomically deletes and returns an authorization code.
+// ConsumeAuthorizationCode atomically deletes and returns an authorization
+// code by its raw value.
 func (m *MemoryStorage) ConsumeAuthorizationCode(_ context.Context, code string) (*AuthorizationCode, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	authCode, ok := m.codes[code]
+	hashed := HashToken(code)
+	authCode, ok := m.codes[hashed]
 	if !ok {
 		return nil, fmt.Errorf("authorization code: %w", ErrNotFound)
 	}
-	delete(m.codes, code)
+	delete(m.codes, hashed)
 	return authCode, nil
 }
 
@@ -141,46 +147,52 @@ func (m *MemoryStorage) CleanupExpiredCodes(_ context.Context) error {
 	return nil
 }
 
-// SaveRefreshToken stores a refresh token.
+// SaveRefreshToken stores a refresh token. Only the SHA-256 digest of the
+// token value is retained; the caller's struct is not mutated, so the raw
+// value it holds stays usable for issuance.
 func (m *MemoryStorage) SaveRefreshToken(_ context.Context, token *RefreshToken) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.refreshTokens[token.Token] = token
+	stored := *token
+	stored.Token = HashToken(token.Token)
+	m.refreshTokens[stored.Token] = &stored
 	return nil
 }
 
-// GetRefreshToken retrieves a refresh token.
+// GetRefreshToken retrieves a refresh token by its raw value.
 func (m *MemoryStorage) GetRefreshToken(_ context.Context, token string) (*RefreshToken, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	refreshToken, ok := m.refreshTokens[token]
+	refreshToken, ok := m.refreshTokens[HashToken(token)]
 	if !ok {
 		return nil, errors.New("refresh token not found")
 	}
 	return refreshToken, nil
 }
 
-// DeleteRefreshToken deletes a refresh token.
+// DeleteRefreshToken deletes a refresh token by its raw value.
 func (m *MemoryStorage) DeleteRefreshToken(_ context.Context, token string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	delete(m.refreshTokens, token)
+	delete(m.refreshTokens, HashToken(token))
 	return nil
 }
 
-// ConsumeRefreshToken atomically deletes and returns a refresh token.
+// ConsumeRefreshToken atomically deletes and returns a refresh token by
+// its raw value.
 func (m *MemoryStorage) ConsumeRefreshToken(_ context.Context, token string) (*RefreshToken, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	refreshToken, ok := m.refreshTokens[token]
+	hashed := HashToken(token)
+	refreshToken, ok := m.refreshTokens[hashed]
 	if !ok {
 		return nil, fmt.Errorf("refresh token: %w", ErrNotFound)
 	}
-	delete(m.refreshTokens, token)
+	delete(m.refreshTokens, hashed)
 	return refreshToken, nil
 }
 

--- a/pkg/oauth/memory_test.go
+++ b/pkg/oauth/memory_test.go
@@ -139,6 +139,9 @@ func TestMemoryStorage_AuthorizationCode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+		if code.Code != "code-123" {
+			t.Errorf("save must not mutate the caller's struct, got code %q", code.Code)
+		}
 	})
 
 	t.Run("get authorization code", func(t *testing.T) {
@@ -146,8 +149,12 @@ func TestMemoryStorage_AuthorizationCode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got.Code != code.Code {
-			t.Errorf("expected code %q, got %q", code.Code, got.Code)
+		// The store holds only the digest, never the raw credential.
+		if got.Code != HashToken("code-123") {
+			t.Errorf("expected stored code to be the digest %q, got %q", HashToken("code-123"), got.Code)
+		}
+		if got.UserID != code.UserID {
+			t.Errorf("expected user ID %q, got %q", code.UserID, got.UserID)
 		}
 	})
 
@@ -183,8 +190,8 @@ func TestMemoryStorage_AuthorizationCode(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got.Code != "consume-me" {
-			t.Errorf("expected code 'consume-me', got %q", got.Code)
+		if got.Code != HashToken("consume-me") {
+			t.Errorf("expected stored code to be the digest of 'consume-me', got %q", got.Code)
 		}
 
 		// Second consume must fail: the code is single-use.
@@ -252,6 +259,9 @@ func TestMemoryStorage_RefreshToken(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+		if token.Token != "token-123" {
+			t.Errorf("save must not mutate the caller's struct, got token %q", token.Token)
+		}
 	})
 
 	t.Run("get refresh token", func(t *testing.T) {
@@ -259,8 +269,12 @@ func TestMemoryStorage_RefreshToken(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got.Token != token.Token {
-			t.Errorf("expected token %q, got %q", token.Token, got.Token)
+		// The store holds only the digest, never the raw credential.
+		if got.Token != HashToken("token-123") {
+			t.Errorf("expected stored token to be the digest %q, got %q", HashToken("token-123"), got.Token)
+		}
+		if got.UserID != token.UserID {
+			t.Errorf("expected user ID %q, got %q", token.UserID, got.UserID)
 		}
 	})
 
@@ -296,8 +310,8 @@ func TestMemoryStorage_RefreshToken(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got.Token != "rotate-me" {
-			t.Errorf("expected token 'rotate-me', got %q", got.Token)
+		if got.Token != HashToken("rotate-me") {
+			t.Errorf("expected stored token to be the digest of 'rotate-me', got %q", got.Token)
 		}
 
 		// Second consume must fail: rotation invalidated the token.

--- a/pkg/oauth/postgres/store.go
+++ b/pkg/oauth/postgres/store.go
@@ -139,7 +139,9 @@ func (s *Store) ListClients(ctx context.Context) (_ []*oauth.Client, retErr erro
 	return clients, nil
 }
 
-// SaveAuthorizationCode stores an authorization code.
+// SaveAuthorizationCode stores an authorization code. Only the SHA-256
+// digest of the code value is persisted (oauth.HashToken), so a database
+// read never yields a usable credential.
 func (s *Store) SaveAuthorizationCode(ctx context.Context, code *oauth.AuthorizationCode) error {
 	claims, err := json.Marshal(code.UserClaims)
 	if err != nil {
@@ -149,7 +151,7 @@ func (s *Store) SaveAuthorizationCode(ctx context.Context, code *oauth.Authoriza
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO oauth_authorization_codes (id, code, client_id, user_id, user_claims, code_challenge, redirect_uri, scope, expires_at, used, created_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
-		code.ID, code.Code, code.ClientID, code.UserID, claims,
+		code.ID, oauth.HashToken(code.Code), code.ClientID, code.UserID, claims,
 		code.CodeChallenge, code.RedirectURI, code.Scope,
 		code.ExpiresAt, code.Used, code.CreatedAt,
 	)
@@ -159,12 +161,13 @@ func (s *Store) SaveAuthorizationCode(ctx context.Context, code *oauth.Authoriza
 	return nil
 }
 
-// GetAuthorizationCode retrieves an authorization code.
+// GetAuthorizationCode retrieves an authorization code by its raw value;
+// the comparison is against the stored SHA-256 digest.
 func (s *Store) GetAuthorizationCode(ctx context.Context, code string) (*oauth.AuthorizationCode, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, code, client_id, user_id, user_claims, code_challenge, redirect_uri, scope, expires_at, used, created_at
 		FROM oauth_authorization_codes
-		WHERE code = $1`, code)
+		WHERE code = $1`, oauth.HashToken(code))
 	return scanAuthorizationCode(row)
 }
 
@@ -176,7 +179,7 @@ func (s *Store) ConsumeAuthorizationCode(ctx context.Context, code string) (*oau
 	row := s.db.QueryRowContext(ctx, `
 		DELETE FROM oauth_authorization_codes
 		WHERE code = $1
-		RETURNING id, code, client_id, user_id, user_claims, code_challenge, redirect_uri, scope, expires_at, used, created_at`, code)
+		RETURNING id, code, client_id, user_id, user_claims, code_challenge, redirect_uri, scope, expires_at, used, created_at`, oauth.HashToken(code))
 	ac, err := scanAuthorizationCode(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("authorization code: %w", oauth.ErrNotFound)
@@ -204,9 +207,9 @@ func scanAuthorizationCode(row *sql.Row) (*oauth.AuthorizationCode, error) {
 	return &ac, nil
 }
 
-// DeleteAuthorizationCode deletes an authorization code.
+// DeleteAuthorizationCode deletes an authorization code by its raw value.
 func (s *Store) DeleteAuthorizationCode(ctx context.Context, code string) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM oauth_authorization_codes WHERE code = $1`, code)
+	_, err := s.db.ExecContext(ctx, `DELETE FROM oauth_authorization_codes WHERE code = $1`, oauth.HashToken(code))
 	if err != nil {
 		return fmt.Errorf("deleting authorization code: %w", err)
 	}
@@ -222,7 +225,9 @@ func (s *Store) CleanupExpiredCodes(ctx context.Context) error {
 	return nil
 }
 
-// SaveRefreshToken stores a refresh token.
+// SaveRefreshToken stores a refresh token. Only the SHA-256 digest of the
+// token value is persisted (oauth.HashToken), so a database read never
+// yields a usable credential.
 func (s *Store) SaveRefreshToken(ctx context.Context, token *oauth.RefreshToken) error {
 	claims, err := json.Marshal(token.UserClaims)
 	if err != nil {
@@ -232,7 +237,7 @@ func (s *Store) SaveRefreshToken(ctx context.Context, token *oauth.RefreshToken)
 	_, err = s.db.ExecContext(ctx, `
 		INSERT INTO oauth_refresh_tokens (id, token, client_id, user_id, user_claims, scope, expires_at, created_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-		token.ID, token.Token, token.ClientID, token.UserID,
+		token.ID, oauth.HashToken(token.Token), token.ClientID, token.UserID,
 		claims, token.Scope, token.ExpiresAt, token.CreatedAt,
 	)
 	if err != nil {
@@ -241,12 +246,13 @@ func (s *Store) SaveRefreshToken(ctx context.Context, token *oauth.RefreshToken)
 	return nil
 }
 
-// GetRefreshToken retrieves a refresh token.
+// GetRefreshToken retrieves a refresh token by its raw value; the
+// comparison is against the stored SHA-256 digest.
 func (s *Store) GetRefreshToken(ctx context.Context, token string) (*oauth.RefreshToken, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, token, client_id, user_id, user_claims, scope, expires_at, created_at
 		FROM oauth_refresh_tokens
-		WHERE token = $1`, token)
+		WHERE token = $1`, oauth.HashToken(token))
 	return scanRefreshToken(row)
 }
 
@@ -259,7 +265,7 @@ func (s *Store) ConsumeRefreshToken(ctx context.Context, token string) (*oauth.R
 	row := s.db.QueryRowContext(ctx, `
 		DELETE FROM oauth_refresh_tokens
 		WHERE token = $1
-		RETURNING id, token, client_id, user_id, user_claims, scope, expires_at, created_at`, token)
+		RETURNING id, token, client_id, user_id, user_claims, scope, expires_at, created_at`, oauth.HashToken(token))
 	rt, err := scanRefreshToken(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("refresh token: %w", oauth.ErrNotFound)
@@ -286,9 +292,9 @@ func scanRefreshToken(row *sql.Row) (*oauth.RefreshToken, error) {
 	return &rt, nil
 }
 
-// DeleteRefreshToken deletes a refresh token.
+// DeleteRefreshToken deletes a refresh token by its raw value.
 func (s *Store) DeleteRefreshToken(ctx context.Context, token string) error {
-	_, err := s.db.ExecContext(ctx, `DELETE FROM oauth_refresh_tokens WHERE token = $1`, token)
+	_, err := s.db.ExecContext(ctx, `DELETE FROM oauth_refresh_tokens WHERE token = $1`, oauth.HashToken(token))
 	if err != nil {
 		return fmt.Errorf("deleting refresh token: %w", err)
 	}

--- a/pkg/oauth/postgres/store_realdb_integration_test.go
+++ b/pkg/oauth/postgres/store_realdb_integration_test.go
@@ -10,6 +10,9 @@ package postgres
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -17,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/txn2/mcp-data-platform/internal/testdb"
+	"github.com/txn2/mcp-data-platform/pkg/database/migrate"
 	"github.com/txn2/mcp-data-platform/pkg/oauth"
 )
 
@@ -129,4 +133,140 @@ func TestOAuthStore_CreateClient_RealDB_NilSlices(t *testing.T) {
 	require.NotNil(t, got)
 	assert.Equal(t, "client-realdb-1", got.ClientID)
 	assert.Equal(t, "RealDB Test Client", got.Name)
+}
+
+// TestOAuthStore_TokensHashedAtRest_RealDB proves credentials are stored only
+// as SHA-256 digests against the real schema: the persisted column value is
+// the digest of the raw credential (never the raw value), while raw-value
+// lookups still succeed because the store hashes at the persistence boundary.
+func TestOAuthStore_TokensHashedAtRest_RealDB(t *testing.T) {
+	db := testdb.New(t)
+	store := New(db)
+	ctx := context.Background()
+
+	const rawToken = "raw-refresh-token-realdb"
+	token := &oauth.RefreshToken{
+		ID:        "rt_realdb_hash",
+		Token:     rawToken,
+		ClientID:  "client-realdb-hash",
+		UserID:    "user-realdb-hash",
+		Scope:     "read",
+		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
+		CreatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, store.SaveRefreshToken(ctx, token))
+
+	var storedToken string
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT token FROM oauth_refresh_tokens WHERE id = $1`, "rt_realdb_hash").
+		Scan(&storedToken))
+	assert.Equal(t, oauth.HashToken(rawToken), storedToken, "column must hold the digest")
+	assert.NotEqual(t, rawToken, storedToken, "column must not hold the raw credential")
+
+	gotToken, err := store.GetRefreshToken(ctx, rawToken)
+	require.NoError(t, err, "raw-value lookup must succeed")
+	assert.Equal(t, "user-realdb-hash", gotToken.UserID)
+
+	consumedToken, err := store.ConsumeRefreshToken(ctx, rawToken)
+	require.NoError(t, err, "raw-value consume must succeed")
+	assert.Equal(t, "user-realdb-hash", consumedToken.UserID)
+
+	const rawCode = "raw-auth-code-realdb"
+	code := &oauth.AuthorizationCode{
+		ID:        "ac_realdb_hash",
+		Code:      rawCode,
+		ClientID:  "client-realdb-hash",
+		UserID:    "user-realdb-hash",
+		Scope:     "read",
+		ExpiresAt: time.Now().UTC().Add(10 * time.Minute),
+		CreatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, store.SaveAuthorizationCode(ctx, code))
+
+	var storedCode string
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT code FROM oauth_authorization_codes WHERE id = $1`, "ac_realdb_hash").
+		Scan(&storedCode))
+	assert.Equal(t, oauth.HashToken(rawCode), storedCode, "column must hold the digest")
+	assert.NotEqual(t, rawCode, storedCode, "column must not hold the raw credential")
+
+	gotCode, err := store.GetAuthorizationCode(ctx, rawCode)
+	require.NoError(t, err, "raw-value lookup must succeed")
+	assert.Equal(t, "user-realdb-hash", gotCode.UserID)
+
+	consumedCode, err := store.ConsumeAuthorizationCode(ctx, rawCode)
+	require.NoError(t, err, "raw-value consume must succeed")
+	assert.Equal(t, "user-realdb-hash", consumedCode.UserID)
+}
+
+// TestOAuthStore_Migration78HashesPlaintext_RealDB proves migration
+// 000078_hash_oauth_tokens converts pre-existing plaintext rows in place:
+// rows inserted as plaintext at version 77 remain valid live sessions after
+// migrating, because the raw-value store lookup finds the hashed row.
+func TestOAuthStore_Migration78HashesPlaintext_RealDB(t *testing.T) {
+	db := testdb.New(t)
+	ctx := context.Background()
+
+	// testdb applies the full migration set; step back to version 77 (one
+	// migration at a time, so this stays correct as later migrations land)
+	// so plaintext rows can exist the way a pre-upgrade deployment left
+	// them.
+	const preHashVersion = 77
+	for {
+		version, dirty, err := migrate.Version(db)
+		require.NoError(t, err, "read migration version")
+		require.False(t, dirty, "migration state must not be dirty")
+		if version == preHashVersion {
+			break
+		}
+		require.Greater(t, version, uint(preHashVersion),
+			"stepped below the pre-hash version without hitting it")
+		require.NoError(t, migrate.Steps(db, -1), "roll back one migration")
+	}
+
+	const rawToken = "plaintext-refresh-token"
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO oauth_refresh_tokens (id, token, client_id, user_id, scope, expires_at, created_at)
+		VALUES ('rt_mig78', $1, 'client-mig78', 'user-mig78', 'read', NOW() + INTERVAL '1 day', NOW())`,
+		rawToken)
+	require.NoError(t, err, "insert plaintext refresh token")
+
+	const rawCode = "plaintext-auth-code"
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO oauth_authorization_codes (id, code, client_id, user_id, code_challenge, redirect_uri, scope, expires_at, created_at)
+		VALUES ('ac_mig78', $1, 'client-mig78', 'user-mig78', '', 'http://localhost/callback', 'read', NOW() + INTERVAL '10 minutes', NOW())`,
+		rawCode)
+	require.NoError(t, err, "insert plaintext authorization code")
+
+	require.NoError(t, migrate.Steps(db, 1), "apply migration 000078")
+
+	store := New(db)
+
+	gotToken, err := store.GetRefreshToken(ctx, rawToken)
+	require.NoError(t, err, "raw-token lookup must succeed after the migration hashed the row")
+	assert.Equal(t, "user-mig78", gotToken.UserID)
+	assert.Equal(t, oauth.HashToken(rawToken), gotToken.Token, "migrated row must hold the digest")
+
+	gotCode, err := store.GetAuthorizationCode(ctx, rawCode)
+	require.NoError(t, err, "raw-code lookup must succeed after the migration hashed the row")
+	assert.Equal(t, "user-mig78", gotCode.UserID)
+	assert.Equal(t, oauth.HashToken(rawCode), gotCode.Code, "migrated row must hold the digest")
+
+	// Re-running the up migration must be a no-op: its WHERE guard skips
+	// already-hashed values, so dirty-migration recovery or an operator
+	// sweep never double-hashes digests (which would invalidate every
+	// outstanding credential without any error).
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "resolve test file path")
+	upPath := filepath.Join(filepath.Dir(thisFile),
+		"..", "..", "database", "migrate", "migrations", "000078_hash_oauth_tokens.up.sql")
+	upSQL, err := os.ReadFile(upPath) //nolint:gosec // fixed in-repo migration path
+	require.NoError(t, err, "read up migration")
+	_, err = db.ExecContext(ctx, string(upSQL))
+	require.NoError(t, err, "re-run up migration")
+
+	_, err = store.GetRefreshToken(ctx, rawToken)
+	require.NoError(t, err, "raw-token lookup must still succeed after re-running the migration")
+	_, err = store.GetAuthorizationCode(ctx, rawCode)
+	require.NoError(t, err, "raw-code lookup must still succeed after re-running the migration")
 }

--- a/pkg/oauth/postgres/store_test.go
+++ b/pkg/oauth/postgres/store_test.go
@@ -35,6 +35,14 @@ const (
 	testNotFoundError = "sql: no rows"
 )
 
+// hashedCodeValue and hashedTokenValue are the at-rest digests the store
+// binds in SQL: it hashes the raw credential at the persistence boundary,
+// so every code/token bind and stored column value is the digest.
+var (
+	hashedCodeValue  = oauth.HashToken(testCodeValue)
+	hashedTokenValue = oauth.HashToken(testTokenValue)
+)
+
 func testClient() *oauth.Client {
 	return &oauth.Client{
 		ID:           "id-1",
@@ -248,7 +256,7 @@ func TestSaveAuthorizationCode(t *testing.T) {
 	code := testAuthCode()
 
 	mock.ExpectExec("INSERT INTO oauth_authorization_codes").
-		WithArgs(code.ID, code.Code, code.ClientID, code.UserID,
+		WithArgs(code.ID, hashedCodeValue, code.ClientID, code.UserID,
 			sqlmock.AnyArg(), code.CodeChallenge, code.RedirectURI,
 			code.Scope, code.ExpiresAt, code.Used, code.CreatedAt).
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -271,18 +279,18 @@ func TestGetAuthorizationCode(t *testing.T) {
 		"id", "code", "client_id", "user_id", "user_claims",
 		"code_challenge", "redirect_uri", "scope", "expires_at", "used", "created_at",
 	}).AddRow(
-		code.ID, code.Code, code.ClientID, code.UserID, claimsJSON,
+		code.ID, hashedCodeValue, code.ClientID, code.UserID, claimsJSON,
 		code.CodeChallenge, code.RedirectURI, code.Scope,
 		code.ExpiresAt, code.Used, code.CreatedAt,
 	)
 
 	mock.ExpectQuery("SELECT .+ FROM oauth_authorization_codes").
-		WithArgs(testCodeValue).
+		WithArgs(hashedCodeValue).
 		WillReturnRows(rows)
 
 	result, err := store.GetAuthorizationCode(context.Background(), testCodeValue)
 	assert.NoError(t, err)
-	assert.Equal(t, code.Code, result.Code)
+	assert.Equal(t, hashedCodeValue, result.Code)
 	assert.Equal(t, code.ClientID, result.ClientID)
 	assert.Equal(t, code.UserID, result.UserID)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -296,7 +304,7 @@ func TestDeleteAuthorizationCode(t *testing.T) {
 	store := New(db)
 
 	mock.ExpectExec("DELETE FROM oauth_authorization_codes").
-		WithArgs(testCodeValue).
+		WithArgs(hashedCodeValue).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err = store.DeleteAuthorizationCode(context.Background(), testCodeValue)
@@ -317,18 +325,18 @@ func TestConsumeAuthorizationCode(t *testing.T) {
 		"id", "code", "client_id", "user_id", "user_claims",
 		"code_challenge", "redirect_uri", "scope", "expires_at", "used", "created_at",
 	}).AddRow(
-		code.ID, code.Code, code.ClientID, code.UserID, claimsJSON,
+		code.ID, hashedCodeValue, code.ClientID, code.UserID, claimsJSON,
 		code.CodeChallenge, code.RedirectURI, code.Scope,
 		code.ExpiresAt, code.Used, code.CreatedAt,
 	)
 
 	mock.ExpectQuery("DELETE FROM oauth_authorization_codes .+ RETURNING").
-		WithArgs(testCodeValue).
+		WithArgs(hashedCodeValue).
 		WillReturnRows(rows)
 
 	result, err := store.ConsumeAuthorizationCode(context.Background(), testCodeValue)
 	assert.NoError(t, err)
-	assert.Equal(t, code.Code, result.Code)
+	assert.Equal(t, hashedCodeValue, result.Code)
 	assert.Equal(t, code.ClientID, result.ClientID)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -341,7 +349,7 @@ func TestConsumeAuthorizationCode_NotFound(t *testing.T) {
 	store := New(db)
 
 	mock.ExpectQuery("DELETE FROM oauth_authorization_codes .+ RETURNING").
-		WithArgs(testCodeValue).
+		WithArgs(hashedCodeValue).
 		WillReturnError(sql.ErrNoRows)
 
 	_, err = store.ConsumeAuthorizationCode(context.Background(), testCodeValue)
@@ -373,7 +381,7 @@ func TestSaveRefreshToken(t *testing.T) {
 	token := testRefreshToken()
 
 	mock.ExpectExec("INSERT INTO oauth_refresh_tokens").
-		WithArgs(token.ID, token.Token, token.ClientID, token.UserID,
+		WithArgs(token.ID, hashedTokenValue, token.ClientID, token.UserID,
 			sqlmock.AnyArg(), token.Scope, token.ExpiresAt, token.CreatedAt).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -395,17 +403,17 @@ func TestGetRefreshToken(t *testing.T) {
 		"id", "token", "client_id", "user_id", "user_claims",
 		"scope", "expires_at", "created_at",
 	}).AddRow(
-		token.ID, token.Token, token.ClientID, token.UserID,
+		token.ID, hashedTokenValue, token.ClientID, token.UserID,
 		claimsJSON, token.Scope, token.ExpiresAt, token.CreatedAt,
 	)
 
 	mock.ExpectQuery("SELECT .+ FROM oauth_refresh_tokens").
-		WithArgs(testTokenValue).
+		WithArgs(hashedTokenValue).
 		WillReturnRows(rows)
 
 	result, err := store.GetRefreshToken(context.Background(), testTokenValue)
 	assert.NoError(t, err)
-	assert.Equal(t, token.Token, result.Token)
+	assert.Equal(t, hashedTokenValue, result.Token)
 	assert.Equal(t, token.ClientID, result.ClientID)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -418,7 +426,7 @@ func TestDeleteRefreshToken(t *testing.T) {
 	store := New(db)
 
 	mock.ExpectExec("DELETE FROM oauth_refresh_tokens WHERE token").
-		WithArgs(testTokenValue).
+		WithArgs(hashedTokenValue).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err = store.DeleteRefreshToken(context.Background(), testTokenValue)
@@ -439,17 +447,17 @@ func TestConsumeRefreshToken(t *testing.T) {
 		"id", "token", "client_id", "user_id", "user_claims",
 		"scope", "expires_at", "created_at",
 	}).AddRow(
-		token.ID, token.Token, token.ClientID, token.UserID,
+		token.ID, hashedTokenValue, token.ClientID, token.UserID,
 		claimsJSON, token.Scope, token.ExpiresAt, token.CreatedAt,
 	)
 
 	mock.ExpectQuery("DELETE FROM oauth_refresh_tokens .+ RETURNING").
-		WithArgs(testTokenValue).
+		WithArgs(hashedTokenValue).
 		WillReturnRows(rows)
 
 	result, err := store.ConsumeRefreshToken(context.Background(), testTokenValue)
 	assert.NoError(t, err)
-	assert.Equal(t, token.Token, result.Token)
+	assert.Equal(t, hashedTokenValue, result.Token)
 	assert.Equal(t, token.ClientID, result.ClientID)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -462,7 +470,7 @@ func TestConsumeRefreshToken_NotFound(t *testing.T) {
 	store := New(db)
 
 	mock.ExpectQuery("DELETE FROM oauth_refresh_tokens .+ RETURNING").
-		WithArgs(testTokenValue).
+		WithArgs(hashedTokenValue).
 		WillReturnError(sql.ErrNoRows)
 
 	_, err = store.ConsumeRefreshToken(context.Background(), testTokenValue)
@@ -648,7 +656,7 @@ func TestGetAuthorizationCode_NotFound(t *testing.T) {
 	store := New(db)
 
 	mock.ExpectQuery("SELECT .+ FROM oauth_authorization_codes").
-		WithArgs("nonexistent").
+		WithArgs(oauth.HashToken("nonexistent")).
 		WillReturnError(errors.New(testNotFoundError))
 
 	_, err = store.GetAuthorizationCode(context.Background(), "nonexistent")
@@ -710,7 +718,7 @@ func TestGetRefreshToken_NotFound(t *testing.T) {
 	store := New(db)
 
 	mock.ExpectQuery("SELECT .+ FROM oauth_refresh_tokens").
-		WithArgs("nonexistent").
+		WithArgs(oauth.HashToken("nonexistent")).
 		WillReturnError(errors.New(testNotFoundError))
 
 	_, err = store.GetRefreshToken(context.Background(), "nonexistent")

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -397,7 +397,9 @@ func (s *Server) handleAuthorizationCodeGrant(ctx context.Context, req TokenRequ
 	// consume fails the grant instead of replaying the code. A storage
 	// outage surfaces as server_error (retryable) rather than
 	// invalid_grant: the code is still stored and single-use still holds.
-	if _, err := s.storage.ConsumeAuthorizationCode(ctx, code.Code); err != nil {
+	// Consume takes the raw request value: the scanned code.Code holds
+	// the at-rest digest, which storage would hash again on lookup.
+	if _, err := s.storage.ConsumeAuthorizationCode(ctx, req.Code); err != nil {
 		slog.Warn("oauth: authorization code consume failed",
 			paramClientID, logsan.SanitizeForLog(req.ClientID), logKeyError, logsan.SanitizeForLog(err.Error()))
 		if errors.Is(err, ErrNotFound) {
@@ -418,7 +420,9 @@ func (s *Server) handleRefreshTokenGrant(ctx context.Context, req TokenRequest) 
 	}
 
 	if token.IsExpired() {
-		if delErr := s.storage.DeleteRefreshToken(ctx, token.Token); delErr != nil {
+		// Delete takes the raw request value: the scanned token.Token
+		// holds the at-rest digest, which storage would hash again.
+		if delErr := s.storage.DeleteRefreshToken(ctx, req.RefreshToken); delErr != nil {
 			slog.Warn("oauth: expired refresh token delete failed",
 				paramClientID, token.ClientID, logKeyError, delErr.Error())
 		}
@@ -444,7 +448,9 @@ func (s *Server) handleRefreshTokenGrant(ctx context.Context, req TokenRequest) 
 	// into two live tokens. A storage outage surfaces as server_error
 	// (retryable) so a spec-compliant client does not discard its
 	// still-valid refresh token over a transient infrastructure blip.
-	if _, err := s.storage.ConsumeRefreshToken(ctx, token.Token); err != nil {
+	// Consume takes the raw request value: the scanned token.Token holds
+	// the at-rest digest, which storage would hash again on lookup.
+	if _, err := s.storage.ConsumeRefreshToken(ctx, req.RefreshToken); err != nil {
 		slog.Warn("oauth: refresh token rotation consume failed",
 			paramClientID, logsan.SanitizeForLog(req.ClientID), logKeyError, logsan.SanitizeForLog(err.Error()))
 		if errors.Is(err, ErrNotFound) {

--- a/pkg/oauth/storage.go
+++ b/pkg/oauth/storage.go
@@ -3,10 +3,21 @@ package oauth
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"net/url"
 	"slices"
 	"time"
 )
+
+// HashToken returns the hex-encoded SHA-256 digest of a token value.
+// Opaque bearer credentials (refresh tokens, authorization codes) are
+// stored only as digests so a database read never yields a usable
+// credential; lookups hash the presented value and compare digests.
+func HashToken(token string) string {
+	digest := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(digest[:])
+}
 
 // Storage defines the interface for OAuth data persistence.
 type Storage interface {
@@ -17,7 +28,9 @@ type Storage interface {
 	DeleteClient(ctx context.Context, clientID string) error
 	ListClients(ctx context.Context) ([]*Client, error)
 
-	// Authorization code management
+	// Authorization code management. Implementations persist only the
+	// SHA-256 digest of the code value (HashToken); the get, delete, and
+	// consume methods take the raw value and hash it before comparison.
 	SaveAuthorizationCode(ctx context.Context, code *AuthorizationCode) error
 	GetAuthorizationCode(ctx context.Context, code string) (*AuthorizationCode, error)
 	DeleteAuthorizationCode(ctx context.Context, code string) error
@@ -29,7 +42,9 @@ type Storage interface {
 	ConsumeAuthorizationCode(ctx context.Context, code string) (*AuthorizationCode, error)
 	CleanupExpiredCodes(ctx context.Context) error
 
-	// Token management
+	// Token management. Implementations persist only the SHA-256 digest
+	// of the token value (HashToken); the get, delete, and consume
+	// methods take the raw value and hash it before comparison.
 	SaveRefreshToken(ctx context.Context, token *RefreshToken) error
 	GetRefreshToken(ctx context.Context, token string) (*RefreshToken, error)
 	DeleteRefreshToken(ctx context.Context, token string) error
@@ -57,7 +72,10 @@ type Client struct {
 
 // AuthorizationCode represents an OAuth authorization code.
 type AuthorizationCode struct {
-	ID            string         `json:"id"`
+	ID string `json:"id"`
+	// Code carries the raw value when issuing; Storage implementations
+	// persist only its SHA-256 digest (HashToken), so records read back
+	// from storage hold the digest, never a usable credential.
 	Code          string         `json:"code"`
 	ClientID      string         `json:"client_id"`
 	UserID        string         `json:"user_id"`
@@ -72,7 +90,10 @@ type AuthorizationCode struct {
 
 // RefreshToken represents an OAuth refresh token.
 type RefreshToken struct {
-	ID         string         `json:"id"`
+	ID string `json:"id"`
+	// Token carries the raw value when issuing; Storage implementations
+	// persist only its SHA-256 digest (HashToken), so records read back
+	// from storage hold the digest, never a usable credential.
 	Token      string         `json:"token"`
 	ClientID   string         `json:"client_id"`
 	UserID     string         `json:"user_id"`

--- a/pkg/oauth/storage_test.go
+++ b/pkg/oauth/storage_test.go
@@ -11,6 +11,33 @@ const (
 	testLoopback127     = "http://127.0.0.1"
 )
 
+func TestHashToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		token    string
+		expected string
+	}{
+		// FIPS 180-4 SHA-256 test vector for "abc".
+		{"known vector", "abc", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"},
+		{"empty string", "", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HashToken(tt.token); got != tt.expected {
+				t.Errorf("HashToken(%q) = %q, want %q", tt.token, got, tt.expected)
+			}
+		})
+	}
+
+	t.Run("digest never equals a non-empty input", func(t *testing.T) {
+		const token = "refresh-token-value"
+		if HashToken(token) == token {
+			t.Error("digest must differ from the raw token")
+		}
+	})
+}
+
 func TestClientValidRedirectURI(t *testing.T) {
 	client := &Client{
 		RedirectURIs: []string{

--- a/pkg/session/handler.go
+++ b/pkg/session/handler.go
@@ -3,7 +3,6 @@ package session
 import (
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/txn2/mcp-data-platform/internal/logsan"
+	"github.com/txn2/mcp-data-platform/pkg/oauth"
 )
 
 // awareSessionKey is the context key for the AwareHandler session ID.
@@ -523,11 +523,13 @@ func extractToken(r *http.Request) string {
 	return auth[bearerPrefixLen:]
 }
 
-// hashToken returns the SHA-256 hex digest of a token, or empty for empty tokens.
+// hashToken returns the SHA-256 hex digest of a token, or empty for empty
+// tokens. The empty-token guard keeps anonymous requests from all mapping
+// to the fixed digest of ""; the digest itself is the platform's shared
+// credential-hashing primitive, oauth.HashToken.
 func hashToken(token string) string {
 	if token == "" {
 		return ""
 	}
-	h := sha256.Sum256([]byte(token))
-	return hex.EncodeToString(h[:])
+	return oauth.HashToken(token)
 }

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -301,6 +301,7 @@ pkg/semantic/datahub -> pkg/observability
 pkg/semantic/datahub -> pkg/semantic
 pkg/semantic/datahub -> pkg/urnbuild
 pkg/session -> internal/logsan
+pkg/session -> pkg/oauth
 pkg/session/postgres -> pkg/session
 pkg/storage/s3 -> pkg/storage
 pkg/storage/s3 -> pkg/urnbuild


### PR DESCRIPTION
Closes #881 (part of #880, finding 1.1).

## Problem

Refresh tokens and authorization codes were stored as plaintext in Postgres: `SaveRefreshToken` inserted the raw token and `GetRefreshToken` looked it up with `WHERE token = $1`, and authorization codes worked the same way (`pkg/oauth/postgres/store.go`). Anyone with read access to the platform database (backup, replica, operator) therefore held live bearer credentials with a 30-day default refresh TTL. Comparable projects (Vault, Hydra, Dex) hash tokens at rest.

## Change

Both stores now persist only the hex-encoded SHA-256 digest of the credential and hash the presented value on lookup, so a database read never yields a usable credential.

**Hashing primitive** (`pkg/oauth/storage.go`)
- New `oauth.HashToken(token string) string`: hex-encoded `sha256.Sum256`.
- The `Storage` interface and the `AuthorizationCode.Code` / `RefreshToken.Token` fields document digest-at-rest semantics: save takes the raw value and persists the digest; get/delete/consume take the raw value and hash it before comparison; records read back from storage hold the digest.

**Postgres store** (`pkg/oauth/postgres/store.go`)
- `SaveAuthorizationCode` / `SaveRefreshToken` insert `HashToken(value)`.
- `Get*`, `Delete*`, and `Consume*` hash the incoming value before the `WHERE` comparison.
- Column names are unchanged (`code`, `token`); only the value representation changes. Both columns are `VARCHAR(255)`, so the 64-char digest fits.

**In-memory store** (`pkg/oauth/memory.go`)
- Identical behavior: map keys and the stored struct field hold the digest. The store copies the struct on save so the caller's raw value (needed for issuance to the client) is never mutated.

**Caller audit** (`pkg/oauth/server.go`)
- Three grant-handler sites passed the scanned struct value back into consume/delete (`code.Code`, `token.Token`). Those fields now hold the at-rest digest, which storage would hash again on lookup, so they now pass the raw request values (`req.Code`, `req.RefreshToken`). No caller echoes the stored value to a client.
- `pkg/session`'s bearer-token digest (`hashToken`) now delegates to `oauth.HashToken` so the platform has one credential-hashing primitive; the new `pkg/session -> pkg/oauth` import edge is a deliberate consolidation and is allowlisted in `testdata/allowed_internal_imports.txt`.

**Migration `000078_hash_oauth_tokens`**
- Up: hashes existing rows in place so live sessions survive the upgrade. Uses `convert_to(value, 'UTF8')` rather than a `::bytea` cast (the cast runs the text through bytea's input parser, which mis-parses or rejects backslashes; `convert_to` is the byte-exact counterpart of Go's `sha256([]byte(value))`). Each `UPDATE` is guarded with `WHERE value !~ '^[0-9a-f]{64}$'` so re-running it (dirty-migration recovery, operator sweep) never double-hashes a digest; issued raw credentials are 43-char base64url strings and cannot match the guard.
- Down: hashing is one-way, so rollback deletes both tables. This is user-visible: every client's next refresh fails and forces a full interactive re-authorization. The migration comment and docs state this plainly.

## Operational notes

- **Rolling upgrades (multi-replica)**: replicas still running the previous binary compare raw values against the now-hashed rows, so refresh grants they serve fail until the rollout completes, and any token such a replica issues after the migration ran is stored plaintext and is invalid under the new binary. Affected clients recover with one interactive re-authorization. Documented in the migration header and in `docs/auth/oauth-server.md` ("Upgrade Note: Hashed Refresh Tokens").
- A dual-read fallback (accept raw-value matches during a transition window) was considered and rejected: a raw-equality lookup arm would let a stolen digest itself authenticate, defeating the feature.
- `oauth_authorization_states` (migration 000076) holds short-lived single-use upstream state values and is unchanged, per the issue's scope.

## Tests

- `TestHashToken`: FIPS 180-4 vector for "abc", empty-string vector, digest-differs-from-input.
- Memory store tests assert the stored value is the digest, raw-value lookups succeed, and save does not mutate the caller's struct.
- sqlmock store tests bind the digest in every INSERT/SELECT/DELETE expectation.
- RealDB integration tests (`pkg/oauth/postgres/store_realdb_integration_test.go`, testcontainers Postgres with the full embedded migration set):
  - `TestOAuthStore_TokensHashedAtRest_RealDB`: raw-SQL column read returns `HashToken(raw)` (not the raw value); `Get`/`Consume` with the raw value succeed, for both credential kinds.
  - `TestOAuthStore_Migration78HashesPlaintext_RealDB`: steps the schema back to version 77 (one migration at a time, targeting the version explicitly so the test stays correct as later migrations land), inserts plaintext rows with raw SQL, applies 000078, and proves raw-value lookups succeed and the rows hold digests. Then re-executes the up migration and proves the idempotency guard: lookups still succeed, nothing double-hashed.
- Existing OAuth flow tests (PKCE, rotation, scope escalation, replay) pass unchanged: the server passes raw request values through the full flows.
- `make verify` green locally (full CI-equivalent suite: race tests, coverage and patch-coverage gates, lint, gosec, govulncheck, semgrep, CodeQL, migrate-check against real Postgres, realdb suite, mutation testing, GoReleaser dry run).

## Docs

- `docs/auth/oauth-server.md`: digest-at-rest paragraph in Storage, new "Hashed Credentials at Rest" row in Security Features, and the upgrade note covering the rolling-upgrade window and rollback behavior.
- `docs/llms.txt` and `docs/llms-full.txt` updated to match.
