### PR TITLE
fix(mcpapps): prompt browser performs the platform session handshake

### DIFF
--- a/apps/prompt-browser/index.html
+++ b/apps/prompt-browser/index.html
@@ -359,6 +359,9 @@
     //    ui/notifications/tool-result notifications and no hostCapabilities.
     // ---------------------------------------------------------------------
     var TOOL_NAME = 'manage_prompt';
+    // INIT_TOOL mints the session handle every other tool requires; it is the
+    // only tool the platform never gates.
+    var INIT_TOOL = 'platform_info';
     var CALL_TIMEOUT_MS = 20000;
 
     var rid = 2; // request id 1 is ui/initialize
@@ -405,25 +408,119 @@
         isLegacy = !hostCaps;
         canMessage = !!(hostCaps && hostCaps.message);
         send({ jsonrpc: '2.0', method: 'ui/notifications/initialized', params: {} });
-        loadList('');
+        boot();
     }
 
-    // callTool invokes an MCP tool through the host and resolves with the
-    // parsed JSON payload of the result's first text content block. On legacy
-    // hosts, results arrive as notifications with no request id; the expect
-    // predicate distinguishes our response from host pushes of the original
-    // tool call's result.
-    var lastCallId = null; // id of the most recently issued callTool request
+    // boot handshakes before the first data call, because every tool other than
+    // platform_info is refused without a handle.
+    //
+    // A failed handshake is not fatal and must not blank the app: a deployment
+    // with handles disabled needs no handle at all, and a persona may allow
+    // manage_prompt while denying platform_info. The list call runs either way
+    // and reports the real refusal if one comes.
+    function boot() {
+        handshake()
+            .catch(function() { /* reported by the list call if it matters */ })
+            .then(function() { loadList(''); });
+    }
 
