### PR TITLE
feat(mcp): declare OutputSchema for stable platform tools (#925)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/getkin/kin-openapi v0.140.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
+	github.com/google/jsonschema-go v0.4.3
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.12.3
 	github.com/modelcontextprotocol/go-sdk v1.6.1
@@ -89,7 +90,6 @@ require (
 	github.com/go-openapi/spec v0.20.6 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-openapi/swag/jsonname v0.25.5 // indirect
-	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/pkg/middleware/mcp_enrichment.go
+++ b/pkg/middleware/mcp_enrichment.go
@@ -202,8 +202,16 @@ func mirrorEnrichmentToStructured(result *mcp.CallToolResult, fromIndex int) {
 // structuredAsMap returns sc as a map[string]any: the value itself if already a
 // map, a JSON round-trip of a typed struct, or a fresh map when nil or not
 // convertible. The original typed structured value is replaced by this map so
-// the enrichment keys can be added without an OutputSchema constraint (the
-// composed trino tools register none).
+// the enrichment keys can be merged in.
+//
+// Interaction with declared OutputSchemas (#925): the tools this middleware
+// enriches (trino_/datahub_/s3_, gated by inferToolkitKind) declare no
+// OutputSchema, so mirroring open-ended enrichment keys here cannot violate one.
+// The platform-owned tools that DO declare a schema (platform_info,
+// list_connections, platform_find_tools, search, fetch) are not enriched, so
+// their structuredContent is never touched here — but their schemas are still
+// built open (additionalProperties allowed; see middleware.OpenToolOutputSchema)
+// so that mirroring would remain schema-valid if any of them were ever enriched.
 func structuredAsMap(sc any) map[string]any {
 	if sc == nil {
 		return map[string]any{}

--- a/pkg/middleware/output_schema.go
+++ b/pkg/middleware/output_schema.go
@@ -1,0 +1,88 @@
+package middleware
+
+import (
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+// ErrorEnvelopeProperty returns the JSON Schema for the machine-readable error
+// object the platform packs under the "error" key of a failed tool result's
+// structuredContent (see BuildErrorResult and MCPErrorContractMiddleware in
+// error_contract.go / mcp_error_contract.go). It is the single shared fragment
+// every schema-declaring tool references, so the {code, category, message, hint}
+// shape is documented identically across the surface. The four documented fields
+// are optional (a hint is not always present) and the object is left open, since
+// the platform prefers admitting an unforeseen field over rejecting a real error.
+func ErrorEnvelopeProperty() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type: "object",
+		Description: "Machine-readable error envelope; present only when the call failed. " +
+			"Branch on error.code / error.category rather than parsing the message prose.",
+		Properties: map[string]*jsonschema.Schema{
+			"code":     stringProp("stable snake_case error code (e.g. not_found, unauthorized)"),
+			"category": stringProp("error category the caller can branch on (e.g. client_input, internal)"),
+			"message":  stringProp("human-readable failure message"),
+			"hint":     stringProp("corrective guidance for the caller, when available"),
+		},
+		PropertyOrder: []string{"code", "category", "message", "hint"},
+	}
+}
+
+// stringProp is a string-typed schema property with the given description.
+func stringProp(description string) *jsonschema.Schema {
+	return &jsonschema.Schema{Type: "string", Description: description}
+}
+
+// OpenToolOutputSchema adapts a struct-derived output schema to the platform's
+// tool-result contract and returns it for inline use in mcp.Tool.OutputSchema.
+//
+// A declared output schema advertises a tool's success body, but a real tool
+// result is polymorphic and may carry more (or less) than that body:
+//
+//   - On failure, MCPErrorContractMiddleware replaces the body with the shared
+//     {error:{code,category,message,hint}} envelope (see error_contract.go), so
+//     no success-body field is guaranteed present on every result.
+//   - The semantic-enrichment middleware may mirror open-ended
+//     semantic/memory/knowledge keys into structuredContent
+//     (mcp_enrichment.go); the platform cannot enumerate those keys ahead of
+//     time. (It fires only for trino_/datahub_/s3_ tools today, none of which
+//     declare a schema, but keeping declared schemas open makes them safe if
+//     that ever changes.)
+//
+// To keep a spec-faithful client from rejecting a valid result, this opens the
+// schema: additionalProperties is allowed (admits injected keys), no property is
+// required (a body-less error envelope validates), and the shared error envelope
+// is declared under the "error" key so a client can branch on result.error.
+// Nested objects keep the strict schemas jsonschema.For derives for them, since
+// only the top level of structuredContent receives middleware-injected keys.
+func OpenToolOutputSchema(base *jsonschema.Schema) *jsonschema.Schema {
+	if base == nil {
+		base = &jsonschema.Schema{Type: "object"}
+	}
+	// An empty schema value ({}) means "true": any additional top-level property
+	// is permitted. This is what admits the error envelope and any future
+	// enrichment key.
+	base.AdditionalProperties = &jsonschema.Schema{}
+	base.Required = nil
+	if base.Properties == nil {
+		base.Properties = map[string]*jsonschema.Schema{}
+	}
+	if _, ok := base.Properties[errorEnvelopeKey]; !ok {
+		base.Properties[errorEnvelopeKey] = ErrorEnvelopeProperty()
+		base.PropertyOrder = append(base.PropertyOrder, errorEnvelopeKey)
+	}
+	return base
+}
+
+// MustOutputSchema derives an open tool output schema (see OpenToolOutputSchema)
+// from the success-body type T. It panics if T cannot be reflected into a JSON
+// Schema, which is a programming error surfaced at package initialization and
+// covered by tests, mirroring regexp.MustCompile.
+func MustOutputSchema[T any]() *jsonschema.Schema {
+	base, err := jsonschema.For[T](nil)
+	if err != nil {
+		panic(fmt.Sprintf("middleware.MustOutputSchema: %v", err))
+	}
+	return OpenToolOutputSchema(base)
+}

--- a/pkg/middleware/output_schema_test.go
+++ b/pkg/middleware/output_schema_test.go
@@ -1,0 +1,143 @@
+package middleware
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resolveJSON round-trips v through JSON (as it would travel over the wire) and
+// returns it as the generic value a resolved schema validates.
+func resolveJSON(t *testing.T, v any) any {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	var out any
+	require.NoError(t, json.Unmarshal(b, &out))
+	return out
+}
+
+func mustResolve(t *testing.T, s *jsonschema.Schema) *jsonschema.Resolved {
+	t.Helper()
+	r, err := s.Resolve(nil)
+	require.NoError(t, err)
+	return r
+}
+
+// bodyType is a representative success-body struct: a couple of required fields
+// plus an omitempty optional one.
+type bodyType struct {
+	Name  string   `json:"name"`
+	Count int      `json:"count"`
+	Notes []string `json:"notes,omitempty"`
+}
+
+func TestOpenToolOutputSchema_OpensAndDeclaresError(t *testing.T) {
+	base, err := jsonschema.For[bodyType](nil)
+	require.NoError(t, err)
+	// jsonschema.For makes structs closed and marks non-omitempty fields required.
+	require.NotNil(t, base.AdditionalProperties)
+	require.NotEmpty(t, base.Required)
+
+	got := OpenToolOutputSchema(base)
+
+	// additionalProperties is opened to the empty ("true") schema.
+	require.NotNil(t, got.AdditionalProperties)
+	assert.Empty(t, got.AdditionalProperties.Type, "additionalProperties should be the open {} schema")
+	// Nothing is required, so a body-less error envelope validates.
+	assert.Nil(t, got.Required)
+	// The shared error envelope is declared.
+	_, hasError := got.Properties[errorEnvelopeKey]
+	assert.True(t, hasError, "schema declares the shared error property")
+	// Original body properties are preserved.
+	assert.Contains(t, got.Properties, "name")
+	assert.Contains(t, got.Properties, "count")
+}
+
+func TestOpenToolOutputSchema_ValidatesSuccessBody(t *testing.T) {
+	schema := MustOutputSchema[bodyType]()
+	resolved := mustResolve(t, schema)
+
+	body := bodyType{Name: "alpha", Count: 3, Notes: []string{"n"}}
+	assert.NoError(t, resolved.Validate(resolveJSON(t, body)),
+		"a full success body validates against its own schema")
+}
+
+func TestOpenToolOutputSchema_ValidatesErrorEnvelope(t *testing.T) {
+	schema := MustOutputSchema[bodyType]()
+	resolved := mustResolve(t, schema)
+
+	// The error contract replaces the body with just the {error} envelope
+	// (BuildErrorResult). It must validate against the declared schema even
+	// though none of the body fields are present.
+	envelope := map[string]any{
+		errorEnvelopeKey: errorPayload{
+			Code:     CodeNotFound,
+			Category: ErrCategoryNotFound,
+			Message:  "nope",
+			Hint:     "try again",
+		},
+	}
+	assert.NoError(t, resolved.Validate(resolveJSON(t, envelope)),
+		"the shared error envelope validates against the declared schema")
+}
+
+func TestOpenToolOutputSchema_AdmitsEnrichmentKeys(t *testing.T) {
+	schema := MustOutputSchema[bodyType]()
+	resolved := mustResolve(t, schema)
+
+	// Enrichment mirrors open-ended top-level keys into structuredContent. The
+	// open schema must admit them alongside the body.
+	enriched := map[string]any{
+		"name":             "alpha",
+		"count":            1,
+		"semantic_context": map[string]any{"description": "a table"},
+		"related_memories": []any{map[string]any{"id": "m1"}},
+	}
+	assert.NoError(t, resolved.Validate(resolveJSON(t, enriched)),
+		"middleware-injected enrichment keys validate against the open schema")
+}
+
+func TestBuildErrorResult_StructuredContentMatchesEnvelopeSchema(t *testing.T) {
+	// Prove the actual BuildErrorResult output conforms to the shared fragment,
+	// so a client branching on result.error is validating against a real shape.
+	res := BuildErrorResult(NotFoundError(CodeNotFound, "missing", "look elsewhere"))
+	require.NotNil(t, res.StructuredContent)
+
+	// The error property fragment validates the envelope's error object.
+	frag := mustResolve(t, ErrorEnvelopeProperty())
+	scMap, ok := resolveJSON(t, res.StructuredContent).(map[string]any)
+	require.True(t, ok)
+	errObj, ok := scMap[errorEnvelopeKey]
+	require.True(t, ok, "BuildErrorResult puts the error object under the shared key")
+	assert.NoError(t, frag.Validate(errObj))
+}
+
+func TestMustOutputSchema_PanicsOnUnreflectableType(t *testing.T) {
+	// A map with a non-string key cannot be reflected into a JSON Schema.
+	assert.Panics(t, func() { _ = MustOutputSchema[map[int]string]() })
+}
+
+func TestOpenToolOutputSchema_NilBaseYieldsOpenObject(t *testing.T) {
+	got := OpenToolOutputSchema(nil)
+	assert.Equal(t, "object", got.Type)
+	require.NotNil(t, got.AdditionalProperties)
+	assert.Empty(t, got.AdditionalProperties.Type)
+	_, ok := got.Properties[errorEnvelopeKey]
+	assert.True(t, ok, "a nil base still gains the shared error property")
+}
+
+func TestOpenToolOutputSchema_PreservesCallerDeclaredError(t *testing.T) {
+	// A base that already declares an "error" property keeps it rather than
+	// being overwritten by the shared fragment.
+	sentinel := &jsonschema.Schema{Type: "string"}
+	base := &jsonschema.Schema{
+		Type:       "object",
+		Properties: map[string]*jsonschema.Schema{errorEnvelopeKey: sentinel},
+	}
+	got := OpenToolOutputSchema(base)
+	assert.Same(t, sentinel, got.Properties[errorEnvelopeKey], "caller's error property is left intact")
+}

--- a/pkg/platform/connections_tool.go
+++ b/pkg/platform/connections_tool.go
@@ -26,7 +26,8 @@ func (p *Platform) registerConnectionsTool() {
 		Title: "List Connections",
 		Description: "List all configured data connections across toolkits (Trino, DataHub, S3, etc.). " +
 			"Each connection includes a count and a bounded sample of the canonical knowledge pages that document it.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true},
+		OutputSchema: connectionsOutputSchema,
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ listConnectionsInput) (*mcp.CallToolResult, any, error) {
 		return p.handleListConnections(ctx, req)
 	})
@@ -60,5 +61,6 @@ func (p *Platform) handleListConnections(ctx context.Context, _ *mcp.CallToolReq
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(data)},
 		},
+		StructuredContent: out,
 	}, nil, nil
 }

