### PR TITLE
fix(mcpapps): stable 500px height for prompt-browser and platform-info apps

### DIFF
--- a/apps/platform-info/index.html
+++ b/apps/platform-info/index.html
@@ -99,6 +99,11 @@ if(__exports != exports)module.exports = exports;return module.exports}));
 
         * { box-sizing: border-box; margin: 0; padding: 0; }
 
+        /* Fixed 500px app shell (#1043). The app declares its own height via the
+           MCP Apps size-changed contract rather than depending on how much content
+           happens to exist; the hero header is pinned and the content scrolls
+           inside the shell so the host iframe never grows or shrinks with content. */
+        html, body { height: 500px; }
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans',
                          Helvetica, Arial, sans-serif;
@@ -106,10 +111,16 @@ if(__exports != exports)module.exports = exports;return module.exports}));
             line-height: 1.5;
             color: var(--text);
             background: var(--bg);
-            padding: 0;
             margin: 0;
             width: 100%;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
         }
+
+        #content { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+        #content .hero { flex-shrink: 0; }
+        .content-scroll { flex: 1; min-height: 0; overflow-y: auto; }
 
         /* Loading */
         .loading {
@@ -767,6 +778,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
             </div>
         </div>
 
+        <div class="content-scroll">
         <!-- Tabs: Overview / Platform / Agent Instructions -->
         <div class="sec">
             <div id="tab-bar" class="tab-bar">
@@ -816,6 +828,7 @@ if(__exports != exports)module.exports = exports;return module.exports}));
         <div id="personas-sec" class="sec hidden">
             <div class="sec-label">Personas</div>
             <div id="persona-row" class="persona-row"></div>
+        </div>
         </div>
     </div>
 
@@ -906,11 +919,34 @@ if(__exports != exports)module.exports = exports;return module.exports}));
 
     function send(msg) { window.parent.postMessage(msg, '*'); }
 
+    // ---------------------------------------------------------------------
+    // MCP Apps height contract (#1043). The host sizes the iframe from the
+    // last ui/notifications/size-changed the view sends; without one the app
+    // renders in the host's default cramped window. The view declares a fixed
+    // 500px viewport (its shell height) and re-reports on any reflow via a
+    // ResizeObserver, mirroring the SDK's useAutoResize pattern. Kept
+    // byte-identical to the prompt-browser app so both speak one contract.
+    // ---------------------------------------------------------------------
+    var APP_HEIGHT = 500;
+    function sendSize() {
+        // Report height only. These apps are laid out at the host's conversation
+        // width, so width stays host-controlled (fluid); we own only the height.
+        send({ jsonrpc: '2.0', method: 'ui/notifications/size-changed',
+               params: { height: APP_HEIGHT } });
+    }
+    function watchSize() {
+        sendSize();
+        if (typeof ResizeObserver === 'function') {
+            new ResizeObserver(function() { sendSize(); }).observe(document.documentElement);
+        }
+    }
+
     window.addEventListener('message', function(e) {
         var m = e.data;
         if (!m || typeof m !== 'object') { return; }
         if (m.id === 1 && m.result !== undefined) {
             send({ jsonrpc: '2.0', method: 'ui/notifications/initialized', params: {} });
+            watchSize();
             if (!ready) { ready = true; callTool(); }
             return;
         }
@@ -1131,9 +1167,6 @@ if(__exports != exports)module.exports = exports;return module.exports}));
 
         document.getElementById('loading').classList.add('hidden');
         document.getElementById('content').classList.remove('hidden');
-
-        send({ jsonrpc: '2.0', method: 'ui/notifications/size-changed',
-               params: { width: document.body.scrollWidth, height: document.body.scrollHeight } });
     }
 
     // Prompt data stored for copy

--- a/apps/prompt-browser/index.html
+++ b/apps/prompt-browser/index.html
@@ -49,6 +49,11 @@
 
         * { box-sizing: border-box; margin: 0; padding: 0; }
 
+        /* Fixed 500px app shell (#1043). The app declares its own height via the
+           MCP Apps size-changed contract rather than depending on how much content
+           happens to exist; each view pins its header and scrolls its body inside
+           the shell so the host iframe never grows or shrinks with content. */
+        html, body { height: 500px; }
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans',
                          Helvetica, Arial, sans-serif;
