### PR TITLE
build(release): SLSA badge to artifact attestations; pin gremlins + scheduled mutation (#886, #889)

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,36 @@
+name: Mutation Testing
+
+# Mutation testing (gremlins) is too slow for a per-commit gate, so it does not
+# run in CI on push/PR. It runs weekly here and on demand via workflow_dispatch.
+# A failing run does not block any merge (a scheduled job cannot); its red/green
+# history is the signal. Locally the same check runs in `make verify-release`.
+on:
+  schedule:
+    # Weekly, Sunday 08:00 UTC (low-traffic window).
+    - cron: '0 8 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    # Mutation testing over ./pkg/... is expensive; cap the run generously.
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.26.5'
+          cache: true
+
+      - name: Install gremlins
+        # Keep this version in sync with GREMLINS_VERSION in the Makefile.
+        run: go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0
+
+      - name: Run mutation testing
+        run: make mutate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*checksums*.txt
+
       - name: Build MCPB bundles
         run: |
           # Extract version from tag (remove 'v' prefix)
@@ -145,7 +153,11 @@ jobs:
           # Publish the server to the MCP registry
           mcp-publisher publish
 
-  # NOTE: SLSA provenance job removed due to false positive "private repository" detection
+  # NOTE: The slsa-github-generator provenance job was removed due to a false
+  # positive "private repository" detection that halts on public repos.
   # See: https://github.com/slsa-framework/slsa-github-generator/issues
-  # The workflow incorrectly detects public repos as private and halts.
-  # Re-add when the upstream bug is fixed.
+  # In its place, the "Attest build provenance" step above produces GitHub
+  # artifact attestations (actions/attest-build-provenance) for the release
+  # archives and checksums, earning the granted attestations: write permission.
+  # The slsa-github-generator job can replace those attestations when the
+  # upstream bug is fixed.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -191,3 +191,9 @@ release:
     cosign verify-blob --bundle mcp-data-platform_{{ .Version }}_linux_amd64.tar.gz.sigstore.json \
       mcp-data-platform_{{ .Version }}_linux_amd64.tar.gz
     ```
+
+    Archives and checksums also carry GitHub artifact attestations. Verify with:
+    ```bash
+    gh attestation verify mcp-data-platform_{{ .Version }}_linux_amd64.tar.gz \
+      --repo txn2/mcp-data-platform
+    ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,10 @@ AI-generated prose (PR descriptions, commit messages, reviews, explanations) is 
    - CodeQL analysis — `security-and-quality` query suite, fails on error-level findings
    - Documentation check — warns when documentation-worthy changes lack doc updates (soft warning)
    - Dead code analysis
-   - Mutation testing (`gremlins unleash --threshold-efficacy 60`) — ≥60% kill rate
    - GoReleaser dry-run — validates build, Docker, and release config
    - All checks must pass locally before considering code "tested"
+
+   Mutation testing (`gremlins unleash --threshold-efficacy 60`, ≥60% kill rate) is deliberately **not** part of `make verify` — it is too slow for a per-commit gate (the Makefile `verify` target carries a comment forbidding its re-addition). It runs in `make verify-release` (pre-tag, local) and on a weekly schedule in CI via `.github/workflows/mutation.yml`; gremlins is version-pinned by `GREMLINS_VERSION` and enforced by tools-check like the other tools.
 
    **Parity-gap incident (2026-05-08, PR #377)**: local `gosec 2.26.1` silently dropped the G704 SSRF taint rule that CI's pinned `v2.22.0` enforces. `make verify` passed locally; CI rejected the same diff with a real SSRF bug. The tools-check version pin is the structural fix — discipline alone has been insufficient.
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ CV_EMBED_DIR := ./internal/contentviewer/dist
 # Tool versions — keep in sync with .github/workflows/ci.yml
 GOLANGCI_LINT_VERSION := v2.11.4
 GOSEC_VERSION := v2.27.1
+GREMLINS_VERSION := v0.6.0
 
 # Go commands
 GO := go
@@ -394,7 +395,18 @@ tools-check:
 	which semgrep > /dev/null 2>&1       || missing="$$missing  semgrep: pip3 install semgrep\n"; \
 	which codeql > /dev/null 2>&1        || missing="$$missing  codeql: brew install codeql\n"; \
 	which deadcode > /dev/null 2>&1      || missing="$$missing  deadcode: go install golang.org/x/tools/cmd/deadcode@latest\n"; \
-	which gremlins > /dev/null 2>&1      || missing="$$missing  gremlins: go install github.com/go-gremlins/gremlins/cmd/gremlins@latest\n"; \
+	if ! which gremlins > /dev/null 2>&1; then \
+		missing="$$missing  gremlins: go install github.com/go-gremlins/gremlins/cmd/gremlins@$(GREMLINS_VERSION)\n"; \
+	else \
+		v=$$(go version -m $$(which gremlins) 2>/dev/null | awk '$$1=="mod" && $$2 ~ /gremlins/ {print $$3}'); \
+		if [ -z "$$v" ] || [ "$$v" = "(devel)" ]; then \
+			v=$$(gremlins --version 2>&1 | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1); \
+			case "$$v" in v*) ;; *) v="v$$v";; esac; \
+		fi; \
+		if [ "$$v" != "$(GREMLINS_VERSION)" ]; then \
+			mismatch="$$mismatch  gremlins: have $$v, want $(GREMLINS_VERSION) — go install github.com/go-gremlins/gremlins/cmd/gremlins@$(GREMLINS_VERSION)\n"; \
+		fi; \
+	fi; \
 	which goreleaser > /dev/null 2>&1    || missing="$$missing  goreleaser: brew install goreleaser\n"; \
 	which swag > /dev/null 2>&1          || missing="$$missing  swag: go install github.com/swaggo/swag/cmd/swag@latest\n"; \
 	if [ -n "$$missing" ]; then \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![codecov](https://codecov.io/gh/txn2/mcp-data-platform/graph/badge.svg)](https://codecov.io/gh/txn2/mcp-data-platform)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13548/badge)](https://www.bestpractices.dev/projects/13548)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/txn2/mcp-data-platform/badge)](https://scorecard.dev/viewer/?uri=github.com/txn2/mcp-data-platform)
-[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 [![Signed by Cosign](https://img.shields.io/badge/artifacts-signed_by_cosign-blue?logo=sigstore&logoColor=white)](https://github.com/sigstore/cosign)
 [![Docker](https://img.shields.io/badge/ghcr.io-txn2%2Fmcp--data--platform-blue?logo=docker)](https://github.com/txn2/mcp-data-platform/pkgs/container/mcp-data-platform)
 


### PR DESCRIPTION
## Summary

Build/release truth-in-labeling batch closing the two remaining #880 Tier-2 findings. Both make the release/CI machinery match the project's public claims. No Go source is touched.

## Changes

### #886 (finding 2.1) — SLSA badge / artifact attestations
- `README.md`: removed the `SLSA 3` badge. The slsa-github-generator provenance job was removed from `release.yml` (its NOTE comment cites a false-positive private-repo detection), so the badge claimed a level the pipeline no longer produces. Remaining badges unchanged.
- `.github/workflows/release.yml`: added an "Attest build provenance" step after GoReleaser using `actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373` (v4.1.1, SHA-pinned per repo convention), attesting `dist/*.tar.gz`, `dist/*.zip`, and `dist/*checksums*.txt`. This earns the already-granted `attestations: write` permission. Verified the globs match real GoReleaser output: `.goreleaser.yml` produces tar.gz archives, a windows `zip` override, and `checksums.txt`.
- `.goreleaser.yml`: added a `gh attestation verify` line to the release-notes footer alongside the existing cosign instructions.
- Amended the SLSA NOTE comment to record that attestations are now in use and the slsa-github-generator job can replace them when the upstream bug is fixed.

### #889 (finding 2.4) — pin gremlins, correct CLAUDE.md, scheduled mutation workflow
- `Makefile`: added `GREMLINS_VERSION := v0.6.0` (current latest release) next to the other tool pins, and added a version-equality check to `tools-check` mirroring the golangci-lint/gosec pattern (primary: `go version -m` build info; fallback: `gremlins --version`). This closes the last tools-check parity gap (#880 called out gremlins as the one unpinned tool at `Makefile:397`). The install hint now uses `@$(GREMLINS_VERSION)` instead of `@latest`.
- `CLAUDE.md`: the Testing Definition list wrongly included mutation testing under `make verify`. Corrected: mutation testing is deliberately NOT in `make verify` (the target carries a comment forbidding its re-addition); it runs in `make verify-release` (pre-tag, local) and weekly in CI. Did not re-add `mutate` to `verify`.
- `.github/workflows/mutation.yml` (new): `schedule` (weekly, Sunday 08:00 UTC) + `workflow_dispatch`, minimal `contents: read` permission, SHA-pinned checkout/setup-go (pins copied from `ci.yml`), installs pinned gremlins, runs `make mutate`, `timeout-minutes: 120`. A failing scheduled run does not block merges by design; its history is the signal.

## Verification (run this turn)

- `make verify` — green ("=== All checks passed ==="; full CI-equivalent suite including tools-check, race tests, lint, gosec/govulncheck, semgrep, CodeQL, coverage, patch-coverage, dead-code, and the GoReleaser dry-run). tools-check now enforces the gremlins pin; verified it passes at v0.6.0 and fails on a forced mismatch (`make tools-check GREMLINS_VERSION=v0.0.1` → FAIL with correct install hint). GoReleaser dry-run (`release-check`) validates the `.goreleaser.yml` footer change.
- `actionlint` (via `go run`) on `release.yml` and `mutation.yml`: no findings in the added attestation step or in `mutation.yml`. The only actionlint output is 3 pre-existing info-level SC2086 warnings at the unchanged `server.json` prep step (line 125), not touched by this PR.

## Cannot be verified pre-merge (post-merge / post-release steps)

- **#886 attestations**: only produced by a real tagged release. After the next release, verify with:
  `gh attestation verify mcp-data-platform_<version>_linux_amd64.tar.gz --repo txn2/mcp-data-platform`
- **#889 mutation workflow**: `schedule` triggers only exist on the default branch after merge; the first real run is the next Sunday 08:00 UTC (or trigger manually via workflow_dispatch to confirm sooner).

## Closing keywords

Closes #886
Closes #889