--- a/pkg/platform/find_tools_tool.go
+++ b/pkg/platform/find_tools_tool.go
@@ -46,10 +46,11 @@ type findToolsOutput struct {
 // intent instead of scanning every name.
 func (p *Platform) registerFindToolsTool() {
 	mcp.AddTool(p.mcpServer, &mcp.Tool{
-		Name:        platformFindToolsName,
-		Title:       "Find Tools",
-		Description: "Find the most relevant platform tools for a natural-language task description, ranked by semantic similarity. Call this once at the start of a task to discover which tools to use instead of reading every tool name. Returns only tools your persona is permitted to call.",
-		Annotations: &mcp.ToolAnnotations{ReadOnlyHint: true},
+		Name:         platformFindToolsName,
+		Title:        "Find Tools",
+		Description:  "Find the most relevant platform tools for a natural-language task description, ranked by semantic similarity. Call this once at the start of a task to discover which tools to use instead of reading every tool name. Returns only tools your persona is permitted to call.",
+		Annotations:  &mcp.ToolAnnotations{ReadOnlyHint: true},
+		OutputSchema: findToolsOutputSchema,
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input findToolsInput) (*mcp.CallToolResult, any, error) {
 		return p.handleFindTools(ctx, req, input)
 	})
@@ -207,14 +208,17 @@ func zeroVector(v []float32) bool {
 	return true
 }
 
-// marshalToolResult renders a tool output struct as a JSON text result.
+// marshalToolResult renders a tool output struct as a result carrying both a
+// JSON text block and StructuredContent, so a declared OutputSchema describes
+// what the tool actually emits.
 func marshalToolResult(out any) (*mcp.CallToolResult, any, error) {
 	data, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		return toolErrorResult("failed to encode result: " + err.Error()), nil, nil
 	}
 	return &mcp.CallToolResult{
-		Content: []mcp.Content{&mcp.TextContent{Text: string(data)}},
+		Content:           []mcp.Content{&mcp.TextContent{Text: string(data)}},
+		StructuredContent: out,
 	}, nil, nil
 }
 

--- a/pkg/platform/info_tool.go
+++ b/pkg/platform/info_tool.go
@@ -194,9 +194,10 @@ const platformInfoTitle = "Platform Info"
 // registerInfoTool registers the platform_info tool with the MCP server.
 func (p *Platform) registerInfoTool() {
 	mcp.AddTool(p.mcpServer, &mcp.Tool{
-		Name:        defaultInitTool,
-		Title:       instructions.InfoToolTitle(p.config.Server.Name, defaultServerName, platformInfoTitle),
-		Description: instructions.InfoToolDescription(p.config.Server.Name, defaultServerName, p.config.Server.Tags),
+		Name:         defaultInitTool,
+		Title:        instructions.InfoToolTitle(p.config.Server.Name, defaultServerName, platformInfoTitle),
+		Description:  instructions.InfoToolDescription(p.config.Server.Name, defaultServerName, p.config.Server.Tags),
+		OutputSchema: infoOutputSchema,
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ platformInfoInput) (*mcp.CallToolResult, any, error) {
 		return p.handleInfo(ctx, req)
 	})
@@ -315,6 +316,7 @@ func (p *Platform) handleInfo(ctx context.Context, _ *mcp.CallToolRequest) (*mcp
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: string(data)},
 		},
+		StructuredContent: info,
 	}, nil, nil
 }
 

