### PR TITLE
bench(s5): per-stage diagnosis instrumentation + isolated supersede sub-benchmark (#964)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -934,6 +934,36 @@ bench-lifecycle-report:
 	@cd bench && $(GO) build -o ../$(BUILD_DIR)/benchrun ./benchrun
 	$(BUILD_DIR)/benchrun -lifecycle -summarize build/bench-results/lifecycle-a3.json
 
+## bench-supersede: Run the isolated supersede sub-benchmark (issue #964; needs bench-up BENCH_ARM=a3; LLM=anthropic|scripted|claude-cli, K=, MODEL=, TEACH_BUDGET=)
+bench-supersede:
+	@mkdir -p build/bench-results
+	@cd bench && $(GO) build -o ../$(BUILD_DIR)/benchrun ./benchrun
+	@echo "Resetting search-first gate state (discovery scopes persist in Postgres across runs)..."
+	@$(BENCH_COMPOSE) exec -T postgres psql -q -U platform -d mcp_platform -v ON_ERROR_STOP=1 \
+		-c "TRUNCATE search_gate_discovery"
+	$(BUILD_DIR)/benchrun \
+		-supersede \
+		-arm a3 \
+		-url $(BENCH_URL) \
+		-credential $(BENCH_KEY) \
+		-protocols bench/protocols \
+		-git-commit $$(git rev-parse HEAD) \
+		-out build/bench-results/supersede-a3.json \
+		$(if $(LLM),-llm $(LLM),) \
+		$(if $(SCRIPT),-script $(SCRIPT),) \
+		$(if $(K),-k $(K),) \
+		$(if $(MODEL),-model $(MODEL),) \
+		$(if $(TEACH_BUDGET),-teach-budget $(TEACH_BUDGET),)
+
+## bench-supersede-smoke: Run the scripted (no-API-key) supersede sub-benchmark against the running a3 platform
+bench-supersede-smoke:
+	@$(MAKE) bench-supersede LLM=scripted SCRIPT=bench/protocols/scripted-lifecycle-smoke.json K=1
+
+## bench-supersede-report: Print the human summary of the last supersede sub-benchmark run
+bench-supersede-report:
+	@cd bench && $(GO) build -o ../$(BUILD_DIR)/benchrun ./benchrun
+	$(BUILD_DIR)/benchrun -supersede -summarize build/bench-results/supersede-a3.json
+
 ## bench-cold-start: Run the cold-start knowledge-growth curriculum (issue #963; needs an empty-seeded a3: bench-up BENCH_ARM=a3 BENCH_SEED_PAGES=0 + bench-seed-datahub-empty; LLM=anthropic|scripted|claude-cli, K=, MODEL=)
 bench-cold-start:
 	@mkdir -p build/bench-results

--- a/bench/README.md
+++ b/bench/README.md
@@ -219,6 +219,62 @@ applicable lifecycle). Harness-level failures (connect, adapter, API read-back)
 are excluded from the metrics and reported separately, mirroring the S1–S3
 pipeline.
 
+### Per-stage diagnosis instrumentation (#964)
+
+Three metrics decompose the S5 gaps the phase-4 data exposed, so a weak headline
+number can be attributed rather than guessed:
+
+- **transfer surfaced** and **used given surfaced** split the transfer rate. A
+  transfer attempt records whether the promoted fact actually appeared in a tool
+  result the learner saw (`transfer_surfaced`), and among those, whether the
+  answer was correct (`transfer_used_given_surfaced`). A low surfaced rate points
+  at delivery (cross-enrichment or search did not carry the fact to the second
+  identity); a low used-given-surfaced rate points at reasoning (the agent had
+  the fact and ignored it). Surfacing is a normalized-substring match of the
+  promoted content against the episode's tool results, so it is a conservative
+  "the fact was present", not a paraphrase match.
+- **capture budget-starved** is, among capture misses, the fraction where the
+  teach episode exhausted its tool-call budget without executing a capture call —
+  the discovery-budget-exhaustion failure mode. A capture request the budget
+  refused (emitted only after the budget was spent) counts as starved, not as an
+  attempted capture. The rate is measured on the in-process loop path, which owns
+  the tool-call budget; claude-cli runs manage their own turn budget, so their
+  capture misses are excluded from this rate (`teach_budget_exhausted` is left
+  unset) rather than miscounted as not-starved.
+
+The **capture-budget lever** `-teach-budget N` overrides the per-episode tool-call
+budget for the capture-bearing stages (teach and update), so the capture-rate
+lift from a larger teach budget can be measured directly against the same
+protocol set.
+
+## Supersede sub-benchmark (#964)
+
+`-supersede` runs the recall-first supersede gate **in isolation**: it drives
+only the supersede protocols (those with an `update` stage) through teach →
+capture-verify → correct → supersede-status check, skipping the promote,
+transfer, personal-recall, and abstain stages that otherwise dilute the signal.
+The isolated harness exists because the S5 duplicate rate was the noisiest S5
+metric (0% vs 42.9% between identical runs); measuring supersede on its own, with
+a per-protocol stability breakdown, makes that instability visible per protocol
+instead of hidden in one blended range.
+
+Metrics: **capture rate**, **supersede rate** (original superseded, higher is
+better), **duplicate rate** (its complement, lower is better), **update
+correctness**, **pass^k**, and a per-protocol `superseded`/`duplicated` count
+across the k attempts. Because the supersede gate is embedding-similarity based
+(nomic-embed-text), the threshold / embedding-model / deterministic-fallback
+evaluation is done by re-running this sub-benchmark against platforms configured
+differently and comparing the supersede rate — the sub-benchmark is the measuring
+instrument; the platform config is the independent variable.
+
+```bash
+make bench-up BENCH_ARM=a3
+make bench-supersede-smoke               # scripted no-API-key validation
+make bench-supersede K=3                 # real run (needs ANTHROPIC_API_KEY)
+make bench-supersede K=3 TEACH_BUDGET=20 # same, with the larger teach budget lever
+make bench-supersede-report              # human summary of the last supersede run
+```
+
 ## Cold-start knowledge growth (#963)
 
 The S1-S3 and S5 suites ablate the platform with a **pre-seeded** knowledge base.
@@ -422,7 +478,7 @@ bench/
     ├── grade/           deterministic graders (numeric, entity, execution-result)
     ├── judge/           LLM judge + calibration harness
     ├── pipeline/        task x k orchestration
