### PR TITLE
security(oauth): HS256 signing-key rotation with kid, hard-fail on missing key for HTTP (#897)

### DIFF
--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -57,6 +57,15 @@ auth:
 # OAuth 2.1 server (for MCP clients like Claude)
 oauth:
   enabled: false
+  # signing_key is required when oauth is enabled on http transport (startup
+  # fails without it): an auto-generated per-process key makes each replica
+  # reject its peers' tokens. Generate with: openssl rand -base64 32
+  # signing_key: "${OAUTH_SIGNING_KEY}"
+  # To rotate without logging users out, move the old key here (verify-only)
+  # while signing_key holds the new one; drop it after the access-token TTL.
+  # previous_signing_keys:
+  #   - "${OAUTH_SIGNING_KEY_OLD}"
+  # allow_ephemeral_signing_key: true  # single-replica http dev only; unsafe for replicas
   dcr:
     enabled: true
     allowed_redirect_patterns:

--- a/docs/auth/oauth-server.md
+++ b/docs/auth/oauth-server.md
@@ -75,9 +75,14 @@ oauth:
   enabled: true
   issuer: "https://mcp.example.com"
 
-  # JWT signing key for access tokens (REQUIRED for production)
+  # JWT signing key for access tokens (REQUIRED on http transport)
   # Generate with: openssl rand -base64 32
   signing_key: "${OAUTH_SIGNING_KEY}"
+
+  # Verify-only keys retained across a rotation (optional). See "Rotating the
+  # signing key" below.
+  # previous_signing_keys:
+  #   - "${OAUTH_SIGNING_KEY_OLD}"
 
   # Pre-registered client for Claude Desktop
   clients:
@@ -108,7 +113,9 @@ oauth:
 |-------|----------|-------------|
 | `oauth.enabled` | Yes | Enable the OAuth server |
 | `oauth.issuer` | Yes | The OAuth issuer URL (your MCP server's public URL) |
-| `oauth.signing_key` | Yes* | HMAC key for signing JWT access tokens (base64 or raw string). Required for production; auto-generated if omitted (tokens won't survive restart). Generate with: `openssl rand -base64 32` |
+| `oauth.signing_key` | Yes* | HMAC key for signing JWT access tokens (base64, 32+ bytes). *Required when `oauth.enabled` and `server.transport: http` (startup fails otherwise); on `stdio` it is auto-generated if omitted (tokens won't survive restart). Generate with: `openssl rand -base64 32` |
+| `oauth.previous_signing_keys` | No | Verify-only base64 keys retained across a signing-key rotation. New tokens are always signed with `signing_key`; tokens minted with a prior key still verify while it stays in this list. See [Rotating the signing key](#rotating-the-signing-key) |
+| `oauth.allow_ephemeral_signing_key` | No | Permit an HTTP deployment to boot without `signing_key`, generating a per-process key instead (default: `false`). **Unsafe for multi-replica deployments**: each replica mints tokens its peers reject. Single-replica HTTP dev only |
 | `oauth.clients` | No | Pre-registered OAuth clients |
 | `oauth.clients[].id` | Yes | Client ID |
 | `oauth.clients[].secret` | Yes | Client secret (use environment variable) |
@@ -126,6 +133,46 @@ oauth:
 | `oauth.upstream.client_id` | No | MCP server's client ID in the upstream IdP |
 | `oauth.upstream.client_secret` | No | MCP server's client secret |
 | `oauth.upstream.redirect_uri` | No | Callback URL for upstream IdP |
+
+### Rotating the signing key
+
+Access tokens are HS256-signed and carry a `kid` (key id) header derived from the signing key, so a verifier can pick the right key after a rotation. New tokens are always signed with `oauth.signing_key`; `oauth.previous_signing_keys` holds additional keys for verification only. This lets you rotate without invalidating live sessions.
+
+On a multi-replica deployment, rotate in **two phases** so that every replica can verify the new key *before* any replica starts signing with it. A single-phase swap (change `signing_key` and roll-restart in one step) causes intermittent 401s: during the rolling restart a not-yet-restarted replica does not yet know the new key and rejects tokens a restarted replica already signed with it.
+
+Start state (key `A` in use):
+
+```yaml
+oauth:
+  signing_key: "${OAUTH_SIGNING_KEY_A}"
+```
+
+1. Generate the new key `B`: `openssl rand -base64 32`.
+2. **Phase 1, teach every replica to verify `B`.** Add `B` to `previous_signing_keys` while keeping `A` as `signing_key`, then roll-restart all replicas. Every replica now verifies both `A` and `B`, but all still sign with `A`, so no token carries the new key yet:
+
+   ```yaml
+   oauth:
+     signing_key: "${OAUTH_SIGNING_KEY_A}"       # still signing with A
+     previous_signing_keys:
+       - "${OAUTH_SIGNING_KEY_B}"                # B is verify-only for now
+   ```
+
+3. **Phase 2, promote `B` to the signer.** Set `signing_key` to `B` and move `A` into `previous_signing_keys`, then roll-restart. Because Phase 1 already taught every replica to verify `B`, a not-yet-restarted replica accepts the `B`-signed tokens a restarted replica issues, so there are no 401s during the rollout:
+
+   ```yaml
+   oauth:
+     signing_key: "${OAUTH_SIGNING_KEY_B}"       # now signing with B
+     previous_signing_keys:
+       - "${OAUTH_SIGNING_KEY_A}"                # A retained for in-flight tokens
+   ```
+
+4. **Retire `A`.** After the access-token TTL has elapsed (1 hour) since Phase 2 completed, no live token is signed with `A`. Remove it from `previous_signing_keys` and roll-restart to complete the rotation.
+
+Tokens issued before `kid` support existed carry no `kid` and are verified against the current key, then each previous key, so an in-place upgrade to this version does not log anyone out.
+
+## Upgrade Note: Signing Key Required on HTTP
+
+Before this version, an HTTP deployment (`server.transport: http` or `sse`) with OAuth enabled but no `oauth.signing_key` booted with an auto-generated per-process key and a warning. That is unsafe for multiple replicas (each replica signs tokens its peers reject), so the platform now **fails to start** in that configuration, naming the missing `oauth.signing_key`. Fix it by configuring a persistent `oauth.signing_key` (the correct action for any real deployment). For a single-replica dev or demo install where an ephemeral key is acceptable, set `oauth.allow_ephemeral_signing_key: true` to restore the previous boot-with-warning behavior. `stdio` deployments are unaffected (single-process by construction, key still auto-generated when omitted).
 
 ## Endpoints
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -737,7 +737,9 @@ Configuration:
 oauth:
   enabled: true
   issuer: "https://mcp.example.com"
-  signing_key: "${OAUTH_SIGNING_KEY}"  # Required: openssl rand -base64 32
+  signing_key: "${OAUTH_SIGNING_KEY}"  # Required on http transport: openssl rand -base64 32
+  previous_signing_keys:               # Optional: verify-only keys retained across a rotation
+    - "${OAUTH_SIGNING_KEY_OLD}"
   clients:
     - id: "claude-desktop"
       secret: "${CLAUDE_CLIENT_SECRET}"
@@ -752,6 +754,8 @@ oauth:
 ```
 
 Access tokens are signed JWTs whose `aud` claim is the issuer URL (the platform is both authorization server and resource server); the requesting client is carried in the `client_id` claim, and the authenticator rejects tokens minted for any other audience.
+
+Access tokens are HS256-signed and carry a `kid` header derived from the signing key, so verifiers select the right key after a rotation. `oauth.signing_key` is **required** when OAuth is enabled on `server.transport: http`/`sse` (startup fails otherwise, naming the key) because an auto-generated per-process key makes each replica reject its peers' tokens; set `oauth.allow_ephemeral_signing_key: true` to override for a single-replica dev setup. On `stdio` the key is auto-generated when omitted. Rotate in two phases so every replica can verify the new key before any replica signs with it (a single-phase swap causes intermittent 401s during the rolling restart): (1) add the new key to `oauth.previous_signing_keys` as verify-only while `signing_key` stays the old key, roll-restart; (2) promote by setting `signing_key` to the new key and moving the old key into `previous_signing_keys`, roll-restart; then drop the old key after the access-token TTL (1h) elapses. Tokens minted before `kid` support carry no header and fall back to current-then-previous key verification, so an in-place upgrade preserves live sessions.
 
 Dynamic Client Registration (`oauth.dcr`) is off by default. Enabling it requires `allowed_redirect_patterns` (regex list): the registration endpoint is unauthenticated, so registration is denied when no patterns are configured (a startup warning flags the misconfiguration). `allow_all_redirect_uris: true` explicitly opts out of pattern matching. Plain HTTP redirect URIs are rejected for non-loopback hosts regardless of configuration; private-use schemes (RFC 8252 native apps) are accepted only through an explicit pattern.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -39,7 +39,7 @@ mcp-data-platform is the orchestration layer for the txn2 MCP ecosystem. DataHub
 - [Auth Overview](https://mcp-data-platform.txn2.com/auth/overview/): Fail-closed security model, stdio vs HTTP authentication
 - [OIDC](https://mcp-data-platform.txn2.com/auth/oidc/): Keycloak, Auth0, Okta, Azure AD setup with required claims; self-healing JWKS cache that refreshes on demand for key rotation
 - [API Keys](https://mcp-data-platform.txn2.com/auth/api-keys/): Service account authentication
-- [OAuth Server](https://mcp-data-platform.txn2.com/auth/oauth-server/): Built-in OAuth 2.1 authorization server for Claude Desktop and other MCP clients, with PKCE, Dynamic Client Registration, upstream IdP integration, refresh tokens hashed at rest, and default-on rate limiting (trusted-proxy-aware per-IP + global backstop) on the `/token` and `/register` endpoints
+- [OAuth Server](https://mcp-data-platform.txn2.com/auth/oauth-server/): Built-in OAuth 2.1 authorization server for Claude Desktop and other MCP clients, with PKCE, Dynamic Client Registration, upstream IdP integration, refresh tokens hashed at rest, HS256 access tokens with `kid`-based signing-key rotation (verify-only previous keys), and default-on rate limiting (trusted-proxy-aware per-IP + global backstop) on the `/token` and `/register` endpoints
 - [OAuth to Upstream MCPs](https://mcp-data-platform.txn2.com/auth/oauth-gateway/): Outbound OAuth to gateway upstreams: client_credentials and authorization_code + PKCE grants, encrypted refresh tokens that survive restarts, background refresh, and a full auth-event history
 
 ## Personas

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -319,6 +319,10 @@ Because portal, admin, and managed-resources mutations can be authenticated by t
 
 The built-in `oauth:` block turns the platform itself into an OAuth 2.1 authorization server, for clients like Claude Desktop that expect to sign in directly to the MCP server rather than through an existing OIDC provider. For most deployments, `auth.oidc` or `auth.api_keys` above are simpler and sufficient. See [OAuth 2.1 Server](../auth/oauth-server.md) for the full config reference, Dynamic Client Registration guidance, and setup walkthrough.
 
+#### Signing key
+
+When `oauth.enabled` is set on `server.transport: http`, `oauth.signing_key` (base64, 32+ bytes) is **required**: startup fails without it, because an auto-generated per-process key makes each replica reject tokens minted by its peers. Set `oauth.allow_ephemeral_signing_key: true` to override this for a single-replica dev setup (unsafe for replicas). On `stdio` the key is auto-generated when omitted (single-process by construction). To rotate the key without logging users out, see [Rotating the signing key](../auth/oauth-server.md#rotating-the-signing-key).
+
 #### Rate limiting
 
 The unauthenticated `/token` and `/register` endpoints are rate limited by default. `/token` runs a bcrypt compare per attempt and `/register` runs a bcrypt hash plus a database insert per request, so both are CPU (and, for `/register`, storage) amplification levers. Each endpoint has a per-client-IP limit plus an internal global backstop that bounds total throughput regardless of how requests attribute to IPs.

--- a/pkg/admin/config_handler.go
+++ b/pkg/admin/config_handler.go
@@ -116,6 +116,7 @@ const (
 	sensKeyPassword        = "password"
 	sensKeyToken           = "token"
 	sensKeySigningKey      = "signing_key"
+	sensKeyPrevSigningKeys = "previous_signing_keys"
 	sensKeyDSN             = "dsn"
 	sensKeySecretAccessKey = "secret_access_key"
 	sensKeyClientSecret    = "client_secret"
@@ -139,6 +140,7 @@ var sensitiveKeys = []string{
 	sensKeyPassword,
 	sensKeyToken,
 	sensKeySigningKey,
+	sensKeyPrevSigningKeys,
 	sensKeyDSN,
 	sensKeySecretAccessKey,
 	sensKeyClientSecret,
@@ -550,9 +552,7 @@ func redactYAML(data []byte) ([]byte, error) {
 func redactMap(m map[string]any) {
 	for k, v := range m {
 		if isSensitiveKey(k) {
-			if s, ok := v.(string); ok && s != "" {
-				m[k] = redactedValue
-			}
+			redactSensitiveValue(m, k, v)
 			continue
 		}
 		switch val := v.(type) {
@@ -560,6 +560,25 @@ func redactMap(m map[string]any) {
 			redactMap(val)
 		case []any:
 			redactSlice(val)
+		}
+	}
+}
+
+// redactSensitiveValue redacts the value stored at a key already known to be
+// sensitive. It handles both a scalar secret (e.g. signing_key) and a list of
+// secrets (e.g. previous_signing_keys), redacting each non-empty string in the
+// list so no element leaks.
+func redactSensitiveValue(m map[string]any, key string, v any) {
+	switch val := v.(type) {
+	case string:
+		if val != "" {
+			m[key] = redactedValue
+		}
+	case []any:
+		for i, item := range val {
+			if s, ok := item.(string); ok && s != "" {
+				val[i] = redactedValue
+			}
 		}
 	}
 }

--- a/pkg/admin/config_handler_test.go
+++ b/pkg/admin/config_handler_test.go
@@ -507,6 +507,33 @@ func TestRedactMap(t *testing.T) {
 		assert.Equal(t, "admin", first["name"])
 	})
 
+	t.Run("redacts a list of secrets under a sensitive key", func(t *testing.T) {
+		// previous_signing_keys is a list of HMAC keys, not a scalar, so each
+		// element must be redacted or the keys leak through /admin/config.
+		m := map[string]any{
+			"previous_signing_keys": []any{"old-key-one", "old-key-two"},
+		}
+		redactMap(m)
+
+		list, ok := m["previous_signing_keys"].([]any)
+		require.True(t, ok, "previous_signing_keys should remain a slice")
+		require.Len(t, list, 2)
+		assert.Equal(t, "[REDACTED]", list[0])
+		assert.Equal(t, "[REDACTED]", list[1])
+	})
+
+	t.Run("does not redact empty strings in a sensitive list", func(t *testing.T) {
+		m := map[string]any{
+			"previous_signing_keys": []any{"", "real-key"},
+		}
+		redactMap(m)
+
+		list, _ := m["previous_signing_keys"].([]any)
+		require.Len(t, list, 2)
+		assert.Equal(t, "", list[0])
+		assert.Equal(t, "[REDACTED]", list[1])
+	})
+
 	t.Run("does not redact empty sensitive values", func(t *testing.T) {
 		m := map[string]any{
 			"password": "",

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -2,21 +2,34 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/oauth/signkey"
 )
+
+// errLegacyNoKID is a sentinel returned by the fast-path keyfunc when a token
+// carries no kid header, signaling parseWithRing to fall back to trying every
+// candidate key. It never escapes the package.
+var errLegacyNoKID = errors.New("token has no kid header")
 
 // OAuthJWTConfig configures the OAuth JWT authenticator.
 type OAuthJWTConfig struct {
 	// Issuer is the expected issuer claim in the JWT.
 	Issuer string
 
-	// SigningKey is the HMAC key used to verify JWT signatures.
+	// SigningKey is the current HMAC key used to sign and verify JWT signatures.
 	SigningKey []byte
+
+	// PreviousSigningKeys are verify-only HMAC keys retained across a signing-key
+	// rotation. Tokens minted with a prior key still verify while that key
+	// remains here; drop keys after the access-token TTL has elapsed since the
+	// rotation to complete it.
+	PreviousSigningKeys [][]byte
 
 	// Audience is the accepted aud claim value. Tokens minted for a
 	// different audience are rejected. Defaults to Issuer, which is the
@@ -35,6 +48,7 @@ type OAuthJWTConfig struct {
 // OAuthJWTAuthenticator validates JWT access tokens issued by our OAuth server.
 type OAuthJWTAuthenticator struct {
 	cfg       OAuthJWTConfig
+	ring      *signkey.Ring
 	extractor *ClaimsExtractor
 }
 
@@ -43,7 +57,8 @@ func NewOAuthJWTAuthenticator(cfg OAuthJWTConfig) (*OAuthJWTAuthenticator, error
 	if cfg.Issuer == "" {
 		return nil, fmt.Errorf("oauth issuer is required")
 	}
-	if len(cfg.SigningKey) == 0 {
+	ring := signkey.NewRing(cfg.SigningKey, cfg.PreviousSigningKeys)
+	if ring == nil {
 		return nil, fmt.Errorf("oauth signing key is required")
 	}
 	if cfg.Audience == "" {
@@ -60,6 +75,7 @@ func NewOAuthJWTAuthenticator(cfg OAuthJWTConfig) (*OAuthJWTAuthenticator, error
 
 	return &OAuthJWTAuthenticator{
 		cfg:       cfg,
+		ring:      ring,
 		extractor: extractor,
 	}, nil
 }
@@ -124,16 +140,11 @@ func (a *OAuthJWTAuthenticator) parseAndValidateToken(tokenString string) (map[s
 	if !LooksLikeJWT(tokenString) {
 		return nil, ErrNotAJWT
 	}
-	// Parse and verify the JWT signature and audience
-	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (any, error) {
-		// Validate the algorithm is HMAC
-		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
-		}
-		return a.cfg.SigningKey, nil
-	}, jwt.WithAudience(a.cfg.Audience))
+	// Parse and verify the JWT signature and audience, selecting the
+	// verification key from the ring by the token's kid header.
+	token, err := a.parseWithRing(tokenString)
 	if err != nil {
-		return nil, fmt.Errorf("parsing token: %w", err)
+		return nil, err
 	}
 
 	if !token.Valid {
@@ -157,6 +168,73 @@ func (a *OAuthJWTAuthenticator) parseAndValidateToken(tokenString string) (map[s
 	maps.Copy(claimsMap, claims)
 
 	return claimsMap, nil
+}
+
+// parseWithRing verifies the token signature against the key ring:
+//
+//   - kid present and known: verify with exactly that key.
+//   - kid present but unknown: reject (the key was retired, or the token is
+//     foreign).
+//   - kid absent (legacy token minted before kid support): try the current key
+//     then each previous key so live pre-upgrade sessions still verify.
+//
+// The common kid-bearing case verifies in a single parse: the keyfunc reads the
+// already-decoded header to select the key. Only a legacy no-kid token pays a
+// second parse via the candidate-key fallback.
+func (a *OAuthJWTAuthenticator) parseWithRing(tokenString string) (*jwt.Token, error) {
+	sawNoKID := false
+	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		kid, _ := t.Header["kid"].(string)
+		if kid == "" {
+			sawNoKID = true
+			return nil, errLegacyNoKID
+		}
+		key, ok := a.ring.VerificationKey(kid)
+		if !ok {
+			return nil, fmt.Errorf("unknown key id %q", kid)
+		}
+		return key, nil
+	}, jwt.WithAudience(a.cfg.Audience))
+	if err == nil {
+		return token, nil
+	}
+	if !sawNoKID {
+		return nil, fmt.Errorf("verifying token: %w", err)
+	}
+	return a.verifyLegacyNoKID(tokenString)
+}
+
+// verifyLegacyNoKID verifies a token that carries no kid header by trying the
+// current key then each previous key. It returns as soon as a key's signature
+// matches: a non-signature error (expiry, audience) means that key IS the signer
+// and the token failed validation for another reason, so that error is surfaced
+// verbatim rather than masked by a later key's signature mismatch. The ring
+// always holds at least the current key, so the loop runs at least once.
+//
+// The algorithm is already pinned to HMAC by parseWithRing's fast-path keyfunc
+// (it checks the method before the kid, and only routes here on a no-kid HMAC
+// token), so the per-key keyfunc here simply returns the candidate key.
+func (a *OAuthJWTAuthenticator) verifyLegacyNoKID(tokenString string) (*jwt.Token, error) {
+	var lastErr error
+	for _, key := range a.ring.CandidateKeys() {
+		token, err := jwt.Parse(tokenString, func(*jwt.Token) (any, error) {
+			return key, nil
+		}, jwt.WithAudience(a.cfg.Audience))
+		if err == nil {
+			return token, nil
+		}
+		if !errors.Is(err, jwt.ErrTokenSignatureInvalid) {
+			// The signature matched this key; the token failed for another
+			// reason (expired, wrong audience). Report that, not a later key's
+			// signature mismatch.
+			return nil, fmt.Errorf("verifying token: %w", err)
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("verifying token: %w", lastErr)
 }
 
 // Verify interface compliance.

--- a/pkg/auth/oauth_rotation_test.go
+++ b/pkg/auth/oauth_rotation_test.go
@@ -1,0 +1,203 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/txn2/mcp-data-platform/pkg/oauth/signkey"
+)
+
+const rotationIssuer = "https://oauth.example.com"
+
+var (
+	keyCurrent  = []byte("current-signing-key-at-least-32-bytes")
+	keyPrevious = []byte("previous-signing-key-at-least-32-byte")
+	keyRetired  = []byte("retired-signing-key-at-least-32-bytesX")
+)
+
+// signToken mints an HS256 token for the rotation issuer signed with key. When
+// setKID is true the token carries the kid derived from key (the post-change
+// behavior); when false it omits the header (a legacy pre-change token).
+func signToken(t *testing.T, key []byte, setKID bool) string {
+	t.Helper()
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iss": rotationIssuer,
+		"sub": "user-123",
+		"aud": rotationIssuer,
+		"exp": now.Add(time.Hour).Unix(),
+		"iat": now.Unix(),
+		"nbf": now.Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	if setKID {
+		token.Header["kid"] = signkey.KeyID(key)
+	}
+	signed, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+	return signed
+}
+
+func newRotationAuth(t *testing.T, current []byte, previous ...[]byte) *OAuthJWTAuthenticator {
+	t.Helper()
+	a, err := NewOAuthJWTAuthenticator(OAuthJWTConfig{
+		Issuer:              rotationIssuer,
+		SigningKey:          current,
+		PreviousSigningKeys: previous,
+	})
+	if err != nil {
+		t.Fatalf("creating authenticator: %v", err)
+	}
+	return a
+}
+
+func mustAuth(t *testing.T, a *OAuthJWTAuthenticator, token string) {
+	t.Helper()
+	if _, err := a.Authenticate(WithToken(context.Background(), token)); err != nil {
+		t.Fatalf("expected token to verify, got error: %v", err)
+	}
+}
+
+func mustReject(t *testing.T, a *OAuthJWTAuthenticator, token string) {
+	t.Helper()
+	if _, err := a.Authenticate(WithToken(context.Background(), token)); err == nil {
+		t.Fatal("expected token to be rejected, but it verified")
+	}
+}
+
+func TestOAuthJWT_KidSelection(t *testing.T) {
+	a := newRotationAuth(t, keyCurrent, keyPrevious)
+
+	t.Run("current key with its kid verifies", func(t *testing.T) {
+		mustAuth(t, a, signToken(t, keyCurrent, true))
+	})
+
+	t.Run("previous key with its kid verifies", func(t *testing.T) {
+		mustAuth(t, a, signToken(t, keyPrevious, true))
+	})
+
+	t.Run("unknown kid is rejected", func(t *testing.T) {
+		// Signed with a key not in the ring; its kid is therefore unknown.
+		mustReject(t, a, signToken(t, keyRetired, true))
+	})
+
+	t.Run("kid pointing at a key that did not sign it is rejected", func(t *testing.T) {
+		// Sign with previous key but forge the current key's kid header: kid
+		// drives selection, so verification uses the current key and the
+		// signature fails.
+		now := time.Now()
+		claims := jwt.MapClaims{
+			"iss": rotationIssuer, "sub": "u", "aud": rotationIssuer,
+			"exp": now.Add(time.Hour).Unix(), "iat": now.Unix(), "nbf": now.Unix(),
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+		token.Header["kid"] = signkey.KeyID(keyCurrent)
+		signed, err := token.SignedString(keyPrevious)
+		if err != nil {
+			t.Fatalf("signing: %v", err)
+		}
+		mustReject(t, a, signed)
+	})
+}
+
+func TestOAuthJWT_LegacyNoKid(t *testing.T) {
+	a := newRotationAuth(t, keyCurrent, keyPrevious)
+
+	t.Run("no-kid token signed with current key verifies", func(t *testing.T) {
+		mustAuth(t, a, signToken(t, keyCurrent, false))
+	})
+
+	t.Run("no-kid token signed with previous key verifies", func(t *testing.T) {
+		mustAuth(t, a, signToken(t, keyPrevious, false))
+	})
+
+	t.Run("no-kid token signed with an unknown key is rejected", func(t *testing.T) {
+		mustReject(t, a, signToken(t, keyRetired, false))
+	})
+}
+
+func TestOAuthJWT_Rotation(t *testing.T) {
+	// Before the old key is dropped: current=new, previous=[old].
+	beforeDrop := newRotationAuth(t, keyCurrent, keyPrevious)
+	oldToken := signToken(t, keyPrevious, true)
+	mustAuth(t, beforeDrop, oldToken)
+
+	// After the old key is dropped from previous_signing_keys.
+	afterDrop := newRotationAuth(t, keyCurrent)
+	mustReject(t, afterDrop, oldToken)
+
+	// The same holds for a legacy (no-kid) token signed with the old key.
+	legacyOld := signToken(t, keyPrevious, false)
+	mustAuth(t, beforeDrop, legacyOld)
+	mustReject(t, afterDrop, legacyOld)
+}
+
+func TestOAuthJWT_RejectsNonHMACAlg(t *testing.T) {
+	a := newRotationAuth(t, keyCurrent, keyPrevious)
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating rsa key: %v", err)
+	}
+
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iss": rotationIssuer, "sub": "u", "aud": rotationIssuer,
+		"exp": now.Add(time.Hour).Unix(), "iat": now.Unix(), "nbf": now.Unix(),
+	}
+	// RS256 is the classic HS/RS confusion vector; the HMAC algorithm pin must
+	// reject an asymmetric-signed token rather than treat the RSA public key as
+	// an HMAC secret.
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	signed, err := token.SignedString(rsaKey)
+	if err != nil {
+		t.Fatalf("signing rs256 token: %v", err)
+	}
+	mustReject(t, a, signed)
+}
+
+func TestOAuthJWT_LegacyExpiredSurfacesExpiryError(t *testing.T) {
+	// A legacy (no-kid) token signed with the current key but expired must report
+	// expiry, not a spurious signature-invalid error from a later candidate key.
+	a := newRotationAuth(t, keyCurrent, keyPrevious)
+
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iss": rotationIssuer, "sub": "u", "aud": rotationIssuer,
+		"exp": now.Add(-time.Hour).Unix(), // expired
+		"iat": now.Add(-2 * time.Hour).Unix(),
+		"nbf": now.Add(-2 * time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString(keyCurrent)
+	if err != nil {
+		t.Fatalf("signing: %v", err)
+	}
+
+	_, authErr := a.Authenticate(WithToken(context.Background(), signed))
+	if authErr == nil {
+		t.Fatal("expected expired token to be rejected")
+	}
+	if !errors.Is(authErr, jwt.ErrTokenExpired) {
+		t.Errorf("error = %v, want it to wrap jwt.ErrTokenExpired (not a signature error)", authErr)
+	}
+}
+
+func TestNewOAuthJWTAuthenticator_PreviousKeysOnly(t *testing.T) {
+	// A ring still requires a current signing key even if previous keys exist.
+	_, err := NewOAuthJWTAuthenticator(OAuthJWTConfig{
+		Issuer:              rotationIssuer,
+		PreviousSigningKeys: [][]byte{keyPrevious},
+	})
+	if err == nil {
+		t.Error("expected error when only previous keys are set (no current signing key)")
+	}
+}

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/txn2/mcp-data-platform/internal/logsan"
+	"github.com/txn2/mcp-data-platform/pkg/oauth/signkey"
 	"github.com/txn2/mcp-data-platform/pkg/observability"
 	"github.com/txn2/mcp-data-platform/pkg/ratelimit"
 )
@@ -162,6 +163,11 @@ type Server struct {
 	httpClient *http.Client
 	metrics    *observability.Metrics
 
+	// signingKID is the kid header stamped on newly minted access tokens,
+	// derived once from the signing key at construction. Empty when no signing
+	// key is configured (opaque-token mode).
+	signingKID string
+
 	// Rate-limiting state for the unauthenticated /token and /register
 	// endpoints. Nil / false when limiting is disabled (see
 	// configureRateLimiting).
@@ -213,6 +219,9 @@ func NewServer(config ServerConfig, storage Storage) (*Server, error) {
 		dcr:        dcr,
 		stateStore: NewMemoryStateStore(),
 		httpClient: &http.Client{Timeout: defaultHTTPTimeoutSeconds * time.Second},
+	}
+	if len(config.SigningKey) > 0 {
+		srv.signingKID = signkey.KeyID(config.SigningKey)
 	}
 	if err := srv.configureRateLimiting(config.RateLimit); err != nil {
 		return nil, err
@@ -588,8 +597,11 @@ func (s *Server) generateAccessToken(clientID, userID string, userClaims map[str
 		claims["claims"] = userClaims
 	}
 
-	// Sign the token
+	// Sign the token. The kid header lets verifiers select the right key after
+	// a rotation; tokens issued before this header existed verify via the
+	// current-then-previous fallback path on the resource-server side.
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	token.Header["kid"] = s.signingKID
 	signedToken, err := token.SignedString(s.config.SigningKey)
 	if err != nil {
 		return "", fmt.Errorf("signing token: %w", err)

--- a/pkg/oauth/server_kid_test.go
+++ b/pkg/oauth/server_kid_test.go
@@ -1,0 +1,55 @@
+package oauth
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/txn2/mcp-data-platform/pkg/oauth/signkey"
+)
+
+func TestGenerateAccessToken_CarriesKID(t *testing.T) {
+	key := []byte("server-signing-key-at-least-32-bytes-x")
+	server, err := NewServer(ServerConfig{
+		Issuer:     "https://oauth.example.com",
+		SigningKey: key,
+	}, NewMemoryStorage())
+	if err != nil {
+		t.Fatalf("creating server: %v", err)
+	}
+
+	tokenStr, err := server.generateAccessToken("client-1", "user-1", nil, "openid")
+	if err != nil {
+		t.Fatalf("generating access token: %v", err)
+	}
+
+	parsed, _, err := jwt.NewParser().ParseUnverified(tokenStr, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("parsing token header: %v", err)
+	}
+
+	kid, ok := parsed.Header["kid"].(string)
+	if !ok || kid == "" {
+		t.Fatalf("token missing kid header: %v", parsed.Header)
+	}
+	if want := signkey.KeyID(key); kid != want {
+		t.Errorf("kid = %q, want %q (SHA-256 of signing key)", kid, want)
+	}
+}
+
+func TestGenerateAccessToken_OpaqueWhenNoKey(t *testing.T) {
+	server, err := NewServer(ServerConfig{Issuer: "https://oauth.example.com"}, NewMemoryStorage())
+	if err != nil {
+		t.Fatalf("creating server: %v", err)
+	}
+
+	// With no signing key, the token is opaque (not a JWT) and has no kid.
+	tokenStr, err := server.generateAccessToken("client-1", "user-1", nil, "openid")
+	if err != nil {
+		t.Fatalf("generating access token: %v", err)
+	}
+	if strings.Count(tokenStr, ".") == jwtPartCount-1 {
+		t.Errorf("expected opaque token without a signing key, got a JWT: %q", tokenStr)
+	}
+}

--- a/pkg/oauth/signkey/signkey.go
+++ b/pkg/oauth/signkey/signkey.go
@@ -1,0 +1,93 @@
+// Package signkey manages the HMAC key ring used to sign and verify HS256 JWT
+// access tokens. It derives a stable key id (kid) from a raw key, selects the
+// active signing key, and resolves a verification key by kid across the current
+// key plus verify-only previous keys so a signing-key rotation does not
+// invalidate live sessions.
+//
+// The kid derivation is deterministic and process-independent: every replica
+// computes the same kid for the same key, which is what lets a token signed by
+// one replica verify on another after a rolling key rotation.
+package signkey
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// kidBytes is the number of leading SHA-256 digest bytes rendered as hex to form
+// a key id. Eight bytes (16 hex chars) is ample to distinguish the small set of
+// keys in a rotation window while keeping the header compact.
+const kidBytes = 8
+
+// KeyID derives the kid header value for a raw HMAC key as the hex encoding of
+// the first kidBytes bytes of its SHA-256 digest. It is stable across processes
+// so every replica computes the same kid for the same key.
+func KeyID(key []byte) string {
+	sum := sha256.Sum256(key)
+	return hex.EncodeToString(sum[:kidBytes])
+}
+
+// Ring resolves a verification key for a token by its kid header across the
+// current signing key plus verify-only previous keys, and yields the ordered
+// candidate list for legacy no-kid tokens. A Ring is immutable after
+// construction and safe for concurrent use.
+//
+// The Ring is used by the resource-server (verification) side. The
+// authorization-server (signing) side stamps its kid with KeyID directly, since
+// it only ever signs with the single active key.
+type Ring struct {
+	byKID   map[string][]byte
+	ordered [][]byte
+}
+
+// NewRing builds a Ring from the current signing key and zero or more
+// verify-only previous keys. Empty previous keys are skipped, and a previous key
+// equal to the current key (same kid) is deduplicated. NewRing returns nil when
+// current is empty, which signals opaque-token mode (no HS256 signing key
+// configured); callers must nil-check before use.
+func NewRing(current []byte, previous [][]byte) *Ring {
+	if len(current) == 0 {
+		return nil
+	}
+	r := &Ring{
+		byKID:   make(map[string][]byte, 1+len(previous)),
+		ordered: make([][]byte, 0, 1+len(previous)),
+	}
+	r.add(current)
+	for _, p := range previous {
+		r.add(p)
+	}
+	return r
+}
+
+// add registers a key under its kid, skipping empty keys and duplicates so the
+// ordered candidate list stays free of repeats (e.g. current listed again in
+// previous_signing_keys).
+func (r *Ring) add(key []byte) {
+	if len(key) == 0 {
+		return
+	}
+	kid := KeyID(key)
+	if _, exists := r.byKID[kid]; exists {
+		return
+	}
+	r.byKID[kid] = key
+	r.ordered = append(r.ordered, key)
+}
+
+// VerificationKey resolves the key to verify a token by its kid header. A token
+// whose kid is not in the ring returns ok=false and must be rejected: an unknown
+// kid means the key was retired (dropped from previous_signing_keys) or the
+// token was minted by a foreign issuer.
+func (r *Ring) VerificationKey(kid string) (key []byte, ok bool) {
+	k, ok := r.byKID[kid]
+	return k, ok
+}
+
+// CandidateKeys returns every key (current first, then previous) for verifying a
+// legacy token that carries no kid header. Such tokens were issued before kid
+// support existed; callers try each key in order so those live sessions survive
+// the upgrade.
+func (r *Ring) CandidateKeys() [][]byte {
+	return r.ordered
+}

--- a/pkg/oauth/signkey/signkey_test.go
+++ b/pkg/oauth/signkey/signkey_test.go
@@ -1,0 +1,87 @@
+package signkey
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestKeyID(t *testing.T) {
+	key := []byte("test-signing-key-at-least-32-bytes-long")
+
+	// Deterministic: same input yields the same kid across calls.
+	if got, want := KeyID(key), KeyID(key); got != want {
+		t.Fatalf("KeyID not deterministic: %q vs %q", got, want)
+	}
+
+	// 8 bytes rendered as hex is 16 characters.
+	if got := KeyID(key); len(got) != 16 {
+		t.Errorf("KeyID length = %d, want 16 (%q)", len(got), got)
+	}
+
+	// Distinct keys yield distinct kids.
+	if KeyID(key) == KeyID([]byte("another-signing-key-at-least-32-bytes")) {
+		t.Error("distinct keys produced the same kid")
+	}
+}
+
+func TestNewRing_NilOnEmptyCurrent(t *testing.T) {
+	if r := NewRing(nil, nil); r != nil {
+		t.Errorf("NewRing(nil, nil) = %v, want nil", r)
+	}
+	if r := NewRing([]byte{}, [][]byte{[]byte("prev")}); r != nil {
+		t.Error("NewRing with empty current should be nil regardless of previous keys")
+	}
+}
+
+func TestRing_VerificationKey(t *testing.T) {
+	current := []byte("current-signing-key-at-least-32-bytes")
+	prev := []byte("previous-signing-key-at-least-32-byte")
+	r := NewRing(current, [][]byte{prev})
+
+	t.Run("current kid resolves", func(t *testing.T) {
+		key, ok := r.VerificationKey(KeyID(current))
+		if !ok || !bytes.Equal(key, current) {
+			t.Errorf("VerificationKey(current kid) = %q, %v", key, ok)
+		}
+	})
+
+	t.Run("previous kid resolves", func(t *testing.T) {
+		key, ok := r.VerificationKey(KeyID(prev))
+		if !ok || !bytes.Equal(key, prev) {
+			t.Errorf("VerificationKey(prev kid) = %q, %v", key, ok)
+		}
+	})
+
+	t.Run("unknown kid rejected", func(t *testing.T) {
+		if _, ok := r.VerificationKey("deadbeefdeadbeef"); ok {
+			t.Error("VerificationKey(unknown) returned ok=true")
+		}
+	})
+}
+
+func TestRing_CandidateKeys(t *testing.T) {
+	current := []byte("current-signing-key-at-least-32-bytes")
+	prev1 := []byte("previous-one-signing-key-32-bytes-long")
+	prev2 := []byte("previous-two-signing-key-32-bytes-long")
+	r := NewRing(current, [][]byte{prev1, prev2})
+
+	got := r.CandidateKeys()
+	if len(got) != 3 {
+		t.Fatalf("CandidateKeys len = %d, want 3", len(got))
+	}
+	if !bytes.Equal(got[0], current) {
+		t.Error("CandidateKeys[0] must be the current key")
+	}
+}
+
+func TestNewRing_DedupesAndSkipsEmpty(t *testing.T) {
+	current := []byte("current-signing-key-at-least-32-bytes")
+	// A previous key equal to current (same kid) is deduplicated, and empty
+	// entries are skipped.
+	r := NewRing(current, [][]byte{current, {}, []byte("other-key-at-least-32-bytes-padding")})
+
+	got := r.CandidateKeys()
+	if len(got) != 2 {
+		t.Fatalf("CandidateKeys len = %d, want 2 (current + one distinct previous)", len(got))
+	}
+}

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -484,13 +484,45 @@ type APIKeyDef struct {
 
 // OAuthConfig configures the OAuth server.
 type OAuthConfig struct {
-	Enabled    bool                 `yaml:"enabled"`
-	Issuer     string               `yaml:"issuer"`
-	SigningKey string               `yaml:"signing_key"` // Base64-encoded HMAC key for JWT signing
-	Clients    []OAuthClientConfig  `yaml:"clients"`
-	DCR        DCRConfig            `yaml:"dcr"`
-	RateLimit  OAuthRateLimitConfig `yaml:"rate_limit"`
-	Upstream   *UpstreamIDPConfig   `yaml:"upstream,omitempty"`
+	Enabled    bool   `yaml:"enabled"`
+	Issuer     string `yaml:"issuer"`
+	SigningKey string `yaml:"signing_key"` // Base64-encoded HMAC key for JWT signing
+	// PreviousSigningKeys are base64-encoded HMAC keys retained for verification
+	// only after a signing-key rotation. New tokens are always signed with
+	// SigningKey; tokens minted with a prior key still verify while that key
+	// remains here. Rotate in two phases (add the new key here as verify-only
+	// everywhere first, then promote it to signing_key) so no replica signs with
+	// a key its peers have not yet learned; see the "Rotating the signing key"
+	// runbook in docs/auth/oauth-server.md.
+	PreviousSigningKeys []string `yaml:"previous_signing_keys"`
+	// AllowEphemeralSigningKey permits an HTTP deployment to boot without a
+	// configured signing_key, generating a per-process key instead. UNSAFE for
+	// multi-replica deployments: each replica mints tokens its peers reject.
+	// Intended only for single-replica HTTP dev setups. Default false.
+	AllowEphemeralSigningKey bool                 `yaml:"allow_ephemeral_signing_key"`
+	Clients                  []OAuthClientConfig  `yaml:"clients"`
+	DCR                      DCRConfig            `yaml:"dcr"`
+	RateLimit                OAuthRateLimitConfig `yaml:"rate_limit"`
+	Upstream                 *UpstreamIDPConfig   `yaml:"upstream,omitempty"`
+}
+
+// errOAuthSigningKeyRequiredMsg is the message emitted by both the config
+// validation gate and the boot-time signing-key gate when an HTTP OAuth
+// deployment has no configured key. Shared so the two gates stay in sync.
+const errOAuthSigningKeyRequiredMsg = "oauth.signing_key is required for http transport " +
+	"(set oauth.allow_ephemeral_signing_key: true only for a single-replica dev setup)"
+
+// requiresConfiguredSigningKey reports whether the deployment must supply an
+// explicit OAuth signing key rather than fall back to a per-process ephemeral
+// key. It is true when the OAuth server is enabled on an HTTP-family transport
+// and the ephemeral escape hatch is not set: across replicas every token must be
+// signed with the same key, or a replica rejects tokens minted by its peers
+// (an intermittent-auth-failure class of bug). stdio is single-process by
+// construction, so it keeps the auto-generate behavior.
+func (c *Config) requiresConfiguredSigningKey() bool {
+	return c.OAuth.Enabled &&
+		isHTTPTransport(c.Server.Transport) &&
+		!c.OAuth.AllowEphemeralSigningKey
 }
 
 // OAuthRateLimitConfig configures rate limiting for the unauthenticated OAuth
@@ -1771,6 +1803,12 @@ func (c *Config) validateOAuth(errs []string) []string {
 	}
 	if c.OAuth.Issuer == "" {
 		errs = append(errs, "oauth.issuer is required when OAuth is enabled")
+	}
+	// On an HTTP deployment a missing signing key would auto-generate a
+	// per-process key each replica's peers reject. Refuse to boot unless the
+	// operator opts into the ephemeral key explicitly.
+	if c.requiresConfiguredSigningKey() && c.OAuth.SigningKey == "" {
+		errs = append(errs, errOAuthSigningKeyRequiredMsg)
 	}
 	// Upstream IdP is required for the authorization flow.
 	if c.OAuth.Upstream == nil {

--- a/pkg/platform/config_test.go
+++ b/pkg/platform/config_test.go
@@ -332,6 +332,69 @@ func TestConfigValidate(t *testing.T) {
 		}
 	})
 
+	t.Run("http + oauth enabled + no signing key = error naming the key", func(t *testing.T) {
+		cfg := &Config{
+			Server: ServerConfig{Transport: "http"},
+			OAuth:  OAuthConfig{Enabled: true, Issuer: "https://oauth.example.com"},
+		}
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("Validate() expected error for http + oauth + no signing key")
+		}
+		if !strings.Contains(err.Error(), "oauth.signing_key") {
+			t.Errorf("error = %v, want it to name oauth.signing_key", err)
+		}
+	})
+
+	t.Run("http + oauth + ephemeral escape hatch = no error", func(t *testing.T) {
+		cfg := &Config{
+			Server: ServerConfig{Transport: "http"},
+			OAuth: OAuthConfig{
+				Enabled:                  true,
+				Issuer:                   "https://oauth.example.com",
+				AllowEphemeralSigningKey: true,
+			},
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate() error = %v, want nil with allow_ephemeral_signing_key", err)
+		}
+	})
+
+	t.Run("http + oauth + signing key configured = no error", func(t *testing.T) {
+		cfg := &Config{
+			Server: ServerConfig{Transport: "http"},
+			OAuth: OAuthConfig{
+				Enabled:    true,
+				Issuer:     "https://oauth.example.com",
+				SigningKey: "c2lnbmluZy1rZXktYXQtbGVhc3QtMzItYnl0ZXMtbG9uZw==",
+			},
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate() error = %v, want nil with signing key set", err)
+		}
+	})
+
+	t.Run("stdio + oauth + no signing key = no signing-key error", func(t *testing.T) {
+		cfg := &Config{
+			Server: ServerConfig{Transport: "stdio"},
+			OAuth:  OAuthConfig{Enabled: true, Issuer: "https://oauth.example.com"},
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate() error = %v, want nil — stdio keeps auto-generate behavior", err)
+		}
+	})
+
+	t.Run("sse transport is treated as http for the signing-key gate", func(t *testing.T) {
+		cfg := &Config{
+			Server: ServerConfig{Transport: "sse"},
+			OAuth:  OAuthConfig{Enabled: true, Issuer: "https://oauth.example.com"},
+		}
+		err := cfg.Validate()
+		if err == nil || !strings.Contains(err.Error(), "oauth.signing_key") {
+			t.Errorf("Validate() error = %v, want signing_key error for sse transport", err)
+		}
+	})
+
 	t.Run("BroadcastChannel under 63 bytes is accepted", func(t *testing.T) {
 		cfg := &Config{
 			Sessions: SessionsConfig{Store: SessionStoreDatabase, BroadcastChannel: "deploy_alpha_events"},

--- a/pkg/platform/oauth_signkey_test.go
+++ b/pkg/platform/oauth_signkey_test.go
@@ -1,0 +1,135 @@
+package platform
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+)
+
+func b64key(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+func TestParseOrGenerateSigningKey_HTTPHardFail(t *testing.T) {
+	p := &Platform{config: &Config{
+		Server: ServerConfig{Transport: "http"},
+		OAuth:  OAuthConfig{Enabled: true, Issuer: "https://oauth.example.com"},
+	}}
+
+	_, err := p.parseOrGenerateSigningKey()
+	if err == nil {
+		t.Fatal("expected startup error for http + oauth + no signing key")
+	}
+}
+
+func TestParseOrGenerateSigningKey_EphemeralEscapeHatch(t *testing.T) {
+	p := &Platform{config: &Config{
+		Server: ServerConfig{Transport: "http"},
+		OAuth: OAuthConfig{
+			Enabled:                  true,
+			Issuer:                   "https://oauth.example.com",
+			AllowEphemeralSigningKey: true,
+		},
+	}}
+
+	key, err := p.parseOrGenerateSigningKey()
+	if err != nil {
+		t.Fatalf("expected ephemeral key generation, got error: %v", err)
+	}
+	if len(key) < minSigningKeyLength {
+		t.Errorf("generated key length = %d, want >= %d", len(key), minSigningKeyLength)
+	}
+}
+
+func TestParseOrGenerateSigningKey_StdioGenerates(t *testing.T) {
+	p := &Platform{config: &Config{
+		Server: ServerConfig{Transport: "stdio"},
+		OAuth:  OAuthConfig{Enabled: true, Issuer: "https://oauth.example.com"},
+	}}
+
+	key, err := p.parseOrGenerateSigningKey()
+	if err != nil {
+		t.Fatalf("stdio should auto-generate, got error: %v", err)
+	}
+	if len(key) < minSigningKeyLength {
+		t.Errorf("generated key length = %d, want >= %d", len(key), minSigningKeyLength)
+	}
+}
+
+func TestParseOrGenerateSigningKey_ConfiguredKey(t *testing.T) {
+	raw := "configured-signing-key-at-least-32-bytes"
+	p := &Platform{config: &Config{
+		Server: ServerConfig{Transport: "http"},
+		OAuth: OAuthConfig{
+			Enabled:    true,
+			Issuer:     "https://oauth.example.com",
+			SigningKey: b64key(raw),
+		},
+	}}
+
+	key, err := p.parseOrGenerateSigningKey()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(key, []byte(raw)) {
+		t.Errorf("decoded key = %q, want %q", key, raw)
+	}
+}
+
+func TestParsePreviousSigningKeys(t *testing.T) {
+	t.Run("empty yields nil", func(t *testing.T) {
+		keys, err := parsePreviousSigningKeys(nil)
+		if err != nil || keys != nil {
+			t.Errorf("parsePreviousSigningKeys() = %v, %v; want nil, nil", keys, err)
+		}
+	})
+
+	t.Run("valid keys decode", func(t *testing.T) {
+		keys, err := parsePreviousSigningKeys([]string{
+			b64key("previous-one-signing-key-32-bytes-long"),
+			b64key("previous-two-signing-key-32-bytes-long"),
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(keys) != 2 {
+			t.Fatalf("got %d keys, want 2", len(keys))
+		}
+	})
+
+	t.Run("invalid base64 errors", func(t *testing.T) {
+		if _, err := parsePreviousSigningKeys([]string{"not!base64!"}); err == nil {
+			t.Error("expected error for invalid base64")
+		}
+	})
+
+	t.Run("too-short key errors", func(t *testing.T) {
+		if _, err := parsePreviousSigningKeys([]string{b64key("short")}); err == nil {
+			t.Error("expected error for key under the minimum length")
+		}
+	})
+}
+
+func TestInitOAuthSigningKey_SetsCurrentAndPrevious(t *testing.T) {
+	current := "current-signing-key-at-least-32-bytes-x"
+	previous := "previous-signing-key-at-least-32-bytes"
+	p := &Platform{config: &Config{
+		Server: ServerConfig{Transport: "http"},
+		OAuth: OAuthConfig{
+			Enabled:             true,
+			Issuer:              "https://oauth.example.com",
+			SigningKey:          b64key(current),
+			PreviousSigningKeys: []string{b64key(previous)},
+		},
+	}}
+
+	if err := p.initOAuthSigningKey(); err != nil {
+		t.Fatalf("initOAuthSigningKey() error = %v", err)
+	}
+	if !bytes.Equal(p.oauthKeys.current, []byte(current)) {
+		t.Errorf("oauthKeys.current = %q, want %q", p.oauthKeys.current, current)
+	}
+	if len(p.oauthKeys.previous) != 1 || !bytes.Equal(p.oauthKeys.previous[0], []byte(previous)) {
+		t.Errorf("oauthKeys.previous = %q, want one entry %q", p.oauthKeys.previous, previous)
+	}
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -160,8 +161,11 @@ type Platform struct {
 	apiKeyAuth    *auth.APIKeyAuthenticator
 
 	// OAuth
-	oauthHandle     *oauthserver.Handle
-	oauthSigningKey []byte
+	oauthHandle *oauthserver.Handle
+	// oauthKeys holds the active signing key plus verify-only previous keys.
+	// Grouped into one field so rotation support does not widen the Platform
+	// struct past its frozen field ceiling.
+	oauthKeys oauthSigningKeys
 
 	// Browser session (OIDC login flow + cookie-based auth for the web UI)
 	browserSession *browserauth.Session
@@ -980,6 +984,16 @@ func (p *Platform) applyConfigEntry(key, value string) {
 	p.config.ApplyConfigEntry(key, value)
 }
 
+// oauthSigningKeys bundles the active OAuth JWT signing key with the verify-only
+// previous keys retained across a rotation, so the Platform carries both in a
+// single field.
+type oauthSigningKeys struct {
+	// current signs new tokens and verifies tokens bearing its kid.
+	current []byte
+	// previous verify tokens minted with a prior key during a rotation window.
+	previous [][]byte
+}
+
 // initOAuthSigningKey parses or generates the OAuth signing key.
 // This must be called before initAuth so the OAuth authenticator can be configured.
 func (p *Platform) initOAuthSigningKey() error {
@@ -991,8 +1005,48 @@ func (p *Platform) initOAuthSigningKey() error {
 	if err != nil {
 		return fmt.Errorf("configuring OAuth signing key: %w", err)
 	}
-	p.oauthSigningKey = signingKey
+	p.oauthKeys.current = signingKey
+
+	previous, err := parsePreviousSigningKeys(p.config.OAuth.PreviousSigningKeys)
+	if err != nil {
+		return fmt.Errorf("configuring OAuth previous signing keys: %w", err)
+	}
+	p.oauthKeys.previous = previous
 	return nil
+}
+
+// parsePreviousSigningKeys decodes the verify-only previous signing keys used to
+// keep live sessions valid across a rotation. Each is decoded and length-checked
+// by the same decodeSigningKey helper as the active key, so both key classes
+// validate identically. A free function (not a *Platform method) so it does not
+// widen the Platform method surface.
+func parsePreviousSigningKeys(raw []string) ([][]byte, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	keys := make([][]byte, 0, len(raw))
+	for i, encoded := range raw {
+		key, err := decodeSigningKey(encoded)
+		if err != nil {
+			return nil, fmt.Errorf("previous signing key %d: %w", i, err)
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+// decodeSigningKey decodes a base64-encoded HMAC signing key and enforces the
+// minimum length. Shared by the active key and the verify-only previous keys so
+// the two never drift apart in how they are decoded or validated.
+func decodeSigningKey(encoded string) ([]byte, error) {
+	key, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decoding signing key: %w", err)
+	}
+	if len(key) < minSigningKeyLength {
+		return nil, fmt.Errorf("signing key must be at least %d bytes", minSigningKeyLength)
+	}
+	return key, nil
 }
 
 // initProviders initializes semantic, query, and storage providers.
@@ -1123,10 +1177,11 @@ func (p *Platform) authInput() iam.Input {
 	return iam.Input{
 		OAuthEnabled: p.config.OAuth.Enabled,
 		OAuthJWT: auth.OAuthJWTConfig{
-			Issuer:        p.config.OAuth.Issuer,
-			SigningKey:    p.oauthSigningKey,
-			RoleClaimPath: oidc.RoleClaimPath,
-			RolePrefix:    oidc.RolePrefix,
+			Issuer:              p.config.OAuth.Issuer,
+			SigningKey:          p.oauthKeys.current,
+			PreviousSigningKeys: p.oauthKeys.previous,
+			RoleClaimPath:       oidc.RoleClaimPath,
+			RolePrefix:          oidc.RolePrefix,
 		},
 		OIDCEnabled: oidc.Enabled,
 		OIDC: auth.OIDCConfig{
@@ -1291,7 +1346,7 @@ func (p *Platform) initOAuth() error {
 	cfg := oauthserver.Config{
 		Issuer:         p.config.OAuth.Issuer,
 		AccessTokenTTL: 1 * time.Hour,
-		SigningKey:     p.oauthSigningKey,
+		SigningKey:     p.oauthKeys.current,
 		Clients:        make([]oauthserver.Client, 0, len(p.config.OAuth.Clients)),
 		DCR: oauthserver.DCR{
 			Enabled:                 p.config.OAuth.DCR.Enabled,
@@ -1347,15 +1402,16 @@ func (p *Platform) initOAuth() error {
 // parseOrGenerateSigningKey parses the configured signing key or generates a random one.
 func (p *Platform) parseOrGenerateSigningKey() ([]byte, error) {
 	if p.config.OAuth.SigningKey != "" {
-		// Decode base64-encoded key from config
-		key, err := base64.StdEncoding.DecodeString(p.config.OAuth.SigningKey)
-		if err != nil {
-			return nil, fmt.Errorf("decoding signing key: %w", err)
-		}
-		if len(key) < minSigningKeyLength {
-			return nil, fmt.Errorf("signing key must be at least %d bytes", minSigningKeyLength)
-		}
-		return key, nil
+		return decodeSigningKey(p.config.OAuth.SigningKey)
+	}
+
+	// No key configured. On an HTTP deployment, refuse to auto-generate: a
+	// per-process key makes each replica reject tokens minted by its peers.
+	// Config.Validate reports the same condition, but Validate is not on every
+	// startup path, so this is the genuine boot-time gate. stdio and the
+	// explicit ephemeral escape hatch fall through to generation.
+	if p.config.requiresConfiguredSigningKey() {
+		return nil, errors.New(errOAuthSigningKeyRequiredMsg)
 	}
 
 	// Generate random key if not configured (not recommended for production)
@@ -1363,7 +1419,13 @@ func (p *Platform) parseOrGenerateSigningKey() ([]byte, error) {
 	if _, err := rand.Read(key); err != nil {
 		return nil, fmt.Errorf("generating random key: %w", err)
 	}
-	slog.Warn("OAuth signing key not configured, generated random key (tokens won't survive restart)")
+	if isHTTPTransport(p.config.Server.Transport) {
+		slog.Warn("OAuth signing key not configured; generated an ephemeral per-process key. " +
+			"UNSAFE for multi-replica deployments: replicas reject each other's tokens. " +
+			"Configure oauth.signing_key for production.")
+	} else {
+		slog.Warn("OAuth signing key not configured, generated random key (tokens won't survive restart)")
+	}
 	return key, nil
 }
 

--- a/scripts/codeql-baseline.txt
+++ b/scripts/codeql-baseline.txt
@@ -35,3 +35,15 @@ go/sql-injection pkg/audit/postgres/store.go:195
 # import and truncateForLog control-char stripping were added in #861;
 # same sink, same exchange, unchanged.
 go/request-forgery pkg/admin/gateway_oauth_handler.go:498
+
+# weak-sensitive-data-hashing on the OAuth signing-key kid derivation
+# (#897). KeyID hashes the HMAC signing key with SHA-256 and truncates to
+# 8 bytes to produce a public key identifier (the JWT `kid` header), the
+# same construction as an RFC 7638 JWK thumbprint or a TLS certificate
+# fingerprint. This is deliberately a fast, deterministic hash: a stable
+# identifier must be reproducible byte-for-byte across replicas, which a
+# salted/slow password hash (bcrypt/scrypt/argon2 — what the rule wants)
+# cannot provide. The kid is non-secret by design and SHA-256's preimage
+# resistance keeps the key unrecoverable from it, so the "sensitive data"
+# the rule worries about is not exposed. Not password/credential storage.
+go/weak-sensitive-data-hashing pkg/oauth/signkey/signkey.go:26

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -60,6 +60,7 @@ pkg/audit -> pkg/observability
 pkg/audit/postgres -> pkg/audit
 pkg/auth -> internal/logsan
 pkg/auth -> pkg/middleware
+pkg/auth -> pkg/oauth/signkey
 pkg/browsersession -> internal/logsan
 pkg/browsersession -> pkg/middleware
 pkg/browsersession -> pkg/user
@@ -106,6 +107,7 @@ pkg/middleware -> pkg/session
 pkg/middleware -> pkg/storage
 pkg/middleware -> pkg/urnbuild
 pkg/oauth -> internal/logsan
+pkg/oauth -> pkg/oauth/signkey
 pkg/oauth -> pkg/observability
 pkg/oauth -> pkg/ratelimit
 pkg/oauth/postgres -> pkg/oauth


### PR DESCRIPTION
## Summary

Adds `kid`-based HS256 signing-key rotation for OAuth access tokens and hard-fails startup when an HTTP deployment runs OAuth without a configured signing key. Part of #880 (finding 3.5).

Before this change, access tokens were HMAC-signed with a single static HS256 key with no `kid` header and no rotation path: rotating the key invalidated every live session. Worse, when no key was configured the platform auto-generated one per process with only a WARN, so a multi-replica HTTP deployment minted tokens each replica's peers rejected — an intermittent-auth-failure class of bug.

## What changed

### Key rotation with `kid`
- **`pkg/oauth/signkey/`** (new package) — a shared HMAC key-ring. `KeyID` derives a stable, process-independent `kid` as the hex of the first 8 bytes of `SHA-256(key)` (the same construction as an RFC 7638 JWK thumbprint). `Ring` resolves a verification key by `kid` across the current key plus verify-only previous keys, and yields the ordered candidate list for legacy no-`kid` tokens. One abstraction consumed by both the signing and verifying sides.
- **`pkg/oauth/server.go`** — stamps the `kid` header on every minted access token. HS256 algorithm pinning is unchanged; opaque-token fallback (no key) is unaffected.
- **`pkg/auth/oauth.go`** — verification selects the key by the token's `kid` in a single parse:
  - known `kid` → verify with exactly that key;
  - unknown `kid` → reject (key retired, or foreign token);
  - no `kid` (legacy, pre-upgrade token) → try current then previous keys, surfacing the signer's real error (e.g. expiry) rather than a later key's masked signature mismatch.

### Config, rotation, and the HTTP hard-fail
- **`pkg/platform/config.go`** — adds `oauth.previous_signing_keys` (base64, verify-only) and `oauth.allow_ephemeral_signing_key` (bool, default false). Config validation errors when OAuth is enabled on an HTTP-family transport with no signing key.
- **`pkg/platform/platform.go`** — parses previous keys, and enforces the same hard-fail at the genuine boot-time gate (`Config.Validate` is not on every startup path). `stdio` keeps the auto-generate-plus-WARN behavior (single-process by construction); the ephemeral escape hatch restores it for single-replica HTTP dev setups with an explicit "unsafe for replicas" warning. The current + previous keys are grouped into one struct field so the change holds the frozen Platform god-object field ceiling.
- **`pkg/admin/config_handler.go`** — redacts `previous_signing_keys` (a list of HMAC secrets) in `GET /admin/config`. The existing redactor only masked scalar secrets; a sensitive list would otherwise have leaked.

### Rotation procedure (two-phase)
Documented in `docs/auth/oauth-server.md`. Rotating on a multi-replica deployment must be two-phase so every replica can verify the new key *before* any replica signs with it:
1. Add the new key to `previous_signing_keys` (verify-only) everywhere, keep the old `signing_key`, roll-restart.
2. Promote: set `signing_key` to the new key, move the old key into `previous_signing_keys`, roll-restart.
3. After the access-token TTL (1h), drop the old key and roll-restart.

A single-phase swap would cause intermittent 401s during the rolling restart, and the docs call this out explicitly.

### Docs
`docs/server/configuration.md`, `docs/auth/oauth-server.md` (rotation runbook + a "Signing Key Required on HTTP" upgrade note), `docs/llms.txt`, `docs/llms-full.txt`, and `configs/platform.yaml`.

## Breaking change

An HTTP deployment (`server.transport: http` or `sse`) with OAuth enabled but **no** `oauth.signing_key` previously booted with an auto-generated per-process key and a warning; it now **fails to start**, naming the missing key. Fix: configure a persistent `oauth.signing_key` (correct for any real deployment), or set `oauth.allow_ephemeral_signing_key: true` for a single-replica dev/demo install. `stdio` deployments are unaffected.

## Acceptance criteria (all covered by tests)

- A token signed with the old key verifies while the old key is in `previous_signing_keys`; it fails after removal. (`TestOAuthJWT_Rotation`)
- New tokens carry a `kid`. (`TestGenerateAccessToken_CarriesKID`)
- A token with an unknown `kid` is rejected; a token with no `kid` verifies against current and previous keys. (`TestOAuthJWT_KidSelection`, `TestOAuthJWT_LegacyNoKid`)
- Config validation: `http` + OAuth enabled + no key = startup error naming `oauth.signing_key`; same config with `allow_ephemeral_signing_key: true` = boot with warning; `stdio` + no key = unchanged. (`TestConfigValidate`, `pkg/platform/oauth_signkey_test.go`)
- Non-HMAC (`alg=none`/RS256) and expired legacy tokens are handled correctly. (`TestOAuthJWT_RejectsNonHMACAlg`, `TestOAuthJWT_LegacyExpiredSurfacesExpiryError`)
- `make doc-check` clean.

## Verification

`make verify` passes end-to-end: race tests, patch coverage 98.6%, lint, gosec, semgrep, CodeQL, mutation testing, dead-code, doc-check, emdash-check, and GoReleaser dry-run.

Two rounds of high-effort adversarial review were run against the diff; every confirmed finding was fixed before this PR (masked legacy-verify error, single-phase→two-phase rotation runbook, admin secret redaction, a stale config comment, and a shared decode helper to prevent current/previous key validation drift).

One CodeQL alert (`go/weak-sensitive-data-hashing` on the `kid` derivation) is baselined with rationale in `scripts/codeql-baseline.txt`: the `kid` is a public key fingerprint, not password storage, and must use a fast deterministic hash so every replica computes the same value.

Closes #897
