### PR TITLE
platform(reload): keep live connections on store-read failure; carry delete intent through the reload bus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ AI-generated prose (PR descriptions, commit messages, reviews, explanations) is 
 
 ## Project Structure
 
-`pkg/` holds 41 top-level packages (all public API). Depth-2 subdirectories are
+`pkg/` holds 42 top-level packages (all public API). Depth-2 subdirectories are
 shown where they represent a distinct implementation (a storage backend, an
 adapter, an indexjobs consumer); helper subpackages are omitted for brevity.
 Regenerate this list with `find pkg -mindepth 1 -maxdepth 1 -type d | sort` and
@@ -159,7 +159,7 @@ diff against the packages below when adding or removing a `pkg/` directory.
 ```
 mcp-data-platform/
 ├── cmd/mcp-data-platform/          # Entry point (main.go)
-├── pkg/                            # PUBLIC API (41 top-level packages)
+├── pkg/                            # PUBLIC API (42 top-level packages)
 │   ├── admin/                      # REST API endpoints for administrative operations
 │   ├── audit/                      # Audit logging (postgres/ = PostgreSQL implementation)
 │   ├── auth/                       # Authentication: OIDC, API keys, claims, middleware
@@ -169,6 +169,7 @@ mcp-data-platform/
 │   ├── configstore/                # Granular key/value storage for platform config (postgres/)
 │   ├── connbackfill/               # Seeds connection_instances with credential-free rows
 │   ├── connoauth/                  # Shared OAuth-to-upstream-MCP implementation across connection kinds
+│   ├── connreconcile/              # Shared remove/add reconcile of a DB connection onto live toolkits (admin hot-reload + reload bus)
 │   ├── connview/                   # Builds the list_connections view (configured + discovered)
 │   ├── database/                   # Database utilities (migrate/ = golang-migrate runner + 75 embedded SQL migrations)
 │   ├── embedding/                  # Text embedding generation for memory vector search

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2455,6 +2455,8 @@ Database-managed toolkit connections. Read endpoints always available; write end
 - `PUT /connection-instances/{kind}/{name}` — Create or update connection instance (database mode only, valid kinds: trino, datahub, s3)
 - `DELETE /connection-instances/{kind}/{name}` — Delete connection instance (database mode only)
 
+Connection changes hot-reload on the handling replica and broadcast to peers over the reload bus; the reconcile mechanics (find toolkits of the kind, remove/add) are shared by the admin path and the peer subscriber (`pkg/connreconcile`). The broadcast carries the operation: create/update makes peers read the store for the new config (a peer keeps its live config if that read transiently fails, rather than dropping it), while delete makes peers remove the connection without any store read (so a transient peer store failure can never leave a deleted connection callable). A delete broadcast from a pre-upgrade replica falls back to the read-and-decide path on newer replicas.
+
 ## Audit Endpoints
 
 Requires `audit.enabled: true` and database. Returns 409 without database.

--- a/docs/server/admin-api.md
+++ b/docs/server/admin-api.md
@@ -1270,6 +1270,28 @@ Deletes a database-managed connection instance. Only available in database confi
 
 **Response:** `204 No Content` (no body)
 
+### Cross-replica hot-reload
+
+Connection create, update, and delete take effect on the handling replica
+immediately (no restart) and are broadcast to peer replicas over the reload bus
+so a multi-replica deployment does not serve stale connections. The reconcile
+mechanics (find every live toolkit of the kind, then remove/add the connection)
+are shared by the admin hot-reload path and the peer subscriber
+(`pkg/connreconcile`) so both apply changes identically.
+
+The broadcast carries the operation so peers apply it safely:
+
+- **Create/update**: peers read the connection store for the new config and
+  re-materialize it. If a peer's store read transiently fails, that peer keeps
+  its currently-live config in place (it is not dropped over a database blip)
+  and a later reload re-materializes it.
+- **Delete**: peers remove the connection from their live toolkits **without a
+  store read**, so a transient store failure on a peer can never leave a deleted
+  connection callable there.
+
+During a rolling upgrade, a delete broadcast from an older replica that predates
+the operation tag falls back to the read-and-decide path on newer replicas.
+
 ## Gateway Endpoints
 
 Gateway connections (kind `mcp`) proxy upstream MCP servers and re-expose

--- a/pkg/admin/connection_handler.go
+++ b/pkg/admin/connection_handler.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/txn2/mcp-data-platform/internal/logsan"
 	"github.com/txn2/mcp-data-platform/pkg/connoauth"
 	"github.com/txn2/mcp-data-platform/pkg/connreconcile"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
@@ -694,12 +695,12 @@ func (h *Handler) findConnectionManager(kind string) toolkit.ConnectionManager {
 func (h *Handler) hotAddConnection(kind, name string, config map[string]any) {
 	for _, f := range connreconcile.New(h.deps.ToolkitRegistry).Upsert(kind, name, config) {
 		if f.Phase == connreconcile.PhaseRemove {
-			slog.Warn("failed to hot-remove connection before re-add", // #nosec G706 -- structured slog call, not a format string
-				logKeyKind, kind, logKeyName, name, logKeyError, f.Err)
+			slog.Warn("failed to hot-remove connection before re-add", // #nosec G706 -- structured slog call; kind/name sanitized
+				logKeyKind, logsan.SanitizeForLog(kind), logKeyName, logsan.SanitizeForLog(name), logKeyError, f.Err)
 			continue
 		}
-		slog.Warn("failed to hot-add connection", // #nosec G706 -- structured slog call, not a format string
-			logKeyKind, kind, logKeyName, name, logKeyError, f.Err)
+		slog.Warn("failed to hot-add connection", // #nosec G706 -- structured slog call; kind/name sanitized
+			logKeyKind, logsan.SanitizeForLog(kind), logKeyName, logsan.SanitizeForLog(name), logKeyError, f.Err)
 	}
 	if h.deps.ReloadNotifier != nil {
 		h.deps.ReloadNotifier.PublishConnectionReload(kind, name, platform.ReloadUpsert)
@@ -711,8 +712,8 @@ func (h *Handler) hotAddConnection(kind, name string, config map[string]any) {
 // reconcile from the store (now missing this row) and drop their copy (#501).
 func (h *Handler) hotRemoveConnection(kind, name string) {
 	for _, f := range connreconcile.New(h.deps.ToolkitRegistry).Remove(kind, name) {
-		slog.Warn("failed to hot-remove connection", // #nosec G706 -- structured slog call, not a format string
-			logKeyKind, kind, logKeyName, name, logKeyError, f.Err)
+		slog.Warn("failed to hot-remove connection", // #nosec G706 -- structured slog call; kind/name sanitized
+			logKeyKind, logsan.SanitizeForLog(kind), logKeyName, logsan.SanitizeForLog(name), logKeyError, f.Err)
 	}
 	if h.deps.ReloadNotifier != nil {
 		h.deps.ReloadNotifier.PublishConnectionReload(kind, name, platform.ReloadDelete)

--- a/pkg/admin/connection_handler.go
+++ b/pkg/admin/connection_handler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/txn2/mcp-data-platform/pkg/connoauth"
+	"github.com/txn2/mcp-data-platform/pkg/connreconcile"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
 	"github.com/txn2/mcp-data-platform/pkg/platform/fieldcrypt"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
@@ -685,42 +686,36 @@ func (h *Handler) findConnectionManager(kind string) toolkit.ConnectionManager {
 // connection retains its registration-time config while the DB row
 // has the new one, and list_connections and api_list_endpoints
 // disagree with the admin UI until restart.
+//
+// The toolkit-reconcile mechanics are shared with the cross-replica reload bus
+// via connreconcile so the two paths cannot drift. The peer broadcast is
+// unconditional: peers rebuild from the store (already written by the caller),
+// so a local in-memory hiccup must not suppress their notification (#501).
 func (h *Handler) hotAddConnection(kind, name string, config map[string]any) {
-	cm := h.findConnectionManager(kind)
-	if cm == nil {
-		return
-	}
-	if cm.HasConnection(name) {
-		if err := cm.RemoveConnection(name); err != nil { // #nosec G706 -- structured slog call, not a format string
-			slog.Warn("failed to hot-remove connection before re-add",
-				logKeyKind, kind, logKeyName, name, logKeyError, err)
-			return
+	for _, f := range connreconcile.New(h.deps.ToolkitRegistry).Upsert(kind, name, config) {
+		if f.Phase == connreconcile.PhaseRemove {
+			slog.Warn("failed to hot-remove connection before re-add", // #nosec G706 -- structured slog call, not a format string
+				logKeyKind, kind, logKeyName, name, logKeyError, f.Err)
+			continue
 		}
+		slog.Warn("failed to hot-add connection", // #nosec G706 -- structured slog call, not a format string
+			logKeyKind, kind, logKeyName, name, logKeyError, f.Err)
 	}
-	if err := cm.AddConnection(name, config); err != nil { // #nosec G706 -- structured slog call, not a format string
-		slog.Warn("failed to hot-add connection",
-			logKeyKind, kind, logKeyName, name, logKeyError, err)
-	}
-	// Tell peer replicas to rebuild this connection from the store too;
-	// the hot-add above only updates this replica (issue #501).
 	if h.deps.ReloadNotifier != nil {
-		h.deps.ReloadNotifier.PublishConnectionReload(kind, name)
+		h.deps.ReloadNotifier.PublishConnectionReload(kind, name, platform.ReloadUpsert)
 	}
 }
 
-// hotRemoveConnection attempts to remove the connection from a live toolkit that
-// implements toolkit.ConnectionManager.
+// hotRemoveConnection removes the connection from every live toolkit of the
+// kind that implements toolkit.ConnectionManager, then broadcasts so peers
+// reconcile from the store (now missing this row) and drop their copy (#501).
 func (h *Handler) hotRemoveConnection(kind, name string) {
-	if cm := h.findConnectionManager(kind); cm != nil && cm.HasConnection(name) {
-		if err := cm.RemoveConnection(name); err != nil { // #nosec G706 -- structured slog call, not a format string
-			slog.Warn("failed to hot-remove connection",
-				logKeyKind, kind, logKeyName, name, logKeyError, err)
-		}
+	for _, f := range connreconcile.New(h.deps.ToolkitRegistry).Remove(kind, name) {
+		slog.Warn("failed to hot-remove connection", // #nosec G706 -- structured slog call, not a format string
+			logKeyKind, kind, logKeyName, name, logKeyError, f.Err)
 	}
-	// Always broadcast: peer replicas reconcile from the store (now
-	// missing this row) and drop their copy of the connection (#501).
 	if h.deps.ReloadNotifier != nil {
-		h.deps.ReloadNotifier.PublishConnectionReload(kind, name)
+		h.deps.ReloadNotifier.PublishConnectionReload(kind, name, platform.ReloadDelete)
 	}
 }
 

--- a/pkg/admin/handler.go
+++ b/pkg/admin/handler.go
@@ -89,7 +89,7 @@ type PromptInfoProvider interface {
 // case the broadcast is skipped.
 type ReloadNotifier interface {
 	PublishCatalogReload(catalogID string)
-	PublishConnectionReload(kind, name string)
+	PublishConnectionReload(kind, name string, op platform.ConnectionReloadOp)
 	PublishPersonaReload()
 	PublishAPIKeyReload()
 }

--- a/pkg/admin/reload_notify_test.go
+++ b/pkg/admin/reload_notify_test.go
@@ -10,22 +10,29 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/txn2/mcp-data-platform/pkg/platform"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
 )
+
+// connBroadcast records a single connection reload broadcast, including the
+// upsert/delete op so tests can assert the intent reaches peers.
+type connBroadcast struct {
+	kind, name, op string
+}
 
 // fakeReloadNotifier records the cross-replica reload broadcasts the
 // admin handler emits after a local config change.
 type fakeReloadNotifier struct {
 	catalogs []string
-	conns    [][2]string
+	conns    []connBroadcast
 	personas int
 	apikeys  int
 }
 
 func (f *fakeReloadNotifier) PublishCatalogReload(id string) { f.catalogs = append(f.catalogs, id) }
-func (f *fakeReloadNotifier) PublishConnectionReload(kind, name string) {
-	f.conns = append(f.conns, [2]string{kind, name})
+func (f *fakeReloadNotifier) PublishConnectionReload(kind, name string, op platform.ConnectionReloadOp) {
+	f.conns = append(f.conns, connBroadcast{kind, name, op.String()})
 }
 func (f *fakeReloadNotifier) PublishPersonaReload() { f.personas++ }
 func (f *fakeReloadNotifier) PublishAPIKeyReload()  { f.apikeys++ }
@@ -51,8 +58,11 @@ func TestReloadNotifier_PublishedOnAdminChange(t *testing.T) {
 	h.hotRemoveConnection("api", "c1")
 
 	require.Equal(t, []string{"things"}, notifier.catalogs, "catalog reload should broadcast")
-	require.Equal(t, [][2]string{{"api", "c1"}, {"api", "c1"}}, notifier.conns,
-		"connection add and remove should each broadcast")
+	require.Equal(t, []connBroadcast{
+		{"api", "c1", "upsert"},
+		{"api", "c1", "delete"},
+	}, notifier.conns,
+		"connection add broadcasts an upsert and remove broadcasts a delete")
 }
 
 // TestReloadNotifier_PersonaBroadcast proves a persona create and delete

--- a/pkg/connreconcile/reconcile.go
+++ b/pkg/connreconcile/reconcile.go
@@ -1,0 +1,126 @@
+// Package connreconcile owns the single copy of the "materialize a DB-managed
+// connection onto the live toolkits" mechanics shared by the admin hot-reload
+// path and the cross-replica reload bus.
+//
+// Both callers previously carried their own copy of the same loop — find every
+// registered toolkit of a kind that implements toolkit.ConnectionManager, then
+// remove-then-add under a HasConnection guard — and the copies had drifted:
+// the admin path touched only the first matching toolkit while the reload bus
+// touched all of them. Centralizing the loop here keeps the two paths from
+// diverging again. Callers retain their own observability and broadcast policy;
+// the reconciler reports which toolkit operations failed and leaves logging,
+// log level, and peer notification to the caller.
+package connreconcile
+
+import (
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
+)
+
+// Phase identifies which toolkit operation produced a Failure so callers can
+// tailor the log message: a failed remove-before-re-add reads differently from
+// a failed add.
+type Phase int
+
+const (
+	// PhaseRemove marks a failure returned by RemoveConnection.
+	PhaseRemove Phase = iota
+	// PhaseAdd marks a failure returned by AddConnection.
+	PhaseAdd
+)
+
+// String renders the phase for structured log output.
+func (p Phase) String() string {
+	if p == PhaseAdd {
+		return "add"
+	}
+	return "remove"
+}
+
+// Failure is one toolkit operation that returned an error during a reconcile.
+// The reconciler reports what failed; the caller owns logging policy (level,
+// message, structured fields).
+type Failure struct {
+	Phase Phase
+	Err   error
+}
+
+// ToolkitSource is the minimal view of the toolkit registry the reconciler
+// needs. Both *registry.Registry and the admin handler's registry seam satisfy
+// it via their All method.
+type ToolkitSource interface {
+	All() []registry.Toolkit
+}
+
+// Reconciler applies connection changes to every registered toolkit of a given
+// kind that implements toolkit.ConnectionManager. It holds no mutable state of
+// its own: the source is the authority on which toolkits currently exist, so a
+// reconciler is cheap to construct per call.
+type Reconciler struct {
+	source ToolkitSource
+}
+
+// New returns a Reconciler bound to the given toolkit source. A nil source is
+// tolerated (every operation becomes a no-op), matching the platform and admin
+// wiring where the toolkit registry may be absent.
+func New(source ToolkitSource) *Reconciler {
+	return &Reconciler{source: source}
+}
+
+// Remove drops name from every matching toolkit that currently holds it.
+// Toolkits that do not hold the connection are skipped, because removing an
+// absent connection is not a state-corrupting error (several toolkits return a
+// not-found error for it). Returns one Failure per toolkit whose
+// RemoveConnection returned an error, in registration order.
+func (r *Reconciler) Remove(kind, name string) []Failure {
+	var failures []Failure
+	for _, cm := range r.managers(kind) {
+		if !cm.HasConnection(name) {
+			continue
+		}
+		if err := cm.RemoveConnection(name); err != nil {
+			failures = append(failures, Failure{Phase: PhaseRemove, Err: err})
+		}
+	}
+	return failures
+}
+
+// Upsert makes config the live config for name on every matching toolkit,
+// removing an existing registration first so a changed config replaces the old
+// one rather than layering on top of it. A toolkit whose remove fails is
+// skipped (its add is not attempted, to avoid stacking on stale state) but the
+// loop continues so other toolkits of the same kind are still updated. Returns
+// one Failure per failed operation, in registration order.
+func (r *Reconciler) Upsert(kind, name string, config map[string]any) []Failure {
+	var failures []Failure
+	for _, cm := range r.managers(kind) {
+		if cm.HasConnection(name) {
+			if err := cm.RemoveConnection(name); err != nil {
+				failures = append(failures, Failure{Phase: PhaseRemove, Err: err})
+				continue
+			}
+		}
+		if err := cm.AddConnection(name, config); err != nil {
+			failures = append(failures, Failure{Phase: PhaseAdd, Err: err})
+		}
+	}
+	return failures
+}
+
+// managers returns every registered toolkit of kind that implements
+// toolkit.ConnectionManager, in registration order.
+func (r *Reconciler) managers(kind string) []toolkit.ConnectionManager {
+	if r.source == nil {
+		return nil
+	}
+	var managers []toolkit.ConnectionManager
+	for _, tk := range r.source.All() {
+		if tk.Kind() != kind {
+			continue
+		}
+		if cm, ok := tk.(toolkit.ConnectionManager); ok {
+			managers = append(managers, cm)
+		}
+	}
+	return managers
+}

--- a/pkg/connreconcile/reconcile_test.go
+++ b/pkg/connreconcile/reconcile_test.go
@@ -1,0 +1,195 @@
+package connreconcile
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/query"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/semantic"
+)
+
+// recordingToolkit is a registry.Toolkit that also implements
+// toolkit.ConnectionManager, recording the Add/Remove call order so the
+// reconciler's sequencing can be asserted.
+type recordingToolkit struct {
+	kind      string
+	name      string
+	has       bool
+	addErr    error
+	removeErr error
+
+	events     []string
+	addConfigs []map[string]any
+}
+
+func (t *recordingToolkit) Kind() string                          { return t.kind }
+func (t *recordingToolkit) Name() string                          { return t.name }
+func (*recordingToolkit) Connection() string                      { return "" }
+func (*recordingToolkit) Tools() []string                         { return nil }
+func (*recordingToolkit) RegisterTools(_ *mcp.Server)             {}
+func (*recordingToolkit) SetSemanticProvider(_ semantic.Provider) {}
+func (*recordingToolkit) SetQueryProvider(_ query.Provider)       {}
+func (*recordingToolkit) Close() error                            { return nil }
+
+func (t *recordingToolkit) HasConnection(string) bool { return t.has }
+func (t *recordingToolkit) AddConnection(name string, config map[string]any) error {
+	t.events = append(t.events, "add:"+name)
+	t.addConfigs = append(t.addConfigs, config)
+	return t.addErr
+}
+
+func (t *recordingToolkit) RemoveConnection(name string) error {
+	t.events = append(t.events, "remove:"+name)
+	return t.removeErr
+}
+
+// plainToolkit implements registry.Toolkit but NOT ConnectionManager, so the
+// reconciler must skip it even when its kind matches.
+type plainToolkit struct{ kind, name string }
+
+func (t *plainToolkit) Kind() string                          { return t.kind }
+func (t *plainToolkit) Name() string                          { return t.name }
+func (*plainToolkit) Connection() string                      { return "" }
+func (*plainToolkit) Tools() []string                         { return nil }
+func (*plainToolkit) RegisterTools(_ *mcp.Server)             {}
+func (*plainToolkit) SetSemanticProvider(_ semantic.Provider) {}
+func (*plainToolkit) SetQueryProvider(_ query.Provider)       {}
+func (*plainToolkit) Close() error                            { return nil }
+
+func mustRegister(t *testing.T, tks ...registry.Toolkit) *registry.Registry {
+	t.Helper()
+	reg := registry.NewRegistry()
+	for _, tk := range tks {
+		if err := reg.Register(tk); err != nil {
+			t.Fatalf("register toolkit: %v", err)
+		}
+	}
+	return reg
+}
+
+func TestReconciler_Remove(t *testing.T) {
+	const kind, name = "api", "c1"
+
+	t.Run("removes only from matching toolkits that hold the connection", func(t *testing.T) {
+		match := &recordingToolkit{kind: kind, name: "match", has: true}
+		absent := &recordingToolkit{kind: kind, name: "absent", has: false}
+		otherKind := &recordingToolkit{kind: "s3", name: "other", has: true}
+		reg := mustRegister(t, match, absent, otherKind)
+
+		failures := New(reg).Remove(kind, name)
+
+		if len(failures) != 0 {
+			t.Fatalf("expected no failures, got %v", failures)
+		}
+		if got := match.events; len(got) != 1 || got[0] != "remove:c1" {
+			t.Errorf("matching toolkit events = %v, want [remove:c1]", got)
+		}
+		if len(absent.events) != 0 {
+			t.Errorf("absent toolkit must not be touched, got %v", absent.events)
+		}
+		if len(otherKind.events) != 0 {
+			t.Errorf("other-kind toolkit must not be touched, got %v", otherKind.events)
+		}
+	})
+
+	t.Run("reports a remove failure as PhaseRemove", func(t *testing.T) {
+		tk := &recordingToolkit{kind: kind, has: true, removeErr: errors.New("boom")}
+		failures := New(mustRegister(t, tk)).Remove(kind, name)
+		if len(failures) != 1 {
+			t.Fatalf("expected one failure, got %d", len(failures))
+		}
+		if failures[0].Phase != PhaseRemove {
+			t.Errorf("phase = %v, want PhaseRemove", failures[0].Phase)
+		}
+	})
+}
+
+func TestReconciler_Upsert(t *testing.T) {
+	const kind, name = "api", "c1"
+	cfg := map[string]any{"base_url": "https://new"}
+
+	t.Run("adds without a prior remove when the connection is absent", func(t *testing.T) {
+		tk := &recordingToolkit{kind: kind, has: false}
+		failures := New(mustRegister(t, tk)).Upsert(kind, name, cfg)
+		if len(failures) != 0 {
+			t.Fatalf("expected no failures, got %v", failures)
+		}
+		if got := tk.events; len(got) != 1 || got[0] != "add:c1" {
+			t.Errorf("events = %v, want [add:c1]", got)
+		}
+		if len(tk.addConfigs) != 1 || tk.addConfigs[0]["base_url"] != "https://new" {
+			t.Errorf("add config = %v, want base_url=https://new", tk.addConfigs)
+		}
+	})
+
+	t.Run("removes then adds when the connection already exists", func(t *testing.T) {
+		tk := &recordingToolkit{kind: kind, has: true}
+		New(mustRegister(t, tk)).Upsert(kind, name, cfg)
+		want := []string{"remove:c1", "add:c1"}
+		if len(tk.events) != 2 || tk.events[0] != want[0] || tk.events[1] != want[1] {
+			t.Errorf("events = %v, want %v", tk.events, want)
+		}
+	})
+
+	t.Run("a failed remove aborts the add for that toolkit", func(t *testing.T) {
+		tk := &recordingToolkit{kind: kind, has: true, removeErr: errors.New("stuck")}
+		failures := New(mustRegister(t, tk)).Upsert(kind, name, cfg)
+		if got := tk.events; len(got) != 1 || got[0] != "remove:c1" {
+			t.Errorf("events = %v, want [remove:c1] (add must be skipped)", got)
+		}
+		if len(failures) != 1 || failures[0].Phase != PhaseRemove {
+			t.Errorf("failures = %v, want one PhaseRemove", failures)
+		}
+	})
+
+	t.Run("a failed add is reported and does not stop other toolkits", func(t *testing.T) {
+		failing := &recordingToolkit{kind: kind, name: "failing", has: false, addErr: errors.New("dial")}
+		healthy := &recordingToolkit{kind: kind, name: "healthy", has: false}
+		failures := New(mustRegister(t, failing, healthy)).Upsert(kind, name, cfg)
+
+		if len(failures) != 1 || failures[0].Phase != PhaseAdd {
+			t.Errorf("failures = %v, want one PhaseAdd", failures)
+		}
+		if got := healthy.events; len(got) != 1 || got[0] != "add:c1" {
+			t.Errorf("healthy toolkit did not receive its add despite the other failing: %v", got)
+		}
+	})
+}
+
+func TestReconciler_SkipsNonManagerAndNilSource(t *testing.T) {
+	const kind, name = "api", "c1"
+
+	t.Run("skips a matching toolkit that is not a ConnectionManager", func(t *testing.T) {
+		plain := &plainToolkit{kind: kind, name: "plain"}
+		manager := &recordingToolkit{kind: kind, name: "manager", has: false}
+		// Registering a same-kind non-manager alongside a real manager proves
+		// the reconciler routes only to the manager, never to the plain toolkit.
+		if failures := New(mustRegister(t, plain, manager)).Upsert(kind, name, nil); failures != nil {
+			t.Errorf("expected no failures, got %v", failures)
+		}
+		if got := manager.events; len(got) != 1 || got[0] != "add:c1" {
+			t.Errorf("manager events = %v, want [add:c1]", got)
+		}
+	})
+
+	t.Run("nil source is a no-op", func(t *testing.T) {
+		if f := New(nil).Remove(kind, name); f != nil {
+			t.Errorf("Remove on nil source = %v, want nil", f)
+		}
+		if f := New(nil).Upsert(kind, name, nil); f != nil {
+			t.Errorf("Upsert on nil source = %v, want nil", f)
+		}
+	})
+}
+
+func TestPhaseString(t *testing.T) {
+	if PhaseRemove.String() != "remove" {
+		t.Errorf("PhaseRemove.String() = %q, want remove", PhaseRemove.String())
+	}
+	if PhaseAdd.String() != "add" {
+		t.Errorf("PhaseAdd.String() = %q, want add", PhaseAdd.String())
+	}
+}

--- a/pkg/platform/reload.go
+++ b/pkg/platform/reload.go
@@ -2,12 +2,56 @@ package platform
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/txn2/mcp-data-platform/pkg/auth"
-	"github.com/txn2/mcp-data-platform/pkg/toolkit"
+	"github.com/txn2/mcp-data-platform/pkg/connreconcile"
 	apigatewaykit "github.com/txn2/mcp-data-platform/pkg/toolkits/apigateway"
 )
+
+// slog keys shared by the connection reloaders.
+const (
+	logKeyKind = "kind"
+	logKeyName = "name"
+)
+
+// ConnectionReloadOp is the intent behind a connection reload broadcast. It is
+// carried through the reload bus so a peer applying a deletion never has to read
+// the store: a delete is a one-shot event whose row is already gone, so a
+// transient store-read failure on the peer could otherwise leave the connection
+// live and callable until an unrelated reload or a restart (issue #885 review).
+type ConnectionReloadOp int
+
+const (
+	// ReloadUpsert marks a created or updated connection: the peer reads the
+	// store for the new config and re-materializes it (keeping the live config
+	// in place if the read transiently fails, per #885).
+	ReloadUpsert ConnectionReloadOp = iota
+	// ReloadDelete marks a deleted connection: the peer removes it from every
+	// matching live toolkit without reading the store.
+	ReloadDelete
+)
+
+// String renders the op for the reload-bus wire payload and logs.
+func (o ConnectionReloadOp) String() string {
+	if o == ReloadDelete {
+		return "delete"
+	}
+	return "upsert"
+}
+
+// parseConnectionReloadOp maps the wire op back to a ConnectionReloadOp. Any
+// value other than the explicit delete marker — including the empty string a
+// pre-#885 replica publishes during a rolling upgrade — is treated as an
+// upsert, so an unrecognized or missing op falls back to the read-and-decide
+// path rather than removing a connection.
+func parseConnectionReloadOp(s string) ConnectionReloadOp {
+	if s == ReloadDelete.String() {
+		return ReloadDelete
+	}
+	return ReloadUpsert
+}
 
 // This file holds the reload re-materialization handlers and the public
 // reload-publish surface, both of which stay on Platform: the handlers reach
@@ -18,22 +62,48 @@ import (
 // reached through the sessions handle; the handlers are injected into it at
 // construction (issue #843).
 
-// reloadConnectionLocal re-materializes one connection on this replica
-// from the connection store. Used both by the reload subscriber (peer
-// announced a change) and indirectly mirrors the admin hot-reload path.
-func (p *Platform) reloadConnectionLocal(kind, name string) {
+// reloadConnectionLocal re-materializes one connection on this replica in
+// response to a peer's reload broadcast. op carries the peer's intent so a
+// deletion is applied without a store read.
+//
+//   - ReloadDelete: remove the connection from every matching toolkit. No store
+//     read happens, so a transient store failure can never leave a deleted
+//     connection live on this replica. A failed removal is logged at WARN, not
+//     ERROR: removing an already-absent connection is not state-corrupting.
+//   - ReloadUpsert (and any legacy event without an op): read the store and
+//     decide. The read outcome drives a three-way branch so a transient read
+//     failure never silently drops a live connection (issue #885):
+//   - read failed (not a not-found): log at ERROR and leave the live config
+//     in place. Removing here would drop a healthy connection over a
+//     database blip; a later upsert event re-materializes it.
+//   - not found (raced with a concurrent delete): remove it.
+//   - present: remove-then-add so the changed config takes effect.
+func (p *Platform) reloadConnectionLocal(kind, name, op string) {
+	rec := connreconcile.New(p.toolkitRegistry)
+	if parseConnectionReloadOp(op) == ReloadDelete {
+		for _, f := range rec.Remove(kind, name) {
+			slog.Warn("reload-bus: failed to remove deleted connection from toolkit",
+				logKeyKind, kind, logKeyName, name, logKeyError, f.Err)
+		}
+		return
+	}
+
 	inst, err := p.connectionStore.Get(context.Background(), kind, name)
-	for _, tk := range p.toolkitRegistry.All() {
-		if tk.Kind() != kind {
-			continue
+	switch {
+	case err != nil && !errors.Is(err, ErrConnectionNotFound):
+		slog.Error("reload-bus: failed to read connection from store; keeping live config",
+			logKeyKind, kind, logKeyName, name, logKeyError, err)
+	case inst == nil:
+		for _, f := range rec.Remove(kind, name) {
+			slog.Warn("reload-bus: failed to remove connection from toolkit",
+				logKeyKind, kind, logKeyName, name, logKeyError, f.Err)
 		}
-		cm, ok := tk.(toolkit.ConnectionManager)
-		if !ok {
-			continue
-		}
-		_ = cm.RemoveConnection(name)
-		if err == nil && inst != nil {
-			_ = cm.AddConnection(name, inst.Config)
+	default:
+		// A failure here leaves a toolkit out of sync with the store, so it is
+		// logged at ERROR; the reconciler still updates the other toolkits.
+		for _, f := range rec.Upsert(kind, name, inst.Config) {
+			slog.Error("reload-bus: failed to reconcile connection onto toolkit",
+				logKeyKind, kind, logKeyName, name, "phase", f.Phase.String(), logKeyError, f.Err)
 		}
 	}
 }
@@ -81,9 +151,11 @@ func (p *Platform) reloadAPIKeyLocal() {
 }
 
 // PublishConnectionReload announces a connection config change to peer
-// replicas. Implements admin.ReloadNotifier. Safe when the layer is nil.
-func (p *Platform) PublishConnectionReload(kind, name string) {
-	p.sessions.PublishConnectionReload(context.Background(), kind, name)
+// replicas. op distinguishes an upsert (peers read the store) from a delete
+// (peers remove without a store read). Implements admin.ReloadNotifier. Safe
+// when the layer is nil.
+func (p *Platform) PublishConnectionReload(kind, name string, op ConnectionReloadOp) {
+	p.sessions.PublishConnectionReload(context.Background(), kind, name, op.String())
 }
 
 // PublishPersonaReload announces a persona change to peer replicas.

--- a/pkg/platform/reload_connection_test.go
+++ b/pkg/platform/reload_connection_test.go
@@ -1,0 +1,344 @@
+package platform
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"slices"
+	"testing"
+
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+)
+
+// recordingConnMgr is a registry.Toolkit that also implements
+// toolkit.ConnectionManager, recording the exact Add/Remove call order so the
+// reloader's decision table can be asserted end to end.
+type recordingConnMgr struct {
+	mockToolkit
+	has       bool  // value returned by HasConnection
+	addErr    error // error returned by AddConnection
+	removeErr error // error returned by RemoveConnection
+
+	events     []string         // "remove:<name>" / "add:<name>" in call order
+	addConfigs []map[string]any // config passed to each AddConnection
+}
+
+func (m *recordingConnMgr) HasConnection(string) bool { return m.has }
+
+func (m *recordingConnMgr) AddConnection(name string, config map[string]any) error {
+	m.events = append(m.events, "add:"+name)
+	m.addConfigs = append(m.addConfigs, config)
+	return m.addErr
+}
+
+func (m *recordingConnMgr) RemoveConnection(name string) error {
+	m.events = append(m.events, "remove:"+name)
+	return m.removeErr
+}
+
+// configurableConnStore returns a fixed (instance, error) pair from Get so the
+// reloader's read-outcome branches can be driven directly.
+type configurableConnStore struct {
+	inst *ConnectionInstance
+	err  error
+}
+
+func (configurableConnStore) List(context.Context) ([]ConnectionInstance, error) { return nil, nil }
+func (s configurableConnStore) Get(context.Context, string, string) (*ConnectionInstance, error) {
+	return s.inst, s.err
+}
+func (configurableConnStore) Set(context.Context, ConnectionInstance) error { return nil }
+func (configurableConnStore) Delete(context.Context, string, string) error  { return nil }
+func (configurableConnStore) Persistent() bool                              { return false }
+
+func TestReloadConnectionLocal(t *testing.T) {
+	const kind, name = "api", "c1"
+	newCfg := map[string]any{"base_url": "https://new"}
+
+	tests := []struct {
+		name       string
+		inst       *ConnectionInstance
+		getErr     error
+		has        bool // HasConnection reported by the toolkit
+		removeErr  error
+		addErr     error
+		wantEvents []string
+		wantAddCfg map[string]any // asserted when a single Add is expected
+		wantLevel  string         // "", "level=WARN", or "level=ERROR"
+	}{
+		{
+			name:       "store read error keeps live config untouched",
+			getErr:     errors.New("db unavailable"),
+			has:        true, // present, yet must not be touched
+			wantEvents: nil,
+			wantLevel:  "level=ERROR",
+		},
+		{
+			name:       "deleted connection is removed from the toolkit",
+			getErr:     ErrConnectionNotFound,
+			has:        true,
+			wantEvents: []string{"remove:c1"},
+		},
+		{
+			name:       "deleted connection absent from toolkit is a no-op",
+			getErr:     ErrConnectionNotFound,
+			has:        false,
+			wantEvents: nil,
+		},
+		{
+			name:       "deleted connection remove error is logged at WARN",
+			getErr:     ErrConnectionNotFound,
+			has:        true,
+			removeErr:  errors.New("boom"),
+			wantEvents: []string{"remove:c1"},
+			wantLevel:  "level=WARN",
+		},
+		{
+			name:       "created connection is added without a prior remove",
+			inst:       &ConnectionInstance{Kind: kind, Name: name, Config: newCfg},
+			has:        false,
+			wantEvents: []string{"add:c1"},
+			wantAddCfg: newCfg,
+		},
+		{
+			name:       "updated connection is removed then re-added with the new config",
+			inst:       &ConnectionInstance{Kind: kind, Name: name, Config: newCfg},
+			has:        true,
+			wantEvents: []string{"remove:c1", "add:c1"},
+			wantAddCfg: newCfg,
+		},
+		{
+			name:       "defensive nil instance with no error is treated as deletion",
+			inst:       nil,
+			getErr:     nil,
+			has:        true,
+			wantEvents: []string{"remove:c1"},
+		},
+		{
+			name:       "add error is logged at ERROR",
+			inst:       &ConnectionInstance{Kind: kind, Name: name, Config: newCfg},
+			has:        false,
+			addErr:     errors.New("dial failed"),
+			wantEvents: []string{"add:c1"},
+			wantLevel:  "level=ERROR",
+		},
+		{
+			name:       "remove error during update aborts the add for that toolkit",
+			inst:       &ConnectionInstance{Kind: kind, Name: name, Config: newCfg},
+			has:        true,
+			removeErr:  errors.New("stuck"),
+			wantEvents: []string{"remove:c1"},
+			wantLevel:  "level=ERROR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tk := &recordingConnMgr{
+				mockToolkit: mockToolkit{kind: kind},
+				has:         tt.has,
+				removeErr:   tt.removeErr,
+				addErr:      tt.addErr,
+			}
+			reg := registry.NewRegistry()
+			if err := reg.Register(tk); err != nil {
+				t.Fatalf("register toolkit: %v", err)
+			}
+
+			var buf bytes.Buffer
+			prev := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+			defer slog.SetDefault(prev)
+
+			p := &Platform{
+				toolkitRegistry: reg,
+				connectionStore: configurableConnStore{inst: tt.inst, err: tt.getErr},
+			}
+			// The table drives the ReloadUpsert (read-and-decide) path; the
+			// ReloadDelete short-circuit is covered separately below.
+			p.reloadConnectionLocal(kind, name, ReloadUpsert.String())
+
+			if !slices.Equal(tk.events, tt.wantEvents) {
+				t.Errorf("events = %v, want %v", tk.events, tt.wantEvents)
+			}
+			if tt.wantAddCfg != nil {
+				if len(tk.addConfigs) != 1 {
+					t.Fatalf("expected exactly one AddConnection, got %d", len(tk.addConfigs))
+				}
+				if got := tk.addConfigs[0]["base_url"]; got != tt.wantAddCfg["base_url"] {
+					t.Errorf("add config base_url = %v, want %v", got, tt.wantAddCfg["base_url"])
+				}
+			}
+
+			logs := buf.String()
+			switch tt.wantLevel {
+			case "":
+				if bytes.Contains(buf.Bytes(), []byte("level=WARN")) ||
+					bytes.Contains(buf.Bytes(), []byte("level=ERROR")) {
+					t.Errorf("expected no WARN/ERROR logs, got: %q", logs)
+				}
+			default:
+				if !bytes.Contains(buf.Bytes(), []byte(tt.wantLevel)) {
+					t.Errorf("expected a %s log line, got: %q", tt.wantLevel, logs)
+				}
+			}
+		})
+	}
+}
+
+// TestReloadConnectionLocal_MultipleToolkitsSameKind pins the acceptance
+// criterion that a failure on one toolkit does not stop other toolkits of the
+// same kind from receiving their update.
+func TestReloadConnectionLocal_MultipleToolkitsSameKind(t *testing.T) {
+	const kind, name = "api", "c1"
+	cfg := map[string]any{"base_url": "https://new"}
+
+	failing := &recordingConnMgr{
+		mockToolkit: mockToolkit{kind: kind, name: "failing"},
+		addErr:      errors.New("boom"),
+	}
+	healthy := &recordingConnMgr{
+		mockToolkit: mockToolkit{kind: kind, name: "healthy"},
+	}
+	reg := registry.NewRegistry()
+	if err := reg.Register(failing); err != nil {
+		t.Fatalf("register failing toolkit: %v", err)
+	}
+	if err := reg.Register(healthy); err != nil {
+		t.Fatalf("register healthy toolkit: %v", err)
+	}
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(prev)
+
+	p := &Platform{
+		toolkitRegistry: reg,
+		connectionStore: configurableConnStore{
+			inst: &ConnectionInstance{Kind: kind, Name: name, Config: cfg},
+		},
+	}
+	p.reloadConnectionLocal(kind, name, ReloadUpsert.String())
+
+	if !slices.Equal(failing.events, []string{"add:c1"}) {
+		t.Errorf("failing toolkit events = %v, want [add:c1]", failing.events)
+	}
+	if !slices.Equal(healthy.events, []string{"add:c1"}) {
+		t.Errorf("healthy toolkit did not receive its add despite the other toolkit failing: %v", healthy.events)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("level=ERROR")) {
+		t.Errorf("expected the failing add to be logged at ERROR, got: %q", buf.String())
+	}
+}
+
+// TestReloadConnectionLocal_NotFoundSemantics pins the real store's not-found
+// convention (a sentinel error, not (nil, nil)) and confirms an upsert reload
+// whose store read races a concurrent delete routes to removal rather than the
+// keep-live error branch.
+func TestReloadConnectionLocal_NotFoundSemantics(t *testing.T) {
+	const kind, name = "api", "c1"
+
+	// The real (Noop) store signals not-found with the ErrConnectionNotFound
+	// sentinel and a nil instance.
+	_, err := (&NoopConnectionStore{}).Get(context.Background(), kind, name)
+	if !errors.Is(err, ErrConnectionNotFound) {
+		t.Fatalf("store not-found convention changed: got %v, want ErrConnectionNotFound", err)
+	}
+
+	tk := &recordingConnMgr{mockToolkit: mockToolkit{kind: kind}, has: true}
+	reg := registry.NewRegistry()
+	if err := reg.Register(tk); err != nil {
+		t.Fatalf("register toolkit: %v", err)
+	}
+	p := &Platform{
+		toolkitRegistry: reg,
+		connectionStore: &NoopConnectionStore{},
+	}
+	p.reloadConnectionLocal(kind, name, ReloadUpsert.String())
+
+	if !slices.Equal(tk.events, []string{"remove:c1"}) {
+		t.Errorf("not-found sentinel was not routed to the deletion branch: events = %v", tk.events)
+	}
+}
+
+// storeReadForbidden is a ConnectionStore whose Get fails the test if called.
+// It proves the ReloadDelete path removes a connection without any store read,
+// which is what closes the #885 gap where a transient read failure on a
+// one-shot delete event could leave a deleted connection live.
+type storeReadForbidden struct{ t *testing.T }
+
+func (storeReadForbidden) List(context.Context) ([]ConnectionInstance, error) {
+	return nil, nil
+}
+
+func (s storeReadForbidden) Get(context.Context, string, string) (*ConnectionInstance, error) {
+	s.t.Helper()
+	s.t.Fatal("ReloadDelete must not read the connection store")
+	return nil, ErrConnectionNotFound // unreachable; satisfies the signature
+}
+func (storeReadForbidden) Set(context.Context, ConnectionInstance) error { return nil }
+func (storeReadForbidden) Delete(context.Context, string, string) error  { return nil }
+func (storeReadForbidden) Persistent() bool                              { return false }
+
+// TestReloadConnectionLocal_DeleteOpSkipsStoreRead proves a ReloadDelete event
+// removes the connection from live toolkits without touching the store, so a
+// store outage on the peer cannot leave a deleted connection callable (#885).
+func TestReloadConnectionLocal_DeleteOpSkipsStoreRead(t *testing.T) {
+	const kind, name = "api", "c1"
+
+	tk := &recordingConnMgr{mockToolkit: mockToolkit{kind: kind}, has: true}
+	reg := registry.NewRegistry()
+	if err := reg.Register(tk); err != nil {
+		t.Fatalf("register toolkit: %v", err)
+	}
+	p := &Platform{
+		toolkitRegistry: reg,
+		connectionStore: storeReadForbidden{t: t}, // Get would fail the test
+	}
+	p.reloadConnectionLocal(kind, name, ReloadDelete.String())
+
+	if !slices.Equal(tk.events, []string{"remove:c1"}) {
+		t.Errorf("ReloadDelete did not remove without a store read: events = %v", tk.events)
+	}
+}
+
+// TestReloadConnectionLocal_DeleteOpRemoveFailureWarns proves a failed removal
+// on the delete path is logged at WARN (not ERROR): the connection is gone from
+// the store, and a toolkit that could not drop it is a degraded-but-benign
+// state, not a corruption.
+func TestReloadConnectionLocal_DeleteOpRemoveFailureWarns(t *testing.T) {
+	const kind, name = "api", "c1"
+
+	tk := &recordingConnMgr{
+		mockToolkit: mockToolkit{kind: kind},
+		has:         true,
+		removeErr:   errors.New("boom"),
+	}
+	reg := registry.NewRegistry()
+	if err := reg.Register(tk); err != nil {
+		t.Fatalf("register toolkit: %v", err)
+	}
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(prev)
+
+	p := &Platform{
+		toolkitRegistry: reg,
+		connectionStore: storeReadForbidden{t: t},
+	}
+	p.reloadConnectionLocal(kind, name, ReloadDelete.String())
+
+	if !slices.Equal(tk.events, []string{"remove:c1"}) {
+		t.Errorf("events = %v, want [remove:c1]", tk.events)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("level=WARN")) {
+		t.Errorf("expected a WARN log for the failed delete-path removal, got: %q", buf.String())
+	}
+	if bytes.Contains(buf.Bytes(), []byte("level=ERROR")) {
+		t.Errorf("delete-path removal failure must not log at ERROR, got: %q", buf.String())
+	}
+}

--- a/pkg/platform/reload_test.go
+++ b/pkg/platform/reload_test.go
@@ -60,17 +60,23 @@ func TestPlatform_ReloadWiring(t *testing.T) {
 	}
 
 	// Reloaders against the live toolkit (rebuild from the fake store).
-	p.reloadConnectionLocal("api", "c1")
+	p.reloadConnectionLocal("api", "c1", ReloadUpsert.String())
 	if !apiTk.HasConnection("c1") {
 		t.Error("reloadConnectionLocal did not add the connection")
 	}
-	p.reloadConnectionLocal("mcp", "ignored") // wrong kind: no-op, exercises the skip
-	p.reloadCatalogLocal("cat-1")             // ReloadConnectionsByCatalog on the api toolkit
-	p.reloadPersonaLocal()                    // reconcile personas from store
-	p.reloadAPIKeyLocal()                     // re-sync api keys from store
+	// A delete op removes the connection from the real toolkit (end-to-end
+	// through Platform + the live apigateway toolkit, not a fake).
+	p.reloadConnectionLocal("api", "c1", ReloadDelete.String())
+	if apiTk.HasConnection("c1") {
+		t.Error("reloadConnectionLocal(delete) did not remove the connection")
+	}
+	p.reloadConnectionLocal("mcp", "ignored", ReloadUpsert.String()) // wrong kind: no-op, exercises the skip
+	p.reloadCatalogLocal("cat-1")                                    // ReloadConnectionsByCatalog on the api toolkit
+	p.reloadPersonaLocal()                                           // reconcile personas from store
+	p.reloadAPIKeyLocal()                                            // re-sync api keys from store
 
 	// Publish delegators (memory bus; no subscriber needed for coverage).
-	p.PublishConnectionReload("api", "c1")
+	p.PublishConnectionReload("api", "c1", ReloadUpsert)
 	p.PublishCatalogReload("cat-1")
 	p.PublishPersonaReload()
 	p.PublishAPIKeyReload()
@@ -80,5 +86,5 @@ func TestPlatform_ReloadWiring(t *testing.T) {
 	}
 
 	// Publish after close must be safe (broadcaster closed).
-	p.PublishConnectionReload("api", "c1")
+	p.PublishConnectionReload("api", "c1", ReloadDelete)
 }

--- a/pkg/platform/sessionsync/reload.go
+++ b/pkg/platform/sessionsync/reload.go
@@ -56,10 +56,12 @@ func newReloadBus(b session.Broadcaster, origin string, h ReloadHandlers, logger
 	return &reloadBus{b: b, origin: origin, handlers: h, logger: logger}
 }
 
-// publishConnection announces that the (kind, name) connection's stored
-// config changed and peers should rebuild it.
-func (rb *reloadBus) publishConnection(ctx context.Context, kind, name string) {
-	rb.publish(ctx, reloadMethodConnection, map[string]any{"kind": kind, "name": name})
+// publishConnection announces that the (kind, name) connection changed and
+// peers should rebuild it. op is the opaque intent string ("upsert"/"delete")
+// carried verbatim to the subscriber so a deletion is applied without a peer
+// store read.
+func (rb *reloadBus) publishConnection(ctx context.Context, kind, name, op string) {
+	rb.publish(ctx, reloadMethodConnection, map[string]any{"kind": kind, "name": name, "op": op})
 }
 
 // publishCatalog announces that an API catalog's specs changed and peers
@@ -146,13 +148,16 @@ func (rb *reloadBus) dispatch(ev session.Event) {
 	}
 }
 
-// dispatchConnection applies a peer's connection reload (kind/name).
+// dispatchConnection applies a peer's connection reload (kind/name/op). op is
+// absent for events from a pre-op replica during a rolling upgrade; it is
+// passed through empty and the handler falls back to a store read.
 func (rb *reloadBus) dispatchConnection(ev session.Event) {
 	kind, _ := ev.Params["kind"].(string)
 	name, _ := ev.Params["name"].(string)
+	op, _ := ev.Params["op"].(string)
 	if rb.handlers.Connection != nil && kind != "" && name != "" {
-		rb.logger.Info("reload-bus: reloading connection from peer", "kind", kind, "name", name)
-		rb.handlers.Connection(kind, name)
+		rb.logger.Info("reload-bus: reloading connection from peer", "kind", kind, "name", name, "op", op)
+		rb.handlers.Connection(kind, name, op)
 	}
 }
 

--- a/pkg/platform/sessionsync/sessionsync.go
+++ b/pkg/platform/sessionsync/sessionsync.go
@@ -66,7 +66,11 @@ type Config struct {
 // subsystem does not participate in cross-replica reload"; the event is ignored.
 // This is also the reloadBus's handler type, so New passes it straight through.
 type ReloadHandlers struct {
-	Connection func(kind, name string)
+	// Connection receives (kind, name, op) where op is the opaque intent string
+	// the publisher passed to PublishConnectionReload ("upsert"/"delete", empty
+	// for a legacy pre-op event). The bus does not interpret op; the handler
+	// does.
+	Connection func(kind, name, op string)
 	Catalog    func(catalogID string)
 	Persona    func()
 	APIKey     func()
@@ -287,13 +291,14 @@ func (h *Handle) StatelessForced() bool {
 	return h != nil && h.forcedStateless
 }
 
-// PublishConnectionReload announces that the (kind, name) connection's stored
-// config changed so peers rebuild it. No-op on a nil Handle.
-func (h *Handle) PublishConnectionReload(ctx context.Context, kind, name string) {
+// PublishConnectionReload announces that the (kind, name) connection changed so
+// peers rebuild it. op is an opaque intent string ("upsert"/"delete") the bus
+// carries verbatim to the peer handler. No-op on a nil Handle.
+func (h *Handle) PublishConnectionReload(ctx context.Context, kind, name, op string) {
 	if h == nil {
 		return
 	}
-	h.reloadBus.publishConnection(ctx, kind, name)
+	h.reloadBus.publishConnection(ctx, kind, name, op)
 }
 
 // PublishCatalogReload announces that an API catalog's specs changed so peers

--- a/pkg/platform/sessionsync/sessionsync_test.go
+++ b/pkg/platform/sessionsync/sessionsync_test.go
@@ -8,7 +8,12 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/txn2/mcp-data-platform/pkg/connreconcile"
+	"github.com/txn2/mcp-data-platform/pkg/query"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/semantic"
 	"github.com/txn2/mcp-data-platform/pkg/session"
 )
 
@@ -159,7 +164,7 @@ func TestClose_NilSafe(t *testing.T) {
 		t.Error("nil-handle StatelessForced must be false")
 	}
 	// Publish delegators must be no-ops on a nil handle.
-	h.PublishConnectionReload(context.Background(), "api", "x")
+	h.PublishConnectionReload(context.Background(), "api", "x", "upsert")
 	h.PublishCatalogReload(context.Background(), "cat")
 	h.PublishPersonaReload(context.Background())
 	h.PublishAPIKeyReload(context.Background())
@@ -212,7 +217,7 @@ func TestHandle_PublishDelegatorsSafe(t *testing.T) {
 	}
 	defer func() { _ = h.Close() }()
 	ctx := context.Background()
-	h.PublishConnectionReload(ctx, "api", "c1")
+	h.PublishConnectionReload(ctx, "api", "c1", "upsert")
 	h.PublishCatalogReload(ctx, "cat-1")
 	h.PublishPersonaReload(ctx)
 	h.PublishAPIKeyReload(ctx)
@@ -223,7 +228,7 @@ func TestHandle_PublishDelegatorsSafe(t *testing.T) {
 // recordingHandlers captures reload-handler invocations on buffered
 // channels so tests can assert delivery (or non-delivery) with a timeout.
 type recordingHandlers struct {
-	conn    chan [2]string
+	conn    chan [3]string // kind, name, op
 	catalog chan string
 	persona chan struct{}
 	apiKey  chan struct{}
@@ -231,7 +236,7 @@ type recordingHandlers struct {
 
 func newRecordingHandlers() recordingHandlers {
 	return recordingHandlers{
-		conn:    make(chan [2]string, 4),
+		conn:    make(chan [3]string, 4),
 		catalog: make(chan string, 4),
 		persona: make(chan struct{}, 4),
 		apiKey:  make(chan struct{}, 4),
@@ -240,7 +245,7 @@ func newRecordingHandlers() recordingHandlers {
 
 func (r recordingHandlers) handlers() ReloadHandlers {
 	return ReloadHandlers{
-		Connection: func(kind, name string) { r.conn <- [2]string{kind, name} },
+		Connection: func(kind, name, op string) { r.conn <- [3]string{kind, name, op} },
 		Catalog:    func(id string) { r.catalog <- id },
 		Persona:    func() { r.persona <- struct{}{} },
 		APIKey:     func() { r.apiKey <- struct{}{} },
@@ -269,13 +274,13 @@ func TestReloadBus_CrossReplica(t *testing.T) {
 	waitForSubscribers(t, b, 2)
 
 	// Replica A handled the admin write and publishes the reload.
-	busA.publishConnection(t.Context(), "api", "Test API")
+	busA.publishConnection(t.Context(), "api", "Test API", "delete")
 
-	// Replica B must apply it.
+	// Replica B must apply it, including the op the publisher passed.
 	select {
 	case got := <-recB.conn:
-		if got != [2]string{"api", "Test API"} {
-			t.Fatalf("replica B reloaded %v, want [api Test API]", got)
+		if got != [3]string{"api", "Test API", "delete"} {
+			t.Fatalf("replica B reloaded %v, want [api Test API delete]", got)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("replica B never received the connection reload (the #501 bug)")
@@ -303,8 +308,10 @@ func TestReloadBus_DispatchRouting(t *testing.T) {
 	if got := <-rec.catalog; got != "cat-1" {
 		t.Errorf("catalog reload id=%q, want cat-1", got)
 	}
-	if got := <-rec.conn; got != [2]string{"mcp", "up"} {
-		t.Errorf("connection reload=%v, want [mcp up]", got)
+	// This event carries no "op" param (a legacy pre-op publisher), so op
+	// decodes to the empty string and the handler falls back to a store read.
+	if got := <-rec.conn; got != [3]string{"mcp", "up", ""} {
+		t.Errorf("connection reload=%v, want [mcp up ]", got)
 	}
 	if _, ok := <-rec.persona; !ok {
 		t.Error("persona reload not dispatched")
@@ -339,7 +346,7 @@ func TestReloadBus_NilHandlerAndUnknownMethod(_ *testing.T) {
 // no-op (single-replica deployments with no broadcaster).
 func TestReloadBus_NilBusPublishSafe(t *testing.T) {
 	var rb *reloadBus
-	rb.publishConnection(t.Context(), "api", "x") // must not panic
+	rb.publishConnection(t.Context(), "api", "x", "upsert") // must not panic
 	rb = newReloadBus(nil, "self", ReloadHandlers{}, nil)
 	rb.publishCatalog(t.Context(), "x") // nil broadcaster: must not panic
 	rb.publishPersona(t.Context())
@@ -368,4 +375,75 @@ func waitForSubscribers(t *testing.T, b *session.MemoryBroadcaster, n int) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatalf("subscribers did not reach %d", n)
+}
+
+// connMgrToolkit is a registry.Toolkit that also implements
+// toolkit.ConnectionManager, recording removals so the reload-bus integration
+// test can assert a delete op reaches a live toolkit through the real bus.
+type connMgrToolkit struct {
+	kind      string
+	present   bool
+	removedCh chan string
+}
+
+func (t *connMgrToolkit) Kind() string                          { return t.kind }
+func (*connMgrToolkit) Name() string                            { return "conn" }
+func (*connMgrToolkit) Connection() string                      { return "" }
+func (*connMgrToolkit) Tools() []string                         { return nil }
+func (*connMgrToolkit) RegisterTools(_ *mcp.Server)             {}
+func (*connMgrToolkit) SetSemanticProvider(_ semantic.Provider) {}
+func (*connMgrToolkit) SetQueryProvider(_ query.Provider)       {}
+func (*connMgrToolkit) Close() error                            { return nil }
+
+func (t *connMgrToolkit) HasConnection(string) bool                { return t.present }
+func (*connMgrToolkit) AddConnection(string, map[string]any) error { return nil }
+func (t *connMgrToolkit) RemoveConnection(name string) error {
+	t.removedCh <- name
+	return nil
+}
+
+// TestReloadBus_ConnectionDeleteAppliedThroughReconciler proves the delete op
+// travels end to end through the REAL reload bus into a connreconcile removal on
+// a live toolkit: replica A publishes a delete, and replica B — whose Connection
+// handler dispatches to a real connreconcile.Reconciler exactly as
+// Platform.reloadConnectionLocal does — removes the connection from its toolkit
+// without ever consulting a store. (The platform wrapper's op parsing is unit
+// tested in pkg/platform; sessionsync cannot import platform without a cycle.)
+func TestReloadBus_ConnectionDeleteAppliedThroughReconciler(t *testing.T) {
+	tk := &connMgrToolkit{kind: "api", present: true, removedCh: make(chan string, 1)}
+	reg := registry.NewRegistry()
+	if err := reg.Register(tk); err != nil {
+		t.Fatalf("register toolkit: %v", err)
+	}
+	rec := connreconcile.New(reg)
+
+	b := session.NewMemoryBroadcaster(nil)
+	defer func() { _ = b.Close() }()
+
+	// Replica B's handler mirrors reloadConnectionLocal's delete branch: on a
+	// delete op it removes via the reconciler with no store read.
+	handlers := ReloadHandlers{
+		Connection: func(kind, name, op string) {
+			if op == "delete" {
+				_ = rec.Remove(kind, name)
+			}
+		},
+	}
+	busA := newReloadBus(b, "replica-a", ReloadHandlers{}, nil)
+	busB := newReloadBus(b, "replica-b", handlers, nil)
+
+	ctx := t.Context()
+	go busB.run(ctx)
+	waitForSubscribers(t, b, 1)
+
+	busA.publishConnection(ctx, "api", "c1", "delete")
+
+	select {
+	case removed := <-tk.removedCh:
+		if removed != "c1" {
+			t.Fatalf("removed %q, want c1", removed)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("delete op did not reach the toolkit removal through the bus")
+	}
 }

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -35,6 +35,7 @@ pkg/admin -> pkg/authevents
 pkg/admin -> pkg/browsersession
 pkg/admin -> pkg/configstore
 pkg/admin -> pkg/connoauth
+pkg/admin -> pkg/connreconcile
 pkg/admin -> pkg/embedding
 pkg/admin -> pkg/indexjobs
 pkg/admin -> pkg/middleware
@@ -67,6 +68,8 @@ pkg/connbackfill -> pkg/connview
 pkg/connbackfill -> pkg/registry
 pkg/connoauth -> internal/logsan
 pkg/connoauth -> pkg/authevents
+pkg/connreconcile -> pkg/registry
+pkg/connreconcile -> pkg/toolkit
 pkg/connview -> pkg/portal/knowledgepage
 pkg/connview -> pkg/registry
 pkg/connview -> pkg/toolkit
@@ -119,6 +122,7 @@ pkg/platform -> pkg/configstore
 pkg/platform -> pkg/configstore/postgres
 pkg/platform -> pkg/connbackfill
 pkg/platform -> pkg/connoauth
+pkg/platform -> pkg/connreconcile
 pkg/platform -> pkg/connview
 pkg/platform -> pkg/database/migrate
 pkg/platform -> pkg/embedding
@@ -171,7 +175,6 @@ pkg/platform -> pkg/semantic/datahub
 pkg/platform -> pkg/session
 pkg/platform -> pkg/storage
 pkg/platform -> pkg/storage/s3
-pkg/platform -> pkg/toolkit
 pkg/platform -> pkg/toolkits/apigateway
 pkg/platform -> pkg/toolkits/apigateway/catalog
 pkg/platform -> pkg/toolkits/apigateway/catalogindex


### PR DESCRIPTION
## Summary

Part of #880 (finding 1.5). Closes #885.

`reloadConnectionLocal` (`pkg/platform/reload.go`) previously ignored the error from `connectionStore.Get`, unconditionally called `RemoveConnection` on every matching toolkit, and re-added the connection only when the read succeeded. A transient database failure during a cross-replica reload therefore removed a live connection from a peer with no log output. The `AddConnection` and `RemoveConnection` errors were also discarded (`_ =`).

This PR fixes that decision table, extracts the connection-reconcile mechanics into a shared package used by both the admin hot-reload path and the reload bus, and closes a follow-on gap where a deleted connection could linger live on a peer whose store read transiently failed.

## The #885 fix

The reload now keys its behavior off the store-read outcome (upsert path), and the store's not-found is signaled by the `ErrConnectionNotFound` sentinel (`pkg/platform/connection_store.go:98`), so the not-found branch uses `errors.Is`:

- **Store read failed** (non-not-found error): log at ERROR and keep the live config in place. Removing here would drop a healthy connection over a database blip, which is exactly the failure this issue exists to prevent. A later upsert re-materializes it.
- **Not found**: remove from matching toolkits; removal errors log at WARN (dropping an already-absent connection is not state-corrupting).
- **Present**: remove-then-add per toolkit; errors log at ERROR and the loop continues so other toolkits of the same kind are still updated.

## Shared reconciler (`pkg/connreconcile`)

The admin hot-reload path (`hotAddConnection` / `hotRemoveConnection`) and the reload bus previously each carried their own "find every toolkit of a kind that implements `ConnectionManager`, then remove/add under a `HasConnection` guard" loop, and the copies had drifted: the admin path touched only the first matching toolkit while the reload bus touched all of them.

The new `pkg/connreconcile` package owns that loop once. `Remove` and `Upsert` return typed per-toolkit `Failure`s; callers keep their own logging level and peer-broadcast policy. `findConnectionManager` remains only for the gateway refresh HTTP handler, which needs the single manager reference and per-phase status codes rather than the fire-and-forget reconcile shape.

The admin peer broadcast is now unconditional. The broadcast signals a store change (already committed by the caller before the in-memory reconcile runs), so a local in-memory reconcile failure must not suppress peer notification; suppressing it would leave peers silently stale on the store change (#501).

## Delete intent through the reload bus

The reload event now carries an operation (`ConnectionReloadOp`: upsert or delete):

- **Upsert** broadcasts read the store on peers and re-materialize (with the keep-live-on-read-failure behavior above).
- **Delete** broadcasts remove the connection from peers' live toolkits WITHOUT a store read, closing the window where a transient peer-side store failure on a one-shot delete event would leave a deleted connection callable until restart.

`sessionsync` stays generic: it carries an opaque `op` string in its existing `map[string]any` params. The typed enum lives in `platform`, where the intent is meaningful, and `admin` references it through its existing dependency on `platform`. A legacy op-less event from a pre-upgrade replica falls back to the read-and-decide path, so a rolling upgrade is safe in both directions.

## Tests

- Table-driven coverage of every reload branch (fake store plus a recording `ConnectionManager`): store-read error keeps the live config, not-found removes, upsert removes-then-adds, and the WARN/ERROR log levels per branch.
- Multi-toolkit fan-out (a failure on one toolkit still updates the others), not-found sentinel pinning against the real store convention, and a delete-op test using a store that fails the test if read (proving the delete path never touches the store).
- `pkg/connreconcile` unit tests (Remove / Upsert / non-manager skip / nil source) at 100 percent.
- Integration: `TestPlatform_ReloadWiring` exercises the delete path against the real apigateway toolkit through a real `Platform`; a `sessionsync` cross-replica test drives a delete op through the real reload bus into a real `connreconcile` removal on a live toolkit; the bus test asserts the op propagates end to end.

## Docs

`docs/server/admin-api.md` gains a "Cross-replica hot-reload" section documenting the upsert/delete propagation semantics, mirrored in `docs/llms-full.txt`.

## Verification

`make verify` is green (tests with race, total and patch coverage, lint, gosec, govulncheck, semgrep, CodeQL, dead-code, mutation, GoReleaser dry-run). The Platform god-object budget holds because this changes method signatures rather than adding methods. `make doc-check` and `make emdash-check` pass.
