### PR TITLE
fix(prompt,portal): admin resolves any prompt or asset by name (#1042)

### DIFF
--- a/internal/platform/promptlayer/admin_resolve_test.go
+++ b/internal/platform/promptlayer/admin_resolve_test.go
@@ -1,0 +1,174 @@
+package promptlayer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/prompt"
+)
+
+// multiOwnerStore is a slice-backed prompt store: unlike the name-keyed
+// mockPromptStore it can hold two personal prompts with the same name owned by
+// different users, which is exactly the #1042 condition. It overrides only the
+// two personal lookups; every other method comes from the embedded mock (an
+// empty map), so Get (shared) misses and resolution falls through as in
+// production.
+type multiOwnerStore struct {
+	*mockPromptStore
+	rows []prompt.Prompt
+}
+
+func (s *multiOwnerStore) GetPersonal(_ context.Context, owner, name string) (*prompt.Prompt, error) {
+	for i := range s.rows {
+		r := s.rows[i]
+		if r.Scope == prompt.ScopePersonal && r.OwnerEmail == owner && r.Name == name {
+			return &r, nil
+		}
+	}
+	return nil, nil //nolint:nilnil // Store interface contract: nil, nil means not found
+}
+
+func (s *multiOwnerStore) ListPersonalByName(_ context.Context, name string) ([]prompt.Prompt, error) {
+	var out []prompt.Prompt
+	for _, r := range s.rows {
+		if r.Scope == prompt.ScopePersonal && r.Name == name {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+// TestResolveManagedPrompt_AdminResolvesForeignPersonal is the core #1042
+// regression: an admin resolves another user's personal prompt by name, matching
+// the admin-wide visibility that list already shows. Before the fix the resolver
+// tried only the caller's own personal prompt and the shared (non-personal) set,
+// so it returned nil for a prompt the admin could see in list.
+func TestResolveManagedPrompt_AdminResolvesForeignPersonal(t *testing.T) {
+	h, store := newTestHandle()
+	store.prompts["example-prompt"] = &prompt.Prompt{
+		ID: "p-a", Name: "example-prompt", Scope: prompt.ScopePersonal,
+		OwnerEmail: "author@example.com", Content: "body", Enabled: true,
+	}
+
+	got, err := h.resolveManagedPrompt(adminCtx(), "example-prompt", "admin@example.com", "", "")
+	require.NoError(t, err)
+	require.NotNil(t, got, "admin resolves another user's personal prompt")
+	assert.Equal(t, "p-a", got.ID)
+}
+
+// TestManagePrompt_AdminGetForeignPersonal drives the full get command: the admin
+// gets a prompt they did not author and receives it, not "not found".
+func TestManagePrompt_AdminGetForeignPersonal(t *testing.T) {
+	h, store := newTestHandle()
+	store.prompts["example-prompt"] = &prompt.Prompt{
+		ID: "p-a", Name: "example-prompt", Scope: prompt.ScopePersonal,
+		OwnerEmail: "author@example.com", Content: "the body", Enabled: true,
+	}
+
+	r, _, err := h.handleManagePrompt(adminCtx(), managePromptInput{
+		Command: "get", Name: "example-prompt",
+	})
+	require.NoError(t, err)
+	require.False(t, r.IsError, "admin get of a foreign personal prompt must succeed: %s", resultText(r))
+	assert.Contains(t, resultText(r), "the body")
+}
+
+// TestResolveManagedPrompt_AdminOwnerDisambiguation: when two owners share a
+// personal-prompt name, owner_email picks the intended one.
+func TestResolveManagedPrompt_AdminOwnerDisambiguation(t *testing.T) {
+	h, _ := newTestHandle()
+	h.store = &multiOwnerStore{
+		mockPromptStore: newMockPromptStore(),
+		rows: []prompt.Prompt{
+			{ID: "p-a", Name: "report", Scope: prompt.ScopePersonal, OwnerEmail: "a@example.com", Content: "a"},
+			{ID: "p-b", Name: "report", Scope: prompt.ScopePersonal, OwnerEmail: "b@example.com", Content: "b"},
+		},
+	}
+
+	got, err := h.resolveManagedPrompt(adminCtx(), "report", "admin@example.com", "", "b@example.com")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "p-b", got.ID, "owner_email targets that owner's personal prompt")
+}
+
+// TestManagePrompt_AdminAmbiguousForeignPersonal: without owner_email, an admin
+// naming a personal prompt held by more than one owner gets an explicit
+// ambiguity error that lists the owners, not a silent wrong pick.
+func TestManagePrompt_AdminAmbiguousForeignPersonal(t *testing.T) {
+	h, _ := newTestHandle()
+	h.store = &multiOwnerStore{
+		mockPromptStore: newMockPromptStore(),
+		rows: []prompt.Prompt{
+			{ID: "p-a", Name: "report", Scope: prompt.ScopePersonal, OwnerEmail: "a@example.com", Content: "a"},
+			{ID: "p-b", Name: "report", Scope: prompt.ScopePersonal, OwnerEmail: "b@example.com", Content: "b"},
+		},
+	}
+
+	r, _, err := h.handleManagePrompt(adminCtx(), managePromptInput{Command: "get", Name: "report"})
+	require.NoError(t, err)
+	require.True(t, r.IsError)
+	msg := resultText(r)
+	assert.Contains(t, msg, "owner_email")
+	assert.Contains(t, msg, "a@example.com")
+	assert.Contains(t, msg, "b@example.com")
+	assert.NotContains(t, msg, "not found", "an ambiguous match is not a not-found")
+}
+
+// TestManagePrompt_NonAdminForeignPersonalIsExplicit: a non-admin naming another
+// owner's personal prompt is told the scope condition, not "not found", and the
+// owner is not disclosed.
+func TestManagePrompt_NonAdminForeignPersonalIsExplicit(t *testing.T) {
+	h, store := newTestHandle()
+	store.prompts["example-prompt"] = &prompt.Prompt{
+		ID: "p-a", Name: "example-prompt", Scope: prompt.ScopePersonal,
+		OwnerEmail: "author@example.com", Content: "body", Enabled: true,
+	}
+
+	r, _, err := h.handleManagePrompt(userCtx("other@example.com", "analyst"), managePromptInput{
+		Command: "get", Name: "example-prompt",
+	})
+	require.NoError(t, err)
+	require.True(t, r.IsError)
+	msg := resultText(r)
+	assert.Contains(t, msg, "owned by another user")
+	assert.NotContains(t, msg, "not found")
+	assert.NotContains(t, msg, "author@example.com", "owner is not disclosed to a non-admin")
+}
+
+// TestResolveManagedPrompt_NonAdminGenuinelyMissing: a name that matches no
+// prompt still resolves to nil (rendered as "not found"), for admin and
+// non-admin alike.
+func TestResolveManagedPrompt_NonAdminGenuinelyMissing(t *testing.T) {
+	h, _ := newTestHandle()
+
+	got, err := h.resolveManagedPrompt(userCtx("u@example.com", "analyst"), "nope", "u@example.com", "", "")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	got, err = h.resolveManagedPrompt(adminCtx(), "nope", "admin@example.com", "", "")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+// TestForeignPersonalPromptError_Message documents the caller-safe wording.
+func TestForeignPersonalPromptError_Message(t *testing.T) {
+	err := error(&foreignPersonalPromptError{name: "x"})
+	var target *foreignPersonalPromptError
+	require.True(t, errors.As(err, &target))
+	assert.Contains(t, err.Error(), "your own personal prompts")
+}
+
+// TestPersonalPromptOwners_Dedup: repeated owners collapse to distinct entries in
+// store order, so an ambiguity message never repeats a name.
+func TestPersonalPromptOwners_Dedup(t *testing.T) {
+	owners := personalPromptOwners([]prompt.Prompt{
+		{OwnerEmail: "a@example.com"},
+		{OwnerEmail: "b@example.com"},
+		{OwnerEmail: "a@example.com"},
+	})
+	assert.Equal(t, []string{"a@example.com", "b@example.com"}, owners)
+}

--- a/internal/platform/promptlayer/patch.go
+++ b/internal/platform/promptlayer/patch.go
@@ -237,7 +237,7 @@ func (h *Handle) readablePrompt(ctx context.Context, input managePromptInput) (*
 	if input.Name == "" {
 		return nil, promptErrorResult("name is required")
 	}
-	pr, err := h.resolveManagedPrompt(ctx, input.Name, resolveEmail(ctx), input.Scope)
+	pr, err := h.resolveManagedPrompt(ctx, input.Name, resolveEmail(ctx), input.Scope, input.OwnerEmail)
 	if err != nil {
 		return nil, h.promptErrorDetail(ctx, promptErrGet, err)
 	}

--- a/internal/platform/promptlayer/promptlayer_test.go
+++ b/internal/platform/promptlayer/promptlayer_test.go
@@ -41,8 +41,14 @@ func (m *mockPromptStore) Get(_ context.Context, name string) (*prompt.Prompt, e
 	if m.getErr != nil {
 		return nil, m.getErr
 	}
-	p := m.prompts[name]
-	return p, nil //nolint:nilnil // interface contract
+	// Mirror the real store: Get resolves only shared (non-personal) prompts;
+	// personal prompts are per-owner and served via GetPersonal.
+	for _, p := range m.prompts {
+		if p.Name == name && p.Scope != prompt.ScopePersonal {
+			return p, nil
+		}
+	}
+	return nil, nil //nolint:nilnil // interface contract
 }
 
 func (m *mockPromptStore) GetPersonal(_ context.Context, ownerEmail, name string) (*prompt.Prompt, error) {
@@ -67,6 +73,19 @@ func (m *mockPromptStore) GetByID(_ context.Context, id string) (*prompt.Prompt,
 		}
 	}
 	return nil, nil //nolint:nilnil // interface contract
+}
+
+func (m *mockPromptStore) ListPersonalByName(_ context.Context, name string) ([]prompt.Prompt, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	var out []prompt.Prompt
+	for _, p := range m.prompts {
+		if p.Scope == prompt.ScopePersonal && p.Name == name {
+			out = append(out, *p)
+		}
+	}
+	return out, nil
 }
 
 func (m *mockPromptStore) Update(_ context.Context, p *prompt.Prompt) error {

--- a/internal/platform/promptlayer/tool.go
+++ b/internal/platform/promptlayer/tool.go
@@ -51,6 +51,7 @@ type managePromptInput struct {
 	Arguments    []prompt.Argument `json:"arguments,omitempty"`
 	Category     string            `json:"category,omitempty"`
 	Scope        string            `json:"scope,omitempty"`
+	OwnerEmail   string            `json:"owner_email,omitempty"`
 	Personas     []string          `json:"personas,omitempty"`
 	Tags         []string          `json:"tags,omitempty"`
 	Status       string            `json:"status,omitempty"`
@@ -221,7 +222,13 @@ func (h *Handle) handlePromptUpdate(ctx context.Context, input managePromptInput
 		return promptErrorResult("name is required"), nil, nil
 	}
 
-	existing, errResult := h.editablePrompt(ctx, input)
+	// Resolve the prompt to edit by name, not by the target scope: on update
+	// input.Scope is the *new* scope to set, so passing it as a resolution filter
+	// would hide the caller's own personal prompt behind a shared-only lookup and
+	// report their prompt as "not found". The new scope is applied below.
+	resolveInput := input
+	resolveInput.Scope = ""
+	existing, errResult := h.editablePrompt(ctx, resolveInput)
 	if errResult != nil {
 		return errResult, nil, nil
 	}
@@ -427,7 +434,7 @@ func (h *Handle) handlePromptDelete(ctx context.Context, input managePromptInput
 		return promptErrorResult("name is required"), nil, nil
 	}
 
-	existing, err := h.resolveManagedPrompt(ctx, input.Name, resolveEmail(ctx), input.Scope)
+	existing, err := h.resolveManagedPrompt(ctx, input.Name, resolveEmail(ctx), input.Scope, input.OwnerEmail)
 	if err != nil {
 		slog.Error(promptErrGet, promptLogKey, input.Name, promptLogKeyErr, err)
 		return h.promptErrorDetail(ctx, promptErrGet, err), nil, nil
@@ -620,7 +627,7 @@ func (h *Handle) handlePromptGet(ctx context.Context, input managePromptInput) (
 		return promptErrorResult("name is required"), nil, nil
 	}
 
-	pr, err := h.resolveManagedPrompt(ctx, input.Name, resolveEmail(ctx), input.Scope)
+	pr, err := h.resolveManagedPrompt(ctx, input.Name, resolveEmail(ctx), input.Scope, input.OwnerEmail)
 	if err != nil {
 		slog.Error(promptErrGet, promptLogKey, input.Name, promptLogKeyErr, err)
 		return h.promptErrorDetail(ctx, promptErrGet, err), nil, nil
@@ -641,18 +648,87 @@ func (h *Handle) handlePromptGet(ctx context.Context, input managePromptInput) (
 	return promptJSONResult(pr)
 }
 
+// ambiguousPersonalPromptError reports that more than one owner has a personal
+// prompt of the addressed name, so an admin's owner-agnostic lookup cannot pick
+// one. It carries the candidate owners so the caller can re-address with
+// owner_email.
+type ambiguousPersonalPromptError struct {
+	name   string
+	owners []string
+}
+
+func (e *ambiguousPersonalPromptError) Error() string {
+	return fmt.Sprintf("multiple personal prompts are named %q (owners: %s); pass owner_email to target one",
+		e.name, strings.Join(e.owners, ", "))
+}
+
+// foreignPersonalPromptError reports that a personal prompt of the addressed
+// name exists but is owned by another user, so a non-admin caller may not reach
+// it. It names the scope condition instead of collapsing to "not found"; the
+// owner is deliberately withheld from non-admins.
+type foreignPersonalPromptError struct {
+	name string
+}
+
+func (e *foreignPersonalPromptError) Error() string {
+	return fmt.Sprintf("a personal prompt named %q exists but is owned by another user; "+
+		"you can only access your own personal prompts", e.name)
+}
+
 // resolveManagedPrompt finds the prompt a manage_prompt command targets by
 // name. Personal names are unique only per owner, so by default the caller's own
 // personal prompt takes precedence; otherwise a globally-unique global/persona
 // prompt is returned. An explicit shared scope (global/persona) skips the
 // personal lookup so a caller who owns a same-named personal prompt can still
 // target the shared one.
-func (h *Handle) resolveManagedPrompt(ctx context.Context, name, email, scope string) (*prompt.Prompt, error) {
+//
+// An admin is unrestricted by design: admin list already surfaces every owner's
+// personal prompts, so the addressing verbs honor the same visibility. When the
+// caller is admin and neither the own-personal nor the shared lookup matches, a
+// personal prompt owned by any user resolves; owner disambiguates when more than
+// one owner shares the name. A non-admin who names another owner's personal
+// prompt gets an explicit scope error rather than a misleading "not found".
+func (h *Handle) resolveManagedPrompt(ctx context.Context, name, email, scope, owner string) (*prompt.Prompt, error) {
 	sharedOnly := scope == prompt.ScopeGlobal || scope == prompt.ScopePersona
+	isAdmin := h.isAdminPersona(ctx)
+
+	// An admin naming an owner commits to that owner's personal prompt: a miss is
+	// a miss and must not silently resolve a different owner's same-named prompt.
+	if isAdmin && owner != "" {
+		return h.getPersonalPrompt(ctx, owner, name)
+	}
+
+	pr, err := h.resolveOwnOrShared(ctx, name, email, sharedOnly)
+	if err != nil {
+		return nil, err
+	}
+	if pr != nil || sharedOnly {
+		return pr, nil
+	}
+
+	// Neither the caller's own personal prompt nor a shared prompt matched.
+	return h.resolvePersonalAcrossOwners(ctx, name, isAdmin)
+}
+
+// getPersonalPrompt fetches an owner's personal prompt with the resolver's error
+// context. Returns nil when no such prompt exists.
+func (h *Handle) getPersonalPrompt(ctx context.Context, owner, name string) (*prompt.Prompt, error) {
+	p, err := h.store.GetPersonal(ctx, owner, name)
+	if err != nil {
+		return nil, fmt.Errorf("resolving personal prompt: %w", err)
+	}
+	return p, nil
+}
+
+// resolveOwnOrShared returns the caller's own personal prompt, or the globally
+// unique shared (global/persona) prompt of the name, or nil when neither exists.
+// An explicit shared scope skips the personal lookup so a caller who owns a
+// same-named personal prompt can still target the shared one.
+func (h *Handle) resolveOwnOrShared(ctx context.Context, name, email string, sharedOnly bool) (*prompt.Prompt, error) {
 	if email != "" && !sharedOnly {
-		personal, err := h.store.GetPersonal(ctx, email, name)
+		personal, err := h.getPersonalPrompt(ctx, email, name)
 		if err != nil {
-			return nil, fmt.Errorf("resolving personal prompt: %w", err)
+			return nil, err
 		}
 		if personal != nil {
 			return personal, nil
@@ -662,7 +738,46 @@ func (h *Handle) resolveManagedPrompt(ctx context.Context, name, email, scope st
 	if err != nil {
 		return nil, fmt.Errorf("resolving shared prompt: %w", err)
 	}
-	return shared, nil
+	return shared, nil // nil when not found
+}
+
+// resolvePersonalAcrossOwners resolves a personal prompt by name regardless of
+// owner, the lookup the default resolver cannot reach. For an admin it returns
+// the single match, or an ambiguity error naming the owners when more than one
+// exists. For a non-admin a match becomes an explicit foreign-prompt error
+// (they may not reach it) rather than a misleading "not found". No match
+// resolves to nil.
+func (h *Handle) resolvePersonalAcrossOwners(ctx context.Context, name string, isAdmin bool) (*prompt.Prompt, error) {
+	matches, err := h.store.ListPersonalByName(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("resolving personal prompt across owners: %w", err)
+	}
+	if len(matches) == 0 {
+		return nil, nil //nolint:nilnil // resolver contract: nil, nil means not found
+	}
+	if !isAdmin {
+		return nil, &foreignPersonalPromptError{name: name}
+	}
+	if len(matches) == 1 {
+		return &matches[0], nil
+	}
+	return nil, &ambiguousPersonalPromptError{name: name, owners: personalPromptOwners(matches)}
+}
+
+// personalPromptOwners returns the distinct owner emails of the given prompts,
+// in the order the store returned them.
+func personalPromptOwners(prompts []prompt.Prompt) []string {
+	owners := make([]string, 0, len(prompts))
+	seen := make(map[string]struct{}, len(prompts))
+	for i := range prompts {
+		o := prompts[i].OwnerEmail
+		if _, ok := seen[o]; ok {
+			continue
+		}
+		seen[o] = struct{}{}
+		owners = append(owners, o)
+	}
+	return owners
 }
 
 // resolveEmail returns the user email from context.
@@ -690,6 +805,18 @@ func (h *Handle) isAdminPersona(ctx context.Context) bool {
 // the logs. Raw errors (which may carry SQL or schema detail) are never shown to
 // non-admins. The full error is always written to the server log by the caller.
 func (h *Handle) promptErrorDetail(ctx context.Context, public string, err error) *mcp.CallToolResult {
+	// Resolution outcomes carry their own caller-safe message: an admin's
+	// ambiguous owner lookup or a non-admin naming another owner's personal
+	// prompt. Surface it verbatim instead of the generic "failed to ..." prefix,
+	// and never through the admin-only raw-error branch below.
+	var amb *ambiguousPersonalPromptError
+	if errors.As(err, &amb) {
+		return promptErrorResult(amb.Error())
+	}
+	var foreign *foreignPersonalPromptError
+	if errors.As(err, &foreign) {
+		return promptErrorResult(foreign.Error())
+	}
 	if h.isAdminPersona(ctx) {
 		return promptErrorResult(fmt.Sprintf("%s: %v", public, err))
 	}
@@ -791,6 +918,13 @@ func managePromptSchema() any {
 				schemaKeyType:        schemaValString,
 				schemaKeyEnum:        []string{prompt.ScopeGlobal, prompt.ScopePersona, prompt.ScopePersonal},
 				schemaKeyDescription: "Visibility scope. Non-admins can only use 'personal'.",
+			},
+			"owner_email": map[string]any{
+				schemaKeyType: schemaValString,
+				schemaKeyDescription: "Owner of a personal prompt to target by name (get, delete, update, " +
+					"patch and the other content verbs). Admin only: lets an operator address or " +
+					"disambiguate another user's personal prompt that admin list already shows. " +
+					"Ignored for non-admins, who can only act on their own prompts.",
 			},
 			"personas": map[string]any{
 				schemaKeyType:        schemaValArray,

--- a/internal/platform/promptlayer/tool_test.go
+++ b/internal/platform/promptlayer/tool_test.go
@@ -527,12 +527,12 @@ func TestResolveManagedPrompt_ScopePreference(t *testing.T) {
 
 	ctx := context.Background()
 
-	got, err := h.resolveManagedPrompt(ctx, "report", "admin@x", "")
+	got, err := h.resolveManagedPrompt(ctx, "report", "admin@x", "", "")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "p", got.ID, "default resolution prefers the caller's personal prompt")
 
-	got, err = h.resolveManagedPrompt(ctx, "report", "admin@x", prompt.ScopeGlobal)
+	got, err = h.resolveManagedPrompt(ctx, "report", "admin@x", prompt.ScopeGlobal, "")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "g", got.ID, "explicit global scope targets the shared prompt")

--- a/pkg/admin/prompt_handler_test.go
+++ b/pkg/admin/prompt_handler_test.go
@@ -71,6 +71,16 @@ func (m *mockPromptStore) GetByID(_ context.Context, id string) (*prompt.Prompt,
 	return nil, nil //nolint:nilnil // Store interface contract: nil, nil means not found
 }
 
+func (m *mockPromptStore) ListPersonalByName(_ context.Context, name string) ([]prompt.Prompt, error) {
+	var out []prompt.Prompt
+	for _, p := range m.prompts {
+		if p.Scope == prompt.ScopePersonal && p.Name == name {
+			out = append(out, *p)
+		}
+	}
+	return out, nil
+}
+
 func (m *mockPromptStore) Update(_ context.Context, p *prompt.Prompt) error {
 	if m.updateErr != nil {
 		return m.updateErr

--- a/pkg/platform/prompt_wiring_test.go
+++ b/pkg/platform/prompt_wiring_test.go
@@ -54,6 +54,16 @@ func (m *wiringPromptStore) GetByID(_ context.Context, id string) (*prompt.Promp
 	return nil, nil //nolint:nilnil // interface contract
 }
 
+func (m *wiringPromptStore) ListPersonalByName(_ context.Context, name string) ([]prompt.Prompt, error) {
+	var out []prompt.Prompt
+	for _, p := range m.prompts {
+		if p.Scope == prompt.ScopePersonal && p.Name == name {
+			out = append(out, *p)
+		}
+	}
+	return out, nil
+}
+
 func (m *wiringPromptStore) Update(_ context.Context, p *prompt.Prompt) error {
 	m.prompts[p.Name] = p
 	return nil

--- a/pkg/portal/prompt_handler_test.go
+++ b/pkg/portal/prompt_handler_test.go
@@ -63,6 +63,16 @@ func (m *mockPromptStore) GetByID(_ context.Context, id string) (*prompt.Prompt,
 	return nil, nil //nolint:nilnil // Store interface contract: nil, nil means not found
 }
 
+func (m *mockPromptStore) ListPersonalByName(_ context.Context, name string) ([]prompt.Prompt, error) {
+	var out []prompt.Prompt
+	for _, p := range m.prompts {
+		if p.Scope == prompt.ScopePersonal && p.Name == name {
+			out = append(out, *p)
+		}
+	}
+	return out, nil
+}
+
 func (m *mockPromptStore) Update(_ context.Context, p *prompt.Prompt) error {
 	if m.updateErr != nil {
 		return m.updateErr

--- a/pkg/prompt/edit_test.go
+++ b/pkg/prompt/edit_test.go
@@ -92,6 +92,10 @@ func (*plainStore) GetByID(context.Context, string) (*Prompt, error) {
 	return nil, nil //nolint:nilnil // interface contract
 }
 
+func (*plainStore) ListPersonalByName(context.Context, string) ([]Prompt, error) {
+	return nil, nil
+}
+
 func (s *plainStore) Update(_ context.Context, p *Prompt) error {
 	if s.err != nil {
 		return s.err

--- a/pkg/prompt/postgres/store.go
+++ b/pkg/prompt/postgres/store.go
@@ -169,6 +169,32 @@ func (s *Store) GetPersonal(ctx context.Context, ownerEmail, name string) (*prom
 	return s.queryOne(ctx, query, ownerEmail, name)
 }
 
+// ListPersonalByName retrieves every personal prompt with the given name across
+// all owners. Personal names are unique only within an owner, so this may return
+// more than one row; an admin uses it to resolve a personal prompt authored by
+// another user and to disambiguate by owner. Returns an empty slice if none match.
+func (s *Store) ListPersonalByName(ctx context.Context, name string) ([]prompt.Prompt, error) {
+	query := promptSelect + ` WHERE name = $1 AND scope = 'personal' ORDER BY owner_email`
+	rows, err := s.db.QueryContext(ctx, query, name)
+	if err != nil {
+		return nil, fmt.Errorf("list personal prompts by name: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []prompt.Prompt
+	for rows.Next() {
+		p, err := scanPrompt(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan prompt: %w", err)
+		}
+		result = append(result, *p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate personal prompts: %w", err)
+	}
+	return result, nil
+}
+
 // GetByID retrieves a prompt by ID. Returns nil, nil if not found.
 func (s *Store) GetByID(ctx context.Context, id string) (*prompt.Prompt, error) {
 	query := promptSelect + ` WHERE id = $1`

--- a/pkg/prompt/postgres/store_realdb_integration_test.go
+++ b/pkg/prompt/postgres/store_realdb_integration_test.go
@@ -217,3 +217,39 @@ func TestStore_Update_RealDB_NilTags(t *testing.T) {
 	assert.NotNil(t, got.Tags)
 	assert.Empty(t, got.Tags)
 }
+
+// TestStore_ListPersonalByName_RealDB is the #1042 store-layer regression: two
+// users own a same-named personal prompt, and ListPersonalByName resolves both
+// across owners while GetPersonal stays owner-keyed. It also confirms the query
+// excludes a same-named global prompt (scope = 'personal' only) and returns
+// empty for an unknown name.
+func TestStore_ListPersonalByName_RealDB(t *testing.T) {
+	store := New(testdb.New(t))
+	ctx := context.Background()
+
+	require.NoError(t, store.Create(ctx, &prompt.Prompt{
+		Name: "report", Content: "a body", Scope: prompt.ScopePersonal,
+		OwnerEmail: "a@example.com", Source: prompt.SourceOperator, Enabled: true,
+	}))
+	require.NoError(t, store.Create(ctx, &prompt.Prompt{
+		Name: "report", Content: "b body", Scope: prompt.ScopePersonal,
+		OwnerEmail: "b@example.com", Source: prompt.SourceOperator, Enabled: true,
+	}))
+	require.NoError(t, store.Create(ctx, &prompt.Prompt{
+		Name: "report", Content: "shared body", Scope: prompt.ScopeGlobal,
+		Source: prompt.SourceOperator, Status: prompt.StatusApproved, Enabled: true,
+	}))
+
+	got, err := store.ListPersonalByName(ctx, "report")
+	require.NoError(t, err)
+	require.Len(t, got, 2, "resolves both owners' personal prompts, not the global one")
+	owners := []string{got[0].OwnerEmail, got[1].OwnerEmail}
+	assert.ElementsMatch(t, []string{"a@example.com", "b@example.com"}, owners)
+	for _, p := range got {
+		assert.Equal(t, prompt.ScopePersonal, p.Scope)
+	}
+
+	none, err := store.ListPersonalByName(ctx, "no-such-prompt")
+	require.NoError(t, err)
+	assert.Empty(t, none)
+}

--- a/pkg/prompt/postgres/store_test.go
+++ b/pkg/prompt/postgres/store_test.go
@@ -188,6 +188,61 @@ func TestGet_NotFound(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestListPersonalByName_MultipleOwners(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := New(db)
+	argsJSON := []byte(`[]`)
+
+	mock.ExpectQuery("SELECT .+ FROM prompts WHERE name = .+ AND scope = 'personal'").
+		WithArgs("report").
+		WillReturnRows(sqlmock.NewRows(selectColumns).
+			AddRow(promptRow("id-a", "report", "personal", argsJSON, "a@example.com")...).
+			AddRow(promptRow("id-b", "report", "personal", argsJSON, "b@example.com")...))
+
+	got, err := store.ListPersonalByName(context.Background(), "report")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "a@example.com", got[0].OwnerEmail)
+	assert.Equal(t, "b@example.com", got[1].OwnerEmail)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestListPersonalByName_None(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := New(db)
+
+	mock.ExpectQuery("SELECT .+ FROM prompts WHERE name = .+ AND scope = 'personal'").
+		WithArgs("missing").
+		WillReturnRows(sqlmock.NewRows(selectColumns))
+
+	got, err := store.ListPersonalByName(context.Background(), "missing")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestListPersonalByName_QueryError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := New(db)
+
+	mock.ExpectQuery("SELECT .+ FROM prompts WHERE name = .+ AND scope = 'personal'").
+		WithArgs("boom").
+		WillReturnError(errors.New("connection refused"))
+
+	got, err := store.ListPersonalByName(context.Background(), "boom")
+	require.Error(t, err)
+	assert.Nil(t, got)
+}
+
 func TestGetByID_Success(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -317,6 +317,14 @@ type Store interface {
 	// disambiguate. Returns nil, nil if not found.
 	GetPersonal(ctx context.Context, ownerEmail, name string) (*Prompt, error)
 
+	// ListPersonalByName retrieves every personal prompt with the given name,
+	// across all owners. Personal names are unique only within an owner, so this
+	// may return more than one row; callers with platform-wide visibility (an
+	// admin resolving a prompt they did not author) use it to address a personal
+	// prompt by name and to disambiguate by owner. Returns an empty slice if none
+	// match.
+	ListPersonalByName(ctx context.Context, name string) ([]Prompt, error)
+
 	// GetByID retrieves a prompt by ID. Returns nil, nil if not found.
 	GetByID(ctx context.Context, id string) (*Prompt, error)
 

--- a/pkg/prompt/versionhttp/handler_test.go
+++ b/pkg/prompt/versionhttp/handler_test.go
@@ -40,6 +40,19 @@ func (s *fakeStore) GetByID(_ context.Context, id string) (*prompt.Prompt, error
 	}
 	return s.prompts[id], nil //nolint:nilnil // interface contract
 }
+
+func (s *fakeStore) ListPersonalByName(_ context.Context, name string) ([]prompt.Prompt, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	var out []prompt.Prompt
+	for _, p := range s.prompts {
+		if p.Scope == prompt.ScopePersonal && p.Name == name {
+			out = append(out, *p)
+		}
+	}
+	return out, nil
+}
 func (*fakeStore) Update(context.Context, *prompt.Prompt) error { return nil }
 func (*fakeStore) Delete(context.Context, string) error         { return nil }
 func (*fakeStore) DeleteByID(context.Context, string) error     { return nil }

--- a/pkg/toolkits/portal/patch_handlers.go
+++ b/pkg/toolkits/portal/patch_handlers.go
@@ -107,7 +107,7 @@ func (t *Toolkit) handlePatch(ctx context.Context, input manageAssetInput) (*mcp
 	if errResult != nil {
 		return errResult, nil, nil
 	}
-	if asset.OwnerID != resolveOwnerID(ctx) {
+	if !t.isAdmin(ctx) && asset.OwnerID != resolveOwnerID(ctx) {
 		return middleware.UnauthorizedResult("you can only patch your own assets",
 			"Ask the owner to apply the change, or save your own copy with save_asset."), nil, nil
 	}
@@ -292,7 +292,11 @@ func (t *Toolkit) loadReadableAsset(ctx context.Context, assetID string) (*porta
 // canReadAsset reports whether the caller owns the asset or holds any share
 // grant on it, directly or through a collection. Read access is deliberately
 // wider than the owner-only write checks: a viewer share is enough to read.
+// An admin is unrestricted by design and reads any asset.
 func (t *Toolkit) canReadAsset(ctx context.Context, asset *portal.Asset) bool {
+	if t.isAdmin(ctx) {
+		return true
+	}
 	userID, email := resolveOwnerID(ctx), resolveOwnerEmail(ctx)
 	if asset.OwnerID == userID {
 		return true

--- a/pkg/toolkits/portal/patch_handlers_test.go
+++ b/pkg/toolkits/portal/patch_handlers_test.go
@@ -373,6 +373,36 @@ func TestManageAssetPatchRequiresOwnership(t *testing.T) {
 	assert.Equal(t, patchReport, f.storedBody(t))
 }
 
+// TestManageAssetPatchAllowsAdmin is the #1042 asset-side regression: an admin
+// is unrestricted by design and patches an asset they do not own, matching the
+// admin-wide access the platform grants everywhere else.
+func TestManageAssetPatchAllowsAdmin(t *testing.T) {
+	f := newPatchFixture(t, patchReport, "text/markdown")
+	f.ctx = middleware.WithPlatformContext(context.Background(), &middleware.PlatformContext{
+		UserID: "operator", UserEmail: "operator@example.com", IsAdmin: true,
+	})
+
+	_, result := f.call(t, manageAssetInput{
+		Action: actionPatch,
+		Edits:  []textpatch.Edit{{Find: "See the table above.", Replace: "See Table 1."}},
+	})
+	require.False(t, result.IsError, errorText(t, result))
+	assert.Contains(t, f.storedBody(t), "See Table 1.", "admin's patch landed on another user's asset")
+}
+
+// TestManageAssetReadVerbsAllowAdmin: an admin reads another user's asset
+// through the content verbs (canReadAsset admits the admin).
+func TestManageAssetReadVerbsAllowAdmin(t *testing.T) {
+	f := newPatchFixture(t, patchReport, "text/markdown")
+	f.ctx = middleware.WithPlatformContext(context.Background(), &middleware.PlatformContext{
+		UserID: "operator", UserEmail: "operator@example.com", IsAdmin: true,
+	})
+
+	got, result := f.call(t, manageAssetInput{Action: actionGetContent})
+	require.False(t, result.IsError, errorText(t, result))
+	assert.Equal(t, patchReport, got["content"])
+}
+
 func TestManageAssetContentVerbsRequireAnAssetID(t *testing.T) {
 	f := newPatchFixture(t, patchReport, "text/markdown")
 

--- a/pkg/toolkits/portal/toolkit.go
+++ b/pkg/toolkits/portal/toolkit.go
@@ -620,7 +620,7 @@ func (t *Toolkit) handleUpdate(ctx context.Context, input manageAssetInput) (*mc
 	}
 
 	ownerID := resolveOwnerID(ctx)
-	if asset.OwnerID != ownerID {
+	if !t.isAdmin(ctx) && asset.OwnerID != ownerID {
 		return toolkit.ErrorResult("you can only update your own assets"), nil, nil
 	}
 
@@ -735,7 +735,7 @@ func (t *Toolkit) handleDelete(ctx context.Context, input manageAssetInput) (*mc
 	}
 
 	ownerID := resolveOwnerID(ctx)
-	if asset.OwnerID != ownerID {
+	if !t.isAdmin(ctx) && asset.OwnerID != ownerID {
 		return toolkit.ErrorResult("you can only delete your own assets"), nil, nil
 	}
 
@@ -782,7 +782,7 @@ func (t *Toolkit) handleRevert(ctx context.Context, input manageAssetInput) (*mc
 	}
 
 	ownerID := resolveOwnerID(ctx)
-	if asset.OwnerID != ownerID {
+	if !t.isAdmin(ctx) && asset.OwnerID != ownerID {
 		return toolkit.ErrorResult("you can only revert your own assets"), nil, nil
 	}
 

--- a/pkg/toolkits/portal/toolkit_test.go
+++ b/pkg/toolkits/portal/toolkit_test.go
@@ -335,6 +335,31 @@ func TestManageAsset_UpdateWrongOwner(t *testing.T) {
 	assert.True(t, result.IsError)
 }
 
+// TestManageAsset_UpdateAdminAnyOwner is the #1042 asset-side regression for the
+// update verb: an admin updates an asset they do not own.
+func TestManageAsset_UpdateAdminAnyOwner(t *testing.T) {
+	store := newInMemoryAssetStore()
+	_ = store.Insert(context.Background(), portal.Asset{
+		ID: "a1", OwnerID: "user1", Name: "Mine", Tags: []string{},
+		Provenance: portal.Provenance{},
+	})
+
+	tk := New(Config{Name: "test", AssetStore: store, S3Bucket: "bucket"})
+
+	ctx := middleware.WithPlatformContext(context.Background(),
+		&middleware.PlatformContext{UserID: "operator", IsAdmin: true})
+
+	result, _, err := tk.handleManageAsset(ctx, nil, manageAssetInput{
+		Action: "update", AssetID: "a1", Name: "Renamed by admin",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError, errorText(t, result))
+
+	got, getErr := store.Get(context.Background(), "a1")
+	require.NoError(t, getErr)
+	assert.Equal(t, "Renamed by admin", got.Name)
+}
+
 func TestManageAsset_Delete(t *testing.T) {
 	store := newInMemoryAssetStore()
 	_ = store.Insert(context.Background(), portal.Asset{
@@ -661,6 +686,31 @@ func TestManageAsset_DeleteWrongOwner(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, result.IsError)
+}
+
+// TestManageAsset_DeleteAdminAnyOwner is the #1042 asset-side regression for the
+// delete verb: an admin deletes an asset they do not own.
+func TestManageAsset_DeleteAdminAnyOwner(t *testing.T) {
+	store := newInMemoryAssetStore()
+	_ = store.Insert(context.Background(), portal.Asset{
+		ID: "a1", OwnerID: "user1", Name: "Mine", Tags: []string{},
+		Provenance: portal.Provenance{},
+	})
+
+	tk := New(Config{Name: "test", AssetStore: store, S3Bucket: "bucket"})
+
+	ctx := middleware.WithPlatformContext(context.Background(),
+		&middleware.PlatformContext{UserID: "operator", IsAdmin: true})
+
+	result, _, err := tk.handleManageAsset(ctx, nil, manageAssetInput{
+		Action: "delete", AssetID: "a1",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError, errorText(t, result))
+
+	got, getErr := store.Get(context.Background(), "a1")
+	require.NoError(t, getErr)
+	assert.NotNil(t, got.DeletedAt)
 }
 
 func TestManageAsset_DeleteNotFound(t *testing.T) {
@@ -1193,6 +1243,31 @@ func TestHandleRevert(t *testing.T) {
 	require.True(t, ok)
 	require.NoError(t, json.Unmarshal([]byte(tc.Text), &parsed))
 	assert.Equal(t, float64(2), parsed["version"])
+}
+
+// TestHandleRevertAdminAnyOwner is the #1042 asset-side regression for the
+// revert verb: an admin reverts an asset they do not own.
+func TestHandleRevertAdminAnyOwner(t *testing.T) {
+	store := newInMemoryAssetStore()
+	vs := newInMemoryVersionStore()
+	s3 := &mockS3Client{getBody: []byte("<html>v1</html>"), getCT: "text/html"}
+	tk := New(Config{
+		Name: "test", AssetStore: store, VersionStore: vs,
+		S3Client: s3, S3Bucket: "bucket", S3Prefix: "assets/",
+	})
+
+	setupCtx := middleware.WithPlatformContext(context.Background(), &middleware.PlatformContext{UserID: "user1"})
+	require.NoError(t, store.Insert(setupCtx, portal.Asset{ID: "a1", OwnerID: "user1", CurrentVersion: 2}))
+	_, cvErr := vs.CreateVersion(setupCtx, portal.AssetVersion{
+		ID: "v1", AssetID: "a1", Version: 1, S3Key: "k1", S3Bucket: "bucket", ContentType: "text/html", SizeBytes: 10,
+	})
+	require.NoError(t, cvErr)
+
+	adminCtx := middleware.WithPlatformContext(context.Background(),
+		&middleware.PlatformContext{UserID: "operator", IsAdmin: true})
+	result, _, err := tk.handleManageAsset(adminCtx, nil, manageAssetInput{Action: "revert", AssetID: "a1", Version: 1})
+	require.NoError(t, err)
+	assert.False(t, result.IsError, errorText(t, result))
 }
 
 func TestHandleRevertMissingAssetID(t *testing.T) {


### PR DESCRIPTION
## Summary

An admin is unrestricted by design, but the prompt and asset addressing verbs did not honor that. With the `admin` persona, `manage_prompt(command="list")` returns prompts at every scope and owner, yet `get`, `patch`, `update`, and `delete` failed on any personal prompt the admin did not author, reporting `prompt "<name>" not found`. Read visibility was admin-wide; write and single-prompt read visibility were owner-scoped, and the two disagreed.

The cause was in name resolution, not authorization. `authorizePromptMutation` already returns "allowed" for any prompt when the caller is admin, but `resolveManagedPrompt` never reached it: it tried only the caller's own personal prompt (`GetPersonal` keyed on the caller's email) and the shared, non-personal set (`Store.Get` excludes personal scope). A personal prompt owned by another user matched neither lookup, so resolution returned nil and the call surfaced as `not found`.

This PR aligns the addressing verbs with the admin model for prompts, applies the same fix to the parallel `manage_asset` content verbs, and replaces the misleading `not found` for the genuinely-limited non-admin path with an explicit scope message.

Closes #1042

## Prompts

- `pkg/prompt.Store` gains `ListPersonalByName(ctx, name)`, which resolves a personal prompt by name across all owners (`WHERE name = $1 AND scope = 'personal'`). Personal names are unique only within an owner, so this can return more than one row. Postgres implementation plus every fake in the tree.
- `resolveManagedPrompt` now takes an `owner` argument. When the caller's own-personal and shared lookups both miss and the caller is an admin, it resolves a personal prompt owned by any user. When more than one owner has a personal prompt of that name, it returns an error naming the owners and asks the caller to pass `owner_email`; a single match resolves directly.
- New `owner_email` tool input (admin only) targets or disambiguates another user's personal prompt. It is ignored for non-admins, who can only act on their own prompts.
- A non-admin that names another owner's personal prompt now receives an explicit scope message ("a personal prompt named ... exists but is owned by another user") instead of a misleading `not found`. The owner is not disclosed to a non-admin.

## Assets

The `manage_asset` content verbs added in the same release (`patch`, `locate`, `get_content`, `outline`, `stats`, `diff`) carried the same admin limitation. Assets already resolve by a globally-unique id, so the gap was purely in the access checks: `canReadAsset` and the owner-only guards for `patch`, `update`, `delete`, and `revert` had no admin branch. All five now admit an admin, matching the admin-unrestricted model.

## Update path correctness

On `update`, the `scope` field is the *new* scope the caller wants to set. It was being passed into `resolveManagedPrompt` as a resolution filter, where a value of `global` or `persona` forces a shared-only lookup. The effect was that a user updating their own personal prompt with `scope: global` had their prompt hidden behind a shared-only lookup and got `not found` rather than "only admins can set global or persona scope". Update now resolves the target by name with the requested new scope cleared, and applies the new scope in the field-mutation step. Update resolution now follows the same own-personal-first-then-shared precedence as `get` and `delete`.

## Test-fidelity fix

The promptlayer mock store's `Get` returned prompts at any scope, unlike the real store, which excludes personal scope. That divergence let the resolver appear to resolve a personal prompt through the shared path and masked the real behavior. The mock now mirrors the real contract, so the tests exercise the true resolution path.

## Tests

- Store: `ListPersonalByName` at the sqlmock unit layer (multiple owners, none, query error) and against real Postgres (two owners share a name; the query excludes a same-named global prompt; unknown name is empty).
- Resolver and full handler: admin resolves a foreign personal prompt through `get`; `owner_email` disambiguation; ambiguous match returns the owner-listing error; non-admin gets the explicit scope message with the owner withheld; a genuinely-missing name still resolves to `not found`.
- Assets: admin `patch`, read verbs, `update`, `delete`, and `revert` succeed on an asset owned by another user.

## Verification

`make verify` passes: gofmt, race tests, total and patch coverage, golangci-lint (including the merge-base new-issues pass), gosec, govulncheck, semgrep, CodeQL, dead-code, doc gates, and the GoReleaser dry-run. New store, resolver, and asset-guard functions are covered above the 80% threshold.
