### PR TITLE
docs: graphite re-skin (technical type, cool palette) + content clarity

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -63,7 +63,7 @@
 
     <div class="hero__intro">
       <p class="hero__lede">
-        <span class="dropcap">m</span>cp-data-platform is the composable MCP server platform for AI assistants that need data with context. Compose <a href="https://mcp-datahub.txn2.com">mcp-datahub</a>, <a href="https://mcp-trino.txn2.com">mcp-trino</a>, and <a href="https://mcp-s3.txn2.com">mcp-s3</a> behind one endpoint with bidirectional cross-enrichment. Query a table and get its meaning, owners, quality scores, and deprecation warnings in the same response. <strong>Semantic first</strong>: every data response includes business context from the semantic layer.
+        mcp-data-platform is the composable MCP server platform for AI assistants that need data with context. Compose <a href="https://mcp-datahub.txn2.com">mcp-datahub</a>, <a href="https://mcp-trino.txn2.com">mcp-trino</a>, and <a href="https://mcp-s3.txn2.com">mcp-s3</a> behind one endpoint with bidirectional cross-enrichment. Query a table and get its meaning, owners, quality scores, and deprecation warnings in the same response. <strong>Semantic first</strong>: every data response includes business context from the semantic layer.
       </p>
       <p class="hero__lede hero__lede--muted">
         OAuth 2.1 inbound, OAuth 2.1 outbound to upstream MCPs, OIDC, API keys, role-based personas, audit logging, admin portal, and a gateway toolkit that re-exposes any third-party MCP server through the same auth pipeline. Run as a single binary or import as a Go library to compose your own platform. Apache 2.0.
@@ -204,89 +204,71 @@ p.Run(ctx)</pre>
       </p>
     </header>
 
-    <ol class="stack">
+    <ul class="stack">
       <li class="stack__row">
-        <span class="stack__num">001</span>
         <div class="stack__main">
           <a class="stack__name" href="cross-enrichment/overview/">semantic cross-enrichment</a>
           <p class="stack__desc">Trino results include DataHub metadata (owners, tags, glossary terms, quality scores, deprecation). DataHub searches show query availability and sample SQL. S3 operations include semantic context. Lineage inheritance fills in column metadata from upstream datasets. Session dedup avoids repeating context already sent.</p>
         </div>
-        <span class="stack__tag">enrichment</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">002</span>
         <div class="stack__main">
           <a class="stack__name" href="server/multi-provider/">composable toolkits</a>
           <p class="stack__desc">DataHub is the only required dependency (the semantic layer). Add <code>mcp-trino</code> for federated SQL and <code>mcp-s3</code> for object storage when you need them. Multi-instance per service, runtime instance selection, isolated failure domains. Add custom toolkits via the <code>Toolkit</code> interface.</p>
         </div>
-        <span class="stack__tag">compose</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">003</span>
         <div class="stack__main">
           <a class="stack__name" href="auth/overview/">oauth 2.1, oidc, api keys</a>
           <p class="stack__desc">OAuth 2.1 server for inbound (Claude Desktop talks OAuth to the platform). OAuth 2.1 client for outbound to upstream MCPs through the gateway, with encrypted refresh tokens persisted across restarts. OIDC discovery for Keycloak, Auth0, Okta, Azure AD. API keys for service accounts. Fail-closed by default.</p>
         </div>
-        <span class="stack__tag">auth</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">004</span>
         <div class="stack__main">
           <a class="stack__name" href="personas/overview/">personas &amp; tool filtering</a>
           <p class="stack__desc">Map OIDC roles to personas. Each persona has allow/deny patterns for tools and connections. Analysts get read access. Admins get everything. Connection-level filtering restricts which toolkit instances a persona can use. Description overrides per persona steer the model differently for different audiences.</p>
         </div>
-        <span class="stack__tag">authz</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">005</span>
         <div class="stack__main">
           <a class="stack__name" href="server/audit/">audit &amp; observability</a>
           <p class="stack__desc">Every tool call is logged to PostgreSQL with user, persona, tool, parameters (sanitized), duration, enrichment metrics, and result hash. SOC2 and HIPAA-friendly retention. Searchable from the admin portal with event-detail drawers. Activity dashboards for personas, tools, and connections. A search-first gate that refuses query tools until the agent discovers table context.</p>
         </div>
-        <span class="stack__tag">audit</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">006</span>
         <div class="stack__main">
           <a class="stack__name" href="server/gateway/">gateway toolkit</a>
           <p class="stack__desc">Re-expose any well-behaved third-party MCP server through the platform's auth, persona, and audit pipeline. Connections authored in the admin portal (DB-backed, encrypted credentials). Tools surface as <code>&lt;connection&gt;__&lt;remote_tool&gt;</code>. OAuth 2.1 client_credentials and authorization_code+PKCE grants. Optional declarative cross-enrichment joins proxied responses with Trino or DataHub.</p>
         </div>
-        <span class="stack__tag">gateway</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">007</span>
         <div class="stack__main">
           <a class="stack__name" href="server/admin-portal/">admin &amp; user portal</a>
           <p class="stack__desc">Built-in web dashboard. Admins manage connections, personas, API keys, configuration entries, audit, knowledge, and gateway connections. Users see their activity, prompts, assets, collections, resources, and shared work. Configurable branding (light/dark logos, implementor brand, public-share notices). Markdown asset viewer with mermaid, GFM tables, and code highlighting.</p>
         </div>
