### PR TITLE
fix(portal): reflow public viewer header on narrow viewports (Closes #1003)

### DIFF
--- a/pkg/portal/templates/public_collection_viewer.html
+++ b/pkg/portal/templates/public_collection_viewer.html
@@ -149,6 +149,20 @@ body {
 }
 .theme-toggle:hover { background: var(--toggle-hover); }
 .theme-toggle svg { width: 16px; height: 16px; }
+/* Narrow viewports: one row cannot fit the brand marks, controls, and
+   title/badge group (everything but the title is flex-shrink:0, so the
+   title collapses and the badges paint over the controls). Wrap the
+   title/badge group onto its own full-width row; the control that
+   follows it in the DOM takes margin-left:auto so the controls and
+   platform brand stay right-aligned on the first row. */
+@media (max-width: 640px) {
+  .header { flex-wrap: wrap; padding: 12px 16px; gap: 8px; }
+  .header-center { order: 1; flex-basis: 100%; flex-wrap: wrap; }
+  .header-center + * { margin-left: auto; }
+  /* Row breaks already separate the groups; a separator can dangle at
+     a row end when the brand wraps. */
+  .separator { display: none; }
+}
 .notice {
   box-sizing: border-box;
   font-size: 11px;

--- a/pkg/portal/templates/public_viewer.html
+++ b/pkg/portal/templates/public_viewer.html
@@ -237,6 +237,21 @@
         }
         .info-toggle:hover { background: var(--toggle-hover); }
         .info-toggle svg { width: 16px; height: 16px; }
+        /* Narrow viewports: one row cannot fit the brand marks, controls,
+           and title/badge group (everything but the title is
+           flex-shrink:0, so the title collapses and the badges paint
+           over the controls). Wrap the title/badge group onto its own
+           full-width row; the control that follows it in the DOM takes
+           margin-left:auto so the controls and platform brand stay
+           right-aligned on the first row. */
+        @media (max-width: 640px) {
+            .header { flex-wrap: wrap; padding: 12px 16px; gap: 8px; }
+            .header-center { order: 1; flex-basis: 100%; flex-wrap: wrap; }
+            .header-center + * { margin-left: auto; }
+            /* Row breaks already separate the groups; a separator can
+               dangle at a row end when the brand wraps. */
+            .separator { display: none; }
+        }
         .modal-overlay {
             position: fixed;
             inset: 0;


### PR DESCRIPTION
## Summary

Closes #1003.

On phone-width viewports the public asset viewer header rendered unusably: the asset title collapsed to zero width and disappeared, and the "Viewing as guest" badge painted on top of the info and theme-toggle buttons. The public collection viewer shares the same header CSS and had the same defect. This PR makes the header responsive: below 640px it reflows into two rows, and desktop rendering is byte-for-byte unchanged.

## Defect

The `.header` is a flex row that never wrapped, and every child except the title is `flex-shrink: 0`: the implementor brand block, both separators, the content-type/version/guest badges, the info and theme buttons, and the platform brand block. The only shrinkable element is `.header-center` (`flex: 1; min-width: 0`), whose only shrinkable content is the `h1`.

Once the fixed-width items exceed the viewport width, two things happen at once: the `h1` (the only thing that can give) collapses to zero width, and `.header-center` is squeezed narrower than its own non-shrinkable badges, which then overflow the box (it has no `overflow: hidden`) and paint over the adjacent buttons.

## Fix

One `@media (max-width: 640px)` block, applied identically to both templates (the collection viewer's header CSS is documented as kept in sync with the asset viewer's):

- `.header` gets `flex-wrap: wrap` with slightly tighter padding and gap, so overflow can never again produce overlapping paint; anything that does not fit wraps.
- `.header-center` (title + badges) moves to its own full-width row via `order: 1; flex-basis: 100%`, with `flex-wrap: wrap` so badges flow below a long title instead of competing with it.
- The control that follows `.header-center` in the DOM takes `margin-left: auto`, keeping the info/theme buttons and platform brand right-aligned on the brand row.
- `.separator` is hidden: the row break already separates the groups, and a separator otherwise dangles at a row end when the platform brand wraps on very narrow screens.

Desktop (>=641px) is untouched: the media query is additive and no existing rule changed.

## Files

- `pkg/portal/templates/public_viewer.html` (asset viewer)
- `pkg/portal/templates/public_collection_viewer.html` (collection viewer)

## Verification

Rendered both templates with representative data (long title, all three badges, guest mode, notice bar, wide implementor word-mark logo) and inspected them in Chrome under true device emulation:

- 390px and 320px, dark and light themes: title visible and ellipsized on its own row, all badges fully legible, and programmatic checks confirmed zero overlapping element rects among header children and no horizontal page scroll (`scrollWidth == innerWidth`).
- Variants: with and without an implementor brand block, on both the asset viewer and the collection viewer.
- 1280px desktop regression: computed styles confirm `flex-wrap: nowrap`, original `12px 24px` padding, and visible separators; the single-row layout is unchanged.
- `make verify` passes (full suite including GoReleaser dry-run).