--- a/pkg/platform/output_schema_integration_test.go
+++ b/pkg/platform/output_schema_integration_test.go
@@ -1,0 +1,164 @@
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPlatformToolsAdvertiseAndHonorOutputSchemas assembles the real platform
+// (with the full middleware chain wired by finalizeSetup), connects an in-memory
+// client, and proves the #925 contract for the stable platform-owned tools:
+// tools/list advertises an OutputSchema for platform_info, list_connections, and
+// platform_find_tools, and a real call's structuredContent validates against the
+// advertised schema. It also proves the error envelope (what the error contract
+// substitutes on failure) validates against each schema.
+func TestPlatformToolsAdvertiseAndHonorOutputSchemas(t *testing.T) {
+	cfg := &Config{
+		Server:   ServerConfig{Name: "test-platform"},
+		Semantic: SemanticConfig{Provider: testProviderNoop},
+		Query:    QueryConfig{Provider: testProviderNoop},
+		Storage:  StorageConfig{Provider: testProviderNoop},
+		// Without a persona that can reach the tools, the deny-all default persona
+		// hides them from tools/list and refuses tools/call; grant an allow-all
+		// persona so the client exercises the real advertised surface.
+		Personas: PersonasConfig{
+			Definitions: map[string]PersonaDef{
+				"default": {DisplayName: "Default", Tools: ToolRulesDef{Allow: []string{"*"}}},
+			},
+			DefaultPersona: "default",
+		},
+	}
+	p, err := New(WithConfig(cfg))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	// Start registers the platform-level tools (platform_info, list_connections,
+	// platform_find_tools) on the MCP server.
+	require.NoError(t, p.Start(ctx))
+	defer func() { _ = p.Stop(ctx) }()
+
+	t1, t2 := mcp.NewInMemoryTransports()
+	ss, err := p.MCPServer().Connect(ctx, t1, nil)
+	require.NoError(t, err)
+	defer func() { _ = ss.Close() }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "c", Version: "v0"}, nil)
+	cs, err := client.Connect(ctx, t2, nil)
+	require.NoError(t, err)
+	defer func() { _ = cs.Close() }()
+
+	schemas := listedPlatformSchemas(ctx, t, cs)
+
+	// platform_info mints the session handle every other tool must thread; call it
+	// first, validate its structuredContent, then reuse the minted session_id.
+	infoSchema, ok := schemas["platform_info"]
+	require.True(t, ok, "platform_info advertises an outputSchema in tools/list")
+	infoRes, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "platform_info", Arguments: map[string]any{}})
+	require.NoError(t, err)
+	require.False(t, infoRes.IsError, "platform_info succeeded: %v", infoRes.Content)
+	require.NotNil(t, infoRes.StructuredContent)
+	validatePlatformSC(t, infoSchema, infoRes.StructuredContent)
+	sessionID := sessionIDFromSC(t, infoRes.StructuredContent)
+	require.NotEmpty(t, sessionID, "platform_info mints a session_id")
+
+	// The session-threaded tools.
+	calls := []struct {
+		tool string
+		args map[string]any
+	}{
+		{"list_connections", map[string]any{"session_id": sessionID}},
+		{"platform_find_tools", map[string]any{"query": "search", "session_id": sessionID}},
+	}
+	for _, c := range calls {
+		t.Run(c.tool, func(t *testing.T) {
+			resolved, ok := schemas[c.tool]
+			require.True(t, ok, "%s advertises an outputSchema in tools/list", c.tool)
+
+			res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: c.tool, Arguments: c.args})
+			require.NoError(t, err, "transport error")
+			require.False(t, res.IsError, "call succeeded: %v", res.Content)
+			require.NotNil(t, res.StructuredContent, "call emits structuredContent")
+			validatePlatformSC(t, resolved, res.StructuredContent)
+		})
+	}
+
+	// The error contract replaces the body with the shared {error} envelope on
+	// failure; it must validate against every declared schema.
+	envelope := map[string]any{
+		"error": map[string]any{
+			"code":     "internal_error",
+			"category": "internal",
+			"message":  "boom",
+		},
+	}
+	for tool, resolved := range schemas {
+		t.Run("error envelope validates: "+tool, func(t *testing.T) {
+			validatePlatformSC(t, resolved, envelope)
+		})
+	}
+}
+
+// sessionIDFromSC extracts the minted session_id from a platform_info result's
+// structured content.
+func sessionIDFromSC(t *testing.T, sc any) string {
+	t.Helper()
+	b, err := json.Marshal(sc)
+	require.NoError(t, err)
+	var m struct {
+		SessionID string `json:"session_id"`
+	}
+	require.NoError(t, json.Unmarshal(b, &m))
+	return m.SessionID
+}
+
+func listedPlatformSchemas(ctx context.Context, t *testing.T, cs *mcp.ClientSession) map[string]*jsonschema.Resolved {
+	t.Helper()
+	lt, err := cs.ListTools(ctx, &mcp.ListToolsParams{})
+	require.NoError(t, err)
+	out := map[string]*jsonschema.Resolved{}
+	for _, tool := range lt.Tools {
+		if tool.OutputSchema == nil {
+			continue
+		}
+		raw, err := json.Marshal(tool.OutputSchema)
+		require.NoError(t, err)
+		var s jsonschema.Schema
+		require.NoError(t, json.Unmarshal(raw, &s))
+		resolved, err := s.Resolve(nil)
+		require.NoError(t, err)
+		out[tool.Name] = resolved
+	}
+	return out
+}
+
+func validatePlatformSC(t *testing.T, resolved *jsonschema.Resolved, sc any) {
+	t.Helper()
+	b, err := json.Marshal(sc)
+	require.NoError(t, err)
+	var v any
+	require.NoError(t, json.Unmarshal(b, &v))
+	assert.NoError(t, resolved.Validate(v), "structuredContent must validate: %s", string(b))
+}
+
+// TestPlatformOutputSchemasAreOpen guards the design decision: every declared
+// platform schema is open (additionalProperties allowed, nothing required) so
+// the error envelope and any future enrichment key never invalidate a result.
+func TestPlatformOutputSchemasAreOpen(t *testing.T) {
+	for name, s := range map[string]*jsonschema.Schema{
+		"platform_info":       infoOutputSchema,
+		"list_connections":    connectionsOutputSchema,
+		"platform_find_tools": findToolsOutputSchema,
+	} {
+		require.NotNil(t, s.AdditionalProperties, "%s: additionalProperties set", name)
+		assert.Empty(t, s.AdditionalProperties.Type, "%s: additionalProperties is the open {} schema", name)
+		assert.Nil(t, s.Required, "%s: no top-level required fields", name)
+		_, ok := s.Properties["error"]
+		assert.True(t, ok, "%s: declares the shared error property", name)
+	}
+}

