### PR TITLE
auth(oidc): self-heal JWKS cache on expiry and key rotation

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -702,6 +702,7 @@ mcp-data-platform implements a **fail-closed** security model. Missing or invali
 ## Security Model
 
 - **Required JWT Claims**: Tokens must include `sub` (subject) and `exp` (expiration)
+- **Self-Healing JWKS Cache**: OIDC signing keys are fetched at startup and cached for one hour. The key-lookup path refreshes on demand (during that request's validation, honoring the request's deadline) when the cache expires or a token bears an unknown key ID (IdP key rotation), so validation survives rotation without a restart. Concurrent requests collapse into a single fetch that runs independently, so a slow issuer cannot pin request goroutines. Refreshes are throttled by the last fetch's outcome: at most once per minute after a success (anti-hammer), and a short recovery window after a failure so a brief issuer outage heals within seconds. A failed refresh on an expired cache rejects the token rather than accepting it unverified.
 - **Default-Deny Personas**: Users without explicit persona have no tool access
 - **Prompt Injection Protection**: DataHub metadata is sanitized before exposure
 - **Read-Only Enforcement**: Trino `read_only: true` blocks write queries at query level

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -37,7 +37,7 @@ mcp-data-platform is the orchestration layer for the txn2 MCP ecosystem. DataHub
 ## Authentication & Security
 
 - [Auth Overview](https://mcp-data-platform.txn2.com/auth/overview/): Fail-closed security model, stdio vs HTTP authentication
-- [OIDC](https://mcp-data-platform.txn2.com/auth/oidc/): Keycloak, Auth0, Okta, Azure AD setup with required claims
+- [OIDC](https://mcp-data-platform.txn2.com/auth/oidc/): Keycloak, Auth0, Okta, Azure AD setup with required claims; self-healing JWKS cache that refreshes on demand for key rotation
 - [API Keys](https://mcp-data-platform.txn2.com/auth/api-keys/): Service account authentication
 - [OAuth Server](https://mcp-data-platform.txn2.com/auth/oauth-server/): Built-in OAuth 2.1 authorization server for Claude Desktop and other MCP clients, with PKCE, Dynamic Client Registration, upstream IdP integration, and refresh tokens hashed at rest
 - [OAuth to Upstream MCPs](https://mcp-data-platform.txn2.com/auth/oauth-gateway/): Outbound OAuth to gateway upstreams: client_credentials and authorization_code + PKCE grants, encrypted refresh tokens that survive restarts, background refresh, and a full auth-event history

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -262,8 +262,10 @@ auth:
 
 Token clock skew is a fixed 30 seconds and is not exposed as a YAML setting.
 
+The JWKS signing keys are fetched from the issuer at startup and cached for one hour. The cache self-heals on demand: a token whose key is missing because the cache has expired, or because the IdP rotated its keys, triggers a single refresh from the issuer, performed during that request's validation and honoring the request's own deadline. Concurrent requests collapse into one fetch, which runs independently so a slow issuer cannot pin request goroutines past their deadlines. Refreshes are throttled by the outcome of the last fetch: after a success the next on-demand refresh is at most once per minute, so a flood of unknown key IDs cannot hammer the issuer; after a failure a short recovery window applies so a brief issuer outage heals within seconds rather than being held down for the full minute. No restart is required after key rotation, and none of this is exposed as a YAML setting.
+
 !!! note "Fail-Closed Security"
-    Authentication follows a fail-closed model. Missing tokens, invalid signatures, expired tokens, or missing required claims (`sub`, `exp`) all result in denied access.
+    Authentication follows a fail-closed model. Missing tokens, invalid signatures, expired tokens, or missing required claims (`sub`, `exp`) all result in denied access. If a JWKS refresh fails while the cache is expired, tokens are rejected rather than accepted unverified.
 
 ### Browser Sessions (OIDC Login for Portal UI)
 

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 )
@@ -27,6 +28,31 @@ const (
 
 	// bitsPerByte is the number of bits in a byte, used for RSA key size calculation.
 	bitsPerByte = 8
+
+	// jwksCacheTTL is how long a fetched JWKS is considered fresh before an
+	// on-demand refresh is triggered by the key-lookup path.
+	jwksCacheTTL = 1 * time.Hour
+
+	// jwksRefreshThrottle bounds how often a successful refresh is followed by
+	// another on-demand refresh. After a success the cache holds fresh keys, so
+	// the only reason to refetch soon is an unknown kid (rotation or a garbage-kid
+	// flood); this window prevents such tokens from hammering the IdP.
+	jwksRefreshThrottle = 1 * time.Minute
+
+	// jwksFailedRefreshThrottle is the (much shorter) window applied after a
+	// FAILED refresh. A failed refresh leaves the cache unable to serve the
+	// requested key (a fail-closed state when the cache is also expired), so
+	// recovery must not wait the full anti-hammer window: a transient IdP blip
+	// should heal within seconds, while a hard outage is still bounded to roughly
+	// one fetch per this interval per replica.
+	jwksFailedRefreshThrottle = 5 * time.Second
+
+	// jwksRefreshTimeout bounds a single on-demand JWKS refresh.
+	jwksRefreshTimeout = 30 * time.Second
+
+	// jwksRefreshKey is the single-flight key that collapses concurrent
+	// on-demand refreshes into one fetch.
+	jwksRefreshKey = "jwks"
 )
 
 // OIDCConfig configures OIDC authentication.
@@ -68,6 +94,31 @@ type OIDCAuthenticator struct {
 	// Cached JWKS
 	mu   sync.RWMutex
 	jwks *jwksCache
+
+	// lastRefreshAttempt records when the most recent on-demand refresh was
+	// attempted, and lastRefreshOK whether it succeeded (both guarded by mu). The
+	// startup FetchJWKS does not set them, so the first cache-miss after boot is
+	// never throttled. The outcome selects the throttle window: a short window
+	// after a failure (fast recovery) and the full anti-hammer window after a
+	// success.
+	lastRefreshAttempt time.Time
+	lastRefreshOK      bool
+
+	// refreshGroup collapses concurrent on-demand refreshes into a single fetch.
+	refreshGroup singleflight.Group
+
+	// now is the clock used for cache expiry and refresh throttling. It defaults
+	// to time.Now and is overridable in tests for deterministic timing.
+	now func() time.Time
+}
+
+// clock returns the current time via the injectable clock, defaulting to
+// time.Now when unset.
+func (a *OIDCAuthenticator) clock() time.Time {
+	if a.now != nil {
+		return a.now()
+	}
+	return time.Now()
 }
 
 type jwksCache struct {
@@ -115,7 +166,7 @@ func (a *OIDCAuthenticator) Authenticate(ctx context.Context) (*middleware.UserI
 	}
 
 	// Parse and validate the JWT
-	claims, err := a.parseAndValidateToken(token)
+	claims, err := a.parseAndValidateToken(ctx, token)
 	if err != nil {
 		return nil, fmt.Errorf("invalid token: %w", err)
 	}
@@ -142,7 +193,7 @@ func (a *OIDCAuthenticator) Authenticate(ctx context.Context) (*middleware.UserI
 // JWT, so ChainedAuthenticator can silently fall through to the next
 // authenticator without logging a misleading "rejected" line for what
 // is actually a normal API-key-handed-to-JWT-authenticator path.
-func (a *OIDCAuthenticator) parseAndValidateToken(tokenString string) (map[string]any, error) {
+func (a *OIDCAuthenticator) parseAndValidateToken(ctx context.Context, tokenString string) (map[string]any, error) {
 	if !LooksLikeJWT(tokenString) {
 		return nil, ErrNotAJWT
 	}
@@ -165,8 +216,9 @@ func (a *OIDCAuthenticator) parseAndValidateToken(tokenString string) (map[strin
 			return nil, fmt.Errorf("token missing kid header")
 		}
 
-		// Get the public key from JWKS cache
-		key, err := a.getPublicKey(kid)
+		// Get the public key from JWKS cache. The inbound request context is
+		// threaded through so an on-demand refresh honors the caller's deadline.
+		key, err := a.getPublicKey(ctx, kid)
 		if err != nil {
 			return nil, fmt.Errorf("getting public key: %w", err)
 		}
@@ -224,26 +276,125 @@ func (a *OIDCAuthenticator) parseTokenWithoutSignatureVerification(tokenString s
 	return claims, nil
 }
 
-// getPublicKey retrieves an RSA public key by key ID from the JWKS cache.
-func (a *OIDCAuthenticator) getPublicKey(kid string) (*rsa.PublicKey, error) {
+// getPublicKey retrieves an RSA public key by key ID from the JWKS cache,
+// self-healing via an on-demand refresh when the cache is expired or the kid is
+// unknown (e.g. after IdP key rotation). Concurrent refreshes are collapsed with
+// single-flight and throttled to at most once per jwksRefreshThrottle.
+//
+// It fails closed: when the cache is expired and the refresh fails, it returns
+// an error wrapping the fetch failure and never yields a key. A throttled or
+// post-refresh miss returns the normal key-not-found error.
+func (a *OIDCAuthenticator) getPublicKey(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	key, expired, found := a.lookupKey(kid)
+	if found {
+		return key, nil
+	}
+
+	if err := a.refreshForLookup(ctx, expired); err != nil {
+		return nil, err
+	}
+
+	key, expired, found = a.lookupKey(kid)
+	switch {
+	case found:
+		return key, nil
+	case expired:
+		return nil, fmt.Errorf("jwks cache expired")
+	default:
+		return nil, fmt.Errorf("key not found: %s", kid)
+	}
+}
+
+// lookupKey returns the cached key for kid under a read lock. found is true only
+// when the cache is loaded, unexpired, and contains kid. expired is true when the
+// cache is absent or stale and therefore a refresh is warranted.
+func (a *OIDCAuthenticator) lookupKey(kid string) (key *rsa.PublicKey, expired, found bool) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
-	if a.jwks == nil {
-		return nil, fmt.Errorf("jwks not loaded")
+	if a.jwks == nil || a.clock().After(a.jwks.expiresAt) {
+		return nil, true, false
 	}
 
-	// Check if cache is expired
-	if time.Now().After(a.jwks.expiresAt) {
-		return nil, fmt.Errorf("jwks cache expired")
+	k, ok := a.jwks.keys[kid]
+	return k, false, ok
+}
+
+// refreshForLookup performs an on-demand, single-flighted, throttled JWKS
+// refresh triggered by a cache miss. cacheExpired reports whether the current
+// cache is stale, which determines the fail-closed semantics.
+//
+// The fetch runs on a detached, bounded context in its own goroutine (via
+// DoChan) so it always completes and populates the cache for future requests,
+// while this caller waits only until its own ctx is done. That way a slow or
+// hung IdP cannot pin a request goroutine past the caller's deadline.
+//
+// It returns an error only when an actual refresh was attempted, failed, and the
+// cache was expired (fail closed), or when the caller's ctx is canceled. When
+// the refresh is throttled, or fails while the cache is still valid (a mere
+// unknown-kid miss), it returns nil and lets the caller re-inspect the cache and
+// report the appropriate not-found error.
+func (a *OIDCAuthenticator) refreshForLookup(ctx context.Context, cacheExpired bool) error {
+	// The throttle is checked inside the single-flight function, not before
+	// DoChan, on purpose: concurrent callers then attach to the one in-flight
+	// fetch and share its result. A pre-DoChan throttle short-circuit would let a
+	// caller that arrives while a refresh is in flight bail early and read the
+	// still-stale (or expired) cache, returning a spurious miss for a token the
+	// in-flight refresh is about to make verifiable. The saved goroutine per
+	// throttled miss is not worth that correctness cost.
+	ch := a.refreshGroup.DoChan(jwksRefreshKey, func() (any, error) {
+		if a.refreshThrottled() {
+			return struct{}{}, nil
+		}
+
+		a.mu.Lock()
+		a.lastRefreshAttempt = a.clock()
+		a.mu.Unlock()
+
+		fctx, cancel := context.WithTimeout(context.Background(), jwksRefreshTimeout)
+		defer cancel()
+		err := a.RefreshJWKS(fctx)
+
+		a.mu.Lock()
+		a.lastRefreshOK = err == nil
+		a.mu.Unlock()
+		return struct{}{}, err
+	})
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("awaiting jwks refresh: %w", ctx.Err())
+	case res := <-ch:
+		if res.Err != nil && cacheExpired {
+			return fmt.Errorf("refreshing jwks: %w", res.Err)
+		}
+		return nil
+	}
+}
+
+// refreshThrottled reports whether an on-demand refresh was attempted within the
+// applicable throttle window. The window is selected by the outcome of the last
+// attempt, not by the current caller's cache state: a failed attempt uses the
+// short recovery window so a transient IdP failure heals quickly, while a
+// successful attempt uses the full anti-hammer window (a success means the cache
+// holds fresh keys, so a soon-after refetch can only be an unknown-kid flood).
+// Keying on the last outcome rather than per-caller state also keeps the window
+// correct when single-flight collapses callers with differing cache states. The
+// startup fetch leaves lastRefreshAttempt zero, so the first on-demand refresh
+// after boot is never throttled.
+func (a *OIDCAuthenticator) refreshThrottled() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	if a.lastRefreshAttempt.IsZero() {
+		return false
 	}
 
-	key, ok := a.jwks.keys[kid]
-	if !ok {
-		return nil, fmt.Errorf("key not found: %s", kid)
+	window := jwksFailedRefreshThrottle
+	if a.lastRefreshOK {
+		window = jwksRefreshThrottle
 	}
-
-	return key, nil
+	return a.clock().Sub(a.lastRefreshAttempt) < window
 }
 
 // validateClaims validates standard JWT claims.
@@ -364,7 +515,7 @@ func (a *OIDCAuthenticator) FetchJWKS(ctx context.Context) error {
 	a.jwks = &jwksCache{
 		keys:      keys,
 		rawKeys:   rawKeys,
-		expiresAt: time.Now().Add(1 * time.Hour),
+		expiresAt: a.clock().Add(jwksCacheTTL),
 	}
 	a.mu.Unlock()
 

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -12,6 +12,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -537,14 +539,14 @@ func TestOIDCAuthenticator_parseAndValidateToken(t *testing.T) {
 	})
 
 	t.Run("only two parts", func(t *testing.T) {
-		_, err := auth.parseAndValidateToken("header.payload")
+		_, err := auth.parseAndValidateToken(context.Background(), "header.payload")
 		if err == nil {
 			t.Error("expected error for JWT with only two parts")
 		}
 	})
 
 	t.Run("invalid base64 payload", func(t *testing.T) {
-		_, err := auth.parseAndValidateToken("header.!!!invalid-base64!!!.sig")
+		_, err := auth.parseAndValidateToken(context.Background(), "header.!!!invalid-base64!!!.sig")
 		if err == nil {
 			t.Error("expected error for invalid base64")
 		}
@@ -552,7 +554,7 @@ func TestOIDCAuthenticator_parseAndValidateToken(t *testing.T) {
 
 	t.Run("invalid JSON payload", func(t *testing.T) {
 		payload := base64.RawURLEncoding.EncodeToString([]byte("not-json"))
-		_, err := auth.parseAndValidateToken("header." + payload + ".sig")
+		_, err := auth.parseAndValidateToken(context.Background(), "header."+payload+".sig")
 		if err == nil {
 			t.Error("expected error for invalid JSON")
 		}
@@ -719,75 +721,80 @@ func TestOIDCAuthenticator_FetchJWKS_JWKSURIEmpty(t *testing.T) {
 }
 
 func TestOIDCAuthenticator_getPublicKey(t *testing.T) {
-	t.Run("JWKS not loaded", func(t *testing.T) {
+	// brokenIssuer serves a discovery endpoint that always fails, so an
+	// on-demand refresh triggered by a cache miss fails deterministically
+	// without touching a real network.
+	brokenIssuer := func(t *testing.T) *OIDCAuthenticator {
+		t.Helper()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "unavailable", http.StatusInternalServerError)
+		}))
+		t.Cleanup(server.Close)
+
 		auth, _ := NewOIDCAuthenticator(OIDCConfig{
-			Issuer:                    "https://issuer.example.com",
+			Issuer:                    server.URL,
 			SkipSignatureVerification: true,
 		})
-		// jwks is nil by default
+		return auth
+	}
 
-		_, err := auth.getPublicKey("test-kid")
+	t.Run("nil cache triggers refresh and fails closed", func(t *testing.T) {
+		auth := brokenIssuer(t)
+		// jwks is nil by default; the refresh attempt fails.
+
+		_, err := auth.getPublicKey(context.Background(), "test-kid")
 		if err == nil {
-			t.Error("expected error for nil JWKS")
+			t.Fatal("expected error for nil JWKS with failing refresh")
 		}
-		if err.Error() != "jwks not loaded" {
+		if !strings.Contains(err.Error(), "refreshing jwks") {
 			t.Errorf(errUnexpected, err)
 		}
 	})
 
-	t.Run("JWKS cache expired", func(t *testing.T) {
-		auth, _ := NewOIDCAuthenticator(OIDCConfig{
-			Issuer:                    "https://issuer.example.com",
-			SkipSignatureVerification: true,
-		})
-		// Set expired cache
+	t.Run("expired cache triggers refresh and fails closed", func(t *testing.T) {
+		auth := brokenIssuer(t)
 		auth.jwks = &jwksCache{
 			keys:      make(map[string]*rsa.PublicKey),
 			expiresAt: time.Now().Add(-time.Hour), // expired an hour ago
 		}
 
-		_, err := auth.getPublicKey("test-kid")
+		_, err := auth.getPublicKey(context.Background(), "test-kid")
 		if err == nil {
-			t.Error("expected error for expired cache")
+			t.Fatal("expected error for expired cache with failing refresh")
 		}
-		if err.Error() != "jwks cache expired" {
+		if !strings.Contains(err.Error(), "refreshing jwks") {
 			t.Errorf(errUnexpected, err)
 		}
 	})
 
-	t.Run("key not found", func(t *testing.T) {
-		auth, _ := NewOIDCAuthenticator(OIDCConfig{
-			Issuer:                    "https://issuer.example.com",
-			SkipSignatureVerification: true,
-		})
-		// Set valid cache but no keys
+	t.Run("unknown kid on valid cache returns key not found", func(t *testing.T) {
+		auth := brokenIssuer(t)
+		// Valid cache without the requested kid. The refresh attempt fails but
+		// the still-valid cache means the caller reports key-not-found.
 		auth.jwks = &jwksCache{
 			keys:      make(map[string]*rsa.PublicKey),
 			expiresAt: time.Now().Add(time.Hour),
 		}
 
-		_, err := auth.getPublicKey("missing-kid")
+		_, err := auth.getPublicKey(context.Background(), "missing-kid")
 		if err == nil {
-			t.Error("expected error for missing key")
+			t.Fatal("expected error for missing key")
 		}
 		if !strings.Contains(err.Error(), "key not found") {
 			t.Errorf(errUnexpected, err)
 		}
 	})
 
-	t.Run("key found", func(t *testing.T) {
-		auth, _ := NewOIDCAuthenticator(OIDCConfig{
-			Issuer:                    "https://issuer.example.com",
-			SkipSignatureVerification: true,
-		})
-		// Set valid cache with a key
+	t.Run("key found on valid cache without refresh", func(t *testing.T) {
+		auth := brokenIssuer(t)
+		// Set valid cache with a key; the fast path returns it with no refresh.
 		testKey := &rsa.PublicKey{N: big.NewInt(12345), E: 65537}
 		auth.jwks = &jwksCache{
 			keys:      map[string]*rsa.PublicKey{"test-kid": testKey},
 			expiresAt: time.Now().Add(time.Hour),
 		}
 
-		key, err := auth.getPublicKey("test-kid")
+		key, err := auth.getPublicKey(context.Background(), "test-kid")
 		if err != nil {
 			t.Fatalf(errUnexpected, err)
 		}
@@ -882,7 +889,7 @@ func TestOIDCAuthenticator_parseAndValidateToken_SignatureVerification(t *testin
 		sig := base64.RawURLEncoding.EncodeToString([]byte("fakesignature"))
 		token := header + "." + payload + "." + sig
 
-		_, err := auth.parseAndValidateToken(token)
+		_, err := auth.parseAndValidateToken(context.Background(), token)
 		if err == nil {
 			t.Fatal("expected error for token without kid")
 		}
@@ -901,7 +908,7 @@ func TestOIDCAuthenticator_parseAndValidateToken_SignatureVerification(t *testin
 		sig := base64.RawURLEncoding.EncodeToString([]byte("fakesignature"))
 		token := header + "." + payload + "." + sig
 
-		_, err := auth.parseAndValidateToken(token)
+		_, err := auth.parseAndValidateToken(context.Background(), token)
 		if err == nil {
 			t.Fatal("expected error for non-RSA signing method")
 		}
@@ -919,7 +926,7 @@ func TestOIDCAuthenticator_parseAndValidateToken_SignatureVerification(t *testin
 		sig := base64.RawURLEncoding.EncodeToString([]byte("fakesignature"))
 		token := header + "." + payload + "." + sig
 
-		_, err := auth.parseAndValidateToken(token)
+		_, err := auth.parseAndValidateToken(context.Background(), token)
 		if err == nil {
 			t.Fatal("expected error for key not found")
 		}
@@ -988,7 +995,7 @@ func TestOIDCAuthenticator_parseAndValidateToken_ValidSignature(t *testing.T) {
 	}
 
 	// Parse and validate the token
-	claims, err := auth.parseAndValidateToken(signedToken)
+	claims, err := auth.parseAndValidateToken(context.Background(), signedToken)
 	if err != nil {
 		t.Fatalf(errUnexpected, err)
 	}
@@ -1037,7 +1044,7 @@ func TestOIDCAuthenticator_parseAndValidateToken_InvalidSignature(t *testing.T) 
 	token.Header["kid"] = "test-key"
 	signedToken, _ := token.SignedString(signingKey) // Signed with wrong key
 
-	_, err := auth.parseAndValidateToken(signedToken)
+	_, err := auth.parseAndValidateToken(context.Background(), signedToken)
 	if err == nil {
 		t.Fatal("expected error for invalid signature")
 	}
@@ -1306,5 +1313,411 @@ func TestOIDCAuthenticator_FetchJWKS_MissingKid(t *testing.T) {
 	// The key is stored with empty string kid
 	if _, ok := auth.jwks.keys[""]; !ok {
 		t.Error("expected key to be stored with empty string kid")
+	}
+}
+
+// jwksTestServer is a controllable JWKS/OIDC discovery server for exercising the
+// on-demand refresh path: it counts /jwks requests, can rotate its signing key,
+// and can be made to fail the /jwks endpoint.
+type jwksTestServer struct {
+	server  *httptest.Server
+	mu      sync.Mutex
+	kid     string
+	key     *rsa.PrivateKey
+	hits    atomic.Int32
+	fail    atomic.Bool
+	delay   time.Duration
+	delayMu sync.Mutex
+}
+
+func newJWKSTestServer(t *testing.T) *jwksTestServer {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, rsaKeyBits)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
+	js := &jwksTestServer{kid: "key-a", key: key}
+	js.server = httptest.NewServer(http.HandlerFunc(js.handle))
+	t.Cleanup(js.server.Close)
+	return js
+}
+
+func (j *jwksTestServer) handle(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case oidcDiscoveryPath:
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jwks_uri": "` + "http://" + r.Host + `/jwks"}`))
+	case jwksPath:
+		j.hits.Add(1)
+		j.delayMu.Lock()
+		d := j.delay
+		j.delayMu.Unlock()
+		if d > 0 {
+			time.Sleep(d)
+		}
+		if j.fail.Load() {
+			http.Error(w, "unavailable", http.StatusInternalServerError)
+			return
+		}
+		j.mu.Lock()
+		kid, key := j.kid, j.key
+		j.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		nB64 := base64.RawURLEncoding.EncodeToString(key.N.Bytes())
+		eB64 := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.PublicKey.E)).Bytes())
+		_, _ = fmt.Fprintf(w, `{"keys": [{"kty": "RSA", "kid": "%s", "use": "sig", "n": "%s", "e": "%s"}]}`, kid, nB64, eB64) //nolint:gocritic // JSON template requires literal quotes, not %q
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// rotate replaces the server's signing key and kid, simulating IdP key rotation.
+func (j *jwksTestServer) rotate(t *testing.T, newKid string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, rsaKeyBits)
+	if err != nil {
+		t.Fatalf("generating rotated RSA key: %v", err)
+	}
+	j.mu.Lock()
+	j.kid, j.key = newKid, key
+	j.mu.Unlock()
+}
+
+// signToken signs a valid JWT with the server's current key and kid.
+func (j *jwksTestServer) signToken(t *testing.T) string {
+	t.Helper()
+	j.mu.Lock()
+	kid, key := j.kid, j.key
+	j.mu.Unlock()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"sub": testUserID,
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+		"iss": j.server.URL,
+	})
+	token.Header["kid"] = kid
+	signed, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+	return signed
+}
+
+func (j *jwksTestServer) currentKid() string {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.kid
+}
+
+func (j *jwksTestServer) setDelay(d time.Duration) {
+	j.delayMu.Lock()
+	j.delay = d
+	j.delayMu.Unlock()
+}
+
+func (j *jwksTestServer) resetHits()      { j.hits.Store(0) }
+func (j *jwksTestServer) fetchCount() int { return int(j.hits.Load()) }
+
+// expireCache forces the authenticator's cached JWKS to appear stale.
+func expireCache(t *testing.T, auth *OIDCAuthenticator) {
+	t.Helper()
+	auth.mu.Lock()
+	defer auth.mu.Unlock()
+	if auth.jwks == nil {
+		t.Fatal("cannot expire a nil JWKS cache")
+	}
+	auth.jwks.expiresAt = time.Now().Add(-time.Minute)
+}
+
+func newSelfHealAuth(t *testing.T, js *jwksTestServer) *OIDCAuthenticator {
+	t.Helper()
+	auth, err := NewOIDCAuthenticator(OIDCConfig{
+		Issuer:                 js.server.URL,
+		SkipIssuerVerification: true,
+	})
+	if err != nil {
+		t.Fatalf("creating authenticator: %v", err)
+	}
+	return auth
+}
+
+// TestOIDCAuthenticator_RefreshOnExpiry verifies token verification succeeds
+// after the JWKS cache TTL has elapsed, where the pre-fix code failed with a
+// cache-expired error (issue #882 finding 1.2).
+func TestOIDCAuthenticator_RefreshOnExpiry(t *testing.T) {
+	js := newJWKSTestServer(t)
+	auth := newSelfHealAuth(t, js)
+
+	token := js.signToken(t)
+	expireCache(t, auth)
+
+	claims, err := auth.parseAndValidateToken(context.Background(), token)
+	if err != nil {
+		t.Fatalf("expected verification to succeed after expiry, got: %v", err)
+	}
+	if claims["sub"] != testUserID {
+		t.Errorf("expected sub=%q, got %v", testUserID, claims["sub"])
+	}
+	if js.fetchCount() < 2 {
+		t.Errorf("expected an on-demand refresh (>=2 total fetches), got %d", js.fetchCount())
+	}
+}
+
+// TestOIDCAuthenticator_KeyRotation verifies a token signed with a rotated key
+// and new kid verifies without a process restart.
+func TestOIDCAuthenticator_KeyRotation(t *testing.T) {
+	js := newJWKSTestServer(t)
+	auth := newSelfHealAuth(t, js)
+
+	tokenA := js.signToken(t)
+	if _, err := auth.parseAndValidateToken(context.Background(), tokenA); err != nil {
+		t.Fatalf("token A should verify from the startup cache: %v", err)
+	}
+
+	js.rotate(t, "key-b")
+	tokenB := js.signToken(t)
+	claims, err := auth.parseAndValidateToken(context.Background(), tokenB)
+	if err != nil {
+		t.Fatalf("token B should verify after on-demand refresh: %v", err)
+	}
+	if claims["sub"] != testUserID {
+		t.Errorf("expected sub=%q, got %v", testUserID, claims["sub"])
+	}
+}
+
+// TestOIDCAuthenticator_SingleFlightRefresh verifies that many concurrent
+// verifications against an expired cache collapse into exactly one JWKS fetch.
+func TestOIDCAuthenticator_SingleFlightRefresh(t *testing.T) {
+	js := newJWKSTestServer(t)
+	js.setDelay(100 * time.Millisecond) // widen the in-flight window
+	auth := newSelfHealAuth(t, js)
+
+	js.resetHits()
+	expireCache(t, auth)
+
+	const n = 50
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	kid := js.currentKid()
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, errs[i] = auth.getPublicKey(context.Background(), kid)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if got := js.fetchCount(); got != 1 {
+		t.Errorf("expected exactly 1 JWKS fetch under single-flight, got %d", got)
+	}
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: unexpected error: %v", i, err)
+		}
+	}
+}
+
+// TestOIDCAuthenticator_RefreshThrottle verifies repeated unknown-kid lookups
+// within the throttle window trigger at most one additional fetch.
+func TestOIDCAuthenticator_RefreshThrottle(t *testing.T) {
+	js := newJWKSTestServer(t)
+	auth := newSelfHealAuth(t, js)
+
+	js.resetHits()
+
+	if _, err := auth.getPublicKey(context.Background(), "unknown-1"); err == nil {
+		t.Fatal("expected key-not-found for unknown-1")
+	}
+	if _, err := auth.getPublicKey(context.Background(), "unknown-2"); err == nil {
+		t.Fatal("expected key-not-found for unknown-2")
+	}
+
+	if got := js.fetchCount(); got != 1 {
+		t.Errorf("expected at most 1 additional fetch within throttle window, got %d", got)
+	}
+}
+
+// fakeClock is a manually-advanced clock for deterministic throttle-window tests.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+// TestOIDCAuthenticator_FailedRefreshRecoversPastShortWindow verifies that after
+// a FAILED refresh the short recovery window applies: an attempt made 10s ago
+// (within the 1-minute anti-hammer window but past the 5s recovery window) does
+// not throttle recovery, so a transient issuer blip heals quickly rather than
+// prolonging the fail-closed outage for the full minute (issue #882 findings 1 & 4).
+func TestOIDCAuthenticator_FailedRefreshRecoversPastShortWindow(t *testing.T) {
+	js := newJWKSTestServer(t)
+	auth := newSelfHealAuth(t, js)
+
+	base := time.Now()
+	auth.now = (&fakeClock{t: base}).now
+	js.resetHits()
+
+	// A refresh FAILED 10s ago and the cache is now expired.
+	auth.mu.Lock()
+	auth.lastRefreshAttempt = base.Add(-10 * time.Second)
+	auth.lastRefreshOK = false
+	auth.jwks.expiresAt = base.Add(-time.Second)
+	auth.mu.Unlock()
+
+	key, err := auth.getPublicKey(context.Background(), js.currentKid())
+	if err != nil {
+		t.Fatalf("expected recovery refresh to succeed past the short window, got: %v", err)
+	}
+	if key == nil {
+		t.Fatal("expected a key after recovery refresh")
+	}
+	if got := js.fetchCount(); got != 1 {
+		t.Errorf("expected exactly 1 recovery fetch, got %d", got)
+	}
+}
+
+// TestOIDCAuthenticator_SuccessfulRefreshUsesLongWindow verifies that after a
+// SUCCESSFUL refresh the full anti-hammer window applies: an unknown-kid lookup
+// 10s later (past the 5s recovery window but within the 1-minute window) still
+// throttles, so garbage-kid floods cannot hammer the issuer between recovery
+// intervals. This holds regardless of the caller's cache state, so single-flight
+// collapsing valid- and expired-cache callers cannot pick the wrong window.
+func TestOIDCAuthenticator_SuccessfulRefreshUsesLongWindow(t *testing.T) {
+	js := newJWKSTestServer(t)
+	auth := newSelfHealAuth(t, js)
+
+	base := time.Now()
+	auth.now = (&fakeClock{t: base}).now
+	js.resetHits()
+
+	// A refresh SUCCEEDED 10s ago; the cache remains valid.
+	auth.mu.Lock()
+	auth.lastRefreshAttempt = base.Add(-10 * time.Second)
+	auth.lastRefreshOK = true
+	auth.jwks.expiresAt = base.Add(jwksCacheTTL)
+	auth.mu.Unlock()
+
+	if _, err := auth.getPublicKey(context.Background(), "unknown-kid"); err == nil {
+		t.Fatal("expected key-not-found for unknown kid")
+	}
+	if got := js.fetchCount(); got != 0 {
+		t.Errorf("expected no fetch within the anti-hammer window, got %d", got)
+	}
+}
+
+// TestOIDCAuthenticator_ThrottledExpiredFailsClosed verifies that when the cache
+// is expired but a refresh was attempted within the throttle window, the lookup
+// fails closed without issuing another fetch.
+func TestOIDCAuthenticator_ThrottledExpiredFailsClosed(t *testing.T) {
+	js := newJWKSTestServer(t)
+	auth := newSelfHealAuth(t, js)
+
+	js.resetHits()
+	// Simulate a very recent refresh attempt so the throttle is active.
+	auth.mu.Lock()
+	auth.lastRefreshAttempt = time.Now()
+	auth.mu.Unlock()
+	expireCache(t, auth)
+
+	_, err := auth.getPublicKey(context.Background(), js.currentKid())
+	if err == nil {
+		t.Fatal("expected fail-closed error for throttled expired cache")
+	}
+	if !strings.Contains(err.Error(), "jwks cache expired") {
+		t.Errorf(errUnexpected, err)
+	}
+	if got := js.fetchCount(); got != 0 {
+		t.Errorf("expected no fetch while throttled, got %d", got)
+	}
+}
+
+// TestOIDCAuthenticator_FailClosedOnRefreshError verifies that when the JWKS
+// endpoint fails after the cache has expired, verification errors and nothing is
+// accepted unverified.
+func TestOIDCAuthenticator_FailClosedOnRefreshError(t *testing.T) {
+	js := newJWKSTestServer(t)
+	auth := newSelfHealAuth(t, js)
+
+	token := js.signToken(t)
+	js.fail.Store(true)
+	expireCache(t, auth)
+
+	if _, err := auth.parseAndValidateToken(context.Background(), token); err == nil {
+		t.Fatal("expected fail-closed error when refresh fails on expired cache")
+	}
+}
+
+// TestOIDCAuthenticator_RefreshHonorsCallerContext verifies that an on-demand
+// refresh does not pin the request goroutine to the fetch: when the caller's
+// context deadline expires while the IdP is slow, getPublicKey returns promptly
+// with the context error instead of blocking for the full fetch (issue #882
+// finding 0).
+func TestOIDCAuthenticator_RefreshHonorsCallerContext(t *testing.T) {
+	js := newJWKSTestServer(t)
+	auth := newSelfHealAuth(t, js)
+
+	// Make the JWKS endpoint slow only after the fast startup fetch.
+	js.setDelay(300 * time.Millisecond)
+	expireCache(t, auth)
+	js.resetHits()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := auth.getPublicKey(ctx, js.currentKid())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error when caller context expires during refresh")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected context.DeadlineExceeded, got: %v", err)
+	}
+	if elapsed >= 300*time.Millisecond {
+		t.Errorf("getPublicKey blocked for %v; should return on the caller deadline, not the fetch", elapsed)
+	}
+}
+
+// TestOIDCAuthenticator_AuthenticateHonorsCallerDeadline drives the caller
+// deadline through the real Authenticate -> parseAndValidateToken -> getPublicKey
+// chain (per CLAUDE.md rule 5), proving the request context actually propagates
+// end to end: with a slow issuer and a short deadline, Authenticate returns
+// promptly with a context error instead of blocking on the fetch.
+func TestOIDCAuthenticator_AuthenticateHonorsCallerDeadline(t *testing.T) {
+	js := newJWKSTestServer(t)
+	auth := newSelfHealAuth(t, js)
+
+	token := js.signToken(t)
+	// Make the issuer slow only after the fast startup fetch, and expire the
+	// cache so validating the token forces an on-demand refresh.
+	js.setDelay(300 * time.Millisecond)
+	expireCache(t, auth)
+	js.resetHits()
+
+	deadlineCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	ctx := WithToken(deadlineCtx, token)
+
+	start := time.Now()
+	_, err := auth.Authenticate(ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected Authenticate to fail when the caller deadline expires during JWKS refresh")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected error to wrap context.DeadlineExceeded, got: %v", err)
+	}
+	if elapsed >= 300*time.Millisecond {
+		t.Errorf("Authenticate blocked for %v; the caller deadline should win over the slow fetch", elapsed)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #882 (part of #880, finding 1.2).

`pkg/auth/oidc.go` previously fetched the OIDC JWKS once at startup and never refreshed it. The cache expired after one hour, after which `getPublicKey` returned a `jwks cache expired` error, and the exported `RefreshJWKS` had no request-path callers. Two consequences:

- Any deployment validating IdP-issued OIDC tokens directly lost **all** OIDC authentication one hour after boot.
- IdP signing-key rotation broke validation regardless of the cache window, requiring a process restart.

This PR makes the JWKS cache self-healing: the key-lookup path refreshes on demand, so validation survives both cache expiry and key rotation without a restart.

## What changed

`getPublicKey` (`pkg/auth/oidc.go`) now triggers an on-demand refresh when the cache is expired or the token's `kid` is not in the cached set, then retries the lookup once before failing:

- **Single-flight** — concurrent lookups collapse into one fetch via `golang.org/x/sync/singleflight` (`DoChan`), so a burst of requests produces exactly one outbound fetch.
- **Outcome-based two-window throttle** — the throttle window is selected by the outcome of the last refresh, not by the caller's cache state:
  - after a **successful** refresh, the next on-demand refresh is throttled to at most once per minute (`jwksRefreshThrottle`), bounding a flood of tokens bearing unknown key IDs;
  - after a **failed** refresh, a short recovery window (`jwksFailedRefreshThrottle`, 5s) applies, so a brief issuer outage heals within seconds rather than being held down for the full minute.
- **Request-context aware** — the inbound context is threaded `Authenticate` → `parseAndValidateToken` → `getPublicKey` → `refreshForLookup`. The fetch itself runs on a detached, bounded context in its own goroutine, and each caller waits only until its own context is done. A slow or hung issuer cannot pin a request goroutine past the caller's deadline.
- **Fail closed** — when the cache is expired and a refresh fails, the token is rejected with an error wrapping the fetch failure; nothing is accepted unverified.
- **No background ticker** — refresh is on-demand only, per the issue's design constraint.

`RefreshJWKS` / `FetchJWKS` remain the fetch implementation; the change is that the request path now drives them. Cache TTL is unchanged (one hour).

## Files

| File | Change |
|------|--------|
| `pkg/auth/oidc.go` | On-demand self-healing refresh: `getPublicKey`, new `lookupKey`, `refreshForLookup`, `refreshThrottled`, injectable `clock`; context threaded through `Authenticate`/`parseAndValidateToken`. |
| `pkg/auth/oidc_test.go` | Acceptance-criteria and edge-case tests (see below); `httptest`-based JWKS server helper with request counter, key rotation, failure injection, and settable delay; injectable fake clock for deterministic window tests. |
| `docs/server/configuration.md` | Documents the self-healing cache, refresh throttle windows, and fail-closed behavior in the OIDC section. |
| `docs/llms.txt`, `docs/llms-full.txt` | Mirror the doc change per the repo's LLM-readable doc convention. |

## Tests

All acceptance criteria from the issue, written against an `httptest` JWKS server:

- **Refresh after expiry** — token verification succeeds after the cache TTL elapses (`TestOIDCAuthenticator_RefreshOnExpiry`), where the previous behavior failed with the cache-expired error.
- **Key rotation** — a token signed with a rotated key and new `kid` verifies without a restart (`TestOIDCAuthenticator_KeyRotation`).
- **Single-flight** — 50 concurrent verifications against an expired cache produce exactly one JWKS fetch (`TestOIDCAuthenticator_SingleFlightRefresh`).
- **Throttle** — repeated unknown-`kid` lookups within the window produce at most one additional fetch (`TestOIDCAuthenticator_RefreshThrottle`).
- **Fail closed** — a 500 from the JWKS endpoint after expiry means verification errors; nothing is accepted unverified (`TestOIDCAuthenticator_FailClosedOnRefreshError`).

Additional coverage:

- Outcome-based windows — a failed prior refresh recovers past the short window (`TestOIDCAuthenticator_FailedRefreshRecoversPastShortWindow`); a successful prior refresh keeps the anti-hammer window (`TestOIDCAuthenticator_SuccessfulRefreshUsesLongWindow`).
- Throttled-and-expired fails closed without an extra fetch (`TestOIDCAuthenticator_ThrottledExpiredFailsClosed`).
- Caller-deadline propagation, both directly (`TestOIDCAuthenticator_RefreshHonorsCallerContext`) and end-to-end through `Authenticate` (`TestOIDCAuthenticator_AuthenticateHonorsCallerDeadline`).

New code is fully covered; `pkg/auth` package coverage is 96.1%.

## Verification

`make verify` passes locally (fmt, race tests, coverage and patch-coverage gates, patch-scoped lint, gosec/govulncheck, semgrep, CodeQL, dead-code, mutation, and GoReleaser dry-run).

## Notes

- `golang.org/x/sync` was already a direct dependency; no new modules added.
- No configuration surface: the refresh behavior is not exposed as a YAML setting.
