### PR TITLE
fix(mcp): advertise platform_info bootstrap pointer in InitializeResult.instructions (#924)

### DIFF
--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -2031,6 +2031,20 @@ func convertCSP(cfg *CSPAppConfig) *mcpapps.CSPConfig {
 	return csp
 }
 
+// initializeInstructions is the static bootstrap pointer advertised in
+// InitializeResult.instructions (the MCP protocol's designated "how to use this
+// server" field). It is deliberately a short routing hint, not the full agent
+// guidance: the initialize field is set once at server construction and cannot
+// vary per persona (initialization precedes authentication in most flows), so
+// the persona-aware, DB-editable guidance stays tool-delivered via platform_info
+// (see info_tool.go and the instructions seam). Do not inline the full
+// agent_instructions content here; a generic bootstrap sentence is the correct
+// scope. The one thing a spec-faithful client needs up front is the call order,
+// because every other tool refuses with SESSION_REQUIRED until platform_info runs.
+const initializeInstructions = "Call the platform_info tool first. It returns " +
+	"platform documentation, workflow requirements, and a session_id that every " +
+	"other tool requires. Then call search before any query tool."
+
 // finalizeSetup completes platform initialization.
 func (p *Platform) finalizeSetup() {
 	// Bind the prompt layer's late collaborators before the middleware chain and
@@ -2044,6 +2058,7 @@ func (p *Platform) finalizeSetup() {
 	}, &mcp.ServerOptions{
 		SchemaCache:  mcp.NewSchemaCache(),
 		Capabilities: p.buildServerCapabilities(),
+		Instructions: initializeInstructions,
 	})
 
 	// Add MCP protocol-level receiving middleware.

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -132,6 +132,50 @@ func TestNew_MinimalConfigWithNoopProviders(t *testing.T) {
 	}
 }
 
+// TestInitializeResultCarriesBootstrapInstructions proves that a client
+// connecting over the real MCP transport receives a non-empty
+// InitializeResult.instructions pointing at platform_info (issue #924). This is
+// an end-to-end assertion through the SDK's initialize handshake, not a check of
+// the ServerOptions field in isolation: it confirms the value we set on the
+// server actually reaches the client in the protocol's designated field.
+func TestInitializeResultCarriesBootstrapInstructions(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Name: "test-platform"},
+		Semantic: SemanticConfig{Provider: testProviderNoop},
+		Query:    QueryConfig{Provider: testProviderNoop},
+		Storage:  StorageConfig{Provider: testProviderNoop},
+	}
+
+	p, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf(testNewErrFmt, err)
+	}
+
+	ctx := context.Background()
+	t1, t2 := mcp.NewInMemoryTransports()
+
+	serverSession, err := p.MCPServer().Connect(ctx, t1, nil)
+	if err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+	defer func() { _ = serverSession.Close() }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0"}, nil)
+	clientSession, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	defer func() { _ = clientSession.Close() }()
+
+	got := clientSession.InitializeResult().Instructions
+	if got == "" {
+		t.Fatal("InitializeResult.Instructions is empty; want a bootstrap pointer to platform_info")
+	}
+	if !strings.Contains(got, "platform_info") {
+		t.Errorf("InitializeResult.Instructions = %q; want it to mention platform_info", got)
+	}
+}
+
 func TestNew_WithInjectedProviders(t *testing.T) {
 	cfg := &Config{
 		Server: ServerConfig{Name: testServerName},


### PR DESCRIPTION
## Summary

The MCP `InitializeResult.instructions` field is the protocol's designated place for "how to use this server," and it was empty for every client: `mcp.NewServer` passed only `SchemaCache` and `Capabilities`. A spec-faithful client that reads the initialize result got nothing, including the one instruction that matters most on this platform, that `platform_info` must be called first because every other tool refuses with `SESSION_REQUIRED` until it is.

This sets `ServerOptions.Instructions` to a short static bootstrap pointer so any client, over any transport, receives a non-empty `instructions` value that routes it to `platform_info` and then `search`.

Closes #924.

## What changed

- **`pkg/platform/platform.go`**
  - New `initializeInstructions` constant, a short routing hint:
    > Call the platform_info tool first. It returns platform documentation, workflow requirements, and a session_id that every other tool requires. Then call search before any query tool.
  - `Instructions: initializeInstructions` is now set in the `mcp.ServerOptions` in `finalizeSetup`.

- **`pkg/platform/platform_test.go`**
  - `TestInitializeResultCarriesBootstrapInstructions` connects an in-memory MCP client to the real server, runs the initialize handshake through the SDK, and asserts the returned `instructions` is non-empty and mentions `platform_info`. This exercises the protocol path end to end rather than checking the option field in isolation.

## Scope of the initialize field

The pointer is intentionally a short bootstrap hint, not the full agent guidance. `InitializeResult.instructions` is set once at server construction and initialization precedes authentication in most flows, so the field cannot vary per persona. The persona-aware, DB-editable guidance remains delivered by the `platform_info` tool, which stays the primary channel and is unchanged by this PR. A comment on the constant records this constraint so a future change does not try to inline the full per-persona instructions here.

No config knob was added; the content is purely bootstrap routing, so a hardcoded sentence is the correct scope for the first pass. Because no package, config, flag, migration, or Makefile target changed, no documentation update is required (`make doc-check` reports nothing to flag).

## Verification

- `make verify` green (fmt, race tests, coverage, patch coverage, lint, gosec, govulncheck, semgrep, CodeQL, dead-code, GoReleaser dry-run).
- `TestInitializeResultCarriesBootstrapInstructions` passes.

## Acceptance criteria

- A client connecting over any transport receives non-empty `instructions` in the initialize result, pointing at `platform_info`.
- `platform_info` behavior unchanged.
- `make verify` green.