--- a/pkg/platform/tool_schemas.go
+++ b/pkg/platform/tool_schemas.go
@@ -1,0 +1,19 @@
+package platform
+
+import (
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+)
+
+// Declared OutputSchemas for the stable, platform-owned tools (#925). Each is an
+// open object schema (additionalProperties allowed, nothing required, shared
+// error envelope declared) derived from the tool's success-body struct; see
+// middleware.OpenToolOutputSchema for the rationale on why the schemas are open
+// rather than strict. Building them once at package init keeps the reflection
+// cost off the per-registration path.
+var (
+	infoOutputSchema        *jsonschema.Schema = middleware.MustOutputSchema[Info]()
+	connectionsOutputSchema *jsonschema.Schema = middleware.MustOutputSchema[listConnectionsOutput]()
+	findToolsOutputSchema   *jsonschema.Schema = middleware.MustOutputSchema[findToolsOutput]()
+)

--- a/pkg/toolkits/search/output_schema_integration_test.go
+++ b/pkg/toolkits/search/output_schema_integration_test.go
@@ -1,0 +1,105 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/middleware"
+)
+
+// TestOutputSchema_AdvertisedAndValidated wires the real search toolkit onto an
+// mcp.Server with the error-contract middleware, connects an in-memory client,
+// and proves the #925 contract end to end: tools/list advertises an OutputSchema
+// for both search and fetch, and a real call's structuredContent validates
+// against the advertised schema across relevance mode, browse mode, the
+// structured found=false answer, and a real tool error (error envelope).
+func TestOutputSchema_AdvertisedAndValidated(t *testing.T) {
+	ctx := context.Background()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "search-test", Version: "v0"}, nil)
+	assembledToolkit().RegisterTools(server)
+	// The error-contract middleware is what replaces a failed body with the
+	// shared {error} envelope; wire it so the error-path assertion exercises the
+	// real normalization, not a hand-built result.
+	server.AddReceivingMiddleware(middleware.MCPErrorContractMiddleware())
+
+	t1, t2 := mcp.NewInMemoryTransports()
+	ss, err := server.Connect(ctx, t1, nil)
+	require.NoError(t, err)
+	defer func() { _ = ss.Close() }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "c", Version: "v0"}, nil)
+	cs, err := client.Connect(ctx, t2, nil)
+	require.NoError(t, err)
+	defer func() { _ = cs.Close() }()
+
+	// tools/list advertises an OutputSchema for search and fetch.
+	schemas := listedOutputSchemas(ctx, t, cs)
+	require.Contains(t, schemas, "search", "search advertises an outputSchema")
+	require.Contains(t, schemas, "fetch", "fetch advertises an outputSchema")
+
+	cases := []struct {
+		name string
+		tool string
+		args map[string]any
+	}{
+		{"search relevance mode", "search", map[string]any{"intent": "alice"}},
+		{"search browse mode", "search", map[string]any{"sources": []any{"knowledge_pages"}}},
+		{"fetch found", "fetch", map[string]any{"reference": "mcp:knowledge_page:kp-1"}},
+		{"fetch structured not-found", "fetch", map[string]any{"reference": "mcp:knowledge_page:missing"}},
+		// A blank reference is a tool error; the contract middleware turns it into
+		// the {error} envelope, which must still validate against the schema.
+		{"fetch tool error", "fetch", map[string]any{"reference": "   "}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: tc.tool, Arguments: tc.args})
+			require.NoError(t, err, "transport error")
+			require.NotNil(t, res.StructuredContent, "call emits structuredContent")
+			validateAgainst(t, schemas[tc.tool], res.StructuredContent)
+		})
+	}
+}
+
+// listedOutputSchemas returns each tool's advertised OutputSchema, resolved and
+// ready to validate, keyed by tool name.
+func listedOutputSchemas(ctx context.Context, t *testing.T, cs *mcp.ClientSession) map[string]*jsonschema.Resolved {
+	t.Helper()
+	lt, err := cs.ListTools(ctx, &mcp.ListToolsParams{})
+	require.NoError(t, err)
+	out := map[string]*jsonschema.Resolved{}
+	for _, tool := range lt.Tools {
+		if tool.OutputSchema == nil {
+			continue
+		}
+		// The advertised schema arrives as generic JSON over the wire; remarshal
+		// it into a *jsonschema.Schema, exactly as a spec-faithful client would to
+		// validate results.
+		raw, err := json.Marshal(tool.OutputSchema)
+		require.NoError(t, err)
+		var s jsonschema.Schema
+		require.NoError(t, json.Unmarshal(raw, &s))
+		resolved, err := s.Resolve(nil)
+		require.NoError(t, err)
+		out[tool.Name] = resolved
+	}
+	return out
+}
+
+// validateAgainst validates a wire-round-tripped structuredContent value against
+// a resolved schema, the same check a spec-faithful client performs.
+func validateAgainst(t *testing.T, resolved *jsonschema.Resolved, sc any) {
+	t.Helper()
+	require.NotNil(t, resolved)
+	b, err := json.Marshal(sc)
+	require.NoError(t, err)
+	var v any
+	require.NoError(t, json.Unmarshal(b, &v))
+	assert.NoError(t, resolved.Validate(v), "structuredContent must validate against the advertised schema: %s", string(b))
+}