-        <span class="stack__tag">portal</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">008</span>
         <div class="stack__main">
           <a class="stack__name" href="knowledge/overview/">knowledge &amp; memory</a>
           <p class="stack__desc">Capture tribal knowledge during AI sessions and write it back to DataHub through a human-in-the-loop governance workflow with changeset rollback. Persistent memory layer (PostgreSQL + pgvector) accumulates preferences, corrections, and domain knowledge across sessions, with staleness detection when referenced entities change.</p>
         </div>
-        <span class="stack__tag">knowledge</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row stack__row--more">
-        <span class="stack__num">···</span>
         <div class="stack__main">
           <a class="stack__name" href="ecosystem/">part of the txn2 mcp data platform</a>
           <p class="stack__desc">Sister projects: <a href="https://mcp-datahub.txn2.com">mcp-datahub</a> for metadata catalogs, <a href="https://mcp-trino.txn2.com">mcp-trino</a> for federated SQL, <a href="https://mcp-s3.txn2.com">mcp-s3</a> for object storage. mcp-data-platform composes all three plus the operational layer that turns them into a platform.</p>
         </div>
-        <span class="stack__tag">+ ecosystem</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
-    </ol>
+    </ul>
   </section>
 
   {# CODA / sister projects, context #}
@@ -354,7 +336,7 @@ p.Run(ctx)</pre>
       <p class="home-footer__label">txn2 / org</p>
       <p class="home-footer__text"><a href="https://txn2.com">txn2.com&nbsp;↗</a><br>
       <span class="home-footer__links__sub">canonical home of the txn2 open source organization</span></p>
-      <p class="home-footer__mono">apache 2.0 license <span class="dot">·</span> <span data-clock>·· UTC</span></p>
+      <p class="home-footer__mono">apache 2.0 license</p>
     </div>
   </div>
   <div class="home-footer__base">
@@ -364,30 +346,3 @@ p.Run(ctx)</pre>
 </footer>
 {% endblock %}
 
-{% block scripts %}
-{{ super() }}
-<script>
-  // Live UTC clock for rail/footer.
-  // Guarded against duplicate registration: Material's instant-nav rehydrates
-  // the body on every navigation back to the homepage; without this guard a
-  // fresh setInterval handle leaks each visit.
-  (function () {
-    if (window.__mcpDataPlatformClock) {
-      window.__mcpDataPlatformClock.tick();
-      return;
-    }
-    function tick() {
-      var now = new Date();
-      var hh = String(now.getUTCHours()).padStart(2, '0');
-      var mm = String(now.getUTCMinutes()).padStart(2, '0');
-      var stamp = hh + ':' + mm + ' UTC';
-      document.querySelectorAll('[data-clock]').forEach(function (el) {
-        el.textContent = stamp;
-      });
-    }
-    tick();
-    var handle = setInterval(tick, 30 * 1000);
-    window.__mcpDataPlatformClock = { tick: tick, handle: handle };
-  })();
-</script>
-{% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -14,7 +14,7 @@
 {% block extrahead %}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..700;1,9..144,300..700&family=Instrument+Sans:wght@400..700&family=JetBrains+Mono:wght@400..700&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap">
 
   <meta name="description" content="{{ config.site_description }}">
   <meta name="keywords" content="mcp, model context protocol, mcp server, mcp platform, datahub, trino, s3, semantic layer, cross-enrichment, oauth 2.1, oidc, personas, audit logging, gateway, go, claude, ai assistant, composable, governance, data platform">
@@ -90,4 +90,40 @@
 {% block content %}
 <a id="main" tabindex="-1" class="skiplink-target" aria-hidden="true"></a>
 {{ super() }}
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+  // Track the active top-rail section across navigations, including Material's
+  // instant navigation (navigation.instant), which swaps page content without
+  // re-rendering the header — so a server-rendered active state would otherwise
+  // stick on whichever page was loaded first. Each rail link owns one or more
+  // path prefixes via data-scope; the longest prefix matching the current path
+  // wins. "$home" matches only the site root.
+  (function () {
+    function trackRail() {
+      var links = document.querySelectorAll('.rail__nav a[data-scope]');
+      if (!links.length) return;
+      var path = location.pathname.replace(/^\/+/, '').replace(/index\.html$/, '');
+      var best = null, bestLen = -1;
+      links.forEach(function (a) {
+        a.removeAttribute('aria-current');
+        (a.getAttribute('data-scope') || '').split(/\s+/).forEach(function (s) {
+          if (!s) return;
+          var hit = (s === '$home') ? (path === '') : (path.indexOf(s) === 0);
+          if (hit && s.length > bestLen) { bestLen = s.length; best = a; }
+        });
+      });
+      if (best) { best.setAttribute('aria-current', 'page'); }
+    }
+    if (window.document$ && typeof window.document$.subscribe === 'function') {
+      window.document$.subscribe(trackRail);
+    } else if (document.readyState !== 'loading') {
+      trackRail();
+    } else {
+      document.addEventListener('DOMContentLoaded', trackRail);
+    }
+  })();
+</script>
 {% endblock %}

--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -13,7 +13,7 @@
   <a class="skiplink" href="#main">skip to content</a>
 
   <a href="{{ '.' | url }}" class="rail__brand" aria-label="{{ config.site_name }} home">
-    <span class="rail__mark" aria-hidden="true">◐</span>
+    <span class="rail__mark" aria-hidden="true"><svg viewBox="10 10 80 80" xmlns="http://www.w3.org/2000/svg"><path class="rail__mark__ring" d="M50,83.333C31.59,83.333 16.667,68.408 16.667,50C16.667,31.588 31.591,16.667 50,16.667C68.408,16.667 83.333,31.589 83.333,50L90,50C90,27.91 72.09,10 50,10C27.909,10 10,27.91 10,50C10,72.09 27.909,90 50,90L50,83.333Z M50,70C38.954,70 30,61.045 30,50C30,38.952 38.954,30 50,30C61.045,30 70,38.952 70,50L76.667,50C76.667,35.273 64.727,23.333 50,23.333C35.272,23.333 23.333,35.273 23.333,50C23.333,64.727 35.272,76.667 50,76.667L50,70Z M50,56.667C46.318,56.667 43.333,53.682 43.333,50C43.333,46.318 46.318,43.333 50,43.333C53.682,43.333 56.667,46.318 56.667,50L63.333,50C63.333,42.637 57.363,36.667 50,36.667C42.635,36.667 36.667,42.637 36.667,50C36.667,57.363 42.635,63.333 50,63.333L50,56.667Z"/><path class="rail__mark__sq" d="M56.667,56.667 H90 V90 H56.667 Z"/></svg></span>
     <span class="rail__name">mcp-data-platform</span>
     <span class="rail__sep" aria-hidden="true">·</span>
     <span class="rail__sub">composable mcp data platform</span>
@@ -21,8 +21,6 @@
 
   <div class="rail__meta">
     <span class="rail__rel">v1.x</span>
-    <span class="rail__dot" aria-hidden="true">●</span>
-    <span data-clock>·· UTC</span>
     <span class="rail__dot" aria-hidden="true">●</span>
     <a href="https://txn2.com" class="rail__org">part of <em class="serif">txn2</em>&nbsp;↗</a>
   </div>
@@ -34,11 +32,11 @@
     </label>
     {%- endif %}
 
-    <a href="{{ '.' | url }}"{% if page.is_homepage %} aria-current="page"{% endif %}>home</a>
-    <a href="{{ 'server/installation/' | url }}">install</a>
-    <a href="{{ 'server/overview/' | url }}">server</a>
-    <a href="{{ 'library/overview/' | url }}">library</a>
-    <a href="{{ 'reference/tools-api/' | url }}">reference</a>
+    <a href="{{ '.' | url }}" data-scope="$home"{% if page.is_homepage %} aria-current="page"{% endif %}>home</a>
+    <a href="{{ 'server/installation/' | url }}" data-scope="server/installation">install</a>
+    <a href="{{ 'server/overview/' | url }}" data-scope="server cross-enrichment auth personas knowledge memory mcpapps concepts security">server</a>
+    <a href="{{ 'library/overview/' | url }}" data-scope="library">library</a>
+    <a href="{{ 'reference/tools-api/' | url }}" data-scope="reference support release-highlights">reference</a>
 
     {%- if "material/search" in config.plugins %}
       {%- set search = config.plugins["material/search"] | attr("config") %}

--- a/docs/reference/benchmarks.md
+++ b/docs/reference/benchmarks.md
@@ -18,6 +18,38 @@ The load harness's throughput numbers are a separate concern; see
 Reading rule: the headline is always arm-vs-arm on a pinned model (the
 platform's effect). Model identity is disclosed but is never the subject.
 
+## How to read this page
+
+Every result compares the **same model on the same tasks**, changing only what
+the agent is connected to. The shorthand in the tables:
+
+**Arms** — the setup being compared:
+
+| Arm | What the agent is connected to |
+| --- | --- |
+| **A0 — raw tools** | The underlying data tools directly (Trino, DataHub, S3), with no platform in between. |
+| **A2 — platform** | This platform: the same tools plus semantic context, cross-enrichment, and the knowledge layer. |
+| **A3 — lifecycle** | A2 plus the memory / `apply_knowledge` lifecycle (used only in the S5 section). |
+
+**Suites** — tasks grouped by what they test:
+
+| Suite | Question it asks |
+| --- | --- |
+| **S1 — discovery** | Can the agent find the right table and columns? (straightforward lookups) |
+| **S3 — knowledge traps** | Questions with a plausible-but-wrong answer, where the fact that disambiguates it lives in business knowledge, not in the raw data. |
+| **S5 — memory lifecycle** | Does a fact taught in one session get captured, recalled, and reused in later, separate sessions? |
+
+**Scores:**
+
+- **`3/3`** (trap table) — passed **3 of 3** attempts on that task. **`0/3`** — failed all three. Each task is run 3 times.
+- **pass^k / pass^3** — a stricter bar than plain accuracy: a task counts as passed only if it passed **every one of the k = 3** attempts. "Accuracy" is the average across attempts; "pass^3" is all-or-nothing per task.
+- **Median / p90 tool calls** — how many tool calls the agent made to reach an answer (p90 = 90th percentile). **"budget exhausted"** means it hit the 30-call cap without answering.
+
+**Trap classes** — the specific mistake each S3 task is designed to catch:
+
+- **`units_cents`** — the values are stored in cents; without knowing that, the agent reports the number as dollars (off by 100×).
+- **`net_revenue`** — the correct figure depends on the business's net-revenue reporting policy, a knowledge-layer fact; without it the agent uses the wrong revenue definition.
+
 ## 1. Phase 1 pilot (design validation)
 
 Status: pilot-scale. Ten tasks, two trap classes, two arms, one model, no
@@ -50,7 +82,8 @@ Arm-by-suite results:
 | S3 median wall clock | 67s | 25s |
 | Arm output tokens | 88k | 33k |
 
-Trap-class breakdown (S3, 3 attempts per task per arm):
+Trap-class breakdown (S3). Each cell is passes / attempts — `3/3` means all
+three attempts passed, `0/3` means all three failed:
 
 | Task | Trap class | a0 | a2 |
 | --- | --- | --- | --- |

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -6,25 +6,31 @@
    ─────────────────────────────────────────────────────────────── */
 
 :root {
-  --ink:        #0B0B09;
-  --ink-2:      #131310;
-  --ink-3:      #1B1A15;
-  --rule:       #2A2922;
-  --rule-2:     #3A3830;
+  /* Graphite grey ground — lifted off near-black so it reads as grey, not black. */
+  --ink:        #1E232A;
+  --ink-2:      #262C34;
+  --ink-3:      #2F3640;
+  --rule:       #3A424C;
+  --rule-2:     #47515C;
 
-  --paper:      #ECE3CE;
-  --paper-dim:  #C9C0AB;
-  --mute:       #968F80;
-  --mute-2:     #5A554B;
+  /* Cool light foreground — replaces the cream "paper". */
+  --paper:      #EDF1F5;
+  --paper-dim:  #C4CCD4;
+  --mute:       #8A95A0;
+  --mute-2:     #5C6670;
 
-  --signal:     #FF5A1F;
-  --signal-2:   #FF8A4C;
-  --acid:       #E1FF6E;
-  --cool:       #6FE1FF;
+  /* Single restrained accent (cyan) + code-syntax hues. */
+  --signal:     #4FC7E6;
+  --signal-2:   #7FD6EC;
+  --acid:       #9BCB86;
+  --cool:       #8FB6D6;
 
-  --serif:      "Fraunces", "Times New Roman", serif;
-  --sans:       "Instrument Sans", -apple-system, "Helvetica Neue", sans-serif;
-  --mono:       "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  /* --serif carries the DISPLAY face used for headings. The direction
+     moved off serif to a technical mono; the token name is kept so the
+     shared txn2 design system stays parity-mapped across sister repos. */
+  --serif:      "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  --sans:       "Geist", -apple-system, "Helvetica Neue", sans-serif;
+  --mono:       "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
 
   --measure:    64ch;
   --rail-h:     56px;
@@ -54,21 +60,21 @@
   --md-primary-bg-color--light:    var(--paper-dim);
 
   --md-accent-fg-color:            var(--signal);
-  --md-accent-fg-color--transparent: rgba(255,90,31,0.10);
+  --md-accent-fg-color--transparent: rgba(79,199,230,0.10);
   --md-accent-bg-color:            var(--ink);
   --md-accent-bg-color--light:     var(--ink-2);
 
   --md-typeset-color:              var(--paper);
   --md-typeset-a-color:            var(--signal);
-  --md-typeset-mark-color:         rgba(255,90,31,0.25);
+  --md-typeset-mark-color:         rgba(79,199,230,0.25);
   --md-typeset-kbd-color:          var(--ink-3);
   --md-typeset-kbd-accent-color:   var(--rule-2);
   --md-typeset-kbd-border-color:   var(--rule);
 
   --md-code-bg-color:              var(--ink-2);
   --md-code-fg-color:              var(--paper);
-  --md-code-hl-color:              rgba(255,90,31,0.15);
-  --md-code-hl-color--light:       rgba(255,90,31,0.08);
+  --md-code-hl-color:              rgba(79,199,230,0.15);
+  --md-code-hl-color--light:       rgba(79,199,230,0.08);
   --md-code-hl-name-color:         var(--paper);
   --md-code-hl-keyword-color:      var(--signal);
   --md-code-hl-string-color:       var(--acid);
@@ -116,9 +122,13 @@
   --md-mermaid-sequence-loop-border-color:  var(--rule-2);
   --md-mermaid-sequence-message-fg-color:   var(--paper-dim);
   --md-mermaid-sequence-message-line-color: var(--mute);
-  --md-mermaid-sequence-note-bg-color:      var(--ink-2);
+  /* Soft filled label, not a hard-bordered box: mermaid under-sizes note
+     rects (text can exceed the rect by ~20px), and a crisp cyan border makes
+     that overflow read as broken. Border matches the fill so there is no hard
+     edge for text to cross. */
+  --md-mermaid-sequence-note-bg-color:      var(--ink-3);
   --md-mermaid-sequence-note-fg-color:      var(--paper);
-  --md-mermaid-sequence-note-border-color:  var(--signal);
+  --md-mermaid-sequence-note-border-color:  var(--ink-3);
   --md-mermaid-sequence-number-bg-color:    var(--signal);
   --md-mermaid-sequence-number-fg-color:    var(--ink);
 }
@@ -154,7 +164,7 @@ body {
 
 img { max-width: 100%; display: block; }
 
-em.serif { font-family: var(--serif); font-style: italic; font-weight: 400; }
+em.serif { font-family: var(--serif); font-style: normal; font-weight: 500; }
 
 /* Skip-to-content link */
 .skiplink {
@@ -203,15 +213,13 @@ body::before {
   background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 1 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
 }
 body::after {
-  background: radial-gradient(ellipse at center, transparent 50%, rgba(0,0,0,0.45) 100%);
+  background: radial-gradient(ellipse at center, transparent 65%, rgba(0,0,0,0.14) 100%);
 }
 
-/* Subtle warm tint behind the canvas, like the reference. */
+/* Flat cool gradient behind the canvas — no colored glow. */
 .md-container,
 .page--home {
   background-image:
-    radial-gradient(circle at 18% 6%, rgba(255,90,31,0.05), transparent 38%),
-    radial-gradient(circle at 92% 84%, rgba(225,255,110,0.025), transparent 42%),
     linear-gradient(180deg, var(--ink) 0%, var(--ink-2) 100%);
 }
 
@@ -238,8 +246,8 @@ body::after {
 .blueprint__grid {
   position: absolute; inset: 0;
   background-image:
-    linear-gradient(to right, rgba(236,227,206,0.04) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(236,227,206,0.04) 1px, transparent 1px);
+    linear-gradient(to right, rgba(199,204,212,0.04) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(199,204,212,0.04) 1px, transparent 1px);
   background-size: 64px 64px;
   -webkit-mask-image: linear-gradient(180deg, transparent, black 12%, black 88%, transparent);
           mask-image: linear-gradient(180deg, transparent, black 12%, black 88%, transparent);
@@ -267,7 +275,7 @@ header.rail {
   align-items: center;
   gap: 24px;
   padding: 14px var(--gutter);
-  background: rgba(11,11,9,0.72);
+  background: rgba(13,15,18,0.72);
   backdrop-filter: blur(14px) saturate(140%);
   -webkit-backdrop-filter: blur(14px) saturate(140%);
   border-bottom: 1px solid var(--rule);
@@ -291,20 +299,23 @@ a.rail__brand:hover .rail__sub  { color: var(--paper-dim); }
 a.rail__brand:focus-visible { outline-offset: 4px; }
 .rail__nav a[aria-current="page"] { color: var(--signal); font-weight: 700; }
 .rail__mark {
-  display: inline-block;
-  color: var(--signal);
-  font-size: 18px;
+  display: inline-flex;
+  width: 20px;
+  height: 20px;
   transform: translateY(-1px);
   animation: spin 24s linear infinite;
 }
+.rail__mark svg { width: 100%; height: 100%; display: block; }
+.rail__mark__ring { fill: var(--paper-dim); }
+.rail__mark__sq   { fill: var(--signal); }
 .rail__name {
-  font-family: var(--serif);
-  font-style: italic;
-  font-size: 22px;
+  font-family: var(--mono);
+  font-style: normal;
+  font-size: 15px;
   text-transform: lowercase;
   letter-spacing: -0.01em;
   color: var(--paper);
-  font-weight: 400;
+  font-weight: 600;
 }
 .rail__sep { color: var(--rule-2); }
 .rail__sub { color: var(--mute); }
@@ -328,7 +339,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .rail__org em.serif {
   color: var(--paper);
-  font-style: italic;
+  font-style: normal;
   font-family: var(--serif);
 }
 .rail__org:hover { color: var(--signal); border-bottom-color: var(--signal); }
@@ -362,8 +373,8 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 @media (max-width: 540px) {
   header.rail { padding: 12px 16px; gap: 10px; }
   .rail__brand { gap: 6px; min-width: 0; }
-  .rail__name { font-size: 18px; }
-  .rail__mark { font-size: 16px; }
+  .rail__name { font-size: 14px; }
+  .rail__mark { width: 17px; height: 17px; }
   .rail__nav { gap: 12px; font-size: 11px; }
   .rail__cta { padding: 5px 8px; }
 }
@@ -475,15 +486,14 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   flex: 0 1 auto;
   min-width: 0;
   font-family: var(--serif);
-  font-weight: 300;
-  /* Smaller scale than sister sites: mcp-data-platform is 17 characters,
-     so the same 8vw / 140px ceiling overflows. Cap at 100px to keep
-     row 1 on a single line at all viewport widths. */
-  font-size: clamp(36px, 6vw, 100px);
-  line-height: 0.95;
-  letter-spacing: -0.035em;
+  font-weight: 500;
+  /* Mono display runs ~1.5x wider than the former optical serif, so the
+     17-character name overflowed at the old 100px ceiling. Cap lower to keep
+     row 1 on a single line beside the left mark and the right hero__stamp. */
+  font-size: clamp(24px, 3.4vw, 52px);
+  line-height: 1.02;
+  letter-spacing: -0.02em;
   margin: 0;
-  font-variation-settings: "opsz" 144;
 }
 .page--home .hero__row--1 em.serif,
 .page--home .hero__row--3 em.serif { white-space: nowrap; }
@@ -495,9 +505,8 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 .page--home .hero__row--2 { animation: rise 1.1s .4s both ease-out; }
 .page--home .hero__row--3 { animation: rise 1.1s .55s both ease-out; }
 .page--home .hero__row em.serif {
-  font-style: italic;
+  font-style: normal;
   color: var(--paper);
-  font-variation-settings: "opsz" 144;
 }
 .page--home .outline {
   -webkit-text-stroke: 1.5px var(--paper);
@@ -545,23 +554,12 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-family: var(--mono);
   font-size: 0.9em;
   color: var(--signal-2);
-  background: rgba(255,90,31,0.08);
+  background: rgba(79,199,230,0.08);
   border-radius: 2px;
   padding: 1px 5px;
 }
 .page--home .hero__lede--muted { color: var(--mute); }
 
-.page--home .dropcap {
-  font-family: var(--serif);
-  font-style: italic;
-  font-size: 3.4em;
-  line-height: 0.85;
-  float: left;
-  padding: 6px 10px 0 0;
-  color: var(--signal);
-  font-weight: 400;
-  font-variation-settings: "opsz" 144;
-}
 
 @media (max-width: 880px) {
   .page--home .hero__main {
@@ -641,15 +639,14 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .page--home .section__title {
   font-family: var(--serif);
-  font-weight: 300;
-  font-size: clamp(36px, 5.5vw, 76px);
-  line-height: 1.0;
-  letter-spacing: -0.025em;
+  font-weight: 600;
+  font-size: clamp(28px, 3.8vw, 52px);
+  line-height: 1.08;
+  letter-spacing: -0.02em;
   color: var(--paper);
-  font-variation-settings: "opsz" 144;
   margin-bottom: 24px;
 }
-.page--home .section__title em.serif { color: var(--signal); font-style: italic; }
+.page--home .section__title em.serif { color: var(--signal); font-style: normal; }
 .page--home .section__lede {
   color: var(--paper-dim);
   max-width: 64ch;
@@ -660,7 +657,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-family: var(--mono);
   font-size: 0.9em;
   color: var(--signal-2);
-  background: rgba(255,90,31,0.08);
+  background: rgba(79,199,230,0.08);
   border-radius: 2px;
   padding: 1px 5px;
 }
@@ -716,13 +713,12 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 .page--home .flagship__url:hover { color: var(--signal-2); border-bottom-color: var(--signal-2); }
 .page--home .flagship__name {
   font-family: var(--serif);
-  font-weight: 300;
-  font-style: italic;
-  font-size: clamp(48px, 5vw, 80px);
-  line-height: 0.95;
-  letter-spacing: -0.03em;
+  font-weight: 600;
+  font-style: normal;
+  font-size: clamp(30px, 3.4vw, 48px);
+  line-height: 1.0;
+  letter-spacing: -0.02em;
   color: var(--paper);
-  font-variation-settings: "opsz" 144;
   margin-bottom: 12px;
 }
 .page--home .flagship__tag {
@@ -735,7 +731,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 .page--home .flagship__tag code {
   font-size: .92em;
   color: var(--signal);
-  background: rgba(255,90,31,0.08);
+  background: rgba(79,199,230,0.08);
   padding: 1px 6px;
   border-radius: 2px;
 }
@@ -748,7 +744,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .page--home .flagship__body code {
   color: var(--signal-2);
-  background: rgba(255,90,31,0.07);
+  background: rgba(79,199,230,0.07);
   padding: 1px 5px;
   border-radius: 2px;
   font-size: .9em;
@@ -767,7 +763,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 .page--home .flagship__card--server { background: var(--ink-2); }
 .page--home .flagship__card--lib {
   background:
-    linear-gradient(135deg, rgba(255,90,31,0.025), transparent 60%),
+    linear-gradient(135deg, rgba(79,199,230,0.025), transparent 60%),
     var(--ink-2);
 }
 
@@ -857,7 +853,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .page--home .stack__row {
   display: grid;
-  grid-template-columns: 80px 1fr 130px 40px;
+  grid-template-columns: 1fr auto;
   align-items: center;
   gap: 24px;
   padding: 24px 8px;
@@ -872,21 +868,15 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .page--home .stack__row:hover .stack__name { color: var(--signal); }
 .page--home .stack__row:hover .stack__year { color: var(--signal); transform: translateX(4px); }
-.page--home .stack__num {
-  font-family: var(--mono);
-  color: var(--mute-2);
-  font-size: 13px;
-  letter-spacing: 0.08em;
-}
 .page--home .stack__name {
   display: block;
   font-family: var(--serif);
-  font-style: italic;
-  font-size: clamp(24px, 2.5vw, 34px);
+  font-style: normal;
+  font-weight: 600;
+  font-size: clamp(22px, 2.2vw, 30px);
   color: var(--paper);
-  line-height: 1.05;
+  line-height: 1.1;
   transition: color .25s;
-  font-variation-settings: "opsz" 144;
   margin-bottom: 6px;
   text-decoration: none;
 }
@@ -900,22 +890,9 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-family: var(--mono);
   font-size: 0.9em;
   color: var(--signal-2);
-  background: rgba(255,90,31,0.08);
+  background: rgba(79,199,230,0.08);
   border-radius: 2px;
   padding: 1px 5px;
-}
-.page--home .stack__tag {
-  font-family: var(--mono);
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  color: var(--mute);
-  text-align: right;
-  border: 1px solid var(--rule);
-  padding: 5px 10px;
-  border-radius: 2px;
-  background: rgba(0,0,0,0.2);
-  justify-self: end;
 }
 .page--home .stack__year {
   font-family: var(--mono);
@@ -932,8 +909,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 
 @media (max-width: 760px) {
-  .page--home .stack__row { grid-template-columns: 50px 1fr 50px; }
-  .page--home .stack__tag { display: none; }
+  .page--home .stack__row { grid-template-columns: 1fr auto; }
 }
 
 /* ──────────────────────────────────────────────────────────────
@@ -958,13 +934,13 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .page--home .coda__big {
   font-family: var(--serif);
-  font-weight: 300;
-  font-size: clamp(28px, 3.6vw, 52px);
-  line-height: 1.15;
-  letter-spacing: -0.02em;
+  font-weight: 500;
+  font-size: clamp(14px, 1.05vw, 16px);
+  line-height: 1.6;
+  letter-spacing: 0;
   color: var(--paper);
-  font-variation-settings: "opsz" 144;
-  margin-bottom: 48px;
+  margin-bottom: 28px;
+  max-width: 72ch;
 }
 .page--home .coda__big a { color: inherit; }
 .page--home .coda__big em.serif { color: var(--signal); }
@@ -1099,8 +1075,8 @@ a.btn:focus-visible { outline-offset: 4px; }
 .home-footer__links a:hover { color: var(--signal); }
 .home-footer__links__sub {
   color: var(--mute);
-  font-style: italic;
-  font-family: var(--serif);
+  font-style: normal;
+  font-family: var(--mono);
   font-size: 12.5px;
   margin-left: 4px;
 }
@@ -1134,7 +1110,7 @@ a.btn:focus-visible { outline-offset: 4px; }
 
 /* Header (kept on inner pages, rail-styled) */
 .md-header {
-  background: rgba(11,11,9,0.86);
+  background: rgba(13,15,18,0.86);
   backdrop-filter: blur(14px) saturate(140%);
   -webkit-backdrop-filter: blur(14px) saturate(140%);
   border-bottom: 1px solid var(--rule);
@@ -1143,17 +1119,17 @@ a.btn:focus-visible { outline-offset: 4px; }
 }
 .md-header[data-md-state="shadow"] { box-shadow: none; }
 .md-header__title {
-  font-family: var(--serif);
-  font-style: italic;
-  font-weight: 300;
-  font-size: 22px;
+  font-family: var(--mono);
+  font-style: normal;
+  font-weight: 600;
+  font-size: 16px;
   letter-spacing: -0.01em;
   color: var(--paper);
 }
 .md-header__title .md-header__topic {
-  font-family: var(--serif);
-  font-style: italic;
-  font-weight: 300;
+  font-family: var(--mono);
+  font-style: normal;
+  font-weight: 600;
   color: var(--paper);
   transition: color .2s ease;
 }
@@ -1253,29 +1229,28 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
   color: var(--mute);
 }
 
-/* Inner-page typography (Fraunces headings, paper body) */
+/* Inner-page typography — headings in the technical mono display face,
+   body in the sans. Non-italic: the direction moved off the italic serif. */
 .md-content { background: transparent; color: var(--paper); }
 .md-typeset { color: var(--paper); font-family: var(--sans); }
 
 .md-typeset h1 {
   font-family: var(--serif);
-  font-weight: 300;
-  font-style: italic;
-  font-variation-settings: "opsz" 144;
-  font-size: clamp(36px, 4.4vw, 60px);
-  line-height: 1.0;
-  letter-spacing: -0.025em;
+  font-weight: 600;
+  font-style: normal;
+  font-size: clamp(30px, 4vw, 46px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
   color: var(--paper);
   margin: 0 0 0.6em;
 }
 .md-typeset h2 {
   font-family: var(--serif);
-  font-weight: 300;
-  font-style: italic;
-  font-variation-settings: "opsz" 144;
-  font-size: clamp(26px, 2.8vw, 38px);
-  line-height: 1.05;
-  letter-spacing: -0.02em;
+  font-weight: 600;
+  font-style: normal;
+  font-size: clamp(22px, 2.4vw, 32px);
+  line-height: 1.15;
+  letter-spacing: -0.015em;
   color: var(--paper);
   margin: 1.6em 0 0.5em;
 }
@@ -1407,11 +1382,11 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
 
 .md-typeset p, .md-typeset li { color: var(--paper); }
 .md-typeset strong { color: var(--paper); font-weight: 700; }
-.md-typeset em { font-family: var(--serif); font-style: italic; }
+.md-typeset em { font-family: var(--sans); font-style: italic; }
 
 .md-typeset a {
   color: var(--signal);
-  border-bottom: 1px solid rgba(255,90,31,0.25);
+  border-bottom: 1px solid rgba(79,199,230,0.25);
   text-decoration: none;
   transition: color .15s, border-color .15s;
 }
@@ -1475,7 +1450,7 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
 }
 .md-clipboard {
   color: var(--mute);
-  background: rgba(11,11,9,0.6);
+  background: rgba(13,15,18,0.6);
   border-radius: 2px;
 }
 .md-clipboard:hover { color: var(--signal); }
@@ -1498,14 +1473,15 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
 /* Admonitions */
 .md-typeset .admonition,
 .md-typeset details {
+  --adm: var(--signal);
   background: var(--ink-2);
   border: 1px solid var(--rule);
-  border-left: 2px solid var(--signal);
   border-radius: 2px;
   box-shadow: none;
   font-size: 14.5px;
   color: var(--paper-dim);
 }
+/* Type is signalled by the title + icon color, not an accent left rail. */
 .md-typeset .admonition-title,
 .md-typeset summary {
   background: transparent;
@@ -1514,22 +1490,32 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
   font-weight: 700;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--paper);
+  color: var(--adm);
   border-bottom: 1px solid var(--rule);
 }
 .md-typeset .admonition-title::before,
-.md-typeset summary::before { background-color: var(--signal); }
+.md-typeset summary::before { background-color: var(--adm); }
 
 .md-typeset .admonition.note,
-.md-typeset details.note { border-left-color: var(--cool); }
+.md-typeset details.note { --adm: var(--cool); }
 .md-typeset .admonition.warning,
-.md-typeset details.warning { border-left-color: var(--signal); }
+.md-typeset details.warning { --adm: var(--signal); }
 .md-typeset .admonition.danger,
-.md-typeset details.danger { border-left-color: var(--signal); }
+.md-typeset details.danger { --adm: var(--signal); }
 .md-typeset .admonition.tip,
-.md-typeset details.tip { border-left-color: var(--acid); }
+.md-typeset details.tip { --adm: var(--acid); }
 .md-typeset .admonition.success,
-.md-typeset details.success { border-left-color: var(--acid); }
+.md-typeset details.success { --adm: var(--acid); }
+
+/* Material ships per-type border + icon colors as 3-class selectors
+   (e.g. `.md-typeset .admonition.warning { border-color: #ff9100 }`) that
+   outrank the neutral base rule above and reintroduce amber/blue boxes.
+   Match that specificity with `[class]` so every admonition keeps a neutral
+   border and takes its title + icon color only from --adm — no colored box. */
+.md-typeset .admonition[class],
+.md-typeset details[class] { border-color: var(--rule); }
+.md-typeset .admonition[class] > .admonition-title::before,
+.md-typeset details[class] > summary::before { background-color: var(--adm); }
 
 /* Tables */
 .md-typeset table:not([class]) {
@@ -1642,10 +1628,20 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
 .md-copyright a:hover { color: var(--signal); }
 .md-social a { color: var(--mute); }
 .md-social a:hover { color: var(--signal); }
-.md-footer__title { background: var(--ink); color: var(--paper); }
-.md-footer__direction { color: var(--mute); font-family: var(--mono); }
-.md-footer__link { color: var(--paper-dim); }
-.md-footer__link:hover { color: var(--signal); opacity: 1; }
+.md-footer__inner { padding: 8px 0; gap: 12px; }
+.md-footer__link { color: var(--paper-dim); padding: 20px 16px; border-radius: 6px; transition: background .2s, color .2s; opacity: 1; }
+.md-footer__link:hover { color: var(--signal); background: var(--ink-3); }
+.md-footer__title { background: transparent; color: var(--paper); font-weight: 500; line-height: 1.3; }
+.md-footer__direction {
+  color: var(--mute);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 1;
+}
+.md-footer__button { color: var(--mute); transition: color .2s; }
+.md-footer__link:hover .md-footer__button { color: var(--signal); }
 
 /* Hide Material's default content button on homepage */
 .page--home .md-content__button { display: none; }
@@ -1737,7 +1733,7 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
   transition: background 0.15s, color 0.15s;
 }
 .mermaid-fs-btn:hover {
-  background: rgba(255,90,31,0.12);
+  background: rgba(79,199,230,0.12);
   color: var(--signal);
 }
 
@@ -1746,7 +1742,7 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
   color: var(--signal);
 }
 .mermaid-fs-close:hover {
-  background: rgba(255,90,31,0.16);
+  background: rgba(79,199,230,0.16);
   color: var(--signal);
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ edit_uri: edit/main/docs/
 not_in_nav: |
   /research/
 
-copyright: Copyright &copy; 2025 - 2026 Craig Johnston / Deasil Works, Inc.
+copyright: Copyright &copy; 2025 - 2026 <a href="https://imti.co">Craig Johnston</a> / <a href="https://deasil.works">Deasil Works, Inc.</a> / <a href="https://plexara.io">Plexara</a>
 
 theme:
   name: material


### PR DESCRIPTION
## Summary

Re-skins the documentation site's type and color system and fixes several legibility and content issues across the homepage and reference pages. The changes are token-driven and apply site-wide (homepage and inner docs) with no structural changes to the MkDocs Material layout.

## Type system

Headings and code are set in Geist Mono and body in Geist; the Fraunces display serif is removed everywhere. Inner-page and homepage headings are non-italic mono. Emphasis in prose is Geist italic rather than a display face.

## Color

The palette is a cool graphite grey ground (`--ink` `#1E232A`) with a single restrained cyan accent (`--signal` `#4FC7E6`). The previous warm palette, the orange radial glow, and the edge vignette that crushed the background toward black are removed; the remaining hardcoded orange tints are remapped to cyan and the blueprint grid lines are cooled. Code-syntax hues are tuned for the grey ground.

## Chrome

The header uses the real `mcp-data-platform` symbol (concentric aperture plus accent square) in place of the glyph mark, and the live UTC clock is removed from the header and footer.

The top-rail navigation now tracks the current section. Each rail link declares the path prefixes it owns via `data-scope`, and a small tracker subscribes to Material's `document$` so the active item follows navigation — including instant navigation, which swaps content without re-rendering the header — instead of remaining on "home".

Admonitions and the active nav item no longer use an accent left rail; type is signalled through the title and icon color, and Material's built-in per-type admonition border colors are neutralized so every callout reads as a plain bordered box on the grey ground.

The previous/next footer links drop the cramped title box for clean labels with a hover state, and the copyright line links Craig Johnston to imti.co, Deasil Works, Inc. to deasil.works, and adds Plexara at plexara.io.

## Homepage

The intro paragraph no longer splits the product name with a dropcap, and the closing "open source" paragraph is set at normal reading size rather than display size.

The "what it does" feature list drops the `001`–`00N` numbering and the uppercase tag chips; it is now an unordered list of capability name plus description.

## Reference content

The benchmarks page gains a "How to read this page" legend up front that defines the shorthand in plain language: the arms (A0 raw tools, A2 platform, A3 lifecycle), the suites (S1 discovery, S3 knowledge traps, S5 memory lifecycle), the scores (`3/3`, pass^k, median and p90 tool calls), and the trap classes (`units_cents`, `net_revenue`). Every definition is derived from the page's existing content.

## Mermaid

Mermaid under-sizes sequence-diagram note rectangles, so note text can exceed the rect by roughly twenty pixels. The note box now uses a fill-matched border instead of a hard accent border, so the overflow reads as a soft label rather than a broken box. Styling is applied through the `--md-mermaid-*` custom properties, which reach the diagram across the Shadow DOM boundary.
