### PR TITLE
security(oauth): reject PKCE method plain at /authorize; advertise S256 only (#892)

### DIFF
--- a/docs/auth/oauth-server.md
+++ b/docs/auth/oauth-server.md
@@ -328,7 +328,7 @@ Expected response:
   "registration_endpoint": "https://mcp.example.com/oauth/register",
   "response_types_supported": ["code"],
   "grant_types_supported": ["authorization_code", "refresh_token"],
-  "code_challenge_methods_supported": ["S256", "plain"],
+  "code_challenge_methods_supported": ["S256"],
   "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"]
 }
 ```

--- a/pkg/oauth/authorize_test.go
+++ b/pkg/oauth/authorize_test.go
@@ -158,6 +158,68 @@ func TestHandleAuthorizeEndpoint(t *testing.T) {
 			t.Errorf("expected client_id=mcp-server, got %s", u.Query().Get("client_id"))
 		}
 	})
+
+	// #892: OAuth 2.1 supports only the S256 code challenge method. A request
+	// using code_challenge_method=plain must be rejected at /authorize with an
+	// invalid_request error; an S256 request continues to succeed.
+	const pkceChallenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+	t.Run("plain code_challenge_method rejected", func(t *testing.T) {
+		storage := NewMemoryStorage()
+		_ = storage.CreateClient(context.Background(), client)
+		server, _ := NewServer(ServerConfig{
+			Issuer: "http://localhost:8080",
+			Upstream: &UpstreamConfig{
+				Issuer:       "http://keycloak:8180/realms/test",
+				ClientID:     testUpstreamClient,
+				ClientSecret: "secret",
+				RedirectURI:  "http://localhost:8080/oauth/callback",
+			},
+		}, storage)
+
+		target := "/oauth/authorize?response_type=code&client_id=client-123&redirect_uri=http://localhost:8080/callback&state=mystate&code_challenge=" + pkceChallenge + "&code_challenge_method=plain"
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, target, http.NoBody)
+		w := httptest.NewRecorder()
+		server.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400 for plain method, got %d", w.Code)
+		}
+
+		var errResp ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+			t.Fatalf("failed to decode error response: %v", err)
+		}
+		if errResp.Error != errInvalidRequest {
+			t.Errorf("expected error=%q, got %q", errInvalidRequest, errResp.Error)
+		}
+	})
+
+	t.Run("S256 code_challenge_method succeeds", func(t *testing.T) {
+		storage := NewMemoryStorage()
+		_ = storage.CreateClient(context.Background(), client)
+		server, _ := NewServer(ServerConfig{
+			Issuer: "http://localhost:8080",
+			Upstream: &UpstreamConfig{
+				Issuer:       "http://keycloak:8180/realms/test",
+				ClientID:     testUpstreamClient,
+				ClientSecret: "secret",
+				RedirectURI:  "http://localhost:8080/oauth/callback",
+			},
+		}, storage)
+
+		target := "/oauth/authorize?response_type=code&client_id=client-123&redirect_uri=http://localhost:8080/callback&state=mystate&code_challenge=" + pkceChallenge + "&code_challenge_method=S256"
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, target, http.NoBody)
+		w := httptest.NewRecorder()
+		server.ServeHTTP(w, req)
+
+		if w.Code != http.StatusFound {
+			t.Fatalf("expected status 302 for S256 method, got %d", w.Code)
+		}
+		if u, _ := url.Parse(w.Header().Get("Location")); u.Host != testKeycloakHost {
+			t.Errorf("expected redirect to keycloak, got %s", u.Host)
+		}
+	})
 }
 
 func TestHandleCallbackEndpoint(t *testing.T) {

--- a/pkg/oauth/pkce.go
+++ b/pkg/oauth/pkce.go
@@ -11,10 +11,8 @@ import (
 type PKCEMethod string
 
 const (
-	// PKCEMethodPlain uses plain text (not recommended).
-	PKCEMethodPlain PKCEMethod = "plain"
-
-	// PKCEMethodS256 uses SHA-256 hashing (recommended).
+	// PKCEMethodS256 uses SHA-256 hashing. Per OAuth 2.1 it is the only
+	// supported code challenge method; the "plain" method is not accepted.
 	PKCEMethodS256 PKCEMethod = "S256"
 
 	// pkceMinLength is the minimum length for code verifiers and challenges per RFC 7636.
@@ -61,8 +59,6 @@ func GenerateCodeChallenge(verifier string, method PKCEMethod) (string, error) {
 	}
 
 	switch method {
-	case PKCEMethodPlain:
-		return verifier, nil
 	case PKCEMethodS256:
 		hash := sha256.Sum256([]byte(verifier))
 		return base64.RawURLEncoding.EncodeToString(hash[:]), nil

--- a/pkg/oauth/pkce_test.go
+++ b/pkg/oauth/pkce_test.go
@@ -98,13 +98,10 @@ func TestValidateCodeChallenge(t *testing.T) {
 func TestGenerateCodeChallenge(t *testing.T) {
 	verifier := strings.Repeat(pkceRepeatChar, pkceMinLen)
 
-	t.Run("plain method", func(t *testing.T) {
-		challenge, err := GenerateCodeChallenge(verifier, PKCEMethodPlain)
-		if err != nil {
-			t.Fatalf("GenerateCodeChallenge() error = %v", err)
-		}
-		if challenge != verifier {
-			t.Error("plain challenge should equal verifier")
+	t.Run("plain method rejected", func(t *testing.T) {
+		_, err := GenerateCodeChallenge(verifier, "plain")
+		if err == nil {
+			t.Error("GenerateCodeChallenge() expected error for plain method")
 		}
 	})
 
@@ -161,13 +158,10 @@ func TestVerifyCodeChallenge(t *testing.T) {
 		}
 	})
 
-	t.Run("plain valid", func(t *testing.T) {
-		valid, err := VerifyCodeChallenge(verifier, verifier, PKCEMethodPlain)
-		if err != nil {
-			t.Fatalf("VerifyCodeChallenge() error = %v", err)
-		}
-		if !valid {
-			t.Error("VerifyCodeChallenge() = false, want true")
+	t.Run("plain rejected", func(t *testing.T) {
+		_, err := VerifyCodeChallenge(verifier, verifier, "plain")
+		if err == nil {
+			t.Error("VerifyCodeChallenge() expected error for plain method")
 		}
 	})
 }

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -291,14 +291,15 @@ func (s *Server) validateAuthorizationRequest(ctx context.Context, req Authoriza
 
 // validatePKCE validates PKCE parameters if required.
 func (*Server) validatePKCE(client *Client, req AuthorizationRequest) error {
-	if !client.RequirePKCE {
-		return nil
-	}
-	if req.CodeChallenge == "" {
+	if client.RequirePKCE && req.CodeChallenge == "" {
 		return fmt.Errorf("code_challenge required")
 	}
-	if req.CodeChallengeMethod != string(PKCEMethodS256) && req.CodeChallengeMethod != string(PKCEMethodPlain) {
-		return fmt.Errorf("invalid code_challenge_method")
+	// Enforce S256 whenever a challenge is supplied, even for clients that do
+	// not require PKCE. A code_challenge stored with a non-S256 method would
+	// otherwise pass /authorize and fail closed only at token exchange, since
+	// verifyCodeChallenge hard-codes S256 (#892). OAuth 2.1 permits S256 only.
+	if req.CodeChallenge != "" && req.CodeChallengeMethod != string(PKCEMethodS256) {
+		return fmt.Errorf("code_challenge_method %q is not supported; use S256", req.CodeChallengeMethod)
 	}
 	return nil
 }
@@ -1108,7 +1109,7 @@ func (s *Server) handleMetadata(w http.ResponseWriter, _ *http.Request) {
 		"registration_endpoint":                 s.config.Issuer + "/register",
 		"response_types_supported":              []string{paramCode},
 		"grant_types_supported":                 []string{grantTypeAuthCode, grantTypeRefreshToken},
-		"code_challenge_methods_supported":      []string{string(PKCEMethodS256), "plain"},
+		"code_challenge_methods_supported":      []string{string(PKCEMethodS256)},
 		"token_endpoint_auth_methods_supported": []string{"client_secret_basic", "client_secret_post"},
 	}
 

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -257,6 +258,39 @@ func TestServerAuthorize_Validation(t *testing.T) {
 			t.Error("expected error for invalid PKCE method")
 		}
 	})
+
+	// #892: a client that does not require PKCE but voluntarily supplies a
+	// code_challenge must still be held to S256 at /authorize. Otherwise the
+	// plain challenge passes here and only fails closed at token exchange.
+	t.Run("plain rejected even when PKCE not required", func(t *testing.T) {
+		client := &Client{
+			ClientID:     testClientID,
+			RedirectURIs: []string{testRedirectURI},
+			Active:       true,
+			RequirePKCE:  false,
+		}
+		storage := &mockStorage{
+			getClientFunc: func(_ context.Context, _ string) (*Client, error) {
+				return client, nil
+			},
+			saveAuthorizationCodeFunc: func(_ context.Context, _ *AuthorizationCode) error {
+				return nil
+			},
+		}
+		server, _ := NewServer(ServerConfig{}, storage)
+
+		_, err := server.Authorize(ctx, AuthorizationRequest{
+			ResponseType:        "code",
+			ClientID:            testClientID,
+			RedirectURI:         testRedirectURI,
+			CodeChallenge:       "challenge",
+			CodeChallengeMethod: "plain",
+		}, testServerUserID, nil)
+
+		if err == nil {
+			t.Error("expected error for plain method on non-PKCE-required client")
+		}
+	})
 }
 
 func TestServerToken(t *testing.T) {
@@ -339,6 +373,17 @@ func TestServerHTTPHandlers(t *testing.T) {
 		}
 		if !strings.Contains(w.Body.String(), "issuer") {
 			t.Error("expected issuer in response")
+		}
+
+		// #892: metadata must advertise S256 only, not plain.
+		var meta struct {
+			CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &meta); err != nil {
+			t.Fatalf("failed to decode metadata: %v", err)
+		}
+		if !reflect.DeepEqual(meta.CodeChallengeMethodsSupported, []string{"S256"}) {
+			t.Errorf("expected code_challenge_methods_supported=[S256], got %v", meta.CodeChallengeMethodsSupported)
 		}
 	})
 
@@ -1768,7 +1813,7 @@ func TestGenerateTokensSaveError(t *testing.T) {
 	}
 }
 
-func TestValidatePKCEPlain(t *testing.T) {
+func TestValidatePKCEPlainRejected(t *testing.T) {
 	ctx := context.Background()
 	hashedSecret, _ := bcrypt.GenerateFromPassword([]byte(testSecret), bcrypt.MinCost)
 
@@ -1793,8 +1838,8 @@ func TestValidatePKCEPlain(t *testing.T) {
 	}
 	server, _ := NewServer(ServerConfig{}, storage)
 
-	// Authorize with plain PKCE
-	code, err := server.Authorize(ctx, AuthorizationRequest{
+	// Authorize with plain PKCE is rejected: OAuth 2.1 supports only S256.
+	_, err := server.Authorize(ctx, AuthorizationRequest{
 		ResponseType:        "code",
 		ClientID:            testClientID,
 		RedirectURI:         testRedirectURI,
@@ -1802,11 +1847,11 @@ func TestValidatePKCEPlain(t *testing.T) {
 		CodeChallenge:       codeChallenge,
 		CodeChallengeMethod: "plain",
 	}, testServerUserID, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("expected error for plain code_challenge_method, got nil")
 	}
-	if code == "" {
-		t.Error("expected non-empty code")
+	if !strings.Contains(err.Error(), "S256") {
+		t.Errorf("expected error to mention S256, got: %v", err)
 	}
 }
 

--- a/pkg/oauth/state.go
+++ b/pkg/oauth/state.go
@@ -21,7 +21,7 @@ type AuthorizationState struct {
 	// CodeChallenge is the PKCE challenge from the client.
 	CodeChallenge string
 
-	// CodeChallengeMethod is the PKCE method (S256 or plain).
+	// CodeChallengeMethod is the PKCE method (S256; the only supported method).
 	CodeChallengeMethod string
 
 	// Scope is the requested scope.


### PR DESCRIPTION
## Summary

Server metadata advertised `code_challenge_methods_supported: ["S256", "plain"]` and `validatePKCE` accepted `plain` at `/authorize`, but the authorization flow only ever verifies S256 at token exchange (`verifyCodeChallenge` hard-codes `PKCEMethodS256`, `pkg/oauth/server.go`). A `plain` client therefore passed `/authorize` and always failed the token step — no security hole (it fails closed), but a spec-compliance bug, and OAuth 2.1 removes `plain` entirely.

This PR makes S256 the only accepted PKCE method: rejected up front at `/authorize`, and removed from advertised metadata.

Closes #892 (part of #880, finding 2.7).

## Changes

**`pkg/oauth/server.go`**
- `validatePKCE` rejects any `code_challenge_method` other than `S256`, with a descriptive error (`code_challenge_method "plain" is not supported; use S256`) returned through the existing `writeError`/`invalid_request` path.
- The check now fires **whenever a `code_challenge` is supplied**, not only when `client.RequirePKCE` is true. The prior early `return nil` for non-PKCE-required clients would have let a voluntary `plain` challenge through `/authorize` and fail closed only at token exchange — the exact defect this issue targets. Enforcing at `/authorize` regardless of `RequirePKCE` closes that path.
- Metadata handler now advertises `code_challenge_methods_supported: ["S256"]`.

**`pkg/oauth/pkce.go`**
- Removed the now-dead `PKCEMethodPlain` constant and its branch in `GenerateCodeChallenge`. `PKCEMethodS256` retained.

**`pkg/oauth/state.go`**
- Updated the `CodeChallengeMethod` doc comment (no longer "S256 or plain").

**`docs/auth/oauth-server.md`**
- Metadata example updated to `["S256"]`. (Grep confirmed no other doc/`llms.txt`/`llms-full.txt` references to a `plain` PKCE method.)

## Tests

Written against the issue's acceptance criteria:

- **`authorize_test.go`** — HTTP-level: `/authorize` with `code_challenge_method=plain` returns `400` `error=invalid_request`; with `S256` it redirects (`302`) to the upstream IdP as before.
- **`server_test.go`** — metadata endpoint asserts the exact slice `["S256"]`; `TestValidatePKCEPlain` inverted to `TestValidatePKCEPlainRejected`; added a case proving `plain` is rejected even when the client does not require PKCE.
- **`pkce_test.go`** — the two `plain`-acceptance subtests converted to assert rejection.

## Rolling-upgrade note

`verifyCodeChallenge` has always hard-coded S256, so a `plain` flow never completed login on the prior binary either — it failed at token exchange. During a mixed-version deployment window, an in-flight authorization persisted with `method=plain` by the old binary will now surface its failure earlier (at `/callback`) rather than at token exchange. No previously-working login regresses; the affected flow is a spec-prohibited client type that failed end-to-end regardless. No defensive code was added for this transient window.

## Verification

- `make verify` green (full CI-equivalent suite: fmt, race tests, coverage ≥80%, patch coverage, lint, gosec/govulncheck, semgrep, CodeQL, dead-code, mutation ≥60%, GoReleaser dry-run).
- High-effort adversarial code review run pre-commit; its one confirmed finding (S256 enforcement skipped for non-PKCE-required clients) is fixed in this PR.