--- a/pkg/toolkits/search/toolkit.go
+++ b/pkg/toolkits/search/toolkit.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/txn2/mcp-data-platform/pkg/knowledge"
@@ -154,6 +155,55 @@ var fetchSchema = json.RawMessage(`{
   }
 }`)
 
+// searchResultSchema is the declared OutputSchema for the search tool. The
+// search tool serves both relevance mode (searchOutput) and browse mode
+// (browseOutput), so the two response shapes are merged into one open schema; see
+// mergedSearchOutputSchema. fetchResultSchema is the fetch tool's schema.
+var (
+	searchResultSchema = middleware.OpenToolOutputSchema(mergedSearchOutputSchema())
+	fetchResultSchema  = middleware.MustOutputSchema[fetchOutput]()
+)
+
+// structuredResult renders v as a search tool result: v is placed in
+// StructuredContent (so the declared OutputSchema describes what the tool
+// actually emits, and structured-output clients receive the body) and, as
+// indented JSON, in a TextContent block for content-only clients. A marshal
+// failure falls back to an in-band error result, matching how the handlers
+// report failures.
+func structuredResult(v any) (*mcp.CallToolResult, any, error) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return toolkit.ErrorResult("internal error marshaling response: " + err.Error()), nil, nil
+	}
+	return &mcp.CallToolResult{
+		Content:           []mcp.Content{&mcp.TextContent{Text: string(b)}},
+		StructuredContent: v,
+	}, nil, nil
+}
+
+// mergedSearchOutputSchema derives a single object schema whose properties are
+// the union of searchOutput (relevance mode) and browseOutput (browse mode),
+// since both are returned by the one search tool depending on the arguments. It
+// panics on a reflection failure, a programming error covered by tests.
+func mergedSearchOutputSchema() *jsonschema.Schema {
+	s, err := jsonschema.For[searchOutput](nil)
+	if err != nil {
+		panic("search: derive searchOutput schema: " + err.Error())
+	}
+	b, err := jsonschema.For[browseOutput](nil)
+	if err != nil {
+		panic("search: derive browseOutput schema: " + err.Error())
+	}
+	for _, name := range b.PropertyOrder {
+		if _, ok := s.Properties[name]; ok {
+			continue
+		}
+		s.Properties[name] = b.Properties[name]
+		s.PropertyOrder = append(s.PropertyOrder, name)
+	}
+	return s
+}
+
 // Toolkit registers the search tool over a knowledge.Router.
 type Toolkit struct {
 	name   string
@@ -196,7 +246,8 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 			"a result may still show pre-edit text right after you change it. To confirm a specific entity's " +
 			"current state after a write, read it directly (datahub_get_entity, or the resulting_state in the " +
 			"apply_knowledge apply response), not search.",
-		InputSchema: searchSchema,
+		InputSchema:  searchSchema,
+		OutputSchema: searchResultSchema,
 	}, t.handleSearch)
 
 	mcp.AddTool(s, &mcp.Tool{
@@ -213,7 +264,8 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 			"datahub_get_lineage or an entity_urns lookup). A reference that is stale, unknown, or outside what " +
 			"you can access returns found=false rather than an error, so a dangling citation is a clean answer. " +
 			"Personal results stay scoped to you: fetch never reads content you could not have found with search.",
-		InputSchema: fetchSchema,
+		InputSchema:  fetchSchema,
+		OutputSchema: fetchResultSchema,
 	}, t.handleFetch)
 }
 
