### PR TITLE
chore(deps): bump mcp-datahub to v1.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/ollama v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
-	github.com/txn2/mcp-datahub v1.11.0
+	github.com/txn2/mcp-datahub v1.12.0
 	github.com/txn2/mcp-s3 v1.3.0
 	github.com/txn2/mcp-trino v1.3.1
 	github.com/yosida95/uritemplate/v3 v3.0.2

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/tmc/langchaingo v0.1.5 h1:PNPFu54wn5uVPRt9GS/quRwdFZW4omSab9/dcFAsGmU
 github.com/tmc/langchaingo v0.1.5/go.mod h1:RLtnUED/hH2v765vdjS9Z6gonErZAXURuJHph0BttqM=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v1.11.0 h1:AdfJbToL5LRuiyhUmaUaU5PtvcKg5EZFSYz5YIK2noU=
-github.com/txn2/mcp-datahub v1.11.0/go.mod h1:zNhJ1JJoVrwIC8DU9fTywVSdCjG7gnnrzbNWL746JYM=
+github.com/txn2/mcp-datahub v1.12.0 h1:ETiPw8QFCpq3FfObB8x+J5RkIIVVJ1+gIXk9BMfwgwA=
+github.com/txn2/mcp-datahub v1.12.0/go.mod h1:zNhJ1JJoVrwIC8DU9fTywVSdCjG7gnnrzbNWL746JYM=
 github.com/txn2/mcp-s3 v1.3.0 h1:T2FlZGSU5pJi78ts+rE9kzZpIg1HD/lciwWqInYXXO0=
 github.com/txn2/mcp-s3 v1.3.0/go.mod h1:sI18zzBkOxGO07DSHap7baPwtEEw+pYBJhT1BGQnYRc=
 github.com/txn2/mcp-trino v1.3.1 h1:A9Ki3Q7S+soLKCOKuVXCi/DO2dvgZRh7h+mDPT1WOCw=


### PR DESCRIPTION
## Summary

Bumps `github.com/txn2/mcp-datahub` from `v1.11.0` to [`v1.12.0`](https://github.com/txn2/mcp-datahub/releases/tag/v1.12.0), a maintenance and correctness release with no breaking changes and no schema-compatibility impact.

## What changed here

- `go.mod`: `github.com/txn2/mcp-datahub v1.11.0` → `v1.12.0`
- `go.sum`: corresponding hash update

`go mod tidy` produced no transitive dependency changes — this is an isolated two-line version bump.

## What v1.12.0 brings (upstream)

- **Tag display-name fix**: tags created through `datahub_create` without an explicit ID previously rendered as UUIDs on read, because a deprecated field returned the UUID entity key instead of the human-readable name. All read paths now select and prefer the display name from tag properties. This is the upstream half of the tag-rendering behavior seen through this platform's DataHub tooling.
- **`datahub_update` parameter handling**: association URNs are now accepted in the generic `value` field as a fallback for tag, glossary term, owner, and domain operations. `target_urn` remains authoritative; the fallback lets agents succeed on the first attempt when they pass the URN generically.
- **CI/CD maintenance**: CodeQL Action suite upgraded to v4.37.0; Docker setup/login actions updated (v4.2.0 / v4.4.0).

Upstream reports the release validated against DataHub v1.5.0.1, with minimum supported v1.3.x.

## Verification

Run locally on this branch:

- `go build ./...` — clean
- `go test ./...` — no failures
- `make verify` — all checks passed (gofmt, race tests, coverage ≥80%, patch coverage, golangci-lint, gosec, govulncheck, semgrep, CodeQL, dead-code, GoReleaser dry-run)

## Compatibility

No breaking API changes; no source changes were required in this repository beyond the dependency version. Schema-compatible per the upstream release notes.