@@ -56,8 +61,17 @@
             line-height: 1.5;
             color: var(--text);
             background: var(--bg);
-            padding: 16px;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
         }
+
+        /* A view fills the shell as a header + scrolling body. */
+        .view { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+        .view-head { flex-shrink: 0; padding: 16px 16px 8px; }
+        .view-scroll { flex: 1; min-height: 0; overflow-y: auto; padding: 0 16px 16px; }
+
+        #loading, #error { margin: 16px; }
 
         .hidden { display: none !important; }
 
@@ -329,23 +343,30 @@
 
     <div id="error" class="banner error hidden"></div>
 
-    <div id="browser" class="hidden">
-        <div class="topbar">
-            <div class="title">Prompt Library<span id="count" class="count"></span></div>
-            <input id="search" class="search" type="text"
-                   placeholder="Search prompts&hellip;" autocomplete="off">
+    <div id="browser" class="view hidden">
+        <div class="view-head">
+            <div class="topbar">
+                <div class="title">Prompt Library<span id="count" class="count"></span></div>
+                <input id="search" class="search" type="text"
+                       placeholder="Search prompts&hellip;" autocomplete="off">
+            </div>
+            <div class="facets">
+                <div class="bucket-tabs" id="buckets"></div>
+                <select id="collection" class="facet-select hidden"></select>
+                <select id="sort" class="facet-select"></select>
+            </div>
         </div>
-        <div class="facets">
-            <div class="bucket-tabs" id="buckets"></div>
-            <select id="collection" class="facet-select hidden"></select>
-            <select id="sort" class="facet-select"></select>
+        <div class="view-scroll">
+            <div id="tags" class="tagrow"></div>
+            <div id="cards"></div>
+            <div id="empty" class="empty hidden"></div>
         </div>
-        <div id="tags" class="tagrow"></div>
-        <div id="cards"></div>
-        <div id="empty" class="empty hidden"></div>
     </div>
 
-    <div id="detail" class="hidden"></div>
+    <div id="detail" class="view hidden">
+        <div class="view-head" id="detail-head"></div>
+        <div class="view-scroll" id="detail-scroll"></div>
+    </div>
 
 <script>
     'use strict';
@@ -373,6 +394,28 @@
     var booted = false;
 
     function send(msg) { window.parent.postMessage(msg, '*'); }
+
+    // ---------------------------------------------------------------------
+    // MCP Apps height contract (#1043). The host sizes the iframe from the
+    // last ui/notifications/size-changed the view sends; without one the app
+    // renders in the host's default cramped window. The view declares a fixed
+    // 500px viewport (its shell height) and re-reports on any reflow via a
+    // ResizeObserver, mirroring the SDK's useAutoResize pattern. Kept
+    // byte-identical to the platform-info app so both speak one contract.
+    // ---------------------------------------------------------------------
+    var APP_HEIGHT = 500;
+    function sendSize() {
+        // Report height only. These apps are laid out at the host's conversation
+        // width, so width stays host-controlled (fluid); we own only the height.
+        send({ jsonrpc: '2.0', method: 'ui/notifications/size-changed',
+               params: { height: APP_HEIGHT } });
+    }
+    function watchSize() {
+        sendSize();
+        if (typeof ResizeObserver === 'function') {
+            new ResizeObserver(function() { sendSize(); }).observe(document.documentElement);
+        }
+    }
 
     window.addEventListener('message', function(e) {
         var m = e.data;
@@ -408,6 +451,7 @@
         isLegacy = !hostCaps;
         canMessage = !!(hostCaps && hostCaps.message);
         send({ jsonrpc: '2.0', method: 'ui/notifications/initialized', params: {} });
+        watchSize();
         boot();
     }
 
@@ -960,13 +1004,16 @@
 
     function openDetail(p) {
         hide('browser');
-        var root = $('detail');
+        var headSlot = $('detail-head');
+        var root = $('detail-scroll');
+        clear(headSlot);
         clear(root);
         argInputs = Object.create(null);
+        root.scrollTop = 0;
 
         var back = el('button', 'back-btn', '‹ Back to library');
         back.addEventListener('click', function() { hide('detail'); show('browser'); });
-        root.appendChild(back);
+        headSlot.appendChild(back);
 
         var head = el('div', 'detail-head');
         head.appendChild(el('span', 'detail-title', displayName(p)));


### PR DESCRIPTION
## Summary

The `prompt-browser` and `platform-info` MCP Apps now render as a stable 500px viewport instead of a cramped, undersized iframe. Each app is a fixed 500px shell with a pinned header and an internally scrolling body, so the host iframe no longer grows or shrinks with content, and the app no longer depends on how much content happens to exist.

Closes #1043

## Background

MCP Apps run in an iframe that the host sizes from the last `ui/notifications/size-changed` notification the view sends (View to Host, `ext-apps/src/spec.types.ts:232`; the host resizes on it in `ext-apps/src/app-bridge.ts:390`). The canonical implementation in the vendored SDK is a ResizeObserver-driven auto-resize, mirrored by the `useAutoResize` React hook (`ext-apps/src/app.ts:1030-1069`).

Both apps hand-roll the MCP Apps postMessage protocol rather than using the SDK, and both handled height incorrectly:

- `prompt-browser` spoke `ui/initialize`, `ui/notifications/initialized`, `tools/call`, and `ui/message`, but never sent `ui/notifications/size-changed`. The host therefore rendered it at its default height, producing the cramped window.
- `platform-info` sent `size-changed` exactly once, at the end of the initial render, from `document.body.scrollHeight`, with no ResizeObserver. It only worked because enough content was rendered to make that single measurement tall enough.

That `platform-info` single send already resized the iframe in production, which confirms the host honors the notification. This change extends a mechanism already working in the codebase rather than introducing a new one.

## What changed

Both apps adopt one shared height model: a fixed 500px shell that declares its own height through the `size-changed` contract, with the header pinned and the body scrolling internally.

`apps/prompt-browser/index.html`

- Fixed 500px shell: `html, body { height: 500px }`, body is a flex column with `overflow: hidden`.
- Per-view layout with `.view` / `.view-head` / `.view-scroll`. The browse view pins the title, search, and facets in the head and scrolls the tags and cards in the body. The detail view pins the back button in the head (`#detail-head`) and scrolls the provenance, argument form, content preview, and actions in the body (`#detail-scroll`). `openDetail` fills the two slots.
- Emits `ui/notifications/size-changed` for the first time.

`apps/platform-info/index.html`

- Same fixed 500px shell. `#content` is a flex column, the hero is pinned (`flex-shrink: 0`), and the tabs and personas sections are wrapped in a scrolling `.content-scroll` region.
- The one-shot `scrollHeight` send is removed and replaced by the shared contract.

Shared contract (byte-identical in both apps)

- `sendSize()` posts `ui/notifications/size-changed` with `{ height: 500 }`. It reports height only, so these inline apps stay fluid-width and host-controlled, which also avoids any width feedback through the observer.
- `watchSize()` sends once after `ui/notifications/initialized` and wires a `ResizeObserver` that re-asserts the height on any host-driven reflow (for example a display-mode change).

There is no discrete padding element in `platform-info` to remove. The prior behavior relied on measuring rendered content height once; replacing that with the fixed shell removes the content-volume dependence. The existing content is real and is left intact.

## Verification

Verified end to end against `apps/test-harness.html`, which simulates the host protocol (responds to `ui/call-tool` with test data). For both apps:

- The app emits `ui/notifications/size-changed` with `{ height: 500 }` and no width.
- With the host honoring that height, `document.body` is 500px with `overflow: hidden`.
- The header stays pinned (prompt-browser browse head 100px, detail back-button head about 62px; platform-info hero 96px) while the body scrolls.
- Injecting tall content proves the scroll region scrolls internally while `document.body.scrollHeight` stays at 500, so the host iframe never grows.
- Switching tabs in platform-info keeps the shell fixed and the hero pinned.
- No console errors in either app.

`make verify` passes on the branch (full CI-equivalent suite, all checks green).

## Out of scope

Migrating the apps onto the `ext-apps` SDK. This change adopts the SDK's height pattern by hand to keep the diff minimal; a full SDK migration is a separate decision.
