### PR TITLE
fix(auth): return HTTP 401 + WWW-Authenticate for invalid tokens on MCP endpoints

### DIFF
--- a/internal/httpserver/httpserver_test.go
+++ b/internal/httpserver/httpserver_test.go
@@ -212,21 +212,21 @@ func TestNewSSEHandler(t *testing.T) {
 	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1.0"}, nil)
 
 	t.Run("without auth", func(t *testing.T) {
-		handler := newSSEHandler(mcpServer, false, "")
+		handler := newSSEHandler(mcpServer, false, "", nil)
 		if handler == nil {
 			t.Fatal("expected non-nil handler")
 		}
 	})
 
 	t.Run("with auth no OAuth", func(t *testing.T) {
-		handler := newSSEHandler(mcpServer, true, "")
+		handler := newSSEHandler(mcpServer, true, "", nil)
 		if handler == nil {
 			t.Fatal("expected non-nil handler")
 		}
 	})
 
 	t.Run("with auth and OAuth", func(t *testing.T) {
-		handler := newSSEHandler(mcpServer, true, "https://mcp.example.com/.well-known/oauth-protected-resource")
+		handler := newSSEHandler(mcpServer, true, "https://mcp.example.com/.well-known/oauth-protected-resource", nil)
 		if handler == nil {
 			t.Fatal("expected non-nil handler")
 		}

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/txn2/mcp-data-platform/internal/ui"
 	"github.com/txn2/mcp-data-platform/pkg/health"
 	httpauth "github.com/txn2/mcp-data-platform/pkg/http"
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
 	"github.com/txn2/mcp-data-platform/pkg/session"
 )
@@ -78,6 +79,11 @@ type httpConfig struct {
 	// mcpServer is closed-out on shutdown so connected agents reconnect to the new
 	// build (#675). Carried on the config so listenAndServe stays within its arg budget.
 	mcpServer *mcp.Server
+	// authenticator is the same auth entry point the protocol middleware uses. The
+	// MCP auth gateway calls it to reject a present-but-invalid token at the HTTP
+	// layer with 401 + WWW-Authenticate (#926). Nil when the platform is nil
+	// (tests) — the gate then stays presence-only.
+	authenticator middleware.Authenticator
 }
 
 func extractHTTPConfig(p *platform.Platform) httpConfig {
@@ -91,21 +97,23 @@ func extractHTTPConfig(p *platform.Platform) httpConfig {
 		cfg.tlsKeyFile = c.Server.TLS.KeyFile
 		cfg.streamableCfg = c.Server.Streamable
 		cfg.shutdownCfg = c.Server.Shutdown
+		cfg.authenticator = p.Authenticator()
 	}
 	return cfg
 }
 
-// newSSEHandler creates an SSE handler with auth middleware.
-func newSSEHandler(mcpServer *mcp.Server, requireAuth bool, resourceMetadataURL string) http.Handler {
+// newSSEHandler creates an SSE handler with auth middleware. When auth is
+// required it always routes through RequireAuthWithOAuth so the invalid-token
+// gate (#926) fires on SSE, matching the streamable transport (mountRootHandler).
+// With no OAuth server, resourceMetadataURL is empty and the 401 simply omits the
+// resource_metadata parameter.
+func newSSEHandler(mcpServer *mcp.Server, requireAuth bool, resourceMetadataURL string, authenticator middleware.Authenticator) http.Handler {
 	sseHandler := mcp.NewSSEHandler(func(*http.Request) *mcp.Server {
 		return mcpServer
 	}, nil)
 
-	if requireAuth && resourceMetadataURL != "" {
-		return httpauth.RequireAuthWithOAuth(resourceMetadataURL)(sseHandler)
-	}
 	if requireAuth {
-		return httpauth.RequireAuth()(sseHandler)
+		return httpauth.RequireAuthWithOAuth(authenticator, resourceMetadataURL)(sseHandler)
 	}
 	return httpauth.OptionalAuth()(sseHandler)
 }
@@ -213,7 +221,7 @@ func Serve(ctx context.Context, mcpServer *mcp.Server, p *platform.Platform, add
 	mountPortalUI(mux, p, ui.Available())
 
 	// Mount SSE handler (legacy clients)
-	wrappedSSE := newSSEHandler(mcpServer, hcfg.requireAuth, rmURL)
+	wrappedSSE := newSSEHandler(mcpServer, hcfg.requireAuth, rmURL, hcfg.authenticator)
 	mux.Handle("/sse", wrappedSSE)
 	mux.Handle("/message", wrappedSSE)
 	log.Println("SSE transport enabled on /sse, /message")
@@ -264,7 +272,7 @@ func buildRootHandler(mcpServer *mcp.Server, p *platform.Platform, hcfg httpConf
 func mountRootHandler(mux *http.ServeMux, rootHandler http.Handler, hcfg httpConfig, rmURL string) {
 	handler := rootHandler
 	if hcfg.requireAuth {
-		handler = httpauth.MCPAuthGateway(rmURL)(handler)
+		handler = httpauth.MCPAuthGateway(hcfg.authenticator, rmURL)(handler)
 		log.Println("Streamable HTTP transport enabled on / (auth required)")
 	} else {
 		log.Println("Streamable HTTP transport enabled on / (anonymous)")

--- a/internal/httpserver/streamable_test.go
+++ b/internal/httpserver/streamable_test.go
@@ -103,7 +103,7 @@ func TestStreamableHTTP_ToolCall_WithAuthGateway(t *testing.T) {
 	streamHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
 
 	// Wrap with MCPAuthGateway (what v0.13.2 uses)
-	handler := httpauth.MCPAuthGateway("")(streamHandler)
+	handler := httpauth.MCPAuthGateway(nil, "")(streamHandler)
 
 	httpServer := httptest.NewServer(handler)
 	defer httpServer.Close()
@@ -170,7 +170,7 @@ func TestStreamableHTTP_ToolCall_WithFullMiddleware(t *testing.T) {
 	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, middleware.ToolCallConfig{Transport: transportHTTP, AdminPersona: "admin"}))
 
 	streamHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
-	handler := httpauth.MCPAuthGateway("")(streamHandler)
+	handler := httpauth.MCPAuthGateway(nil, "")(streamHandler)
 	httpServer := httptest.NewServer(handler)
 	defer httpServer.Close()
 
@@ -317,7 +317,7 @@ func TestStreamableHTTP_OAuthJWT_WithRoles(t *testing.T) {
 	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, middleware.ToolCallConfig{Transport: transportHTTP, AdminPersona: "admin"}))
 
 	streamHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
-	handler := httpauth.MCPAuthGateway("")(streamHandler)
+	handler := httpauth.MCPAuthGateway(nil, "")(streamHandler)
 	httpServer := httptest.NewServer(handler)
 	defer httpServer.Close()
 
@@ -365,6 +365,150 @@ func TestStreamableHTTP_OAuthJWT_WithRoles(t *testing.T) {
 	}
 }
 
+// TestStreamableHTTP_AuthGateway_InvalidToken proves the HTTP-layer conformance
+// surface for issue #926 end-to-end: with the gateway wired to the same
+// authenticator the protocol layer uses, a present-but-invalid token (expired,
+// unknown signature, garbage) is rejected at the HTTP boundary with 401 +
+// WWW-Authenticate error="invalid_token" — the signal MCP clients key their
+// OAuth re-auth flow off — rather than passing the transport to fail in-band on
+// a 200. A valid token still reaches the protocol layer with identity intact,
+// asserted via a full tool-call round trip.
+func TestStreamableHTTP_AuthGateway_InvalidToken(t *testing.T) {
+	signingKey := []byte("test-signing-key-32-bytes-long!!")
+	issuer := "https://mcp.test/oauth"
+	rmURL := issuer + "/.well-known/oauth-protected-resource"
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "0.0.1"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "echo"}, func(_ context.Context, _ *mcp.CallToolRequest, args struct{ Message string }) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "echo: " + args.Message}}}, nil, nil
+	})
+
+	authenticator, authorizer := buildProductionMiddleware(t, signingKey, issuer)
+	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, middleware.ToolCallConfig{Transport: transportHTTP, AdminPersona: "admin"}))
+
+	streamHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
+	// Wire the gateway with the same authenticator (production passes p.Authenticator()).
+	handler := httpauth.MCPAuthGateway(authenticator, rmURL)(streamHandler)
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+
+	// Expired token: signed with the correct key but exp in the past.
+	expiredClaims := jwt.MapClaims{
+		"iss": issuer, "sub": "user-123", "aud": issuer,
+		"exp": time.Now().Add(-time.Hour).Unix(),
+		"iat": time.Now().Add(-2 * time.Hour).Unix(),
+	}
+	expiredToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, expiredClaims).SignedString(signingKey)
+	if err != nil {
+		t.Fatalf("signing expired token: %v", err)
+	}
+	// Unknown token: valid JWT shape, signed with a foreign key.
+	unknownToken := makeTestJWT(t, []byte("a-foreign-signing-key-32-byteslong"), issuer, "user-x", nil)
+
+	// The gate validates the present credential with the same authenticator the
+	// protocol layer uses, so any invalid token — an unverifiable JWT or an
+	// unrecognized opaque credential — is rejected at the HTTP boundary.
+	reject := []struct {
+		name  string
+		token string // "" means no Authorization header
+	}{
+		{"expired", expiredToken},
+		{"unknown signature", unknownToken},
+		{"malformed jwt", "aaa.bbb.ccc"},
+		{"unrecognized credential", "not-a-known-credential"},
+	}
+	for _, tc := range reject {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := postInitialize(t, httpServer.URL, tc.token)
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401", resp.StatusCode)
+			}
+			www := resp.Header.Get("WWW-Authenticate")
+			if !strings.Contains(www, `error="invalid_token"`) {
+				t.Errorf("WWW-Authenticate = %q, want error=\"invalid_token\"", www)
+			}
+			if !strings.Contains(www, `resource_metadata="`+rmURL+`"`) {
+				t.Errorf("WWW-Authenticate = %q, want resource_metadata", www)
+			}
+		})
+	}
+
+	t.Run("absent token has no invalid_token code", func(t *testing.T) {
+		resp := postInitialize(t, httpServer.URL, "")
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+		www := resp.Header.Get("WWW-Authenticate")
+		if strings.Contains(www, "invalid_token") {
+			t.Errorf("WWW-Authenticate = %q, absent credential must not report invalid_token", www)
+		}
+		if !strings.Contains(www, `resource_metadata="`+rmURL+`"`) {
+			t.Errorf("WWW-Authenticate = %q, want resource_metadata", www)
+		}
+	})
+
+	t.Run("valid token reaches protocol layer", func(t *testing.T) {
+		token := makeTestJWT(t, signingKey, issuer, "user-123", map[string]any{
+			"email":        "admin@example.com",
+			"realm_access": map[string]any{"roles": []any{"dp_admin"}},
+		})
+		httpClient := &http.Client{Transport: &authRoundTripper{token: token, base: http.DefaultTransport}}
+		client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+		session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{
+			Endpoint:   httpServer.URL,
+			HTTPClient: httpClient,
+		}, nil)
+		if err != nil {
+			t.Fatalf(fmtConnectFailed, err)
+		}
+		defer func() { _ = session.Close() }()
+
+		result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+			Name:      "echo",
+			Arguments: map[string]any{"Message": "hello"},
+		})
+		if err != nil {
+			t.Fatalf(fmtCallToolFailed, err)
+		}
+		if result.IsError {
+			tc, _ := result.Content[0].(*mcp.TextContent)
+			t.Fatalf("tool returned error: %s", tc.Text)
+		}
+		tc, ok := result.Content[0].(*mcp.TextContent)
+		if !ok {
+			t.Fatalf(fmtWantTextContent, result.Content[0])
+		}
+		if tc.Text != wantEchoReply {
+			t.Errorf(fmtGotWant, tc.Text, wantEchoReply)
+		}
+	})
+}
+
+// postInitialize sends a raw MCP initialize POST to the streamable endpoint with
+// the given bearer token ("" omits the Authorization header). The auth gateway
+// runs before the MCP handler, so a rejected request never reaches the handler
+// and the request body is only exercised on the accepted path.
+func postInitialize(t *testing.T, url, token string) *http.Response {
+	t.Helper()
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST initialize: %v", err)
+	}
+	return resp
+}
+
 // TestStreamableHTTP_OAuthJWT_NoRoles_DeniedByPersona reproduces the
 // production bug: OAuth JWT is VALID (auth succeeds) but the Keycloak
 // user has NO dp_* roles, so Authorizer falls back to the default