+    // ---------------------------------------------------------------------
+    // Session handle. The platform refuses any tool call that does not carry a
+    // platform_info-minted session_id (SESSION_REQUIRED), and an app's calls
+    // reach the server over the same MCP transport as an agent's, so the app
+    // performs the handshake itself and threads the handle on every call. A
+    // deployment with handles disabled returns no session_id, in which case
+    // nothing is threaded and behavior is unchanged.
+    // ---------------------------------------------------------------------
+    var sessionId = null;         // handle minted by platform_info, or null
+    var pendingHandshake = null;  // in-flight handshake, shared by concurrent callers
+
+    function handshake() {
+        if (pendingHandshake) { return pendingHandshake; }
+        pendingHandshake = issueCall(INIT_TOOL, {}, isInfoPayload, { id: null, canceled: false, init: true }).then(
+            function(d) {
+                pendingHandshake = null;
+                sessionId = (d && typeof d.session_id === 'string' && d.session_id) || null;
+            },
+            function(err) {
+                pendingHandshake = null;
+                throw err;
+            }
+        );
+        return pendingHandshake;
+    }
+
+    function withSession(args) {
+        if (!sessionId) { return args; }
+        var merged = {};
+        Object.keys(args || {}).forEach(function(k) { merged[k] = args[k]; });
+        merged.session_id = sessionId;
+        return merged;
+    }
+
+    // isSessionError matches the refusals the platform issues when a call
+    // carries no usable session identity. All three are recovered the same way,
+    // by calling platform_info and retrying: SESSION_REQUIRED and
+    // SESSION_EXPIRED come from the explicit handle resolver, SETUP_REQUIRED
+    // from the transport-keyed session gate a deployment may run instead.
+    function isSessionError(err) {
+        return /SESSION_REQUIRED|SESSION_EXPIRED|SETUP_REQUIRED/.test((err && err.message) || '');
+    }
+
+    // CANCELED marks a call dropped by its caller rather than by the platform,
+    // so a superseded call never reaches an error banner.
+    var CANCELED = 'canceled';
+
+    function isCanceled(err) { return !!err && err.message === CANCELED; }
+
+    // callTool invokes a platform tool with the session handle threaded and
+    // returns {promise, cancel}.
+    //
+    // It waits on an in-flight handshake instead of issuing with a handle it
+    // knows was just discarded, and recovers once from a session refusal by
+    // re-handshaking and replaying. cancel() drops the request AND blocks a
+    // replay that has not gone out yet: on legacy hosts responses are matched by
+    // payload shape, so a superseded call that survived into a replay would
+    // leave a second waiter of the same shape and the two responses could settle
+    // the wrong callers.
     function callTool(name, args, expect) {
+        var call = { id: null, canceled: false };
+        var promise = (pendingHandshake || Promise.resolve())
+            .catch(function() { /* the call reports the refusal, if any */ })
+            .then(function() { return issueCall(name, withSession(args), expect, call); })
+            .catch(function(err) {
+                if (call.canceled || !isSessionError(err)) { throw err; }
+                sessionId = null;
+                return handshake().then(function() {
+                    if (call.canceled) { throw new Error(CANCELED); }
+                    return issueCall(name, withSession(args), expect, call);
+                });
+            });
+        return {
+            promise: promise,
+            cancel: function() {
+                call.canceled = true;
+                var p = call.id !== null ? pending[call.id] : null;
+                if (call.id !== null) { dropPending(call.id); }
+                if (p) { p.reject(new Error(CANCELED)); }
+            }
+        };
+    }
+
+    // issueCall sends one tools/call and resolves with the parsed JSON payload
+    // of the result's first text content block. On legacy hosts, results arrive
+    // as notifications with no request id; the expect predicate distinguishes
+    // our response from host pushes of the original tool call's result.
+    function issueCall(name, args, expect, call) {
         return new Promise(function(resolve, reject) {
+            if (call.canceled) { reject(new Error(CANCELED)); return; }
             var id = rid++;
-            lastCallId = id;
+            call.id = id;
             var timer = setTimeout(function() {
                 dropPending(id);
                 reject(new Error('The request to the platform timed out.'));
             }, CALL_TIMEOUT_MS);
-            pending[id] = { resolve: resolve, reject: reject, timer: timer, expect: expect };
+            pending[id] = { resolve: resolve, reject: reject, timer: timer, expect: expect, init: !!call.init };
             if (isLegacy) { legacyWaiters.push(id); }
             send({
                 jsonrpc: '2.0', id: id,
@@ -461,17 +558,19 @@
     // carries no request id) with a pending call: the oldest waiter whose
     // expect predicate accepts the payload wins; a payload no waiter accepts
     // is a host push of the original tool call's result and is ignored. An
-    // unparseable or error payload cannot be shape-matched, so it settles the
+    // unparseable or error payload cannot be shape-matched. A session refusal
+    // invalidates the handle for every in-flight gated call, so it settles all
+    // of them and each recovers independently; settling only the oldest would
+    // make an unrelated call perform the recovery while the refused one hung to
+    // its timeout. The handshake is excluded, since platform_info is never
+    // gated and so is never the call being refused. Any other error settles the
     // oldest waiter (the error banner's Retry recovers a rare mismatch).
     function onLegacyToolResult(result) {
         if (legacyWaiters.length === 0) { return; } // host push of the original call's result
         var payload;
         try { payload = parseToolResult(result); }
         catch (err) {
-            var oldest = legacyWaiters[0];
-            var op = pending[oldest];
-            dropPending(oldest);
-            op.reject(err);
+            rejectWaiters(isSessionError(err) ? gatedWaiters() : [legacyWaiters[0]], err);
             return;
         }
         for (var i = 0; i < legacyWaiters.length; i++) {
@@ -483,6 +582,24 @@
             return;
         }
         // No waiter matched: an unrelated host push.
+    }
+
+    // gatedWaiters returns the pending legacy waiters a session refusal can
+    // apply to, i.e. every waiter except the handshake's.
+    function gatedWaiters() {
+        return legacyWaiters.filter(function(id) {
+            return pending[id] && !pending[id].init;
+        });
+    }
+
+    // rejectWaiters settles the named pending calls with the same error.
+    function rejectWaiters(ids, err) {
+        ids.forEach(function(id) {
+            var p = pending[id];
+            if (!p) { return; }
+            dropPending(id);
+            p.reject(err);
+        });
     }
 
     function parseToolResult(result) {
@@ -565,16 +682,27 @@
 
     function displayName(p) { return p.display_name || p.name; }
 
+    // isInfoPayload matches a platform_info result. config_version and features
+    // are unconditional on that payload and appear on no manage_prompt payload,
+    // so they discriminate it on legacy hosts, where responses are correlated by
+    // shape rather than by request id.
+    function isInfoPayload(d) {
+        return !!d && d.config_version !== undefined && d.features !== undefined;
+    }
+
+    // isListPayload must reject a platform_info payload explicitly: platform_info
+    // also carries a prompts array (the registered MCP prompts), so the prompts
+    // test alone would let the handshake response satisfy a waiting list call.
     function isListPayload(d) {
-        return !!d && (Array.isArray(d.prompts) || d.count !== undefined);
+        return !!d && !isInfoPayload(d) && (Array.isArray(d.prompts) || d.count !== undefined);
     }
 
     function isUsePayload(d) {
         return !!d && (d.status === 'resolved' || d.status === 'ambiguous');
     }
 
-    var listSeq = 0;       // drops stale responses when searches overlap
-    var activeListId = null; // pending list request, canceled when superseded
+    var listSeq = 0;           // drops stale responses when searches overlap
+    var activeListCall = null; // in-flight list call, canceled when superseded
 
     function loadList(query) {
         hide('error'); hide('detail');
@@ -582,14 +710,14 @@
         // only the initial load shows the full-page loading state.
         if ($('browser').classList.contains('hidden')) { show('loading'); }
         var seq = ++listSeq;
-        // Cancel a superseded in-flight list call so at most one list waiter
-        // exists (legacy hosts correlate responses by shape, not id).
-        if (activeListId !== null && pending[activeListId]) { dropPending(activeListId); }
+        // Cancel a superseded list call, including a session replay it has not
+        // issued yet, so at most one list waiter exists (legacy hosts correlate
+        // responses by shape, not id).
+        if (activeListCall) { activeListCall.cancel(); }
         var args = { command: 'list' };
         if (query) { args.query = query; args.limit = 50; }
-        var call = callTool(TOOL_NAME, args, isListPayload);
-        activeListId = lastCallId;
-        call
+        activeListCall = callTool(TOOL_NAME, args, isListPayload);
+        activeListCall.promise
             .then(function(d) {
                 if (seq !== listSeq) { return; }
                 state.prompts = normalizePrompts(d.prompts);
@@ -599,7 +727,7 @@
                 renderBrowser();
             })
             .catch(function(err) {
-                if (seq !== listSeq) { return; }
+                if (seq !== listSeq || isCanceled(err)) { return; }
                 hide('loading');
                 showError(err.message, function() { loadList(state.query); });
             });
@@ -1006,7 +1134,7 @@
         btn.textContent = 'Running…';
 
         var handle = p.id ? 'mcp:prompt:' + p.id : p.name;
-        callTool(TOOL_NAME, { command: 'use', name: handle, args: argValues() }, isUsePayload)
+        callTool(TOOL_NAME, { command: 'use', name: handle, args: argValues() }, isUsePayload).promise
             .then(function(d) {
                 if (d.status !== 'resolved') {
                     throw new Error(d.message || 'The prompt could not be resolved.');

--- a/apps/test-harness.html
+++ b/apps/test-harness.html
@@ -197,6 +197,7 @@
         </select>
         <button onclick="sendTestData()">Send Test Data</button>
         <button class="secondary" onclick="reloadApp()">Reload App</button>
+        <button class="secondary" onclick="expireSession()">Expire Session</button>
     </div>
     <div class="main">
         <div class="editor-panel">
@@ -360,6 +361,69 @@
             }
         };
 
+        // HANDSHAKE_RESPONSE is what the harness answers a platform_info call
+        // with, regardless of which app is selected or what the test-data
+        // textarea holds. An app must handshake before any other tool call: the
+        // platform mints the session handle here and refuses every other tool
+        // that does not carry it (SESSION_REQUIRED).
+        //
+        // It mirrors the real payload in the two ways an app depends on:
+        // config_version and features are what an app uses to tell an info
+        // payload from a tool payload on hosts that correlate responses by
+        // shape, and prompts is present because the real payload carries the
+        // server's registered MCP prompts. That prompts array is the reason an
+        // app cannot identify a list result by a prompts array alone, so a
+        // harness without it would hide the collision instead of reproducing it.
+        var HANDSHAKE_RESPONSE = {
+            name: 'mcp-data-platform',
+            version: '0.0.0-harness',
+            session_expires_at: '2099-01-01T00:00:00Z',
+            toolkits: ['platform'],
+            prompts: [
+                { name: 'registered-mcp-prompt', description: 'a server-registered MCP prompt, not a library prompt' }
+            ],
+            features: { semantic_enrichment: false, query_enrichment: false, audit_logging: false },
+            config_version: { api_version: 'v1', supported_versions: ['v1'], latest_version: 'v1' }
+        };
+
+        // The live handle. Each handshake mints a fresh one and supersedes the
+        // last, as the platform does, so a call presenting an older handle is
+        // refused rather than silently accepted.
+        var handleSeq = 0;
+        var currentHandle = '';
+
+        function mintHandle() {
+            handleSeq++;
+            currentHandle = 'sess_harness_' + handleSeq;
+            return currentHandle;
+        }
+
+        // sessionRefusal returns the platform's refusal text for a call whose
+        // session handle is missing or no longer valid, or '' when the handle is
+        // good. The SESSION_REQUIRED and SESSION_EXPIRED tokens are what an app
+        // matches on to decide to re-handshake, so they are reproduced verbatim
+        // from pkg/middleware/mcp_session_handle.go.
+        function sessionRefusal(sid) {
+            if (!sid) {
+                return 'SESSION_REQUIRED: Call platform_info first. It returns a session_id you must '
+                     + 'pass as the session_id argument on every subsequent tool call.';
+            }
+            if (sid !== currentHandle) {
+                return 'SESSION_EXPIRED: Your session_id is unknown or expired. Call platform_info again '
+                     + 'to mint a fresh session_id, then pass it on every subsequent tool call.';
+            }
+            return '';
+        }
+
+        // expireSession revokes the live handle so the next tool call is refused
+        // with SESSION_EXPIRED, making the app's expired-handle recovery
+        // exercisable in development. A correct app re-handshakes and replays
+        // the call without the user seeing an error.
+        function expireSession() {
+            currentHandle = '';
+            log('Session expired. The next tool call will be refused with SESSION_EXPIRED.', 'error');
+        }
+
         // buildUseResponse simulates the manage_prompt use command against the
         // prompt-browser test data: resolve by mcp:prompt:<id> or name, then
         // substitute {arg} placeholders.
@@ -508,9 +572,47 @@
             if (m.method === 'ui/call-tool') {
                 var app = appSelectEl.value;
                 var cfg = appTestData[app] || appTestData['query-results'];
+                var callName = (m.params && m.params.name) || cfg.toolName;
+                var callArgs = (m.params && m.params.arguments) || {};
+
+                // The session handshake. The platform-info app is excluded
+                // because platform_info is the tool it renders, so its call must
+                // still receive the editable test data from the textarea.
+                if (callName === 'platform_info' && app !== 'platform-info') {
+                    var info = JSON.parse(JSON.stringify(HANDSHAKE_RESPONSE));
+                    info.session_id = mintHandle();
+                    e.source.postMessage({
+                        jsonrpc: '2.0',
+                        method: 'ui/notifications/tool-result',
+                        params: {
+                            toolName: 'platform_info',
+                            content: [{ type: 'text', text: JSON.stringify(info) }]
+                        }
+                    }, '*');
+                    log('Handshake: issued session_id ' + info.session_id, 'success');
+                    return;
+                }
+
+                // Enforce the session handle gate the way a deployment does, so
+                // an app that skips the handshake or keeps a stale handle fails
+                // here rather than only in production.
+                var refusal = callName === 'platform_info' ? '' : sessionRefusal(callArgs.session_id);
+                if (refusal) {
+                    e.source.postMessage({
+                        jsonrpc: '2.0',
+                        method: 'ui/notifications/tool-result',
+                        params: {
+                            toolName: callName,
+                            isError: true,
+                            content: [{ type: 'text', text: refusal }]
+                        }
+                    }, '*');
+                    log('Refused ' + callName + ': ' + refusal.split(':')[0], 'error');
+                    return;
+                }
+
                 try {
                     var data;
-                    var callArgs = (m.params && m.params.arguments) || {};
                     if (app === 'prompt-browser' && callArgs.command === 'use') {
                         data = buildUseResponse(callArgs);
                     } else {

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2512,6 +2512,23 @@ Workflow:
 | `fullscreen` | Takes over entire viewport |
 | `pip` | Picture-in-picture floating window |
 
+### Apps Calling Tools (Session Handshake)
+
+An app can call tools itself with `tools/call`, or `ui/call-tool` on hosts speaking protocol `2025-01-09`. Tool visibility defaults to `["model", "app"]`, so every tool the server exposes is app-callable.
+
+App tool calls reach the server over the same MCP transport as the agent's and meet the same gates. When the session handle requirement is on, the platform refuses any call that does not carry a `session_id` minted by `platform_info` with `SESSION_REQUIRED`. An app that calls any tool other than `platform_info` must handshake:
+
+1. Call `platform_info` with empty arguments before the first data call. The result's first text content block is JSON carrying `session_id`.
+2. Thread that value as the `session_id` argument on every subsequent call, in whatever wrapper issues the call, so no call site can forget it.
+3. On a rejection whose message contains `SESSION_REQUIRED`, `SESSION_EXPIRED`, or `SETUP_REQUIRED` (the transport-keyed session gate a deployment may run instead), discard the handle, call `platform_info` again, and replay the call once. Handles expire on inactivity.
+4. A handshake result with no `session_id` means handles are not enabled in that deployment; send no `session_id` argument.
+
+`platform_info` is never gated, since it mints the handle, so the handshake itself cannot be refused.
+
+Correlation hazard: hosts that deliver results as `ui/notifications/tool-result` notifications send no request id, so an app matching responses by payload shape must distinguish the `platform_info` result from its own tool's result. `config_version` and `features` are unconditional on the `platform_info` payload. Do not key on `prompts`: `platform_info` also carries a `prompts` array listing the server's registered MCP prompts.
+
+`apps/prompt-browser/index.html` implements this (`handshake`, `withSession`, `callTool`). The test harness enforces the gate: it mints a `session_id` on `platform_info` and refuses any other call whose handle is missing or stale with the platform's own `SESSION_REQUIRED` / `SESSION_EXPIRED` text. Its **Expire Session** button revokes the live handle so the recovery path is exercisable in development.
+
 ## Tutorial
 
 For a complete step-by-step guide to building an MCP App, see the [MCP Apps Tutorial](mcpapps/tutorial.md). The tutorial walks through building a `platform-info` app and covers:

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -76,7 +76,7 @@ mcp-data-platform is the orchestration layer for the txn2 MCP ecosystem. DataHub
 
 - [Overview](https://mcp-data-platform.txn2.com/mcpapps/overview/): Interactive UI panels rendered inline in the MCP host. Built-in platform-info and prompt-browser apps, branding via config, custom apps via assets_path
 - [Configuration](https://mcp-data-platform.txn2.com/mcpapps/configuration/): MCP Apps enabled by default; branding overrides, custom app registration, CSP settings
-- [Development](https://mcp-data-platform.txn2.com/mcpapps/development/): Docker-based development with a test harness and live-edit asset overrides
+- [Development](https://mcp-data-platform.txn2.com/mcpapps/development/): Docker-based development with a test harness and live-edit asset overrides; apps calling tools must handshake with platform_info and thread the session_id
 - [Tutorial](https://mcp-data-platform.txn2.com/mcpapps/tutorial/): Step-by-step guide building a platform-info app
 
 ## Go Library

--- a/docs/mcpapps/development.md
+++ b/docs/mcpapps/development.md
@@ -94,6 +94,34 @@ window.addEventListener('message', (event) => {
 });
 ```
 
+### Calling Tools from an App
+
+An app is not limited to the result that rendered it. It can call tools itself with `tools/call`, or `ui/call-tool` on hosts speaking protocol `2025-01-09`. Tool visibility defaults to `["model", "app"]`, so every tool this server exposes is app-callable.
+
+Those calls reach the server over the same MCP transport as the agent's and are gated the same way. When the session handle requirement is on, the platform refuses any tool call that does not carry a `session_id` minted by `platform_info`:
+
+```
+SESSION_REQUIRED: Call platform_info first. It returns a session_id you must
+pass as the session_id argument on every subsequent tool call.
+```
+
+An app that calls any tool other than `platform_info` must therefore handshake first:
+
+1. Call `platform_info` with empty arguments before the first data call. The result's first text content block is JSON carrying `session_id`.
+2. Thread that value as the `session_id` argument on every subsequent call. Do it in whatever wrapper issues the call, so no call site can forget it.
+3. On a rejection whose message contains `SESSION_REQUIRED`, `SESSION_EXPIRED`, or `SETUP_REQUIRED`, discard the stored handle, call `platform_info` again, and replay the call once. Handles expire on inactivity, so a long-lived app will hit this. `SETUP_REQUIRED` comes from the transport-keyed session gate a deployment may run instead of explicit handles; its remedy is the same call.
+4. Treat a handshake result with no `session_id` as "handles are not enabled in this deployment" and send no `session_id` argument. Threading nothing is correct there.
+
+`platform_info` is never gated, because it is the tool that mints the handle. The handshake itself cannot be refused for want of a handle.
+
+Do not make the handshake fatal. A deployment may have handles off, and a persona may allow your app's tool while denying `platform_info`, so a failed handshake should still let the first data call run and report whatever the platform actually says. Blanking the app on a `platform_info` failure breaks cases that worked before the handshake existed.
+
+`apps/prompt-browser/index.html` implements this. Its `handshake`, `withSession`, and `callTool` functions are the smallest complete version.
+
+One correlation hazard: hosts that deliver results as `ui/notifications/tool-result` notifications send no request id, so an app that matches responses by payload shape must be able to tell the `platform_info` result from its own tool's result. `config_version` and `features` are unconditional on the `platform_info` payload and identify it. Do not key on `prompts`: `platform_info` also carries a `prompts` array listing the server's registered MCP prompts.
+
+The test harness enforces this gate. It answers a `platform_info` call from any app other than `platform-info` with a handshake payload carrying a freshly minted `session_id`, and refuses any other tool call whose `session_id` is missing or stale with the same `SESSION_REQUIRED` / `SESSION_EXPIRED` text the platform returns. An app that skips the handshake therefore fails in development rather than only in a gated deployment. The **Expire Session** button revokes the live handle so the next call is refused, which is how you exercise the recovery path without waiting for a real expiry.
+
 ### Minimal Example
 
 ```html
@@ -200,6 +228,7 @@ graph LR
 |---------|----------|
 | Changes not appearing | Click Reload App, or hard refresh (Cmd+Shift+R) |
 | "No results to display" | Check browser console for errors |
+| App shows `SESSION_REQUIRED` | The app called a tool before handshaking; see [Calling Tools from an App](#calling-tools-from-an-app) |
 | Trino not responding | Wait for startup: `curl http://localhost:8090/v1/info` |
 | Port already in use | `docker compose -f docker-compose.dev.yml down` |
 

--- a/docs/mcpapps/overview.md
+++ b/docs/mcpapps/overview.md
@@ -23,6 +23,12 @@ flowchart LR
 3. Host fetches the HTML app and renders it in an iframe
 4. App receives tool results via `postMessage` and displays interactive UI
 
+## Apps Calling Tools
+
+An app can call tools itself, not just render the result that opened it. Those calls travel the same MCP transport as the agent's and meet the same gates, so when the session handle requirement is on, an app must call `platform_info` first and thread the `session_id` it returns on every subsequent call. Skipping the handshake produces a `SESSION_REQUIRED` refusal on the app's first data call.
+
+`platform_info` itself is never gated, since it is the tool that mints the handle. See [Development](development.md#calling-tools-from-an-app) for the handshake, the expired-handle recovery path, and the response-correlation hazard on hosts that deliver results as notifications.
+
 ## Platform vs Apps
 
 **MCP Data Platform provides:**


### PR DESCRIPTION
Closes #1032

The prompt browser MCP App added in #1011 could not make a single tool call in a deployment with the session handle gate on. Its first action after `ui/initialize` is a `manage_prompt` list, which the platform refuses with `SESSION_REQUIRED` because the call carries no `platform_info`-minted `session_id`, so the app rendered its own error banner instead of the library. List, search-as-you-type, and Run were all dead.

An app's tool calls reach the server over the same MCP transport as an agent's and meet the same gates. `pkg/middleware/mcp_session_handle.go:173` exempts only the init tool, operator-configured exempt tools, and the stateless in-memory shims (`Source=rest` / `Source=admin`); a host-proxied app call arrives as `Source=mcp` and is gated exactly like an agent call. So the app now performs the platform handshake itself, the same contract every other caller follows. No server-side gate changes.

## The handshake

`platform_info` is app-callable. MCP Apps tool visibility defaults to `["model", "app"]`, and the spec scopes `"app"` per server connection rather than per app-tool binding (`ext-apps/specification/2026-01-26/apps.mdx:399-401`), so an app bound to `manage_prompt` may still call it. Its result's first text block is the JSON payload carrying `session_id` (`pkg/platform/info_tool.go:283-320`).

`callTool` owns the whole session concern and returns `{promise, cancel}`:

- It waits on an in-flight handshake instead of issuing with a handle it knows was just discarded, so a call started during recovery is not sent pre-refused.
- It merges `session_id` into the arguments in one place, covering list, search, and use.
- It recovers once from `SESSION_REQUIRED`, `SESSION_EXPIRED`, or `SETUP_REQUIRED` by discarding the handle, re-handshaking, and replaying. `SETUP_REQUIRED` is the transport-keyed session gate (`pkg/middleware/mcp_session_gate.go:212`) a deployment may run instead of explicit handles; its remedy is the same call.
- `cancel()` drops the request and blocks a replay that has not gone out yet, so a superseded search cannot leave a second waiter behind.

A deployment with handles disabled returns no `session_id`, in which case nothing is threaded and behavior is unchanged.

A failed handshake is not fatal. The list call runs regardless and reports whatever the platform actually says. Handles may be off, and a persona may allow `manage_prompt` while denying `platform_info` (`pkg/persona/filter.go` is default-deny with no exemption for it), so blanking the app on a `platform_info` failure would break cases that worked before the handshake existed. With the gate on and the handshake refused, the app self-heals through the list call's own recovery and never shows a banner.

## Response correlation

Hosts speaking protocol `2025-01-09` deliver results as `ui/notifications/tool-result` notifications, which carry no request id, so the app matches responses by payload shape. Adding a second kind of call introduced two hazards, both handled here.

The `platform_info` payload carries a `prompts` array listing the server's registered MCP prompts (`Info.Prompts`, `pkg/platform/info_tool.go:31`), confirmed live at 5 entries against a running server. Identifying a list result by a `prompts` array alone would therefore let the handshake response satisfy a waiting list call and render the server's MCP prompt list in place of the user's library. A list result is now identified by `count` plus the absence of `config_version` and `features`, both of which are unconditional on the info payload and appear on no `manage_prompt` payload.

A session refusal invalidates the handle for every in-flight gated call, so it settles all of them and each recovers through the shared handshake. Settling only the oldest waiter would make an unrelated call perform the recovery while the refused one hung to its 20 second timeout. The handshake's own waiter is excluded, since `platform_info` is never gated and so is never the call being refused.

## Test harness

`apps/test-harness.html` enforces the gate rather than describing it, so an app that skips the handshake fails in development instead of only in production:

- `platform_info` mints a fresh handle per call and supersedes the last, as the platform does.
- Any other call whose handle is missing or stale is refused with the platform's verbatim `SESSION_REQUIRED` / `SESSION_EXPIRED` text as an `isError` result.
- The handshake payload carries a `prompts` array, so the correlation collision above reproduces in the harness rather than being hidden by a simplified fixture.
- A new **Expire Session** control revokes the live handle, making the expired-handle recovery path drivable on demand.

The `platform-info` app is excluded from the minting branch, since `platform_info` is the tool it renders and its call must still receive the editable test data.

## Verification

Driven against a real server (HTTP transport, Postgres, handle gate on by default) with the app in an MCP Apps host bridged to the live MCP endpoint, on both the `2026-01-26` and `2025-01-09` protocol paths:

- Reproduced the reported failure: `manage_prompt` with no handle returns `SESSION_REQUIRED`; `platform_info` mints a `dps_` handle; the same call carrying it succeeds; an unknown handle returns `SESSION_EXPIRED`.
- Fixed app: boot renders the library, search-as-you-type returns ranked results, a detail opens, and Run resolves and inserts the rendered prompt, with no banner.
- `audit_logs` rows for the app's `manage_prompt` calls carry the caller identity and the resolved `dps_` handle as `session_id`.
- Confirmed `session_id` is injected into `manage_prompt`'s input schema on `tools/list` and absent from `platform_info`'s.

Against a host that enforces the gate under controlled latency and expiry:

- Overlapping searches across an expiry: both calls refused, one shared handshake, only the current query replayed, correct results under the correct query.
- A list call and a `use` call refused together: both settle promptly, both replay on one handshake, Run completes.
- Handles disabled: no `session_id` argument sent, library renders.
- Handshake failure: transient failure self-heals with no banner; persistent failure shows the platform's message with a working Retry, and the panel is never blank at any point during boot, failure, or retry.

`make verify` passes.

## Documentation

`docs/mcpapps/development.md` gains a "Calling Tools from an App" section covering the handshake, the expired-handle recovery path, the rule that a failed handshake must not be fatal, the correlation hazard, and what the harness enforces, plus a troubleshooting row. `docs/mcpapps/overview.md` gains a short "Apps Calling Tools" section pointing at it. Mirrored into `docs/llms.txt` and `docs/llms-full.txt`.