-    ├── lifecycle/       S5 protocol runner, stage graders, metrics, results model
+    ├── lifecycle/       S5 protocol runner, stage graders, metrics, results model, per-stage diagnosis instrumentation + isolated supersede sub-benchmark (#964)
     ├── coldstart/       cold-start curriculum runner, learning-curve metrics, results model
     ├── report/          results model, aggregates, cross-arm comparison
     └── target/          endpoint + Bearer auth

--- a/bench/benchrun/main.go
+++ b/bench/benchrun/main.go
@@ -57,6 +57,8 @@ type config struct {
 	merge         string
 	coldStart     bool
 	curriculumDir string
+	supersede     bool
+	teachBudget   int
 }
 
 func main() {
@@ -100,6 +102,8 @@ func parseFlags() config {
 	flag.StringVar(&cfg.merge, "merge", "", "comma-separated per-pass lifecycle result JSONs (with -lifecycle): merge independent k=1 passes into one k=N result and exit")
 	flag.BoolVar(&cfg.coldStart, "cold-start", false, "run the cold-start knowledge-growth curriculum (issue #963) instead of the task suites")
 	flag.StringVar(&cfg.curriculumDir, "curriculum", "curriculum", "curriculum YAML directory (with -cold-start)")
+	flag.BoolVar(&cfg.supersede, "supersede", false, "run the isolated supersede sub-benchmark (issue #964: the supersede protocols only) instead of the full S5 lifecycle")
+	flag.IntVar(&cfg.teachBudget, "teach-budget", 0, "override the per-episode tool-call budget for the capture-bearing stages (teach, update); 0 = protocol budget (issue #964 capture-budget lever)")
 	flag.Parse()
 	return cfg
 }
@@ -112,6 +116,9 @@ func run(cfg config) error {
 	}
 	if cfg.coldStart {
 		return runColdStart(cfg)
+	}
+	if cfg.supersede {
+		return runSupersede(cfg)
 	}
 	if cfg.lifecycle {
 		return runLifecycle(cfg)
@@ -147,6 +154,12 @@ func runSummarize(cfg config) error {
 	switch {
 	case cfg.coldStart:
 		res, err := coldstart.LoadJSON(cfg.summarize)
+		if err != nil {
+			return err
+		}
+		fmt.Print(res.HumanSummary())
+	case cfg.supersede:
+		res, err := lifecycle.LoadSupersedeJSON(cfg.summarize)
 		if err != nil {
 			return err
 		}
@@ -193,6 +206,7 @@ func runLifecycle(cfg config) error {
 		GitCommit:     cfg.gitCommit,
 		AuditTimeout:  cfg.auditTimeout,
 		IdentityKeys:  cfg.identityKeys,
+		TeachBudget:   cfg.teachBudget,
 		// Flush the results file after every protocol so an interruption (timeout,
 		// exhausted API budget, crash) never discards completed, paid-for work.
 		OnProtocol: func(r *lifecycle.Results) {
@@ -216,6 +230,60 @@ func runLifecycle(cfg config) error {
 		opts.Factory = factory
 	}
 	res, runErr := lifecycle.Run(context.Background(), opts)
+	if res != nil {
+		if err := writeAndSummarize(res, cfg.out); err != nil {
+			return err
+		}
+	}
+	return runErr
+}
+
+// runSupersede executes the isolated supersede sub-benchmark (issue #964) and
+// writes outputs. It reuses the lifecycle adapter/factory wiring but drives only
+// the supersede protocols through teach -> capture -> correct -> status-check,
+// producing the focused supersede scorecard. Like the other runs the results
+// JSON is flushed per attempt so an interruption never discards paid-for work.
+func runSupersede(cfg config) error {
+	if cfg.arm == "" {
+		return errors.New("-arm is required")
+	}
+	if cfg.baseline != "" {
+		return errors.New("-baseline is not supported with -supersede (the regression gate scores S1-S3 task suites, not supersede metrics)")
+	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	opts := lifecycle.Options{
+		Target:        target.Target{BaseURL: cfg.url, Credential: cfg.credential},
+		HTTPTimeout:   cfg.httpTimeout,
+		Arm:           cfg.arm,
+		K:             cfg.k,
+		ProtocolsDir:  cfg.protocolsDir,
+		TranscriptDir: transcriptDir(cfg.out),
+		LLMProvider:   cfg.llmProvider,
+		GitCommit:     cfg.gitCommit,
+		AuditTimeout:  cfg.auditTimeout,
+		IdentityKeys:  cfg.identityKeys,
+		TeachBudget:   cfg.teachBudget,
+		OnSupersede: func(r *lifecycle.SupersedeResults) {
+			if err := r.WriteJSON(cfg.out); err != nil {
+				log.Warn("checkpoint write", "error", err)
+			}
+		},
+		Log: log,
+	}
+	if cfg.llmProvider == claudeCLIProvider {
+		runner, version, err := buildClaudeRunner(cfg)
+		if err != nil {
+			return err
+		}
+		opts.ClaudeCLI, opts.ClientVersion = runner, version
+	} else {
+		factory, err := buildLifecycleFactory(cfg)
+		if err != nil {
+			return err
+		}
+		opts.Factory = factory
+	}
+	res, runErr := lifecycle.RunSupersede(context.Background(), opts)
 	if res != nil {
 		if err := writeAndSummarize(res, cfg.out); err != nil {
 			return err

--- a/bench/benchrun/main_test.go
+++ b/bench/benchrun/main_test.go
@@ -76,6 +76,24 @@ func TestMergeRequiresLifecycle(t *testing.T) {
 	}
 }
 
+// TestSupersedeRequiresArm proves the supersede sub-benchmark refuses to start
+// without an arm rather than launching an unattributable run.
+func TestSupersedeRequiresArm(t *testing.T) {
+	if err := runSupersede(config{supersede: true}); err == nil {
+		t.Fatal("supersede run accepted an empty arm")
+	}
+}
+
+// TestSupersedeRejectsBaseline proves -baseline is refused for supersede runs:
+// the regression gate scores the S1-S3 task shape, not supersede metrics, so a
+// silently-ignored -baseline would give a false sense of gating.
+func TestSupersedeRejectsBaseline(t *testing.T) {
+	err := runSupersede(config{supersede: true, arm: "a3", baseline: "b.json"})
+	if err == nil {
+		t.Fatal("supersede run accepted -baseline")
+	}
+}
+
 // baselineFile writes a results JSON to a temp path and returns it, standing in
 // for a committed baseline that gateOnBaseline loads from disk.
 func baselineFile(t *testing.T, r *report.Results) string {

--- a/bench/internal/agent/agent.go
+++ b/bench/internal/agent/agent.go
@@ -15,6 +15,13 @@ import (
 // stops with whatever text it has.
 const extraIterations = 2
 
+// BudgetRefusalText is the tool-result text returned for a call the budget
+// refused (never executed). It is exported so transcript consumers can tell a
+// budget-refused tool request apart from one that actually ran — a capture
+// request refused for budget did not "attempt" capture in any way that could
+// have succeeded.
+const BudgetRefusalText = "tool-call budget exhausted; no further tool calls are executed"
+
 // ToolExecutor executes one tool call against the live session and returns its
 // result. Transport-level failures are reported as error results so the model
 // can adapt, mirroring how a real client surfaces them.
@@ -91,7 +98,7 @@ func executeCalls(ctx context.Context, calls []llm.ToolCall, budget int, exec To
 			res.BudgetExhausted = true
 			reply.ToolResults = append(reply.ToolResults, llm.ToolResult{
 				CallID:  call.ID,
-				Text:    "tool-call budget exhausted; no further tool calls are executed",
+				Text:    BudgetRefusalText,
 				IsError: true,
 			})
 			continue

--- a/bench/internal/lifecycle/diagnosis_test.go
+++ b/bench/internal/lifecycle/diagnosis_test.go
@@ -1,0 +1,186 @@
+package lifecycle
+
+import (
+	"context"
+	"testing"
+
+	"github.com/txn2/mcp-data-platform/bench/internal/llm"
+	"github.com/txn2/mcp-data-platform/bench/internal/protocol"
+)
+
+// TestAggregateDecomposition verifies the transfer-gap and capture-budget
+// decompositions from synthesized runs, independent of the live harness.
+func TestAggregateDecomposition(t *testing.T) {
+	res := &Results{
+		Manifest: Manifest{K: 1},
+		Runs: []ProtocolRun{
+			// transfer: surfaced and used
+			{ProtocolID: "a", Captured: new(true), TransferSurfaced: new(true), TransferCorrect: new(true)},
+			// transfer: surfaced but not used
+			{ProtocolID: "b", Captured: new(true), TransferSurfaced: new(true), TransferCorrect: new(false)},
+			// transfer: not surfaced
+			{ProtocolID: "c", Captured: new(true), TransferSurfaced: new(false), TransferCorrect: new(false)},
+			// capture miss, budget-starved before any capture call
+			{ProtocolID: "d", Captured: new(false), CaptureAttempted: new(false), TeachBudgetExhausted: new(true)},
+			// capture miss, but capture was attempted (not a budget-starvation miss)
+			{ProtocolID: "e", Captured: new(false), CaptureAttempted: new(true), TeachBudgetExhausted: new(false)},
+			// capture miss on a path where budget is not observable (claude-cli:
+			// TeachBudgetExhausted nil) — excluded from the starvation denominator.
+			{ProtocolID: "f", Captured: new(false), CaptureAttempted: new(false), TeachBudgetExhausted: nil},
+		},
+	}
+	res.Aggregate()
+	m := res.Metrics
+
+	if m.TransferSurfaced.Num != 2 || m.TransferSurfaced.Den != 3 {
+		t.Errorf("transfer surfaced = %d/%d, want 2/3", m.TransferSurfaced.Num, m.TransferSurfaced.Den)
+	}
+	if m.TransferUsedGivenSurfaced.Num != 1 || m.TransferUsedGivenSurfaced.Den != 2 {
+		t.Errorf("used given surfaced = %d/%d, want 1/2", m.TransferUsedGivenSurfaced.Num, m.TransferUsedGivenSurfaced.Den)
+	}
+	// Capture misses are runs d and e; only d was budget-starved before capture.
+	if m.CaptureBudgetStarved.Num != 1 || m.CaptureBudgetStarved.Den != 2 {
+		t.Errorf("capture budget-starved = %d/%d, want 1/2", m.CaptureBudgetStarved.Num, m.CaptureBudgetStarved.Den)
+	}
+}
+
+// TestTransferSurfacedWiring drives the full lifecycle and asserts TransferSurfaced
+// tracks whether the promoted fact reached the learner in a tool result.
+func TestTransferSurfacedWiring(t *testing.T) {
+	t.Run("surfaced and used", func(t *testing.T) {
+		fp := newFakePlatform(t)
+		fp.surfaceText = okProtocol().Fact // cross-enrichment carries the fact into search results
+		dir := t.TempDir()
+		writeProtocols(t, dir, okProtocol())
+		res, err := Run(context.Background(), runOptions(fp, dir, scriptFactory(okScript())))
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		run := res.Runs[0]
+		assertTrue(t, "transfer surfaced", run.TransferSurfaced)
+		assertTrue(t, "transfer correct", run.TransferCorrect)
+		if res.Metrics.TransferUsedGivenSurfaced.Rate != 1 {
+			t.Fatalf("used-given-surfaced = %v, want 1", res.Metrics.TransferUsedGivenSurfaced.Rate)
+		}
+	})
+
+	t.Run("surfaced but not used", func(t *testing.T) {
+		fp := newFakePlatform(t)
+		fp.surfaceText = okProtocol().Fact
+		dir := t.TempDir()
+		writeProtocols(t, dir, okProtocol())
+		scripts := okScript()
+		// The learner sees the fact but answers wrong: surfaced, not used.
+		scripts["lc-ok"][StageTransfer] = []llm.Step{searchStep(), {FinalText: "FINAL ANSWER: 0.00"}}
+		res, err := Run(context.Background(), runOptions(fp, dir, scriptFactory(scripts)))
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		run := res.Runs[0]
+		assertTrue(t, "transfer surfaced", run.TransferSurfaced)
+		assertFalse(t, "transfer correct", run.TransferCorrect)
+	})
+
+	t.Run("promoted but not surfaced", func(t *testing.T) {
+		fp := newFakePlatform(t) // surfaceText empty: the fact never reaches the learner
+		dir := t.TempDir()
+		writeProtocols(t, dir, okProtocol())
+		res, err := Run(context.Background(), runOptions(fp, dir, scriptFactory(okScript())))
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		assertFalse(t, "transfer surfaced", res.Runs[0].TransferSurfaced)
+	})
+}
+
+// starvedProtocol teaches under a tight budget, so a teacher that searches
+// without capturing runs out of budget before ever reaching the capture tool.
+func starvedProtocol() protocol.Protocol {
+	p := okProtocol()
+	p.ID = "lc-starve"
+	p.Transfer = nil // capture fails, so the advanced stages never run anyway
+	p.BudgetToolCalls = 2
+	return p
+}
+
+// starvedScript never calls capture and burns the whole budget searching.
+func starvedScript() map[string]llm.Script {
+	return map[string]llm.Script{
+		"lc-starve": {
+			StageTeach:   {searchStep(), searchStep(), searchStep(), {FinalText: "could not save in time"}},
+			StageRecall:  {searchStep(), {FinalText: "FINAL ANSWER: 999.99"}},
+			StageAbstain: {{FinalText: "FINAL ANSWER: INSUFFICIENT INFORMATION"}},
+		},
+	}
+}
+
+func TestCaptureBudgetStarvation(t *testing.T) {
+	fp := newFakePlatform(t)
+	dir := t.TempDir()
+	writeProtocols(t, dir, starvedProtocol())
+	res, err := Run(context.Background(), runOptions(fp, dir, scriptFactory(starvedScript())))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	run := res.Runs[0]
+	if run.Error != "" {
+		t.Fatalf("unexpected harness error: %s", run.Error)
+	}
+	assertFalse(t, "captured", run.Captured)
+	assertFalse(t, "capture attempted", run.CaptureAttempted)
+	assertTrue(t, "teach budget exhausted", run.TeachBudgetExhausted)
+	if res.Metrics.CaptureBudgetStarved.Num != 1 || res.Metrics.CaptureBudgetStarved.Den != 1 {
+		t.Fatalf("capture budget-starved = %d/%d, want 1/1",
+			res.Metrics.CaptureBudgetStarved.Num, res.Metrics.CaptureBudgetStarved.Den)
+	}
+}
+
+// TestTeachBudgetOverrideEnablesCapture shows the capture-budget lever: the same
+// teacher that starves at the protocol budget captures when given a larger one.
+func TestTeachBudgetOverrideEnablesCapture(t *testing.T) {
+	dir := t.TempDir()
+	p := starvedProtocol()
+	p.ID = "lc-lever"
+	writeProtocols(t, dir, p)
+	// A teacher that searches three times, THEN captures — reaching capture only
+	// if the budget allows a fourth tool call.
+	scripts := map[string]llm.Script{
+		"lc-lever": {
+			StageTeach:   {searchStep(), searchStep(), searchStep(), captureStep("definition"), {FinalText: "saved"}},
+			StageRecall:  {searchStep(), {FinalText: "FINAL ANSWER: 123.45"}},
+			StageAbstain: {{FinalText: "FINAL ANSWER: INSUFFICIENT INFORMATION"}},
+		},
+	}
+
+	t.Run("starves at protocol budget", func(t *testing.T) {
+		fp := newFakePlatform(t)
+		res, err := Run(context.Background(), runOptions(fp, dir, scriptFactory(scripts)))
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		run := res.Runs[0]
+		assertFalse(t, "captured without override", run.Captured)
+		// The teacher does emit a capture call, but only after the budget is spent,
+		// so it is budget-refused (never executed): this is a budget-starvation
+		// miss, not an attempted-but-unlanded capture.
+		assertFalse(t, "capture attempted (budget-refused capture does not count)", run.CaptureAttempted)
+		if res.Metrics.CaptureBudgetStarved.Num != 1 || res.Metrics.CaptureBudgetStarved.Den != 1 {
+			t.Fatalf("capture budget-starved = %d/%d, want 1/1 (a budget-refused capture is a starvation miss)",
+				res.Metrics.CaptureBudgetStarved.Num, res.Metrics.CaptureBudgetStarved.Den)
+		}
+	})
+
+	t.Run("captures with a larger teach budget", func(t *testing.T) {
+		fp := newFakePlatform(t)
+		opts := runOptions(fp, dir, scriptFactory(scripts))
+		opts.TeachBudget = 10
+		res, err := Run(context.Background(), opts)
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		run := res.Runs[0]
+		assertTrue(t, "captured with override", run.Captured)
+		assertTrue(t, "capture attempted", run.CaptureAttempted)
+		assertFalse(t, "teach budget exhausted", run.TeachBudgetExhausted)
+	})
+}

--- a/bench/internal/lifecycle/episode.go
+++ b/bench/internal/lifecycle/episode.go
@@ -70,6 +70,9 @@ type episodeSpec struct {
 	prompt   string
 	system   string
 	budget   int
+	// surfaceFact, when non-empty, is the promoted content whose presence in a
+	// tool result marks FactSurfaced on the record (set for the transfer stage).
+	surfaceFact string
 }
 
 // runEpisode drives one fresh MCP session end to end: authenticate as the pool
@@ -142,6 +145,7 @@ func (e *runEnv) runEpisode(ctx context.Context, spec episodeSpec) (EpisodeRecor
 	rec.OutputTokens = result.Usage.OutputTokens
 	rec.CacheReadTokens = result.Usage.CacheReadInputTokens
 	rec.CacheCreationTokens = result.Usage.CacheCreationInputTokens
+	rec.recordInstrumentation(spec, result.Transcript, result.BudgetExhausted)
 	final := result.FinalAnswer
 	rec.FinalAnswer = final
 	e.writeTranscript(spec, result)
@@ -184,6 +188,7 @@ func (e *runEnv) runClaudeCLIEpisode(ctx context.Context, spec episodeSpec) (Epi
 	rec.OutputTokens = cres.Usage.OutputTokens
 	rec.CacheReadTokens = cres.Usage.CacheReadInputTokens
 	rec.CacheCreationTokens = cres.Usage.CacheCreationInputTokens
+	rec.recordInstrumentation(spec, cres.Transcript, false)
 	rec.FinalAnswer = cres.FinalText
 	e.recordPlatformVersion(cres.PlatformVersion)
 	e.writeClaudeTranscript(spec, cres.Transcript)

--- a/bench/internal/lifecycle/instrument.go
+++ b/bench/internal/lifecycle/instrument.go
@@ -1,0 +1,137 @@
+package lifecycle
+
+import (
+	"strings"
+
+	"github.com/txn2/mcp-data-platform/bench/internal/agent"
+	"github.com/txn2/mcp-data-platform/bench/internal/llm"
+	"github.com/txn2/mcp-data-platform/bench/internal/protocol"
+)
+
+// Per-stage diagnosis instrumentation (issue #964). These helpers derive
+// stage-level signals from the provider-agnostic transcript, so they work
+// identically for the in-process loop and the claude-cli path (both produce the
+// same []llm.Message). Keeping the derivation transcript-based (rather than
+// hooking each execution path) means the loop and CLI paths cannot diverge on
+// what "the teacher called capture" or "the fact surfaced" means.
+
+// recordInstrumentation fills an episode's per-stage diagnosis fields from its
+// transcript (issue #964): whether the capture tool was called, whether the
+// budget was exhausted, and — when a surface target is set — whether the fact
+// surfaced in a tool result. Both episode paths (loop and claude-cli) call this
+// with the transcript they produced, so the two paths cannot diverge on the
+// derivation.
+func (rec *EpisodeRecord) recordInstrumentation(spec episodeSpec, transcript []llm.Message, budgetExhausted bool) {
+	rec.BudgetExhausted = budgetExhausted
+	rec.CaptureAttempted = captureToolCalled(transcript)
+	if spec.surfaceFact != "" {
+		s := factSurfaced(spec.surfaceFact, transcript)
+		rec.FactSurfaced = &s
+	}
+}
+
+// captureToolCalled reports whether the episode actually executed a knowledge
+// capture call. A capture request the budget refused (emitted only after the
+// tool-call budget was spent, so it never ran) does NOT count: it is a
+// budget-starvation miss, not an "attempted capture that failed to land". This
+// keeps the capture-budget diagnosis honest — a teacher that only reaches for
+// capture after burning its budget on discovery is starved, not a landing
+// failure. It distinguishes a capture miss caused by never reaching an executed
+// capture (budget starvation) from one where capture ran but the insight did
+// not land.
+func captureToolCalled(msgs []llm.Message) bool {
+	captureIDs := map[string]bool{}
+	for _, m := range msgs {
+		for _, c := range m.ToolCalls {
+			if isCaptureTool(c.Name) {
+				captureIDs[c.ID] = true
+			}
+		}
+	}
+	if len(captureIDs) == 0 {
+		return false
+	}
+	for _, m := range msgs {
+		for _, r := range m.ToolResults {
+			// A capture call ran when its paired result is present and is not the
+			// budget-refusal sentinel. A server-side capture error still counts as
+			// executed (that is a landing failure, a different bucket).
+			if captureIDs[r.CallID] && r.Text != agent.BudgetRefusalText {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isCaptureTool reports whether a tool name is the knowledge-capture tool. The
+// suffix match tolerates a renamed or namespaced capture tool without silently
+// classifying every teach episode as a capture miss.
+func isCaptureTool(name string) bool {
+	return name == "memory_capture" || strings.HasSuffix(name, "_capture")
+}
+
+// factSurfaced reports whether the promoted fact appeared in any tool result the
+// episode saw. Combined with answer correctness it decomposes the transfer gap:
+// a promoted fact that never surfaces is a delivery failure (enrichment/search
+// did not carry it to the second identity), while one that surfaces but is not
+// used is a reasoning failure (the agent had it and ignored it). Matching is on
+// the normalized fact text; the datahub sink applies the fact verbatim as the
+// entity description, so cross-enrichment returns it verbatim.
+func factSurfaced(fact string, msgs []llm.Message) bool {
+	needle := normalizeText(fact)
+	if needle == "" {
+		return false
+	}
+	for _, m := range msgs {
+		for _, r := range m.ToolResults {
+			if r.IsError {
+				continue
+			}
+			if strings.Contains(normalizeText(r.Text), needle) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// normalizeText lowercases and collapses every run of non-alphanumeric bytes to
+// a single space, so surfacing detection is robust to whitespace, casing, and
+// punctuation differences between the stored fact and its rendering in a tool
+// result. It intentionally does not stem or reorder tokens: the surfaced signal
+// must stay a conservative "the fact text is present", not a fuzzy paraphrase
+// match that could over-report delivery.
+func normalizeText(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	prevSpace := true // leading spaces are trimmed by never emitting them
+	for _, r := range strings.ToLower(s) {
+		if isAlphaNum(r) {
+			b.WriteRune(r)
+			prevSpace = false
+			continue
+		}
+		if !prevSpace {
+			b.WriteByte(' ')
+			prevSpace = true
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// isAlphaNum reports whether a rune is an ASCII letter or digit.
+func isAlphaNum(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+}
+
+// surfacedTarget returns the promoted content whose presence in a tool result
+// marks the transfer fact as surfaced: the datahub sink applies the fact as the
+// entity description, and the knowledge-page sink applies the page body. Both
+// are what cross-enrichment / search deliver to the second identity.
+func surfacedTarget(p protocol.Protocol) string {
+	if p.Sink == protocol.SinkKnowledgePage && p.Page != nil {
+		return p.Page.Body
+	}
+	return p.Fact
+}

--- a/bench/internal/lifecycle/instrument_test.go
+++ b/bench/internal/lifecycle/instrument_test.go
@@ -1,0 +1,114 @@
+package lifecycle
+
+import (
+	"testing"
+
+	"github.com/txn2/mcp-data-platform/bench/internal/agent"
+	"github.com/txn2/mcp-data-platform/bench/internal/llm"
+	"github.com/txn2/mcp-data-platform/bench/internal/protocol"
+)
+
+func TestNormalizeText(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"  Net Revenue!  ", "net revenue"},
+		{"Net\tRevenue\nexcludes  returns.", "net revenue excludes returns"},
+		{"URN:li:dataset", "urn li dataset"},
+		{"---", ""},
+		{"a1b2", "a1b2"},
+	}
+	for _, c := range cases {
+		if got := normalizeText(c.in); got != c.want {
+			t.Errorf("normalizeText(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// executedCapture is a two-turn transcript: an assistant capture request paired
+// with a non-refusal tool result, i.e. a capture that actually ran.
+func executedCapture(name string) []llm.Message {
+	return []llm.Message{
+		{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "c1", Name: name}}},
+		{Role: "user", ToolResults: []llm.ToolResult{{CallID: "c1", Text: "captured in-1"}}},
+	}
+}
+
+func TestCaptureToolCalled(t *testing.T) {
+	// A capture request the budget refused (only its refusal result is present)
+	// must not count as an executed capture.
+	budgetRefused := []llm.Message{
+		{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "memory_capture"}}},
+		{Role: "user", ToolResults: []llm.ToolResult{{CallID: "c1", Text: agent.BudgetRefusalText, IsError: true}}},
+	}
+	// A capture that ran but errored server-side still counts (a landing failure,
+	// not a budget-starvation miss).
+	serverError := []llm.Message{
+		{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "memory_capture"}}},
+		{Role: "user", ToolResults: []llm.ToolResult{{CallID: "c1", Text: "capture failed: entity not found", IsError: true}}},
+	}
+	cases := []struct {
+		name string
+		msgs []llm.Message
+		want bool
+	}{
+		{"empty", nil, false},
+		{"only search", []llm.Message{{Role: "assistant", ToolCalls: []llm.ToolCall{{Name: "search"}}}}, false},
+		{"executed memory_capture", executedCapture("memory_capture"), true},
+		{"executed suffix capture", executedCapture("knowledge_capture"), true},
+		{"apply is not capture", []llm.Message{{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "apply_knowledge"}}},
+			{Role: "user", ToolResults: []llm.ToolResult{{CallID: "c1", Text: "applied"}}}}, false},
+		{"capture requested but never executed (no result)",
+			[]llm.Message{{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "memory_capture"}}}}, false},
+		{"capture budget-refused", budgetRefused, false},
+		{"capture ran but errored", serverError, true},
+	}
+	for _, c := range cases {
+		if got := captureToolCalled(c.msgs); got != c.want {
+			t.Errorf("%s: captureToolCalled = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestFactSurfaced(t *testing.T) {
+	fact := "Net revenue excludes returns and discounts."
+	surfaced := []llm.Message{{Role: "user", ToolResults: []llm.ToolResult{
+		{Text: "search results\nDescription: NET REVENUE excludes returns and discounts. (owner: fin)"},
+	}}}
+	notSurfaced := []llm.Message{{Role: "user", ToolResults: []llm.ToolResult{
+		{Text: "search results: 3 datasets matched, none documented"},
+	}}}
+	errorResult := []llm.Message{{Role: "user", ToolResults: []llm.ToolResult{
+		{Text: "Net revenue excludes returns and discounts.", IsError: true}, // error results do not count as surfaced
+	}}}
+
+	if !factSurfaced(fact, surfaced) {
+		t.Error("expected fact surfaced when present in a result (case/punctuation-insensitive)")
+	}
+	if factSurfaced(fact, notSurfaced) {
+		t.Error("expected fact not surfaced when absent")
+	}
+	if factSurfaced(fact, errorResult) {
+		t.Error("an error tool result must not count as surfacing")
+	}
+	if factSurfaced("", surfaced) {
+		t.Error("an empty fact must never count as surfaced")
+	}
+}
+
+func TestSurfacedTarget(t *testing.T) {
+	datahub := protocol.Protocol{Sink: protocol.SinkDataHub, Fact: "the fact"}
+	if got := surfacedTarget(datahub); got != "the fact" {
+		t.Errorf("datahub sink target = %q, want the fact", got)
+	}
+	page := protocol.Protocol{Sink: protocol.SinkKnowledgePage, Fact: "the fact",
+		Page: &protocol.PagePayload{Body: "the page body"}}
+	if got := surfacedTarget(page); got != "the page body" {
+		t.Errorf("page sink target = %q, want the page body", got)
+	}
+	// A page sink with no page payload falls back to the fact rather than panicking.
+	if got := surfacedTarget(protocol.Protocol{Sink: protocol.SinkKnowledgePage, Fact: "the fact"}); got != "the fact" {
+		t.Errorf("page sink without payload target = %q, want the fact", got)
+	}
+}

--- a/bench/internal/lifecycle/report.go
+++ b/bench/internal/lifecycle/report.go
@@ -57,6 +57,23 @@ type EpisodeRecord struct {
 	ToolCalls    int    `json:"tool_calls"`
 	ToolErrors   int    `json:"tool_errors"`
 	SearchCalled bool   `json:"search_called"`
+	// CaptureAttempted is true when the episode actually executed a
+	// knowledge-capture call (a budget-refused capture request does not count). On
+	// a teach episode it distinguishes a capture miss caused by never reaching an
+	// executed capture (budget starvation) from one where capture ran but the
+	// insight did not land (issue #964 capture-budget gap).
+	CaptureAttempted bool `json:"capture_attempted,omitempty"`
+	// BudgetExhausted is true when the episode hit its tool-call budget. It is
+	// meaningful only on the in-process loop path, which owns the tool-call
+	// budget; the claude-cli path runs its own turn budget and leaves it false
+	// (the run-level TeachBudgetExhausted is left nil there, so a claude-cli
+	// capture miss is excluded from the budget-starvation rate rather than
+	// miscounted as not-starved).
+	BudgetExhausted bool `json:"budget_exhausted,omitempty"`
+	// FactSurfaced, when set, reports whether the promoted fact appeared in a tool
+	// result this episode saw. Set only for episodes that pass a surface target
+	// (the transfer stage); nil otherwise.
+	FactSurfaced *bool  `json:"fact_surfaced,omitempty"`
 	FinalAnswer  string `json:"final_answer,omitempty"`
 	WallMS       int64  `json:"wall_ms"`
 	InputTokens  int64  `json:"input_tokens"`
@@ -84,14 +101,23 @@ type ProtocolRun struct {
 
 	InsightID string `json:"insight_id,omitempty"`
 
-	Captured        *bool `json:"captured,omitempty"`         // insight recorded and entity-linked
-	RecallCorrect   *bool `json:"recall_correct,omitempty"`   // personal recall answer correct
-	RecallSurfaced  *bool `json:"recall_surfaced,omitempty"`  // search surfaced the memory unprompted
-	Promoted        *bool `json:"promoted,omitempty"`         // applied + changeset links the insight (nil for update protocols)
-	TransferCorrect *bool `json:"transfer_correct,omitempty"` // cross-identity recall correct
-	UpdateCorrect   *bool `json:"update_correct,omitempty"`   // recall flipped to the corrected value
-	Duplicated      *bool `json:"duplicated,omitempty"`       // supersede left more than one live insight
-	AbstainCorrect  *bool `json:"abstain_correct,omitempty"`  // abstained on a never-taught fact
+	Captured         *bool `json:"captured,omitempty"`          // insight recorded and entity-linked
+	RecallCorrect    *bool `json:"recall_correct,omitempty"`    // personal recall answer correct
+	RecallSurfaced   *bool `json:"recall_surfaced,omitempty"`   // search surfaced the memory unprompted
+	Promoted         *bool `json:"promoted,omitempty"`          // applied + changeset links the insight (nil for update protocols)
+	TransferCorrect  *bool `json:"transfer_correct,omitempty"`  // cross-identity recall correct
+	TransferSurfaced *bool `json:"transfer_surfaced,omitempty"` // promoted fact appeared in a tool result the learner saw
+	UpdateCorrect    *bool `json:"update_correct,omitempty"`    // recall flipped to the corrected value
+	Duplicated       *bool `json:"duplicated,omitempty"`        // supersede left more than one live insight
+	AbstainCorrect   *bool `json:"abstain_correct,omitempty"`   // abstained on a never-taught fact
+
+	// Capture-budget diagnosis (issue #964), read from the teach episode. Nil
+	// when the teach episode never ran (harness abort before teach).
+	CaptureAttempted *bool `json:"capture_attempted,omitempty"` // teach episode executed a capture call
+	// TeachBudgetExhausted is nil when budget exhaustion is not observable (the
+	// claude-cli path runs its own turn budget), which excludes the run from the
+	// budget-starvation rate.
+	TeachBudgetExhausted *bool `json:"teach_budget_exhausted,omitempty"` // teach episode hit its tool-call budget (loop path only)
 
 	Episodes []EpisodeRecord `json:"episodes"`
 	Error    string          `json:"error,omitempty"` // harness failure that aborted the run
@@ -149,6 +175,54 @@ func (r *Rate) add(v *bool) {
 	}
 }
 
+// addConditional folds one outcome into a conditional rate: the run counts
+// toward the denominator only when it belongs to the conditioning subset (e.g.
+// "among transfer attempts where the fact surfaced"). It backs the transfer-gap
+// and capture-budget decompositions, whose denominators are subsets of the
+// attempts rather than a single nil-able outcome.
+func (r *Rate) addConditional(applicable, value bool) {
+	if !applicable {
+		return
+	}
+	r.Den++
+	if value {
+		r.Num++
+	}
+	if r.Den > 0 {
+		r.Rate = float64(r.Num) / float64(r.Den)
+	}
+}
+
+// complement returns the rate of the opposite outcome over the same
+// denominator, so a pair like supersede/duplicate is stored once and derived
+// once rather than accumulated twice (which could silently drift apart).
+func (r Rate) complement() Rate {
+	c := Rate{Num: r.Den - r.Num, Den: r.Den}
+	if c.Den > 0 {
+		c.Rate = float64(c.Num) / float64(c.Den)
+	}
+	return c
+}
+
+// captureMissed reports whether capture was applicable to a run and failed.
+func captureMissed(captured *bool) bool { return captured != nil && !*captured }
+
+// captureBudgetObservable reports whether a run belongs in the
+// CaptureBudgetStarved denominator: capture must have missed AND the teach
+// episode's budget exhaustion must be observable (TeachBudgetExhausted set — the
+// loop path). A claude-cli run leaves TeachBudgetExhausted nil, so it is excluded
+// rather than miscounted as not-starved.
+func captureBudgetObservable(r ProtocolRun) bool {
+	return captureMissed(r.Captured) && r.TeachBudgetExhausted != nil
+}
+
+// budgetStarved reports whether a run's teach episode exhausted its tool-call
+// budget without ever calling capture (the discovery-budget-exhaustion failure
+// mode).
+func budgetStarved(r ProtocolRun) bool {
+	return boolTrue(r.TeachBudgetExhausted) && !boolTrue(r.CaptureAttempted)
+}
+
 // Metrics is the S5 lifecycle scorecard (issue #944).
 type Metrics struct {
 	Protocols       int `json:"protocols"`
@@ -172,6 +246,23 @@ type Metrics struct {
 	UpdateCorrectness Rate `json:"update_correctness"`
 	DuplicateRate     Rate `json:"duplicate_rate"` // fraction of supersedes that duplicated (lower is better)
 	AbstentionRate    Rate `json:"abstention_rate"`
+
+	// Transfer-gap decomposition (issue #964). TransferSurfaced is the fraction
+	// of transfer attempts where the promoted fact reached the learner in a tool
+	// result; TransferUsedGivenSurfaced is, among those, the fraction answered
+	// correctly. A low TransferSurfaced points at delivery (enrichment/search);
+	// a low TransferUsedGivenSurfaced points at reasoning (the agent had it and
+	// ignored it).
+	TransferSurfaced          Rate `json:"transfer_surfaced"`
+	TransferUsedGivenSurfaced Rate `json:"transfer_used_given_surfaced"`
+
+	// CaptureBudgetStarved is, among capture misses whose budget exhaustion is
+	// observable (the loop path), the fraction where the teach episode exhausted
+	// its tool-call budget without executing a capture call — the
+	// discovery-budget-exhaustion failure mode (issue #964). claude-cli misses are
+	// excluded (their budget exhaustion is not observable), not counted as
+	// not-starved.
+	CaptureBudgetStarved Rate `json:"capture_budget_starved"`
 
 	PassK Rate `json:"pass_k"` // protocols passing all k full lifecycles / protocols
 }
@@ -208,9 +299,12 @@ func (res *Results) Aggregate() {
 		m.PersonalRecall.add(r.RecallCorrect)
 		m.UnpromptedSurface.add(r.RecallSurfaced)
 		m.TransferRate.add(r.TransferCorrect)
+		m.TransferSurfaced.add(r.TransferSurfaced)
+		m.TransferUsedGivenSurfaced.addConditional(boolTrue(r.TransferSurfaced), boolTrue(r.TransferCorrect))
 		m.UpdateCorrectness.add(r.UpdateCorrect)
 		m.DuplicateRate.add(r.Duplicated)
 		m.AbstentionRate.add(r.AbstainCorrect)
+		m.CaptureBudgetStarved.addConditional(captureBudgetObservable(r), budgetStarved(r))
 	}
 	m.Protocols = len(order)
 	m.PassK = passKRate(order, byProtocol, res.Manifest.K)
@@ -288,9 +382,12 @@ func (res *Results) HumanSummary() string {
 	writeMetric(&b, "personal recall", mt.PersonalRecall)
 	writeMetric(&b, "unprompted surface", mt.UnpromptedSurface)
 	writeMetric(&b, "transfer rate", mt.TransferRate)
+	writeMetric(&b, "  transfer surfaced", mt.TransferSurfaced)
+	writeMetric(&b, "  used given surfaced", mt.TransferUsedGivenSurfaced)
 	writeMetric(&b, "update correctness", mt.UpdateCorrectness)
 	writeMetric(&b, "duplicate rate", mt.DuplicateRate)
 	writeMetric(&b, "abstention rate", mt.AbstentionRate)
+	writeMetric(&b, "capture budget-starved", mt.CaptureBudgetStarved)
 	writeMetric(&b, "pass^k (protocols)", mt.PassK)
 	if failures := res.harnessFailures(); len(failures) > 0 {
 		b.WriteString("\nharness failures (excluded from metrics):\n")

--- a/bench/internal/lifecycle/runner.go
+++ b/bench/internal/lifecycle/runner.go
@@ -59,12 +59,20 @@ type Options struct {
 	// discovery scope). It must be positive: the lifecycle needs distinct teacher
 	// and learner identities, so there is no single-identity mode.
 	IdentityKeys int
+	// TeachBudget, when > 0, overrides the per-episode tool-call budget for the
+	// capture-bearing stages (teach and update). It is the capture-budget lever
+	// (issue #964): a larger teach-stage budget lets the teacher finish discovery
+	// and still reach the capture tool. Zero uses the protocol's BudgetToolCalls.
+	TeachBudget int
 	// OnProtocol, if set, is called after every protocol attempt with the
 	// aggregated results so far. benchrun wires it to flush the results file, so
 	// a run that spends real API budget always leaves every completed protocol on
 	// disk — an interruption never discards paid-for work.
 	OnProtocol func(*Results)
-	Log        *slog.Logger
+	// OnSupersede mirrors OnProtocol for the isolated supersede sub-benchmark
+	// (RunSupersede): it flushes the focused results after each attempt.
+	OnSupersede func(*SupersedeResults)
+	Log         *slog.Logger
 }
 
 // Run executes every protocol k times and returns the aggregated lifecycle
@@ -75,16 +83,7 @@ func Run(ctx context.Context, opts Options) (*Results, error) {
 	if err != nil {
 		return nil, err
 	}
-	res := &Results{Manifest: Manifest{
-		StartedAt:       time.Now().UTC(),
-		GitCommit:       opts.GitCommit,
-		Target:          opts.Target.BaseURL,
-		Arm:             opts.Arm,
-		LLMProvider:     opts.LLMProvider,
-		Seed:            gen.Seed,
-		ProtocolSetHash: protocol.Hash(protocols),
-		K:               opts.K,
-	}}
+	res := &Results{Manifest: newManifest(opts, protocols)}
 	// The lifecycle needs distinct teacher and learner identities per attempt (the
 	// transfer stage is cross-identity by construction), so a single-identity run
 	// is invalid — unlike the S1-S3 pipeline, there is no meaningful IdentityKeys=0
@@ -97,26 +96,54 @@ func Run(ctx context.Context, opts Options) (*Results, error) {
 		return nil, fmt.Errorf("%d identities needed (%d protocols x k=%d x %d) exceed the pool of %d; raise -identity-keys and the config pool",
 			need, len(protocols), opts.K, identitiesPerRun, opts.IdentityKeys)
 	}
+	env := newRunEnv(opts)
+	defer env.closeAdmin()
+
+	failures := env.runAll(ctx, protocols, res)
+	env.finishManifest(&res.Manifest)
+	res.Aggregate()
+	if failures > 0 {
+		return res, fmt.Errorf("%d protocol run(s) failed at the harness level; see runs[].error", failures)
+	}
+	return res, nil
+}
+
+// newManifest builds the run manifest shared by the full lifecycle and the
+// isolated supersede sub-benchmark, so a new manifest field is added in one
+// place. The protocol-set hash covers exactly the protocols this run drove.
+func newManifest(opts Options, protocols []protocol.Protocol) Manifest {
+	return Manifest{
+		StartedAt:       time.Now().UTC(),
+		GitCommit:       opts.GitCommit,
+		Target:          opts.Target.BaseURL,
+		Arm:             opts.Arm,
+		LLMProvider:     opts.LLMProvider,
+		Seed:            gen.Seed,
+		ProtocolSetHash: protocol.Hash(protocols),
+		K:               opts.K,
+	}
+}
+
+// newRunEnv wires the per-run clients (insights/changesets, audit, reviewer)
+// shared by both entry points, so a newly-wired client is added once.
+func newRunEnv(opts Options) *runEnv {
 	life := lifecycleapi.New(opts.Target.BaseURL, opts.Target.HTTPClient(opts.HTTPTimeout))
-	env := &runEnv{
+	return &runEnv{
 		opts:     opts,
 		log:      opts.Log,
 		audit:    auditapi.New(opts.Target.BaseURL, opts.Target.HTTPClient(opts.HTTPTimeout)),
 		life:     life,
 		reviewer: promote.Reviewer{Life: life, Log: opts.Log},
 	}
-	defer env.closeAdmin()
+}
 
-	failures := env.runAll(ctx, protocols, res)
-	res.Manifest.FinishedAt = time.Now().UTC()
-	res.Manifest.PlatformVersion = env.platformVersion
-	res.Manifest.Model = env.model
-	res.Manifest.ClientVersion = opts.ClientVersion
-	res.Aggregate()
-	if failures > 0 {
-		return res, fmt.Errorf("%d protocol run(s) failed at the harness level; see runs[].error", failures)
-	}
-	return res, nil
+// finishManifest stamps the carry-over fields captured during the run onto the
+// manifest at the end of either entry point.
+func (e *runEnv) finishManifest(m *Manifest) {
+	m.FinishedAt = time.Now().UTC()
+	m.PlatformVersion = e.platformVersion
+	m.Model = e.model
+	m.ClientVersion = e.opts.ClientVersion
 }
 
 // runAll executes every protocol k times, appending each run to res and
@@ -209,15 +236,45 @@ func (e *runEnv) runAdvancedStages(ctx context.Context, p protocol.Protocol, tea
 	return false
 }
 
+// teachBudget returns the effective tool-call budget for a capture-bearing
+// stage, honoring the TeachBudget override (issue #964 capture-budget lever).
+func (e *runEnv) teachBudget(p protocol.Protocol) int {
+	if e.opts.TeachBudget > 0 {
+		return e.opts.TeachBudget
+	}
+	return p.BudgetToolCalls
+}
+
 // teachAndRecall runs the teach and personal-recall episodes and verifies
 // capture via the insights API. Returns true when a harness failure aborts the
 // run.
 func (e *runEnv) teachAndRecall(ctx context.Context, p protocol.Protocol, teacherSeq int, run *ProtocolRun) bool {
+	if abort := e.teachAndCapture(ctx, p, teacherSeq, run); abort {
+		return true
+	}
+	return e.recall(ctx, p, teacherSeq, run)
+}
+
+// teachAndCapture runs the teach episode and verifies capture via the insights
+// API. It records the capture-budget diagnosis (whether the teacher reached the
+// capture tool and whether it exhausted its budget) so a capture miss can be
+// attributed. Returns true when a harness failure aborts the run.
+func (e *runEnv) teachAndCapture(ctx context.Context, p protocol.Protocol, teacherSeq int, run *ProtocolRun) bool {
 	teach, _ := e.runEpisode(ctx, episodeSpec{
 		stage: StageTeach, identity: "teacher", seq: teacherSeq,
-		prompt: p.Teach.Prompt, system: teachSystem, budget: p.BudgetToolCalls,
+		prompt: p.Teach.Prompt, system: teachSystem, budget: e.teachBudget(p),
 	})
 	run.Episodes = append(run.Episodes, teach)
+	attempted := teach.CaptureAttempted
+	run.CaptureAttempted = &attempted
+	// Budget exhaustion is observable only on the in-process loop path, which owns
+	// the tool-call budget. The claude-cli path runs its own turn budget, so leave
+	// TeachBudgetExhausted nil there — a nil value excludes the run from the
+	// budget-starvation rate rather than falsely asserting it was not starved.
+	if e.opts.ClaudeCLI == nil {
+		exhausted := teach.BudgetExhausted
+		run.TeachBudgetExhausted = &exhausted
+	}
 	if teach.Error != "" {
 		run.Error = "teach: " + teach.Error
 		return true
@@ -233,7 +290,12 @@ func (e *runEnv) teachAndRecall(ctx context.Context, p protocol.Protocol, teache
 	if insight != nil {
 		run.InsightID = insight.ID
 	}
+	return false
+}
 
+// recall runs the personal-recall episode (same identity, fresh session) and
+// grades it. Returns true when a harness failure aborts the run.
+func (e *runEnv) recall(ctx context.Context, p protocol.Protocol, teacherSeq int, run *ProtocolRun) bool {
 	recall, ans := e.runEpisode(ctx, episodeSpec{
 		stage: StageRecall, identity: "teacher", seq: teacherSeq,
 		prompt: p.Recall.Prompt, system: recallSystem(p.Recall.Grading.Kind), budget: p.BudgetToolCalls,
@@ -245,7 +307,7 @@ func (e *runEnv) teachAndRecall(ctx context.Context, p protocol.Protocol, teache
 	}
 	rc := gradeRecall(ans, p.Recall.Grading)
 	run.RecallCorrect = &rc
-	if captured {
+	if boolTrue(run.Captured) {
 		surfaced := recall.SearchCalled
 		run.RecallSurfaced = &surfaced
 	}
@@ -267,6 +329,7 @@ func (e *runEnv) promoteAndTransfer(ctx context.Context, p protocol.Protocol, le
 	transfer, ans := e.runEpisode(ctx, episodeSpec{
 		stage: StageTransfer, identity: "learner", seq: learnerSeq,
 		prompt: p.Transfer.Prompt, system: recallSystem(p.Transfer.Grading.Kind), budget: p.BudgetToolCalls,
+		surfaceFact: surfacedTarget(p),
 	})
 	run.Episodes = append(run.Episodes, transfer)
 	if transfer.Error != "" {
@@ -275,6 +338,7 @@ func (e *runEnv) promoteAndTransfer(ctx context.Context, p protocol.Protocol, le
 	}
 	tc := gradeRecall(ans, p.Transfer.Grading)
 	run.TransferCorrect = &tc
+	run.TransferSurfaced = transfer.FactSurfaced
 	return false
 }
 
@@ -287,7 +351,7 @@ func (e *runEnv) supersede(ctx context.Context, p protocol.Protocol, teacherSeq 
 	}
 	upd, _ := e.runEpisode(ctx, episodeSpec{
 		stage: StageUpdate, identity: "teacher", seq: teacherSeq,
-		prompt: p.Update.Prompt, system: teachSystem, budget: p.BudgetToolCalls,
+		prompt: p.Update.Prompt, system: teachSystem, budget: e.teachBudget(p),
 	})
 	run.Episodes = append(run.Episodes, upd)
 	if upd.Error != "" {

--- a/bench/internal/lifecycle/runner_test.go
+++ b/bench/internal/lifecycle/runner_test.go
@@ -47,8 +47,9 @@ type fakePlatform struct {
 	changesets     []lifecycleapi.Changeset
 	events         []auditapi.Event
 	httpSrv        *httptest.Server
-	applyFails     bool // apply_knowledge returns a tool error (measured miss)
-	noChangesetRef bool // apply records the changeset but leaves insight.changeset_ref empty
+	applyFails     bool   // apply_knowledge returns a tool error (measured miss)
+	noChangesetRef bool   // apply records the changeset but leaves insight.changeset_ref empty
+	surfaceText    string // appended to every search result (models cross-enrichment surfacing the fact)
 }
 
 func newFakePlatform(t *testing.T) *fakePlatform {
@@ -162,8 +163,15 @@ func (fp *fakePlatform) addSearch(server *mcp.Server) {
 		func(_ context.Context, _ *mcp.CallToolRequest, args map[string]any) (*mcp.CallToolResult, any, error) {
 			fp.mu.Lock()
 			fp.recordLocked(args, "search")
+			// surfaceText models cross-enrichment carrying the promoted fact into a
+			// search result, so the transfer-surfaced instrumentation can be exercised
+			// end to end. Empty (the default) means the fact never surfaces.
+			text := "search results"
+			if fp.surfaceText != "" {
+				text += "\n" + fp.surfaceText
+			}
 			fp.mu.Unlock()
-			return okResult("search results"), nil, nil
+			return okResult(text), nil, nil
 		})
 }
 

--- a/bench/internal/lifecycle/supersede.go
+++ b/bench/internal/lifecycle/supersede.go
@@ -1,0 +1,119 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/txn2/mcp-data-platform/bench/internal/protocol"
+)
+
+// supersedeIdentitiesPerRun is the identities one supersede attempt consumes.
+// Unlike the full lifecycle it needs only the teacher (teach + correct + recall
+// are all the same identity); there is no cross-identity transfer stage. Each
+// attempt still uses a fresh identity so an earlier attempt's live insight on
+// the same pool identity never confuses the supersede-status read-back.
+const supersedeIdentitiesPerRun = 1
+
+// RunSupersede runs the targeted supersede sub-benchmark (issue #964): the
+// recall-first supersede gate measured in isolation. For each supersede protocol
+// (teach then correct, no promote/transfer) it drives teach -> capture-verify ->
+// correct -> supersede-status check, k times, and reports how reliably the
+// restatement supersedes the original rather than leaving a duplicate. Isolating
+// supersede from the full lifecycle removes the transfer/abstain/promote noise
+// that made the S5 duplicate rate a wide range (0% vs 42.9% between identical
+// runs), and lets the embedding-similarity gate's stability be evaluated on its
+// own — re-run against platforms configured with different similarity
+// thresholds, embedding models, or a deterministic fallback to compare.
+func RunSupersede(ctx context.Context, opts Options) (*SupersedeResults, error) {
+	all, err := protocol.Load(opts.ProtocolsDir)
+	if err != nil {
+		return nil, err
+	}
+	protocols := supersedeProtocols(all)
+	if len(protocols) == 0 {
+		return nil, fmt.Errorf("no supersede protocols (with an update stage) in %s", opts.ProtocolsDir)
+	}
+	if opts.IdentityKeys <= 0 {
+		return nil, errors.New("supersede requires an identity pool (-identity-keys > 0): each attempt teaches under a fresh identity")
+	}
+	need := len(protocols) * opts.K * supersedeIdentitiesPerRun
+	if need > opts.IdentityKeys {
+		return nil, fmt.Errorf("%d identities needed (%d supersede protocols x k=%d) exceed the pool of %d; raise -identity-keys and the config pool",
+			need, len(protocols), opts.K, opts.IdentityKeys)
+	}
+
+	res := &SupersedeResults{Manifest: newManifest(opts, protocols)}
+	env := newRunEnv(opts)
+	defer env.closeAdmin()
+
+	failures := env.runAllSupersede(ctx, protocols, res)
+	env.finishManifest(&res.Manifest)
+	res.Aggregate()
+	if failures > 0 {
+		return res, fmt.Errorf("%d supersede run(s) failed at the harness level; see runs[].error", failures)
+	}
+	return res, nil
+}
+
+// supersedeProtocols keeps only the protocols that exercise supersede (an update
+// stage). Transfer protocols are excluded by construction — protocol.Validate
+// makes update and transfer mutually exclusive.
+func supersedeProtocols(all []protocol.Protocol) []protocol.Protocol {
+	out := make([]protocol.Protocol, 0, len(all))
+	for _, p := range all {
+		if p.Update != nil {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// runAllSupersede executes every supersede protocol k times, appending each run
+// to res and returning the count of harness-level failures.
+func (e *runEnv) runAllSupersede(ctx context.Context, protocols []protocol.Protocol, res *SupersedeResults) int {
+	failures := 0
+	attemptIndex := 0
+	for _, p := range protocols {
+		for attempt := 1; attempt <= e.opts.K; attempt++ {
+			run := e.runSupersedeProtocol(ctx, p, attempt, attemptIndex)
+			if run.Error != "" {
+				failures++
+			}
+			res.Runs = append(res.Runs, run)
+			attemptIndex++
+			e.checkpointSupersede(res)
+		}
+	}
+	return failures
+}
+
+// checkpointSupersede flushes the results so far after each attempt so an
+// interruption never discards completed, paid-for work.
+func (e *runEnv) checkpointSupersede(res *SupersedeResults) {
+	if e.opts.OnSupersede == nil {
+		return
+	}
+	res.Aggregate()
+	e.opts.OnSupersede(res)
+}
+
+// runSupersedeProtocol drives one supersede attempt: teach and verify capture,
+// then supersede (correct the fact and re-check the taught insight's status). It
+// reuses the full lifecycle's teach/capture and supersede stages so the isolated
+// sub-benchmark and the S5 suite exercise the identical, correctness-critical
+// code — only the surrounding stages differ.
+func (e *runEnv) runSupersedeProtocol(ctx context.Context, p protocol.Protocol, attempt, attemptIndex int) ProtocolRun {
+	e.currentProtocolID = p.ID
+	run := ProtocolRun{ProtocolID: p.ID, Title: p.Title, Sink: p.Sink, Attempt: attempt}
+	teacherSeq := attemptIndex*supersedeIdentitiesPerRun + 1
+
+	if abort := e.teachAndCapture(ctx, p, teacherSeq, &run); abort {
+		return run
+	}
+	if !boolTrue(run.Captured) || run.InsightID == "" {
+		return run // capture missed: supersede is not applicable, excluded from the rate
+	}
+	e.supersede(ctx, p, teacherSeq, &run)
+	return run
+}

--- a/bench/internal/lifecycle/supersede_report.go
+++ b/bench/internal/lifecycle/supersede_report.go
@@ -1,0 +1,206 @@
+package lifecycle
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// SupersedeResults is the isolated supersede sub-benchmark output (issue #964).
+// It reuses ProtocolRun as the per-attempt record — each attempt runs the same
+// teach/capture and supersede stages the S5 suite uses — but scores only the
+// supersede-relevant outcomes and adds a per-protocol stability breakdown, so
+// the 0%-vs-42.9% duplicate-rate instability the phase-4 data exposed is visible
+// per protocol rather than hidden in one blended range.
+type SupersedeResults struct {
+	Manifest Manifest         `json:"manifest"`
+	Runs     []ProtocolRun    `json:"runs"`
+	Metrics  SupersedeMetrics `json:"metrics"`
+}
+
+// SupersedeMetrics is the focused supersede scorecard. SupersedeRate and
+// DuplicateRate are complements over the same denominator (captured attempts
+// whose supersede ran); both are reported because a reader scans for either the
+// success or the failure framing.
+type SupersedeMetrics struct {
+	Protocols       int `json:"protocols"`
+	Attempts        int `json:"attempts"`
+	HarnessFailures int `json:"harness_failures"`
+
+	TotalInputTokens         int64 `json:"total_input_tokens"`
+	TotalOutputTokens        int64 `json:"total_output_tokens"`
+	TotalCacheReadTokens     int64 `json:"total_cache_read_tokens"`
+	TotalCacheCreationTokens int64 `json:"total_cache_creation_tokens"`
+
+	CaptureRate       Rate `json:"capture_rate"`
+	SupersedeRate     Rate `json:"supersede_rate"`     // among captured attempts, the original was superseded (higher is better)
+	DuplicateRate     Rate `json:"duplicate_rate"`     // among captured attempts, a duplicate was left (lower is better)
+	UpdateCorrectness Rate `json:"update_correctness"` // post-correction recall flipped to the new value
+
+	PassK       Rate                    `json:"pass_k"`       // protocols cleanly superseding on all k attempts
+	PerProtocol []SupersedeProtocolStat `json:"per_protocol"` // per-protocol stability across the k attempts
+}
+
+// SupersedeProtocolStat is one protocol's outcome counts across its k attempts.
+// Superseded+Duplicated over a captured attempt count below k exposes exactly
+// the instability the sub-benchmark targets (e.g. 2/3 superseded, 1/3 duplicated
+// on identical inputs).
+type SupersedeProtocolStat struct {
+	ProtocolID string `json:"protocol_id"`
+	Title      string `json:"title"`
+	Attempts   int    `json:"attempts"`
+	Captured   int    `json:"captured"`
+	Superseded int    `json:"superseded"`
+	Duplicated int    `json:"duplicated"`
+}
+
+// Aggregate computes the supersede metrics from the runs.
+func (res *SupersedeResults) Aggregate() {
+	m := SupersedeMetrics{}
+	byProtocol := map[string]*SupersedeProtocolStat{}
+	var order []string
+	for i := range res.Runs {
+		r := res.Runs[i]
+		stat, ok := byProtocol[r.ProtocolID]
+		if !ok {
+			order = append(order, r.ProtocolID)
+			stat = &SupersedeProtocolStat{ProtocolID: r.ProtocolID, Title: r.Title}
+			byProtocol[r.ProtocolID] = stat
+		}
+		for _, e := range r.Episodes {
+			m.TotalInputTokens += e.InputTokens
+			m.TotalOutputTokens += e.OutputTokens
+			m.TotalCacheReadTokens += e.CacheReadTokens
+			m.TotalCacheCreationTokens += e.CacheCreationTokens
+		}
+		if r.Error != "" {
+			m.HarnessFailures++
+			continue
+		}
+		m.Attempts++
+		foldSupersedeStat(stat, r)
+		m.CaptureRate.add(r.Captured)
+		m.DuplicateRate.add(r.Duplicated)
+		m.UpdateCorrectness.add(r.UpdateCorrect)
+	}
+	// SupersedeRate is the complement of DuplicateRate over the same denominator
+	// (captured attempts whose supersede ran), derived once so the two can never
+	// drift out of the complement relationship the report advertises.
+	m.SupersedeRate = m.DuplicateRate.complement()
+	m.Protocols = len(order)
+	m.PassK = supersedePassKRate(order, res.Runs, res.Manifest.K)
+	for _, id := range order {
+		m.PerProtocol = append(m.PerProtocol, *byProtocol[id])
+	}
+	res.Metrics = m
+}
+
+// foldSupersedeStat accumulates one graded attempt into its protocol's stability
+// counts.
+func foldSupersedeStat(stat *SupersedeProtocolStat, r ProtocolRun) {
+	stat.Attempts++
+	if boolTrue(r.Captured) {
+		stat.Captured++
+	}
+	if r.Duplicated != nil {
+		if *r.Duplicated {
+			stat.Duplicated++
+		} else {
+			stat.Superseded++
+		}
+	}
+}
+
+// supersedePassKRate is the fraction of protocols whose every one of the k
+// attempts captured, superseded cleanly (no duplicate), and flipped recall.
+func supersedePassKRate(order []string, runs []ProtocolRun, k int) Rate {
+	byProtocol := map[string][]ProtocolRun{}
+	for _, r := range runs {
+		byProtocol[r.ProtocolID] = append(byProtocol[r.ProtocolID], r)
+	}
+	r := Rate{Den: len(order)}
+	for _, id := range order {
+		attempts := byProtocol[id]
+		if len(attempts) != k {
+			continue
+		}
+		all := true
+		for _, a := range attempts {
+			if !supersedePassed(a) {
+				all = false
+				break
+			}
+		}
+		if all {
+			r.Num++
+		}
+	}
+	if r.Den > 0 {
+		r.Rate = float64(r.Num) / float64(r.Den)
+	}
+	return r
+}
+
+// supersedePassed reports whether one attempt cleanly superseded: captured the
+// fact, left no duplicate, and flipped the post-correction recall.
+func supersedePassed(r ProtocolRun) bool {
+	return r.Error == "" && boolTrue(r.Captured) && !boolTrue(r.Duplicated) && boolTrue(r.UpdateCorrect)
+}
+
+// WriteJSON persists the supersede results.
+func (res *SupersedeResults) WriteJSON(path string) error {
+	raw, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal supersede results: %w", err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		return fmt.Errorf("write supersede results: %w", err)
+	}
+	return nil
+}
+
+// LoadSupersedeJSON reads results written by SupersedeResults.WriteJSON.
+func LoadSupersedeJSON(path string) (*SupersedeResults, error) {
+	raw, err := os.ReadFile(path) // #nosec G304 -- operator-supplied results path
+	if err != nil {
+		return nil, fmt.Errorf("read supersede results: %w", err)
+	}
+	var res SupersedeResults
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, fmt.Errorf("parse supersede results: %w", err)
+	}
+	return &res, nil
+}
+
+// HumanSummary renders the supersede sub-benchmark for a terminal.
+func (res *SupersedeResults) HumanSummary() string {
+	var b strings.Builder
+	m := res.Manifest
+	provider := m.LLMProvider
+	if m.ClientVersion != "" {
+		provider = fmt.Sprintf("%s via %s", m.LLMProvider, m.ClientVersion)
+	}
+	fmt.Fprintf(&b, "bench supersede (S5 isolated): arm=%s model=%s (%s) k=%d\n", m.Arm, m.Model, provider, m.K)
+	fmt.Fprintf(&b, "  platform %s @ %s | commit %s | seed %d | protocols %s\n",
+		m.PlatformVersion, m.Target, short(m.GitCommit), m.Seed, short(m.ProtocolSetHash))
+	fmt.Fprintf(&b, "  %s .. %s\n\n", m.StartedAt.Format(time.RFC3339), m.FinishedAt.Format(time.RFC3339))
+	mt := res.Metrics
+	fmt.Fprintf(&b, "protocols %d  attempts %d  harness failures %d\n", mt.Protocols, mt.Attempts, mt.HarnessFailures)
+	fmt.Fprintf(&b, "tokens: input %d  output %d  cache read %d  cache write %d (apply current model pricing for cost)\n\n",
+		mt.TotalInputTokens, mt.TotalOutputTokens, mt.TotalCacheReadTokens, mt.TotalCacheCreationTokens)
+	writeMetric(&b, "capture rate", mt.CaptureRate)
+	writeMetric(&b, "supersede rate", mt.SupersedeRate)
+	writeMetric(&b, "duplicate rate", mt.DuplicateRate)
+	writeMetric(&b, "update correctness", mt.UpdateCorrectness)
+	writeMetric(&b, "pass^k (protocols)", mt.PassK)
+	if len(mt.PerProtocol) > 0 {
+		b.WriteString("\nper-protocol stability (superseded/duplicated of captured attempts):\n")
+		for _, s := range mt.PerProtocol {
+			fmt.Fprintf(&b, "  %-24s cap %d/%d  superseded %d  duplicated %d\n",
+				s.ProtocolID, s.Captured, s.Attempts, s.Superseded, s.Duplicated)
+		}
+	}
+	return b.String()
+}

--- a/bench/internal/lifecycle/supersede_test.go
+++ b/bench/internal/lifecycle/supersede_test.go
@@ -1,0 +1,154 @@
+package lifecycle
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/txn2/mcp-data-platform/bench/internal/llm"
+)
+
+// supersedeOnlyScript plays just the stages the isolated sub-benchmark drives:
+// teach (capture), update (correct), and the post-correction recall. Recall,
+// transfer, and abstain never run, so they are absent by design.
+func supersedeOnlyScript(protocolID, updateCategory string) map[string]llm.Script {
+	return map[string]llm.Script{
+		protocolID: {
+			StageTeach:        {captureStep("definition"), {FinalText: "saved"}},
+			StageUpdate:       {captureStep(updateCategory), {FinalText: "saved"}},
+			StageUpdateRecall: {searchStep(), {FinalText: "FINAL ANSWER: 200.00"}},
+		},
+	}
+}
+
+func TestRunSupersedeCleanSupersede(t *testing.T) {
+	fp := newFakePlatform(t)
+	dir := t.TempDir()
+	p := updateProtocol()
+	writeProtocols(t, dir, p)
+	// "correction" makes the fake supersede the prior pending insight: no duplicate.
+	res, err := RunSupersede(context.Background(), runOptions(fp, dir, scriptFactory(supersedeOnlyScript(p.ID, "correction"))))
+	if err != nil {
+		t.Fatalf("run supersede: %v", err)
+	}
+	m := res.Metrics
+	if m.Protocols != 1 || m.Attempts != 1 || m.HarnessFailures != 0 {
+		t.Fatalf("counts = protocols %d attempts %d failures %d, want 1/1/0", m.Protocols, m.Attempts, m.HarnessFailures)
+	}
+	if m.CaptureRate.Rate != 1 || m.SupersedeRate.Rate != 1 || m.DuplicateRate.Rate != 0 || m.UpdateCorrectness.Rate != 1 {
+		t.Fatalf("metrics = capture %v supersede %v duplicate %v update %v, want 1/1/0/1",
+			m.CaptureRate.Rate, m.SupersedeRate.Rate, m.DuplicateRate.Rate, m.UpdateCorrectness.Rate)
+	}
+	if m.PassK.Rate != 1 {
+		t.Fatalf("pass^k = %v, want 1", m.PassK.Rate)
+	}
+	if len(m.PerProtocol) != 1 {
+		t.Fatalf("per-protocol stats = %d, want 1", len(m.PerProtocol))
+	}
+	s := m.PerProtocol[0]
+	if s.Captured != 1 || s.Superseded != 1 || s.Duplicated != 0 {
+		t.Fatalf("per-protocol = cap %d superseded %d dup %d, want 1/1/0", s.Captured, s.Superseded, s.Duplicated)
+	}
+}
+
+func TestRunSupersedeDuplicate(t *testing.T) {
+	fp := newFakePlatform(t)
+	dir := t.TempDir()
+	p := updateProtocol()
+	writeProtocols(t, dir, p)
+	// "definition" (not "correction") leaves the prior insight live: a duplicate.
+	res, err := RunSupersede(context.Background(), runOptions(fp, dir, scriptFactory(supersedeOnlyScript(p.ID, "definition"))))
+	if err != nil {
+		t.Fatalf("run supersede: %v", err)
+	}
+	m := res.Metrics
+	if m.SupersedeRate.Rate != 0 || m.DuplicateRate.Rate != 1 {
+		t.Fatalf("metrics = supersede %v duplicate %v, want 0/1", m.SupersedeRate.Rate, m.DuplicateRate.Rate)
+	}
+	if m.PassK.Rate != 0 {
+		t.Fatalf("pass^k = %v, want 0 (a duplicate fails)", m.PassK.Rate)
+	}
+	if s := m.PerProtocol[0]; s.Duplicated != 1 || s.Superseded != 0 {
+		t.Fatalf("per-protocol = superseded %d dup %d, want 0/1", s.Superseded, s.Duplicated)
+	}
+}
+
+// TestRunSupersedeCaptureMiss proves a supersede attempt whose teach never
+// captures is excluded from the supersede/duplicate denominators (the gate can
+// only be measured on a fact that actually landed).
+func TestRunSupersedeCaptureMiss(t *testing.T) {
+	fp := newFakePlatform(t)
+	dir := t.TempDir()
+	p := updateProtocol()
+	writeProtocols(t, dir, p)
+	scripts := map[string]llm.Script{
+		p.ID: {StageTeach: {{FinalText: "I will not save anything"}}}, // no capture
+	}
+	res, err := RunSupersede(context.Background(), runOptions(fp, dir, scriptFactory(scripts)))
+	if err != nil {
+		t.Fatalf("run supersede: %v", err)
+	}
+	m := res.Metrics
+	if m.CaptureRate.Num != 0 || m.CaptureRate.Den != 1 {
+		t.Fatalf("capture rate = %d/%d, want 0/1", m.CaptureRate.Num, m.CaptureRate.Den)
+	}
+	if m.SupersedeRate.Den != 0 || m.DuplicateRate.Den != 0 {
+		t.Fatalf("supersede/duplicate denominators = %d/%d, want 0/0 (no captured attempt to supersede)",
+			m.SupersedeRate.Den, m.DuplicateRate.Den)
+	}
+	if s := m.PerProtocol[0]; s.Captured != 0 || s.Superseded != 0 || s.Duplicated != 0 {
+		t.Fatalf("per-protocol = cap %d superseded %d dup %d, want 0/0/0", s.Captured, s.Superseded, s.Duplicated)
+	}
+}
+
+func TestRunSupersedeRejectsNonSupersedeProtocols(t *testing.T) {
+	fp := newFakePlatform(t)
+	dir := t.TempDir()
+	writeProtocols(t, dir, okProtocol()) // promote/transfer protocol, no update stage
+	_, err := RunSupersede(context.Background(), runOptions(fp, dir, scriptFactory(okScript())))
+	if err == nil || !strings.Contains(err.Error(), "no supersede protocols") {
+		t.Fatalf("expected no-supersede-protocols error, got %v", err)
+	}
+}
+
+func TestSupersedeResultsRoundTrip(t *testing.T) {
+	fp := newFakePlatform(t)
+	dir := t.TempDir()
+	p := updateProtocol()
+	writeProtocols(t, dir, p)
+	res, err := RunSupersede(context.Background(), runOptions(fp, dir, scriptFactory(supersedeOnlyScript(p.ID, "correction"))))
+	if err != nil {
+		t.Fatalf("run supersede: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "supersede.json")
+	if err := res.WriteJSON(out); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	loaded, err := LoadSupersedeJSON(out)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded.Metrics.SupersedeRate.Rate != res.Metrics.SupersedeRate.Rate {
+		t.Fatalf("round-trip supersede rate = %v, want %v", loaded.Metrics.SupersedeRate.Rate, res.Metrics.SupersedeRate.Rate)
+	}
+	if summary := loaded.HumanSummary(); !strings.Contains(summary, "supersede") {
+		t.Fatalf("summary missing supersede header:\n%s", summary)
+	}
+}
+
+func TestRunSupersedeCheckpoints(t *testing.T) {
+	fp := newFakePlatform(t)
+	dir := t.TempDir()
+	p := updateProtocol()
+	writeProtocols(t, dir, p)
+	opts := runOptions(fp, dir, scriptFactory(supersedeOnlyScript(p.ID, "correction")))
+	var snapshots int
+	opts.OnSupersede = func(*SupersedeResults) { snapshots++ }
+	if _, err := RunSupersede(context.Background(), opts); err != nil {
+		t.Fatalf("run supersede: %v", err)
+	}
+	if snapshots != 1 {
+		t.Fatalf("checkpoints = %d, want 1", snapshots)
+	}
+}


### PR DESCRIPTION
Closes #964. Part 2 of 4 under #958.

## What this delivers

The phase-4 S5 data left three lifecycle metrics as noisy ranges rather than point estimates: cross-identity transfer (~42-47%), capture failures from discovery-budget exhaustion, and duplicate/supersede detection that disagreed 0% vs 42.9% between identical runs. This adds the per-stage instrumentation that attributes each of those gaps and an isolated supersede sub-benchmark so the supersede gate can be measured on its own. The instrumentation is the durable deliverable; the real-run diagnosis it enables is budget-gated and runnable from the new CLI surface.

All new signals are derived from the provider-agnostic episode transcript, so they behave identically on the in-process loop path and the real `claude -p` (claude-cli) path — the two paths cannot diverge on what "the teacher executed capture" or "the fact surfaced" means.

## Transfer gap: delivery vs. reasoning

The transfer rate alone cannot tell whether a promoted fact failed to reach the second identity or reached it and was ignored. Each transfer attempt now records `TransferSurfaced`: whether the promoted fact appeared in a tool result the learner actually saw (a normalized-substring match of the promoted content — the datahub-sink description or the knowledge-page body — against the episode's non-error tool results). Two report metrics decompose the gap:

- `transfer_surfaced` — among transfer attempts, the fraction where the promoted fact surfaced. A low value points at delivery (cross-enrichment or search did not carry it across identities).
- `transfer_used_given_surfaced` — among the surfaced attempts, the fraction answered correctly. A low value points at reasoning (the agent had the fact and did not use it).

## Capture-budget gap

Transcripts showed the teacher sometimes spending its whole tool-call budget on discovery before ever reaching the capture tool. Each run now records, from the teach episode, whether an actual capture executed (`CaptureAttempted`) and whether the budget was exhausted (`TeachBudgetExhausted`), yielding `capture_budget_starved`: among capture misses, the fraction where the teacher exhausted its budget without executing a capture call.

Two subtleties keep this metric honest:

- A capture request the budget refused (emitted only after the budget was spent, so it never ran) counts as budget-starved, not as an attempted-but-unlanded capture. `CaptureAttempted` requires an executed, non-budget-refused capture call.
- Budget exhaustion is observable only on the in-process loop path, which owns the tool-call budget. The claude-cli path runs its own turn budget, so `TeachBudgetExhausted` is left unset there and those capture misses are excluded from the rate rather than miscounted as not-starved.

`-teach-budget N` overrides the per-episode tool-call budget for the capture-bearing stages (teach and update), so the capture-rate lift from a larger teach budget can be measured directly against the same protocol set.

## Isolated supersede sub-benchmark

`-supersede` drives the recall-first supersede gate in isolation: only the supersede protocols (those with an `update` stage), through teach -> capture-verify -> correct -> supersede-status check, skipping the promote, transfer, personal-recall, and abstain stages that otherwise dilute the signal. It reuses the existing teach/capture and supersede stage code, so the sub-benchmark and the full S5 suite exercise the identical correctness-critical path.

The focused scorecard reports capture rate, supersede rate (the structural complement of duplicate rate, derived once so they cannot drift apart), update correctness, pass^k, and a per-protocol `superseded`/`duplicated` breakdown across the k attempts — so the 0%-vs-42.9% instability is visible per protocol instead of blended into one range. Because the gate is embedding-similarity based (nomic-embed-text), the threshold / embedding-model / deterministic-fallback evaluation is done by re-running this sub-benchmark against differently-configured platforms and comparing the supersede rate: the sub-benchmark is the measuring instrument, the platform config is the independent variable.

## CLI and Makefile surface

- `benchrun -supersede` runs the sub-benchmark; `-supersede -summarize <file>` prints its human summary. `-teach-budget N` applies to both the full lifecycle and the supersede run. `-baseline` is refused for supersede runs (the regression gate scores the S1-S3 task shape, not supersede metrics).
- `make bench-supersede`, `make bench-supersede-smoke` (scripted, no API key), and `make bench-supersede-report`, mirroring the existing lifecycle and cold-start targets.

## Testing

`make bench-test` (build, vet, race-detected unit tests) and `golangci-lint run ./...` are green on the bench module. New coverage: the instrumentation helpers and report decomposition are at 100%; `RunSupersede` and the supersede report aggregate are exercised for clean supersede, duplicate, capture-miss, non-supersede-protocol rejection, checkpoint flush, and JSON round-trip. The transfer decomposition, capture-budget starvation, the budget-refused-capture edge case, the claude-cli exclusion, and the `-teach-budget` lever are each covered by an integration test that drives the real assembled runner against a fake MCP platform.

The only main-module change is three additive `bench-*` Makefile targets; the substantive documentation is in `bench/README.md`.

## Not in scope

Real-run diagnosis numbers for the three gaps are budget-gated (the definition of done frames them as the evaluation deliverable) and are produced by running the new instrumented harness and sub-benchmark. This PR is the harness. Confidence intervals over a larger protocol set (#965) and the harness-hardening follow-ups (#966) are separate children of #958.