@@ -385,7 +529,7 @@ func TestStreamableHTTP_OAuthJWT_NoRoles_DeniedByPersona(t *testing.T) {
 	server.AddReceivingMiddleware(middleware.MCPToolCallMiddleware(authenticator, authorizer, nil, middleware.ToolCallConfig{Transport: transportHTTP, AdminPersona: "admin"}))
 
 	streamHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
-	handler := httpauth.MCPAuthGateway("")(streamHandler)
+	handler := httpauth.MCPAuthGateway(nil, "")(streamHandler)
 	httpServer := httptest.NewServer(handler)
 	defer httpServer.Close()
 

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -90,8 +90,15 @@ func NewChainedAuthenticator(cfg ChainedAuthConfig, authenticators ...middleware
 // lastErr tracks the most recent real (non-sentinel) error so a
 // failed-everywhere chain surfaces a meaningful reason instead of the
 // noisy ErrNotAJWT sentinel.
+//
+// transientErr separately retains a middleware.ErrValidationUnavailable (e.g.
+// OIDC JWKS unreachable). A successful authenticator still wins outright — a
+// valid API key authenticates during an IdP blip — but when nothing succeeds, a
+// transient failure is surfaced ahead of a definitive one so the caller can
+// distinguish "could not validate" from "invalid" and fail open rather than
+// hard-reject.
 func (c *ChainedAuthenticator) Authenticate(ctx context.Context) (*middleware.UserInfo, error) {
-	var lastErr error
+	var lastErr, transientErr error
 	reqID, tool := correlationFields(ctx)
 
 	for i, auth := range c.authenticators {
@@ -103,6 +110,10 @@ func (c *ChainedAuthenticator) Authenticate(ctx context.Context) (*middleware.Us
 			continue
 		}
 		if errors.Is(err, ErrNotAJWT) {
+			continue
+		}
+		if errors.Is(err, middleware.ErrValidationUnavailable) {
+			transientErr = err
 			continue
 		}
 		slog.Debug("chained auth: verification failed for this authenticator, trying next",
@@ -123,6 +134,9 @@ func (c *ChainedAuthenticator) Authenticate(ctx context.Context) (*middleware.Us
 		}, nil
 	}
 
+	if transientErr != nil {
+		return nil, transientErr
+	}
 	if lastErr != nil {
 		return nil, lastErr
 	}

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -99,6 +99,42 @@ func TestChainedAuthenticator(t *testing.T) {
 	})
 }
 
+func TestChainedAuthenticator_TransientError(t *testing.T) {
+	transient := fmt.Errorf("jwks unreachable: %w", middleware.ErrValidationUnavailable)
+
+	t.Run("surfaces transient error preferentially over a definitive one", func(t *testing.T) {
+		// Order mirrors production: a JWT authenticator hits a transient JWKS
+		// failure, then the API key authenticator definitively rejects. The chain
+		// must surface the transient error so the caller can fail open.
+		jwtAuth := &mockAuthenticator{err: transient}
+		apiKeyAuth := &mockAuthenticator{err: errors.New("invalid API key")}
+
+		chained := NewChainedAuthenticator(ChainedAuthConfig{}, jwtAuth, apiKeyAuth)
+
+		_, err := chained.Authenticate(context.Background())
+		if !errors.Is(err, middleware.ErrValidationUnavailable) {
+			t.Fatalf("error = %v, want it to wrap middleware.ErrValidationUnavailable", err)
+		}
+	})
+
+	t.Run("a later success still wins over an earlier transient error", func(t *testing.T) {
+		// A valid API key must authenticate even while the OIDC JWKS endpoint is
+		// down — the transient error must not mask a real success.
+		jwtAuth := &mockAuthenticator{err: transient}
+		apiKeyAuth := &mockAuthenticator{userInfo: &middleware.UserInfo{UserID: "svc"}}
+
+		chained := NewChainedAuthenticator(ChainedAuthConfig{}, jwtAuth, apiKeyAuth)
+
+		userInfo, err := chained.Authenticate(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if userInfo.UserID != "svc" {
+			t.Errorf("UserID = %q, want 'svc'", userInfo.UserID)
+		}
+	})
+}
+
 func TestChainedAuthenticator_EmptyChain(t *testing.T) {
 	t.Run("empty chain fails", func(t *testing.T) {
 		chained := NewChainedAuthenticator(ChainedAuthConfig{})

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -283,9 +283,12 @@ func (a *OIDCAuthenticator) parseTokenWithoutSignatureVerification(tokenString s
 // unknown (e.g. after IdP key rotation). Concurrent refreshes are collapsed with
 // single-flight and throttled to at most once per jwksRefreshThrottle.
 //
-// It fails closed: when the cache is expired and the refresh fails, it returns
-// an error wrapping the fetch failure and never yields a key. A throttled or
-// post-refresh miss returns the normal key-not-found error.
+// It never yields a key it cannot verify. When the cache is expired and the
+// refresh fails — the IdP is transiently unreachable — it returns an error
+// wrapping middleware.ErrValidationUnavailable so callers can distinguish "could not
+// validate" from "invalid" (the HTTP auth gate fails OPEN on it; see that
+// sentinel). A miss against a FRESH cache (unknown/retired kid) is instead a
+// definitive not-found error, which stays fail-closed (401) at every layer.
 func (a *OIDCAuthenticator) getPublicKey(ctx context.Context, kid string) (*rsa.PublicKey, error) {
 	key, expired, found := a.lookupKey(kid)
 	if found {
@@ -301,8 +304,13 @@ func (a *OIDCAuthenticator) getPublicKey(ctx context.Context, kid string) (*rsa.
 	case found:
 		return key, nil
 	case expired:
-		return nil, errors.New("jwks cache expired")
+		// Cache still stale after the refresh attempt: we could not obtain fresh
+		// keys, so validity is undetermined (transient) rather than definitively
+		// invalid. See middleware.ErrValidationUnavailable.
+		return nil, fmt.Errorf("jwks cache expired: %w", middleware.ErrValidationUnavailable)
 	default:
+		// Fresh cache, but this kid is absent: a definitive miss (unknown/retired
+		// key, or a token from another issuer), not a transient failure.
 		return nil, fmt.Errorf("key not found: %s", kid)
 	}
 }
@@ -368,7 +376,10 @@ func (a *OIDCAuthenticator) refreshForLookup(ctx context.Context, cacheExpired b
 		return fmt.Errorf("awaiting jwks refresh: %w", ctx.Err())
 	case res := <-ch:
 		if res.Err != nil && cacheExpired {
-			return fmt.Errorf("refreshing jwks: %w", res.Err)
+			// A refresh was attempted, failed, and the cache is expired: the IdP
+			// is transiently unreachable, so validity is undetermined rather than
+			// definitively invalid. Mark it so the HTTP gate can fail open.
+			return fmt.Errorf("refreshing jwks: %w: %w", middleware.ErrValidationUnavailable, res.Err)
 		}
 		return nil
 	}

--- a/pkg/auth/oidc_test.go
+++ b/pkg/auth/oidc_test.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
 )
 
 const (
@@ -749,6 +751,11 @@ func TestOIDCAuthenticator_getPublicKey(t *testing.T) {
 		if !strings.Contains(err.Error(), "refreshing jwks") {
 			t.Errorf(errUnexpected, err)
 		}
+		// An unreachable IdP with no usable cache is a transient failure, so the
+		// HTTP gate can fail open rather than drop a possibly-valid client.
+		if !errors.Is(err, middleware.ErrValidationUnavailable) {
+			t.Errorf("error = %v, want it to wrap middleware.ErrValidationUnavailable", err)
+		}
 	})
 
 	t.Run("expired cache triggers refresh and fails closed", func(t *testing.T) {
@@ -764,6 +771,9 @@ func TestOIDCAuthenticator_getPublicKey(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "refreshing jwks") {
 			t.Errorf(errUnexpected, err)
+		}
+		if !errors.Is(err, middleware.ErrValidationUnavailable) {
+			t.Errorf("error = %v, want it to wrap middleware.ErrValidationUnavailable", err)
 		}
 	})
 
@@ -782,6 +792,11 @@ func TestOIDCAuthenticator_getPublicKey(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "key not found") {
 			t.Errorf(errUnexpected, err)
+		}
+		// A fresh cache that simply lacks the kid is a DEFINITIVE miss, not a
+		// transient failure: the gate must fail closed (401), not fail open.
+		if errors.Is(err, middleware.ErrValidationUnavailable) {
+			t.Errorf("error = %v, must NOT wrap middleware.ErrValidationUnavailable (definitive miss)", err)
 		}
 	})
 
@@ -932,6 +947,28 @@ func TestOIDCAuthenticator_parseAndValidateToken_SignatureVerification(t *testin
 		}
 		if !strings.Contains(err.Error(), "key not found") {
 			t.Errorf("expected 'key not found' error, got: %v", err)
+		}
+	})
+
+	t.Run("transient JWKS failure propagates middleware.ErrValidationUnavailable", func(t *testing.T) {
+		auth := createAuthWithMockJWKS(t)
+		// Expire the cache and make the IdP unreachable, so the on-demand refresh
+		// during validation fails and the cache cannot be renewed. This proves the
+		// transient sentinel survives jwt.Parse's keyfunc error wrapping all the
+		// way out of parseAndValidateToken, so the chain and HTTP gate can act on it.
+		auth.jwks.expiresAt = time.Now().Add(-time.Hour)
+		auth.cfg.Issuer = "http://127.0.0.1:1" // unreachable
+
+		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT","kid":"test-key"}`))
+		payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"user","exp":9999999999}`))
+		token := header + "." + payload + "." + base64.RawURLEncoding.EncodeToString([]byte("sig"))
+
+		_, err := auth.parseAndValidateToken(context.Background(), token)
+		if err == nil {
+			t.Fatal("expected error when JWKS is unreachable")
+		}
+		if !errors.Is(err, middleware.ErrValidationUnavailable) {
+			t.Errorf("error = %v, want it to wrap middleware.ErrValidationUnavailable", err)
 		}
 	})
 }

--- a/pkg/http/authmiddleware.go
+++ b/pkg/http/authmiddleware.go
@@ -2,11 +2,54 @@
 package http
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/txn2/mcp-data-platform/pkg/auth"
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
 )
+
+// extractHTTPToken pulls a credential from the request: a Bearer token from the
+// Authorization header, falling back to the X-API-Key header. Returns "" when
+// neither is present.
+func extractHTTPToken(r *http.Request) string {
+	if after, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer "); ok && after != "" {
+		return after
+	}
+	return r.Header.Get("X-API-Key")
+}
+
+// quoteEscape escapes a value for embedding in an RFC 7235 quoted-string:
+// backslash and double-quote become quoted-pairs. resourceMetadataURL is
+// operator config, not attacker-controlled, but escaping keeps a stray quote in
+// an issuer URL from truncating the WWW-Authenticate parameter a client parses.
+func quoteEscape(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	return strings.ReplaceAll(s, `"`, `\"`)
+}
+
+// bearerChallenge builds the WWW-Authenticate header value that drives the MCP
+// OAuth discovery/re-auth flow.
+//
+// Per the MCP authorization spec and RFC 9728, resourceMetadataURL points MCP
+// clients at the /.well-known/oauth-protected-resource endpoint. Per RFC 6750
+// section 3, errCode (when non-empty, e.g. "invalid_token") is emitted so a
+// client can distinguish an absent credential from a present-but-rejected one.
+// Pass errCode "" for the absent-credential case.
+func bearerChallenge(resourceMetadataURL, errCode string) string {
+	var params []string
+	if resourceMetadataURL != "" {
+		params = append(params, `resource_metadata="`+quoteEscape(resourceMetadataURL)+`"`)
+	}
+	if errCode != "" {
+		params = append(params, `error="`+errCode+`"`)
+	}
+	if len(params) == 0 {
+		return "Bearer"
+	}
+	return "Bearer " + strings.Join(params, ", ")
+}
 
 // AuthMiddleware extracts authentication tokens from HTTP headers and adds them to the request context.
 // This middleware should be applied to SSE handlers to enable HTTP-level authentication.
@@ -14,18 +57,7 @@ func AuthMiddleware(requireAuth bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
-			var token string
-
-			// Extract Bearer token from Authorization header
-			authHeader := r.Header.Get("Authorization")
-			if after, ok := strings.CutPrefix(authHeader, "Bearer "); ok {
-				token = after
-			}
-
-			// If no Bearer token, try X-API-Key header
-			if token == "" {
-				token = r.Header.Get("X-API-Key")
-			}
+			token := extractHTTPToken(r)
 
 			// If auth is required and no token found, return 401
 			if requireAuth && token == "" {
@@ -57,40 +89,21 @@ func AuthMiddleware(requireAuth bool) func(http.Handler) http.Handler {
 // The resourceMetadataURL should point to the server's
 // /.well-known/oauth-protected-resource endpoint.
 //
-// This middleware does NOT validate tokens — it only checks for their presence.
-// Actual token validation happens in the MCP protocol middleware chain.
-func MCPAuthGateway(resourceMetadataURL string) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			var token string
-
-			authHeader := r.Header.Get("Authorization")
-			if after, ok := strings.CutPrefix(authHeader, "Bearer "); ok {
-				token = after
-			}
-			if token == "" {
-				token = r.Header.Get("X-API-Key")
-			}
-
-			if token == "" {
-				if resourceMetadataURL != "" {
-					w.Header().Set("WWW-Authenticate",
-						`Bearer resource_metadata="`+resourceMetadataURL+`"`)
-				} else {
-					w.Header().Set("WWW-Authenticate", "Bearer")
-				}
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
-			}
-
-			// Bridge the token to context so the MCP connection inherits it.
-			// For Streamable HTTP the SDK creates a long-lived connection from
-			// the initialize request's context; placing the token here ensures
-			// it is available for all subsequent requests on that connection.
-			ctx := auth.WithToken(r.Context(), token)
-			next.ServeHTTP(w, r.WithContext(ctx))
-		})
-	}
+// When authenticator is non-nil, a present credential is validated at the HTTP
+// layer: an expired/revoked/unknown token is rejected with the same HTTP 401 +
+// WWW-Authenticate, adding RFC 6750's error="invalid_token" (issue #926). This
+// is the conformance surface MCP clients key their re-auth flow off — a client
+// holding an expired token must see a 401, not an in-band protocol error on a
+// 200 response. The gate calls the same authenticator the protocol middleware
+// uses, so a valid API key still passes (it is authenticated here) while an
+// invalid credential is rejected. MCPToolCallMiddleware re-validates as defense
+// in depth and is what builds the PlatformContext identity; this HTTP check does
+// not replace it.
+//
+// When authenticator is nil the gate is presence-only (the platform is nil in
+// transport-level tests).
+func MCPAuthGateway(authenticator middleware.Authenticator, resourceMetadataURL string) func(http.Handler) http.Handler {
+	return oauthGate(authenticator, resourceMetadataURL, "Unauthorized", "Unauthorized")
 }
 
 // RequireAuth returns middleware that requires authentication.
@@ -100,36 +113,64 @@ func RequireAuth() func(http.Handler) http.Handler {
 
 // RequireAuthWithOAuth returns middleware that requires authentication and
 // includes the WWW-Authenticate header with resource metadata URL in 401
-// responses, enabling OAuth discovery for MCP clients.
-func RequireAuthWithOAuth(resourceMetadataURL string) func(http.Handler) http.Handler {
+// responses, enabling OAuth discovery for MCP clients. It is the SSE
+// counterpart to MCPAuthGateway and shares its validation semantics: when
+// authenticator is non-nil, a present-but-invalid token receives HTTP 401 +
+// WWW-Authenticate with error="invalid_token" (issue #926) rather than passing
+// the HTTP layer to fail in-band. When authenticator is nil the gate is
+// presence-only.
+func RequireAuthWithOAuth(authenticator middleware.Authenticator, resourceMetadataURL string) func(http.Handler) http.Handler {
+	return oauthGate(authenticator, resourceMetadataURL,
+		"Unauthorized: missing authentication token",
+		"Unauthorized: invalid authentication token")
+}
+
+// oauthGate is the shared implementation behind MCPAuthGateway (streamable HTTP)
+// and RequireAuthWithOAuth (SSE): the two MCP transports gate identically, so
+// the logic lives in one place. It extracts a credential, and on failure returns
+// HTTP 401 with the OAuth-discovery WWW-Authenticate header — with RFC 6750's
+// error="invalid_token" when a token was present but rejected, and without it
+// when none was supplied. absentMsg and invalidMsg are the respective 401 body
+// strings, which differ only in wording between the two transports.
+//
+// authenticator, when non-nil, validates a present credential so an expired or
+// otherwise invalid token is rejected at the HTTP layer (issue #926) — the
+// signal MCP clients key their OAuth re-auth flow off. It is the same entry
+// point the protocol middleware uses (a valid token — JWT or API key — passes;
+// an invalid one is rejected). The protocol layer re-validates as defense in
+// depth, so validation runs at both layers by design.
+func oauthGate(authenticator middleware.Authenticator, resourceMetadataURL, absentMsg, invalidMsg string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx := r.Context()
-			var token string
-
-			authHeader := r.Header.Get("Authorization")
-			if after, ok := strings.CutPrefix(authHeader, "Bearer "); ok {
-				token = after
-			}
-
+			token := extractHTTPToken(r)
 			if token == "" {
-				token = r.Header.Get("X-API-Key")
-			}
-
-			if token == "" {
-				if resourceMetadataURL != "" {
-					w.Header().Set("WWW-Authenticate",
-						`Bearer resource_metadata="`+resourceMetadataURL+`"`)
-				} else {
-					w.Header().Set("WWW-Authenticate", "Bearer")
-				}
-				http.Error(w, "Unauthorized: missing authentication token", http.StatusUnauthorized)
+				w.Header().Set("WWW-Authenticate", bearerChallenge(resourceMetadataURL, ""))
+				http.Error(w, absentMsg, http.StatusUnauthorized)
 				return
 			}
 
-			ctx = auth.WithToken(ctx, token)
-			r = r.WithContext(ctx)
-			next.ServeHTTP(w, r)
+			// Bridge the token to context so the MCP connection inherits it.
+			// For Streamable HTTP the SDK creates a long-lived connection from
+			// the initialize request's context; placing the token here ensures
+			// it is available for all subsequent requests on that connection.
+			ctx := auth.WithToken(r.Context(), token)
+
+			if authenticator != nil {
+				if _, err := authenticator.Authenticate(ctx); err != nil && !errors.Is(err, middleware.ErrValidationUnavailable) {
+					// Fail closed on a definitive rejection (expired/invalid/unknown
+					// token). Fail OPEN on ErrValidationUnavailable — a transient
+					// dependency failure (e.g. OIDC JWKS unreachable) means validity
+					// is undetermined, so pass through to the protocol layer rather
+					// than drop a possibly-valid client. Access is not granted: during
+					// the same outage the protocol layer cannot validate either, so a
+					// tool call is still rejected in-band.
+					w.Header().Set("WWW-Authenticate", bearerChallenge(resourceMetadataURL, "invalid_token"))
+					http.Error(w, invalidMsg, http.StatusUnauthorized)
+					return
+				}
+			}
+
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }

--- a/pkg/http/authmiddleware_test.go
+++ b/pkg/http/authmiddleware_test.go
@@ -2,11 +2,18 @@ package http //nolint:revive // var-naming: intentional package name to match di
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/txn2/mcp-data-platform/pkg/auth"
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
 )
 
 func TestAuthMiddleware(t *testing.T) {
@@ -160,7 +167,7 @@ func TestMCPAuthGateway(t *testing.T) {
 
 	t.Run("returns 401 with WWW-Authenticate when no credentials", func(t *testing.T) {
 		rmURL := "https://mcp.example.com/.well-known/oauth-protected-resource"
-		handler := MCPAuthGateway(rmURL)(okHandler)
+		handler := MCPAuthGateway(nil, rmURL)(okHandler)
 
 		req := httptest.NewRequestWithContext(context.Background(), "POST", "/", http.NoBody)
 		rr := httptest.NewRecorder()
@@ -178,7 +185,7 @@ func TestMCPAuthGateway(t *testing.T) {
 	})
 
 	t.Run("returns 401 with plain Bearer when no resource metadata URL", func(t *testing.T) {
-		handler := MCPAuthGateway("")(okHandler)
+		handler := MCPAuthGateway(nil, "")(okHandler)
 
 		req := httptest.NewRequestWithContext(context.Background(), "POST", "/", http.NoBody)
 		rr := httptest.NewRecorder()
@@ -198,7 +205,7 @@ func TestMCPAuthGateway(t *testing.T) {
 		inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 			extractedToken = auth.GetToken(r.Context())
 		})
-		handler := MCPAuthGateway("https://mcp.example.com/.well-known/oauth-protected-resource")(inner)
+		handler := MCPAuthGateway(nil, "https://mcp.example.com/.well-known/oauth-protected-resource")(inner)
 
 		req := httptest.NewRequestWithContext(context.Background(), "POST", "/", http.NoBody)
 		req.Header.Set("Authorization", "Bearer some-token")
@@ -216,7 +223,7 @@ func TestMCPAuthGateway(t *testing.T) {
 		inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 			extractedToken = auth.GetToken(r.Context())
 		})
-		handler := MCPAuthGateway("https://mcp.example.com/.well-known/oauth-protected-resource")(inner)
+		handler := MCPAuthGateway(nil, "https://mcp.example.com/.well-known/oauth-protected-resource")(inner)
 
 		req := httptest.NewRequestWithContext(context.Background(), "POST", "/", http.NoBody)
 		req.Header.Set("X-API-Key", "some-api-key")
@@ -230,7 +237,7 @@ func TestMCPAuthGateway(t *testing.T) {
 	})
 
 	t.Run("rejects Authorization header without Bearer prefix", func(t *testing.T) {
-		handler := MCPAuthGateway("")(okHandler)
+		handler := MCPAuthGateway(nil, "")(okHandler)
 
 		req := httptest.NewRequestWithContext(context.Background(), "POST", "/", http.NoBody)
 		req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
@@ -248,7 +255,7 @@ func TestRequireAuthWithOAuth(t *testing.T) {
 	rmURL := "https://mcp.example.com/.well-known/oauth-protected-resource"
 
 	t.Run("returns 401 with WWW-Authenticate when no token", func(t *testing.T) {
-		handler := RequireAuthWithOAuth(rmURL)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handler := RequireAuthWithOAuth(nil, rmURL)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
 
@@ -268,7 +275,7 @@ func TestRequireAuthWithOAuth(t *testing.T) {
 	})
 
 	t.Run("returns 401 with plain Bearer when no resource metadata URL", func(t *testing.T) {
-		handler := RequireAuthWithOAuth("")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handler := RequireAuthWithOAuth(nil, "")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
 
@@ -287,7 +294,7 @@ func TestRequireAuthWithOAuth(t *testing.T) {
 
 	t.Run("passes through and sets token with Bearer", func(t *testing.T) {
 		var extractedToken string
-		handler := RequireAuthWithOAuth(rmURL)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		handler := RequireAuthWithOAuth(nil, rmURL)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 			extractedToken = auth.GetToken(r.Context())
 		}))
 
@@ -304,7 +311,7 @@ func TestRequireAuthWithOAuth(t *testing.T) {
 
 	t.Run("passes through and sets token with API key", func(t *testing.T) {
 		var extractedToken string
-		handler := RequireAuthWithOAuth(rmURL)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		handler := RequireAuthWithOAuth(nil, rmURL)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 			extractedToken = auth.GetToken(r.Context())
 		}))
 
@@ -318,4 +325,183 @@ func TestRequireAuthWithOAuth(t *testing.T) {
 			t.Errorf("expected token 'my-api-key', got %q", extractedToken)
 		}
 	})
+}
+
+// mintGatewayJWT signs an HS256 token for the gateway validation tests. Signing
+// with a key other than the authenticator's verification key yields a token that
+// is syntactically a JWT but fails verification (an "unknown" token).
+func mintGatewayJWT(t *testing.T, key []byte, issuer string, exp time.Time) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"iss": issuer,
+		"sub": "user-123",
+		"aud": issuer,
+		"exp": exp.Unix(),
+		"iat": time.Now().Add(-time.Minute).Unix(),
+	}
+	signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(key)
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+	return signed
+}
+
+// TestMCPGateways_ValidateToken covers issue #926: with the platform's
+// authenticator wired in, both MCP HTTP gateways must reject a present-but-
+// invalid token (expired, unknown-signature, malformed, or unrecognized) with
+// HTTP 401 + WWW-Authenticate carrying error="invalid_token", while a valid
+// credential — a JWT or an API key, including one whose value happens to be
+// JWT-shaped — reaches the inner handler with its credential bridged into the
+// request context. Absent credentials keep the pre-existing 401 without the
+// invalid_token error code.
+func TestMCPGateways_ValidateToken(t *testing.T) {
+	signingKey := []byte("test-signing-key-at-least-32-bytes!!")
+	issuer := "https://oauth.example.com"
+	rmURL := "https://mcp.example.com/.well-known/oauth-protected-resource"
+
+	// A JWT-shaped API key value (three dot-separated segments) guards against a
+	// regression where a JWT-shaped key is misrouted to the JWT authenticator and
+	// rejected before the API-key authenticator in the chain can accept it.
+	apiKeyValue := "team.prod.k9f2x"
+	oauthAuth, err := auth.NewOAuthJWTAuthenticator(auth.OAuthJWTConfig{
+		Issuer:     issuer,
+		SigningKey: signingKey,
+	})
+	if err != nil {
+		t.Fatalf("building OAuth authenticator: %v", err)
+	}
+	apiKeyAuth := auth.NewAPIKeyAuthenticator(auth.APIKeyConfig{
+		Keys: []auth.APIKey{{Key: apiKeyValue, Name: "svc", Roles: []string{"admin"}}},
+	})
+	// The same chain order production uses: JWT first, API key last.
+	validator := auth.NewChainedAuthenticator(
+		auth.ChainedAuthConfig{AllowAnonymous: false}, oauthAuth, apiKeyAuth)
+
+	validToken := mintGatewayJWT(t, signingKey, issuer, time.Now().Add(time.Hour))
+	expiredToken := mintGatewayJWT(t, signingKey, issuer, time.Now().Add(-time.Hour))
+	unknownToken := mintGatewayJWT(t, []byte("a-different-signing-key-32-byteslong"), issuer, time.Now().Add(time.Hour))
+
+	gateways := []struct {
+		name string
+		ctor func(middleware.Authenticator, string) func(http.Handler) http.Handler
+	}{
+		{"streamable", MCPAuthGateway},
+		{"sse", RequireAuthWithOAuth},
+	}
+
+	cases := []struct {
+		name        string
+		token       string // bearer token value; "" means no Authorization header
+		wantStatus  int
+		wantReach   bool // inner handler should run
+		wantInvalid bool // WWW-Authenticate should carry error="invalid_token"
+	}{
+		{"valid JWT reaches handler", validToken, http.StatusOK, true, false},
+		{"valid JWT-shaped API key reaches handler", apiKeyValue, http.StatusOK, true, false},
+		{"expired JWT rejected", expiredToken, http.StatusUnauthorized, false, true},
+		{"unknown-signature JWT rejected", unknownToken, http.StatusUnauthorized, false, true},
+		{"malformed JWT rejected", "aaa.bbb.ccc", http.StatusUnauthorized, false, true},
+		{"unrecognized credential rejected", "not-a-known-credential", http.StatusUnauthorized, false, true},
+		{"absent token rejected", "", http.StatusUnauthorized, false, false},
+	}
+
+	for _, gw := range gateways {
+		for _, tc := range cases {
+			t.Run(gw.name+"/"+tc.name, func(t *testing.T) {
+				var reached bool
+				var bridged string
+				inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					reached = true
+					bridged = auth.GetToken(r.Context())
+					w.WriteHeader(http.StatusOK)
+				})
+				handler := gw.ctor(validator, rmURL)(inner)
+
+				req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", http.NoBody)
+				if tc.token != "" {
+					req.Header.Set("Authorization", "Bearer "+tc.token)
+				}
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+
+				if rr.Code != tc.wantStatus {
+					t.Fatalf("status = %d, want %d", rr.Code, tc.wantStatus)
+				}
+				if reached != tc.wantReach {
+					t.Errorf("inner handler reached = %v, want %v", reached, tc.wantReach)
+				}
+				if tc.wantReach && bridged != tc.token {
+					t.Errorf("bridged token = %q, want %q", bridged, tc.token)
+				}
+				if tc.wantStatus != http.StatusUnauthorized {
+					return
+				}
+				www := rr.Header().Get("WWW-Authenticate")
+				if !strings.Contains(www, `resource_metadata="`+rmURL+`"`) {
+					t.Errorf("WWW-Authenticate = %q, want resource_metadata", www)
+				}
+				if gotInvalid := strings.Contains(www, `error="invalid_token"`); gotInvalid != tc.wantInvalid {
+					t.Errorf("WWW-Authenticate = %q, invalid_token present = %v, want %v", www, gotInvalid, tc.wantInvalid)
+				}
+			})
+		}
+	}
+}
+
+// stubAuthenticator returns a fixed error (or a success when err is nil).
+type stubAuthenticator struct{ err error }
+
+func (s stubAuthenticator) Authenticate(context.Context) (*middleware.UserInfo, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &middleware.UserInfo{UserID: "u"}, nil
+}
+
+// TestMCPGateways_FailOpenOnTransient asserts the gate fails OPEN (passes the
+// request through to the protocol layer) when the authenticator reports a
+// transient validation failure (middleware.ErrValidationUnavailable, e.g. the OIDC
+// JWKS endpoint is unreachable), and fails CLOSED (401) on a definitive
+// rejection. An IdP blip must not drop a possibly-valid client, while a
+// genuinely invalid token is still rejected.
+func TestMCPGateways_FailOpenOnTransient(t *testing.T) {
+	rmURL := "https://mcp.example.com/.well-known/oauth-protected-resource"
+
+	tests := []struct {
+		name      string
+		err       error
+		wantReach bool
+		wantCode  int
+	}{
+		{"transient failure fails open", fmt.Errorf("verifying token: %w", middleware.ErrValidationUnavailable), true, http.StatusOK},
+		{"definitive failure fails closed", errors.New("invalid token"), false, http.StatusUnauthorized},
+	}
+	for _, gwName := range []string{"streamable", "sse"} {
+		ctor := MCPAuthGateway
+		if gwName == "sse" {
+			ctor = RequireAuthWithOAuth
+		}
+		for _, tc := range tests {
+			t.Run(gwName+"/"+tc.name, func(t *testing.T) {
+				var reached bool
+				inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					reached = true
+					w.WriteHeader(http.StatusOK)
+				})
+				handler := ctor(stubAuthenticator{err: tc.err}, rmURL)(inner)
+
+				req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", http.NoBody)
+				req.Header.Set("Authorization", "Bearer some.jwt.token")
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, req)
+
+				if rr.Code != tc.wantCode {
+					t.Fatalf("status = %d, want %d", rr.Code, tc.wantCode)
+				}
+				if reached != tc.wantReach {
+					t.Errorf("inner handler reached = %v, want %v", reached, tc.wantReach)
+				}
+			})
+		}
+	}
 }

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -15,6 +15,22 @@ type Authenticator interface {
 	Authenticate(ctx context.Context) (*UserInfo, error)
 }
 
+// ErrValidationUnavailable is the sentinel an authenticator wraps when it could
+// not COMPLETE validation because a dependency was transiently unavailable (e.g.
+// the OIDC JWKS endpoint was unreachable and the key cache had expired) — as
+// opposed to a definitive rejection (bad signature, expired token, unknown key
+// in a fresh cache). It lets a caller distinguish "this token is invalid" from
+// "I could not tell right now": the HTTP auth gate fails OPEN on it, passing the
+// request to the protocol layer rather than dropping a possibly-valid client
+// during an IdP blip, and the protocol layer reports a retryable outage rather
+// than an identity failure. This never grants access — during the same outage
+// the protocol layer cannot validate the token either, so a tool call is still
+// rejected in-band; only auth-independent requests (initialize/list) proceed.
+//
+// It lives here (not in pkg/auth) so the protocol middleware can branch on it
+// without importing pkg/auth, which would cycle.
+var ErrValidationUnavailable = errors.New("token validation temporarily unavailable")
+
 // ToolkitLookup provides toolkit metadata for a given tool name.
 type ToolkitLookup interface {
 	// GetToolkitForTool returns toolkit info (kind, name, connection) for a tool.

--- a/pkg/middleware/mcp.go
+++ b/pkg/middleware/mcp.go
@@ -283,6 +283,18 @@ func authenticateAndAuthorize(
 				"request_id", params.pc.RequestID,
 				"error", err.Error(),
 			)
+			// A transient validation-unavailable failure (e.g. the OIDC JWKS
+			// endpoint is unreachable) is a server-side outage, not a credential
+			// problem: report it as retryable so a valid caller is not misdirected
+			// to re-authenticate. The HTTP gate fails open on the same signal, but
+			// tool calls still cannot be authorized until the dependency recovers.
+			if errors.Is(err, ErrValidationUnavailable) {
+				return BuildErrorResult(NewToolError(
+					CodeFeatureUnavailable, ErrCategoryUnavailable,
+					"authentication temporarily unavailable: "+err.Error(),
+					"The identity provider could not be reached to validate your credentials. This is a transient server-side condition, not a problem with your credentials. Retry shortly.",
+				)), nil
+			}
 			return BuildErrorResult(NewToolError(
 				CodeUnauthenticated, ErrCategoryAuth,
 				"authentication failed: "+err.Error(),

--- a/pkg/middleware/mcp_test.go
+++ b/pkg/middleware/mcp_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
@@ -113,6 +115,55 @@ func TestMCPToolCallMiddleware_AuthenticationFailure(t *testing.T) {
 	}
 	if !toolResult.IsError {
 		t.Error("expected IsError to be true")
+	}
+}
+
+// TestMCPToolCallMiddleware_TransientAuthOutage asserts that when the
+// authenticator reports a transient validation-unavailable failure (e.g. the
+// OIDC JWKS endpoint is unreachable), the tool call is rejected as a retryable
+// outage — NOT as an identity problem — so a valid caller is not misdirected to
+// re-authenticate during a server-side dependency outage.
+func TestMCPToolCallMiddleware_TransientAuthOutage(t *testing.T) {
+	authenticator := &mcpTestAuthenticator{
+		err: fmt.Errorf("verifying token: %w", ErrValidationUnavailable),
+	}
+	authorizer := &mcpTestAuthorizer{authorized: true}
+
+	middleware := MCPToolCallMiddleware(authenticator, authorizer, nil, ToolCallConfig{Transport: mcpTestStdio, AdminPersona: "admin"})
+
+	next := func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
+		t.Fatal("next should not be called on auth outage")
+		return nil, nil //nolint:nilnil // unreachable after t.Fatal
+	}
+
+	handler := middleware(next)
+	result, err := handler(context.Background(), mcpTestMethod, newMCPTestRequest(mcpTestToolName))
+	if err != nil {
+		t.Fatalf(mcpTestErrFmt, err)
+	}
+
+	toolResult, ok := result.(*mcp.CallToolResult)
+	if !ok {
+		t.Fatalf(mcpTestResultFmt, result)
+	}
+	if !toolResult.IsError {
+		t.Fatal("expected IsError to be true")
+	}
+	if len(toolResult.Content) == 0 {
+		t.Fatal("expected content in result")
+	}
+	tc, ok := toolResult.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", toolResult.Content[0])
+	}
+	// The retryable-outage error carries the feature_unavailable code and must
+	// NOT carry the "identity problem" framing that would misdirect a valid
+	// caller to re-authenticate during a server-side dependency outage.
+	if !strings.Contains(tc.Text, CodeFeatureUnavailable) {
+		t.Errorf("text = %q, want it to carry code %q", tc.Text, CodeFeatureUnavailable)
+	}
+	if strings.Contains(tc.Text, "identity problem") {
+		t.Errorf("text = %q, must not misdirect a valid caller to re-authenticate during an outage", tc.Text)
 	}
 }
 

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -13,6 +13,7 @@ internal/httpserver -> pkg/gatewayhttp
 internal/httpserver -> pkg/health
 internal/httpserver -> pkg/http
 internal/httpserver -> pkg/knowledge
+internal/httpserver -> pkg/middleware
 internal/httpserver -> pkg/observability/proxy
 internal/httpserver -> pkg/persona
 internal/httpserver -> pkg/pkcestore
@@ -157,6 +158,7 @@ pkg/gatewayhttp -> pkg/middleware
 pkg/gatewayhttp -> pkg/observability
 pkg/gatewayhttp -> pkg/toolkits/apigateway
 pkg/http -> pkg/auth
+pkg/http -> pkg/middleware
 pkg/indexjobs -> pkg/embedding
 pkg/knowledge -> pkg/embedding
 pkg/knowledge -> pkg/memory


### PR DESCRIPTION
## Summary

The HTTP gate on the MCP endpoints was presence-only: it checked that a Bearer token or `X-API-Key` existed but did not validate it. An absent token got the correct `HTTP 401` with `WWW-Authenticate`, but a present-and-invalid token (expired, revoked, garbage) passed the transport and was rejected later as an in-band protocol error on a `200` response.

The MCP authorization spec keys the client re-authentication flow off `HTTP 401`: a client holding an expired token is supposed to receive `401` + `WWW-Authenticate`, rediscover the resource metadata, and rerun the OAuth flow. A client that re-auths only on `401` could wedge against this server — its calls failed in-band while the transport kept answering `200`.

This PR validates the credential at the HTTP layer for both MCP transports and returns `401` with the re-auth challenge on failure, while distinguishing a definitive rejection from a transient dependency outage so a brief IdP blip does not drop otherwise-valid clients.

Closes #926

## What changed

**HTTP-layer validation (`pkg/http`, `internal/httpserver`)**

- `MCPAuthGateway` (streamable HTTP) and `RequireAuthWithOAuth` (SSE) now validate a present credential with the platform authenticator — the same entry point the protocol middleware uses.
- On a definitive rejection the gate returns:

  ```
  HTTP 401
  WWW-Authenticate: Bearer resource_metadata="<url>", error="invalid_token"
  ```

  per RFC 6750 §3 and RFC 9728, which is what MCP clients key their OAuth re-auth flow off.
- Absent credentials keep the pre-existing `401` **without** the `error="invalid_token"` code.
- Valid credentials — a JWT **or** an API key, including a key whose value happens to be JWT-shaped — pass through with the token bridged into the request context.
- The protocol middleware (`MCPToolCallMiddleware`) continues to validate as defense in depth and remains the component that builds the `PlatformContext` identity; the HTTP check does not replace it.
- SSE gates consistently with streamable regardless of whether an OAuth resource-metadata URL is configured. Shared helpers cover token extraction and the `WWW-Authenticate` challenge; the `resource_metadata` value is quoted-string escaped.

**Transient-outage handling (`pkg/auth`, `pkg/middleware`)**

Validation can fail for two very different reasons, and the response must differ:

| Condition | Gate | Protocol layer |
|---|---|---|
| Definitive rejection (bad signature, expired token, unknown key in a fresh cache) | `401` + `error="invalid_token"` | identity error, re-authenticate |
| Transient failure (OIDC JWKS unreachable, key cache expired) | fail **open** — pass through | retryable outage error |

- New sentinel `middleware.ErrValidationUnavailable` marks "could not complete validation" as opposed to "invalid". The OIDC authenticator wraps it only when the key cache is expired **and** a refresh fails; a miss against a fresh cache stays a definitive not-found.
- The chained authenticator surfaces a transient error ahead of a definitive one when nothing succeeds, but a valid credential (e.g. an API key) still authenticates during the outage.
- The gate fails open on the sentinel so an IdP blip does not drop a possibly-valid client. This never grants access: during the same outage the protocol layer cannot validate the token either, so a tool call is still rejected in-band — only auth-independent requests (`initialize`, `tools/list`) proceed. The protocol layer reports a `feature_unavailable`/retryable error rather than misdirecting a valid caller to re-authenticate.

The sentinel lives in `pkg/middleware` so the protocol middleware can branch on it without importing `pkg/auth` (which would cycle).

## Tests

- httptest tables over expired / unknown-signature / malformed / valid / absent credentials across **both** transports, asserting status, `WWW-Authenticate`, and that valid credentials reach the handler with the token bridged.
- A JWT-shaped API key case that authenticates (guards against misrouting a dotted key to the JWT authenticator).
- End-to-end streamable test through the real handler + middleware stack: invalid tokens rejected at the HTTP boundary, a valid token completing a tool call with identity intact.
- Transient-path coverage at every seam: OIDC `getPublicKey` returns the sentinel on an expired-cache refresh failure and not on a fresh-cache miss; the sentinel survives `jwt.Parse` out of `parseAndValidateToken`; the chained authenticator prioritizes it (and a later success still wins); the gate fails open on it; the protocol layer emits the retryable-outage error instead of the identity framing.

`make verify` passes: tests with race, 100% patch coverage, lint, gosec/govulncheck, semgrep, CodeQL query suite, GoReleaser dry-run.

## Manual verification before release

The acceptance criterion "the OAuth re-auth loop demonstrably triggers in a real client" requires a live deployment: deploy this branch, present an expired platform-issued token to a real client (e.g. Claude.ai), and confirm it receives the `401`, rediscovers the resource metadata, and completes a fresh OAuth flow.

## Notes on scope

- Double validation (HTTP gate + protocol layer) is intended defense in depth.
- The API-key bcrypt scan on a non-matching token is a pre-existing property of the authenticator chain, already reachable via `tools/call` in the DB-backed deployments where hashed keys exist; this PR does not change it.
- The import ratchet allowlist gains two edges (`pkg/http` and `internal/httpserver` -> `pkg/middleware`): the HTTP gate legitimately references `middleware.Authenticator`. Same-direction edges, regenerated per the ratchet's documented workflow.