@@ -269,7 +321,7 @@ func (t *Toolkit) handleSearch(ctx context.Context, _ *mcp.CallToolRequest, inpu
 	for _, g := range groups {
 		shown += len(g.Hits)
 	}
-	return toolkit.JSONResultTyped(searchOutput{
+	return structuredResult(searchOutput{
 		Groups:         groups,
 		Coverage:       coverage,
 		Count:          shown,
@@ -294,7 +346,7 @@ func (t *Toolkit) handleFetch(ctx context.Context, _ *mcp.CallToolRequest, input
 	doc, err := t.router.Fetch(ctx, ref, callerFromContext(ctx))
 	if err != nil {
 		if errors.Is(err, knowledge.ErrNotFound) {
-			return toolkit.JSONResultTyped(fetchOutput{
+			return structuredResult(fetchOutput{
 				Found:     false,
 				Reference: ref,
 				Message: "no content found for this reference; it may be stale, not a recognized " +
@@ -304,7 +356,7 @@ func (t *Toolkit) handleFetch(ctx context.Context, _ *mcp.CallToolRequest, input
 		return toolkit.ErrorResult("fetch failed: " + err.Error()), nil, nil
 	}
 
-	return toolkit.JSONResultTyped(fetchOutput{
+	return structuredResult(fetchOutput{
 		Found:     true,
 		Reference: ref,
 		Document:  doc,
@@ -348,7 +400,7 @@ func (t *Toolkit) handleBrowse(ctx context.Context, input searchInput) (*mcp.Cal
 	if items == nil {
 		items = []knowledge.Hit{}
 	}
-	return toolkit.JSONResultTyped(browseOutput{
+	return structuredResult(browseOutput{
 		Source: source,
 		Total:  page.Total,
 		Offset: page.Offset,


### PR DESCRIPTION
Closes #925

## Summary

Declares `OutputSchema` for the stable, platform-owned MCP tools and makes each one emit `structuredContent` that matches its declared schema, completing the structured-content story so spec-faithful clients can validate what they receive.

Five tools now advertise an output schema and populate structured output:

| Tool | Body type | Package |
| --- | --- | --- |
| `platform_info` | `Info` | `pkg/platform` |
| `list_connections` | `connview.Output` | `pkg/platform` |
| `platform_find_tools` | `findToolsOutput` | `pkg/platform` |
| `search` | `searchOutput` ∪ `browseOutput` | `pkg/toolkits/search` |
| `fetch` | `fetchOutput` | `pkg/toolkits/search` |

Passthrough/proxy tools (gateway-forwarded tools, `api_invoke_endpoint` raw bodies) are intentionally left schema-less: the platform cannot guarantee an upstream-owned shape, and declaring one it can't honor would be worse than none.

## Why declared schemas are open (the written decision)

A single tool result is polymorphic. Beyond the success body it may carry:

- the shared `{error:{code,category,message,hint}}` envelope that `MCPErrorContractMiddleware` substitutes on any failure (`pkg/middleware/error_contract.go:119-141`, `pkg/middleware/mcp_error_contract.go:63-90`); and
- open-ended enrichment keys the semantic-enrichment middleware may mirror into `structuredContent` (`pkg/middleware/mcp_enrichment.go:178-200`).

So every declared schema is built **open**: `additionalProperties` allowed, no property `required`, and the shared `error` envelope declared. This keeps a spec-faithful client from rejecting a body-less error result or an enriched result. The rationale lives in one place — `middleware.OpenToolOutputSchema` — and is cross-referenced from the enrichment comment at `pkg/middleware/mcp_enrichment.go:202-214`.

Note on scope: the five schema-declaring tools are **not** semantically enriched. `inferToolkitKind` (`pkg/middleware/mcp_enrichment.go:279-290`) gates enrichment to `trino_`/`datahub_`/`s3_` prefixes only, and those enriched tools continue to declare no schema — so the enrichment mirror's open-map behavior remains correct. The declared schemas are still kept open so they would stay valid if any of them were ever enriched.

## Why explicit `OutputSchema` instead of a typed `Out`

The SDK (`go-sdk@v1.6.1`, `mcp/server.go:360-393`) derives a schema from the handler's `Out` type and re-validates the returned value. On the error path a handler returns a nil `Out`; for a non-`any` `Out` the SDK substitutes the zero body struct and writes it into `StructuredContent`, clobbering the error envelope. Keeping `Out = any` and setting `Tool.OutputSchema` explicitly gives the handler full control: the SDK advertises the schema in `tools/list` but never re-validates or overwrites the handler's structured content.

## Shared helpers (`pkg/middleware/output_schema.go`, new)

- `ErrorEnvelopeProperty()` — the single `{code,category,message,hint}` schema fragment every declaring tool references, so the error shape is documented identically across the surface.
- `OpenToolOutputSchema(base)` — opens a struct-derived schema (additionalProperties allowed, `required` cleared, error envelope declared) and returns it for inline use in `Tool.OutputSchema`.
- `MustOutputSchema[T]()` — derives an open schema from a body type `T` at package init (panics on an unreflectable type, mirroring `regexp.MustCompile`).

`search` serves two response shapes from one tool (relevance `searchOutput` and browse `browseOutput`), so `mergedSearchOutputSchema` unions their properties into one open schema. The search package sets structured content through a small local `structuredResult` helper rather than growing `pkg/toolkit` (which would have tripped `TestPackageCohesion`).

## Tests

- `pkg/toolkits/search/output_schema_integration_test.go` — wires the real toolkit onto an `mcp.Server` with the error-contract middleware, connects an in-memory client, asserts `tools/list` advertises the schema, and validates `structuredContent` against the advertised schema across relevance mode, browse mode, the structured `found=false` answer, and a real tool error (the error envelope).
- `pkg/platform/output_schema_integration_test.go` — assembles the full platform (real middleware chain), threads the minted `session_id` from `platform_info`, and validates each tool's structured output plus the error envelope against the advertised schema.
- `pkg/middleware/output_schema_test.go` — unit coverage of the helpers (100% on the new functions): opening semantics, success-body validation, error-envelope validation, enrichment-key admission, and that `BuildErrorResult`'s real output conforms to the shared fragment.

## Acceptance criteria

- [x] The chosen platform tools advertise output schemas in `tools/list`; live calls validate against them including when the error contract fires.
- [x] A written decision covering how middleware-injected keys interact with declared schemas (`OpenToolOutputSchema` doc comment + `mcp_enrichment.go` comment).
- [x] `make verify` green (tests+race, coverage ≥80%, patch coverage, lint, gosec/govulncheck, semgrep, codeql, dead-code, goreleaser dry-run).
