### PR TITLE
chore(toolkits): dedup shared helpers + idiom cleanups + perfsprint guard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - unconvert          # Unnecessary type conversions
     - whitespace         # Whitespace issues
     - godot              # Comment punctuation
+    - perfsprint         # errors.New over verb-less fmt.Errorf (#901 finding 3.9)
 
     # ===== Code Quality =====
     - gocritic           # Comprehensive checks
@@ -407,6 +408,23 @@ linters:
       errorf-multi: true
       asserts: true
       comparison: true
+
+    # perfsprint scoped to the errorf check only: a verb-less fmt.Errorf must be
+    # errors.New (the durable guard behind #901 finding 3.9). The other
+    # perfsprint nudges (strconv/concat/Sprintf simplifications) are left off to
+    # keep the linter targeted and non-noisy; CI is only-new-issues, so this
+    # gates new code without a mass rewrite of existing Sprintf usage.
+    perfsprint:
+      integer-format: false # off: strconv nudges for ints
+      int-conversion: false
+      error-format: true    # parent gate for err-error + errorf; must be on
+      err-error: false      # off: do not rewrite .Error() calls
+      errorf: true          # on: verb-less fmt.Errorf -> errors.New
+      string-format: false  # off: Sprintf1 + strconcat simplifications
+      sprintf1: false
+      strconcat: false
+      bool-format: false
+      hex-format: false
 
   exclusions:
     generated: lax

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,8 +97,10 @@ linters:
     # threshold is in tokens; 150 is the upstream default and a
     # deliberately permissive starting point. CI runs only-new-issues,
     # so the handful of pre-existing clones are grandfathered and only
-    # NEW duplication fails the gate. Ratchet the threshold DOWN in a
-    # follow-up once the existing clones are consolidated.
+    # NEW duplication fails the gate. The largest known clones — the
+    # triplicated annotation converter and the per-toolkit error/JSON
+    # result helpers — were consolidated into pkg/toolkit (#899); ratchet
+    # the threshold DOWN in a follow-up once the remaining clones are gone.
     dupl:
       threshold: 150
 
