### PR TITLE
feat(apigateway): address invoke/export by operation_id (#1046)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2955,6 +2955,10 @@ The API gateway toolkit (`kind: api`) proxies arbitrary REST/HTTP APIs through t
 
 OpenAPI specs are stored separately in **API catalogs** (see the next section), globally-owned and versioned bundles that many connections can reference.
 
+## Addressing an operation
+
+`api_invoke_endpoint` and `api_export` address an operation either by `operation_id` (the stable id `api_list_endpoints` / `api_get_endpoint_schema` return) or by raw `method` + `path`; supply one form, not both. With `operation_id` the platform resolves the method and path template from the catalog, and `path_params` (valid only with `operation_id`) fills the `{placeholder}` segments, URL-escaped for you, so a cataloged call never hand-substitutes `/v1/users/{id}`. Pass `spec` alongside `operation_id` to disambiguate when the id is defined by more than one component spec.
+
 ## When to use
 
 Use the API gateway for REST/HTTP upstreams (Salesforce, Google APIs, GitHub, Stripe, internal HTTP services). For upstream MCP servers, use the MCP gateway (`kind: mcp`) instead.

--- a/docs/server/api-gateway.md
+++ b/docs/server/api-gateway.md
@@ -6,6 +6,34 @@ The toolkit exposes four MCP tools — `api_invoke_endpoint`, `api_list_endpoint
 
 OpenAPI specs that describe each upstream are stored separately in **API catalogs** — versioned, globally-owned bundles that many connections can reference. See [API Catalogs](api-catalogs.md) for the full surface.
 
+## Addressing an operation
+
+`api_invoke_endpoint` (and `api_export`, which mirrors its input) address an operation in one of two ways:
+
+- **By `operation_id`**: the stable identifier `api_list_endpoints` and `api_get_endpoint_schema` return (for example `getUser`). This is the natural continuation of the discovery flow: read a schema by `operation_id`, then invoke the same `operation_id`. The platform resolves it to the method and path template from the connection's catalog. For a templated path, pass the placeholder values in `path_params` and the platform substitutes and URL-escapes them, so you never hand-build `/v1/users/123` from `/v1/users/{id}`:
+
+  ```json
+  {
+    "connection": "vendor",
+    "operation_id": "getUser",
+    "path_params": { "id": "123" }
+  }
+  ```
+
+  When the same `operation_id` is defined by more than one component spec in the catalog, pass `spec` to disambiguate; the error names the candidate specs.
+
+- **By `method` + `path`**: the raw addressing for uncataloged calls or connections with no spec. You substitute any path parameters yourself:
+
+  ```json
+  {
+    "connection": "vendor",
+    "method": "GET",
+    "path": "/v1/users/123"
+  }
+  ```
+
+Supply one form or the other, not both. `path_params` is only valid alongside `operation_id`.
+
 ## When to use
 
 Use the API gateway for upstreams that expose a REST API and authenticate with a bearer token, an API key, or OAuth 2.1. Common targets:

--- a/pkg/toolkits/apigateway/export.go
+++ b/pkg/toolkits/apigateway/export.go
@@ -201,8 +201,11 @@ func (t *Toolkit) SetExportDeps(deps ExportDeps) {
 // idempotency_key, create_public_link).
 type exportInput struct {
 	Connection       string            `json:"connection"`
-	Method           string            `json:"method"`
-	Path             string            `json:"path"`
+	Method           string            `json:"method,omitempty"`
+	Path             string            `json:"path,omitempty"`
+	OperationID      string            `json:"operation_id,omitempty"`
+	Spec             string            `json:"spec,omitempty"`
+	PathParams       map[string]string `json:"path_params,omitempty"`
 	Query            map[string]any    `json:"query_params"`
 	Headers          map[string]string `json:"headers"`
 	Body             any               `json:"body"`
@@ -241,6 +244,7 @@ func (t *Toolkit) registerExportTool(s *mcp.Server) {
 		Title: "Export API Endpoint Response",
 		Description: "Invoke an upstream API endpoint and stream the response into a portal asset INSTEAD of returning it through the model context. " +
 			"Use this when api_invoke_endpoint reports body_truncated, when you expect a response too large to be useful through the model, or when you want to hand off the data to trino_query / s3_get_object / a portal share. " +
+			"Address the operation either by operation_id (with any path template values in path_params) or by method+path directly, exactly like api_invoke_endpoint; supply one form, not both. " +
 			"Returns asset metadata (id, URL, size, content type) — the data is NOT returned through this response. " +
 			"NAMING: keep `name` short and portable, ASCII letters / digits / spaces / hyphens / dots only. " +
 			"The name doubles as the download filename.",
@@ -286,6 +290,19 @@ func (t *Toolkit) handleExport(ctx context.Context, _ *mcp.CallToolRequest, in e
 	if uc == nil {
 		return toolkit.ErrorResult("authentication required for api_export"), nil, nil
 	}
+
+	// Resolve operation_id addressing into concrete method+path before
+	// route-policy and upstream work, so api_export speaks the same
+	// operation_id shortcut as api_invoke_endpoint (issue #1046).
+	// endpointPath (not "path") avoids shadowing the "path" import.
+	method, endpointPath, addrErr := operationAddressing{
+		Method: in.Method, Path: in.Path, OperationID: in.OperationID,
+		Spec: in.Spec, PathParams: in.PathParams,
+	}.resolve(c)
+	if addrErr != nil {
+		return toolkit.ErrorResult(addrErr.Error()), nil, nil
+	}
+	in.Method, in.Path = method, endpointPath
 
 	// Honor the same route policy that api_invoke_endpoint does so
 	// a persona scoped to GET /v1/users cannot export from

--- a/pkg/toolkits/apigateway/invoke.go
+++ b/pkg/toolkits/apigateway/invoke.go
@@ -72,10 +72,20 @@ var methodsAllowingBody = map[string]bool{
 
 // InvokeInput is the parsed argument shape for api_invoke_endpoint.
 // Field names match the JSON schema.
+//
+// An operation is addressed one of two ways (issue #1046): by
+// OperationID (+ optional Spec, + optional PathParams substituted into
+// the resolved path template), or by the raw Method+Path. handleInvoke
+// resolves OperationID to Method+Path via operationAddressing before any
+// downstream processing, so every field below Method/Path sees the
+// concrete values regardless of which form the caller used.
 type InvokeInput struct {
 	Connection     string            `json:"connection"`
-	Method         string            `json:"method"`
-	Path           string            `json:"path"`
+	Method         string            `json:"method,omitempty"`
+	Path           string            `json:"path,omitempty"`
+	OperationID    string            `json:"operation_id,omitempty"`
+	Spec           string            `json:"spec,omitempty"`
+	PathParams     map[string]string `json:"path_params,omitempty"`
 	Query          map[string]any    `json:"query_params,omitempty"`
 	Headers        map[string]string `json:"headers,omitempty"`
 	Body           any               `json:"body,omitempty"`

--- a/pkg/toolkits/apigateway/operation_target.go
+++ b/pkg/toolkits/apigateway/operation_target.go
@@ -1,0 +1,152 @@
+package apigateway
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// operationAddressing carries the two mutually-exclusive ways a caller
+// can name the operation an invoke/export call targets:
+//
+//   - operation_id (+ optional spec, + optional path_params): the stable
+//     identifier api_get_endpoint_schema and api_list_endpoints already
+//     speak. path_params are substituted into the operation's path
+//     template so the caller never hand-substitutes /users/{id}.
+//   - method + path: the raw addressing for uncataloged calls, where
+//     the caller has already substituted any path parameters.
+//
+// resolve collapses either form to the concrete (method, path) the rest
+// of the request pipeline (route policy, validatePath, buildURL)
+// consumes, so exactly one place understands the operation_id shortcut
+// and the buffered invoke, raw passthrough, and api_export paths cannot
+// drift on it (issue #1046).
+type operationAddressing struct {
+	Method      string
+	Path        string
+	OperationID string
+	Spec        string
+	PathParams  map[string]string
+}
+
+// resolve returns the concrete (method, path) for the call. In the plain
+// method+path mode it returns them unchanged. In the operation_id mode it
+// resolves the id against the connection's catalog and substitutes
+// path_params into the resolved path template. It is an error to supply
+// both addressing modes at once, or to supply path_params without an
+// operation_id (there is no template to substitute into).
+func (a operationAddressing) resolve(c *conn) (method, path string, err error) {
+	if a.OperationID == "" {
+		if len(a.PathParams) > 0 {
+			return "", "", errors.New("apigateway: path_params requires operation_id; without operation_id, substitute values into path directly")
+		}
+		if a.Method == "" && a.Path == "" {
+			return "", "", errors.New("apigateway: provide operation_id, or method and path")
+		}
+		return a.Method, a.Path, nil
+	}
+	if a.Method != "" || a.Path != "" {
+		return "", "", errors.New("apigateway: provide either operation_id or method+path, not both")
+	}
+	return resolveOperationTarget(c, a)
+}
+
+// resolveOperationTarget maps an operation_id (with optional spec filter
+// and path_params) to the concrete (method, path) a call needs. It reuses
+// the same resolveOperation walk api_get_endpoint_schema uses so the id
+// that reads a schema is exactly the id that invokes it. Errors are
+// caller-actionable: no catalog, id-not-found, ambiguity across specs, or
+// a path-parameter mismatch.
+func resolveOperationTarget(c *conn, a operationAddressing) (method, path string, err error) {
+	if len(c.specs) == 0 {
+		return "", "", errors.New("apigateway: connection has no catalog specs; call with method+path instead of operation_id")
+	}
+	match, candidates := resolveOperation(c, a.OperationID, a.Spec)
+	if match == nil {
+		if len(candidates) > 1 {
+			return "", "", ambiguousOperationError(a.OperationID, candidates)
+		}
+		return "", "", fmt.Errorf("apigateway: operation_id %q not found in connection catalog", a.OperationID)
+	}
+	concrete, subErr := substitutePathParams(match.path, a.PathParams)
+	if subErr != nil {
+		return "", "", subErr
+	}
+	return match.method, concrete, nil
+}
+
+// substitutePathParams replaces each {name} placeholder segment in an
+// OpenAPI path template with the matching value from params,
+// URL-path-escaping each value so a substituted id cannot smuggle path
+// structure into the request. Placeholder matching is whole-segment,
+// mirroring the toolkit's other template matchers (isPlaceholderSegment,
+// segmentMatches) so the substitution and the resolver agree on what a
+// placeholder is. A template with no placeholders returns unchanged.
+//
+// Errors are returned for a missing required parameter, an empty value
+// (which would collapse to an empty path segment), or a stray parameter
+// that matches no placeholder (a typo guard — the caller almost always
+// meant a different name or a query_params entry).
+func substitutePathParams(template string, params map[string]string) (string, error) {
+	segs := strings.Split(template, pathSep)
+	used := make(map[string]bool, len(params))
+	var missing []string
+	for i, seg := range segs {
+		if !isPlaceholderSegment(seg) {
+			continue
+		}
+		name := seg[1 : len(seg)-1]
+		val, ok := params[name]
+		if !ok {
+			missing = append(missing, name)
+			continue
+		}
+		if val == "" {
+			return "", fmt.Errorf("apigateway: path parameter %q is empty; provide a non-empty value", name)
+		}
+		segs[i] = url.PathEscape(val)
+		used[name] = true
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return "", fmt.Errorf("apigateway: missing required path parameter(s): %s", strings.Join(missing, ", "))
+	}
+	if unknown := unusedParams(params, used); len(unknown) > 0 {
+		return "", fmt.Errorf("apigateway: path parameter(s) not present in the operation path template: %s", strings.Join(unknown, ", "))
+	}
+	return strings.Join(segs, pathSep), nil
+}
+
+// unusedParams returns the sorted names in params that were not consumed
+// by a placeholder. Empty when every supplied parameter matched.
+func unusedParams(params map[string]string, used map[string]bool) []string {
+	var unknown []string
+	for name := range params {
+		if !used[name] {
+			unknown = append(unknown, name)
+		}
+	}
+	sort.Strings(unknown)
+	return unknown
+}
+
+// ambiguousOperationError formats the "operation_id defined in more than
+// one spec" case into a caller-actionable error naming the candidate
+// specs, so the model can retry with spec=<name>. Mirrors the
+// disambiguation contract api_get_endpoint_schema exposes.
+func ambiguousOperationError(operationID string, candidates []schemaCandidate) error {
+	specs := make([]string, 0, len(candidates))
+	seen := make(map[string]bool, len(candidates))
+	for _, c := range candidates {
+		if seen[c.Spec] {
+			continue
+		}
+		seen[c.Spec] = true
+		specs = append(specs, c.Spec)
+	}
+	sort.Strings(specs)
+	return fmt.Errorf("apigateway: operation_id %q is defined in multiple specs (%s); pass spec to disambiguate",
+		operationID, strings.Join(specs, ", "))
+}

--- a/pkg/toolkits/apigateway/operation_target_test.go
+++ b/pkg/toolkits/apigateway/operation_target_test.go
@@ -1,0 +1,454 @@
+package apigateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// --- unit: substitutePathParams ---
+
+func TestSubstitutePathParams(t *testing.T) {
+	cases := []struct {
+		name     string
+		template string
+		params   map[string]string
+		want     string
+		wantErr  string
+	}{
+		{
+			name:     "no placeholders returns unchanged",
+			template: "/v1/things",
+			params:   nil,
+			want:     "/v1/things",
+		},
+		{
+			name:     "single placeholder substituted",
+			template: "/v1/users/{id}",
+			params:   map[string]string{"id": "123"},
+			want:     "/v1/users/123",
+		},
+		{
+			name:     "multiple placeholders substituted",
+			template: "/v1/orgs/{org}/users/{id}",
+			params:   map[string]string{"org": "acme", "id": "42"},
+			want:     "/v1/orgs/acme/users/42",
+		},
+		{
+			name:     "value is URL-path-escaped",
+			template: "/v1/files/{name}",
+			params:   map[string]string{"name": "a b/c"},
+			want:     "/v1/files/a%20b%2Fc",
+		},
+		{
+			name:     "missing required parameter errors",
+			template: "/v1/users/{id}",
+			params:   nil,
+			wantErr:  "missing required path parameter",
+		},
+		{
+			name:     "empty value errors",
+			template: "/v1/users/{id}",
+			params:   map[string]string{"id": ""},
+			wantErr:  "is empty",
+		},
+		{
+			name:     "unknown parameter errors",
+			template: "/v1/users/{id}",
+			params:   map[string]string{"id": "1", "typo": "x"},
+			wantErr:  "not present in the operation path template",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := substitutePathParams(c.template, c.params)
+			if c.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), c.wantErr) {
+					t.Fatalf("err = %v; want substring %q", err, c.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("got %q; want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestSubstitutePathParams_ReportsAllMissing proves the error names
+// every unfilled placeholder in one shot so the caller can fix the
+// call in a single retry rather than discovering them one at a time.
+func TestSubstitutePathParams_ReportsAllMissing(t *testing.T) {
+	_, err := substitutePathParams("/v1/orgs/{org}/users/{id}", nil)
+	if err == nil {
+		t.Fatal("expected error for missing params")
+	}
+	for _, want := range []string{"org", "id"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name missing param %q", err.Error(), want)
+		}
+	}
+}
+
+// --- unit: operationAddressing.resolve XOR contract ---
+
+func TestOperationAddressing_Resolve_PlainMode(t *testing.T) {
+	method, path, err := operationAddressing{Method: "GET", Path: "/v1/x"}.resolve(&conn{})
+	if err != nil {
+		t.Fatalf("plain mode should not error: %v", err)
+	}
+	if method != "GET" || path != "/v1/x" {
+		t.Errorf("plain mode should pass through; got %q %q", method, path)
+	}
+}
+
+func TestOperationAddressing_Resolve_RejectsEmpty(t *testing.T) {
+	_, _, err := operationAddressing{}.resolve(&conn{})
+	if err == nil || !strings.Contains(err.Error(), "provide operation_id, or method and path") {
+		t.Fatalf("expected empty-addressing rejection; got %v", err)
+	}
+}
+
+func TestOperationAddressing_Resolve_RejectsBothForms(t *testing.T) {
+	_, _, err := operationAddressing{
+		Method: "GET", Path: "/v1/x", OperationID: "listThings",
+	}.resolve(&conn{})
+	if err == nil || !strings.Contains(err.Error(), "either operation_id or method+path") {
+		t.Fatalf("expected both-forms rejection; got %v", err)
+	}
+}
+
+func TestOperationAddressing_Resolve_PathParamsWithoutOperationID(t *testing.T) {
+	_, _, err := operationAddressing{
+		Method: "GET", Path: "/v1/x", PathParams: map[string]string{"id": "1"},
+	}.resolve(&conn{})
+	if err == nil || !strings.Contains(err.Error(), "path_params requires operation_id") {
+		t.Fatalf("expected path_params-without-operation_id rejection; got %v", err)
+	}
+}
+
+// --- unit: resolveOperationTarget against a catalog ---
+
+// opTargetSpec is a two-operation spec (a collection and a templated
+// item) with no servers block, so the effective base path is empty and
+// each operation's full path equals its spec-relative path.
+const opTargetSpec = `openapi: 3.0.0
+info:
+  title: things
+  version: "1"
+paths:
+  /things:
+    get:
+      operationId: listThings
+      summary: List things
+      responses:
+        "200":
+          description: ok
+  /things/{id}:
+    get:
+      operationId: getThing
+      summary: Get one thing
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok`
+
+func setupOpTargetToolkit(t *testing.T, baseURL string) *Toolkit {
+	t.Helper()
+	tk := New("api")
+	setupCatalogWithSpec(t, tk, "things", "default", opTargetSpec)
+	if err := tk.AddConnection("c", map[string]any{
+		"base_url":   baseURL,
+		"catalog_id": "things",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	return tk
+}
+
+func TestResolveOperationTarget_NoSpecs(t *testing.T) {
+	c := &conn{}
+	_, _, err := resolveOperationTarget(c, operationAddressing{OperationID: "listThings"})
+	if err == nil || !strings.Contains(err.Error(), "no catalog specs") {
+		t.Fatalf("expected no-catalog error; got %v", err)
+	}
+}
+
+func TestResolveOperationTarget_NotFound(t *testing.T) {
+	tk := setupOpTargetToolkit(t, "https://x")
+	c := tk.connections["c"]
+	_, _, err := resolveOperationTarget(c, operationAddressing{OperationID: "noSuchOp"})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not-found error; got %v", err)
+	}
+}
+
+func TestResolveOperationTarget_Collection(t *testing.T) {
+	tk := setupOpTargetToolkit(t, "https://x")
+	c := tk.connections["c"]
+	method, path, err := resolveOperationTarget(c, operationAddressing{OperationID: "listThings"})
+	if err != nil {
+		t.Fatalf("resolve listThings: %v", err)
+	}
+	if method != "GET" || path != "/things" {
+		t.Errorf("got %q %q; want GET /things", method, path)
+	}
+}
+
+func TestResolveOperationTarget_TemplatedPath(t *testing.T) {
+	tk := setupOpTargetToolkit(t, "https://x")
+	c := tk.connections["c"]
+	method, path, err := resolveOperationTarget(c, operationAddressing{
+		OperationID: "getThing", PathParams: map[string]string{"id": "abc"},
+	})
+	if err != nil {
+		t.Fatalf("resolve getThing: %v", err)
+	}
+	if method != "GET" || path != "/things/abc" {
+		t.Errorf("got %q %q; want GET /things/abc", method, path)
+	}
+}
+
+func TestResolveOperationTarget_TemplatedPathMissingParam(t *testing.T) {
+	tk := setupOpTargetToolkit(t, "https://x")
+	c := tk.connections["c"]
+	_, _, err := resolveOperationTarget(c, operationAddressing{OperationID: "getThing"})
+	if err == nil || !strings.Contains(err.Error(), "missing required path parameter") {
+		t.Fatalf("expected missing-param error; got %v", err)
+	}
+}
+
+func TestResolveOperationTarget_AmbiguousAcrossSpecs(t *testing.T) {
+	tk := New("api")
+	store := setupCatalogWithSpec(t, tk, "vendor", "users",
+		minimalSpecWith(`/v1/things:
+    `+pathOpYAML("get", "list", "Users-side list")))
+	if err := store.UpsertSpec(context.Background(), "vendor",
+		newSpecEntry("orders", minimalSpecWith(`/v1/things:
+    `+pathOpYAML("get", "list", "Orders-side list")))); err != nil {
+		t.Fatalf("UpsertSpec orders: %v", err)
+	}
+	if err := tk.AddConnection("c", map[string]any{
+		"base_url": "https://x", "catalog_id": "vendor",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	c := tk.connections["c"]
+	_, _, err := resolveOperationTarget(c, operationAddressing{OperationID: "list"})
+	if err == nil || !strings.Contains(err.Error(), "multiple specs") {
+		t.Fatalf("expected ambiguity error; got %v", err)
+	}
+	// The error must name both candidate specs so the model can retry.
+	for _, spec := range []string{"users", "orders"} {
+		if !strings.Contains(err.Error(), spec) {
+			t.Errorf("ambiguity error %q does not name spec %q", err.Error(), spec)
+		}
+	}
+	// A spec filter resolves the ambiguity.
+	method, path, err := resolveOperationTarget(c, operationAddressing{OperationID: "list", Spec: "orders"})
+	if err != nil {
+		t.Fatalf("resolve with spec filter: %v", err)
+	}
+	if method != "GET" || path != "/v1/things" {
+		t.Errorf("got %q %q; want GET /v1/things", method, path)
+	}
+}
+
+// --- integration: handleInvoke by operation_id against a live upstream ---
+
+// TestHandleInvoke_ByOperationID_TemplatedPath proves the full path:
+// an operation_id + path_params resolves, through the real handler and
+// HTTP client, into a concrete GET /things/abc reaching the upstream —
+// closing the manual list-then-remember-method-and-path bookkeeping the
+// issue describes (#1046).
+func TestHandleInvoke_ByOperationID_TemplatedPath(t *testing.T) {
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"abc"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	tk := setupOpTargetToolkit(t, srv.URL)
+	res, payload, err := tk.handleInvoke(context.Background(), &mcp.CallToolRequest{}, InvokeInput{
+		Connection:  "c",
+		OperationID: "getThing",
+		PathParams:  map[string]string{"id": "abc"},
+	})
+	if err != nil {
+		t.Fatalf("handleInvoke: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("unexpected error result: %s", textContent(res))
+	}
+	if gotMethod != "GET" || gotPath != "/things/abc" {
+		t.Errorf("upstream saw %q %q; want GET /things/abc", gotMethod, gotPath)
+	}
+	out, ok := payload.(InvokeOutput)
+	if !ok {
+		t.Fatalf("payload is not InvokeOutput: %T", payload)
+	}
+	if out.Status != http.StatusOK {
+		t.Errorf("Status = %d; want 200", out.Status)
+	}
+}
+
+// TestHandleInvoke_ByOperationID_Collection proves a non-templated
+// operation resolves without path_params.
+func TestHandleInvoke_ByOperationID_Collection(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	tk := setupOpTargetToolkit(t, srv.URL)
+	res, _, err := tk.handleInvoke(context.Background(), &mcp.CallToolRequest{}, InvokeInput{
+		Connection:  "c",
+		OperationID: "listThings",
+	})
+	if err != nil {
+		t.Fatalf("handleInvoke: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("unexpected error result: %s", textContent(res))
+	}
+	if gotPath != "/things" {
+		t.Errorf("upstream saw %q; want /things", gotPath)
+	}
+}
+
+// TestHandleInvoke_ByOperationID_RejectsBothForms proves the XOR guard
+// fires at the handler boundary, returning a tool error rather than an
+// ambiguous call.
+func TestHandleInvoke_ByOperationID_RejectsBothForms(t *testing.T) {
+	tk := setupOpTargetToolkit(t, "https://x")
+	res, _, _ := tk.handleInvoke(context.Background(), &mcp.CallToolRequest{}, InvokeInput{
+		Connection:  "c",
+		Method:      "GET",
+		Path:        "/things",
+		OperationID: "listThings",
+	})
+	if res == nil || !res.IsError {
+		t.Fatalf("expected error result for both-forms input; got %+v", res)
+	}
+	if !strings.Contains(textContent(res), "either operation_id or method+path") {
+		t.Errorf("error message = %q", textContent(res))
+	}
+}
+
+// TestHandleInvoke_ByOperationID_NotFound proves an unknown id surfaces
+// a caller-actionable error, not a silent empty call.
+func TestHandleInvoke_ByOperationID_NotFound(t *testing.T) {
+	tk := setupOpTargetToolkit(t, "https://x")
+	res, _, _ := tk.handleInvoke(context.Background(), &mcp.CallToolRequest{}, InvokeInput{
+		Connection:  "c",
+		OperationID: "noSuchOp",
+	})
+	if res == nil || !res.IsError {
+		t.Fatalf("expected error result; got %+v", res)
+	}
+	if !strings.Contains(textContent(res), "not found") {
+		t.Errorf("error message = %q", textContent(res))
+	}
+}
+
+// --- integration: handleExport by operation_id ---
+
+// TestHandleExport_ByOperationID proves api_export speaks the same
+// operation_id shortcut: the resolved concrete path reaches the
+// upstream and the exported asset is persisted.
+func TestHandleExport_ByOperationID(t *testing.T) {
+	var gotMethod, gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"abc"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	tk := New("api")
+	setupCatalogWithSpec(t, tk, "things", "default", opTargetSpec)
+	if err := tk.AddConnection("c", map[string]any{
+		"base_url": upstream.URL, "catalog_id": "things",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	store := &fakeExportAssetStore{}
+	deps := defaultExportDeps(store, &fakeExportVersionStore{}, &fakeExportS3Client{})
+	tk.SetExportDeps(deps)
+
+	res, payload, err := tk.handleExport(context.Background(), &mcp.CallToolRequest{}, exportInput{
+		Connection:  "c",
+		OperationID: "getThing",
+		PathParams:  map[string]string{"id": "abc"},
+		Name:        "thing abc",
+	})
+	if err != nil {
+		t.Fatalf("handleExport: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("unexpected error result: %s", textContent(res))
+	}
+	if gotMethod != "GET" || gotPath != "/things/abc" {
+		t.Errorf("upstream saw %q %q; want GET /things/abc", gotMethod, gotPath)
+	}
+	out, ok := payload.(*exportOutput)
+	if !ok {
+		t.Fatalf("payload is not *exportOutput: %T", payload)
+	}
+	if out.AssetID == "" {
+		t.Error("AssetID is empty")
+	}
+	if len(store.inserted) != 1 {
+		t.Fatalf("AssetStore.Insert called %d times; want 1", len(store.inserted))
+	}
+}
+
+// TestHandleExport_ByOperationID_RejectsBothForms mirrors the invoke
+// XOR guard on the export surface.
+func TestHandleExport_ByOperationID_RejectsBothForms(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	tk := New("api")
+	setupCatalogWithSpec(t, tk, "things", "default", opTargetSpec)
+	if err := tk.AddConnection("c", map[string]any{
+		"base_url": upstream.URL, "catalog_id": "things",
+	}); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	deps := defaultExportDeps(&fakeExportAssetStore{}, &fakeExportVersionStore{}, &fakeExportS3Client{})
+	tk.SetExportDeps(deps)
+
+	res, _, _ := tk.handleExport(context.Background(), &mcp.CallToolRequest{}, exportInput{
+		Connection:  "c",
+		Method:      "GET",
+		Path:        "/things",
+		OperationID: "listThings",
+		Name:        "x",
+	})
+	if res == nil || !res.IsError {
+		t.Fatalf("expected error result for both-forms input; got %+v", res)
+	}
+	if !strings.Contains(textContent(res), "either operation_id or method+path") {
+		t.Errorf("error message = %q", textContent(res))
+	}
+}

--- a/pkg/toolkits/apigateway/schemas.go
+++ b/pkg/toolkits/apigateway/schemas.go
@@ -81,20 +81,33 @@ var getEndpointSchemaInputSchema = json.RawMessage(`{
 //nolint:gochecknoglobals // MCP tool schema must be a package-level var
 var apiExportInputSchema = json.RawMessage(`{
   "type": "object",
-  "required": ["connection", "method", "path", "name"],
+  "required": ["connection", "name"],
   "properties": {
     "connection": {
       "type": "string",
       "description": "Name of the registered API connection (kind=api). Required."
     },
+    "operation_id": {
+      "type": "string",
+      "description": "The operation_id returned by api_list_endpoints / api_get_endpoint_schema. Address the operation by this stable identifier instead of method+path; the platform resolves it to method and path from the connection's catalog. Supply either operation_id or method+path, not both. For a templated path, pass the placeholder values in path_params."
+    },
+    "path_params": {
+      "type": "object",
+      "description": "Values for the {placeholder} segments of the resolved operation's path template, e.g. {\"id\": \"123\"} for /v1/users/{id}. Only valid with operation_id. Every template placeholder must have a value; each value is URL-escaped into its segment.",
+      "additionalProperties": {"type": "string"}
+    },
+    "spec": {
+      "type": "string",
+      "description": "Optional component spec name, used only with operation_id to disambiguate when the same operation_id is defined by more than one spec in the connection's catalog."
+    },
     "method": {
       "type": "string",
       "enum": ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "PROPFIND", "MKCOL", "MOVE", "COPY"],
-      "description": "HTTP method. Required."
+      "description": "HTTP method. Required unless operation_id is supplied."
     },
     "path": {
       "type": "string",
-      "description": "Request path joined to the connection's base URL. Required. Must start with \"/\"."
+      "description": "Request path joined to the connection's base URL. Required unless operation_id is supplied. Must start with \"/\"."
     },
     "query_params": {
       "type": "object",
@@ -144,20 +157,33 @@ var apiExportInputSchema = json.RawMessage(`{
 //nolint:gochecknoglobals // MCP tool schema must be a package-level var
 var invokeEndpointSchema = json.RawMessage(`{
   "type": "object",
-  "required": ["connection", "method", "path"],
+  "required": ["connection"],
   "properties": {
     "connection": {
       "type": "string",
       "description": "Name of the registered API connection (kind=api). Required. Use list_connections to discover available connections."
     },
+    "operation_id": {
+      "type": "string",
+      "description": "The operation_id returned by api_list_endpoints / api_get_endpoint_schema. Address the operation by this stable identifier instead of method+path; the platform resolves it to the method and path template from the connection's catalog. Supply either operation_id or method+path, not both. For a templated path (e.g. /v1/users/{id}), pass the placeholder values in path_params rather than substituting them by hand."
+    },
+    "path_params": {
+      "type": "object",
+      "description": "Values for the {placeholder} segments of the resolved operation's path template, e.g. {\"id\": \"123\"} for /v1/users/{id}. Only valid with operation_id. Every template placeholder must have a value; each value is URL-escaped into its segment.",
+      "additionalProperties": {"type": "string"}
+    },
+    "spec": {
+      "type": "string",
+      "description": "Optional component spec name, used only with operation_id to disambiguate when the same operation_id is defined by more than one spec in the connection's catalog. The ambiguity error names the candidate specs."
+    },
     "method": {
       "type": "string",
       "enum": ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "PROPFIND", "MKCOL", "MOVE", "COPY"],
-      "description": "HTTP method. Required."
+      "description": "HTTP method. Required unless operation_id is supplied. Use for raw or uncataloged calls."
     },
     "path": {
       "type": "string",
-      "description": "Request path joined to the connection's base URL. Examples: \"/v1/users/123\", \"/api/items\". Required. Must start with \"/\"."
+      "description": "Request path joined to the connection's base URL. Examples: \"/v1/users/123\", \"/api/items\". Required unless operation_id is supplied. Must start with \"/\". When you use method+path you substitute any path parameters yourself."
     },
     "query_params": {
       "type": "object",

--- a/pkg/toolkits/apigateway/toolkit.go
+++ b/pkg/toolkits/apigateway/toolkit.go
@@ -433,7 +433,10 @@ func (t *Toolkit) RegisterTools(s *mcp.Server) {
 		Description: "Make an authenticated HTTP request against a registered API connection. " +
 			"The connection's auth (none/bearer/api_key) is applied automatically; the model " +
 			"never handles credentials. Returns status, selected response headers, and the parsed " +
-			"or text response body. Method is restricted to GET, POST, PUT, DELETE, PATCH, HEAD, " +
+			"or text response body. Address the operation either by operation_id (the same id " +
+			"api_list_endpoints / api_get_endpoint_schema return, with any path template values " +
+			"passed in path_params) or by method+path directly; supply one form, not both. " +
+			"Method is restricted to GET, POST, PUT, DELETE, PATCH, HEAD, " +
 			"PROPFIND, MKCOL, MOVE, COPY; " +
 			"path is joined to the connection's base_url; response bodies above the connection's " +
 			"max_response_bytes are truncated and flagged. Use list_connections to discover " +
@@ -1127,6 +1130,19 @@ func (t *Toolkit) handleInvoke(ctx context.Context, _ *mcp.CallToolRequest, in I
 	if !ok {
 		return toolkit.ErrorResult(fmt.Sprintf("connection %q not found (use list_connections to discover api connections)", in.Connection)), nil, nil
 	}
+
+	// Resolve operation_id addressing into concrete method+path before
+	// any gating or upstream work, so the route policy, path validation,
+	// and audit all see the same values a plain method+path call would
+	// (issue #1046).
+	method, path, addrErr := operationAddressing{
+		Method: in.Method, Path: in.Path, OperationID: in.OperationID,
+		Spec: in.Spec, PathParams: in.PathParams,
+	}.resolve(c)
+	if addrErr != nil {
+		return toolkit.ErrorResult(addrErr.Error()), nil, nil
+	}
+	in.Method, in.Path = method, path
 
 	// Run the route policy BEFORE invoke() so an unauthorized call
 	// never produces an outbound HTTP request — and never appears in


### PR DESCRIPTION
## Summary

`api_invoke_endpoint` and `api_export` now address an operation by `operation_id` as an alternative to `method` + `path`. This closes the discovery/invoke identifier mismatch described in #1046: `api_get_endpoint_schema` keys an operation on `operation_id`, but `api_invoke_endpoint` previously accepted only `method` + `path`, so an agent that had just fetched a schema by `operation_id` had to go back to an earlier `api_list_endpoints` response, find the row for that id, and read `method` and `path` off it to reconstruct the call. Now the id an agent reads a schema from is the id it invokes with.

## The two addressing modes

An operation is now addressed one of two ways on both `api_invoke_endpoint` and `api_export`:

- By `operation_id` (plus optional `spec` and `path_params`): the stable identifier `api_list_endpoints` and `api_get_endpoint_schema` return. The platform resolves it to the method and path template from the connection's catalog. For a templated path, `path_params` supplies the `{placeholder}` values and the platform substitutes and URL-escapes them, so a cataloged call never hand-builds `/v1/users/123` from `/v1/users/{id}`.
- By `method` + `path`: the raw addressing for uncataloged calls or connections with no spec, unchanged from before. The caller substitutes any path parameters itself.

Design decisions the issue left to be settled:

- Precedence: the two modes are mutually exclusive. Supplying both `operation_id` and `method`/`path` is a caller error, as is supplying neither. `path_params` is only valid alongside `operation_id`.
- Disambiguation: when the same `operation_id` is defined by more than one component spec in the connection's catalog, `spec` selects the right one; the ambiguity error names the candidate specs so the model can retry in one turn.

Example (by `operation_id` with a path parameter):

```json
{
  "connection": "vendor",
  "operation_id": "getUser",
  "path_params": { "id": "123" }
}
```

## Implementation

A single shared resolver, `operationAddressing.resolve`, lives in the new `pkg/toolkits/apigateway/operation_target.go` and is called from both `handleInvoke` and `handleExport` before any gating or upstream work. It reuses the existing `resolveOperation` walk that `api_get_endpoint_schema` already uses, so the id that reads a schema and the id that invokes it are resolved by one code path and cannot drift. This mirrors the shared operation-resolution approach from #876 rather than forking per tool.

Resolution runs up front, so the rest of the pipeline sees the concrete method and path:

- The persona route policy is evaluated against the resolved `method` + `path`, so an `operation_id` call is authorized exactly like the equivalent `method` + `path` call. No authorization bypass is introduced.
- `validatePath` and the host-pinned `buildURL` SSRF guards run on the resolved path. Path-parameter values are `url.PathEscape`d into their segment, so a value cannot smuggle path structure or change the request host, and `validatePath` still rejects literal `.`/`..` segments.
- Audit and outbound metrics observe the concrete path (the instrumented transport resolves the operation label from the actual request), so metric and audit attribution are unaffected.

The REST gateway shim (`pkg/gatewayhttp`) is intentionally left on `method` + `path`. It is a transport adapter for non-MCP HTTP clients, outside the agent workflow this issue targets; the underlying handler still accepts `operation_id` if those arguments are passed.

## Tests

`pkg/toolkits/apigateway/operation_target_test.go` adds:

- Unit coverage for `substitutePathParams` (no placeholders, single and multiple placeholders, URL-escaping, missing/empty/unknown parameters, all-missing reported at once).
- Unit coverage for the `operationAddressing.resolve` XOR contract (plain passthrough, both-forms rejected, `path_params` without `operation_id` rejected, empty addressing rejected).
- Unit coverage for `resolveOperationTarget` (no catalog, not found, collection vs templated path, missing path parameter, ambiguity across specs and its `spec` resolution).
- Integration coverage that drives the real `handleInvoke` and `handleExport` handlers through the HTTP client against an `httptest` upstream, asserting an `operation_id` + `path_params` call reaches the upstream as a concrete `GET /things/abc` and, for export, persists the asset.

Patch coverage is 98.9% on changed lines. `make verify` passes end to end (fmt, race tests, coverage, patch coverage, lint, security, semgrep, CodeQL, doc gates, GoReleaser dry run, Playwright e2e).

## Docs

`docs/server/api-gateway.md` gains an "Addressing an operation" section; `docs/llms-full.txt` gains the matching condensed paragraph.

Closes #1046
