### PR TITLE
CITATION.cff: drop stale DOI scaffolding, record concept DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,6 @@
 # Citation metadata for mcp-data-platform and its knowledge-layer benchmark
 # report. Format: Citation File Format 1.2.0 (https://citation-file-format.github.io).
 # GitHub renders a "Cite this repository" button from this file.
-#
-# The Zenodo archival DOI is pending; uncomment the `doi:` lines and fill in
-# the minted identifier after archiving the tagged release (see .zenodo.json).
 cff-version: 1.2.0
 message: "If you use this software or cite its benchmark report, please cite it as below."
 title: mcp-data-platform
@@ -19,7 +16,6 @@ authors:
 repository-code: "https://github.com/txn2/mcp-data-platform"
 url: "https://mcp-data-platform.txn2.com"
 license: Apache-2.0
-# doi: 10.5281/zenodo.XXXXXXX   # add after Zenodo archival
 preferred-citation:
   type: report
   title: >-
@@ -37,3 +33,7 @@ preferred-citation:
   url: "https://mcp-data-platform.txn2.com/reference/benchmark-report/"
   version: "1.0"
   doi: 10.5281/zenodo.21438045
+  identifiers:
+    - type: doi
+      value: 10.5281/zenodo.21438044
+      description: "Concept DOI (resolves to the latest report version)"


### PR DESCRIPTION
## Summary

Follow-up cleanup to #985. `CITATION.cff` shipped with scaffolding comments that were meant to be removed once the Zenodo DOI was filled in, so the file carried a "DOI is pending; uncomment the `doi:` lines" note and a commented `# doi: ...XXXXXXX  # add after Zenodo archival` placeholder sitting right next to the already-recorded DOI. This removes both and records the concept DOI.

## Changes

- Remove the stale "archival DOI is pending / uncomment / add after archival" header comment.
- Remove the commented top-level `# doi: ...XXXXXXX` placeholder (the software repo has no Zenodo DOI of its own; the report deposit's DOI lives on `preferred-citation`).
- Keep the version DOI `10.5281/zenodo.21438045` as the citation DOI, since the citation is explicitly version 1.0.
- Add the concept DOI `10.5281/zenodo.21438044` as a labeled `identifiers` entry ("resolves to the latest report version"), so the version-specific and all-versions DOIs are not confused when Report v1.1 lands (#984).

## Notes

`CITATION.cff` is metadata read by GitHub's "Cite this repository" feature; it is not inspected by any `make verify` gate. The file parses as valid CFF 1.2.0, and a sweep of the sibling artifacts (`.zenodo.json`, the report, the llms files, `bench/report/`) confirmed no other stale scaffolding remains.