### PR TITLE
fix(admin): reject unknown JSON fields on write endpoints (#923)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2454,6 +2454,10 @@ REST endpoints for managing the platform outside the MCP protocol. Mounted under
 
 All endpoints require admin persona authentication via `X-API-Key` or `Authorization: Bearer` headers. Errors use RFC 9457 Problem Details format.
 
+## Request Body Validation
+
+Write endpoints decode JSON bodies strictly: an unknown or mis-named field is rejected with `400 Bad Request` naming the offending field (e.g. `unknown field "tools"`), rather than being silently dropped. This prevents a typo from changing behavior: for authorization-defining resources such as personas, a dropped `deny_tools` would otherwise create a more permissive persona than intended. `POST /personas` with the nested `{"tools": {"allow": [...]}}` shape (documented fields are the flat `allow_tools`/`deny_tools`) and `POST /tools/call` with `arguments` (documented field is `parameters`) are both rejected.
+
 ## Interactive API Documentation
 
 Swagger UI is served at `GET /api/v1/admin/docs/index.html`. The OpenAPI spec is auto-generated from source code annotations and available at `/api/v1/admin/docs/doc.json`. Regenerate with `make swagger`.

--- a/docs/server/admin-api.md
+++ b/docs/server/admin-api.md
@@ -91,6 +91,29 @@ All errors follow [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9
 }
 ```
 
+### Request Body Validation
+
+Write endpoints decode JSON request bodies strictly: an unknown or mis-named
+field is rejected with `400 Bad Request` naming the offending field, rather than
+being silently dropped. This prevents a typo from changing behavior: for
+authorization-defining resources such as personas, a dropped `deny_tools` field
+would otherwise create a more permissive persona than intended.
+
+```json
+{
+  "type": "about:blank",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "unknown field \"tools\""
+}
+```
+
+For example, `POST /personas` with the nested config shape
+`{"tools": {"allow": [...]}}` is rejected because the documented fields are the
+flat `allow_tools`/`deny_tools`; likewise `POST /tools/call` with `arguments`
+(instead of the documented `parameters`) is rejected rather than executing the
+tool with empty parameters.
+
 ## Operating Mode Behavior
 
 Some endpoints are only available in certain [operating modes](operating-modes.md). When a feature is enabled in config but unavailable at runtime (e.g., no database), endpoints return `409 Conflict` with an explanation. When a feature is disabled in config, endpoints return `404 Not Found`.

--- a/pkg/admin/api_gateway_oauth_handler.go
+++ b/pkg/admin/api_gateway_oauth_handler.go
@@ -60,8 +60,9 @@ func (h *Handler) startAPIGatewayOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body startGatewayOAuthRequest
-	if r.Body != nil {
-		_ = json.NewDecoder(r.Body).Decode(&body)
+	if err := decodeStrictOptional(w, r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	verifier, state, ok := generatePKCEPair(w)

--- a/pkg/admin/assets.go
+++ b/pkg/admin/assets.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -230,8 +229,8 @@ func (h *Handler) updateAdminAsset(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req adminUpdateAssetRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/pkg/admin/authkey_handler.go
+++ b/pkg/admin/authkey_handler.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -71,8 +70,8 @@ func (h *Handler) listAuthKeys(w http.ResponseWriter, _ *http.Request) {
 // @Router       /admin/auth/keys [post]
 func (h *Handler) createAuthKey(w http.ResponseWriter, r *http.Request) {
 	var req authKeyCreateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/pkg/admin/catalog_handler.go
+++ b/pkg/admin/catalog_handler.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -50,11 +49,6 @@ const (
 	// multipartMemoryLimit is the in-memory buffer for
 	// http.Request.ParseMultipartForm before spillover to disk.
 	multipartMemoryLimit int64 = 2 << 20 // 2 MiB
-
-	// errInvalidRequestBody is the 400 message returned when the
-	// request payload doesn't unmarshal. Centralized so revive's
-	// add-constant rule stays happy.
-	errInvalidRequestBody = "invalid request body"
 
 	// catalogPathID is the {id} path placeholder for catalog routes.
 	catalogPathID = "id"
@@ -212,8 +206,8 @@ type createCatalogRequest struct {
 // @Router       /admin/api-catalogs [post]
 func (h *Handler) createCatalog(w http.ResponseWriter, r *http.Request) {
 	var req createCatalogRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errInvalidRequestBody)
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if req.DisplayName == "" {
@@ -281,8 +275,8 @@ type updateCatalogRequest struct {
 func (h *Handler) updateCatalog(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue(catalogPathID)
 	var req updateCatalogRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errInvalidRequestBody)
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	err := h.deps.APICatalogStore.UpdateCatalog(r.Context(), id, apicatalog.Update{
@@ -380,8 +374,8 @@ type cloneCatalogRequest struct {
 func (h *Handler) cloneCatalog(w http.ResponseWriter, r *http.Request) {
 	srcID := r.PathValue(catalogPathID)
 	var req cloneCatalogRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errInvalidRequestBody)
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	src, err := h.deps.APICatalogStore.GetCatalog(r.Context(), srcID)
@@ -641,8 +635,12 @@ func (h *Handler) upsertCatalogSpec(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue(catalogPathID)
 	specName := r.PathValue(catalogPathSpec)
 	var req upsertCatalogSpecRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, errInvalidRequestBody)
+	// The inline `content` field carries a full OpenAPI spec, which routinely
+	// exceeds the small default admin body cap; allow the same 10 MiB bound the
+	// multipart upload path uses (plus JSON framing overhead) so large specs
+	// still save. Unknown-field rejection still applies.
+	if err := decodeStrictLimit(w, r, &req, catalogSpecMaxUploadBytes+1024); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	entry, err := h.materializeSpec(r.Context(), specName, req)

--- a/pkg/admin/catalog_handler_test.go
+++ b/pkg/admin/catalog_handler_test.go
@@ -218,6 +218,28 @@ func TestCatalog_UpsertSpecInline(t *testing.T) {
 	}
 }
 
+// TestCatalog_UpsertSpecAcceptsLargeInlineContent guards the #923 review
+// finding: the inline `content` path must not inherit the small default admin
+// body cap, since real OpenAPI specs routinely exceed 1 MiB. A >1 MiB spec must
+// still save.
+func TestCatalog_UpsertSpecAcceptsLargeInlineContent(t *testing.T) {
+	t.Parallel()
+	h, _ := newCatalogTestHandler(t)
+	doJSON(t, h, http.MethodPost, "/api/v1/admin/api-catalogs", map[string]any{
+		"id": "p", "name": "p", "display_name": "P",
+	})
+	// Valid OpenAPI YAML padded past 1 MiB via a large description scalar.
+	big := strings.Repeat("a", (1<<20)+4096)
+	content := "openapi: 3.0.0\ninfo:\n  title: x\n  version: '1'\n  description: " + big + "\npaths: {}\n"
+	res := doJSON(t, h, http.MethodPut, "/api/v1/admin/api-catalogs/p/specs/default", map[string]any{
+		"source_kind": "inline",
+		"content":     content,
+	})
+	if res.Code != http.StatusOK {
+		t.Fatalf("large inline spec upsert: %d %s", res.Code, res.Body.String())
+	}
+}
+
 func TestCatalog_UpsertSpecRejectsInvalidSource(t *testing.T) {
 	t.Parallel()
 	h, _ := newCatalogTestHandler(t)

--- a/pkg/admin/config_handler.go
+++ b/pkg/admin/config_handler.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -430,8 +429,8 @@ func (h *Handler) setConfigEntry(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req setConfigEntryRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/pkg/admin/connection_handler.go
+++ b/pkg/admin/connection_handler.go
@@ -3,7 +3,6 @@ package admin
 import (
 	"context"
 	"crypto/x509"
-	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"log/slog"
@@ -162,8 +161,8 @@ func (h *Handler) setConnectionInstance(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var req setConnectionInstanceRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/pkg/admin/connection_oauth_handler.go
+++ b/pkg/admin/connection_oauth_handler.go
@@ -104,8 +104,9 @@ func (h *Handler) startConnectionOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body startConnectionOAuthRequest
-	if r.Body != nil {
-		_ = json.NewDecoder(r.Body).Decode(&body)
+	if err := decodeStrictOptional(w, r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
 	}
 	verifier, state, ok := generatePKCEPair(w)
 	if !ok {

--- a/pkg/admin/decode.go
+++ b/pkg/admin/decode.go
@@ -1,0 +1,92 @@
+package admin
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// maxAdminBodyBytes caps the size of a decoded admin write request body. Admin
+// payloads (persona definitions, connection configs, tool arguments) are small;
+// this bound protects the decoder from an oversized or hostile body. Callers
+// that stream large uploads (e.g. catalog spec files) manage their own limits.
+const maxAdminBodyBytes = 1 << 20 // 1 MiB
+
+// errInvalidBody is the generic RFC 9457 detail for a malformed JSON body that
+// is not an unknown-field or over-size error. It matches the wording other
+// admin handlers already return for decode failures.
+const errInvalidBody = "invalid request body"
+
+// decodeStrict decodes a required JSON request body into dst, rejecting unknown
+// fields so a mis-named or schema-mismatched field surfaces as a 400 instead of
+// being silently dropped. For authorization-defining resources (personas, tool
+// access) a dropped field can turn a typo into a policy change, so strict
+// decoding is the safe default for every admin write endpoint. The body is
+// capped at maxAdminBodyBytes. The returned error's message is safe to hand to
+// writeError as the problem+json detail (it names the offending field for the
+// unknown-field case).
+func decodeStrict(w http.ResponseWriter, r *http.Request, dst any) error {
+	return decodeStrictLimit(w, r, dst, maxAdminBodyBytes)
+}
+
+// decodeStrictLimit is decodeStrict with a caller-supplied body cap. Endpoints
+// that legitimately carry large inline payloads (e.g. an OpenAPI spec's
+// `content` field, which the sibling multipart path allows up to 10 MiB) pass
+// their own bound instead of the small maxAdminBodyBytes default.
+func decodeStrictLimit(w http.ResponseWriter, r *http.Request, dst any, maxBytes int64) error {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		return decodeError(err)
+	}
+	// Reject trailing data after the first JSON value so a body like
+	// `{...}{...}` is not silently accepted with only the first object read.
+	if dec.More() {
+		return errors.New(errInvalidBody)
+	}
+	return nil
+}
+
+// decodeStrictOptional behaves like decodeStrict but treats an empty body as a
+// success (leaving dst at its zero value). Use it for endpoints whose body is
+// optional (e.g. an OAuth start with an optional return_url) but which should
+// still reject unknown fields when a body is present.
+func decodeStrictOptional(w http.ResponseWriter, r *http.Request, dst any) error {
+	if r.Body == nil {
+		return nil
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxAdminBodyBytes)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil // empty body: leave dst zero-valued
+		}
+		return decodeError(err)
+	}
+	if dec.More() {
+		return errors.New(errInvalidBody)
+	}
+	return nil
+}
+
+// decodeError maps a json.Decoder error to a safe RFC 9457 detail string. The
+// stdlib unknown-field error text ("json: unknown field \"tools\"") already
+// quotes the field name, so it is surfaced verbatim (minus the "json: " prefix)
+// to tell the caller exactly which field was rejected. Over-size and all other
+// decode errors collapse to stable, non-leaky messages.
+func decodeError(err error) error {
+	var maxErr *http.MaxBytesError
+	if errors.As(err, &maxErr) {
+		return errors.New("request body too large")
+	}
+	const unknownPrefix = "json: unknown field "
+	if msg := err.Error(); strings.HasPrefix(msg, unknownPrefix) {
+		return fmt.Errorf("unknown field %s", strings.TrimPrefix(msg, unknownPrefix))
+	}
+	return errors.New(errInvalidBody)
+}

--- a/pkg/admin/decode_test.go
+++ b/pkg/admin/decode_test.go
@@ -1,0 +1,163 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type decodeTarget struct {
+	Name  string   `json:"name"`
+	Tags  []string `json:"tags,omitempty"`
+	Count int      `json:"count,omitempty"`
+}
+
+func newDecodeRequest(body string) (*httptest.ResponseRecorder, *http.Request) {
+	r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", strings.NewReader(body))
+	return httptest.NewRecorder(), r
+}
+
+func TestDecodeStrict(t *testing.T) {
+	t.Run("decodes a valid body", func(t *testing.T) {
+		w, r := newDecodeRequest(`{"name":"a","tags":["x"],"count":2}`)
+		var dst decodeTarget
+		require.NoError(t, decodeStrict(w, r, &dst))
+		assert.Equal(t, "a", dst.Name)
+		assert.Equal(t, []string{"x"}, dst.Tags)
+		assert.Equal(t, 2, dst.Count)
+	})
+
+	t.Run("rejects an unknown field naming it", func(t *testing.T) {
+		w, r := newDecodeRequest(`{"name":"a","tools":{"allow":["*"]}}`)
+		var dst decodeTarget
+		err := decodeStrict(w, r, &dst)
+		require.Error(t, err)
+		assert.Equal(t, `unknown field "tools"`, err.Error())
+	})
+
+	t.Run("rejects malformed JSON with a generic message", func(t *testing.T) {
+		w, r := newDecodeRequest(`{bad`)
+		var dst decodeTarget
+		err := decodeStrict(w, r, &dst)
+		require.Error(t, err)
+		assert.Equal(t, errInvalidBody, err.Error())
+	})
+
+	t.Run("rejects trailing data after the first value", func(t *testing.T) {
+		w, r := newDecodeRequest(`{"name":"a"}{"name":"b"}`)
+		var dst decodeTarget
+		err := decodeStrict(w, r, &dst)
+		require.Error(t, err)
+		assert.Equal(t, errInvalidBody, err.Error())
+	})
+
+	t.Run("rejects an oversized body", func(t *testing.T) {
+		big := `{"name":"` + strings.Repeat("a", maxAdminBodyBytes+16) + `"}`
+		w, r := newDecodeRequest(big)
+		var dst decodeTarget
+		err := decodeStrict(w, r, &dst)
+		require.Error(t, err)
+		assert.Equal(t, "request body too large", err.Error())
+	})
+
+	t.Run("rejects an empty required body", func(t *testing.T) {
+		w, r := newDecodeRequest("")
+		var dst decodeTarget
+		err := decodeStrict(w, r, &dst)
+		require.Error(t, err)
+		assert.Equal(t, errInvalidBody, err.Error())
+	})
+}
+
+func TestDecodeStrictLimit(t *testing.T) {
+	t.Run("accepts a body larger than the default cap under a bigger limit", func(t *testing.T) {
+		// A payload that exceeds maxAdminBodyBytes but fits a caller-supplied
+		// larger bound must still decode (issue #923 regression: catalog spec
+		// content routinely exceeds the small default cap).
+		big := `{"name":"` + strings.Repeat("a", maxAdminBodyBytes+16) + `"}`
+		w, r := newDecodeRequest(big)
+		var dst decodeTarget
+		require.NoError(t, decodeStrictLimit(w, r, &dst, maxAdminBodyBytes*4))
+		assert.Equal(t, maxAdminBodyBytes+16, len(dst.Name))
+	})
+
+	t.Run("still rejects unknown fields under a bigger limit", func(t *testing.T) {
+		w, r := newDecodeRequest(`{"name":"a","nope":1}`)
+		var dst decodeTarget
+		err := decodeStrictLimit(w, r, &dst, maxAdminBodyBytes*4)
+		require.Error(t, err)
+		assert.Equal(t, `unknown field "nope"`, err.Error())
+	})
+
+	t.Run("enforces the supplied limit", func(t *testing.T) {
+		big := `{"name":"` + strings.Repeat("a", 4096) + `"}`
+		w, r := newDecodeRequest(big)
+		var dst decodeTarget
+		err := decodeStrictLimit(w, r, &dst, 1024)
+		require.Error(t, err)
+		assert.Equal(t, "request body too large", err.Error())
+	})
+}
+
+func TestDecodeStrictOptional(t *testing.T) {
+	t.Run("treats an empty body as success", func(t *testing.T) {
+		w, r := newDecodeRequest("")
+		var dst decodeTarget
+		require.NoError(t, decodeStrictOptional(w, r, &dst))
+		assert.Equal(t, decodeTarget{}, dst)
+	})
+
+	t.Run("treats a nil body as success", func(t *testing.T) {
+		r := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", nil)
+		r.Body = nil
+		var dst decodeTarget
+		require.NoError(t, decodeStrictOptional(httptest.NewRecorder(), r, &dst))
+	})
+
+	t.Run("still rejects unknown fields when a body is present", func(t *testing.T) {
+		w, r := newDecodeRequest(`{"return_to":"/x"}`)
+		var dst decodeTarget
+		err := decodeStrictOptional(w, r, &dst)
+		require.Error(t, err)
+		assert.Equal(t, `unknown field "return_to"`, err.Error())
+	})
+
+	t.Run("decodes a present valid body", func(t *testing.T) {
+		w, r := newDecodeRequest(`{"name":"a"}`)
+		var dst decodeTarget
+		require.NoError(t, decodeStrictOptional(w, r, &dst))
+		assert.Equal(t, "a", dst.Name)
+	})
+}
+
+// TestNoBareBodyDecodeInHandlers guards the acceptance criterion that no admin
+// write endpoint returns to a lenient json.NewDecoder(r.Body).Decode that would
+// silently drop unknown fields. New handlers must route request bodies through
+// decodeStrict / decodeStrictOptional. decode.go itself is the one legitimate
+// site of the raw decoder.
+func TestNoBareBodyDecodeInHandlers(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	const bare = "json.NewDecoder(r.Body).Decode"
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.go") || name == "decode.go" {
+			continue
+		}
+		data, rerr := os.ReadFile(filepath.Clean(name))
+		require.NoError(t, rerr)
+		assert.NotContains(t, string(data), bare,
+			"%s uses a lenient body decode; route it through decodeStrict/decodeStrictOptional (issue #923)", name)
+	}
+}

--- a/pkg/admin/enrichment_handler.go
+++ b/pkg/admin/enrichment_handler.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -101,8 +100,8 @@ func (h *Handler) dryRunEnrichmentRule(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body dryRunEnrichmentRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeStrict(w, r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -242,8 +241,8 @@ func (h *Handler) createEnrichmentRule(w http.ResponseWriter, r *http.Request) {
 	connection := r.PathValue(pathKeyName)
 
 	var body enrichmentRuleBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeStrict(w, r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	rule := enrichment.Rule{
@@ -303,8 +302,8 @@ func (h *Handler) updateEnrichmentRule(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body enrichmentRuleBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeStrict(w, r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	existing.ToolName = body.ToolName

--- a/pkg/admin/gateway_handler.go
+++ b/pkg/admin/gateway_handler.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -217,8 +216,8 @@ func (h *Handler) tryTestLiveConnection(w http.ResponseWriter, r *http.Request, 
 // Writes the appropriate HTTP error and returns ok=false on any failure path.
 func (h *Handler) parseTestConnectionConfig(w http.ResponseWriter, r *http.Request, name string) (gatewaykit.Config, bool) {
 	var req testGatewayConnectionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return gatewaykit.Config{}, false
 	}
 	if req.Config == nil {

--- a/pkg/admin/gateway_oauth_handler.go
+++ b/pkg/admin/gateway_oauth_handler.go
@@ -97,8 +97,9 @@ func (h *Handler) startGatewayOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body startGatewayOAuthRequest
-	if r.Body != nil {
-		_ = json.NewDecoder(r.Body).Decode(&body)
+	if err := decodeStrictOptional(w, r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	verifier, state, ok := generatePKCEPair(w)

--- a/pkg/admin/indexjobs_handler.go
+++ b/pkg/admin/indexjobs_handler.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -316,8 +315,8 @@ func (h *Handler) dismissIndexJobsFailure(w http.ResponseWriter, r *http.Request
 		return
 	}
 	var req dismissRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if req.Kind == "" || req.SourceID == "" {
@@ -358,8 +357,8 @@ func (h *Handler) reindexIndexJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req reindexRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if req.Kind == "" {

--- a/pkg/admin/knowledge.go
+++ b/pkg/admin/knowledge.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
@@ -136,8 +135,8 @@ func (h *KnowledgeHandler) UpdateInsightStatus(w http.ResponseWriter, r *http.Re
 	id := r.PathValue(pathParamID)
 
 	var req statusUpdateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -200,8 +199,8 @@ func (h *KnowledgeHandler) UpdateInsight(w http.ResponseWriter, r *http.Request)
 	id := r.PathValue(pathParamID)
 
 	var req insightUpdateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/pkg/admin/persona_handler.go
+++ b/pkg/admin/persona_handler.go
@@ -203,8 +203,8 @@ func (h *Handler) getPersona(w http.ResponseWriter, r *http.Request) {
 // @Router       /admin/personas [post]
 func (h *Handler) createPersona(w http.ResponseWriter, r *http.Request) {
 	var req personaCreateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -267,8 +267,8 @@ func (h *Handler) updatePersona(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 
 	var req personaCreateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -557,8 +557,8 @@ func (h *Handler) testPersonaAccess(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req testPersonaAccessRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if req.ToolName == "" {

--- a/pkg/admin/persona_handler_test.go
+++ b/pkg/admin/persona_handler_test.go
@@ -347,6 +347,41 @@ func TestCreatePersona(t *testing.T) {
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
+
+	// Issue #923: an authorization-defining resource must never silently drop a
+	// mis-named field. The nested YAML-config shape {"tools":{"allow":[...]}}
+	// would otherwise create a deny-all persona (grants dropped) with a 201, and
+	// a typo'd deny key ("deny_tols") would create a MORE permissive persona
+	// than intended. Strict decoding turns both into a named 400.
+	t.Run("rejects nested tools field from YAML-config shape", func(t *testing.T) {
+		pReg := &mockPersonaRegistry{}
+		h := NewHandler(Deps{PersonaRegistry: pReg, Config: testConfig(), ConfigStore: &mockConfigStore{mode: "database"}}, nil)
+
+		body := `{"name":"analyst","display_name":"Data Analyst","roles":["analyst"],"tools":{"allow":["trino_*"],"deny":["*_delete_*"]}}`
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/personas", strings.NewReader(body))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		pd := decodeProblem(w.Body.Bytes())
+		assert.Contains(t, pd.Detail, "unknown field")
+		assert.Contains(t, pd.Detail, `"tools"`)
+	})
+
+	t.Run("rejects typo'd deny_tols key", func(t *testing.T) {
+		pReg := &mockPersonaRegistry{}
+		h := NewHandler(Deps{PersonaRegistry: pReg, Config: testConfig(), ConfigStore: &mockConfigStore{mode: "database"}}, nil)
+
+		body := `{"name":"analyst","display_name":"Data Analyst","roles":["analyst"],"allow_tools":["*"],"deny_tols":["trino_execute"]}`
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/personas", strings.NewReader(body))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		pd := decodeProblem(w.Body.Bytes())
+		assert.Contains(t, pd.Detail, "unknown field")
+		assert.Contains(t, pd.Detail, `"deny_tols"`)
+	})
 }
 
 func TestUpdatePersona(t *testing.T) {

--- a/pkg/admin/prompt_handler.go
+++ b/pkg/admin/prompt_handler.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"context"
-	"encoding/json"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -229,8 +228,8 @@ func (h *Handler) getPrompt(w http.ResponseWriter, r *http.Request) {
 // @Router       /admin/prompts [post]
 func (h *Handler) createPrompt(w http.ResponseWriter, r *http.Request) {
 	var req adminPromptCreateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -339,8 +338,8 @@ func (h *Handler) updatePrompt(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req adminPromptUpdateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid request body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/pkg/admin/tools.go
+++ b/pkg/admin/tools.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -120,7 +119,7 @@ func (h *Handler) callTool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req, err := decodeToolCallRequest(r)
+	req, err := decodeToolCallRequest(w, r)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -161,16 +160,22 @@ func (h *Handler) callTool(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// decodeToolCallRequest reads and validates a toolCallRequest from an HTTP request.
-func decodeToolCallRequest(r *http.Request) (*toolCallRequest, error) {
-	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1MB limit
-	if err != nil {
-		return nil, errors.New("failed to read request body")
-	}
+// decodeToolCallRequest reads and validates a toolCallRequest from an HTTP
+// request. Decoding is strict: an unknown field (e.g. "arguments" instead of
+// the documented "parameters") is rejected with a named 400 rather than
+// silently dropped, which would otherwise run the tool with empty parameters
+// and surface a confusing downstream schema error.
+func decodeToolCallRequest(w http.ResponseWriter, r *http.Request) (*toolCallRequest, error) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxAdminBodyBytes)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
 
 	var req toolCallRequest
-	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, fmt.Errorf("invalid JSON: %w", err)
+	if err := dec.Decode(&req); err != nil {
+		return nil, decodeError(err)
+	}
+	if dec.More() {
+		return nil, errors.New(errInvalidBody)
 	}
 
 	if req.ToolName == "" {

--- a/pkg/admin/tools_detail.go
+++ b/pkg/admin/tools_detail.go
@@ -446,8 +446,8 @@ func (h *Handler) parseVisibilityRequest(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusNotFound, fmt.Sprintf("tool %q not found", name))
 		return "", req, false
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return "", req, false
 	}
 	return name, req, true

--- a/pkg/admin/tools_test.go
+++ b/pkg/admin/tools_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -209,6 +210,37 @@ func TestCallTool(t *testing.T) {
 		h.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	// Issue #923: the documented field is "parameters"; sending "arguments"
+	// used to run the tool with empty parameters and produce a confusing
+	// downstream schema error. Strict decoding rejects the unknown field by name.
+	t.Run("rejects unknown arguments field naming it", func(t *testing.T) {
+		h := NewHandler(Deps{MCPServer: newTestMCPServer()}, nil)
+		body := []byte(`{"tool_name":"trino_query","arguments":{"sql":"SELECT 1"}}`)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/tools/call", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		pd := decodeProblem(w.Body.Bytes())
+		assert.Contains(t, pd.Detail, "unknown field")
+		assert.Contains(t, pd.Detail, `"arguments"`)
+	})
+
+	// Issue #923 review: an oversized tool-call body must surface as a clear
+	// "request body too large" (via MaxBytesReader), consistent with every other
+	// swept endpoint, not a misleading generic parse error from a truncated read.
+	t.Run("reports oversized body clearly", func(t *testing.T) {
+		h := NewHandler(Deps{MCPServer: newTestMCPServer()}, nil)
+		body := []byte(`{"tool_name":"trino_query","parameters":{"sql":"` + strings.Repeat("a", (1<<20)+16) + `"}}`)
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/admin/tools/call", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		pd := decodeProblem(w.Body.Bytes())
+		assert.Equal(t, "request body too large", pd.Detail)
 	})
 
 	t.Run("returns error when no MCP server", func(t *testing.T) {

--- a/pkg/admin/user_handler.go
+++ b/pkg/admin/user_handler.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -143,8 +142,8 @@ func (h *Handler) getUser(w http.ResponseWriter, r *http.Request) {
 // @Router       /admin/users [post]
 func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 	var req userCreateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	email, err := user.NormalizeEmail(req.Email)
@@ -208,8 +207,8 @@ func (h *Handler) updateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req userUpdateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if err := decodeStrict(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if err := validateUserUpdate(req); err != nil {

--- a/scripts/codeql-baseline.txt
+++ b/scripts/codeql-baseline.txt
@@ -32,9 +32,11 @@ go/sql-injection pkg/audit/postgres/store.go:195
 # taint surface; the runtime behavior is unchanged. The line moved from
 # 522 to 494 when the PKCE store (PKCEState struct + pkceTTL const) was
 # extracted to pkg/pkcestore (#636), then from 494 to 498 when the logsan
-# import and truncateForLog control-char stripping were added in #861;
+# import and truncateForLog control-char stripping were added in #861,
+# then from 498 to 499 when the OAuth-start handler was routed through the
+# shared strict-decode helper in #923 (one extra line above this sink);
 # same sink, same exchange, unchanged.
-go/request-forgery pkg/admin/gateway_oauth_handler.go:498
+go/request-forgery pkg/admin/gateway_oauth_handler.go:499
 
 # weak-sensitive-data-hashing on the OAuth signing-key kid derivation
 # (#897). KeyID hashes the HMAC signing key with SHA-256 and truncates to


### PR DESCRIPTION
## Summary

Admin REST write endpoints decoded JSON request bodies leniently, so a request whose field names do not match the schema was silently accepted with the mis-named fields dropped. For an authorization-defining resource this converts a typo into a policy change. This PR routes every admin write body through a shared strict decoder that rejects unknown fields with an RFC 9457 `400` naming the offending field.

Fixes #923.

## The problem

Two behaviors were observed on a live deployment, both from an agent driving the API:

1. `POST /api/v1/admin/personas` with the YAML-config shape `{"tools": {"allow": [...], "deny": [...]}}` (instead of the documented flat `allow_tools`/`deny_tools`) returned **201 Created** with `allow_tools: []`, `deny_tools: []` (a deny-all persona), with no indication the grants were dropped. The inverse is worse: `{"allow_tools": ["*"], "deny_tols": ["trino_execute"]}` would silently create a persona with the deny list gone, i.e. **more** permissive than intended.
2. `POST /api/v1/admin/tools/call` with `{"tool_name": ..., "arguments": {...}}` (documented field is `parameters`) executed the tool with empty parameters, surfacing a confusing downstream schema error instead of a `400` naming the unknown field.

The validation posture was inconsistent: the same handlers already returned clean problem+json for missing required fields (`"tool_name is required"`), but wrong-but-present fields were silently dropped. There was no `DisallowUnknownFields` call anywhere in the repository.

## What changed

**Shared strict-decode helper** (`pkg/admin/decode.go`):
- `decodeStrict(w, r, dst)` — `DisallowUnknownFields`, 1 MiB `MaxBytesReader` cap, rejects trailing data, returns a problem+json detail that names the offending field (`unknown field "tools"`).
- `decodeStrictLimit(w, r, dst, maxBytes)` — same, with a caller-supplied body cap for endpoints that carry large inline payloads.
- `decodeStrictOptional(w, r, dst)` — for endpoints whose body is optional (OAuth-start `return_url`); treats an empty body as success but still rejects unknown fields.
- `decodeError` maps decoder errors to safe, non-leaky detail strings (`unknown field "x"`, `request body too large`, or a generic `invalid request body`).

**Swept all 26 non-test decode sites** in `pkg/admin` onto the helpers (24 required-body handlers plus 3 optional OAuth-start handlers), and made the separate `json.Unmarshal` path in `decodeToolCallRequest` strict as well. Per-handler semantic validation (required-field checks, etc.) is preserved.

**Regression guard**: `TestNoBareBodyDecodeInHandlers` greps every non-test source file in `pkg/admin` for `json.NewDecoder(r.Body).Decode`, so a new handler cannot silently reintroduce a lenient decode.

## Body-size handling

- The inline catalog-spec content path (`PUT /api/v1/admin/api-catalogs/{id}/specs/{spec}`) allows 10 MiB, matching the multipart upload path, since a full OpenAPI spec in the `content` field routinely exceeds the 1 MiB default. Unknown fields are still rejected.
- Oversized bodies report `request body too large` uniformly, since every endpoint (including `tools/call`) bounds the body with `MaxBytesReader`.

## Behavior notes

- Persona create/update rejects response-only fields (`tools`, `source`, `context`) that appear in a `personaDetail` GET response but are not part of the request shape; clients send the documented flat `allow_tools`/`deny_tools` shape.
- OAuth-start endpoints reject a body carrying an unknown field (e.g. a typo'd `return_url`); the documented `{"return_url": ...}` shape and empty bodies succeed.

## Tests

- Persona: the exact observed `{"tools": {...}}` body is rejected with a `400` naming `tools`; a typo'd `deny_tols` is likewise rejected by name.
- Tools/call: an `arguments` field is rejected naming it; an oversized body reports `request body too large`.
- Catalog: a >1 MiB inline spec still saves.
- Helper unit tests cover valid decode, unknown-field, malformed JSON, trailing data, oversize, empty required vs. optional bodies, and the custom-limit path.

## UI

The portal is the primary client of these endpoints. The persona editor payload (hand-mapped) and the `tools/call` payload use the documented field names, so no UI change was required. The full frontend suite (290 tests) and the MSW route-conformance test are green.

## Docs

- `docs/server/admin-api.md` gains a "Request Body Validation" section describing the strict-decode contract and the two example rejections.
- `docs/llms-full.txt` updated to match.
- No swagger change: the schemas observed during testing were already correct; only enforcement was missing.
- `scripts/codeql-baseline.txt`: the pre-existing gateway OAuth token-exchange request-forgery finding shifted one line (an extra line above the sink); the baseline entry and its move-history note were updated. Same sink, unchanged runtime behavior.

## Acceptance criteria

- [x] The two observed requests return `400` problem+json naming the unknown field; the documented shapes still succeed.
- [x] No admin write endpoint remains on a bare `Decode`, guarded by `TestNoBareBodyDecodeInHandlers`.
- [x] Frontend and MSW conformance tests green; `make verify` green.
