### PR TITLE
bench(s5): harness hardening — output isolation, S5 regression gate, claude-cli cache tokens (#966)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -247,6 +247,12 @@ budget for the capture-bearing stages (teach and update), so the capture-rate
 lift from a larger teach budget can be measured directly against the same
 protocol set.
 
+### Harness hardening (#966)
+
+- **Regression gate.** `-baseline <committed.json>` with `-lifecycle` gates the run against a committed S5 baseline and exits nonzero when a headline lifecycle metric regresses, so CI catches a lifecycle capability loss the same way it already catches an S1-S3 one. It applies to both a single-process run and a `-merge`d k=N scorecard (the canonical multi-pass artifact CI gates). The gated metrics are capture rate, personal recall, transfer rate, update correctness, abstention rate, duplicate rate (an increase past tolerance is the regression), and pass^k; a metric that either run did not exercise (zero denominator) is skipped as a coverage gap, not scored as a drop. The #964 diagnostic decompositions are deliberately not gated — their small denominators would trip the gate on noise; they exist to explain a regression, not define one. The gate refuses a cross-arm comparison, and a cross-client-path one (anthropic vs claude-cli), rather than producing a meaningless verdict; it compares the client path, not the exact CLI version, so a benign `claude` bump does not disable it. Default tolerances are loose (5 points) to absorb run-to-run variance.
+- **Output isolation.** The transcript directory is keyed on the full `-out` filename (`results.json` -> `results.json.transcripts/`), so several passes written into the same directory under different output names — even ones sharing a stem but differing by extension — never overwrite one another's raw transcripts. The `-merge` step refuses an `-out` that is the same on-disk file as one of its input passes (compared by device+inode, so a case-variant or symlinked alias is caught too), so a merged scorecard never clobbers the raw per-pass evidence it was built from. Together these mean multi-pass orchestration cannot silently discard paid-for data.
+- **claude-cli cache tokens.** A cached `claude -p` run's `cache_read_input_tokens` / `cache_creation_input_tokens` flow through the stream parser into each lifecycle `EpisodeRecord` and are summed into the run's `total_cache_read_tokens` / `total_cache_creation_tokens`, so a cached run self-reports its true cost basis (cache reads bill far below fresh input). The full parser -> `EpisodeRecord` -> aggregate path is covered by a test that drives the real parser on a canned cached stream; that a real `claude` process emits those fields is confirmed by one real cached run.
+
 ## Supersede sub-benchmark (#964)
 
 `-supersede` runs the recall-first supersede gate **in isolation**: it drives
@@ -478,7 +484,7 @@ bench/
     ├── grade/           deterministic graders (numeric, entity, execution-result)
     ├── judge/           LLM judge + calibration harness
     ├── pipeline/        task x k orchestration
-    ├── lifecycle/       S5 protocol runner, stage graders, metrics, results model, per-stage diagnosis instrumentation + isolated supersede sub-benchmark (#964)
+    ├── lifecycle/       S5 protocol runner, stage graders, metrics, results model, per-stage diagnosis instrumentation + isolated supersede sub-benchmark (#964), S5 regression gate (#966)
     ├── coldstart/       cold-start curriculum runner, learning-curve metrics, results model
     ├── report/          results model, aggregates, cross-arm comparison
     └── target/          endpoint + Bearer auth

--- a/bench/benchrun/main.go
+++ b/bench/benchrun/main.go
@@ -98,7 +98,7 @@ func parseFlags() config {
 	flag.StringVar(&cfg.calibration, "calibration", "judge/calibration.yaml", "judge calibration file (with -calibrate)")
 	flag.BoolVar(&cfg.lifecycle, "lifecycle", false, "run the S5 memory-insight-knowledge lifecycle protocols instead of the S1-S3 task suites")
 	flag.StringVar(&cfg.protocolsDir, "protocols", "protocols", "protocol YAML directory (with -lifecycle)")
-	flag.StringVar(&cfg.baseline, "baseline", "", "committed baseline results JSON: after the run, gate on per-suite regression and exit nonzero if the candidate falls below it")
+	flag.StringVar(&cfg.baseline, "baseline", "", "committed baseline results JSON: after the run, gate on regression and exit nonzero if the candidate falls below it (S1-S3 per-suite, or S5 lifecycle metrics with -lifecycle)")
 	flag.StringVar(&cfg.merge, "merge", "", "comma-separated per-pass lifecycle result JSONs (with -lifecycle): merge independent k=1 passes into one k=N result and exit")
 	flag.BoolVar(&cfg.coldStart, "cold-start", false, "run the cold-start knowledge-growth curriculum (issue #963) instead of the task suites")
 	flag.StringVar(&cfg.curriculumDir, "curriculum", "curriculum", "curriculum YAML directory (with -cold-start)")
@@ -187,13 +187,6 @@ func runLifecycle(cfg config) error {
 	if cfg.arm == "" {
 		return errors.New("-arm is required")
 	}
-	if cfg.baseline != "" {
-		// The regression gate compares per-suite S1-S3 accuracy/pass^k/efficiency
-		// (report.Results). Lifecycle runs produce a different metric shape
-		// (lifecycle.Results: capture/recall/transfer rates), so the S1-S3 gate
-		// cannot score them. Refuse loudly rather than silently ignore -baseline.
-		return errors.New("-baseline is not supported with -lifecycle (the regression gate scores S1-S3 task suites, not lifecycle metrics)")
-	}
 	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	opts := lifecycle.Options{
 		Target:        target.Target{BaseURL: cfg.url, Credential: cfg.credential},
@@ -216,18 +209,8 @@ func runLifecycle(cfg config) error {
 		},
 		Log: log,
 	}
-	if cfg.llmProvider == claudeCLIProvider {
-		runner, version, err := buildClaudeRunner(cfg)
-		if err != nil {
-			return err
-		}
-		opts.ClaudeCLI, opts.ClientVersion = runner, version
-	} else {
-		factory, err := buildLifecycleFactory(cfg)
-		if err != nil {
-			return err
-		}
-		opts.Factory = factory
+	if err := configureLifecycleProvider(cfg, &opts); err != nil {
+		return err
 	}
 	res, runErr := lifecycle.Run(context.Background(), opts)
 	if res != nil {
@@ -235,7 +218,55 @@ func runLifecycle(cfg config) error {
 			return err
 		}
 	}
-	return runErr
+	if runErr != nil {
+		return runErr
+	}
+	if cfg.baseline != "" && res != nil {
+		return gateOnLifecycleBaseline(res, cfg.baseline)
+	}
+	return nil
+}
+
+// configureLifecycleProvider sets the model-driving fields on a lifecycle
+// Options from the config: the real claude-cli runner (plus its client version)
+// or the in-process adapter factory. Shared by the full lifecycle and supersede
+// runs, which drive episodes identically.
+func configureLifecycleProvider(cfg config, opts *lifecycle.Options) error {
+	if cfg.llmProvider == claudeCLIProvider {
+		runner, version, err := buildClaudeRunner(cfg)
+		if err != nil {
+			return err
+		}
+		opts.ClaudeCLI, opts.ClientVersion = runner, version
+		return nil
+	}
+	factory, err := buildLifecycleFactory(cfg)
+	if err != nil {
+		return err
+	}
+	opts.Factory = factory
+	return nil
+}
+
+// gateOnLifecycleBaseline compares the just-completed lifecycle run against a
+// committed baseline and returns a non-nil error (nonzero exit) if any headline
+// S5 metric regressed beyond the default thresholds, so CI catches a lifecycle
+// capability loss the same way it catches an S1-S3 one (issue #966).
+func gateOnLifecycleBaseline(candidate *lifecycle.Results, baselinePath string) error {
+	base, err := lifecycle.LoadJSON(baselinePath)
+	if err != nil {
+		return fmt.Errorf("load lifecycle baseline: %w", err)
+	}
+	if err := lifecycle.BaselineCompatible(candidate, base); err != nil {
+		return fmt.Errorf("baseline %s: %w", baselinePath, err)
+	}
+	t := lifecycle.DefaultThresholds()
+	regs := lifecycle.CheckRegression(candidate, base, t)
+	fmt.Print(lifecycle.RegressionReport(candidate, base, t, regs))
+	if len(regs) > 0 {
+		return fmt.Errorf("lifecycle regression gate: %d metric(s) fell below baseline %s", len(regs), baselinePath)
+	}
+	return nil
 }
 
 // runSupersede executes the isolated supersede sub-benchmark (issue #964) and
@@ -270,18 +301,8 @@ func runSupersede(cfg config) error {
 		},
 		Log: log,
 	}
-	if cfg.llmProvider == claudeCLIProvider {
-		runner, version, err := buildClaudeRunner(cfg)
-		if err != nil {
-			return err
-		}
-		opts.ClaudeCLI, opts.ClientVersion = runner, version
-	} else {
-		factory, err := buildLifecycleFactory(cfg)
-		if err != nil {
-			return err
-		}
-		opts.Factory = factory
+	if err := configureLifecycleProvider(cfg, &opts); err != nil {
+		return err
 	}
 	res, runErr := lifecycle.RunSupersede(context.Background(), opts)
 	if res != nil {
@@ -448,6 +469,9 @@ func buildLifecycleFactory(cfg config) (lifecycle.AdapterFactory, error) {
 // on protocol id and run count (lifecycle.passKRate), not on the Attempt field.
 func runMergeLifecycle(cfg config) error {
 	paths := strings.Split(cfg.merge, ",")
+	if err := ensureDistinctMergeOutput(cfg.out, paths); err != nil {
+		return err
+	}
 	merged := &lifecycle.Results{}
 	for i, p := range paths {
 		if err := foldPass(merged, strings.TrimSpace(p), i+1); err != nil {
@@ -461,6 +485,39 @@ func runMergeLifecycle(cfg config) error {
 	}
 	fmt.Print(merged.HumanSummary())
 	fmt.Println("results:", cfg.out)
+	// The merged k=N scorecard is the canonical thing CI gates, so -baseline must
+	// apply here too (not only to a single-process run) — otherwise the standard
+	// multi-pass workflow would silently skip the regression gate.
+	if cfg.baseline != "" {
+		return gateOnLifecycleBaseline(merged, cfg.baseline)
+	}
+	return nil
+}
+
+// ensureDistinctMergeOutput refuses a merge whose -out would overwrite one of
+// its input passes. The merged scorecard is derived data; clobbering a raw
+// per-pass file with it would destroy paid-for evidence that can never be
+// regenerated without re-running. Collision is detected with os.SameFile
+// (device+inode), which — unlike a string comparison of cleaned paths — catches
+// a case-variant spelling on a case-insensitive filesystem (macOS/Windows) and a
+// symlinked input/output pair, both of which resolve to the same on-disk file.
+// If the output path does not yet exist (even via a case-insensitive or symlink
+// alias), no input can be overwritten, so the merge is allowed.
+func ensureDistinctMergeOutput(out string, inputs []string) error {
+	outInfo, err := os.Stat(out)
+	if err != nil {
+		return nil //nolint:nilerr // a non-existent output cannot overwrite any input
+	}
+	for _, in := range inputs {
+		in = strings.TrimSpace(in)
+		inInfo, err := os.Stat(in)
+		if err != nil {
+			continue // a missing input is foldPass's error to report with a clearer message
+		}
+		if os.SameFile(outInfo, inInfo) {
+			return fmt.Errorf("-out %s is the same file as input pass %s; choose a distinct output path so raw pass data is never overwritten", out, in)
+		}
+	}
 	return nil
 }
 
@@ -637,9 +694,16 @@ func gateOnBaseline(candidate *report.Results, baselinePath string) error {
 	return nil
 }
 
-// transcriptDir derives the transcript directory from the results path.
+// transcriptDir derives the per-run transcript directory from the results path.
+// It keys on the FULL output filename (extension included), not just its parent
+// directory or stem, so several passes or runs written into the SAME directory
+// under different -out names each get their own transcript directory and never
+// overwrite one another's raw transcripts (results.json -> results.json.transcripts/).
+// Keeping the extension means two outputs that share a stem but differ by
+// extension (results.json, results.txt) do not collide. Isolating on the output
+// name means multi-pass orchestration cannot silently clobber paid-for data.
 func transcriptDir(out string) string {
-	return filepath.Join(filepath.Dir(out), "transcripts")
+	return filepath.Join(filepath.Dir(out), filepath.Base(out)+".transcripts")
 }
 
 // claudeCLIProvider is the -llm value selecting the real Claude Code client

--- a/bench/benchrun/main_test.go
+++ b/bench/benchrun/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -73,6 +74,156 @@ func TestMergeRequiresLifecycle(t *testing.T) {
 	handled, err := runReadOnly(config{merge: "x.json"}) // lifecycle: false
 	if !handled || err == nil {
 		t.Fatalf("bare -merge did not error (handled=%v err=%v)", handled, err)
+	}
+}
+
+// TestTranscriptDirIsolatesByOutputName proves two passes written into the same
+// directory under different -out names get distinct transcript directories, so
+// one pass never overwrites another's raw transcripts.
+func TestTranscriptDirIsolatesByOutputName(t *testing.T) {
+	a := transcriptDir("build/bench-results/lifecycle-pass1.json")
+	b := transcriptDir("build/bench-results/lifecycle-pass2.json")
+	if a == b {
+		t.Fatalf("passes in the same dir collided: both -> %s", a)
+	}
+	// Same stem, different extension must not collide (the extension is kept).
+	if transcriptDir("out/results.json") == transcriptDir("out/results.txt") {
+		t.Fatal("results.json and results.txt collided on transcript dir")
+	}
+	if got := transcriptDir("out/results.json"); got != filepath.Join("out", "results.json.transcripts") {
+		t.Fatalf("transcriptDir = %s, want out/results.json.transcripts", got)
+	}
+}
+
+// TestMergeRefusesToOverwriteInput proves a merge whose -out is the same file as
+// one of its input passes is rejected, so derived data never clobbers raw pass
+// evidence.
+func TestMergeRefusesToOverwriteInput(t *testing.T) {
+	dir := t.TempDir()
+	p1 := writeLifecyclePass(t, "p1", "a3", 1, "lc-x")
+	p2 := writeLifecyclePass(t, "p2", "a3", 1, "lc-x")
+	// -out is the same file as the first input pass.
+	if err := runMergeLifecycle(config{lifecycle: true, merge: p1 + "," + p2, out: p1}); err == nil {
+		t.Fatal("merge overwrote an input pass file")
+	}
+	// A distinct output path is accepted.
+	out := filepath.Join(dir, "merged.json")
+	if err := runMergeLifecycle(config{lifecycle: true, merge: p1 + "," + p2, out: out}); err != nil {
+		t.Fatalf("merge to a distinct path failed: %v", err)
+	}
+}
+
+// TestMergeGatesOnBaseline proves the -baseline regression gate runs on the
+// merged k=N scorecard (the canonical multi-pass artifact), not only on a
+// single-process run — the fix for -merge silently skipping the gate.
+func TestMergeGatesOnBaseline(t *testing.T) {
+	mkFailingPass := func(name string) string {
+		r := &lifecycle.Results{Manifest: lifecycle.Manifest{Arm: "a3", K: 1, ProtocolSetHash: "h1", Model: "m", Seed: 930}}
+		r.Runs = append(r.Runs, lifecycle.ProtocolRun{ProtocolID: "lc-x", Captured: new(false), RecallCorrect: new(false)})
+		p := filepath.Join(t.TempDir(), name+".json")
+		if err := r.WriteJSON(p); err != nil {
+			t.Fatalf("write pass: %v", err)
+		}
+		return p
+	}
+	p1, p2 := mkFailingPass("p1"), mkFailingPass("p2")
+	base := lifecycleBaselineFile(t, healthyLifecycleMetrics()) // capture/recall 90%
+	out := filepath.Join(t.TempDir(), "merged.json")
+	if err := runMergeLifecycle(config{lifecycle: true, merge: p1 + "," + p2, out: out, baseline: base}); err == nil {
+		t.Fatal("merge did not gate the merged scorecard against a regressing baseline")
+	}
+}
+
+// TestEnsureDistinctMergeOutput proves the collision check is by underlying file
+// (os.SameFile), so a symlink aliasing an input is caught while a distinct,
+// not-yet-existing output is allowed.
+func TestEnsureDistinctMergeOutput(t *testing.T) {
+	dir := t.TempDir()
+	pass := filepath.Join(dir, "pass1.json")
+	if err := os.WriteFile(pass, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureDistinctMergeOutput(pass, []string{pass, filepath.Join(dir, "pass2.json")}); err == nil {
+		t.Fatal("identical input/output file was allowed")
+	}
+	// A symlink to an input resolves to the same file, so it is caught.
+	link := filepath.Join(dir, "alias.json")
+	if err := os.Symlink(pass, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureDistinctMergeOutput(link, []string{pass}); err == nil {
+		t.Fatal("a symlinked output aliasing an input was allowed")
+	}
+	// A distinct, not-yet-existing output is allowed.
+	if err := ensureDistinctMergeOutput(filepath.Join(dir, "merged.json"), []string{pass}); err != nil {
+		t.Fatalf("distinct output rejected: %v", err)
+	}
+}
+
+// lifecycleRate builds a lifecycle.Rate for the gate tests.
+func lifecycleRate(num, den int) lifecycle.Rate {
+	r := lifecycle.Rate{Num: num, Den: den}
+	if den > 0 {
+		r.Rate = float64(num) / float64(den)
+	}
+	return r
+}
+
+// healthyLifecycleMetrics is a passing S5 scorecard.
+func healthyLifecycleMetrics() lifecycle.Metrics {
+	return lifecycle.Metrics{
+		Attempts:          10,
+		CaptureRate:       lifecycleRate(9, 10),
+		PersonalRecall:    lifecycleRate(9, 10),
+		TransferRate:      lifecycleRate(8, 10),
+		UpdateCorrectness: lifecycleRate(5, 5),
+		AbstentionRate:    lifecycleRate(9, 10),
+		DuplicateRate:     lifecycleRate(0, 5),
+		PassK:             lifecycleRate(7, 10),
+	}
+}
+
+// lifecycleBaselineFile writes an a3 lifecycle results JSON standing in for a
+// committed S5 baseline the gate loads from disk.
+func lifecycleBaselineFile(t *testing.T, m lifecycle.Metrics) string {
+	t.Helper()
+	r := &lifecycle.Results{Manifest: lifecycle.Manifest{Arm: "a3"}, Metrics: m}
+	p := filepath.Join(t.TempDir(), "life-baseline.json")
+	if err := r.WriteJSON(p); err != nil {
+		t.Fatalf("write lifecycle baseline: %v", err)
+	}
+	return p
+}
+
+// TestLifecycleGatePasses proves a lifecycle candidate that holds the line
+// returns nil (exit 0), so the S5 gate does not fail a healthy run.
+func TestLifecycleGatePasses(t *testing.T) {
+	base := lifecycleBaselineFile(t, healthyLifecycleMetrics())
+	cand := &lifecycle.Results{Manifest: lifecycle.Manifest{Arm: "a3"}, Metrics: healthyLifecycleMetrics()}
+	if err := gateOnLifecycleBaseline(cand, base); err != nil {
+		t.Fatalf("clean lifecycle candidate was gated: %v", err)
+	}
+}
+
+// TestLifecycleGateFailsOnRegression proves the S5 gate exits nonzero when a
+// lifecycle metric falls below the baseline beyond tolerance.
+func TestLifecycleGateFailsOnRegression(t *testing.T) {
+	base := lifecycleBaselineFile(t, healthyLifecycleMetrics())
+	m := healthyLifecycleMetrics()
+	m.TransferRate = lifecycleRate(50, 100) // 80% -> 50%
+	cand := &lifecycle.Results{Manifest: lifecycle.Manifest{Arm: "a3"}, Metrics: m}
+	if err := gateOnLifecycleBaseline(cand, base); err == nil {
+		t.Fatal("a transfer-rate collapse should fail the gate")
+	}
+}
+
+// TestLifecycleGateRejectsArmMismatch proves the gate refuses a cross-arm
+// comparison rather than producing a meaningless verdict.
+func TestLifecycleGateRejectsArmMismatch(t *testing.T) {
+	base := lifecycleBaselineFile(t, healthyLifecycleMetrics())
+	cand := &lifecycle.Results{Manifest: lifecycle.Manifest{Arm: "a2"}, Metrics: healthyLifecycleMetrics()}
+	if err := gateOnLifecycleBaseline(cand, base); err == nil {
+		t.Fatal("a cross-arm lifecycle gate should be refused")
 	}
 }
 

--- a/bench/internal/lifecycle/claudecli_test.go
+++ b/bench/internal/lifecycle/claudecli_test.go
@@ -23,6 +23,59 @@ const claudeRecallStream = `{"type":"system","subtype":"init","mcp_servers":[{"n
 {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"FINAL ANSWER: 500"}]}}
 {"type":"result","subtype":"success","is_error":false,"result":"FINAL ANSWER: 500","session_id":"cc-1","usage":{"input_tokens":30,"output_tokens":8}}`
 
+// claudeCachedStream is a claude-cli recall transcript whose terminal result
+// event reports cache tokens, so the end-to-end cache-token flow (parser ->
+// Result.Usage -> EpisodeRecord) can be asserted through the real parser.
+const claudeCachedStream = `{"type":"system","subtype":"init","mcp_servers":[{"name":"bench","status":"connected"}]}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"i0","name":"mcp__bench__platform_info","input":{}}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"i0","is_error":false,"content":"{\"session_id\":\"dps_cc_9\",\"version\":\"fake-1.0.0\"}"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"FINAL ANSWER: 500"}]}}
+{"type":"result","subtype":"success","is_error":false,"result":"FINAL ANSWER: 500","session_id":"cc-9","usage":{"input_tokens":40,"output_tokens":9,"cache_read_input_tokens":1200,"cache_creation_input_tokens":80}}`
+
+// TestClaudeCLIEpisodeRecordsCacheTokens verifies #966 end to end: a cached
+// claude-cli run's cache tokens flow through the real parser into the lifecycle
+// EpisodeRecord, so a cached run self-reports its true cost basis (cache reads
+// bill far below fresh input) rather than being estimated from input/output
+// totals. The one remaining gap — that a real `claude` process actually emits
+// these fields — is confirmed by a single real cached run (see bench/README.md).
+func TestClaudeCLIEpisodeRecordsCacheTokens(t *testing.T) {
+	fp := newFakePlatform(t)
+	runner, err := claudecli.New(claudecli.Options{
+		Model: "claude-sonnet-5",
+		Exec: func(context.Context, claudecli.CommandSpec) ([]byte, []byte, error) {
+			return []byte(claudeCachedStream), nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("claudecli.New: %v", err)
+	}
+	tgt := target.Target{BaseURL: fp.httpSrv.URL, Credential: fp.base}
+	env := &runEnv{
+		opts:  Options{Target: tgt, HTTPTimeout: 10 * time.Second, Arm: "a3", ClaudeCLI: runner, IdentityKeys: 32, AuditTimeout: time.Second},
+		log:   slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})),
+		audit: auditapi.New(fp.httpSrv.URL, tgt.HTTPClient(10*time.Second)),
+	}
+	env.currentProtocolID = "p-cache"
+
+	rec, _ := env.runClaudeCLIEpisode(context.Background(), episodeSpec{
+		stage: StageRecall, identity: "teacher", seq: 1, prompt: "q", system: "s", budget: 5,
+	})
+	if rec.Error != "" {
+		t.Fatalf("episode error: %s", rec.Error)
+	}
+	if rec.CacheReadTokens != 1200 || rec.CacheCreationTokens != 80 {
+		t.Fatalf("EpisodeRecord cache tokens = read %d write %d, want 1200/80", rec.CacheReadTokens, rec.CacheCreationTokens)
+	}
+	// The aggregate must sum the per-episode cache split so a run self-reports its
+	// cached cost basis.
+	res := &Results{Runs: []ProtocolRun{{Episodes: []EpisodeRecord{rec}}}}
+	res.Aggregate()
+	if res.Metrics.TotalCacheReadTokens != 1200 || res.Metrics.TotalCacheCreationTokens != 80 {
+		t.Fatalf("aggregate cache totals = read %d write %d, want 1200/80",
+			res.Metrics.TotalCacheReadTokens, res.Metrics.TotalCacheCreationTokens)
+	}
+}
+
 // TestClaudeCLIEpisode drives the lifecycle claude-cli episode path directly:
 // the stubbed client returns a recall transcript that calls search, and the
 // harness maps the client result, reads audit best effort by the pool

--- a/bench/internal/lifecycle/regression.go
+++ b/bench/internal/lifecycle/regression.go
@@ -1,0 +1,180 @@
+package lifecycle
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Thresholds bound how far a candidate lifecycle run may fall below a committed
+// baseline before it counts as a regression (issue #966). RateDrop is the
+// tolerated absolute drop for the higher-is-better rates (0.05 = five percentage
+// points); DuplicateIncrease is the tolerated absolute increase in the
+// duplicate rate (lower is better); PassKDrop is the tolerated pass^k drop.
+//
+// The defaults match the S1-S3 gate's loose bounds: lifecycle runs are
+// stochastic and the per-metric denominators are small, so a gate that trips on
+// one-point noise would fire on every rerun. The gate exists to catch a real
+// lifecycle capability loss (capture stops landing, transfer stops surfacing,
+// the supersede gate starts leaving duplicates), not run-to-run variance.
+type Thresholds struct {
+	RateDrop          float64
+	DuplicateIncrease float64
+	PassKDrop         float64
+}
+
+// DefaultThresholds returns the standard lifecycle regression bounds.
+func DefaultThresholds() Thresholds {
+	return Thresholds{RateDrop: 0.05, DuplicateIncrease: 0.05, PassKDrop: 0.05}
+}
+
+// MetricRegression is one breached threshold for one lifecycle metric.
+type MetricRegression struct {
+	Metric    string  `json:"metric"`
+	Baseline  float64 `json:"baseline"`
+	Candidate float64 `json:"candidate"`
+	Limit     float64 `json:"limit"` // the value at or beyond which it counts as a regression
+	// LowerIsBetter marks the duplicate-rate direction, where a regression is an
+	// increase past the limit rather than a drop below it.
+	LowerIsBetter bool `json:"lower_is_better,omitempty"`
+}
+
+// gatedMetric names one lifecycle metric the gate scores. Only the headline
+// capability rates are gated; the #964 diagnostic decompositions (transfer
+// surfaced / used-given-surfaced / capture budget-starved) are deliberately not
+// gated — their denominators are small enough that gating them would trip on
+// noise, and they exist to explain a regression, not to define one.
+type gatedMetric struct {
+	name          string
+	get           func(Metrics) Rate
+	lowerIsBetter bool
+}
+
+var gatedMetrics = []gatedMetric{
+	{"capture_rate", func(m Metrics) Rate { return m.CaptureRate }, false},
+	{"personal_recall", func(m Metrics) Rate { return m.PersonalRecall }, false},
+	{"transfer_rate", func(m Metrics) Rate { return m.TransferRate }, false},
+	{"update_correctness", func(m Metrics) Rate { return m.UpdateCorrectness }, false},
+	{"abstention_rate", func(m Metrics) Rate { return m.AbstentionRate }, false},
+	{"duplicate_rate", func(m Metrics) Rate { return m.DuplicateRate }, true},
+}
+
+// BaselineCompatible reports whether a candidate lifecycle run may be gated
+// against a baseline at all. Comparing across arms or across the anthropic vs
+// claude-cli client path, or against a baseline that graded nothing, produces
+// meaningless verdicts, so the gate refuses rather than silently mis-report.
+func BaselineCompatible(candidate, baseline *Results) error {
+	if candidate.Manifest.Arm != baseline.Manifest.Arm {
+		return fmt.Errorf("arm mismatch: candidate %q vs baseline %q — a baseline is only comparable within the same arm",
+			candidate.Manifest.Arm, baseline.Manifest.Arm)
+	}
+	// Gate on the client PATH (anthropic vs claude-cli), not the exact CLI
+	// version: a benign `claude` patch bump must not disable the regression gate.
+	// Anthropic runs record an empty ClientVersion; claude-cli runs record a
+	// non-empty one, so parity is an emptiness comparison.
+	if (candidate.Manifest.ClientVersion == "") != (baseline.Manifest.ClientVersion == "") {
+		return fmt.Errorf("client path mismatch: candidate %q vs baseline %q — anthropic and claude-cli numbers are not comparable",
+			clientLabel(candidate.Manifest.ClientVersion), clientLabel(baseline.Manifest.ClientVersion))
+	}
+	if baseline.Metrics.Attempts == 0 {
+		return errors.New("baseline graded no attempts — nothing to gate against")
+	}
+	return nil
+}
+
+// clientLabel names the client path for an error message.
+func clientLabel(v string) string {
+	if v == "" {
+		return "in-process (anthropic)"
+	}
+	return "claude-cli " + v
+}
+
+// CheckRegression compares a candidate lifecycle run against a baseline metric by
+// metric and returns every breached threshold. A metric that either run did not
+// exercise (zero denominator on either side) is skipped — a coverage gap is not
+// a capability loss. A candidate that graded no attempts at all is a single
+// coverage regression, not one per metric. An empty result means the candidate
+// held the line. Call BaselineCompatible first — this assumes same-arm,
+// same-client-path.
+func CheckRegression(candidate, baseline *Results, t Thresholds) []MetricRegression {
+	if candidate.Metrics.Attempts == 0 {
+		return []MetricRegression{{Metric: "coverage", Baseline: 1, Candidate: 0, Limit: 1}}
+	}
+	var regs []MetricRegression
+	for _, gm := range gatedMetrics {
+		b := gm.get(baseline.Metrics)
+		c := gm.get(candidate.Metrics)
+		// A metric is comparable only when BOTH runs exercised it. A zero
+		// denominator on either side is a coverage gap (a partial protocol set),
+		// not a capability loss, so scoring it would flag a false regression.
+		if b.Den == 0 || c.Den == 0 {
+			continue
+		}
+		if reg, ok := rateRegression(gm.name, b, c, t.rateTolerance(gm.lowerIsBetter), gm.lowerIsBetter); ok {
+			regs = append(regs, reg)
+		}
+	}
+	if bp, cp := baseline.Metrics.PassK, candidate.Metrics.PassK; bp.Den > 0 && cp.Den > 0 {
+		if reg, ok := rateRegression("pass_k", bp, cp, t.PassKDrop, false); ok {
+			regs = append(regs, reg)
+		}
+	}
+	sort.Slice(regs, func(i, j int) bool { return regs[i].Metric < regs[j].Metric })
+	return regs
+}
+
+// rateTolerance returns the tolerance for a metric given its direction.
+func (t Thresholds) rateTolerance(lowerIsBetter bool) float64 {
+	if lowerIsBetter {
+		return t.DuplicateIncrease
+	}
+	return t.RateDrop
+}
+
+// rateRegression returns the regression a candidate rate breached against its
+// baseline, if any. For a higher-is-better metric the breach is a drop below
+// baseline-tolerance; for a lower-is-better metric it is a rise above
+// baseline+tolerance.
+func rateRegression(name string, b, c Rate, tol float64, lowerIsBetter bool) (MetricRegression, bool) {
+	if lowerIsBetter {
+		limit := b.Rate + tol
+		if c.Rate > limit {
+			return MetricRegression{Metric: name, Baseline: b.Rate, Candidate: c.Rate, Limit: limit, LowerIsBetter: true}, true
+		}
+		return MetricRegression{}, false
+	}
+	limit := b.Rate - tol
+	if c.Rate < limit {
+		return MetricRegression{Metric: name, Baseline: b.Rate, Candidate: c.Rate, Limit: limit}, true
+	}
+	return MetricRegression{}, false
+}
+
+// RegressionReport renders a lifecycle regression check for a terminal, naming
+// the baseline and candidate so a CI log records exactly what was compared.
+func RegressionReport(candidate, baseline *Results, t Thresholds, regs []MetricRegression) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "lifecycle regression check: candidate %s @ %s vs baseline %s @ %s\n",
+		candidate.Manifest.Arm, short(candidate.Manifest.PlatformVersion),
+		baseline.Manifest.Arm, short(baseline.Manifest.PlatformVersion))
+	fmt.Fprintf(&b, "  thresholds: rate -%.0f pts, duplicate +%.0f pts, pass^k -%.0f pts\n",
+		t.RateDrop*100, t.DuplicateIncrease*100, t.PassKDrop*100)
+	if len(regs) == 0 {
+		b.WriteString("  PASS: no lifecycle metric regressed beyond thresholds\n")
+		return b.String()
+	}
+	fmt.Fprintf(&b, "  FAIL: %d regression(s)\n", len(regs))
+	for _, r := range regs {
+		switch {
+		case r.Metric == "coverage":
+			b.WriteString("    coverage: candidate graded no attempts (baseline did)\n")
+		case r.LowerIsBetter:
+			fmt.Fprintf(&b, "    %s: %.1f%% -> %.1f%% (limit %.1f%%, lower is better)\n", r.Metric, r.Baseline*100, r.Candidate*100, r.Limit*100)
+		default:
+			fmt.Fprintf(&b, "    %s: %.1f%% -> %.1f%% (limit %.1f%%)\n", r.Metric, r.Baseline*100, r.Candidate*100, r.Limit*100)
+		}
+	}
+	return b.String()
+}

--- a/bench/internal/lifecycle/regression_test.go
+++ b/bench/internal/lifecycle/regression_test.go
@@ -1,0 +1,137 @@
+package lifecycle
+
+import (
+	"strings"
+	"testing"
+)
+
+func rate(num, den int) Rate {
+	r := Rate{Num: num, Den: den}
+	if den > 0 {
+		r.Rate = float64(num) / float64(den)
+	}
+	return r
+}
+
+// baseMetrics is a healthy baseline scorecard: every headline rate high, no
+// duplicates.
+func baseMetrics() Metrics {
+	return Metrics{
+		Attempts:          10,
+		CaptureRate:       rate(9, 10),
+		PersonalRecall:    rate(9, 10),
+		TransferRate:      rate(8, 10),
+		UpdateCorrectness: rate(5, 5),
+		AbstentionRate:    rate(9, 10),
+		DuplicateRate:     rate(0, 5),
+		PassK:             rate(7, 10),
+	}
+}
+
+func lifecycleResults(arm, client string, m Metrics) *Results {
+	return &Results{Manifest: Manifest{Arm: arm, ClientVersion: client}, Metrics: m}
+}
+
+func TestBaselineCompatible(t *testing.T) {
+	base := lifecycleResults("a3", "", baseMetrics())
+	if err := BaselineCompatible(lifecycleResults("a3", "", baseMetrics()), base); err != nil {
+		t.Fatalf("same arm/client should be compatible: %v", err)
+	}
+	if err := BaselineCompatible(lifecycleResults("a2", "", baseMetrics()), base); err == nil {
+		t.Fatal("arm mismatch should be refused")
+	}
+	if err := BaselineCompatible(lifecycleResults("a3", "claude 1.2", baseMetrics()), base); err == nil {
+		t.Fatal("client-path mismatch (claude-cli candidate vs anthropic baseline) should be refused")
+	}
+	// Path parity, not exact version: two claude-cli runs on different CLI
+	// versions are still comparable, so a benign version bump does not disable
+	// the gate.
+	claudeBase := lifecycleResults("a3", "claude 1.2", baseMetrics())
+	if err := BaselineCompatible(lifecycleResults("a3", "claude 1.3", baseMetrics()), claudeBase); err != nil {
+		t.Fatalf("two claude-cli versions should be comparable: %v", err)
+	}
+	if err := BaselineCompatible(lifecycleResults("a3", "", Metrics{}), lifecycleResults("a3", "", Metrics{})); err == nil {
+		t.Fatal("an empty baseline should be refused")
+	}
+}
+
+func TestCheckRegressionClean(t *testing.T) {
+	cand := lifecycleResults("a3", "", baseMetrics())
+	if regs := CheckRegression(cand, lifecycleResults("a3", "", baseMetrics()), DefaultThresholds()); len(regs) != 0 {
+		t.Fatalf("identical candidate regressed: %+v", regs)
+	}
+	// A small drop within tolerance (5 pts) does not trip.
+	m := baseMetrics()
+	m.CaptureRate = rate(85, 100) // 90% -> 85%, exactly at the limit, not below
+	if regs := CheckRegression(lifecycleResults("a3", "", m), lifecycleResults("a3", "", baseMetrics()), DefaultThresholds()); len(regs) != 0 {
+		t.Fatalf("a drop to exactly the limit should not trip: %+v", regs)
+	}
+}
+
+func TestCheckRegressionRateDrop(t *testing.T) {
+	m := baseMetrics()
+	m.TransferRate = rate(70, 100) // 80% -> 70%, a 10-pt drop past the 5-pt tolerance
+	regs := CheckRegression(lifecycleResults("a3", "", m), lifecycleResults("a3", "", baseMetrics()), DefaultThresholds())
+	if len(regs) != 1 || regs[0].Metric != "transfer_rate" || regs[0].LowerIsBetter {
+		t.Fatalf("expected one transfer_rate drop, got %+v", regs)
+	}
+}
+
+func TestCheckRegressionDuplicateIncrease(t *testing.T) {
+	m := baseMetrics()
+	m.DuplicateRate = rate(3, 5) // 0% -> 60%, a duplicate-rate rise (lower is better)
+	regs := CheckRegression(lifecycleResults("a3", "", m), lifecycleResults("a3", "", baseMetrics()), DefaultThresholds())
+	if len(regs) != 1 || regs[0].Metric != "duplicate_rate" || !regs[0].LowerIsBetter {
+		t.Fatalf("expected one duplicate_rate increase marked lower-is-better, got %+v", regs)
+	}
+}
+
+func TestCheckRegressionSkipsZeroDenominatorBaseline(t *testing.T) {
+	base := baseMetrics()
+	base.TransferRate = rate(0, 0) // baseline never ran transfer: no comparison point
+	cand := baseMetrics()
+	cand.TransferRate = rate(0, 3) // candidate ran it and failed, but it must be skipped
+	regs := CheckRegression(lifecycleResults("a3", "", cand), lifecycleResults("a3", "", base), DefaultThresholds())
+	for _, r := range regs {
+		if r.Metric == "transfer_rate" {
+			t.Fatalf("a zero-denominator baseline metric must be skipped, got %+v", regs)
+		}
+	}
+}
+
+func TestCheckRegressionSkipsZeroDenominatorCandidate(t *testing.T) {
+	// The candidate ran a partial protocol set that never exercised transfer, so
+	// its transfer denominator is 0 even though it graded other attempts. That is
+	// a coverage gap, not a capability loss, and must not be scored as a 0% drop.
+	cand := baseMetrics()
+	cand.TransferRate = rate(0, 0)
+	regs := CheckRegression(lifecycleResults("a3", "", cand), lifecycleResults("a3", "", baseMetrics()), DefaultThresholds())
+	for _, r := range regs {
+		if r.Metric == "transfer_rate" {
+			t.Fatalf("an unexercised candidate metric must be skipped, got %+v", regs)
+		}
+	}
+}
+
+func TestCheckRegressionCoverage(t *testing.T) {
+	cand := Metrics{Attempts: 0} // candidate graded nothing
+	regs := CheckRegression(lifecycleResults("a3", "", cand), lifecycleResults("a3", "", baseMetrics()), DefaultThresholds())
+	if len(regs) != 1 || regs[0].Metric != "coverage" {
+		t.Fatalf("a zero-attempt candidate should be a single coverage regression, got %+v", regs)
+	}
+}
+
+func TestRegressionReport(t *testing.T) {
+	base := lifecycleResults("a3", "", baseMetrics())
+	if out := RegressionReport(base, base, DefaultThresholds(), nil); !strings.Contains(out, "PASS") {
+		t.Fatalf("clean report should say PASS:\n%s", out)
+	}
+	m := baseMetrics()
+	m.DuplicateRate = rate(3, 5)
+	cand := lifecycleResults("a3", "", m)
+	regs := CheckRegression(cand, base, DefaultThresholds())
+	out := RegressionReport(cand, base, DefaultThresholds(), regs)
+	if !strings.Contains(out, "FAIL") || !strings.Contains(out, "duplicate_rate") || !strings.Contains(out, "lower is better") {
+		t.Fatalf("regression report missing expected content:\n%s", out)
+	}
+}

--- a/bench/internal/lifecycle/runner.go
+++ b/bench/internal/lifecycle/runner.go
@@ -46,7 +46,10 @@ type Options struct {
 	Factory       AdapterFactory
 	// ClaudeCLI, when non-nil, runs each episode through a real `claude -p`
 	// client (connecting to the platform directly and threading its own handle)
-	// instead of the in-process agent loop. Factory is unused in this mode.
+	// instead of the in-process agent loop. Factory is unused in this mode. The
+	// claude-cli episode path — including cache-token threading through the
+	// EpisodeRecord (#966) — is testable via claudecli.Options.Exec, which injects
+	// canned stream bytes through the real parser.
 	ClaudeCLI *claudecli.Runner
 	// ClientVersion is recorded on the manifest for the ClaudeCLI path.
 	ClientVersion string


### PR DESCRIPTION
Closes #966. Part 4 of 4 under #958 — the harness-hardening follow-ups from the phase-4 work. Fully unit-testable locally; the one manual step is confirming a real cached `claude` run emits cache tokens.

## Output isolation — raw data is never overwritten

Multi-pass S5 runs write a results JSON and a directory of per-episode transcripts per pass. Two gaps let a pass silently clobber another's paid-for data:

- The transcript directory was `<dir>/transcripts/`, derived only from the output's parent directory, so two passes written into the same directory under different `-out` names shared one transcript directory and overwrote each other. It is now keyed on the full output filename (`results.json` -> `results.json.transcripts/`). Keeping the extension means two outputs sharing a stem but differing by extension (`results.json`, `results.txt`) also stay distinct.
- `-merge` wrote its combined scorecard to `-out` with no check that `-out` was one of the input passes. The merge now refuses an `-out` that is the same on-disk file as any input, compared with `os.SameFile` (device + inode) rather than a string compare — so a case-variant spelling on a case-insensitive filesystem (macOS/Windows default) and a symlinked alias are both caught, not just an exact path match.

## S5 regression gate

The `-baseline` gate previously scored only the S1-S3 task suites and refused `-lifecycle`. It now gates the S5 lifecycle metrics too, so a lifecycle capability loss fails CI the same way an S1-S3 one does.

- Gated metrics: capture rate, personal recall, transfer rate, update correctness, abstention rate, duplicate rate (an increase past tolerance is the regression, since lower is better), and pass^k. Default tolerances are loose (5 points) to absorb the stochastic, small-denominator variance these runs carry.
- It applies to a single-process run and to a `-merge`d k=N scorecard — the canonical multi-pass artifact CI actually gates.
- A metric that either run did not exercise (zero denominator on either side) is skipped as a coverage gap, not scored as a 0% drop, so a partial protocol set does not produce a false regression. A candidate that graded nothing is a single coverage regression.
- Compatibility is refused across arms and across the client path (anthropic vs claude-cli). The path check compares emptiness of `client_version`, not the exact string, so a benign `claude` patch bump does not disable the gate.
- The #964 diagnostic decompositions (transfer surfaced / used-given-surfaced / capture budget-starved) are deliberately not gated — their denominators are small enough that gating them would trip on noise; they exist to explain a regression, not define one.

## claude-cli cache tokens, end to end

A cached `claude -p` run's `cache_read_input_tokens` / `cache_creation_input_tokens` flow through the stream parser into each lifecycle `EpisodeRecord` and are summed into the run's `total_cache_read_tokens` / `total_cache_creation_tokens`, so a cached run self-reports its true cost basis (cache reads bill far below fresh input). The full parser -> `EpisodeRecord` -> aggregate path is now covered by a test that drives the real parser on a canned cached stream through the existing `claudecli.Options.Exec` seam; that a real `claude` process emits those fields is confirmed by one real cached run.

## Testing

`make bench-test` (build, vet, race-detected unit tests) and `golangci-lint run ./...` are green on the bench module. New coverage: the regression gate (compatibility, per-metric drop, duplicate-rate increase, both-side zero-denominator skip, coverage, path-parity, report rendering) at 84-100%; the merge overwrite guard and its symlink/SameFile behavior; the transcript-directory isolation including the same-stem-different-extension case; the merged-scorecard gate wiring; and the claude-cli cache-token flow through the EpisodeRecord and aggregate totals.

## Notes

Two trivial helpers are duplicated across independent package boundaries — a five-line `client_version` label in the lifecycle gate mirrors one in the S1-S3 `report` gate, and the gate test fixtures exist in both the `benchrun` and `lifecycle` test packages. Both were left in place: consolidating either would mean a new shared package or a cross-package exported test helper, which adds more coupling and surface than the duplication costs.

This is the last of the four #958 children. Related: #963 (cold-start suite), #964 (per-stage diagnosis + supersede sub-benchmark), #965 (confidence intervals and scale, which needs real-run budget).
