### PR TITLE
test(ci): execute orphaned integration-tagged tests + add escape guard

### DIFF
--- a/integration_guard_test.go
+++ b/integration_guard_test.go
@@ -1,0 +1,170 @@
+package mcp_data_platform_test
+
+import (
+	"fmt"
+	"go/ast"
+	"go/build/constraint"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// This guard closes the "integration test that never runs" gap (#880 finding
+// 3.1). CI executes integration-tagged tests only through `make test-realdb`,
+// which runs `go test -tags=integration -run 'RealDB' ./...`. A test whose
+// name does not contain "RealDB" therefore runs nowhere automated and rots
+// silently. TestIntegrationTestsAreExecuted fails when such an orphan exists,
+// turning silent rot into a compile-adjacent failure.
+
+// allowlistedIntegrationDirs maps a repo-relative directory prefix to the
+// justification for why every integration-tagged test under it may skip the
+// RealDB-executed pattern. These suites need external systems CI does not
+// provide and stay manual.
+var allowlistedIntegrationDirs = map[string]string{
+	"test/e2e":   "manual e2e suite against a live DataHub / assembled server; a nightly is #880 finding 3.4",
+	"test/smoke": "manual post-deploy smoke against a running MCP server (requires MCP_API_KEY)",
+}
+
+// allowlistedIntegrationFuncs maps "relpath::FuncName" to a justification for a
+// single integration-tagged test that cannot run under `make test-realdb`.
+var allowlistedIntegrationFuncs = map[string]string{
+	"pkg/platform/integration_embedjobs_realollama_test.go::TestEmbedJobs_RealOllama_BatchedPathCompletes": "requires a live Ollama container + model pull; too heavy for the per-commit RealDB gate",
+}
+
+// TestIntegrationTestsAreExecuted walks the module for integration-tagged test
+// files and fails unless every test function either matches the "RealDB"
+// pattern that `make test-realdb` runs or carries a justified allowlist entry.
+func TestIntegrationTestsAreExecuted(t *testing.T) {
+	projectRoot, err := filepath.Abs(".")
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	walkErr := filepath.Walk(projectRoot, func(path string, info os.FileInfo, fErr error) error {
+		if fErr != nil {
+			return fErr
+		}
+		if info.IsDir() {
+			if path != projectRoot && skipWalkDir(info.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(info.Name(), "_test.go") {
+			return nil
+		}
+		content, readErr := os.ReadFile(path) //nolint:gosec // test reads project sources
+		if readErr != nil {
+			return fmt.Errorf("reading %s: %w", path, readErr)
+		}
+		if !requiresIntegrationTag(content) {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(projectRoot, path)
+		require.NoError(t, relErr)
+		rel = filepath.ToSlash(rel)
+
+		file, parseErr := parser.ParseFile(fset, path, content, 0)
+		require.NoError(t, parseErr, "parsing %s", rel)
+
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || !isTestFuncName(fn.Name.Name) {
+				continue
+			}
+			require.True(t, integrationTestReachesCI(rel, fn.Name.Name),
+				integrationOrphanMessage(rel, fn.Name.Name))
+		}
+		return nil
+	})
+	require.NoError(t, walkErr)
+}
+
+// skipWalkDir reports whether a directory should be pruned from the walk:
+// version control, dependency trees, and hidden directories hold no
+// first-party Go tests.
+func skipWalkDir(name string) bool {
+	switch name {
+	case ".git", "node_modules", "vendor", "testdata":
+		return true
+	}
+	return strings.HasPrefix(name, ".")
+}
+
+// requiresIntegrationTag reports whether the file's build constraints require
+// the "integration" build tag: it builds when integration is set but not when
+// no tags are set. Build constraints precede the package clause, so the scan
+// stops there.
+func requiresIntegrationTag(content []byte) bool {
+	for line := range strings.SplitSeq(string(content), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "package ") {
+			return false
+		}
+		if !constraint.IsGoBuild(trimmed) {
+			continue
+		}
+		expr, err := constraint.Parse(trimmed)
+		if err != nil {
+			return false
+		}
+		withTag := expr.Eval(func(tag string) bool { return tag == "integration" })
+		withoutTag := expr.Eval(func(string) bool { return false })
+		return withTag && !withoutTag
+	}
+	return false
+}
+
+// isTestFuncName reports whether name is a Go test function name: "Test"
+// followed by a non-lowercase rune. TestMain is the process entry point, not a
+// test the runner executes, so it is excluded.
+func isTestFuncName(name string) bool {
+	if name == "TestMain" {
+		return false
+	}
+	rest, ok := strings.CutPrefix(name, "Test")
+	if !ok || rest == "" {
+		return false
+	}
+	r := rest[0]
+	return r < 'a' || r > 'z'
+}
+
+// integrationTestReachesCI reports whether an integration-tagged test at rel
+// with the given function name runs in a CI-executed pattern or is justified
+// on an allowlist.
+func integrationTestReachesCI(rel, name string) bool {
+	if strings.Contains(name, "RealDB") {
+		return true
+	}
+	for dir := range allowlistedIntegrationDirs {
+		if rel == dir || strings.HasPrefix(rel, dir+"/") {
+			return true
+		}
+	}
+	_, ok := allowlistedIntegrationFuncs[rel+"::"+name]
+	return ok
+}
+
+// integrationOrphanMessage tells the author exactly which options resolve an
+// orphaned integration test.
+func integrationOrphanMessage(rel, name string) string {
+	return fmt.Sprintf(
+		"integration-tagged test %s in %s runs nowhere automated: CI executes integration "+
+			"tests only via `make test-realdb` (go test -tags=integration -run 'RealDB' ./...), "+
+			"and this name does not contain \"RealDB\".\nResolve it one of three ways:\n"+
+			"  1. Needs only Docker/testcontainers (or nothing special): rename it to contain "+
+			"\"RealDB\" (e.g. %s_RealDB) so `make test-realdb` runs it.\n"+
+			"  2. Needs no infrastructure at all: remove the `//go:build integration` tag so it "+
+			"runs in the plain `go test ./...` step.\n"+
+			"  3. Needs an external service CI cannot provide (Ollama, a running MCP, live "+
+			"DataHub): add an explicit env-var t.Skip and an allowlist entry in "+
+			"integration_guard_test.go (allowlistedIntegrationDirs or allowlistedIntegrationFuncs) "+
+			"with a one-line reason.",
+		name, rel, name)
+}

--- a/pkg/database/migrate/migrate_test.go
+++ b/pkg/database/migrate/migrate_test.go
@@ -5,6 +5,8 @@ package migrate
 import (
 	"context"
 	"database/sql"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,22 +17,50 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-func TestMigrations(t *testing.T) {
+// latestMigrationVersion returns the highest version number in the embedded
+// migration set. Deriving it here keeps the round-trip assertions correct as
+// migrations are added, instead of hardcoding a count that silently rots (the
+// gap that let this test go stale at version 2 while the set grew past 79).
+func latestMigrationVersion(t *testing.T) uint {
+	t.Helper()
+	entries, err := migrations.ReadDir("migrations")
+	require.NoError(t, err)
+	var maxVersion uint
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".up.sql") {
+			continue
+		}
+		numStr, _, ok := strings.Cut(name, "_")
+		require.True(t, ok, "unexpected migration filename %q", name)
+		n, parseErr := strconv.ParseUint(numStr, 10, 64)
+		require.NoError(t, parseErr, "parsing version from %q", name)
+		if uint(n) > maxVersion {
+			maxVersion = uint(n)
+		}
+	}
+	require.NotZero(t, maxVersion, "should find at least one migration")
+	return maxVersion
+}
+
+func TestMigrations_RealDB(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
 
 	ctx := context.Background()
 
-	// Start PostgreSQL container
-	pgContainer, err := postgres.Run(ctx, "postgres:15",
+	// Start PostgreSQL container. The pgvector image is required because the
+	// migration set creates the `vector` extension (000031+); a plain postgres
+	// image fails the CREATE EXTENSION with "extension vector is not available".
+	pgContainer, err := postgres.Run(ctx, "pgvector/pgvector:pg16",
 		postgres.WithDatabase("testdb"),
 		postgres.WithUsername("testuser"),
 		postgres.WithPassword("testpass"),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second),
+				WithStartupTimeout(5*time.Minute),
 		),
 	)
 	require.NoError(t, err)
@@ -44,6 +74,8 @@ func TestMigrations(t *testing.T) {
 	db, err := sql.Open("postgres", connStr)
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
+
+	latest := latestMigrationVersion(t)
 
 	// Test Run (up)
 	t.Run("Run applies migrations", func(t *testing.T) {
@@ -76,7 +108,7 @@ func TestMigrations(t *testing.T) {
 		version, dirty, err := Version(db)
 		require.NoError(t, err)
 		require.False(t, dirty)
-		require.Equal(t, uint(2), version)
+		require.Equal(t, latest, version)
 	})
 
 	// Test Run is idempotent
@@ -87,7 +119,7 @@ func TestMigrations(t *testing.T) {
 		version, dirty, err := Version(db)
 		require.NoError(t, err)
 		require.False(t, dirty)
-		require.Equal(t, uint(2), version)
+		require.Equal(t, latest, version)
 	})
 
 	// Test Down
@@ -179,7 +211,7 @@ func configKey(t *testing.T, db *sql.DB, name, key string) (string, bool) {
 // 000050 migration rewrites the api row onto the canonical schema,
 // leaves the mcp row untouched, preserves the encrypted secret blob
 // verbatim, is idempotent, and reverses cleanly on down.
-func TestMigration050_UnifyOAuthRoundTrip(t *testing.T) {
+func TestMigration050_UnifyOAuthRoundTrip_RealDB(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}

--- a/pkg/mcpapps/integration_test.go
+++ b/pkg/mcpapps/integration_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package mcpapps_test
 
 import (
@@ -126,7 +124,10 @@ func TestMCPAppsIntegration(t *testing.T) {
 			t.Fatalf("Middleware call failed: %v", err)
 		}
 
-		listResult := result.(*mcp.ListToolsResult)
+		listResult, ok := result.(*mcp.ListToolsResult)
+		if !ok {
+			t.Fatalf("result type = %T, want *mcp.ListToolsResult", result)
+		}
 
 		// Find trino_query and verify _meta.ui
 		for _, tool := range listResult.Tools {
@@ -138,7 +139,10 @@ func TestMCPAppsIntegration(t *testing.T) {
 				if !ok {
 					t.Fatal("trino_query should have ui in Meta")
 				}
-				uiMap := ui.(map[string]string)
+				uiMap, ok := ui.(map[string]string)
+				if !ok {
+					t.Fatalf("ui meta type = %T, want map[string]string", ui)
+				}
 				if uiMap["resourceUri"] != "ui://query-results" {
 					t.Errorf("resourceUri = %q, want ui://query-results", uiMap["resourceUri"])
 				}
@@ -154,7 +158,7 @@ func TestMCPAppsIntegration(t *testing.T) {
 
 	t.Run("resource handler serves HTML", func(t *testing.T) {
 		// Read the HTML directly from the filesystem
-		content, err := os.ReadFile(filepath.Join(appsDir, "index.html"))
+		content, err := os.ReadFile(filepath.Join(appsDir, "index.html")) //nolint:gosec // test reads a fixed repo asset under apps/
 		if err != nil {
 			t.Fatalf("Failed to read index.html: %v", err)
 		}
@@ -175,7 +179,7 @@ func TestMCPAppsIntegration(t *testing.T) {
 func TestQueryResultsHTML(t *testing.T) {
 	appsDir := testAppsDir(t)
 
-	content, err := os.ReadFile(filepath.Join(appsDir, "index.html"))
+	content, err := os.ReadFile(filepath.Join(appsDir, "index.html")) //nolint:gosec // test reads a fixed repo asset under apps/
 	if err != nil {
 		t.Fatalf("Failed to read index.html: %v", err)
 	}
@@ -195,13 +199,11 @@ func TestQueryResultsHTML(t *testing.T) {
 	}
 }
 
-// TestFullPlatformIntegration tests with actual Platform config.
-func TestFullPlatformIntegration(t *testing.T) {
-	t.Log("To test the full platform integration:")
-	t.Log("1. Build: go build -o mcp-data-platform ./cmd/mcp-data-platform")
-	t.Log("2. Create config with mcpapps.enabled: true and apps configured with assets_path")
-	t.Log("3. Run: npx @anthropics/mcp-inspector ./mcp-data-platform --config <config.yaml>")
-	t.Log("4. In Inspector: List Tools -> verify trino_query has _meta.ui")
-	t.Log("5. In Inspector: List Resources -> verify ui://query-results exists")
-	t.Log("6. In Inspector: Read Resource ui://query-results -> verify HTML")
-}
+// Manual full-platform verification (no automated assertion possible without a
+// running server, so it is documented here rather than as a no-op test):
+//  1. Build: go build -o mcp-data-platform ./cmd/mcp-data-platform
+//  2. Create config with mcpapps.enabled: true and apps configured with assets_path
+//  3. Run: npx @anthropics/mcp-inspector ./mcp-data-platform --config <config.yaml>
+//  4. In Inspector: List Tools -> verify trino_query has _meta.ui
+//  5. In Inspector: List Resources -> verify ui://query-results exists
+//  6. In Inspector: Read Resource ui://query-results -> verify HTML

--- a/pkg/platform/integration_embedding_noop_test.go
+++ b/pkg/platform/integration_embedding_noop_test.go
@@ -38,7 +38,7 @@ import (
 //
 // This proves the structural property that no zero-vector row can
 // reach the embeddings table while in the unconfigured state.
-func TestEmbeddingNoop_EndToEnd(t *testing.T) {
+func TestEmbeddingNoop_EndToEnd_RealDB(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}

--- a/pkg/platform/integration_embedjobs_progress_test.go
+++ b/pkg/platform/integration_embedjobs_progress_test.go
@@ -87,7 +87,7 @@ func (*inMemorySink) FindGaps(_ context.Context) ([]string, error)              
 // counter from the worker's chunk callback through the Postgres
 // UPDATE to the List read path (#430), now against the generic
 // index_jobs queue.
-func TestIndexJobsProgress_EndToEnd(t *testing.T) {
+func TestIndexJobsProgress_EndToEnd_RealDB(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}

--- a/pkg/platform/integration_test.go
+++ b/pkg/platform/integration_test.go
@@ -14,17 +14,16 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
+
 	"github.com/txn2/mcp-data-platform/pkg/audit"
 	auditpostgres "github.com/txn2/mcp-data-platform/pkg/audit/postgres"
 	"github.com/txn2/mcp-data-platform/pkg/database/migrate"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
-	"github.com/txn2/mcp-data-platform/pkg/persona"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
-	"github.com/txn2/mcp-data-platform/pkg/tuning"
 )
 
-// TestAuditLogging_EndToEnd tests that audit logging works with a real PostgreSQL database.
-func TestAuditLogging_EndToEnd(t *testing.T) {
+// TestAuditLogging_EndToEnd_RealDB tests that audit logging works with a real PostgreSQL database.
+func TestAuditLogging_EndToEnd_RealDB(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -98,8 +97,8 @@ func TestAuditLogging_EndToEnd(t *testing.T) {
 	assert.Equal(t, int64(100), got.DurationMS)
 }
 
-// TestAuditAdapter_Integration tests the middleware adapter with a real database.
-func TestAuditAdapter_Integration(t *testing.T) {
+// TestAuditAdapter_Integration_RealDB tests the middleware adapter with a real database.
+func TestAuditAdapter_Integration_RealDB(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -171,52 +170,8 @@ func TestAuditAdapter_Integration(t *testing.T) {
 	assert.Equal(t, "datahub_search", events[0].ToolName)
 }
 
-// TestRuleEngine_Integration tests that rule engine actually affects behavior.
-func TestRuleEngine_Integration(t *testing.T) {
-	rules := &tuning.Rules{
-		QualityThreshold: 0.7,
-		MaxQueryLimit:    10000,
-	}
-
-	engine := tuning.NewRuleEngine(rules)
-
-	// Verify rule engine configuration surfaces the configured limits.
-	assert.Equal(t, 10000, engine.GetMaxQueryLimit())
-}
-
-// TestPersonaContext_Integration tests that persona context overrides work correctly.
-func TestPersonaContext_Integration(t *testing.T) {
-	registry := persona.NewRegistry()
-
-	// Register persona with context overrides
-	err := registry.Register(&persona.Persona{
-		Name:        "analyst",
-		DisplayName: "Data Analyst",
-		Description: "Analyze data and run queries",
-		Roles:       []string{"analyst"},
-		Context: persona.ContextOverrides{
-			DescriptionPrefix:       "You are a data analyst assistant.",
-			AgentInstructionsSuffix: "Always check DataHub before running queries.",
-		},
-		Priority: 10,
-	})
-	require.NoError(t, err)
-
-	// Get persona and verify context overrides
-	p, ok := registry.Get("analyst")
-	require.True(t, ok)
-
-	desc := p.ApplyDescription("Base platform description")
-	assert.Contains(t, desc, "You are a data analyst assistant.")
-	assert.Contains(t, desc, "Base platform description")
-
-	instructions := p.ApplyAgentInstructions("Base instructions")
-	assert.Contains(t, instructions, "Always check DataHub before running queries.")
-	assert.Contains(t, instructions, "Base instructions")
-}
-
-// TestPlatform_WithDatabase tests platform initialization with a real database.
-func TestPlatform_WithDatabase(t *testing.T) {
+// TestPlatform_WithDatabase_RealDB tests platform initialization with a real database.
+func TestPlatform_WithDatabase_RealDB(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}


### PR DESCRIPTION
Closes #893. Part of #880 (finding 3.1).

## Problem

CI executes integration-tagged tests through exactly one path: the `test` job runs `make test-realdb`, which is `go test -count=1 -tags=integration -run 'RealDB' ./...`. The plain `go test ./...` step never passes `-tags=integration`, and `make test-integration` is in neither `verify` nor CI.

Consequence: any integration-tagged test whose function name does not contain `RealDB` ran **nowhere automated** and rotted silently. This PR proved the rot was real — see the migrate test below.

## What changed (test-only, 6 files)

### 1. Route testcontainers-only tests into the RealDB gate (rename)

These need only Docker/testcontainers, so renaming them to contain `RealDB` makes the existing `make test-realdb` CI step run them with zero workflow changes:

- `pkg/database/migrate/migrate_test.go`: `TestMigrations` -> `TestMigrations_RealDB`, `TestMigration050_UnifyOAuthRoundTrip` -> `..._RealDB`
- `pkg/platform/integration_test.go`: `TestAuditLogging_EndToEnd`, `TestAuditAdapter_Integration`, `TestPlatform_WithDatabase` -> `*_RealDB`
- `pkg/platform/integration_embedjobs_progress_test.go`: `TestIndexJobsProgress_EndToEnd_RealDB`
- `pkg/platform/integration_embedding_noop_test.go`: `TestEmbeddingNoop_EndToEnd_RealDB`

### 2. Run infrastructure-free tests in the plain test step (drop the tag)

`pkg/mcpapps/integration_test.go` uses only an in-memory MCP server and reads a committed repo asset (`apps/query-results/index.html`), so it needs no build tag. Removing the tag runs it in `go test ./...`. Removing the tag also exposed the file to the default-build linter, surfacing pre-existing findings that are fixed here: two unchecked type assertions (errcheck) and two `os.ReadFile(variable)` reads (gosec G304, annotated `//nolint` as fixed-repo-asset test reads).

Two tests formerly in `pkg/platform/integration_test.go` (`TestRuleEngine_Integration`, `TestPersonaContext_Integration`) were **deleted** rather than relocated: they were near-tautological and their behavior is already covered by executed unit tests in `pkg/tuning/rules_test.go` (`TestRuleEngine_Methods`) and `pkg/persona/persona_test.go` (`TestApplyDescription`, `TestApplyAgentInstructions`).

### 3. Fix a real defect the revival surfaced

`TestMigrations_RealDB` had never executed and had rotted:

- It used a plain `postgres:15` image, which fails `CREATE EXTENSION IF NOT EXISTS vector` (migration 000031+) with `extension "vector" is not available`. Fixed to `pgvector/pgvector:pg16` (matching the rest of the RealDB suite) with the standard 5m startup wait.
- It hardcoded `require.Equal(t, uint(2), version)` and `Steps` assumptions from when the set had 2 migrations; the set now has 79. The expected latest version is now derived from the embedded migration FS (`latestMigrationVersion`), so the assertions cannot rot again as migrations are added.

The runner itself was never broken (every other RealDB test already calls `migrate.Run`); only the stale test was.

### 4. Guard against future orphans

New `integration_guard_test.go` (repo root, no build tag, next to `verify_test.go`) walks the module, detects integration-tagged files by parsing their build constraints (`go/build/constraint`), extracts test function names with `go/parser`, and fails unless each function either:

- contains `RealDB` (executed by `make test-realdb`), or
- is covered by a justified allowlist entry: `test/e2e` and `test/smoke` (manual suites needing live DataHub / a running MCP), or the single live-Ollama test (`TestEmbedJobs_RealOllama_BatchedPathCompletes`).

The failure message tells the author the three exact options (rename to `RealDB`, drop the tag, or allowlist with a reason). Verified: adding a dummy orphan makes the guard fail; removing it makes it pass.

## Verification

`make verify` passed green locally (includes `make test-realdb`, so the revived tests now gate every commit).

Revived tests executing under `-tags=integration -run RealDB`:

```
--- PASS: TestMigrations_RealDB (3.17s)
    --- PASS: TestMigrations_RealDB/Run_applies_migrations
    --- PASS: TestMigrations_RealDB/Version_returns_current_version
    --- PASS: TestMigrations_RealDB/Run_is_idempotent
    --- PASS: TestMigrations_RealDB/Down_rolls_back_migrations
    --- PASS: TestMigrations_RealDB/Steps_applies_n_migrations
--- PASS: TestMigration050_UnifyOAuthRoundTrip_RealDB (0.83s)
--- PASS: TestAuditLogging_EndToEnd_RealDB (2.36s)
--- PASS: TestAuditAdapter_Integration_RealDB (2.13s)
--- PASS: TestPlatform_WithDatabase_RealDB (2.20s)
--- PASS: TestIndexJobsProgress_EndToEnd_RealDB (2.45s)
--- PASS: TestEmbeddingNoop_EndToEnd_RealDB (3.16s)
```

mcpapps tests now executing in the plain `go test` step:

```
--- PASS: TestMCPAppsIntegration
--- PASS: TestQueryResultsHTML
ok  github.com/txn2/mcp-data-platform/pkg/mcpapps
```

## Acceptance criteria

- [x] Every integration-tagged test function runs in a CI-executed pattern or carries a justified allowlist entry; the guard enforces it and fails on a new orphan (verified with a dummy).
- [x] `make test-realdb` passes locally with the revived tests actually executing (output above).
- [x] CI's existing jobs pass unmodified (no workflow changes; routing goes through the existing `test-realdb` step).

## Out of scope / follow-ups

- The nightly for `test/e2e` is #880 finding 3.4 (separate ticket); those suites stay manual and are allowlisted here.
- The live-Ollama test stays manual (self-provisions an Ollama container + model pull, too heavy for the per-commit gate).