@@ -395,6 +397,10 @@ linters:
         - .Wrapf(
         - .WithMessage(
         - .WithStack(
+        # toolkit.JSONResultTyped is a result constructor for typed MCP tool
+        # handlers; its (any, error) tail exists only to match the handler
+        # signature and is always (nil, nil), so there is no error to wrap (#899).
+        - .JSONResultTyped(
 
     errorlint:
       errorf: true
@@ -411,6 +417,21 @@ linters:
       - path: generated
         linters:
           - all
+
+      # MCP tool handlers surface failures in-band via CallToolResult.IsError and
+      # return a nil Go error — a returned Go error would abort the call instead
+      # of letting the model read the message. nilerr flags this legitimate
+      # convention, so it is disabled for tool-handler code (#901) rather than
+      # suppressed on dozens of individual lines. Scoped to nilerr only; packages
+      # that return nil after an error for OTHER reasons (best-effort availability
+      # in pkg/storage, pkg/query, pkg/semantic; the resource re-read fallback)
+      # keep their per-line justification.
+      - path: pkg/toolkits/
+        linters:
+          - nilerr
+      - path: pkg/platform/(find_tools|info|connections)_tool\.go
+        linters:
+          - nilerr
 
       # Main packages can have longer functions
       - path: cmd/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ AI-generated prose (PR descriptions, commit messages, reviews, explanations) is 
 
 ## Project Structure
 
-`pkg/` holds 43 top-level packages (all public API). Depth-2 subdirectories are
+`pkg/` holds 42 top-level packages (all public API). Depth-2 subdirectories are
 shown where they represent a distinct implementation (a storage backend, an
 adapter, an indexjobs consumer); helper subpackages are omitted for brevity.
 Regenerate this list with `find pkg -mindepth 1 -maxdepth 1 -type d | sort` and
@@ -160,13 +160,12 @@ diff against the packages below when adding or removing a `pkg/` directory.
 ```
 mcp-data-platform/
 ├── cmd/mcp-data-platform/          # Entry point (main.go)
-├── pkg/                            # PUBLIC API (43 top-level packages)
+├── pkg/                            # PUBLIC API (42 top-level packages)
 │   ├── admin/                      # REST API endpoints for administrative operations
 │   ├── audit/                      # Audit logging (postgres/ = PostgreSQL implementation)
 │   ├── auth/                       # Authentication: OIDC, API keys, claims, middleware
 │   ├── authevents/                 # Durable audit history for the OAuth authorization flow
 │   ├── browsersession/             # Browser-based OIDC authentication (cookie sessions)
-│   ├── client/                     # Reserved placeholder (currently empty, no Go files)
 │   ├── configstore/                # Granular key/value storage for platform config (postgres/)
 │   ├── connbackfill/               # Seeds connection_instances with credential-free rows
 │   ├── connoauth/                  # Shared OAuth-to-upstream-MCP implementation across connection kinds

--- a/cmd/mcp-data-platform/main.go
+++ b/cmd/mcp-data-platform/main.go
@@ -765,10 +765,10 @@ func mountResourcesAPI(mux *http.ServeMux, p *platform.Platform) {
 			if errors.Is(err, browsersession.ErrCSRFInvalid) {
 				return nil, resource.ErrForbidden
 			}
-			return nil, fmt.Errorf("authentication required")
+			return nil, errors.New("authentication required")
 		}
 		if user == nil {
-			return nil, fmt.Errorf("authentication required")
+			return nil, errors.New("authentication required")
 		}
 		return buildResourceClaims(user, pr, adminPersona), nil
 	}

--- a/pkg/admin/tools.go
+++ b/pkg/admin/tools.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -164,7 +165,7 @@ func (h *Handler) callTool(w http.ResponseWriter, r *http.Request) {
 func decodeToolCallRequest(r *http.Request) (*toolCallRequest, error) {
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1MB limit
 	if err != nil {
-		return nil, fmt.Errorf("failed to read request body")
+		return nil, errors.New("failed to read request body")
 	}
 
 	var req toolCallRequest
@@ -173,7 +174,7 @@ func decodeToolCallRequest(r *http.Request) (*toolCallRequest, error) {
 	}
 
 	if req.ToolName == "" {
-		return nil, fmt.Errorf("tool_name is required")
+		return nil, errors.New("tool_name is required")
 	}
 
 	return &req, nil

--- a/pkg/audit/postgres/store.go
+++ b/pkg/audit/postgres/store.go
@@ -380,7 +380,13 @@ func (*Store) scanEvent(rows *sql.Rows) (audit.Event, error) {
 	}
 
 	if len(params) > 0 {
-		_ = json.Unmarshal(params, &event.Parameters)
+		if err := json.Unmarshal(params, &event.Parameters); err != nil {
+			// A corrupt parameters blob must not break history listing:
+			// return the event with empty Parameters and record the anomaly.
+			slog.Warn("audit: corrupt parameters JSON in stored event",
+				"event_id", event.ID, slogKeyError, err)
+			event.Parameters = nil
+		}
 	}
 	if eventKind.Valid {
 		event.EventKind = audit.EventType(eventKind.String)

--- a/pkg/audit/postgres/store_test.go
+++ b/pkg/audit/postgres/store_test.go
@@ -1,9 +1,11 @@
 package postgres
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -434,6 +436,65 @@ func TestScanEvent_AllFields(t *testing.T) {
 
 	got := results[0]
 	assertEventEqual(t, event, got)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestScanEvent_CorruptParametersJSON verifies that a row whose parameters
+// column holds invalid JSON is still returned (with empty Parameters) and that
+// the anomaly is logged at WARN: a single corrupt row must not break the whole
+// history listing.
+func TestScanEvent_CorruptParametersJSON(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var logs bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
+
+	store := New(db, Config{RetentionDays: 90})
+	event := newTestEvent()
+
+	rows := sqlmock.NewRows(selectColumns).AddRow(
+		event.ID,
+		event.Timestamp,
+		event.DurationMS,
+		event.RequestID,
+		event.SessionID,
+		event.UserID,
+		event.UserEmail,
+		event.Persona,
+		event.ToolName,
+		event.ToolkitKind,
+		event.ToolkitName,
+		event.Connection,
+		[]byte("{not valid json"), // corrupt parameters blob
+		event.Success,
+		event.ErrorMessage,
+		event.ResponseChars,
+		event.RequestChars,
+		event.ContentBlocks,
+		event.Transport,
+		event.Source,
+		event.EnrichmentApplied,
+		event.EnrichmentTokensFull,
+		event.EnrichmentTokensDedup,
+		event.EnrichmentMode,
+		event.EnrichmentMatchKind,
+		event.Authorized,
+		string(event.EventKind),
+	)
+	mock.ExpectQuery("SELECT .+ FROM audit_logs").WillReturnRows(rows)
+
+	results, err := store.Query(context.Background(), audit.QueryFilter{})
+	require.NoError(t, err)
+	require.Len(t, results, 1, "corrupt row must still be returned")
+
+	assert.Equal(t, event.ID, results[0].ID)
+	assert.Empty(t, results[0].Parameters, "corrupt parameters must yield empty Parameters")
+	assert.Contains(t, logs.String(), "corrupt parameters JSON")
+	assert.Contains(t, logs.String(), event.ID, "warning must name the event ID")
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/pkg/auth/apikey.go
+++ b/pkg/auth/apikey.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -79,7 +80,7 @@ func NewAPIKeyAuthenticator(cfg APIKeyConfig) *APIKeyAuthenticator {
 func (a *APIKeyAuthenticator) Authenticate(ctx context.Context) (*middleware.UserInfo, error) {
 	token := GetToken(ctx)
 	if token == "" {
-		return nil, fmt.Errorf("no API key found in context")
+		return nil, errors.New("no API key found in context")
 	}
 
 	a.mu.RLock()
@@ -106,7 +107,7 @@ func (a *APIKeyAuthenticator) Authenticate(ctx context.Context) (*middleware.Use
 	}
 
 	if matchedKey == nil {
-		return nil, fmt.Errorf("invalid API key")
+		return nil, errors.New("invalid API key")
 	}
 
 	if matchedKey.IsExpired() {

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -126,7 +126,7 @@ func (c *ChainedAuthenticator) Authenticate(ctx context.Context) (*middleware.Us
 	if lastErr != nil {
 		return nil, lastErr
 	}
-	return nil, fmt.Errorf("authentication failed")
+	return nil, errors.New("authentication failed")
 }
 
 // Verify interface compliance.
@@ -148,7 +148,7 @@ func (*BearerTokenExtractor) Extract(ctx context.Context) (string, error) {
 	// This is a placeholder - actual extraction depends on transport
 	token := GetToken(ctx)
 	if token == "" {
-		return "", fmt.Errorf("no bearer token found")
+		return "", errors.New("no bearer token found")
 	}
 
 	// Strip "Bearer " prefix if present
@@ -170,7 +170,7 @@ func (*APIKeyExtractor) Extract(ctx context.Context) (string, error) {
 	// This is a placeholder - actual extraction depends on transport
 	token := GetToken(ctx)
 	if token == "" {
-		return "", fmt.Errorf("no API key found")
+		return "", errors.New("no API key found")
 	}
 	return token, nil
 }

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -55,11 +55,11 @@ type OAuthJWTAuthenticator struct {
 // NewOAuthJWTAuthenticator creates a new OAuth JWT authenticator.
 func NewOAuthJWTAuthenticator(cfg OAuthJWTConfig) (*OAuthJWTAuthenticator, error) {
 	if cfg.Issuer == "" {
-		return nil, fmt.Errorf("oauth issuer is required")
+		return nil, errors.New("oauth issuer is required")
 	}
 	ring := signkey.NewRing(cfg.SigningKey, cfg.PreviousSigningKeys)
 	if ring == nil {
-		return nil, fmt.Errorf("oauth signing key is required")
+		return nil, errors.New("oauth signing key is required")
 	}
 	if cfg.Audience == "" {
 		cfg.Audience = cfg.Issuer
@@ -84,7 +84,7 @@ func NewOAuthJWTAuthenticator(cfg OAuthJWTConfig) (*OAuthJWTAuthenticator, error
 func (a *OAuthJWTAuthenticator) Authenticate(ctx context.Context) (*middleware.UserInfo, error) {
 	token := GetToken(ctx)
 	if token == "" {
-		return nil, fmt.Errorf("no token found in context")
+		return nil, errors.New("no token found in context")
 	}
 
 	// Parse and validate the JWT
@@ -96,7 +96,7 @@ func (a *OAuthJWTAuthenticator) Authenticate(ctx context.Context) (*middleware.U
 	// Extract user ID from sub claim
 	userID, _ := claims["sub"].(string)
 	if userID == "" {
-		return nil, fmt.Errorf("missing sub claim")
+		return nil, errors.New("missing sub claim")
 	}
 
 	// Extract nested user claims (from upstream IdP)
@@ -148,13 +148,13 @@ func (a *OAuthJWTAuthenticator) parseAndValidateToken(tokenString string) (map[s
 	}
 
 	if !token.Valid {
-		return nil, fmt.Errorf("invalid token")
+		return nil, errors.New("invalid token")
 	}
 
 	// Extract claims as map
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
-		return nil, fmt.Errorf("invalid claims type")
+		return nil, errors.New("invalid claims type")
 	}
 
 	// Verify issuer

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"math/big"
@@ -131,7 +132,7 @@ type jwksCache struct {
 // NewOIDCAuthenticator creates a new OIDC authenticator.
 func NewOIDCAuthenticator(cfg OIDCConfig) (*OIDCAuthenticator, error) {
 	if cfg.Issuer == "" {
-		return nil, fmt.Errorf("oidc issuer is required")
+		return nil, errors.New("oidc issuer is required")
 	}
 
 	extractor := &ClaimsExtractor{
@@ -163,7 +164,7 @@ func NewOIDCAuthenticator(cfg OIDCConfig) (*OIDCAuthenticator, error) {
 func (a *OIDCAuthenticator) Authenticate(ctx context.Context) (*middleware.UserInfo, error) {
 	token := GetToken(ctx)
 	if token == "" {
-		return nil, fmt.Errorf("no token found in context")
+		return nil, errors.New("no token found in context")
 	}
 
 	// Parse and validate the JWT
@@ -214,7 +215,7 @@ func (a *OIDCAuthenticator) parseAndValidateToken(ctx context.Context, tokenStri
 		// Get the key ID from the header
 		kid, ok := token.Header["kid"].(string)
 		if !ok {
-			return nil, fmt.Errorf("token missing kid header")
+			return nil, errors.New("token missing kid header")
 		}
 
 		// Get the public key from JWKS cache. The inbound request context is
@@ -231,13 +232,13 @@ func (a *OIDCAuthenticator) parseAndValidateToken(ctx context.Context, tokenStri
 	}
 
 	if !token.Valid {
-		return nil, fmt.Errorf("invalid token")
+		return nil, errors.New("invalid token")
 	}
 
 	// Extract claims as map
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
-		return nil, fmt.Errorf("invalid claims type")
+		return nil, errors.New("invalid claims type")
 	}
 
 	// Convert to map[string]any for compatibility
@@ -257,7 +258,7 @@ func (a *OIDCAuthenticator) parseAndValidateToken(ctx context.Context, tokenStri
 func (a *OIDCAuthenticator) parseTokenWithoutSignatureVerification(tokenString string) (map[string]any, error) {
 	parts := strings.Split(tokenString, ".")
 	if len(parts) != jwtPartCount {
-		return nil, fmt.Errorf("invalid JWT format")
+		return nil, errors.New("invalid JWT format")
 	}
 
 	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
@@ -300,7 +301,7 @@ func (a *OIDCAuthenticator) getPublicKey(ctx context.Context, kid string) (*rsa.
 	case found:
 		return key, nil
 	case expired:
-		return nil, fmt.Errorf("jwks cache expired")
+		return nil, errors.New("jwks cache expired")
 	default:
 		return nil, fmt.Errorf("key not found: %s", kid)
 	}
@@ -416,12 +417,12 @@ func (*OIDCAuthenticator) validateRequiredClaims(claims map[string]any) error {
 	// REQUIRE sub claim - every token must have a subject
 	sub, ok := claims["sub"].(string)
 	if !ok || sub == "" {
-		return fmt.Errorf("missing or invalid sub claim")
+		return errors.New("missing or invalid sub claim")
 	}
 
 	// REQUIRE exp claim - tokens must have an expiration
 	if _, ok := claims["exp"].(float64); !ok {
-		return fmt.Errorf("missing exp claim")
+		return errors.New("missing exp claim")
 	}
 
 	return nil
@@ -435,16 +436,16 @@ func (a *OIDCAuthenticator) validateTimeClaims(claims map[string]any) error {
 	// Check expiration with clock skew allowance
 	exp, ok := claims["exp"].(float64)
 	if !ok {
-		return fmt.Errorf("missing exp claim")
+		return errors.New("missing exp claim")
 	}
 	if now > int64(exp)+skew {
-		return fmt.Errorf("token expired")
+		return errors.New("token expired")
 	}
 
 	// Check nbf (not before) if present
 	if nbf, ok := claims["nbf"].(float64); ok {
 		if now < int64(nbf)-skew {
-			return fmt.Errorf("token not yet valid")
+			return errors.New("token not yet valid")
 		}
 	}
 
@@ -452,7 +453,7 @@ func (a *OIDCAuthenticator) validateTimeClaims(claims map[string]any) error {
 	if a.cfg.MaxTokenAge > 0 {
 		if iat, ok := claims["iat"].(float64); ok {
 			if now-int64(iat) > int64(a.cfg.MaxTokenAge.Seconds()) {
-				return fmt.Errorf("token too old")
+				return errors.New("token too old")
 			}
 		}
 	}
@@ -465,13 +466,13 @@ func (a *OIDCAuthenticator) validateIdentityClaims(claims map[string]any) error 
 	// Check issuer
 	if !a.cfg.SkipIssuerVerification {
 		if iss, ok := claims["iss"].(string); !ok || iss != a.cfg.Issuer {
-			return fmt.Errorf("invalid issuer")
+			return errors.New("invalid issuer")
 		}
 	}
 
 	// REQUIRE audience when configured
 	if a.cfg.Audience != "" && !a.checkAudience(claims) {
-		return fmt.Errorf("invalid audience")
+		return errors.New("invalid audience")
 	}
 
 	return nil
@@ -530,7 +531,7 @@ func (a *OIDCAuthenticator) discoverJWKSURI(ctx context.Context) (string, error)
 		return "", fmt.Errorf("discovering jwks uri: %w", err)
 	}
 	if doc.JWKSURI == "" {
-		return "", fmt.Errorf("jwks_uri not found in discovery document")
+		return "", errors.New("jwks_uri not found in discovery document")
 	}
 	return doc.JWKSURI, nil
 }
@@ -561,7 +562,7 @@ func (a *OIDCAuthenticator) fetchAndParseJWKS(ctx context.Context, jwksURI strin
 
 	keys, rawKeys := a.parseJWKSKeys(jwksResponse.Keys)
 	if len(keys) == 0 {
-		return nil, nil, fmt.Errorf("no valid RSA signing keys found in JWKS")
+		return nil, nil, errors.New("no valid RSA signing keys found in JWKS")
 	}
 
 	return keys, rawKeys, nil

--- a/pkg/authevents/store_postgres.go
+++ b/pkg/authevents/store_postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -102,7 +103,7 @@ func (s *PostgresStore) Insert(ctx context.Context, ev Event) error {
 // matches the index direction so the query is index-only.
 func (s *PostgresStore) List(ctx context.Context, f Filter) ([]Event, error) {
 	if f.Limit <= 0 {
-		return nil, fmt.Errorf("authevents: List requires positive Limit")
+		return nil, errors.New("authevents: List requires positive Limit")
 	}
 	if f.Limit > maxListLimit {
 		f.Limit = maxListLimit

--- a/pkg/browsersession/cookie.go
+++ b/pkg/browsersession/cookie.go
@@ -1,6 +1,7 @@
 package browsersession
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -68,12 +69,12 @@ func VerifySession(tokenString string, key []byte) (*SessionClaims, error) {
 	}
 
 	if !token.Valid {
-		return nil, fmt.Errorf("invalid session token")
+		return nil, errors.New("invalid session token")
 	}
 
 	mapClaims, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
-		return nil, fmt.Errorf("unexpected claims type")
+		return nil, errors.New("unexpected claims type")
 	}
 
 	return extractSessionClaims(mapClaims)
@@ -83,7 +84,7 @@ func VerifySession(tokenString string, key []byte) (*SessionClaims, error) {
 func extractSessionClaims(mc jwt.MapClaims) (*SessionClaims, error) {
 	sub, _ := mc[claimSub].(string)
 	if sub == "" {
-		return nil, fmt.Errorf("missing sub claim")
+		return nil, errors.New("missing sub claim")
 	}
 
 	email, _ := mc[claimEmail].(string)

--- a/pkg/browsersession/oidcflow.go
+++ b/pkg/browsersession/oidcflow.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -102,13 +103,13 @@ type Flow struct {
 // NewFlow creates a new OIDC flow by performing provider discovery.
 func NewFlow(ctx context.Context, cfg FlowConfig) (*Flow, error) {
 	if cfg.Issuer == "" {
-		return nil, fmt.Errorf("issuer is required")
+		return nil, errors.New("issuer is required")
 	}
 	if cfg.ClientID == "" {
-		return nil, fmt.Errorf("client_id is required")
+		return nil, errors.New("client_id is required")
 	}
 	if cfg.RedirectURI == "" {
-		return nil, fmt.Errorf("redirect_uri is required")
+		return nil, errors.New("redirect_uri is required")
 	}
 	if len(cfg.Cookie.Key) < minKeyLength {
 		return nil, fmt.Errorf("cookie signing key must be at least %d bytes", minKeyLength)
@@ -268,17 +269,17 @@ func (f *Flow) redirectWithError(w http.ResponseWriter, r *http.Request, errCode
 func (f *Flow) validateCallbackState(r *http.Request, state string) (verifier, returnTo string, err error) {
 	stateCookie, err := r.Cookie(stateCookieName)
 	if err != nil {
-		return "", "", fmt.Errorf("missing state cookie")
+		return "", "", errors.New("missing state cookie")
 	}
 
 	stateData, err := verifyStateData(stateCookie.Value, f.cfg.Cookie.Key)
 	if err != nil {
-		return "", "", fmt.Errorf("invalid state cookie")
+		return "", "", errors.New("invalid state cookie")
 	}
 
 	parsed, err := url.ParseQuery(stateData)
 	if err != nil || parsed.Get(logKeyState) != state {
-		return "", "", fmt.Errorf("state mismatch")
+		return "", "", errors.New("state mismatch")
 	}
 
 	// Re-sanitize on read: signed cookies prove integrity but the
@@ -482,7 +483,7 @@ func (f *Flow) exchangeCode(ctx context.Context, code, verifier string) (*tokenR
 	}
 
 	if tokenResp.IDToken == "" {
-		return nil, fmt.Errorf("no id_token in response")
+		return nil, errors.New("no id_token in response")
 	}
 
 	return &tokenResp, nil
@@ -496,7 +497,7 @@ func (f *Flow) exchangeCode(ctx context.Context, code, verifier string) (*tokenR
 func (f *Flow) parseIDToken(idToken string) (*SessionClaims, error) {
 	parts := strings.Split(idToken, ".")
 	if len(parts) != jwtPartCount {
-		return nil, fmt.Errorf("invalid JWT format")
+		return nil, errors.New("invalid JWT format")
 	}
 
 	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
@@ -526,7 +527,7 @@ func (f *Flow) parseIDToken(idToken string) (*SessionClaims, error) {
 
 	sub, _ := claims[claimSub].(string)
 	if sub == "" {
-		return nil, fmt.Errorf("missing sub claim in id_token")
+		return nil, errors.New("missing sub claim in id_token")
 	}
 
 	email, _ := claims[claimEmail].(string)
@@ -555,7 +556,7 @@ func extractName(claims map[string]any) (first, last string) {
 func (f *Flow) validateIssuer(claims map[string]any) error {
 	iss, _ := claims["iss"].(string)
 	if iss == "" {
-		return fmt.Errorf("missing iss claim in id_token")
+		return errors.New("missing iss claim in id_token")
 	}
 	if iss != f.cfg.Issuer {
 		return fmt.Errorf("id_token issuer %q does not match configured issuer %q", iss, f.cfg.Issuer)
@@ -583,7 +584,7 @@ func (f *Flow) validateAudience(claims map[string]any) error {
 			return fmt.Errorf("id_token audience does not contain client_id %q", f.cfg.ClientID)
 		}
 	default:
-		return fmt.Errorf("missing or invalid aud claim in id_token")
+		return errors.New("missing or invalid aud claim in id_token")
 	}
 	return nil
 }
@@ -592,10 +593,10 @@ func (f *Flow) validateAudience(claims map[string]any) error {
 func validateExpiration(claims map[string]any) error {
 	exp, ok := claims[claimExp].(float64)
 	if !ok {
-		return fmt.Errorf("missing exp claim in id_token")
+		return errors.New("missing exp claim in id_token")
 	}
 	if time.Now().Unix() > int64(exp) {
-		return fmt.Errorf("id_token has expired")
+		return errors.New("id_token has expired")
 	}
 	return nil
 }
@@ -671,7 +672,7 @@ func (f *Flow) discover(ctx context.Context) (oidcEndpoints, error) {
 	}
 
 	if ep.AuthorizationEndpoint == "" || ep.TokenEndpoint == "" {
-		return oidcEndpoints{}, fmt.Errorf("discovery missing required endpoints")
+		return oidcEndpoints{}, errors.New("discovery missing required endpoints")
 	}
 
 	return ep, nil
@@ -717,12 +718,12 @@ func verifyStateData(tokenString string, key []byte) (string, error) {
 
 	mc, ok := token.Claims.(jwt.MapClaims)
 	if !ok {
-		return "", fmt.Errorf("unexpected claims type")
+		return "", errors.New("unexpected claims type")
 	}
 
 	data, ok := mc["data"].(string)
 	if !ok {
-		return "", fmt.Errorf("missing data claim")
+		return "", errors.New("missing data claim")
 	}
 
 	return data, nil

--- a/pkg/client/.gitkeep
+++ b/pkg/client/.gitkeep
@@ -1,2 +1,0 @@
-# Placeholder for client package
-# Add your client implementation here

--- a/pkg/connoauth/parse.go
+++ b/pkg/connoauth/parse.go
@@ -1,6 +1,7 @@
 package connoauth
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -88,7 +89,7 @@ const (
 // structurally malformed (wrong value type for a key, or an
 // unrecognized grant / auth_mode). It wraps a descriptive message;
 // callers map it to a 400 / startup-skip without string-matching.
-var ErrInvalidConfig = fmt.Errorf("connoauth: invalid oauth config")
+var ErrInvalidConfig = errors.New("connoauth: invalid oauth config")
 
 // deprecationWarned dedups the legacy-key deprecation warning to one
 // emission per (kind, name) per process lifetime, so a connection read

--- a/pkg/connview/connview.go
+++ b/pkg/connview/connview.go
@@ -8,6 +8,8 @@ package connview
 import (
 	"context"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/toolkit"
@@ -17,6 +19,11 @@ import (
 // list_connections output stays small even when a connection is widely documented.
 // The full total is still reported via Entry.KnowledgePageCount.
 const maxKnowledgePages = 5
+
+// knowledgeEnrichConcurrency bounds the parallel per-connection knowledge-page
+// lookups in enrichWithKnowledge, so a deployment with many connections cannot
+// open an unbounded number of concurrent DB queries.
+const knowledgeEnrichConcurrency = 8
 
 // dataKinds are the toolkit kinds that represent a data connection in the fallback
 // (non-ConnectionLister) path.
@@ -123,22 +130,34 @@ func enrichWithKnowledge(ctx context.Context, pages PageLookup, entries []Entry)
 	if pages == nil {
 		return
 	}
+	// Fan out the independent per-connection reverse lookups (bounded), each
+	// writing only its own index slot so no synchronization on entries is
+	// needed (the house pattern in pkg/knowledge/router.go). errgroup provides
+	// the concurrency bound; no goroutine returns an error, because a
+	// per-connection failure degrades only that entry — it must never fail the
+	// whole view, exactly as the previous serial loop did.
+	var g errgroup.Group
+	g.SetLimit(knowledgeEnrichConcurrency)
 	for i := range entries {
-		e := &entries[i]
-		refs, err := pages.ListPagesReferencing(ctx, knowledgepage.EntityRef{
-			TargetType:     knowledgepage.RefTargetConnection,
-			ConnectionKind: e.Kind,
-			ConnectionName: e.Name,
-		})
-		if err != nil || len(refs) == 0 {
-			continue
-		}
-		e.KnowledgePageCount = len(refs)
-		for _, pg := range refs {
-			if len(e.KnowledgePages) >= maxKnowledgePages {
-				break
+		g.Go(func() error {
+			e := &entries[i]
+			refs, err := pages.ListPagesReferencing(ctx, knowledgepage.EntityRef{
+				TargetType:     knowledgepage.RefTargetConnection,
+				ConnectionKind: e.Kind,
+				ConnectionName: e.Name,
+			})
+			if err != nil || len(refs) == 0 {
+				return nil //nolint:nilerr // a per-connection lookup error degrades only this entry, never the whole view (matches the prior serial loop)
 			}
-			e.KnowledgePages = append(e.KnowledgePages, KnowledgePage{ID: pg.ID, Slug: pg.Slug, Title: pg.Title})
-		}
+			e.KnowledgePageCount = len(refs)
+			for _, pg := range refs {
+				if len(e.KnowledgePages) >= maxKnowledgePages {
+					break
+				}
+				e.KnowledgePages = append(e.KnowledgePages, KnowledgePage{ID: pg.ID, Slug: pg.Slug, Title: pg.Title})
+			}
+			return nil
+		})
 	}
+	_ = g.Wait() // no arm returns an error, so Wait cannot fail
 }

--- a/pkg/connview/connview_test.go
+++ b/pkg/connview/connview_test.go
@@ -3,7 +3,9 @@ package connview
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
@@ -119,4 +121,69 @@ func TestBuild_LookupErrorSkipped(t *testing.T) {
 	out := Build(context.Background(), []registry.Toolkit{tk}, nil, fakePages{err: errors.New("boom")})
 	require.Len(t, out.Connections, 1)
 	assert.Zero(t, out.Connections[0].KnowledgePageCount, "a lookup error leaves the connection unenriched, not failed")
+}
+
+// concurrencyRecorder is a PageLookup that records the peak number of
+// simultaneously in-flight lookups. Each arm signals arrival on a barrier and
+// waits for the others, so overlap is observed deterministically; a timeout
+// stops a serial regression from hanging (it leaves maxSeen at 1 and the
+// assertion fails cleanly).
+type concurrencyRecorder struct {
+	barrier sync.WaitGroup
+	mu      sync.Mutex
+	live    int
+	maxSeen int
+	byConn  map[string][]knowledgepage.PageRef
+}
+
+func (r *concurrencyRecorder) ListPagesReferencing(_ context.Context, ref knowledgepage.EntityRef) ([]knowledgepage.PageRef, error) {
+	r.mu.Lock()
+	r.live++
+	if r.live > r.maxSeen {
+		r.maxSeen = r.live
+	}
+	r.mu.Unlock()
+
+	r.barrier.Done()
+	waited := make(chan struct{})
+	go func() { r.barrier.Wait(); close(waited) }()
+	select {
+	case <-waited:
+	case <-time.After(2 * time.Second):
+	}
+
+	r.mu.Lock()
+	r.live--
+	r.mu.Unlock()
+	return r.byConn[ref.ConnectionKind+"/"+ref.ConnectionName], nil
+}
+
+// TestBuild_KnowledgeEnrichmentFansOut proves the per-connection knowledge
+// lookups run concurrently (maxSeen > 1) while producing output identical to
+// the previous serial loop: every connection enriched, order preserved.
+func TestBuild_KnowledgeEnrichmentFansOut(t *testing.T) {
+	const n = 5
+	conns := make([]toolkit.ConnectionDetail, 0, n)
+	byConn := map[string][]knowledgepage.PageRef{}
+	for i := range n {
+		name := "c" + string(rune('0'+i))
+		conns = append(conns, toolkit.ConnectionDetail{Name: name})
+		byConn["trino/"+name] = pageRefs(2)
+	}
+	tk := &listerTK{mockTK: mockTK{kind: "trino"}, conns: conns}
+	rec := &concurrencyRecorder{byConn: byConn}
+	rec.barrier.Add(n)
+
+	out := Build(context.Background(), []registry.Toolkit{tk}, nil, rec)
+
+	require.Len(t, out.Connections, n)
+	for i, e := range out.Connections {
+		assert.Equal(t, "c"+string(rune('0'+i)), e.Name, "connection order preserved")
+		assert.Equal(t, 2, e.KnowledgePageCount)
+		assert.Len(t, e.KnowledgePages, 2)
+	}
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	assert.Greater(t, rec.maxSeen, 1, "per-connection lookups must run concurrently")
 }

--- a/pkg/indexjobs/registry.go
+++ b/pkg/indexjobs/registry.go
@@ -1,6 +1,7 @@
 package indexjobs
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -38,14 +39,14 @@ func NewRegistry() *Registry {
 // storage.
 func (r *Registry) Register(source Source, sink Sink) error {
 	if source == nil || sink == nil {
-		return fmt.Errorf("indexjobs: register: source and sink must both be non-nil")
+		return errors.New("indexjobs: register: source and sink must both be non-nil")
 	}
 	if source.Kind() != sink.Kind() {
 		return fmt.Errorf("indexjobs: register: source kind %q != sink kind %q", source.Kind(), sink.Kind())
 	}
 	kind := source.Kind()
 	if kind == "" {
-		return fmt.Errorf("indexjobs: register: empty source kind")
+		return errors.New("indexjobs: register: empty source kind")
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/memory/duplicates.go
+++ b/pkg/memory/duplicates.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -44,7 +45,7 @@ const pairNeighborK = 3
 // is seen from both sides) and returned highest-similarity first.
 func (s *postgresStore) SimilarActivePairs(ctx context.Context, createdBy string, minScore float64, limit int) ([]SimilarPair, error) {
 	if createdBy == "" {
-		return nil, fmt.Errorf("similar-pair search requires an owner scope (createdBy)")
+		return nil, errors.New("similar-pair search requires an owner scope (createdBy)")
 	}
 	limit = clampStoreLimit(limit)
 

--- a/pkg/memory/noop.go
+++ b/pkg/memory/noop.go
@@ -2,7 +2,7 @@ package memory
 
 import (
 	"context"
-	"fmt"
+	"errors"
 )
 
 // NewNoopStore creates a no-op Store for use when no database is available.
@@ -18,7 +18,7 @@ func (*noopStore) Insert(_ context.Context, _ Record) error { return nil }
 
 // Get always returns not-found.
 func (*noopStore) Get(_ context.Context, _ string) (*Record, error) {
-	return nil, fmt.Errorf("memory record not found")
+	return nil, errors.New("memory record not found")
 }
 
 // Update is a no-op.

--- a/pkg/memory/postgres.go
+++ b/pkg/memory/postgres.go
@@ -144,7 +144,7 @@ func (s *postgresStore) Update(ctx context.Context, id string, updates RecordUpd
 	}
 
 	if !hasUpdates {
-		return fmt.Errorf("no fields to update")
+		return errors.New("no fields to update")
 	}
 
 	qb = qb.Set("updated_at", time.Now()).Where(sq.Eq{"id": id})

--- a/pkg/middleware/mcp.go
+++ b/pkg/middleware/mcp.go
@@ -426,7 +426,7 @@ func resolveSource(ctx context.Context) string {
 func extractToolName(req mcp.Request) (string, error) {
 	params := req.GetParams()
 	if params == nil {
-		return "", fmt.Errorf("missing params")
+		return "", errors.New("missing params")
 	}
 
 	callParams, ok := params.(*mcp.CallToolParamsRaw)
@@ -436,11 +436,11 @@ func extractToolName(req mcp.Request) (string, error) {
 
 	// Check if the pointer itself is nil (type assertion can succeed with nil pointer)
 	if callParams == nil {
-		return "", fmt.Errorf("missing params")
+		return "", errors.New("missing params")
 	}
 
 	if callParams.Name == "" {
-		return "", fmt.Errorf("missing tool name")
+		return "", errors.New("missing tool name")
 	}
 
 	return callParams.Name, nil

--- a/pkg/middleware/mcp_resources.go
+++ b/pkg/middleware/mcp_resources.go
@@ -428,7 +428,7 @@ func extractPersonaAdminRoles(roles []string) []string {
 // extractResourceURI extracts the URI from a resources/read request.
 func extractResourceURI(req mcp.Request) (string, error) {
 	if req == nil {
-		return "", fmt.Errorf("nil request")
+		return "", errors.New("nil request")
 	}
 	params, ok := req.GetParams().(*mcp.ReadResourceParams)
 	if !ok || params == nil {

--- a/pkg/oauth/dcr.go
+++ b/pkg/oauth/dcr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -104,11 +105,11 @@ type DCRResponse struct {
 // Register registers a new OAuth client.
 func (s *DCRService) Register(ctx context.Context, req DCRRequest) (*DCRResponse, error) {
 	if !s.config.Enabled {
-		return nil, fmt.Errorf("dynamic client registration is disabled")
+		return nil, errors.New("dynamic client registration is disabled")
 	}
 
 	if len(s.patterns) == 0 && !s.config.AllowAllRedirectURIs {
-		return nil, fmt.Errorf("dynamic client registration is not configured: set allowed_redirect_patterns to the redirect URIs your clients use, or set allow_all_redirect_uris: true to explicitly accept any redirect URI")
+		return nil, errors.New("dynamic client registration is not configured: set allowed_redirect_patterns to the redirect URIs your clients use, or set allow_all_redirect_uris: true to explicitly accept any redirect URI")
 	}
 
 	if err := s.validateRedirectURIs(req.RedirectURIs); err != nil {

--- a/pkg/oauth/pkce.go
+++ b/pkg/oauth/pkce.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"regexp"
 )
@@ -31,7 +32,7 @@ func ValidateCodeVerifier(verifier string) error {
 
 	validPattern := regexp.MustCompile(`^[A-Za-z0-9\-._~]+$`)
 	if !validPattern.MatchString(verifier) {
-		return fmt.Errorf("code verifier contains invalid characters")
+		return errors.New("code verifier contains invalid characters")
 	}
 
 	return nil
@@ -46,7 +47,7 @@ func ValidateCodeChallenge(challenge string) error {
 	// Base64 URL-safe characters
 	validPattern := regexp.MustCompile(`^[A-Za-z0-9\-_]+$`)
 	if !validPattern.MatchString(challenge) {
-		return fmt.Errorf("code challenge contains invalid characters")
+		return errors.New("code challenge contains invalid characters")
 	}
 
 	return nil

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -309,16 +309,16 @@ type ErrorResponse struct {
 func (s *Server) validateAuthorizationRequest(ctx context.Context, req AuthorizationRequest) (*Client, error) {
 	client, err := s.storage.GetClient(ctx, req.ClientID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid client_id")
+		return nil, errors.New("invalid client_id")
 	}
 	if !client.Active {
-		return nil, fmt.Errorf("client is not active")
+		return nil, errors.New("client is not active")
 	}
 	if !client.ValidRedirectURI(req.RedirectURI) {
-		return nil, fmt.Errorf("invalid redirect_uri")
+		return nil, errors.New("invalid redirect_uri")
 	}
 	if req.ResponseType != paramCode {
-		return nil, fmt.Errorf("unsupported response_type")
+		return nil, errors.New("unsupported response_type")
 	}
 	return client, nil
 }
@@ -326,7 +326,7 @@ func (s *Server) validateAuthorizationRequest(ctx context.Context, req Authoriza
 // validatePKCE validates PKCE parameters if required.
 func (*Server) validatePKCE(client *Client, req AuthorizationRequest) error {
 	if client.RequirePKCE && req.CodeChallenge == "" {
-		return fmt.Errorf("code_challenge required")
+		return errors.New("code_challenge required")
 	}
 	// Enforce S256 whenever a challenge is supplied, even for clients that do
 	// not require PKCE. A code_challenge stored with a non-S256 method would
@@ -388,23 +388,23 @@ func (s *Server) Token(ctx context.Context, req TokenRequest) (*TokenResponse, e
 		s.metrics.RecordOAuthRefresh(ctx, observability.UpstreamStatus(err), time.Since(start))
 		return resp, err
 	default:
-		return nil, fmt.Errorf("unsupported grant_type")
+		return nil, errors.New("unsupported grant_type")
 	}
 }
 
 // validateAuthorizationCode validates the authorization code state.
 func (*Server) validateAuthorizationCode(code *AuthorizationCode, req TokenRequest) error {
 	if code.Used {
-		return fmt.Errorf("authorization code already used")
+		return errors.New("authorization code already used")
 	}
 	if code.IsExpired() {
-		return fmt.Errorf("authorization code expired")
+		return errors.New("authorization code expired")
 	}
 	if code.ClientID != req.ClientID {
-		return fmt.Errorf("client_id mismatch")
+		return errors.New("client_id mismatch")
 	}
 	if !matchesRedirectURI(code.RedirectURI, req.RedirectURI) {
-		return fmt.Errorf("redirect_uri mismatch")
+		return errors.New("redirect_uri mismatch")
 	}
 	return nil
 }
@@ -413,10 +413,10 @@ func (*Server) validateAuthorizationCode(code *AuthorizationCode, req TokenReque
 func (s *Server) validateClientCredentials(ctx context.Context, req TokenRequest) (*Client, error) {
 	client, err := s.storage.GetClient(ctx, req.ClientID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid client_id")
+		return nil, errors.New("invalid client_id")
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(client.ClientSecret), []byte(req.ClientSecret)); err != nil {
-		return nil, fmt.Errorf("invalid client credentials")
+		return nil, errors.New("invalid client credentials")
 	}
 	return client, nil
 }
@@ -427,11 +427,11 @@ func (*Server) verifyCodeChallenge(code *AuthorizationCode, req TokenRequest) er
 		return nil
 	}
 	if req.CodeVerifier == "" {
-		return fmt.Errorf("code_verifier required")
+		return errors.New("code_verifier required")
 	}
 	valid, err := VerifyCodeChallenge(req.CodeVerifier, code.CodeChallenge, PKCEMethodS256)
 	if err != nil || !valid {
-		return fmt.Errorf("invalid code_verifier")
+		return errors.New("invalid code_verifier")
 	}
 	return nil
 }
@@ -440,7 +440,7 @@ func (*Server) verifyCodeChallenge(code *AuthorizationCode, req TokenRequest) er
 func (s *Server) handleAuthorizationCodeGrant(ctx context.Context, req TokenRequest) (*TokenResponse, error) {
 	code, err := s.storage.GetAuthorizationCode(ctx, req.Code)
 	if err != nil {
-		return nil, fmt.Errorf("invalid authorization code")
+		return nil, errors.New("invalid authorization code")
 	}
 
 	if err := s.validateAuthorizationCode(code, req); err != nil {
@@ -467,7 +467,7 @@ func (s *Server) handleAuthorizationCodeGrant(ctx context.Context, req TokenRequ
 		slog.Warn("oauth: authorization code consume failed",
 			paramClientID, logsan.SanitizeForLog(req.ClientID), logKeyError, logsan.SanitizeForLog(err.Error()))
 		if errors.Is(err, ErrNotFound) {
-			return nil, fmt.Errorf("invalid authorization code")
+			return nil, errors.New("invalid authorization code")
 		}
 		return nil, fmt.Errorf("consuming authorization code: %w", ErrStorageFailure)
 	}
@@ -480,7 +480,7 @@ func (s *Server) handleRefreshTokenGrant(ctx context.Context, req TokenRequest) 
 	// Retrieve refresh token
 	token, err := s.storage.GetRefreshToken(ctx, req.RefreshToken)
 	if err != nil {
-		return nil, fmt.Errorf("invalid refresh token")
+		return nil, errors.New("invalid refresh token")
 	}
 
 	if token.IsExpired() {
@@ -490,21 +490,21 @@ func (s *Server) handleRefreshTokenGrant(ctx context.Context, req TokenRequest) 
 			slog.Warn("oauth: expired refresh token delete failed",
 				paramClientID, token.ClientID, logKeyError, delErr.Error())
 		}
-		return nil, fmt.Errorf("refresh token expired")
+		return nil, errors.New("refresh token expired")
 	}
 
 	if token.ClientID != req.ClientID {
-		return nil, fmt.Errorf("client_id mismatch")
+		return nil, errors.New("client_id mismatch")
 	}
 
 	// Validate client credentials
 	client, err := s.storage.GetClient(ctx, req.ClientID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid client_id")
+		return nil, errors.New("invalid client_id")
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(client.ClientSecret), []byte(req.ClientSecret)); err != nil {
-		return nil, fmt.Errorf("invalid client credentials")
+		return nil, errors.New("invalid client credentials")
 	}
 
 	// Rotate: atomically consume the old refresh token, failing the grant
@@ -518,7 +518,7 @@ func (s *Server) handleRefreshTokenGrant(ctx context.Context, req TokenRequest) 
 		slog.Warn("oauth: refresh token rotation consume failed",
 			paramClientID, logsan.SanitizeForLog(req.ClientID), logKeyError, logsan.SanitizeForLog(err.Error()))
 		if errors.Is(err, ErrNotFound) {
-			return nil, fmt.Errorf("invalid refresh token")
+			return nil, errors.New("invalid refresh token")
 		}
 		return nil, fmt.Errorf("rotating refresh token: %w", ErrStorageFailure)
 	}
@@ -539,7 +539,7 @@ func resolveRefreshScope(requested, granted string) (string, error) {
 		return granted, nil
 	}
 	if !isScopeSubset(requested, granted) {
-		return "", fmt.Errorf("invalid scope: exceeds originally granted scope")
+		return "", errors.New("invalid scope: exceeds originally granted scope")
 	}
 	return requested, nil
 }
@@ -657,7 +657,7 @@ func (s *Server) Issuer() string {
 // RegisterClient handles Dynamic Client Registration.
 func (s *Server) RegisterClient(ctx context.Context, req DCRRequest) (*DCRResponse, error) {
 	if s.dcr == nil {
-		return nil, fmt.Errorf("dynamic client registration is disabled")
+		return nil, errors.New("dynamic client registration is disabled")
 	}
 	return s.dcr.Register(ctx, req)
 }
@@ -1016,7 +1016,7 @@ func (s *Server) buildUpstreamAuthURL(ctx context.Context, state string) (string
 // retryable server_error rather than a hardcoded-path fallback.
 func (s *Server) buildUpstreamAuthURLWithPrompt(ctx context.Context, state string, usePromptNone bool) (string, error) {
 	if s.upstreamResolver == nil {
-		return "", fmt.Errorf("upstream IdP not configured")
+		return "", errors.New("upstream IdP not configured")
 	}
 	authEndpoint, err := s.upstreamResolver.authorizationEndpoint(ctx)
 	if err != nil {
@@ -1056,7 +1056,7 @@ type upstreamTokenResponse struct {
 // exchangeUpstreamCode exchanges an authorization code with the upstream IdP.
 func (s *Server) exchangeUpstreamCode(ctx context.Context, code string) (*upstreamTokenResponse, error) {
 	if s.upstreamResolver == nil {
-		return nil, fmt.Errorf("upstream IdP not configured")
+		return nil, errors.New("upstream IdP not configured")
 	}
 	tokenURL, err := s.upstreamResolver.tokenEndpoint(ctx)
 	if err != nil {

--- a/pkg/oauth/upstream_discovery.go
+++ b/pkg/oauth/upstream_discovery.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -69,7 +70,7 @@ func (r *upstreamEndpointResolver) authorizationEndpoint(ctx context.Context) (s
 		return "", err
 	}
 	if doc.AuthorizationEndpoint == "" {
-		return "", fmt.Errorf("authorization_endpoint not found in discovery document")
+		return "", errors.New("authorization_endpoint not found in discovery document")
 	}
 	return doc.AuthorizationEndpoint, nil
 }
@@ -86,7 +87,7 @@ func (r *upstreamEndpointResolver) tokenEndpoint(ctx context.Context) (string, e
 		return "", err
 	}
 	if doc.TokenEndpoint == "" {
-		return "", fmt.Errorf("token_endpoint not found in discovery document")
+		return "", errors.New("token_endpoint not found in discovery document")
 	}
 	return doc.TokenEndpoint, nil
 }

--- a/pkg/persona/registry.go
+++ b/pkg/persona/registry.go
@@ -1,6 +1,7 @@
 package persona
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -28,7 +29,7 @@ func (r *Registry) Register(p *Persona) error {
 	defer r.mu.Unlock()
 
 	if p.Name == "" {
-		return fmt.Errorf("persona name is required")
+		return errors.New("persona name is required")
 	}
 	if err := validateAPIRoutes(p.APIRoutes); err != nil {
 		return fmt.Errorf("persona %q: %w", p.Name, err)

--- a/pkg/platform/branding/branding.go
+++ b/pkg/platform/branding/branding.go
@@ -18,6 +18,7 @@
 package branding
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -159,7 +160,7 @@ func (h *Handle) ResolveImplementorLogo() string {
 // or exceeds the size limit.
 func fetchLogoSVG(url string) (string, error) {
 	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
-		return "", fmt.Errorf("unsupported scheme")
+		return "", errors.New("unsupported scheme")
 	}
 
 	client := &http.Client{Timeout: logoFetchTimeout}

--- a/pkg/platform/connections_tool.go
+++ b/pkg/platform/connections_tool.go
@@ -48,7 +48,7 @@ func (p *Platform) handleListConnections(ctx context.Context, _ *mcp.CallToolReq
 
 	data, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
-		return &mcp.CallToolResult{ //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError, not as Go errors
+		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: "Error: " + err.Error()},
 			},

--- a/pkg/platform/custom_resources.go
+++ b/pkg/platform/custom_resources.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -55,19 +56,19 @@ func buildCustomResourceResult(def CustomResourceDef) (*mcp.ReadResourceResult, 
 // validateCustomResourceDef checks that a CustomResourceDef is complete and unambiguous.
 func validateCustomResourceDef(def CustomResourceDef) error {
 	if def.URI == "" {
-		return fmt.Errorf("uri is required")
+		return errors.New("uri is required")
 	}
 	if def.Name == "" {
-		return fmt.Errorf("name is required")
+		return errors.New("name is required")
 	}
 	if def.MIMEType == "" {
-		return fmt.Errorf("mime_type is required")
+		return errors.New("mime_type is required")
 	}
 	if def.Content == "" && def.ContentFile == "" {
-		return fmt.Errorf("one of content or content_file is required")
+		return errors.New("one of content or content_file is required")
 	}
 	if def.Content != "" && def.ContentFile != "" {
-		return fmt.Errorf("content and content_file are mutually exclusive")
+		return errors.New("content and content_file are mutually exclusive")
 	}
 	return nil
 }

--- a/pkg/platform/find_tools_tool.go
+++ b/pkg/platform/find_tools_tool.go
@@ -68,7 +68,6 @@ func (p *Platform) handleFindTools(ctx context.Context, _ *mcp.CallToolRequest, 
 
 	tools, err := p.enumerateGlobalTools(ctx)
 	if err != nil {
-		//nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError, not as Go errors
 		return toolErrorResult("failed to enumerate tools: " + err.Error()), nil, nil
 	}
 	descByName := make(map[string]*mcp.Tool, len(tools))
@@ -212,7 +211,6 @@ func zeroVector(v []float32) bool {
 func marshalToolResult(out any) (*mcp.CallToolResult, any, error) {
 	data, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
-		//nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError, not as Go errors
 		return toolErrorResult("failed to encode result: " + err.Error()), nil, nil
 	}
 	return &mcp.CallToolResult{

--- a/pkg/platform/info_tool.go
+++ b/pkg/platform/info_tool.go
@@ -303,7 +303,7 @@ func (p *Platform) handleInfo(ctx context.Context, _ *mcp.CallToolRequest) (*mcp
 
 	data, err := json.MarshalIndent(info, "", "  ")
 	if err != nil {
-		return &mcp.CallToolResult{ //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError, not as Go errors
+		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{Text: "Error: " + err.Error()},
 			},

--- a/pkg/platform/knowledgelayer/knowledgelayer.go
+++ b/pkg/platform/knowledgelayer/knowledgelayer.go
@@ -24,6 +24,7 @@ package knowledgelayer
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -127,7 +128,7 @@ func NewFromInsightStore(db *sql.DB, store knowledgekit.InsightStore, embeddingP
 
 	if cfg.ApplyEnabled {
 		if db == nil {
-			return nil, fmt.Errorf("knowledgelayer: apply enabled requires a non-nil database")
+			return nil, errors.New("knowledgelayer: apply enabled requires a non-nil database")
 		}
 		if err := h.configureApply(db, embeddingProv, cfg); err != nil {
 			return nil, err

--- a/pkg/platform/lifecycle.go
+++ b/pkg/platform/lifecycle.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -79,7 +80,7 @@ func (l *Lifecycle) Start(ctx context.Context) error {
 	defer l.mu.Unlock()
 
 	if l.started {
-		return fmt.Errorf("lifecycle already started")
+		return errors.New("lifecycle already started")
 	}
 
 	for i, c := range l.components {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -295,7 +295,7 @@ func New(opts ...Option) (*Platform, error) {
 	}
 
 	if options.Config == nil {
-		return nil, fmt.Errorf("config is required")
+		return nil, errors.New("config is required")
 	}
 
 	p := &Platform{

--- a/pkg/portal/handler.go
+++ b/pkg/portal/handler.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -1334,7 +1335,7 @@ type shareTarget struct {
 func buildShare(target shareTarget, createdBy string, req createShareRequest) (Share, error) {
 	token, err := GenerateShareToken()
 	if err != nil {
-		return Share{}, fmt.Errorf("failed to generate share token")
+		return Share{}, errors.New("failed to generate share token")
 	}
 
 	email := strings.ToLower(strings.TrimSpace(req.SharedWithEmail))
@@ -1374,7 +1375,7 @@ func buildShare(target shareTarget, createdBy string, req createShareRequest) (S
 	if req.ExpiresIn != "" {
 		dur, parseErr := time.ParseDuration(req.ExpiresIn)
 		if parseErr != nil {
-			return Share{}, fmt.Errorf("invalid expires_in duration")
+			return Share{}, errors.New("invalid expires_in duration")
 		}
 		exp := time.Now().Add(dur)
 		share.ExpiresAt = &exp
@@ -2283,7 +2284,7 @@ func resolveSharePermission(req createShareRequest, email string) (SharePermissi
 	perm := PermissionViewer
 	if req.Permission != "" {
 		if !ValidSharePermission(req.Permission) {
-			return "", fmt.Errorf("invalid permission: must be viewer or editor")
+			return "", errors.New("invalid permission: must be viewer or editor")
 		}
 		perm = SharePermission(req.Permission)
 	}

--- a/pkg/portal/knowledgepage/entity_ref_urn.go
+++ b/pkg/portal/knowledgepage/entity_ref_urn.go
@@ -1,6 +1,7 @@
 package knowledgepage
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -52,7 +53,7 @@ func ParseEntityRef(s string) (EntityRef, error) {
 	s = strings.TrimSpace(s)
 	switch {
 	case s == "":
-		return EntityRef{}, fmt.Errorf("empty entity reference")
+		return EntityRef{}, errors.New("empty entity reference")
 	case strings.HasPrefix(s, externalURNPrefix):
 		// A DataHub URN never embeds the internal mcp: scheme; if it does, the
 		// caller crossed the two namespaces (e.g. urn:li:mcp:connection:(x)). Reject
@@ -139,12 +140,12 @@ func parseSimpleMCPRef(typ, id, s string) (EntityRef, error) {
 // parseConnectionTuple parses the "(kind,name)" body of a connection reference.
 func parseConnectionTuple(body string) (kind, name string, err error) {
 	if !strings.HasPrefix(body, "(") || !strings.HasSuffix(body, ")") {
-		return "", "", fmt.Errorf("connection reference must be (kind,name)")
+		return "", "", errors.New("connection reference must be (kind,name)")
 	}
 	inner := body[1 : len(body)-1]
 	kind, name, ok := strings.Cut(inner, ",")
 	if !ok || kind == "" || name == "" {
-		return "", "", fmt.Errorf("connection reference must be (kind,name)")
+		return "", "", errors.New("connection reference must be (kind,name)")
 	}
 	return kind, name, nil
 }

--- a/pkg/portal/store.go
+++ b/pkg/portal/store.go
@@ -487,7 +487,7 @@ func applyUpdateFields(qb sq.UpdateBuilder, updates AssetUpdate) (sq.UpdateBuild
 		hasUpdates = true
 	}
 	if !hasUpdates {
-		return qb, fmt.Errorf("no fields to update")
+		return qb, errors.New("no fields to update")
 	}
 	// When an indexed field (name, description, tags) changes, drop the
 	// embedding so the reconciler re-embeds against the new text off the
@@ -1054,7 +1054,7 @@ func NewNoopAssetStore() AssetStore {
 func (*noopAssetStore) Insert(_ context.Context, _ Asset) error { return nil }
 
 func (*noopAssetStore) Get(_ context.Context, _ string) (*Asset, error) { //nolint:revive // interface impl
-	return nil, fmt.Errorf("asset not found")
+	return nil, errors.New("asset not found")
 }
 
 func (*noopAssetStore) GetByIDs(_ context.Context, _ []string) (map[string]*Asset, error) { //nolint:revive // interface impl
@@ -1062,7 +1062,7 @@ func (*noopAssetStore) GetByIDs(_ context.Context, _ []string) (map[string]*Asse
 }
 
 func (*noopAssetStore) GetByIdempotencyKey(_ context.Context, _, _ string) (*Asset, error) { //nolint:revive // interface impl
-	return nil, fmt.Errorf("asset not found")
+	return nil, errors.New("asset not found")
 }
 
 func (*noopAssetStore) List(_ context.Context, _ AssetFilter) ([]Asset, int, error) { //nolint:revive // interface impl
@@ -1085,11 +1085,11 @@ func NewNoopShareStore() ShareStore {
 func (*noopShareStore) Insert(_ context.Context, _ Share) error { return nil }
 
 func (*noopShareStore) GetByID(_ context.Context, _ string) (*Share, error) { //nolint:revive // interface impl
-	return nil, fmt.Errorf("share not found")
+	return nil, errors.New("share not found")
 }
 
 func (*noopShareStore) GetByToken(_ context.Context, _ string) (*Share, error) { //nolint:revive // interface impl
-	return nil, fmt.Errorf("share not found")
+	return nil, errors.New("share not found")
 }
 
 func (*noopShareStore) ListByAsset(_ context.Context, _ string) ([]Share, error) { //nolint:revive // interface impl
@@ -1109,7 +1109,7 @@ func (*noopShareStore) ListSharedPromptsWithUser(_ context.Context, _, _ string)
 }
 
 func (*noopShareStore) GetUserCollectionPermission(_ context.Context, _, _, _ string) (SharePermission, error) { //nolint:revive // interface impl
-	return "", fmt.Errorf("no shares")
+	return "", errors.New("no shares")
 }
 
 func (*noopShareStore) ListSharedWithUser(_ context.Context, _, _ string, _, _ int) ([]SharedAsset, int, error) { //nolint:revive // interface impl
@@ -1424,11 +1424,11 @@ func (*noopVersionStore) ListByAsset(_ context.Context, _ string, _, _ int) ([]A
 }
 
 func (*noopVersionStore) GetByVersion(_ context.Context, _ string, _ int) (*AssetVersion, error) { //nolint:revive // interface impl
-	return nil, fmt.Errorf("version not found")
+	return nil, errors.New("version not found")
 }
 
 func (*noopVersionStore) GetLatest(_ context.Context, _ string) (*AssetVersion, error) { //nolint:revive // interface impl
-	return nil, fmt.Errorf("version not found")
+	return nil, errors.New("version not found")
 }
 
 // Verify interface compliance.

--- a/pkg/portal/types.go
+++ b/pkg/portal/types.go
@@ -3,6 +3,7 @@
 package portal
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -224,7 +225,7 @@ const maxTagLength = 100
 // ValidateAssetName checks that a name is non-empty and within length limits.
 func ValidateAssetName(name string) error {
 	if name == "" {
-		return fmt.Errorf("name is required")
+		return errors.New("name is required")
 	}
 	if len(name) > maxNameLength {
 		return fmt.Errorf("name exceeds %d characters", maxNameLength)
@@ -235,7 +236,7 @@ func ValidateAssetName(name string) error {
 // ValidateContentType checks that a content type is non-empty.
 func ValidateContentType(ct string) error {
 	if ct == "" {
-		return fmt.Errorf("content_type is required")
+		return errors.New("content_type is required")
 	}
 	return nil
 }
@@ -377,7 +378,7 @@ const maxItemsPerSection = 100
 // ValidateCollectionName checks that a collection name is valid.
 func ValidateCollectionName(name string) error {
 	if name == "" {
-		return fmt.Errorf("name is required")
+		return errors.New("name is required")
 	}
 	if len(name) > maxNameLength {
 		return fmt.Errorf("name exceeds %d characters", maxNameLength)
@@ -438,10 +439,10 @@ func ValidateEmail(email string) error {
 	}
 	parts := strings.SplitN(email, "@", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return fmt.Errorf("invalid email address")
+		return errors.New("invalid email address")
 	}
 	if !strings.Contains(parts[1], ".") {
-		return fmt.Errorf("invalid email address")
+		return errors.New("invalid email address")
 	}
 	return nil
 }

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -5,6 +5,7 @@ package prompt
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"time"
@@ -33,13 +34,13 @@ var validScopes = map[string]bool{
 // ValidateName checks that a prompt name is well-formed.
 func ValidateName(name string) error {
 	if name == "" {
-		return fmt.Errorf("name is required")
+		return errors.New("name is required")
 	}
 	if len(name) > maxNameLength {
 		return fmt.Errorf("name must be at most %d characters", maxNameLength)
 	}
 	if !validNamePattern.MatchString(name) {
-		return fmt.Errorf("name must contain only lowercase letters, digits, hyphens, and underscores")
+		return errors.New("name must contain only lowercase letters, digits, hyphens, and underscores")
 	}
 	return nil
 }
@@ -140,7 +141,7 @@ func (p *Prompt) ApplyStatusTransition(newStatus, supersededBy, actorEmail strin
 		return err
 	}
 	if newStatus == StatusApproved && !isAdmin {
-		return fmt.Errorf("only admins can approve a prompt")
+		return errors.New("only admins can approve a prompt")
 	}
 	switch newStatus {
 	case StatusApproved:
@@ -161,7 +162,7 @@ func (p *Prompt) ApplyStatusTransition(newStatus, supersededBy, actorEmail strin
 // scope does not change until an admin approves (see ApprovePromotion).
 func (p *Prompt) ApplyPromotionRequest(requestedScope string, requestedPersonas []string) error {
 	if p.Scope != ScopePersonal {
-		return fmt.Errorf("only personal prompts can request promotion")
+		return errors.New("only personal prompts can request promotion")
 	}
 	if p.Status == StatusDeprecated || p.Status == StatusSuperseded {
 		return fmt.Errorf("cannot request promotion of a %s prompt", p.Status)
@@ -170,7 +171,7 @@ func (p *Prompt) ApplyPromotionRequest(requestedScope string, requestedPersonas 
 		return fmt.Errorf("requested scope must be %q or %q", ScopePersona, ScopeGlobal)
 	}
 	if requestedScope == ScopePersona && len(requestedPersonas) == 0 {
-		return fmt.Errorf("persona promotion requires at least one persona")
+		return errors.New("persona promotion requires at least one persona")
 	}
 	p.ReviewRequested = true
 	p.RequestedScope = requestedScope
@@ -189,13 +190,13 @@ func (p *Prompt) ApplyPromotionRequest(requestedScope string, requestedPersonas 
 // request). The caller is responsible for checking the target shared name is free.
 func (p *Prompt) ApprovePromotion(actorEmail string, now time.Time) error {
 	if !p.ReviewRequested {
-		return fmt.Errorf("prompt has no pending promotion request")
+		return errors.New("prompt has no pending promotion request")
 	}
 	if p.Scope != ScopePersonal {
 		// The scope was changed (e.g. via a direct admin edit) after the request
 		// was filed; the stale request must not silently re-scope it.
 		p.clearPromotionRequest()
-		return fmt.Errorf("prompt is no longer personal; promotion request is stale")
+		return errors.New("prompt is no longer personal; promotion request is stale")
 	}
 	if p.RequestedScope != ScopePersona && p.RequestedScope != ScopeGlobal {
 		return fmt.Errorf("invalid requested scope %q", p.RequestedScope)

--- a/pkg/query/trino/adapter.go
+++ b/pkg/query/trino/adapter.go
@@ -3,6 +3,7 @@ package trino
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -71,10 +72,10 @@ type Adapter struct {
 // New creates a new Trino adapter with a real client.
 func New(cfg Config) (*Adapter, error) {
 	if cfg.Host == "" {
-		return nil, fmt.Errorf("trino host is required")
+		return nil, errors.New("trino host is required")
 	}
 	if cfg.User == "" {
-		return nil, fmt.Errorf("trino user is required")
+		return nil, errors.New("trino user is required")
 	}
 	if cfg.Port == 0 {
 		if cfg.SSL {
@@ -120,7 +121,7 @@ func New(cfg Config) (*Adapter, error) {
 // NewWithClient creates a new Trino adapter with a provided client (for testing).
 func NewWithClient(cfg Config, client Client) (*Adapter, error) {
 	if client == nil {
-		return nil, fmt.Errorf("trino client is required")
+		return nil, errors.New("trino client is required")
 	}
 	if cfg.DefaultLimit == 0 {
 		cfg.DefaultLimit = defaultQueryLimit

--- a/pkg/resource/handler.go
+++ b/pkg/resource/handler.go
@@ -187,7 +187,7 @@ type uploadedFile struct {
 func readUploadedFile(r *http.Request) (*uploadedFile, error) {
 	file, header, err := r.FormFile("file")
 	if err != nil {
-		return nil, fmt.Errorf("file is required")
+		return nil, errors.New("file is required")
 	}
 	defer func() { _ = file.Close() }()
 

--- a/pkg/resource/validate.go
+++ b/pkg/resource/validate.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -53,7 +54,7 @@ func ValidateCategory(cat string) error {
 func ValidateDisplayName(name string) error {
 	n := utf8.RuneCountInString(strings.TrimSpace(name))
 	if n == 0 {
-		return fmt.Errorf("display_name is required")
+		return errors.New("display_name is required")
 	}
 	if n > MaxDisplayNameLen {
 		return fmt.Errorf("display_name exceeds %d characters", MaxDisplayNameLen)
@@ -65,7 +66,7 @@ func ValidateDisplayName(name string) error {
 func ValidateDescription(desc string) error {
 	n := utf8.RuneCountInString(strings.TrimSpace(desc))
 	if n == 0 {
-		return fmt.Errorf("description is required")
+		return errors.New("description is required")
 	}
 	if n > MaxDescriptionLen {
 		return fmt.Errorf("description exceeds %d characters", MaxDescriptionLen)
@@ -103,7 +104,7 @@ func ValidateScope(scope Scope, scopeID string) error {
 	switch scope {
 	case ScopeGlobal:
 		if scopeID != "" {
-			return fmt.Errorf("scope_id must be empty for global scope")
+			return errors.New("scope_id must be empty for global scope")
 		}
 	case ScopePersona, ScopeUser:
 		if scopeID == "" {
@@ -120,13 +121,13 @@ func ValidateScope(scope Scope, scopeID string) error {
 func SanitizeFilename(name string) (string, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return "", fmt.Errorf("filename is empty")
+		return "", errors.New("filename is empty")
 	}
 
 	name = normalizeFilename(name)
 
 	if name == "" || name == "." {
-		return "", fmt.Errorf("filename contains only invalid characters")
+		return "", errors.New("filename contains only invalid characters")
 	}
 
 	ext := filepath.Ext(name)

--- a/pkg/semantic/datahub/adapter.go
+++ b/pkg/semantic/datahub/adapter.go
@@ -98,7 +98,7 @@ type Adapter struct {
 // New creates a new DataHub adapter with a real client.
 func New(cfg Config) (*Adapter, error) {
 	if cfg.URL == "" {
-		return nil, fmt.Errorf("datahub URL is required")
+		return nil, errors.New("datahub URL is required")
 	}
 	if cfg.Platform == "" {
 		cfg.Platform = defaultPlatform
@@ -128,7 +128,7 @@ func New(cfg Config) (*Adapter, error) {
 // NewWithClient creates a new DataHub adapter with a provided client (for testing).
 func NewWithClient(cfg Config, client Client) (*Adapter, error) {
 	if client == nil {
-		return nil, fmt.Errorf("datahub client is required")
+		return nil, errors.New("datahub client is required")
 	}
 	if cfg.Platform == "" {
 		cfg.Platform = defaultPlatform

--- a/pkg/storage/s3/adapter.go
+++ b/pkg/storage/s3/adapter.go
@@ -3,6 +3,7 @@ package s3
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -47,7 +48,7 @@ type Adapter struct {
 // New creates a new S3 adapter with an existing client.
 func New(cfg Config, client Client) (*Adapter, error) {
 	if client == nil {
-		return nil, fmt.Errorf("s3 client is required")
+		return nil, errors.New("s3 client is required")
 	}
 	return &Adapter{
 		cfg:    cfg,

--- a/pkg/toolkit/annotations.go
+++ b/pkg/toolkit/annotations.go
@@ -1,0 +1,32 @@
+package toolkit
+
+import "github.com/modelcontextprotocol/go-sdk/mcp"
+
+// AnnotationConfig is the YAML-configurable set of MCP tool annotation hints
+// shared by every toolkit. Each field is a pointer so an unset hint (inherit
+// the tool's built-in default) is distinct from an explicit false.
+type AnnotationConfig struct {
+	ReadOnlyHint    *bool `yaml:"read_only_hint"`
+	DestructiveHint *bool `yaml:"destructive_hint"`
+	IdempotentHint  *bool `yaml:"idempotent_hint"`
+	OpenWorldHint   *bool `yaml:"open_world_hint"`
+}
+
+// AnnotationsToMCP converts an AnnotationConfig into MCP tool annotations,
+// applying only the hints the operator explicitly set.
+func AnnotationsToMCP(cfg AnnotationConfig) *mcp.ToolAnnotations {
+	ann := &mcp.ToolAnnotations{}
+	if cfg.ReadOnlyHint != nil {
+		ann.ReadOnlyHint = *cfg.ReadOnlyHint
+	}
+	if cfg.DestructiveHint != nil {
+		ann.DestructiveHint = cfg.DestructiveHint
+	}
+	if cfg.IdempotentHint != nil {
+		ann.IdempotentHint = *cfg.IdempotentHint
+	}
+	if cfg.OpenWorldHint != nil {
+		ann.OpenWorldHint = cfg.OpenWorldHint
+	}
+	return ann
+}

--- a/pkg/toolkit/annotations_test.go
+++ b/pkg/toolkit/annotations_test.go
@@ -1,0 +1,36 @@
+package toolkit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnnotationsToMCP(t *testing.T) {
+	tr, fa := true, false
+
+	t.Run("all unset yields empty annotations", func(t *testing.T) {
+		ann := AnnotationsToMCP(AnnotationConfig{})
+		require.NotNil(t, ann)
+		assert.False(t, ann.ReadOnlyHint)
+		assert.Nil(t, ann.DestructiveHint)
+		assert.False(t, ann.IdempotentHint)
+		assert.Nil(t, ann.OpenWorldHint)
+	})
+
+	t.Run("set hints are applied", func(t *testing.T) {
+		ann := AnnotationsToMCP(AnnotationConfig{
+			ReadOnlyHint:    &tr,
+			DestructiveHint: &fa,
+			IdempotentHint:  &tr,
+			OpenWorldHint:   &fa,
+		})
+		assert.True(t, ann.ReadOnlyHint)
+		require.NotNil(t, ann.DestructiveHint)
+		assert.False(t, *ann.DestructiveHint)
+		assert.True(t, ann.IdempotentHint)
+		require.NotNil(t, ann.OpenWorldHint)
+		assert.False(t, *ann.OpenWorldHint)
+	})
+}

--- a/pkg/toolkit/result.go
+++ b/pkg/toolkit/result.go
@@ -1,0 +1,47 @@
+package toolkit
+
+import (
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// ErrorResult builds an MCP tool result carrying an in-band error.
+//
+// Tool handlers surface failures through CallToolResult.IsError rather than a
+// transport-level JSON-RPC error: a handler that returns a Go error aborts the
+// call, whereas an in-band error lets the model read and react to the message.
+// The message is marshaled as a JSON struct, never formatted into a JSON
+// literal, so it is escaped correctly for any input.
+func ErrorResult(msg string) *mcp.CallToolResult {
+	// A struct with a single string field cannot fail to marshal, so the error
+	// is intentionally ignored rather than handled with an unreachable branch.
+	b, _ := json.Marshal(struct { //nolint:errcheck // marshaling one string field cannot fail
+		Error string `json:"error"`
+	}{Error: msg})
+	return &mcp.CallToolResult{
+		IsError: true,
+		Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+	}
+}
+
+// JSONResult marshals v to indented JSON and returns it as an MCP tool result.
+// A marshal failure is surfaced as an in-band ErrorResult rather than a Go
+// error, matching how tool handlers report failures.
+func JSONResult(v any) *mcp.CallToolResult {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return ErrorResult("internal error marshaling response: " + err.Error())
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+	}
+}
+
+// JSONResultTyped adapts JSONResult to the typed tool-handler return signature
+// (ctx, req, in) (*mcp.CallToolResult, Out, error). The middle structured-output
+// value is unused; handlers that emit structured content build the result
+// directly.
+func JSONResultTyped(v any) (*mcp.CallToolResult, any, error) {
+	return JSONResult(v), nil, nil
+}

--- a/pkg/toolkit/result_test.go
+++ b/pkg/toolkit/result_test.go
@@ -1,0 +1,58 @@
+package toolkit
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resultText returns the text of a single-content tool result.
+func resultText(t *testing.T, res *mcp.CallToolResult) string {
+	t.Helper()
+	require.Len(t, res.Content, 1)
+	tc, ok := res.Content[0].(*mcp.TextContent)
+	require.True(t, ok, "content should be text")
+	return tc.Text
+}
+
+func TestErrorResult(t *testing.T) {
+	res := ErrorResult("boom")
+	require.True(t, res.IsError)
+	// The message is JSON-escaped via a struct, not formatted into a literal.
+	assert.JSONEq(t, `{"error":"boom"}`, resultText(t, res))
+}
+
+func TestErrorResult_EscapesMessage(t *testing.T) {
+	// A quote in the message must not break the JSON envelope.
+	res := ErrorResult(`he said "hi"`)
+	var envelope struct {
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &envelope))
+	assert.Equal(t, `he said "hi"`, envelope.Error)
+}
+
+func TestJSONResult(t *testing.T) {
+	res := JSONResult(map[string]any{"n": 1})
+	assert.False(t, res.IsError)
+	assert.JSONEq(t, `{"n":1}`, resultText(t, res))
+}
+
+func TestJSONResult_MarshalFailureIsInBandError(t *testing.T) {
+	// A channel cannot be marshaled; the failure must surface as an in-band
+	// error result, never a panic or a dropped response.
+	res := JSONResult(make(chan int))
+	require.True(t, res.IsError)
+	assert.Contains(t, resultText(t, res), "marshaling")
+}
+
+func TestJSONResultTyped(t *testing.T) {
+	res, out, err := JSONResultTyped(map[string]any{"n": 2})
+	require.NoError(t, err)
+	assert.Nil(t, out, "the structured-output value is unused")
+	assert.False(t, res.IsError)
+	assert.JSONEq(t, `{"n":2}`, resultText(t, res))
+}

--- a/pkg/toolkits/apigateway/export.go
+++ b/pkg/toolkits/apigateway/export.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // exportToolName is the MCP tool name. The trino_export pattern
@@ -266,27 +268,27 @@ func (t *Toolkit) handleExport(ctx context.Context, _ *mcp.CallToolRequest, in e
 	policy := t.routePolicy
 	t.mu.RUnlock()
 	if deps == nil {
-		return errorResult("api_export is not configured (portal asset store unavailable)"), nil, nil
+		return toolkit.ErrorResult("api_export is not configured (portal asset store unavailable)"), nil, nil
 	}
 	if in.Connection == "" {
-		return errorResult("connection is required"), nil, nil
+		return toolkit.ErrorResult("connection is required"), nil, nil
 	}
 	if !connOK {
-		return errorResult(fmt.Sprintf("connection %q not found", in.Connection)), nil, nil
+		return toolkit.ErrorResult(fmt.Sprintf("connection %q not found", in.Connection)), nil, nil
 	}
 	if in.Name == "" {
-		return errorResult("name is required (becomes the asset's download filename)"), nil, nil
+		return toolkit.ErrorResult("name is required (becomes the asset's download filename)"), nil, nil
 	}
 	uc := resolveExportUser(ctx, deps)
 	if uc == nil {
-		return errorResult("authentication required for api_export"), nil, nil
+		return toolkit.ErrorResult("authentication required for api_export"), nil, nil
 	}
 
 	// Honor the same route policy that api_invoke_endpoint does so
 	// a persona scoped to GET /v1/users cannot export from
 	// DELETE /v1/users/{id}.
 	if _, mErr := validateMethod(in.Method); mErr != nil {
-		return errorResult(mErr.Error()), nil, nil
+		return toolkit.ErrorResult(mErr.Error()), nil, nil
 	}
 	if denial := checkRoutePolicy(ctx, policy, InvokeInput{
 		Connection: in.Connection, Method: in.Method, Path: in.Path,
@@ -295,7 +297,7 @@ func (t *Toolkit) handleExport(ctx context.Context, _ *mcp.CallToolRequest, in e
 	}
 
 	if existing := checkExportIdempotency(ctx, deps, uc, in); existing != nil {
-		return jsonResult(existing), existing, nil
+		return toolkit.JSONResult(existing), existing, nil
 	}
 
 	out, runErr := t.runExport(ctx, runExportArgs{
@@ -303,9 +305,9 @@ func (t *Toolkit) handleExport(ctx context.Context, _ *mcp.CallToolRequest, in e
 		webdavRoutes: c.webdavRoutes(), uc: uc, in: in,
 	})
 	if runErr != nil {
-		return errorResult(runErr.Error()), nil, nil
+		return toolkit.ErrorResult(runErr.Error()), nil, nil
 	}
-	return jsonResult(out), out, nil
+	return toolkit.JSONResult(out), out, nil
 }
 
 // resolveExportUser fetches the platform-injected user context. nil

--- a/pkg/toolkits/apigateway/memguard.go
+++ b/pkg/toolkits/apigateway/memguard.go
@@ -7,6 +7,8 @@ import (
 	"maps"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // Structured error codes the gateway emits for memory-protection
@@ -182,5 +184,5 @@ func budgetOrErrorResult(err error) *mcp.CallToolResult {
 	if errors.As(err, &be) {
 		return be.result()
 	}
-	return errorResult(err.Error())
+	return toolkit.ErrorResult(err.Error())
 }

--- a/pkg/toolkits/apigateway/raw.go
+++ b/pkg/toolkits/apigateway/raw.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // RawSink receives an upstream response streamed by the raw passthrough
@@ -91,7 +93,7 @@ func (*Toolkit) handleInvokeRaw(ctx context.Context, c *conn, in InvokeInput, ra
 
 	req, err := buildUpstreamRequest(callCtx, c.cfg, c.auth, catalogView{specs: c.specs, webdavRoutes: c.webdavRoutes()}, in)
 	if err != nil {
-		return errorResult(err.Error()), nil, nil
+		return toolkit.ErrorResult(err.Error()), nil, nil
 	}
 
 	// #nosec G107 G704 -- req.URL is host-pinned by buildURL + validatePath,
@@ -100,7 +102,7 @@ func (*Toolkit) handleInvokeRaw(ctx context.Context, c *conn, in InvokeInput, ra
 	// constraint even on the streamed path.
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return errorResult(scrubTransportError(err)), nil, nil
+		return toolkit.ErrorResult(scrubTransportError(err)), nil, nil
 	}
 	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup
 
@@ -170,7 +172,7 @@ func copyRawHeaders(h http.Header, sink RawSink) {
 // passthrough has begun streaming. The REST shim ignores its body when
 // the sink already wrote a response; the audit middleware records it.
 func rawStreamedResult(connection string, status int, n int64) *mcp.CallToolResult {
-	return jsonResult(map[string]any{
+	return toolkit.JSONResult(map[string]any{
 		"raw_streamed":    true,
 		"connection":      connection,
 		"upstream_status": status,

--- a/pkg/toolkits/apigateway/schema_lookup.go
+++ b/pkg/toolkits/apigateway/schema_lookup.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // ToolGetEndpointSchema is the MCP tool name for the per-endpoint
@@ -113,26 +115,26 @@ const maxResponseChars = 50000
 
 func (t *Toolkit) handleGetEndpointSchema(_ context.Context, _ *mcp.CallToolRequest, in GetEndpointSchemaInput) (*mcp.CallToolResult, any, error) {
 	if in.Connection == "" {
-		return errorResult("connection is required"), nil, nil
+		return toolkit.ErrorResult("connection is required"), nil, nil
 	}
 	if in.OperationID == "" {
-		return errorResult("operation_id is required"), nil, nil
+		return toolkit.ErrorResult("operation_id is required"), nil, nil
 	}
 	t.mu.RLock()
 	c, ok := t.connections[in.Connection]
 	t.mu.RUnlock()
 	if !ok {
-		return errorResult(fmt.Sprintf("connection %q not found", in.Connection)), nil, nil
+		return toolkit.ErrorResult(fmt.Sprintf("connection %q not found", in.Connection)), nil, nil
 	}
 	if len(c.specs) == 0 {
-		return errorResult("connection has no catalog specs configured"), nil, nil
+		return toolkit.ErrorResult("connection has no catalog specs configured"), nil, nil
 	}
 	match, candidates := resolveOperation(c, in.OperationID, in.Spec)
 	if match == nil {
 		if len(candidates) > 1 {
 			return ambiguousResult(in.OperationID, candidates), nil, nil
 		}
-		return errorResult(fmt.Sprintf("operation_id %q not found", in.OperationID)), nil, nil
+		return toolkit.ErrorResult(fmt.Sprintf("operation_id %q not found", in.OperationID)), nil, nil
 	}
 	out := buildEndpointSchemaOutput(match)
 	return cappedJSONResult(out), out, nil
@@ -537,7 +539,7 @@ func addStringIfPresent(m map[string]any, key, value string) {
 func cappedJSONResult(out EndpointSchemaOutput) *mcp.CallToolResult {
 	encoded, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
-		return errorResult("internal: marshal endpoint schema: " + err.Error())
+		return toolkit.ErrorResult("internal: marshal endpoint schema: " + err.Error())
 	}
 	if len(encoded) <= maxResponseChars {
 		return &mcp.CallToolResult{
@@ -568,7 +570,7 @@ func ambiguousResult(operationID string, candidates []schemaCandidate) *mcp.Call
 	}
 	encoded, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
-		return errorResult("operation_id is ambiguous")
+		return toolkit.ErrorResult("operation_id is ambiguous")
 	}
 	return &mcp.CallToolResult{
 		IsError: true,

--- a/pkg/toolkits/apigateway/toolkit.go
+++ b/pkg/toolkits/apigateway/toolkit.go
@@ -2,7 +2,6 @@ package apigateway
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -567,21 +566,21 @@ const defaultListEndpointsLimit = 50
 
 func (t *Toolkit) handleListEndpoints(ctx context.Context, _ *mcp.CallToolRequest, in ListEndpointsInput) (*mcp.CallToolResult, any, error) {
 	if in.Connection == "" {
-		return errorResult("connection is required"), nil, nil
+		return toolkit.ErrorResult("connection is required"), nil, nil
 	}
 	t.mu.RLock()
 	c, ok := t.connections[in.Connection]
 	policy := t.routePolicy
 	t.mu.RUnlock()
 	if !ok {
-		return errorResult(fmt.Sprintf("connection %q not found (use list_connections to discover api connections)", in.Connection)), nil, nil
+		return toolkit.ErrorResult(fmt.Sprintf("connection %q not found (use list_connections to discover api connections)", in.Connection)), nil, nil
 	}
 	if len(c.operations) == 0 {
 		out := ListEndpointsOutput{
 			Operations: []OperationSummary{},
 			Note:       "no catalog_id configured for this connection; call api_invoke_endpoint with method+path directly",
 		}
-		return jsonResult(out), out, nil
+		return toolkit.JSONResult(out), out, nil
 	}
 	// Multi-spec gate: when the connection's catalog bundles more than
 	// one component spec and the caller did not name one, return the
@@ -599,7 +598,7 @@ func (t *Toolkit) handleListEndpoints(ctx context.Context, _ *mcp.CallToolReques
 				"spec=<name> to list operations in one spec, or call api_list_specs to browse them",
 				len(summaries)),
 		}
-		return jsonResult(out), out, nil
+		return toolkit.JSONResult(out), out, nil
 	}
 	// Filter through the route policy so a persona only sees the
 	// operations it could actually invoke. Without this, a persona
@@ -620,7 +619,7 @@ func (t *Toolkit) handleListEndpoints(ctx context.Context, _ *mcp.CallToolReques
 	}
 	mode, modeErr := parseRankingMode(in.Ranking)
 	if modeErr != nil {
-		return errorResult(modeErr.Error()), nil, nil
+		return toolkit.ErrorResult(modeErr.Error()), nil, nil
 	}
 	// Default-ON semantic ranking: when the caller does not pin a
 	// ranking, resolve an omitted value to hybrid whenever this
@@ -641,7 +640,7 @@ func (t *Toolkit) handleListEndpoints(ctx context.Context, _ *mcp.CallToolReques
 	})
 	out := ListEndpointsOutput{Operations: ranked}
 	out.Note = rankingFallbackNote(rankingDefaulted, mode, fallbackReason)
-	return jsonResult(out), out, nil
+	return toolkit.JSONResult(out), out, nil
 }
 
 // handleListSpecs returns one summary per component spec in the
@@ -652,23 +651,23 @@ func (t *Toolkit) handleListEndpoints(ctx context.Context, _ *mcp.CallToolReques
 // an empty Specs list and a Note pointing at the direct-invoke path.
 func (t *Toolkit) handleListSpecs(_ context.Context, _ *mcp.CallToolRequest, in ListSpecsInput) (*mcp.CallToolResult, any, error) {
 	if in.Connection == "" {
-		return errorResult("connection is required"), nil, nil
+		return toolkit.ErrorResult("connection is required"), nil, nil
 	}
 	t.mu.RLock()
 	c, ok := t.connections[in.Connection]
 	t.mu.RUnlock()
 	if !ok {
-		return errorResult(fmt.Sprintf("connection %q not found (use list_connections to discover api connections)", in.Connection)), nil, nil
+		return toolkit.ErrorResult(fmt.Sprintf("connection %q not found (use list_connections to discover api connections)", in.Connection)), nil, nil
 	}
 	if len(c.specs) == 0 {
 		out := ListSpecsOutput{
 			Specs: []SpecSummary{},
 			Note:  "no catalog configured for this connection; call api_invoke_endpoint with method+path directly",
 		}
-		return jsonResult(out), out, nil
+		return toolkit.JSONResult(out), out, nil
 	}
 	out := ListSpecsOutput{Specs: buildSpecSummaries(c)}
-	return jsonResult(out), out, nil
+	return toolkit.JSONResult(out), out, nil
 }
 
 // buildSpecSummaries projects a connection's parsed specs into the
@@ -1092,7 +1091,7 @@ func (t *Toolkit) Close() error {
 // clients can consume it directly).
 func (t *Toolkit) handleInvoke(ctx context.Context, _ *mcp.CallToolRequest, in InvokeInput) (*mcp.CallToolResult, any, error) {
 	if in.Connection == "" {
-		return errorResult("connection is required"), nil, nil
+		return toolkit.ErrorResult("connection is required"), nil, nil
 	}
 	t.mu.RLock()
 	c, ok := t.connections[in.Connection]
@@ -1100,14 +1099,14 @@ func (t *Toolkit) handleInvoke(ctx context.Context, _ *mcp.CallToolRequest, in I
 	budget := t.memBudget
 	t.mu.RUnlock()
 	if !ok {
-		return errorResult(fmt.Sprintf("connection %q not found (use list_connections to discover api connections)", in.Connection)), nil, nil
+		return toolkit.ErrorResult(fmt.Sprintf("connection %q not found (use list_connections to discover api connections)", in.Connection)), nil, nil
 	}
 
 	// Run the route policy BEFORE invoke() so an unauthorized call
 	// never produces an outbound HTTP request — and never appears in
 	// the upstream's access log.
 	if res := checkRoutePolicy(ctx, policy, in); res != nil {
-		return res, nil, nil //nolint:nilerr // tool error surfaced via result
+		return res, nil, nil
 	}
 
 	// Raw passthrough (issue #535): when the REST shim has installed a
@@ -1136,7 +1135,7 @@ func (t *Toolkit) handleInvoke(ctx context.Context, _ *mcp.CallToolRequest, in I
 		if errors.As(err, &nb) {
 			return nb.result(hasExport), nil, nil
 		}
-		return budgetOrErrorResult(err), nil, nil //nolint:nilerr // MCP protocol — failures surfaced via result
+		return budgetOrErrorResult(err), nil, nil
 	}
 	// Clear the api_export hint when the toolkit was built without
 	// export deps — the model would otherwise be told to use a tool
@@ -1170,7 +1169,7 @@ func (t *Toolkit) handleInvoke(ctx context.Context, _ *mcp.CallToolRequest, in I
 //     successful proxies of upstream errors flow through as wire
 //     HTTP 200 with the upstream code embedded in the body.
 func buildInvokeResult(out InvokeOutput) *mcp.CallToolResult {
-	result := jsonResult(out)
+	result := toolkit.JSONResult(out)
 	outcome := ClassifyInvokeOutcome(out)
 	result.Meta = mcp.Meta{observability.MetaAuditOutcome: outcome}
 	if msg := auditOutcomeMessage(out); msg != "" {
@@ -1215,10 +1214,10 @@ func checkRoutePolicy(ctx context.Context, policy RoutePolicy, in InvokeInput) *
 	}
 	method, mErr := validateMethod(in.Method)
 	if mErr != nil {
-		return errorResult(mErr.Error())
+		return toolkit.ErrorResult(mErr.Error())
 	}
 	if pErr := validatePath(in.Path); pErr != nil {
-		return errorResult(pErr.Error())
+		return toolkit.ErrorResult(pErr.Error())
 	}
 	allowed, reason := policy.Allow(ctx, in.Connection, method, in.Path)
 	if allowed {
@@ -1228,31 +1227,7 @@ func checkRoutePolicy(ctx context.Context, policy RoutePolicy, in InvokeInput) *
 	if reason != "" {
 		msg = msg + ": " + reason
 	}
-	return errorResult(msg)
-}
-
-// jsonResult creates a successful MCP result with the JSON-encoded
-// payload as text content. Mirrors the helper used by other
-// in-repo toolkits so the chat surface formatting stays consistent.
-func jsonResult(data any) *mcp.CallToolResult {
-	b, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		return errorResult("internal error: " + err.Error())
-	}
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
-	}
-}
-
-func errorResult(msg string) *mcp.CallToolResult {
-	b, err := json.Marshal(map[string]string{"error": msg})
-	if err != nil {
-		b = []byte(`{"error": "internal error"}`)
-	}
-	return &mcp.CallToolResult{
-		IsError: true,
-		Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
-	}
+	return toolkit.ErrorResult(msg)
 }
 
 // newHTTPClient builds the per-connection HTTP client. Redirects

--- a/pkg/toolkits/apigateway/toolkit_test.go
+++ b/pkg/toolkits/apigateway/toolkit_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/txn2/mcp-data-platform/pkg/connoauth"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 func TestNew_DefaultsToKindWhenNameEmpty(t *testing.T) {
@@ -741,7 +742,7 @@ func TestInvoke_ConnectTimeout_FiresFast(t *testing.T) {
 }
 
 func TestErrorResult_ProducesIsError(t *testing.T) {
-	r := errorResult("bad thing")
+	r := toolkit.ErrorResult("bad thing")
 	if !r.IsError {
 		t.Error("IsError = false")
 	}
@@ -751,7 +752,7 @@ func TestErrorResult_ProducesIsError(t *testing.T) {
 }
 
 func TestJSONResult_EmbedsPayload(t *testing.T) {
-	r := jsonResult(map[string]any{"x": 1})
+	r := toolkit.JSONResult(map[string]any{"x": 1})
 	if r.IsError {
 		t.Error("jsonResult set IsError")
 	}

--- a/pkg/toolkits/datahub/config.go
+++ b/pkg/toolkits/datahub/config.go
@@ -1,8 +1,11 @@
 package datahub
 
 import (
+	"errors"
 	"fmt"
 	"time"
+
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // ParseConfig parses a DataHub toolkit configuration from a map.
@@ -20,7 +23,7 @@ func ParseConfig(cfg map[string]any) (Config, error) {
 		c.URL = getString(cfg, "endpoint")
 	}
 	if c.URL == "" {
-		return c, fmt.Errorf("url is required")
+		return c, errors.New("url is required")
 	}
 
 	// Optional string fields
@@ -53,12 +56,7 @@ func ParseConfig(cfg map[string]any) (Config, error) {
 }
 
 // AnnotationConfig holds tool annotation overrides from configuration.
-type AnnotationConfig struct {
-	ReadOnlyHint    *bool `yaml:"read_only_hint"`
-	DestructiveHint *bool `yaml:"destructive_hint"`
-	IdempotentHint  *bool `yaml:"idempotent_hint"`
-	OpenWorldHint   *bool `yaml:"open_world_hint"`
-}
+type AnnotationConfig = toolkit.AnnotationConfig
 
 // getAnnotationsMap extracts annotation overrides from a config map.
 func getAnnotationsMap(cfg map[string]any, key string) map[string]AnnotationConfig { //nolint:unparam // consistent with getStringMap

--- a/pkg/toolkits/datahub/toolkit.go
+++ b/pkg/toolkits/datahub/toolkit.go
@@ -2,6 +2,7 @@
 package datahub
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/query"
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 const (
@@ -95,7 +97,7 @@ func New(name string, cfg Config) (*Toolkit, error) {
 // validateConfig validates the required configuration fields.
 func validateConfig(cfg Config) error {
 	if cfg.URL == "" {
-		return fmt.Errorf("datahub URL is required")
+		return errors.New("datahub URL is required")
 	}
 	return nil
 }
@@ -178,27 +180,9 @@ func toDataHubAnnotations(m map[string]AnnotationConfig) map[dhtools.ToolName]*m
 	}
 	result := make(map[dhtools.ToolName]*mcp.ToolAnnotations, len(m))
 	for k, v := range m {
-		result[dhtools.ToolName(k)] = annotationConfigToMCP(v)
+		result[dhtools.ToolName(k)] = toolkit.AnnotationsToMCP(v)
 	}
 	return result
-}
-
-// annotationConfigToMCP converts an AnnotationConfig to an mcp.ToolAnnotations.
-func annotationConfigToMCP(cfg AnnotationConfig) *mcp.ToolAnnotations {
-	ann := &mcp.ToolAnnotations{}
-	if cfg.ReadOnlyHint != nil {
-		ann.ReadOnlyHint = *cfg.ReadOnlyHint
-	}
-	if cfg.DestructiveHint != nil {
-		ann.DestructiveHint = cfg.DestructiveHint
-	}
-	if cfg.IdempotentHint != nil {
-		ann.IdempotentHint = *cfg.IdempotentHint
-	}
-	if cfg.OpenWorldHint != nil {
-		ann.OpenWorldHint = cfg.OpenWorldHint
-	}
-	return ann
 }
 
 // Kind returns the toolkit kind.

--- a/pkg/toolkits/datahub/toolkit_test.go
+++ b/pkg/toolkits/datahub/toolkit_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/query"
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 const (
@@ -452,7 +453,7 @@ func TestAnnotationConfigToMCP(t *testing.T) {
 			IdempotentHint:  &idempotent,
 			OpenWorldHint:   &openWorld,
 		}
-		ann := annotationConfigToMCP(cfg)
+		ann := toolkit.AnnotationsToMCP(cfg)
 		if !ann.ReadOnlyHint {
 			t.Error("expected ReadOnlyHint=true")
 		}
@@ -469,7 +470,7 @@ func TestAnnotationConfigToMCP(t *testing.T) {
 
 	t.Run("no fields set", func(t *testing.T) {
 		cfg := AnnotationConfig{}
-		ann := annotationConfigToMCP(cfg)
+		ann := toolkit.AnnotationsToMCP(cfg)
 		if ann.ReadOnlyHint {
 			t.Error("expected ReadOnlyHint=false")
 		}

--- a/pkg/toolkits/gateway/oauth.go
+++ b/pkg/toolkits/gateway/oauth.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -128,7 +129,7 @@ func (p *clientCredentialsTokenProvider) fetchLocked(ctx context.Context) (strin
 		return "", fmt.Errorf("gateway: oauth client_credentials: %w", err)
 	}
 	if tok == nil || tok.AccessToken == "" {
-		return "", fmt.Errorf("gateway: oauth client_credentials: empty access token")
+		return "", errors.New("gateway: oauth client_credentials: empty access token")
 	}
 	p.cached = tok
 	return tok.AccessToken, nil

--- a/pkg/toolkits/gateway/toolkit.go
+++ b/pkg/toolkits/gateway/toolkit.go
@@ -1269,7 +1269,7 @@ func (t *Toolkit) makeForwarder(u *upstream, remoteName, localName string) mcp.T
 			if rerr != nil {
 				msg := "reconnect after dropped session failed: " + rerr.Error()
 				u.recordError(msg)
-				return upstreamErr(connection, msg), nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError, not as Go errors
+				return upstreamErr(connection, msg), nil
 			}
 			res, err = callTool(ctx, fresh, callTimeout, remoteName, args)
 		}

--- a/pkg/toolkits/knowledge/bulk_untag.go
+++ b/pkg/toolkits/knowledge/bulk_untag.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // bulkUntagMaxEntities bounds how many entities one bulk_untag call processes, so
@@ -42,19 +43,19 @@ var bulkUntagEntityTypes = []string{
 // requires explicit confirmation because it is destructive across many entities.
 func (t *Toolkit) handleBulkUntag(ctx context.Context, input applyKnowledgeInput) (*mcp.CallToolResult, any, error) {
 	if input.TagURN == "" {
-		return errorResult("tag_urn is required for bulk_untag"), nil, nil
+		return toolkit.ErrorResult("tag_urn is required for bulk_untag"), nil, nil
 	}
 	tagURN := normalizeTagURN(input.TagURN)
 	if t.semanticProvider == nil {
-		return errorResult("bulk_untag requires a semantic search provider to enumerate entities; none is configured"), nil, nil
+		return toolkit.ErrorResult("bulk_untag requires a semantic search provider to enumerate entities; none is configured"), nil, nil
 	}
 
 	urns, truncated, err := t.enumerateTaggedEntities(ctx, tagURN)
 	if err != nil {
-		return errorResult("bulk_untag: enumerating entities for tag failed: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("bulk_untag: enumerating entities for tag failed: " + err.Error()), nil, nil
 	}
 	if len(urns) == 0 {
-		return jsonResult(map[string]any{
+		return toolkit.JSONResultTyped(map[string]any{
 			fieldTagURN:         tagURN,
 			"entities_untagged": 0,
 			fieldMessage:        "No entities carry this tag within the searchable catalog.",
@@ -69,7 +70,7 @@ func (t *Toolkit) handleBulkUntag(ctx context.Context, input applyKnowledgeInput
 
 	affected, failed := t.removeTagFromEntities(ctx, urns, tagURN)
 	if len(affected) == 0 {
-		return errorResult("bulk_untag: found entities but failed to remove the tag from any of them"), nil, nil
+		return toolkit.ErrorResult("bulk_untag: found entities but failed to remove the tag from any of them"), nil, nil
 	}
 
 	csID, err := t.recordBulkUntagChangeset(ctx, tagURN, authorFromContext(ctx), affected)
@@ -78,10 +79,10 @@ func (t *Toolkit) handleBulkUntag(ctx context.Context, input applyKnowledgeInput
 		// this as an error so the operator investigates rather than trusting a
 		// changeset_id that does not resolve.
 		slog.Error("knowledge: bulk_untag failed to record changeset", "tag_urn", tagURN, "error", err)
-		return errorResult(fmt.Sprintf(
+		return toolkit.ErrorResult(fmt.Sprintf(
 			"bulk_untag removed %s from %d entities but FAILED to record the audit changeset: %v; "+
 				"the operation is not in the audit log and has no rollback handle.",
-			tagURN, len(affected), err)), nil, nil //nolint:nilerr // MCP protocol
+			tagURN, len(affected), err)), nil, nil
 	}
 
 	return bulkUntagSuccess(bulkUntagOutcome{
@@ -192,7 +193,7 @@ func bulkUntagConfirmation(tagURN string, urns []string, truncated bool) (*mcp.C
 	if truncated {
 		resp["truncated"] = true
 	}
-	return jsonResult(resp)
+	return toolkit.JSONResultTyped(resp)
 }
 
 // bulkUntagOutcome carries the result of a bulk_untag run into the success response.
@@ -227,7 +228,7 @@ func bulkUntagSuccess(o bulkUntagOutcome) (*mcp.CallToolResult, any, error) {
 		msg += fmt.Sprintf(" Only the first %d entities were processed (the catalog holds more); re-run bulk_untag to clear the remainder.", o.attempted)
 	}
 	resp[fieldMessage] = msg
-	return jsonResult(resp)
+	return toolkit.JSONResultTyped(resp)
 }
 
 // sampleURNs returns at most bulkUntagURNSample URNs so a response never echoes an

--- a/pkg/toolkits/knowledge/changeset_store.go
+++ b/pkg/toolkits/knowledge/changeset_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -254,7 +255,7 @@ type noopChangesetStore struct{}
 func (*noopChangesetStore) InsertChangeset(_ context.Context, _ Changeset) error { return nil } //nolint:revive // interface impl
 
 func (*noopChangesetStore) GetChangeset(_ context.Context, _ string) (*Changeset, error) { //nolint:revive // interface impl
-	return nil, fmt.Errorf("changeset not found")
+	return nil, errors.New("changeset not found")
 }
 
 func (*noopChangesetStore) ListChangesets(_ context.Context, _ ChangesetFilter) ([]Changeset, int, error) { //nolint:revive // interface impl

--- a/pkg/toolkits/knowledge/page_sink.go
+++ b/pkg/toolkits/knowledge/page_sink.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/embedding"
 	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // Sink discriminators for the apply action. The default (empty / sinkDataHub)
@@ -153,14 +154,14 @@ func (t *Toolkit) SetPageWriter(pw pageWriter) {
 // applied.
 func (t *Toolkit) promoteToPage(ctx context.Context, input applyKnowledgeInput) (*mcp.CallToolResult, any, error) {
 	if t.pageWriter == nil {
-		return errorResult("knowledge-page promotion is not configured on this deployment"), nil, nil
+		return toolkit.ErrorResult("knowledge-page promotion is not configured on this deployment"), nil, nil
 	}
 	page := input.Page
 	if page == nil {
-		return errorResult("page object (slug, title, body) is required for sink=knowledge_page"), nil, nil
+		return toolkit.ErrorResult("page object (slug, title, body) is required for sink=knowledge_page"), nil, nil
 	}
 	if msg := validatePagePromotion(*page); msg != "" {
-		return errorResult(msg), nil, nil
+		return toolkit.ErrorResult(msg), nil, nil
 	}
 
 	// Mis-routing guard: every source insight must be page-class. This also
@@ -168,7 +169,7 @@ func (t *Toolkit) promoteToPage(ctx context.Context, input applyKnowledgeInput) 
 	// promotion onto the page instead of being dropped (#664).
 	originClass, entityURNs, err := t.collectPageInsightRefs(ctx, input.InsightIDs)
 	if err != nil {
-		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult(err.Error()), nil, nil
 	}
 
 	// Parse the caller's explicit references (independent of body text, #690). A
@@ -176,14 +177,14 @@ func (t *Toolkit) promoteToPage(ctx context.Context, input applyKnowledgeInput) 
 	// than a silently dropped citation.
 	explicitRefs, err := parsePageReferences(page.References)
 	if err != nil {
-		return errorResult("invalid page reference: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("invalid page reference: " + err.Error()), nil, nil
 	}
 
 	// Look up the slug once: both the dedup gate (create vs update) and the
 	// find-or-create write below consult this single result (#705).
 	existing, err := t.lookupExistingPage(ctx, page.Slug)
 	if err != nil {
-		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult(err.Error()), nil, nil
 	}
 
 	// Create-time duplicate gate (#705): on a slug miss, block a near-duplicate
@@ -192,10 +193,10 @@ func (t *Toolkit) promoteToPage(ctx context.Context, input applyKnowledgeInput) 
 	// resolves the duplicate question first.
 	candidates, err := t.duplicateCandidates(ctx, *page, existing)
 	if err != nil {
-		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult(err.Error()), nil, nil
 	}
 	if len(candidates) > 0 {
-		return jsonResult(map[string]any{
+		return toolkit.JSONResultTyped(map[string]any{
 			"duplicate_blocked": true,
 			"candidates":        candidates,
 			fieldMessage: "A similar knowledge page already exists. Prefer updating existing knowledge over creating a duplicate: " +
@@ -204,7 +205,7 @@ func (t *Toolkit) promoteToPage(ctx context.Context, input applyKnowledgeInput) 
 	}
 
 	if t.requireConfirmation && !input.Confirm {
-		return jsonResult(map[string]any{
+		return toolkit.JSONResultTyped(map[string]any{
 			"confirmation_required": true,
 			"slug":                  page.Slug,
 			fieldMessage:            "Set confirm: true to promote this knowledge to a page.",
@@ -221,7 +222,7 @@ func (t *Toolkit) promoteToPage(ctx context.Context, input applyKnowledgeInput) 
 	// page or leave it partially written).
 	plan, err := t.preparePageRefs(ctx, *page, entityURNs, explicitRefs, appliedBy)
 	if err != nil {
-		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult(err.Error()), nil, nil
 	}
 
 	tags := tagsWithOrigin(page.Tags, originClass)
@@ -229,7 +230,7 @@ func (t *Toolkit) promoteToPage(ctx context.Context, input applyKnowledgeInput) 
 		input: *page, tags: tags, appliedBy: appliedBy, plan: plan, existing: existing,
 	})
 	if err != nil {
-		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult(err.Error()), nil, nil
 	}
 
 	return t.recordPageChangesetAndMarkApplied(ctx, input, prom, appliedBy)
@@ -568,7 +569,7 @@ func promotedRefsFromURNs(urns []string) []knowledgepage.EntityRef {
 func (t *Toolkit) recordPageChangesetAndMarkApplied(ctx context.Context, input applyKnowledgeInput, prom *pagePromotion, appliedBy string) (*mcp.CallToolResult, any, error) {
 	csID, err := generateID()
 	if err != nil {
-		return errorResult("internal error generating changeset ID"), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("internal error generating changeset ID"), nil, nil
 	}
 	insightIDs := input.InsightIDs
 	if insightIDs == nil {
@@ -584,7 +585,7 @@ func (t *Toolkit) recordPageChangesetAndMarkApplied(ctx context.Context, input a
 		AppliedBy:        appliedBy,
 	}
 	if err := t.changesetStore.InsertChangeset(ctx, cs); err != nil {
-		return errorResult("failed to record changeset: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to record changeset: " + err.Error()), nil, nil
 	}
 	for _, insID := range insightIDs {
 		if err := t.store.MarkApplied(ctx, insID, appliedBy, csID); err != nil {
@@ -625,7 +626,7 @@ func (t *Toolkit) recordPageChangesetAndMarkApplied(ctx context.Context, input a
 		}
 	}
 	result[fieldMessage] = msg
-	return jsonResult(result)
+	return toolkit.JSONResultTyped(result)
 }
 
 // collectPageInsightRefs fetches each source insight and gathers the references

--- a/pkg/toolkits/knowledge/rollback.go
+++ b/pkg/toolkits/knowledge/rollback.go
@@ -467,7 +467,7 @@ func stringSetField(m map[string]any, key string) map[string]bool {
 // failures uniformly (see writeRollbackError / rollbackErrorResult).
 func revertPageChangeset(ctx context.Context, deps RollbackDeps, cs *Changeset, rolledBackBy string) (*RollbackResult, error) {
 	if deps.Pages == nil {
-		return nil, fmt.Errorf("knowledge-page rollback is not configured on this deployment")
+		return nil, errors.New("knowledge-page rollback is not configured on this deployment")
 	}
 	slug := strings.TrimPrefix(cs.TargetURN, pageTargetPrefix)
 	page, err := deps.Pages.GetBySlug(ctx, slug)

--- a/pkg/toolkits/knowledge/rollback_handlers.go
+++ b/pkg/toolkits/knowledge/rollback_handlers.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // changesetSummary is the discovery-surface view of a changeset, omitting the
@@ -26,10 +28,10 @@ type changesetSummary struct {
 // aspects to their pre-change state.
 func (t *Toolkit) handleRollback(ctx context.Context, input applyKnowledgeInput) (*mcp.CallToolResult, any, error) {
 	if input.ChangesetID == "" {
-		return errorResult("changeset_id is required for rollback action"), nil, nil
+		return toolkit.ErrorResult("changeset_id is required for rollback action"), nil, nil
 	}
 	if t.requireConfirmation && !input.Confirm {
-		return jsonResult(map[string]any{
+		return toolkit.JSONResultTyped(map[string]any{
 			"confirmation_required": true,
 			"changeset_id":          input.ChangesetID,
 			fieldMessage:            "Set confirm: true to roll back this changeset.",
@@ -38,10 +40,10 @@ func (t *Toolkit) handleRollback(ctx context.Context, input applyKnowledgeInput)
 
 	cs, err := t.changesetStore.GetChangeset(ctx, input.ChangesetID)
 	if err != nil {
-		return errorResult("changeset not found: " + input.ChangesetID), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("changeset not found: " + input.ChangesetID), nil, nil
 	}
 	if input.EntityURN != "" && cs.TargetURN != input.EntityURN {
-		return errorResult("changeset " + input.ChangesetID + " does not belong to entity " + input.EntityURN), nil, nil
+		return toolkit.ErrorResult("changeset " + input.ChangesetID + " does not belong to entity " + input.EntityURN), nil, nil
 	}
 
 	deps := RollbackDeps{Writer: t.datahubWriter, Changesets: t.changesetStore, Insights: t.store, Pages: t.pageWriter}
@@ -49,7 +51,7 @@ func (t *Toolkit) handleRollback(ctx context.Context, input applyKnowledgeInput)
 	if err != nil {
 		return rollbackErrorResult(err), nil, nil
 	}
-	return jsonResult(result)
+	return toolkit.JSONResultTyped(result)
 }
 
 // rollbackErrorResult maps rollback failures to user-facing tool errors with the
@@ -60,15 +62,15 @@ func rollbackErrorResult(err error) *mcp.CallToolResult {
 	var pageEdited *PageEditedError
 	switch {
 	case errors.Is(err, ErrChangesetAlreadyRolledBack):
-		return errorResult("changeset has already been rolled back")
+		return toolkit.ErrorResult("changeset has already been rolled back")
 	case errors.As(err, &unrevertible):
-		return errorResult(unrevertible.Error())
+		return toolkit.ErrorResult(unrevertible.Error())
 	case errors.As(err, &conflict):
-		return errorResult(conflict.Error())
+		return toolkit.ErrorResult(conflict.Error())
 	case errors.As(err, &pageEdited):
-		return errorResult(pageEdited.Error())
+		return toolkit.ErrorResult(pageEdited.Error())
 	default:
-		return errorResult("rollback failed: " + err.Error())
+		return toolkit.ErrorResult("rollback failed: " + err.Error())
 	}
 }
 
@@ -76,7 +78,7 @@ func rollbackErrorResult(err error) *mcp.CallToolResult {
 // discover rollback targets without already holding their ids.
 func (t *Toolkit) handleListChangesets(ctx context.Context, input applyKnowledgeInput) (*mcp.CallToolResult, any, error) {
 	if input.EntityURN == "" {
-		return errorResult("entity_urn is required for list_changesets action"), nil, nil
+		return toolkit.ErrorResult("entity_urn is required for list_changesets action"), nil, nil
 	}
 
 	changesets, total, err := t.changesetStore.ListChangesets(ctx, ChangesetFilter{
@@ -84,7 +86,7 @@ func (t *Toolkit) handleListChangesets(ctx context.Context, input applyKnowledge
 		Limit:     MaxLimit,
 	})
 	if err != nil {
-		return errorResult("failed to list changesets: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to list changesets: " + err.Error()), nil, nil
 	}
 
 	summaries := make([]changesetSummary, 0, len(changesets))
@@ -92,7 +94,7 @@ func (t *Toolkit) handleListChangesets(ctx context.Context, input applyKnowledge
 		summaries = append(summaries, toChangesetSummary(&changesets[i]))
 	}
 
-	return jsonResult(map[string]any{
+	return toolkit.JSONResultTyped(map[string]any{
 		fieldEntityURN: input.EntityURN,
 		"total":        total,
 		"changesets":   summaries,

--- a/pkg/toolkits/knowledge/store.go
+++ b/pkg/toolkits/knowledge/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -313,7 +314,7 @@ func (s *postgresStore) Update(ctx context.Context, id string, updates InsightUp
 	}
 
 	if !hasUpdates {
-		return fmt.Errorf("no fields to update")
+		return errors.New("no fields to update")
 	}
 
 	qb = qb.Where(sq.Eq{"id": id}).Where(sq.NotEq{colStatus: StatusApplied})
@@ -581,7 +582,7 @@ type noopStore struct{}
 func (*noopStore) Insert(_ context.Context, _ Insight) error { return nil } //nolint:revive // interface impl
 
 func (*noopStore) Get(_ context.Context, _ string) (*Insight, error) { //nolint:revive // interface impl
-	return nil, fmt.Errorf("insight not found")
+	return nil, errors.New("insight not found")
 }
 
 func (*noopStore) List(_ context.Context, _ InsightFilter) ([]Insight, int, error) { //nolint:revive // interface impl

--- a/pkg/toolkits/knowledge/toolkit.go
+++ b/pkg/toolkits/knowledge/toolkit.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -22,6 +23,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/query"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // PromptCreator creates and registers prompts at runtime.
@@ -269,7 +271,7 @@ func (*Toolkit) Close() error {
 // handleApplyKnowledge dispatches to the appropriate action handler.
 func (t *Toolkit) handleApplyKnowledge(ctx context.Context, _ *mcp.CallToolRequest, input applyKnowledgeInput) (*mcp.CallToolResult, any, error) {
 	if err := ValidateAction(input.Action); err != nil {
-		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult(err.Error()), nil, nil
 	}
 	return t.dispatchApplyAction(ctx, input)
 }
@@ -296,7 +298,7 @@ func (t *Toolkit) dispatchApplyAction(ctx context.Context, input applyKnowledgeI
 	case actionBulkUntag:
 		return t.handleBulkUntag(ctx, input)
 	default:
-		return errorResult("unknown action: " + input.Action), nil, nil
+		return toolkit.ErrorResult("unknown action: " + input.Action), nil, nil
 	}
 }
 
@@ -351,11 +353,11 @@ func (t *Toolkit) handleBulkReview(ctx context.Context, input applyKnowledgeInpu
 func (t *Toolkit) bulkReviewCounts(ctx context.Context) (*mcp.CallToolResult, any, error) {
 	stats, err := t.store.Stats(ctx, InsightFilter{Status: StatusPending})
 	if err != nil {
-		return errorResult("failed to get stats: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to get stats: " + err.Error()), nil, nil
 	}
 	sample, _, err := t.store.List(ctx, InsightFilter{Status: StatusPending, Limit: MaxLimit})
 	if err != nil {
-		return errorResult("failed to list insights: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to list insights: " + err.Error()), nil, nil
 	}
 
 	result := map[string]any{
@@ -371,7 +373,7 @@ func (t *Toolkit) bulkReviewCounts(ctx context.Context) (*mcp.CallToolResult, an
 		// returns every pending insight including entity-agnostic ones.
 		result["by_entity_complete"] = false
 	}
-	return jsonResult(result)
+	return toolkit.JSONResultTyped(result)
 }
 
 // bulkReviewItemized returns the complete pending queue: aggregate counts and a
@@ -384,7 +386,7 @@ func (t *Toolkit) bulkReviewCounts(ctx context.Context) (*mcp.CallToolResult, an
 func (t *Toolkit) bulkReviewItemized(ctx context.Context, input applyKnowledgeInput) (*mcp.CallToolResult, any, error) {
 	pending, err := t.collectPending(ctx)
 	if err != nil {
-		return errorResult("failed to list pending insights: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to list pending insights: " + err.Error()), nil, nil
 	}
 
 	byCategory := make(map[string]int)
@@ -423,7 +425,7 @@ func (t *Toolkit) bulkReviewItemized(ctx context.Context, input applyKnowledgeIn
 		// Page on with next_offset to read the rest (#724).
 		result["page_size_capped"] = true
 	}
-	return jsonResult(result)
+	return toolkit.JSONResultTyped(result)
 }
 
 // bulkReviewItem is the per-insight shape returned by itemized bulk_review. It is
@@ -644,12 +646,12 @@ func buildEntitySummaries(insights []Insight) []EntityInsightSummary {
 // handleReview returns insights for a specific entity with current metadata.
 func (t *Toolkit) handleReview(ctx context.Context, input applyKnowledgeInput) (*mcp.CallToolResult, any, error) {
 	if input.EntityURN == "" {
-		return errorResult("entity_urn is required for review action"), nil, nil
+		return toolkit.ErrorResult("entity_urn is required for review action"), nil, nil
 	}
 
 	insights, _, err := t.store.List(ctx, InsightFilter{EntityURN: input.EntityURN, Limit: MaxLimit})
 	if err != nil {
-		return errorResult("failed to list insights: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to list insights: " + err.Error()), nil, nil
 	}
 
 	var currentMeta *EntityMetadata
@@ -666,13 +668,13 @@ func (t *Toolkit) handleReview(ctx context.Context, input applyKnowledgeInput) (
 		"insights":         insights,
 	}
 
-	return jsonResult(result)
+	return toolkit.JSONResultTyped(result)
 }
 
 // handleSynthesize gathers approved insights and returns a structured proposal.
 func (t *Toolkit) handleSynthesize(ctx context.Context, input applyKnowledgeInput) (*mcp.CallToolResult, any, error) {
 	if input.EntityURN == "" {
-		return errorResult("entity_urn is required for synthesize action"), nil, nil
+		return toolkit.ErrorResult("entity_urn is required for synthesize action"), nil, nil
 	}
 
 	// Get approved insights for this entity
@@ -683,7 +685,7 @@ func (t *Toolkit) handleSynthesize(ctx context.Context, input applyKnowledgeInpu
 	}
 	insights, _, err := t.store.List(ctx, filter)
 	if err != nil {
-		return errorResult("failed to list insights: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to list insights: " + err.Error()), nil, nil
 	}
 
 	// Filter by specific IDs if provided
@@ -715,7 +717,7 @@ func (t *Toolkit) handleSynthesize(ctx context.Context, input applyKnowledgeInpu
 			"Review the insight text above and the current metadata, then construct changes for the apply action."
 	}
 
-	return jsonResult(result)
+	return toolkit.JSONResultTyped(result)
 }
 
 // buildProposedChanges assembles proposed changes from insight suggested actions.
@@ -750,23 +752,23 @@ func (t *Toolkit) handleApply(ctx context.Context, input applyKnowledgeInput) (*
 	case sinkKnowledgePage:
 		return t.promoteToPage(ctx, input)
 	default:
-		return errorResult("unknown sink: " + input.Sink + " (valid: datahub, knowledge_page)"), nil, nil
+		return toolkit.ErrorResult("unknown sink: " + input.Sink + " (valid: datahub, knowledge_page)"), nil, nil
 	}
 
 	if input.EntityURN == "" {
-		return errorResult("entity_urn is required for apply action"), nil, nil
+		return toolkit.ErrorResult("entity_urn is required for apply action"), nil, nil
 	}
 	if err := ValidateApplyChanges(input.Changes); err != nil {
-		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult(err.Error()), nil, nil
 	}
 	// Reject unsafe change combinations up front, before the confirmation round-trip.
 	if err := validateChangeCombination(input.EntityURN, input.Changes); err != nil {
-		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult(err.Error()), nil, nil
 	}
 
 	// Check confirmation requirement
 	if t.requireConfirmation && !input.Confirm {
-		return jsonResult(map[string]any{
+		return toolkit.JSONResultTyped(map[string]any{
 			"confirmation_required": true,
 			fieldEntityURN:          input.EntityURN,
 			"changes_count":         len(input.Changes),
@@ -779,13 +781,13 @@ func (t *Toolkit) handleApply(ctx context.Context, input applyKnowledgeInput) (*
 	// Get current metadata for recording previous values
 	prevMeta, err := t.datahubWriter.GetCurrentMetadata(ctx, input.EntityURN)
 	if err != nil {
-		return errorResult("failed to get current metadata: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to get current metadata: " + err.Error()), nil, nil
 	}
 
 	// Apply all changes atomically — collect writes first, then execute
 	createdURNs, err := t.executeChanges(ctx, input.EntityURN, input.Changes)
 	if err != nil {
-		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult(err.Error()), nil, nil
 	}
 
 	return t.recordChangesetAndMarkApplied(ctx, input, prevMeta, appliedBy, createdURNs)
@@ -795,7 +797,7 @@ func (t *Toolkit) handleApply(ctx context.Context, input applyKnowledgeInput) (*
 func (t *Toolkit) recordChangesetAndMarkApplied(ctx context.Context, input applyKnowledgeInput, prevMeta *EntityMetadata, appliedBy string, createdURNs []string) (*mcp.CallToolResult, any, error) {
 	csID, err := generateID()
 	if err != nil {
-		return errorResult("internal error generating changeset ID"), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("internal error generating changeset ID"), nil, nil
 	}
 
 	insightIDs := input.InsightIDs
@@ -822,7 +824,7 @@ func (t *Toolkit) recordChangesetAndMarkApplied(ctx context.Context, input apply
 	}
 
 	if err := t.changesetStore.InsertChangeset(ctx, cs); err != nil {
-		return errorResult("failed to record changeset: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to record changeset: " + err.Error()), nil, nil
 	}
 
 	// Mark source insights as applied
@@ -853,7 +855,7 @@ func (t *Toolkit) recordChangesetAndMarkApplied(ctx context.Context, input apply
 		result["created_ids"] = createdURNs
 	}
 
-	return jsonResult(result)
+	return toolkit.JSONResultTyped(result)
 }
 
 // authorFromContext returns the acting user's identity for authorship fields
@@ -1221,7 +1223,7 @@ func (t *Toolkit) dispatchCuratedQuery(ctx context.Context, urn string, c ApplyC
 // dispatchAddPrompt handles add_prompt changes by creating a platform prompt.
 func (t *Toolkit) dispatchAddPrompt(ctx context.Context, c ApplyChange) (string, error) {
 	if t.promptCreator == nil {
-		return "", fmt.Errorf("prompt creation not available: feature not initialized")
+		return "", errors.New("prompt creation not available: feature not initialized")
 	}
 	desc := c.QueryDescription
 	if desc == "" {
@@ -1381,7 +1383,7 @@ func normalizeStructuredPropertyURN(name string) string {
 func parsePropertyValues(detail string) ([]any, error) {
 	detail = strings.TrimSpace(detail)
 	if detail == "" {
-		return nil, fmt.Errorf("detail is required for structured property values")
+		return nil, errors.New("detail is required for structured property values")
 	}
 
 	// Try parsing as JSON array first, using UseNumber to preserve int64/float64 types
@@ -1452,7 +1454,7 @@ func parseColumnTarget(target string) (string, bool) {
 // handleApproveReject transitions insight statuses.
 func (t *Toolkit) handleApproveReject(ctx context.Context, input applyKnowledgeInput, targetStatus string) (*mcp.CallToolResult, any, error) {
 	if len(input.InsightIDs) == 0 {
-		return errorResult("insight_ids is required for " + input.Action + " action"), nil, nil
+		return toolkit.ErrorResult("insight_ids is required for " + input.Action + " action"), nil, nil
 	}
 
 	pc := middleware.GetPlatformContext(ctx)
@@ -1490,7 +1492,7 @@ func (t *Toolkit) handleApproveReject(ctx context.Context, input applyKnowledgeI
 		result["errors"] = errors
 	}
 
-	return jsonResult(result)
+	return toolkit.JSONResultTyped(result)
 }
 
 // generateID generates a cryptographically random hex ID.
@@ -1500,30 +1502,6 @@ func generateID() (string, error) {
 		return "", fmt.Errorf("generating random bytes: %w", err)
 	}
 	return hex.EncodeToString(b), nil
-}
-
-// errorResult creates an error CallToolResult.
-func errorResult(msg string) *mcp.CallToolResult {
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: fmt.Sprintf(`{"error": %q}`, msg)},
-		},
-		IsError: true,
-	}
-}
-
-// jsonResult marshals a value to JSON and returns it as a CallToolResult.
-func jsonResult(v any) (*mcp.CallToolResult, any, error) {
-	data, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return errorResult("internal error marshaling response"), nil, nil //nolint:nilerr // MCP protocol
-	}
-
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: string(data)},
-		},
-	}, nil, nil
 }
 
 // registerPrompt registers the knowledge capture guidance prompt

--- a/pkg/toolkits/knowledge/toolkit_test.go
+++ b/pkg/toolkits/knowledge/toolkit_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/memory"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // Test constants to avoid repeated string literals.
@@ -737,7 +738,7 @@ func TestToolkit_RegistersPrompt(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestErrorResult(t *testing.T) {
-	result := errorResult("something went wrong")
+	result := toolkit.ErrorResult("something went wrong")
 	assert.True(t, result.IsError)
 	assert.NotEmpty(t, result.Content)
 
@@ -748,7 +749,7 @@ func TestErrorResult(t *testing.T) {
 
 func TestJsonResult(t *testing.T) {
 	data := map[string]any{"key": "value", "count": float64(42)}
-	result, _, err := jsonResult(data)
+	result, _, err := toolkit.JSONResultTyped(data)
 	require.Nil(t, err)
 	require.False(t, result.IsError)
 

--- a/pkg/toolkits/knowledge/types.go
+++ b/pkg/toolkits/knowledge/types.go
@@ -2,6 +2,7 @@
 package knowledge
 
 import (
+	"errors"
 	"fmt"
 	"time"
 )
@@ -32,7 +33,7 @@ var validCategories = map[category]bool{
 // ValidateCategory checks whether a category value is valid.
 func ValidateCategory(c string) error {
 	if c == "" {
-		return fmt.Errorf("category is required and must be one of: correction, business_context, data_quality, usage_guidance, relationship, enhancement")
+		return errors.New("category is required and must be one of: correction, business_context, data_quality, usage_guidance, relationship, enhancement")
 	}
 	if !validCategories[category(c)] {
 		return fmt.Errorf("invalid category %q: must be one of: correction, business_context, data_quality, usage_guidance, relationship, enhancement", c)
@@ -502,7 +503,7 @@ type ApplyChange struct {
 // ValidateApplyChanges validates the changes slice for the apply action.
 func ValidateApplyChanges(changes []ApplyChange) error {
 	if len(changes) == 0 {
-		return fmt.Errorf("changes is required and must not be empty")
+		return errors.New("changes is required and must not be empty")
 	}
 	if len(changes) > MaxApplyChanges {
 		return fmt.Errorf("changes exceeds maximum of %d (got %d)", MaxApplyChanges, len(changes))
@@ -530,7 +531,7 @@ func validateChangeRequiredFields(c ApplyChange) error {
 		return requireField(c.QuerySQL, "query_sql is required for add_curated_query")
 	case string(actionAddContextDocument):
 		if c.Target == "" || c.Detail == "" {
-			return fmt.Errorf("target (title) and detail (content) are required for add_context_document")
+			return errors.New("target (title) and detail (content) are required for add_context_document")
 		}
 	case string(actionUpdateContextDocument):
 		return requireField(c.Target, "target (document ID) is required for update_context_document")
@@ -540,7 +541,7 @@ func validateChangeRequiredFields(c ApplyChange) error {
 		return validateAddPromptFields(c)
 	case string(actionSetCustomProperty):
 		if c.Target == "" || c.Detail == "" {
-			return fmt.Errorf("target (property key) and detail (value) are required for set_custom_property")
+			return errors.New("target (property key) and detail (value) are required for set_custom_property")
 		}
 	case string(actionRemoveCustomProperty):
 		return requireField(c.Target, "target (property key) is required for remove_custom_property")
@@ -565,10 +566,10 @@ func requireField(value, msg string) error {
 // validateAddPromptFields validates required fields for the add_prompt change type.
 func validateAddPromptFields(c ApplyChange) error {
 	if c.Target == "" {
-		return fmt.Errorf("target (prompt name) is required for add_prompt")
+		return errors.New("target (prompt name) is required for add_prompt")
 	}
 	if c.Detail == "" {
-		return fmt.Errorf("detail (prompt content) is required for add_prompt")
+		return errors.New("detail (prompt content) is required for add_prompt")
 	}
 	return nil
 }

--- a/pkg/toolkits/memory/capture.go
+++ b/pkg/toolkits/memory/capture.go
@@ -13,6 +13,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/embedding"
 	memstore "github.com/txn2/mcp-data-platform/pkg/memory"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // memoryCaptureToolName is the unified write verb (#633). It lives in the memory
@@ -157,17 +158,17 @@ type memoryCaptureOutput struct {
 func (t *Toolkit) handleMemoryCapture(ctx context.Context, _ *mcp.CallToolRequest, input memoryCaptureInput) (*mcp.CallToolResult, any, error) {
 	content := strings.TrimSpace(input.Content)
 	if msg := validateCaptureInput(input, content); msg != "" {
-		return errorResult(msg), nil, nil
+		return toolkit.ErrorResult(msg), nil, nil
 	}
 
 	pc := middleware.GetPlatformContext(ctx)
 	if pc == nil || pc.UserEmail == "" {
-		return errorResult("a user identity (email) is required to capture knowledge"), nil, nil
+		return toolkit.ErrorResult("a user identity (email) is required to capture knowledge"), nil, nil
 	}
 
 	id, err := generateID()
 	if err != nil {
-		return errorResult("failed to generate ID"), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to generate ID"), nil, nil
 	}
 
 	actor := captureActor{UserID: pc.UserID, Email: pc.UserEmail, Persona: pc.PersonaName, SessionID: pc.SessionID}
@@ -175,7 +176,7 @@ func (t *Toolkit) handleMemoryCapture(ctx context.Context, _ *mcp.CallToolReques
 
 	out, err := t.applyCapture(ctx, &rec, input.Type, actor, input.ThreadIDs)
 	if err != nil {
-		return errorResult("failed to capture: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to capture: " + err.Error()), nil, nil
 	}
 
 	return captureSuccess(rec, out)
@@ -415,7 +416,7 @@ func captureSuccess(rec memstore.Record, out captureOutcome) (*mcp.CallToolResul
 	if len(out.Superseded) > 0 {
 		best = out.Superseded[0]
 	}
-	return jsonResult(memoryCaptureOutput{
+	return toolkit.JSONResult(memoryCaptureOutput{
 		ID:                rec.ID,
 		SinkClass:         rec.SinkClass,
 		Status:            rec.Status,

--- a/pkg/toolkits/memory/manage.go
+++ b/pkg/toolkits/memory/manage.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/embedding"
 	memstore "github.com/txn2/mcp-data-platform/pkg/memory"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 const idLength = 16
@@ -53,7 +53,7 @@ func (t *Toolkit) handleManage(ctx context.Context, _ *mcp.CallToolRequest, inpu
 	case "":
 		return helpResult(), nil, nil
 	default:
-		return errorResult(fmt.Sprintf("unknown command %q: use update, forget, list, review_stale, review_duplicates, or consolidate (create with memory_capture)", input.Command)), nil, nil
+		return toolkit.ErrorResult(fmt.Sprintf("unknown command %q: use update, forget, list, review_stale, review_duplicates, or consolidate (create with memory_capture)", input.Command)), nil, nil
 	}
 }
 
@@ -76,7 +76,7 @@ func (t *Toolkit) embeddingBreadcrumbs(emb []float32, content string) (model str
 // handleUpdate modifies an existing memory record.
 func (t *Toolkit) handleUpdate(ctx context.Context, input manageInput) (*mcp.CallToolResult, any, error) {
 	if input.ID == "" {
-		return errorResult("id is required for update"), nil, nil
+		return toolkit.ErrorResult("id is required for update"), nil, nil
 	}
 
 	if result := verifyOwnership(ctx, t.store, input.ID, cmdUpdate); result != nil {
@@ -85,14 +85,14 @@ func (t *Toolkit) handleUpdate(ctx context.Context, input manageInput) (*mcp.Cal
 
 	if input.Content != "" {
 		if err := memstore.ValidateContent(input.Content); err != nil {
-			return errorResult(err.Error()), nil, nil
+			return toolkit.ErrorResult(err.Error()), nil, nil
 		}
 	}
 	if err := memstore.ValidateCategory(input.Category); err != nil {
-		return errorResult(err.Error()), nil, nil
+		return toolkit.ErrorResult(err.Error()), nil, nil
 	}
 	if err := memstore.ValidateConfidence(input.Confidence); err != nil {
-		return errorResult(err.Error()), nil, nil
+		return toolkit.ErrorResult(err.Error()), nil, nil
 	}
 
 	updates := memstore.RecordUpdate{
@@ -118,10 +118,10 @@ func (t *Toolkit) handleUpdate(ctx context.Context, input manageInput) (*mcp.Cal
 	}
 
 	if err := t.store.Update(ctx, input.ID, updates); err != nil {
-		return errorResult("failed to update memory: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to update memory: " + err.Error()), nil, nil
 	}
 
-	return jsonResult(map[string]any{
+	return toolkit.JSONResult(map[string]any{
 		"id":         input.ID,
 		fieldMessage: "Memory updated successfully.",
 	}), nil, nil
@@ -130,7 +130,7 @@ func (t *Toolkit) handleUpdate(ctx context.Context, input manageInput) (*mcp.Cal
 // handleForget soft-deletes a memory record.
 func (t *Toolkit) handleForget(ctx context.Context, input manageInput) (*mcp.CallToolResult, any, error) {
 	if input.ID == "" {
-		return errorResult("id is required for forget"), nil, nil
+		return toolkit.ErrorResult("id is required for forget"), nil, nil
 	}
 
 	if result := verifyOwnership(ctx, t.store, input.ID, "archive"); result != nil {
@@ -138,10 +138,10 @@ func (t *Toolkit) handleForget(ctx context.Context, input manageInput) (*mcp.Cal
 	}
 
 	if err := t.store.Delete(ctx, input.ID); err != nil {
-		return errorResult("failed to archive memory: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to archive memory: " + err.Error()), nil, nil
 	}
 
-	return jsonResult(map[string]any{
+	return toolkit.JSONResult(map[string]any{
 		"id":         input.ID,
 		fieldMessage: "Memory archived successfully.",
 	}), nil, nil
@@ -154,10 +154,10 @@ func verifyOwnership(ctx context.Context, store memstore.Store, id, action strin
 	pc := middleware.GetPlatformContext(ctx)
 	record, err := store.Get(ctx, id)
 	if err != nil {
-		return errorResult("memory not found")
+		return toolkit.ErrorResult("memory not found")
 	}
 	if pc.UserEmail != "" && record.CreatedBy != pc.UserEmail {
-		return errorResult("you can only " + action + " your own memories")
+		return toolkit.ErrorResult("you can only " + action + " your own memories")
 	}
 	return nil
 }
@@ -183,10 +183,10 @@ func (t *Toolkit) handleList(ctx context.Context, input manageInput) (*mcp.CallT
 
 	records, total, err := t.store.List(ctx, filter)
 	if err != nil {
-		return errorResult("failed to list memories: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to list memories: " + err.Error()), nil, nil
 	}
 
-	return jsonResult(map[string]any{
+	return toolkit.JSONResult(map[string]any{
 		"records": records,
 		"total":   total,
 		"limit":   filter.EffectiveLimit(),
@@ -206,10 +206,10 @@ func (t *Toolkit) handleReviewStale(ctx context.Context, input manageInput) (*mc
 
 	records, total, err := t.store.List(ctx, filter)
 	if err != nil {
-		return errorResult("failed to list stale memories: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to list stale memories: " + err.Error()), nil, nil
 	}
 
-	return jsonResult(map[string]any{
+	return toolkit.JSONResult(map[string]any{
 		"records":    records,
 		"total":      total,
 		"limit":      filter.EffectiveLimit(),
@@ -238,11 +238,11 @@ func (t *Toolkit) handleReviewStale(ctx context.Context, input manageInput) (*mc
 func (t *Toolkit) handleReviewDuplicates(ctx context.Context, input manageInput) (*mcp.CallToolResult, any, error) {
 	finder, ok := t.store.(memstore.DuplicateFinder)
 	if !ok {
-		return errorResult("review_duplicates requires the database-backed memory store with vector search"), nil, nil
+		return toolkit.ErrorResult("review_duplicates requires the database-backed memory store with vector search"), nil, nil
 	}
 	pc := middleware.GetPlatformContext(ctx)
 	if pc == nil || pc.UserEmail == "" {
-		return errorResult("a user identity (email) is required to review duplicates"), nil, nil
+		return toolkit.ErrorResult("a user identity (email) is required to review duplicates"), nil, nil
 	}
 
 	// Over-fetch by one so an exactly-full page can be distinguished from a
@@ -254,7 +254,7 @@ func (t *Toolkit) handleReviewDuplicates(ctx context.Context, input manageInput)
 	want := effectiveDuplicateLimit(input.Limit)
 	pairs, err := finder.SimilarActivePairs(ctx, pc.UserEmail, recallSuggestThreshold, want+1)
 	if err != nil {
-		return errorResult("failed to list duplicate candidates: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to list duplicate candidates: " + err.Error()), nil, nil
 	}
 	moreByLimit := len(pairs) > want
 	if moreByLimit {
@@ -273,7 +273,7 @@ func (t *Toolkit) handleReviewDuplicates(ctx context.Context, input manageInput)
 		// Consolidate the shown pairs and re-run to surface the rest.
 		result["more_pairs"] = true
 	}
-	return jsonResult(result), nil, nil
+	return toolkit.JSONResult(result), nil, nil
 }
 
 // reviewDuplicatesMessage builds the review_duplicates guidance: the always-on
@@ -299,10 +299,10 @@ func reviewDuplicatesMessage(shown int, more bool) string {
 // than discarding the duplicate outright.
 func (t *Toolkit) handleConsolidate(ctx context.Context, input manageInput) (*mcp.CallToolResult, any, error) {
 	if input.ID == "" || input.DuplicateID == "" {
-		return errorResult("consolidate requires id (the record to keep) and duplicate_id (the record it supersedes)"), nil, nil
+		return toolkit.ErrorResult("consolidate requires id (the record to keep) and duplicate_id (the record it supersedes)"), nil, nil
 	}
 	if input.ID == input.DuplicateID {
-		return errorResult("id and duplicate_id must differ"), nil, nil
+		return toolkit.ErrorResult("id and duplicate_id must differ"), nil, nil
 	}
 
 	keep, result := t.fetchConsolidatePair(ctx, input.ID, input.DuplicateID)
@@ -310,14 +310,14 @@ func (t *Toolkit) handleConsolidate(ctx context.Context, input manageInput) (*mc
 		return result, nil, nil
 	}
 	if keep.Status != memstore.StatusActive {
-		return errorResult("the record to keep must be active (status: " + keep.Status + ")"), nil, nil
+		return toolkit.ErrorResult("the record to keep must be active (status: " + keep.Status + ")"), nil, nil
 	}
 
 	if err := t.store.Supersede(ctx, input.DuplicateID, input.ID); err != nil {
-		return errorResult("failed to consolidate: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to consolidate: " + err.Error()), nil, nil
 	}
 
-	return jsonResult(map[string]any{
+	return toolkit.JSONResult(map[string]any{
 		"id":         input.ID,
 		"superseded": input.DuplicateID,
 		fieldMessage: "Duplicate consolidated: the kept record now supersedes it.",
@@ -348,13 +348,13 @@ func (t *Toolkit) fetchConsolidatePair(ctx context.Context, keepID, duplicateID 
 		return nil
 	})
 	if err := g.Wait(); err != nil {
-		return nil, errorResult("memory not found")
+		return nil, toolkit.ErrorResult("memory not found")
 	}
 
 	pc := middleware.GetPlatformContext(ctx)
 	for _, r := range []*memstore.Record{keep, dup} {
 		if pc != nil && pc.UserEmail != "" && r.CreatedBy != pc.UserEmail {
-			return nil, errorResult("you can only " + cmdConsolidate + " your own memories")
+			return nil, toolkit.ErrorResult("you can only " + cmdConsolidate + " your own memories")
 		}
 	}
 	return keep, nil
@@ -362,7 +362,7 @@ func (t *Toolkit) fetchConsolidatePair(ctx context.Context, keepID, duplicateID 
 
 // helpResult returns the list of available commands.
 func helpResult() *mcp.CallToolResult {
-	return jsonResult(map[string]any{
+	return toolkit.JSONResult(map[string]any{
 		"commands": map[string]string{
 			cmdUpdate:           "Update an existing memory (requires id)",
 			cmdForget:           "Archive a memory (requires id)",
@@ -381,28 +381,4 @@ func generateID() (string, error) {
 		return "", fmt.Errorf("generating random ID: %w", err)
 	}
 	return hex.EncodeToString(b), nil
-}
-
-// jsonResult creates a successful MCP result with JSON content.
-func jsonResult(data any) *mcp.CallToolResult {
-	b, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		return errorResult("internal error: " + err.Error())
-	}
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
-	}
-}
-
-// errorResult creates an error MCP result.
-func errorResult(msg string) *mcp.CallToolResult {
-	b, err := json.Marshal(map[string]string{"error": msg})
-	if err != nil {
-		// Fallback: plain text if marshal fails (should never happen for a string).
-		b = []byte(`{"error": "internal error"}`)
-	}
-	return &mcp.CallToolResult{
-		IsError: true,
-		Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
-	}
 }

--- a/pkg/toolkits/memory/manage_test.go
+++ b/pkg/toolkits/memory/manage_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/embedding"
 	memstore "github.com/txn2/mcp-data-platform/pkg/memory"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // ---------------------------------------------------------------------------
@@ -759,7 +760,7 @@ func TestGenerateID(t *testing.T) {
 func TestJsonResult(t *testing.T) {
 	t.Parallel()
 
-	result := jsonResult(map[string]string{"key": "value"})
+	result := toolkit.JSONResult(map[string]string{"key": "value"})
 	require.NotNil(t, result)
 	assert.False(t, result.IsError)
 	require.Len(t, result.Content, 1)
@@ -773,7 +774,7 @@ func TestJsonResult(t *testing.T) {
 func TestErrorResult(t *testing.T) {
 	t.Parallel()
 
-	result := errorResult("something went wrong")
+	result := toolkit.ErrorResult("something went wrong")
 	require.NotNil(t, result)
 	assert.True(t, result.IsError)
 	require.Len(t, result.Content, 1)

--- a/pkg/toolkits/portal/collection_handlers.go
+++ b/pkg/toolkits/portal/collection_handlers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/portal"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // collectionDeletedMsg is returned when an operation targets a soft-deleted collection.
@@ -24,17 +25,17 @@ func (t *Toolkit) getActiveCollection(ctx context.Context, id string) (*portal.C
 			"Verify the collection_id; call manage_artifact action=list_collections to see your collections.")
 	}
 	if coll.DeletedAt != nil {
-		return nil, errorResult(collectionDeletedMsg)
+		return nil, toolkit.ErrorResult(collectionDeletedMsg)
 	}
 	return coll, nil
 }
 
 func (t *Toolkit) handleCreateCollection(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
 	if err := portal.ValidateCollectionName(input.Name); err != nil {
-		return errorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil
+		return toolkit.ErrorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil
 	}
 	if err := portal.ValidateCollectionDescription(input.Description); err != nil {
-		return errorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil
+		return toolkit.ErrorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil
 	}
 
 	ownerID := resolveOwnerID(ctx)
@@ -42,7 +43,7 @@ func (t *Toolkit) handleCreateCollection(ctx context.Context, input manageArtifa
 
 	collID, err := generateID()
 	if err != nil {
-		return errorResult("internal error generating collection ID"), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("internal error generating collection ID"), nil, nil
 	}
 
 	coll := portal.Collection{
@@ -54,19 +55,19 @@ func (t *Toolkit) handleCreateCollection(ctx context.Context, input manageArtifa
 	}
 
 	if err := t.collectionStore.Insert(ctx, coll); err != nil {
-		return errorResult("failed to create collection: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to create collection: " + err.Error()), nil, nil
 	}
 
 	if len(input.Sections) > 0 {
 		sections, err := convertSections(input.Sections)
 		if err != nil {
-			return errorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil //nolint:nilerr // MCP protocol
+			return toolkit.ErrorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil
 		}
 		if err := t.collectionStore.SetSections(ctx, collID, sections); err != nil {
 			// Include collection_id so the agent can retry set_sections on the orphaned collection.
-			return errorResult(fmt.Sprintf(
+			return toolkit.ErrorResult(fmt.Sprintf(
 				"collection %s created but failed to set sections: %s", collID, err.Error(),
-			)), nil, nil //nolint:nilerr // MCP protocol
+			)), nil, nil
 		}
 	}
 
@@ -77,7 +78,7 @@ func (t *Toolkit) handleCreateCollection(ctx context.Context, input manageArtifa
 	if t.baseURL != "" {
 		result["portal_url"] = t.baseURL + "/portal/collections/" + collID
 	}
-	return jsonResult(result)
+	return toolkit.JSONResultTyped(result)
 }
 
 func (t *Toolkit) handleListCollections(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
@@ -90,14 +91,14 @@ func (t *Toolkit) handleListCollections(ctx context.Context, input manageArtifac
 		Offset:  input.Offset,
 	})
 	if err != nil {
-		return errorResult("failed to list collections: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to list collections: " + err.Error()), nil, nil
 	}
 
 	if collections == nil {
 		collections = []portal.Collection{}
 	}
 
-	return jsonResult(map[string]any{
+	return toolkit.JSONResultTyped(map[string]any{
 		"collections": collections,
 		fieldTotal:    total,
 	})
@@ -107,7 +108,7 @@ func (t *Toolkit) handleListCollections(ctx context.Context, input manageArtifac
 // access is intentionally broader than write, matching the asset get behavior.
 func (t *Toolkit) handleGetCollection(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
 	if input.CollectionID == "" {
-		return errorResult("collection_id is required for get_collection action"), nil, nil
+		return toolkit.ErrorResult("collection_id is required for get_collection action"), nil, nil
 	}
 
 	coll, errResult := t.getActiveCollection(ctx, input.CollectionID)
@@ -115,12 +116,12 @@ func (t *Toolkit) handleGetCollection(ctx context.Context, input manageArtifactI
 		return errResult, nil, nil
 	}
 
-	return jsonResult(coll)
+	return toolkit.JSONResultTyped(coll)
 }
 
 func (t *Toolkit) handleUpdateCollection(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
 	if input.CollectionID == "" {
-		return errorResult("collection_id is required for update_collection action"), nil, nil
+		return toolkit.ErrorResult("collection_id is required for update_collection action"), nil, nil
 	}
 
 	coll, errResult := t.getActiveCollection(ctx, input.CollectionID)
@@ -130,7 +131,7 @@ func (t *Toolkit) handleUpdateCollection(ctx context.Context, input manageArtifa
 
 	ownerID := resolveOwnerID(ctx)
 	if coll.OwnerID != ownerID {
-		return errorResult("you can only update your own collections"), nil, nil
+		return toolkit.ErrorResult("you can only update your own collections"), nil, nil
 	}
 
 	name := coll.Name
@@ -143,27 +144,27 @@ func (t *Toolkit) handleUpdateCollection(ctx context.Context, input manageArtifa
 	}
 
 	if err := portal.ValidateCollectionName(name); err != nil {
-		return errorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil
+		return toolkit.ErrorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil
 	}
 	if err := portal.ValidateCollectionDescription(desc); err != nil {
-		return errorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil
+		return toolkit.ErrorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil
 	}
 
 	if err := t.collectionStore.Update(ctx, input.CollectionID, name, desc); err != nil {
-		return errorResult("failed to update collection: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to update collection: " + err.Error()), nil, nil
 	}
 
 	updated, err := t.collectionStore.Get(ctx, input.CollectionID)
 	if err != nil {
-		return errorResult("updated but failed to retrieve collection: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("updated but failed to retrieve collection: " + err.Error()), nil, nil
 	}
 
-	return jsonResult(updated)
+	return toolkit.JSONResultTyped(updated)
 }
 
 func (t *Toolkit) handleDeleteCollection(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
 	if input.CollectionID == "" {
-		return errorResult("collection_id is required for delete_collection action"), nil, nil
+		return toolkit.ErrorResult("collection_id is required for delete_collection action"), nil, nil
 	}
 
 	coll, errResult := t.getActiveCollection(ctx, input.CollectionID)
@@ -173,14 +174,14 @@ func (t *Toolkit) handleDeleteCollection(ctx context.Context, input manageArtifa
 
 	ownerID := resolveOwnerID(ctx)
 	if coll.OwnerID != ownerID {
-		return errorResult("you can only delete your own collections"), nil, nil
+		return toolkit.ErrorResult("you can only delete your own collections"), nil, nil
 	}
 
 	if err := t.collectionStore.SoftDelete(ctx, input.CollectionID); err != nil {
-		return errorResult("failed to delete collection: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to delete collection: " + err.Error()), nil, nil
 	}
 
-	return jsonResult(map[string]any{
+	return toolkit.JSONResultTyped(map[string]any{
 		"collection_id": input.CollectionID,
 		fieldMessage:    "Collection deleted successfully.",
 	})
@@ -188,7 +189,7 @@ func (t *Toolkit) handleDeleteCollection(ctx context.Context, input manageArtifa
 
 func (t *Toolkit) handleSetSections(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
 	if input.CollectionID == "" {
-		return errorResult("collection_id is required for set_sections action"), nil, nil
+		return toolkit.ErrorResult("collection_id is required for set_sections action"), nil, nil
 	}
 
 	coll, errResult := t.getActiveCollection(ctx, input.CollectionID)
@@ -198,24 +199,24 @@ func (t *Toolkit) handleSetSections(ctx context.Context, input manageArtifactInp
 
 	ownerID := resolveOwnerID(ctx)
 	if coll.OwnerID != ownerID {
-		return errorResult("you can only modify your own collections"), nil, nil
+		return toolkit.ErrorResult("you can only modify your own collections"), nil, nil
 	}
 
 	sections, err := convertSections(input.Sections)
 	if err != nil {
-		return errorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult(fmt.Sprintf(validationMsgFmt, err)), nil, nil
 	}
 
 	if err := t.collectionStore.SetSections(ctx, input.CollectionID, sections); err != nil {
-		return errorResult("failed to set sections: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to set sections: " + err.Error()), nil, nil
 	}
 
 	updated, err := t.collectionStore.Get(ctx, input.CollectionID)
 	if err != nil {
-		return errorResult("sections updated but failed to retrieve collection: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("sections updated but failed to retrieve collection: " + err.Error()), nil, nil
 	}
 
-	return jsonResult(updated)
+	return toolkit.JSONResultTyped(updated)
 }
 
 // convertSections transforms MCP input sections into portal CollectionSection

--- a/pkg/toolkits/portal/search.go
+++ b/pkg/toolkits/portal/search.go
@@ -9,6 +9,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/embedding"
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/portal"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // rankingLexical and rankingHybrid label which ranking path produced the
@@ -62,13 +63,13 @@ func (t *Toolkit) handleSearch(ctx context.Context, input manageArtifactInput) (
 		Limit:     input.Limit,
 	})
 	if err != nil {
-		return errorResult("failed to search assets: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to search assets: " + err.Error()), nil, nil
 	}
 	if scored == nil {
 		scored = []portal.ScoredAsset{}
 	}
 
-	return jsonResult(map[string]any{
+	return toolkit.JSONResultTyped(map[string]any{
 		"assets":     scored,
 		fieldTotal:   len(scored),
 		fieldRanking: ranking,

--- a/pkg/toolkits/portal/thread_actions.go
+++ b/pkg/toolkits/portal/thread_actions.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/portal"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // Feedback thread actions for manage_artifact (Phase 2 / #602). These are
@@ -39,7 +40,7 @@ const (
 
 func (t *Toolkit) handleListThreads(ctx context.Context, input manageFeedbackInput) (*mcp.CallToolResult, any, error) {
 	if t.threadStore == nil {
-		return errorResult(threadsUnavail), nil, nil
+		return toolkit.ErrorResult(threadsUnavail), nil, nil
 	}
 	// No target at all: return the caller's pending feedback across everything
 	// (the discovery entry point — "review any pending feedback").
@@ -48,10 +49,10 @@ func (t *Toolkit) handleListThreads(ctx context.Context, input manageFeedbackInp
 	}
 	targetType, ok := threadScopeFromInput(input)
 	if !ok {
-		return errorResult(threadScopeErr), nil, nil
+		return toolkit.ErrorResult(threadScopeErr), nil, nil
 	}
 	if !t.callerCanAccessTarget(ctx, targetType, input.AssetID, input.CollectionID) {
-		return errorResult("you can only view feedback on artifacts you own or can edit"), nil, nil
+		return toolkit.ErrorResult("you can only view feedback on artifacts you own or can edit"), nil, nil
 	}
 
 	threads, total, err := t.threadStore.ListThreads(ctx, portal.ThreadFilter{
@@ -66,12 +67,12 @@ func (t *Toolkit) handleListThreads(ctx context.Context, input manageFeedbackInp
 		Offset:             input.Offset,
 	})
 	if err != nil {
-		return errorResult("failed to list threads: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
+		return toolkit.ErrorResult("failed to list threads: " + err.Error()), nil, nil
 	}
 	if threads == nil {
 		threads = []portal.ThreadWithMeta{}
 	}
-	return jsonResult(map[string]any{"threads": threads, fieldTotal: total})
+	return toolkit.JSONResultTyped(map[string]any{"threads": threads, fieldTotal: total})
 }
 
 // hasThreadTarget reports whether the input scopes feedback to a single target
@@ -98,11 +99,11 @@ func (t *Toolkit) handleListPendingFeedback(ctx context.Context, input manageFee
 	}
 	assetIDs, err := g.AssetIDs(ctx, portal.KeepEditorShares)
 	if err != nil {
-		return errorResult("failed to gather your artifacts: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to gather your artifacts: " + err.Error()), nil, nil
 	}
 	collIDs, err := g.CollectionIDs(ctx, portal.KeepEditorShares)
 	if err != nil {
-		return errorResult("failed to gather your artifacts: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to gather your artifacts: " + err.Error()), nil, nil
 	}
 
 	filter := portal.ThreadFilter{
@@ -123,12 +124,12 @@ func (t *Toolkit) handleListPendingFeedback(ctx context.Context, input manageFee
 
 	pending, pendingTotal, err := t.threadStore.ListThreads(ctx, filter)
 	if err != nil {
-		return errorResult("failed to list pending feedback: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to list pending feedback: " + err.Error()), nil, nil
 	}
 
 	awaiting, awaitingTotal := t.awaitingMyValidation(ctx, uid, email)
 
-	return jsonResult(map[string]any{
+	return toolkit.JSONResultTyped(map[string]any{
 		"pending":                   normalizeThreads(pending),
 		"pending_total":             pendingTotal,
 		"awaiting_my_validation":    normalizeThreads(awaiting),
@@ -170,17 +171,17 @@ func (t *Toolkit) handleGetThread(ctx context.Context, input manageFeedbackInput
 	}
 	events, err := t.threadStore.ListEvents(ctx, thread.ID)
 	if err != nil {
-		return errorResult("failed to load thread events: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
+		return toolkit.ErrorResult("failed to load thread events: " + err.Error()), nil, nil
 	}
 	if events == nil {
 		events = []portal.ThreadEvent{}
 	}
-	return jsonResult(map[string]any{"thread": thread, "events": events})
+	return toolkit.JSONResultTyped(map[string]any{"thread": thread, "events": events})
 }
 
 func (t *Toolkit) handleReplyThread(ctx context.Context, input manageFeedbackInput) (*mcp.CallToolResult, any, error) {
 	if strings.TrimSpace(input.Body) == "" {
-		return errorResult("body is required for the reply action"), nil, nil
+		return toolkit.ErrorResult("body is required for the reply action"), nil, nil
 	}
 	thread, errRes := t.loadThread(ctx, input.ThreadID, false)
 	if errRes != nil {
@@ -195,9 +196,9 @@ func (t *Toolkit) handleReplyThread(ctx context.Context, input manageFeedbackInp
 		Body:        input.Body,
 	})
 	if err != nil {
-		return errorResult("failed to reply: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
+		return toolkit.ErrorResult("failed to reply: " + err.Error()), nil, nil
 	}
-	return jsonResult(evt)
+	return toolkit.JSONResultTyped(evt)
 }
 
 func (t *Toolkit) handleResolveThread(ctx context.Context, input manageFeedbackInput) (*mcp.CallToolResult, any, error) {
@@ -208,9 +209,9 @@ func (t *Toolkit) handleResolveThread(ctx context.Context, input manageFeedbackI
 	resolved := portal.ThreadStatusResolved
 	if err := t.threadStore.UpdateThread(ctx, thread.ID,
 		portal.ThreadUpdate{Status: &resolved}, resolveOwnerID(ctx), resolveOwnerEmail(ctx)); err != nil {
-		return errorResult("failed to resolve thread: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
+		return toolkit.ErrorResult("failed to resolve thread: " + err.Error()), nil, nil
 	}
-	return jsonResult(map[string]any{"thread_id": thread.ID, "status": resolved})
+	return toolkit.JSONResultTyped(map[string]any{"thread_id": thread.ID, "status": resolved})
 }
 
 func (t *Toolkit) handleRequestValidation(ctx context.Context, input manageFeedbackInput) (*mcp.CallToolResult, any, error) {
@@ -219,9 +220,9 @@ func (t *Toolkit) handleRequestValidation(ctx context.Context, input manageFeedb
 		return errRes, nil, nil
 	}
 	if err := t.threadStore.RequestValidation(ctx, thread.ID, resolveOwnerID(ctx), resolveOwnerEmail(ctx)); err != nil {
-		return errorResult("failed to request validation: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
+		return toolkit.ErrorResult("failed to request validation: " + err.Error()), nil, nil
 	}
-	return jsonResult(map[string]any{"thread_id": thread.ID, "validation_state": portal.ValidationStatePending})
+	return toolkit.JSONResultTyped(map[string]any{"thread_id": thread.ID, "validation_state": portal.ValidationStatePending})
 }
 
 // handleRespondValidation records the SME's answer to a validation request.
@@ -229,26 +230,26 @@ func (t *Toolkit) handleRequestValidation(ctx context.Context, input manageFeedb
 // author (the SME the request was routed to), not the artifact owner.
 func (t *Toolkit) handleRespondValidation(ctx context.Context, input manageFeedbackInput) (*mcp.CallToolResult, any, error) {
 	if t.threadStore == nil {
-		return errorResult(threadsUnavail), nil, nil
+		return toolkit.ErrorResult(threadsUnavail), nil, nil
 	}
 	if input.ThreadID == "" {
-		return errorResult("thread_id is required"), nil, nil
+		return toolkit.ErrorResult("thread_id is required"), nil, nil
 	}
 	if input.ValidationResult != portal.ValidationStateValidated && input.ValidationResult != portal.ValidationStateDisputed {
-		return errorResult("validation_result must be 'validated' or 'disputed'"), nil, nil
+		return toolkit.ErrorResult("validation_result must be 'validated' or 'disputed'"), nil, nil
 	}
 	thread, err := t.threadStore.GetThread(ctx, input.ThreadID)
 	if err != nil {
-		return errorResult("thread not found: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
+		return toolkit.ErrorResult("thread not found: " + err.Error()), nil, nil
 	}
 	if !t.callerIsThreadAuthor(ctx, thread) {
-		return errorResult("only the feedback author can respond to a validation request"), nil, nil
+		return toolkit.ErrorResult("only the feedback author can respond to a validation request"), nil, nil
 	}
 	resp := portal.ValidationResponse{Result: input.ValidationResult, Reason: input.ValidationReason}
 	if err := t.threadStore.RespondValidation(ctx, thread.ID, resp, resolveOwnerID(ctx), resolveOwnerEmail(ctx)); err != nil {
-		return errorResult("failed to respond to validation: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
+		return toolkit.ErrorResult("failed to respond to validation: " + err.Error()), nil, nil
 	}
-	return jsonResult(map[string]any{"thread_id": thread.ID, "validation_state": input.ValidationResult})
+	return toolkit.JSONResultTyped(map[string]any{"thread_id": thread.ID, "validation_state": input.ValidationResult})
 }
 
 // callerIsThreadAuthor reports whether the caller authored the thread (or is an
@@ -320,17 +321,17 @@ func (t *Toolkit) callerMayLinkThread(ctx context.Context, id string) bool {
 // error result (and nil thread) on failure.
 func (t *Toolkit) loadThread(ctx context.Context, threadID string, moderate bool) (*portal.Thread, *mcp.CallToolResult) {
 	if t.threadStore == nil {
-		return nil, errorResult(threadsUnavail)
+		return nil, toolkit.ErrorResult(threadsUnavail)
 	}
 	if threadID == "" {
-		return nil, errorResult("thread_id is required")
+		return nil, toolkit.ErrorResult("thread_id is required")
 	}
 	thread, err := t.threadStore.GetThread(ctx, threadID)
 	if err != nil {
-		return nil, errorResult("thread not found: " + err.Error())
+		return nil, toolkit.ErrorResult("thread not found: " + err.Error())
 	}
 	if !t.callerCanActOnThread(ctx, thread, moderate) {
-		return nil, errorResult("you can only act on feedback for artifacts you own or can edit")
+		return nil, toolkit.ErrorResult("you can only act on feedback for artifacts you own or can edit")
 	}
 	return thread, nil
 }

--- a/pkg/toolkits/portal/toolkit.go
+++ b/pkg/toolkits/portal/toolkit.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path"
@@ -19,6 +19,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/query"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 const (
@@ -373,7 +374,7 @@ func (*Toolkit) Close() error { return nil }
 // handleSaveArtifact persists an artifact to S3 and records metadata.
 func (t *Toolkit) handleSaveArtifact(ctx context.Context, _ *mcp.CallToolRequest, input saveArtifactInput) (*mcp.CallToolResult, any, error) {
 	if err := t.validateAndCheckSize(input); err != nil {
-		return errorResult(err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult(err.Error()), nil, nil
 	}
 
 	userID := resolveOwnerID(ctx)
@@ -382,16 +383,16 @@ func (t *Toolkit) handleSaveArtifact(ctx context.Context, _ *mcp.CallToolRequest
 
 	assetID, err := generateID()
 	if err != nil {
-		return errorResult("internal error generating asset ID"), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("internal error generating asset ID"), nil, nil
 	}
 
 	s3Key := t.buildS3Key(userID, assetID, input.ContentType)
 
 	if t.s3Client == nil {
-		return errorResult("content storage not configured"), nil, nil
+		return toolkit.ErrorResult("content storage not configured"), nil, nil
 	}
 	if err := t.s3Client.PutObject(ctx, t.s3Bucket, s3Key, []byte(input.Content), input.ContentType); err != nil {
-		return errorResult("failed to upload content: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to upload content: " + err.Error()), nil, nil
 	}
 
 	prov := buildProvenance(ctx, userID, sessionID)
@@ -422,13 +423,13 @@ func (t *Toolkit) handleSaveArtifact(ctx context.Context, _ *mcp.CallToolRequest
 	}
 
 	if err := t.assetStore.Insert(ctx, asset); err != nil {
-		return errorResult("failed to save asset metadata: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to save asset metadata: " + err.Error()), nil, nil
 	}
 
 	// Create initial v1 version record.
 	versionID, err := generateID()
 	if err != nil {
-		return errorResult("failed to generate version ID: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to generate version ID: " + err.Error()), nil, nil
 	}
 	v1 := portal.AssetVersion{
 		ID:            versionID,
@@ -441,10 +442,10 @@ func (t *Toolkit) handleSaveArtifact(ctx context.Context, _ *mcp.CallToolRequest
 		ChangeSummary: "Initial version",
 	}
 	if _, err := t.versionStore.CreateVersion(ctx, v1); err != nil {
-		return errorResult("failed to create initial version record: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to create initial version record: " + err.Error()), nil, nil
 	}
 
-	return jsonResult(t.buildSaveOutput(assetID, prov))
+	return toolkit.JSONResultTyped(t.buildSaveOutput(assetID, prov))
 }
 
 // manageActionHandler is a function that handles a manage_artifact action.
@@ -457,7 +458,7 @@ type feedbackActionHandler func(ctx context.Context, input manageFeedbackInput) 
 func (t *Toolkit) handleManageFeedback(ctx context.Context, _ *mcp.CallToolRequest, input manageFeedbackInput) (*mcp.CallToolResult, any, error) {
 	handler, ok := t.feedbackActions[input.Action]
 	if !ok {
-		return errorResult(fmt.Sprintf(
+		return toolkit.ErrorResult(fmt.Sprintf(
 			"invalid action %q: must be one of: list, get, reply, resolve, request_validation, respond_validation",
 			input.Action)), nil, nil
 	}
@@ -499,7 +500,7 @@ func (t *Toolkit) buildFeedbackActions() map[string]feedbackActionHandler {
 func (t *Toolkit) handleManageArtifact(ctx context.Context, _ *mcp.CallToolRequest, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
 	handler, ok := t.actions[input.Action]
 	if !ok {
-		return errorResult(fmt.Sprintf(
+		return toolkit.ErrorResult(fmt.Sprintf(
 			"invalid action %q: must be one of: list, get, update, delete, list_versions, revert, search, "+
 				"create_collection, list_collections, get_collection, update_collection, delete_collection, set_sections",
 			input.Action)), nil, nil
@@ -515,7 +516,7 @@ func (t *Toolkit) handleList(ctx context.Context, input manageArtifactInput) (*m
 		Limit:   input.Limit,
 	})
 	if err != nil {
-		return errorResult("failed to list assets: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to list assets: " + err.Error()), nil, nil
 	}
 
 	if assets == nil {
@@ -526,39 +527,39 @@ func (t *Toolkit) handleList(ctx context.Context, input manageArtifactInput) (*m
 		"assets":   assets,
 		fieldTotal: total,
 	}
-	return jsonResult(result)
+	return toolkit.JSONResultTyped(result)
 }
 
 func (t *Toolkit) handleGet(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
 	if input.AssetID == "" {
-		return errorResult("asset_id is required for get action"), nil, nil
+		return toolkit.ErrorResult("asset_id is required for get action"), nil, nil
 	}
 
 	asset, err := t.assetStore.Get(ctx, input.AssetID)
 	if err != nil {
-		return middleware.NotFoundResult("asset not found: "+err.Error(), assetNotFoundHint), nil, nil //nolint:nilerr // MCP protocol
+		return middleware.NotFoundResult("asset not found: "+err.Error(), assetNotFoundHint), nil, nil
 	}
 
 	if asset.DeletedAt != nil {
-		return errorResult("asset has been deleted"), nil, nil
+		return toolkit.ErrorResult("asset has been deleted"), nil, nil
 	}
 
-	return jsonResult(asset)
+	return toolkit.JSONResultTyped(asset)
 }
 
 func (t *Toolkit) handleUpdate(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
 	if input.AssetID == "" {
-		return errorResult("asset_id is required for update action"), nil, nil
+		return toolkit.ErrorResult("asset_id is required for update action"), nil, nil
 	}
 
 	asset, err := t.assetStore.Get(ctx, input.AssetID)
 	if err != nil {
-		return middleware.NotFoundResult("asset not found: "+err.Error(), assetNotFoundHint), nil, nil //nolint:nilerr // MCP protocol
+		return middleware.NotFoundResult("asset not found: "+err.Error(), assetNotFoundHint), nil, nil
 	}
 
 	ownerID := resolveOwnerID(ctx)
 	if asset.OwnerID != ownerID {
-		return errorResult("you can only update your own artifacts"), nil, nil
+		return toolkit.ErrorResult("you can only update your own artifacts"), nil, nil
 	}
 
 	updates := portal.AssetUpdate{
@@ -581,22 +582,22 @@ func (t *Toolkit) handleUpdate(ctx context.Context, input manageArtifactInput) (
 	hasMetadata := updates.Name != nil || updates.Description != nil || updates.Tags != nil
 
 	if !hasContent && !hasMetadata {
-		return errorResult("no fields to update: provide content, name, description, or tags"), nil, nil
+		return toolkit.ErrorResult("no fields to update: provide content, name, description, or tags"), nil, nil
 	}
 
 	if hasContent {
 		if contentErr := t.uploadContentUpdate(ctx, asset, input); contentErr != nil {
-			return errorResult("failed to upload new content: " + contentErr.Error()), nil, nil //nolint:nilerr // MCP protocol
+			return toolkit.ErrorResult("failed to upload new content: " + contentErr.Error()), nil, nil
 		}
 	}
 
 	if hasMetadata {
 		if err := t.assetStore.Update(ctx, input.AssetID, updates); err != nil {
-			return errorResult("failed to update asset: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+			return toolkit.ErrorResult("failed to update asset: " + err.Error()), nil, nil
 		}
 	}
 
-	return jsonResult(map[string]any{
+	return toolkit.JSONResultTyped(map[string]any{
 		fieldAssetID: input.AssetID,
 		fieldMessage: "Asset updated successfully.",
 	})
@@ -619,7 +620,7 @@ func (t *Toolkit) uploadContentUpdate(ctx context.Context, asset *portal.Asset, 
 	s3Key := path.Join(t.s3Prefix, asset.OwnerID, asset.ID, versionID, "content"+ext)
 
 	if t.s3Client == nil {
-		return fmt.Errorf("content storage not configured")
+		return errors.New("content storage not configured")
 	}
 	if err := t.s3Client.PutObject(ctx, t.s3Bucket, s3Key, []byte(input.Content), ct); err != nil {
 		return fmt.Errorf("s3 put: %w", err)
@@ -644,24 +645,24 @@ func (t *Toolkit) uploadContentUpdate(ctx context.Context, asset *portal.Asset, 
 
 func (t *Toolkit) handleDelete(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
 	if input.AssetID == "" {
-		return errorResult("asset_id is required for delete action"), nil, nil
+		return toolkit.ErrorResult("asset_id is required for delete action"), nil, nil
 	}
 
 	asset, err := t.assetStore.Get(ctx, input.AssetID)
 	if err != nil {
-		return middleware.NotFoundResult("asset not found: "+err.Error(), assetNotFoundHint), nil, nil //nolint:nilerr // MCP protocol
+		return middleware.NotFoundResult("asset not found: "+err.Error(), assetNotFoundHint), nil, nil
 	}
 
 	ownerID := resolveOwnerID(ctx)
 	if asset.OwnerID != ownerID {
-		return errorResult("you can only delete your own artifacts"), nil, nil
+		return toolkit.ErrorResult("you can only delete your own artifacts"), nil, nil
 	}
 
 	if err := t.assetStore.SoftDelete(ctx, input.AssetID); err != nil {
-		return errorResult("failed to delete asset: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to delete asset: " + err.Error()), nil, nil
 	}
 
-	return jsonResult(map[string]any{
+	return toolkit.JSONResultTyped(map[string]any{
 		fieldAssetID: input.AssetID,
 		fieldMessage: "Asset deleted successfully.",
 	})
@@ -669,7 +670,7 @@ func (t *Toolkit) handleDelete(ctx context.Context, input manageArtifactInput) (
 
 func (t *Toolkit) handleListVersions(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
 	if input.AssetID == "" {
-		return errorResult("asset_id is required for list_versions action"), nil, nil
+		return toolkit.ErrorResult("asset_id is required for list_versions action"), nil, nil
 	}
 
 	limit := input.Limit
@@ -678,12 +679,12 @@ func (t *Toolkit) handleListVersions(ctx context.Context, input manageArtifactIn
 	}
 	versions, total, err := t.versionStore.ListByAsset(ctx, input.AssetID, limit, 0)
 	if err != nil {
-		return errorResult("failed to list versions: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to list versions: " + err.Error()), nil, nil
 	}
 	if versions == nil {
 		versions = []portal.AssetVersion{}
 	}
-	return jsonResult(map[string]any{
+	return toolkit.JSONResultTyped(map[string]any{
 		"versions": versions,
 		fieldTotal: total,
 	})
@@ -691,41 +692,41 @@ func (t *Toolkit) handleListVersions(ctx context.Context, input manageArtifactIn
 
 func (t *Toolkit) handleRevert(ctx context.Context, input manageArtifactInput) (*mcp.CallToolResult, any, error) {
 	if !input.validForRevert() {
-		return errorResult("asset_id and version (> 0) are required for revert action"), nil, nil
+		return toolkit.ErrorResult("asset_id and version (> 0) are required for revert action"), nil, nil
 	}
 
 	asset, err := t.assetStore.Get(ctx, input.AssetID)
 	if err != nil {
-		return middleware.NotFoundResult("asset not found: "+err.Error(), assetNotFoundHint), nil, nil //nolint:nilerr // MCP protocol
+		return middleware.NotFoundResult("asset not found: "+err.Error(), assetNotFoundHint), nil, nil
 	}
 
 	ownerID := resolveOwnerID(ctx)
 	if asset.OwnerID != ownerID {
-		return errorResult("you can only revert your own artifacts"), nil, nil
+		return toolkit.ErrorResult("you can only revert your own artifacts"), nil, nil
 	}
 
 	targetVer, err := t.versionStore.GetByVersion(ctx, input.AssetID, input.Version)
 	if err != nil {
-		return middleware.NotFoundResult("version not found: "+err.Error(), "Call manage_artifact action=list_versions to see valid version numbers."), nil, nil //nolint:nilerr // MCP protocol
+		return middleware.NotFoundResult("version not found: "+err.Error(), "Call manage_artifact action=list_versions to see valid version numbers."), nil, nil
 	}
 
 	if t.s3Client == nil {
-		return errorResult("content storage not configured"), nil, nil
+		return toolkit.ErrorResult("content storage not configured"), nil, nil
 	}
 	data, _, err := t.s3Client.GetObject(ctx, targetVer.S3Bucket, targetVer.S3Key)
 	if err != nil {
-		return errorResult("failed to read version content: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to read version content: " + err.Error()), nil, nil
 	}
 
 	versionID, err := generateID()
 	if err != nil {
-		return errorResult("failed to generate version ID: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to generate version ID: " + err.Error()), nil, nil
 	}
 	ext := portal.ExtensionForContentType(targetVer.ContentType)
 	newKey := path.Join(t.s3Prefix, asset.OwnerID, asset.ID, versionID, "content"+ext)
 
 	if err := t.s3Client.PutObject(ctx, t.s3Bucket, newKey, data, targetVer.ContentType); err != nil {
-		return errorResult("failed to upload reverted content: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to upload reverted content: " + err.Error()), nil, nil
 	}
 
 	av := portal.AssetVersion{
@@ -741,10 +742,10 @@ func (t *Toolkit) handleRevert(ctx context.Context, input manageArtifactInput) (
 	assignedVersion, err := t.versionStore.CreateVersion(ctx, av)
 	if err != nil {
 		t.cleanupOrphanedS3(ctx, t.s3Bucket, newKey)
-		return errorResult("failed to create revert version: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol
+		return toolkit.ErrorResult("failed to create revert version: " + err.Error()), nil, nil
 	}
 
-	return jsonResult(map[string]any{
+	return toolkit.JSONResultTyped(map[string]any{
 		fieldAssetID: input.AssetID,
 		"version":    assignedVersion,
 		fieldMessage: fmt.Sprintf("Reverted to version %d. New version: %d.", input.Version, assignedVersion),
@@ -832,7 +833,7 @@ func validateSaveInput(input saveArtifactInput) error {
 		return fmt.Errorf(validationFmt, err)
 	}
 	if input.Content == "" {
-		return fmt.Errorf("content is required")
+		return errors.New("content is required")
 	}
 	if err := portal.ValidateDescription(input.Description); err != nil {
 		return fmt.Errorf(validationFmt, err)
@@ -870,31 +871,6 @@ func generateID() (string, error) {
 		return "", fmt.Errorf("generating random bytes: %w", err)
 	}
 	return hex.EncodeToString(b), nil
-}
-
-func errorResult(msg string) *mcp.CallToolResult {
-	errObj := struct {
-		Error string `json:"error"`
-	}{Error: msg}
-	data, _ := json.Marshal(errObj) //nolint:errcheck // simple struct, cannot fail
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: string(data)},
-		},
-		IsError: true,
-	}
-}
-
-func jsonResult(v any) (*mcp.CallToolResult, any, error) {
-	data, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return errorResult("internal error marshaling response"), nil, nil //nolint:nilerr // MCP protocol
-	}
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: string(data)},
-		},
-	}, nil, nil
 }
 
 // Verify interface compliance.

--- a/pkg/toolkits/s3/config.go
+++ b/pkg/toolkits/s3/config.go
@@ -2,6 +2,8 @@ package s3
 
 import (
 	"time"
+
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 const (
@@ -57,12 +59,7 @@ func ParseConfig(cfg map[string]any) (Config, error) {
 }
 
 // AnnotationConfig holds tool annotation overrides from configuration.
-type AnnotationConfig struct {
-	ReadOnlyHint    *bool `yaml:"read_only_hint"`
-	DestructiveHint *bool `yaml:"destructive_hint"`
-	IdempotentHint  *bool `yaml:"idempotent_hint"`
-	OpenWorldHint   *bool `yaml:"open_world_hint"`
-}
+type AnnotationConfig = toolkit.AnnotationConfig
 
 // getAnnotationsMap extracts annotation overrides from a config map.
 func getAnnotationsMap(cfg map[string]any, key string) map[string]AnnotationConfig { //nolint:unparam // consistent with getStringMap

--- a/pkg/toolkits/s3/toolkit.go
+++ b/pkg/toolkits/s3/toolkit.go
@@ -181,27 +181,9 @@ func toS3Annotations(m map[string]AnnotationConfig) map[s3tools.ToolName]*mcp.To
 	}
 	result := make(map[s3tools.ToolName]*mcp.ToolAnnotations, len(m))
 	for k, v := range m {
-		result[s3tools.ToolName(k)] = annotationConfigToMCP(v)
+		result[s3tools.ToolName(k)] = toolkit.AnnotationsToMCP(v)
 	}
 	return result
-}
-
-// annotationConfigToMCP converts an AnnotationConfig to an mcp.ToolAnnotations.
-func annotationConfigToMCP(cfg AnnotationConfig) *mcp.ToolAnnotations {
-	ann := &mcp.ToolAnnotations{}
-	if cfg.ReadOnlyHint != nil {
-		ann.ReadOnlyHint = *cfg.ReadOnlyHint
-	}
-	if cfg.DestructiveHint != nil {
-		ann.DestructiveHint = cfg.DestructiveHint
-	}
-	if cfg.IdempotentHint != nil {
-		ann.IdempotentHint = *cfg.IdempotentHint
-	}
-	if cfg.OpenWorldHint != nil {
-		ann.OpenWorldHint = cfg.OpenWorldHint
-	}
-	return ann
 }
 
 // Kind returns the toolkit kind.

--- a/pkg/toolkits/s3/toolkit_test.go
+++ b/pkg/toolkits/s3/toolkit_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/txn2/mcp-data-platform/pkg/query"
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 const (
@@ -466,7 +467,7 @@ func TestS3AnnotationConfigToMCP(t *testing.T) {
 			IdempotentHint:  &idempotent,
 			OpenWorldHint:   &openWorld,
 		}
-		ann := annotationConfigToMCP(cfg)
+		ann := toolkit.AnnotationsToMCP(cfg)
 		if !ann.ReadOnlyHint {
 			t.Error("expected ReadOnlyHint=true")
 		}
@@ -483,7 +484,7 @@ func TestS3AnnotationConfigToMCP(t *testing.T) {
 
 	t.Run("no fields set", func(t *testing.T) {
 		cfg := AnnotationConfig{}
-		ann := annotationConfigToMCP(cfg)
+		ann := toolkit.AnnotationsToMCP(cfg)
 		if ann.ReadOnlyHint {
 			t.Error("expected ReadOnlyHint=false")
 		}

--- a/pkg/toolkits/search/toolkit.go
+++ b/pkg/toolkits/search/toolkit.go
@@ -22,6 +22,7 @@ import (
 	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/query"
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // toolName is the MCP tool name for the universal search entry point; fetchToolName
@@ -253,7 +254,7 @@ func (t *Toolkit) handleSearch(ctx context.Context, _ *mcp.CallToolRequest, inpu
 		Limit:      input.Limit,
 	})
 	if err != nil {
-		return errorResult("search failed: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
+		return toolkit.ErrorResult("search failed: " + err.Error()), nil, nil
 	}
 
 	groups := res.Groups
@@ -268,7 +269,7 @@ func (t *Toolkit) handleSearch(ctx context.Context, _ *mcp.CallToolRequest, inpu
 	for _, g := range groups {
 		shown += len(g.Hits)
 	}
-	return jsonResult(searchOutput{
+	return toolkit.JSONResultTyped(searchOutput{
 		Groups:         groups,
 		Coverage:       coverage,
 		Count:          shown,
@@ -287,23 +288,23 @@ func (t *Toolkit) handleSearch(ctx context.Context, _ *mcp.CallToolRequest, inpu
 func (t *Toolkit) handleFetch(ctx context.Context, _ *mcp.CallToolRequest, input fetchInput) (*mcp.CallToolResult, any, error) {
 	ref := strings.TrimSpace(input.Reference)
 	if ref == "" {
-		return errorResult("fetch requires a reference"), nil, nil
+		return toolkit.ErrorResult("fetch requires a reference"), nil, nil
 	}
 
 	doc, err := t.router.Fetch(ctx, ref, callerFromContext(ctx))
 	if err != nil {
 		if errors.Is(err, knowledge.ErrNotFound) {
-			return jsonResult(fetchOutput{
+			return toolkit.JSONResultTyped(fetchOutput{
 				Found:     false,
 				Reference: ref,
 				Message: "no content found for this reference; it may be stale, not a recognized " +
 					"reference form, or outside what you can access",
 			})
 		}
-		return errorResult("fetch failed: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
+		return toolkit.ErrorResult("fetch failed: " + err.Error()), nil, nil
 	}
 
-	return jsonResult(fetchOutput{
+	return toolkit.JSONResultTyped(fetchOutput{
 		Found:     true,
 		Reference: ref,
 		Document:  doc,
@@ -319,7 +320,7 @@ func (t *Toolkit) handleFetch(ctx context.Context, _ *mcp.CallToolRequest, input
 func (t *Toolkit) handleBrowse(ctx context.Context, input searchInput) (*mcp.CallToolResult, any, error) {
 	sources := nonBlank(input.Sources)
 	if len(sources) != 1 {
-		return errorResult("provide intent or entity_urns to search, or exactly one `sources` entry " +
+		return toolkit.ErrorResult("provide intent or entity_urns to search, or exactly one `sources` entry " +
 			"(with no intent/entity_urns) to browse it; browsable sources: " +
 			strings.Join(t.router.BrowsableSources(), ", ")), nil, nil
 	}
@@ -333,13 +334,13 @@ func (t *Toolkit) handleBrowse(ctx context.Context, input searchInput) (*mcp.Cal
 	if err != nil {
 		switch {
 		case errors.Is(err, knowledge.ErrUnknownSource):
-			return errorResult(fmt.Sprintf("unknown source %q; known sources: %s",
+			return toolkit.ErrorResult(fmt.Sprintf("unknown source %q; known sources: %s",
 				source, strings.Join(knowledge.KnownSources(), ", "))), nil, nil
 		case errors.Is(err, knowledge.ErrSourceNotBrowsable):
-			return errorResult(fmt.Sprintf("source %q cannot be enumerated here; browsable sources: %s",
+			return toolkit.ErrorResult(fmt.Sprintf("source %q cannot be enumerated here; browsable sources: %s",
 				source, strings.Join(t.router.BrowsableSources(), ", "))), nil, nil
 		default:
-			return errorResult("browse failed: " + err.Error()), nil, nil //nolint:nilerr // MCP protocol: tool errors are returned in CallToolResult.IsError
+			return toolkit.ErrorResult("browse failed: " + err.Error()), nil, nil
 		}
 	}
 
@@ -347,7 +348,7 @@ func (t *Toolkit) handleBrowse(ctx context.Context, input searchInput) (*mcp.Cal
 	if items == nil {
 		items = []knowledge.Hit{}
 	}
-	return jsonResult(browseOutput{
+	return toolkit.JSONResultTyped(browseOutput{
 		Source: source,
 		Total:  page.Total,
 		Offset: page.Offset,
@@ -378,29 +379,6 @@ func callerFromContext(ctx context.Context) knowledge.Caller {
 		return knowledge.Caller{}
 	}
 	return knowledge.Caller{UserID: pc.UserID, Email: pc.UserEmail, Persona: pc.PersonaName}
-}
-
-// errorResult creates an error CallToolResult.
-func errorResult(msg string) *mcp.CallToolResult {
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: fmt.Sprintf(`{"error": %q}`, msg)},
-		},
-		IsError: true,
-	}
-}
-
-// jsonResult marshals a value to JSON and returns it as a CallToolResult.
-func jsonResult(v any) (*mcp.CallToolResult, any, error) {
-	data, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return errorResult("internal error marshaling response"), nil, nil //nolint:nilerr // MCP protocol
-	}
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			&mcp.TextContent{Text: string(data)},
-		},
-	}, nil, nil
 }
 
 // Verify interface compliance with registry.Toolkit.

--- a/pkg/toolkits/trino/config.go
+++ b/pkg/toolkits/trino/config.go
@@ -1,9 +1,12 @@
 package trino
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
+
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 // MultiConfig holds configuration for a multi-connection Trino toolkit.
@@ -49,7 +52,7 @@ func ParseConfig(cfg map[string]any) (Config, error) {
 	// Required fields
 	v, ok := cfg["host"].(string)
 	if !ok {
-		return c, fmt.Errorf("host is required")
+		return c, errors.New("host is required")
 	}
 	c.Host = v
 
@@ -133,12 +136,7 @@ func getInt64(cfg map[string]any, key string, defaultVal int64) int64 {
 }
 
 // AnnotationConfig holds tool annotation overrides from configuration.
-type AnnotationConfig struct {
-	ReadOnlyHint    *bool `yaml:"read_only_hint"`
-	DestructiveHint *bool `yaml:"destructive_hint"`
-	IdempotentHint  *bool `yaml:"idempotent_hint"`
-	OpenWorldHint   *bool `yaml:"open_world_hint"`
-}
+type AnnotationConfig = toolkit.AnnotationConfig
 
 // getAnnotationsMap extracts annotation overrides from a config map.
 func getAnnotationsMap(cfg map[string]any, key string) map[string]AnnotationConfig { //nolint:unparam // consistent with getStringMap

--- a/pkg/toolkits/trino/export.go
+++ b/pkg/toolkits/trino/export.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path"
@@ -542,7 +543,7 @@ func (t *Toolkit) executeExportQuery(ctx context.Context, sql, connection string
 	}
 
 	if t.client == nil {
-		return nil, fmt.Errorf("no Trino client available")
+		return nil, errors.New("no Trino client available")
 	}
 	result, err := t.client.Query(ctx, sql, opts)
 	if err != nil {
@@ -650,7 +651,7 @@ func buildExportProvenance(ctx context.Context, deps *ExportDeps, p exportProven
 // parseExportInput parses the MCP request into an exportInput.
 func parseExportInput(req mcp.CallToolRequest) (exportInput, error) {
 	if req.Params == nil || len(req.Params.Arguments) == 0 {
-		return exportInput{}, fmt.Errorf("missing arguments")
+		return exportInput{}, errors.New("missing arguments")
 	}
 	var input exportInput
 	if err := json.Unmarshal(req.Params.Arguments, &input); err != nil {
@@ -662,16 +663,16 @@ func parseExportInput(req mcp.CallToolRequest) (exportInput, error) {
 // validateExportInput validates all input fields.
 func validateExportInput(input exportInput, cfg ExportConfig) error {
 	if input.SQL == "" {
-		return fmt.Errorf("sql is required")
+		return errors.New("sql is required")
 	}
 	if input.Format == "" {
-		return fmt.Errorf("format is required")
+		return errors.New("format is required")
 	}
 	if _, err := newFormatter(input.Format); err != nil {
 		return err
 	}
 	if input.Name == "" {
-		return fmt.Errorf("name is required")
+		return errors.New("name is required")
 	}
 	if len(input.Name) > maxExportNameLength {
 		return fmt.Errorf("name exceeds %d characters", maxExportNameLength)

--- a/pkg/toolkits/trino/readonly.go
+++ b/pkg/toolkits/trino/readonly.go
@@ -3,7 +3,7 @@ package trino
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	trinotools "github.com/txn2/mcp-trino/pkg/tools"
 )
@@ -20,7 +20,7 @@ func NewReadOnlyInterceptor() *ReadOnlyInterceptor {
 // Intercept checks if the query is a write operation and blocks it in read-only mode.
 func (*ReadOnlyInterceptor) Intercept(_ context.Context, sql string, _ trinotools.ToolName) (string, error) {
 	if trinotools.IsWriteSQL(sql) {
-		return "", fmt.Errorf("write operations not allowed in read-only mode")
+		return "", errors.New("write operations not allowed in read-only mode")
 	}
 	return sql, nil
 }

--- a/pkg/toolkits/trino/toolkit.go
+++ b/pkg/toolkits/trino/toolkit.go
@@ -2,6 +2,7 @@
 package trino
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -163,7 +164,7 @@ func New(name string, cfg Config) (*Toolkit, error) {
 // toolkits that would clobber each other's tool registrations.
 func NewMulti(cfg MultiConfig) (*Toolkit, error) {
 	if len(cfg.Instances) == 0 {
-		return nil, fmt.Errorf("at least one trino instance is required")
+		return nil, errors.New("at least one trino instance is required")
 	}
 
 	// Resolve the default connection name.
@@ -329,10 +330,10 @@ func buildToolkitOptions(cfg Config, elicit *ElicitationMiddleware, connRequired
 // validateConfig validates the required configuration fields.
 func validateConfig(cfg Config) error {
 	if cfg.Host == "" {
-		return fmt.Errorf("trino host is required")
+		return errors.New("trino host is required")
 	}
 	if cfg.User == "" {
-		return fmt.Errorf("trino user is required")
+		return errors.New("trino user is required")
 	}
 	return nil
 }
@@ -415,27 +416,9 @@ func toTrinoAnnotations(m map[string]AnnotationConfig) map[trinotools.ToolName]*
 	}
 	result := make(map[trinotools.ToolName]*mcp.ToolAnnotations, len(m))
 	for k, v := range m {
-		result[trinotools.ToolName(k)] = annotationConfigToMCP(v)
+		result[trinotools.ToolName(k)] = toolkit.AnnotationsToMCP(v)
 	}
 	return result
-}
-
-// annotationConfigToMCP converts an AnnotationConfig to an mcp.ToolAnnotations.
-func annotationConfigToMCP(cfg AnnotationConfig) *mcp.ToolAnnotations {
-	ann := &mcp.ToolAnnotations{}
-	if cfg.ReadOnlyHint != nil {
-		ann.ReadOnlyHint = *cfg.ReadOnlyHint
-	}
-	if cfg.DestructiveHint != nil {
-		ann.DestructiveHint = cfg.DestructiveHint
-	}
-	if cfg.IdempotentHint != nil {
-		ann.IdempotentHint = *cfg.IdempotentHint
-	}
-	if cfg.OpenWorldHint != nil {
-		ann.OpenWorldHint = cfg.OpenWorldHint
-	}
-	return ann
 }
 
 // Kind returns the toolkit kind.
@@ -527,7 +510,7 @@ func (t *Toolkit) ListConnections() []toolkit.ConnectionDetail {
 // Requires multi-connection mode (created via NewMulti).
 func (t *Toolkit) AddConnection(name string, config map[string]any) error {
 	if t.manager == nil {
-		return fmt.Errorf("dynamic connections require multi-connection mode")
+		return errors.New("dynamic connections require multi-connection mode")
 	}
 
 	conn := multiserver.ConnectionConfig{
@@ -559,7 +542,7 @@ func (t *Toolkit) AddConnection(name string, config map[string]any) error {
 // Requires multi-connection mode (created via NewMulti).
 func (t *Toolkit) RemoveConnection(name string) error {
 	if t.manager == nil {
-		return fmt.Errorf("dynamic connections require multi-connection mode")
+		return errors.New("dynamic connections require multi-connection mode")
 	}
 	if err := t.manager.RemoveConnection(name); err != nil {
 		return fmt.Errorf("removing trino connection %s: %w", name, err)

--- a/pkg/toolkits/trino/toolkit_test.go
+++ b/pkg/toolkits/trino/toolkit_test.go
@@ -452,7 +452,7 @@ func TestAnnotationConfigToMCP(t *testing.T) {
 			IdempotentHint:  &idempotent,
 			OpenWorldHint:   &openWorld,
 		}
-		ann := annotationConfigToMCP(cfg)
+		ann := toolkit.AnnotationsToMCP(cfg)
 		if !ann.ReadOnlyHint {
 			t.Error("expected ReadOnlyHint=true")
 		}
@@ -469,7 +469,7 @@ func TestAnnotationConfigToMCP(t *testing.T) {
 
 	t.Run("no fields set", func(t *testing.T) {
 		cfg := AnnotationConfig{}
-		ann := annotationConfigToMCP(cfg)
+		ann := toolkit.AnnotationsToMCP(cfg)
 		if ann.ReadOnlyHint {
 			t.Error("expected ReadOnlyHint=false (default)")
 		}

--- a/pkg/user/validate.go
+++ b/pkg/user/validate.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"errors"
 	"fmt"
 	"net/mail"
 	"strings"
@@ -17,7 +18,7 @@ const MaxNameLen = 100
 func NormalizeEmail(email string) (string, error) {
 	e := strings.ToLower(strings.TrimSpace(email))
 	if e == "" {
-		return "", fmt.Errorf("email is required")
+		return "", errors.New("email is required")
 	}
 	addr, err := mail.ParseAddress(e)
 	if err != nil {

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -329,6 +329,7 @@ pkg/toolkits/apigateway/catalogindex -> pkg/indexjobs
 pkg/toolkits/apigateway/catalogindex -> pkg/toolkits/apigateway/catalog
 pkg/toolkits/datahub -> pkg/query
 pkg/toolkits/datahub -> pkg/semantic
+pkg/toolkits/datahub -> pkg/toolkit
 pkg/toolkits/gateway -> internal/logsan
 pkg/toolkits/gateway -> pkg/authevents
 pkg/toolkits/gateway -> pkg/connoauth
@@ -346,18 +347,21 @@ pkg/toolkits/knowledge -> pkg/prompt
 pkg/toolkits/knowledge -> pkg/query
 pkg/toolkits/knowledge -> pkg/registry
 pkg/toolkits/knowledge -> pkg/semantic
+pkg/toolkits/knowledge -> pkg/toolkit
 pkg/toolkits/memory -> pkg/embedding
 pkg/toolkits/memory -> pkg/memory
 pkg/toolkits/memory -> pkg/middleware
 pkg/toolkits/memory -> pkg/query
 pkg/toolkits/memory -> pkg/registry
 pkg/toolkits/memory -> pkg/semantic
+pkg/toolkits/memory -> pkg/toolkit
 pkg/toolkits/portal -> pkg/embedding
 pkg/toolkits/portal -> pkg/middleware
 pkg/toolkits/portal -> pkg/portal
 pkg/toolkits/portal -> pkg/query
 pkg/toolkits/portal -> pkg/registry
 pkg/toolkits/portal -> pkg/semantic
+pkg/toolkits/portal -> pkg/toolkit
 pkg/toolkits/s3 -> pkg/observability
 pkg/toolkits/s3 -> pkg/query
 pkg/toolkits/s3 -> pkg/semantic
@@ -366,6 +370,7 @@ pkg/toolkits/search -> pkg/knowledge
 pkg/toolkits/search -> pkg/middleware
 pkg/toolkits/search -> pkg/query
 pkg/toolkits/search -> pkg/semantic
+pkg/toolkits/search -> pkg/toolkit
 pkg/toolkits/tools/toolsindex -> pkg/indexjobs
 pkg/toolkits/trino -> pkg/mcpcontext
 pkg/toolkits/trino -> pkg/query


### PR DESCRIPTION
Closes #899, closes #901. Part of #880 (findings 3.7 and 3.9).

Two related cleanup tickets landed together (their file-level hunks interleave in `.golangci.yml` and the toolkit packages, so splitting per-item wasn't safe). 88 files, +898/-657.

## #899 - deduplicate toolkit scaffolding into `pkg/toolkit`

`pkg/toolkit` is the designated shared-types package; the duplicated scaffolding moves there.

**Annotation converter** (`pkg/toolkit/annotations.go`): `AnnotationConfig` and `annotationConfigToMCP` were byte-identical in `trino`, `datahub`, and `s3`. They become `toolkit.AnnotationConfig` and `toolkit.AnnotationsToMCP`; each toolkit keeps a `type AnnotationConfig = toolkit.AnnotationConfig` alias so its YAML config API and unmarshalling are unchanged.

**Result helpers** (`pkg/toolkit/result.go`): `errorResult`/`jsonResult` were reimplemented with diverging bodies in `memory`, `portal`, `search`, `knowledge`, and `apigateway`. They collapse to:
- `ErrorResult(msg string) *mcp.CallToolResult`
- `JSONResult(v any) *mcp.CallToolResult`
- `JSONResultTyped(v any) (*mcp.CallToolResult, any, error)` - the adapter for typed handlers whose signature is `(ctx, req, in) (*CallToolResult, Out, error)`

`search` and `knowledge` previously built error JSON via `fmt.Sprintf("{\"error\": %q}", msg)` (the Sprintf-into-JSON anti-pattern); they now use the struct-marshaled shape the other three already used. No test or `docs/` payload depended on the old `{"error": ...}` spacing (verified).

Also: regenerated the import-ratchet golden (exactly 5 new `toolkits/* -> toolkit` edges, no other coupling) and updated the `dupl` grandfather note in `.golangci.yml`.

Acceptance greps:
- `grep -rn "func annotationConfigToMCP" pkg/` -> 0
- `grep -rn "func errorResult\|func jsonResult" pkg/toolkits/` -> 0

## #901 - idiom cleanups

1. **nilerr consolidation.** 84 per-line `//nolint:nilerr` suppressions in tool-handler code are replaced by a single `nilerr`-only `.golangci.yml` exclusion scoped to `pkg/toolkits/` and the `pkg/platform/*_tool.go` handlers. **Deviation from the ticket's assumption:** the ticket stated all ~101 suppressions "encode the same MCP convention." They do not - 14 (non-test) encode different conventions and are **kept per-line**: best-effort availability (`pkg/storage/s3`, `pkg/query/trino`, `pkg/semantic/datahub`), decline-not-failure (`pkg/knowledge/provider_*`), enrichment best-effort (`pkg/middleware/mcp_enrichment.go`), and the resource re-read fallback (`pkg/resource/handler.go`). Blanket-disabling nilerr there would hide genuinely different intent.
2. **`errors.New`.** 172 verb-less `fmt.Errorf("...")` become `errors.New` across 50 non-test files (behavior identical). **Scope:** non-test source only; ~306 test-file instances were left to avoid tripling the diff for no gate or behavior benefit. The perfsprint guard below prevents regressions regardless.
3. **Audit read path** (`pkg/audit/postgres/store.go`): a corrupt `parameters` JSON blob was silently swallowed (`_ = json.Unmarshal(...)`). It now logs WARN with the event ID and returns the event with empty `Parameters`, so one corrupt row cannot break history listing. Unit test added (`TestScanEvent_CorruptParametersJSON`).
4. **connview fan-out** (`pkg/connview/connview.go`): `enrichWithKnowledge` issued one `ListPagesReferencing` per connection serially. It now fans out via `errgroup` with `SetLimit(8)`, writing index slots (the `pkg/knowledge/router.go` house pattern), preserving output order and the exact per-arm degrade semantics (a single lookup error degrades only that entry). Concurrency-proving test added (passes under `-race`).
5. **Delete `pkg/client/`** (contained only `.gitkeep`); updated the CLAUDE.md structure map and package count (43 -> 42).

## perfsprint regression guard (#901 finding 3.9, second commit)

A one-time `fmt.Errorf` sweep regresses without a gate. This enables `perfsprint` scoped to the `errorf` check only (`error-format` parent on, `err-error` off; integer/string/bool/hex checks off), so it flags exactly "fmt.Errorf can be replaced with errors.New" and none of the Sprintf/strconv nudges. perfsprint ships inside the pinned `golangci-lint` binary, so tools-check is unaffected. CI is only-new-issues, so pre-existing violations (the left test-file instances, const-arg cases) are grandfathered - new/changed code is gated without a mass rewrite.

## Verification

- `make verify` green on the code (all checks passed).
- `make lint` (patch-scoped, `--new-from-patch`, same as CI) reports `0 issues` after the perfsprint addition, and `golangci-lint config verify` passes.
- Patch coverage 85.7% (>= 80%). New `pkg/toolkit` helpers are 100% covered.

## Out of scope

Leaves #894, #895, #896, #898 as the remaining open #880 tickets.