### PR TITLE
fix(mcpapps): open the prompt library on request, real iframe height, brand the library

### DIFF
--- a/apps/platform-info/index.html
+++ b/apps/platform-info/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="height: 500px">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -99,10 +99,14 @@ if(__exports != exports)module.exports = exports;return module.exports}));
 
         * { box-sizing: border-box; margin: 0; padding: 0; }
 
-        /* Fixed 500px app shell (#1043). The app declares its own height via the
-           MCP Apps size-changed contract rather than depending on how much content
-           happens to exist; the hero header is pinned and the content scrolls
-           inside the shell so the host iframe never grows or shrinks with content. */
+        /* Fixed 500px app shell. Claude sizes the iframe by reading
+           documentElement's height directly and ignores ui/notifications/size-changed
+           (anthropics/claude-ai-mcp #69), so the height is declared as an INLINE
+           style on <html> (present at first paint, which is what Claude snapshots)
+           in addition to this rule and the size-changed message the app still
+           sends for spec-compliant hosts. The hero header is pinned and the
+           content scrolls inside the shell. Keep this value in sync with the
+           inline style="height:..." on the <html> element above. */
         html, body { height: 500px; }
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans',

--- a/apps/prompt-browser/index.html
+++ b/apps/prompt-browser/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="height: 640px">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Prompt Library</title>
-    <script id="app-config" type="application/json">{}</script>
+    <script id="app-config" type="application/json">{"brand_name":"","logo_svg":"","logo_url":"","brand_url":""}</script>
     <style>
         :root {
             --bg: #0d1117;
@@ -49,11 +49,16 @@
 
         * { box-sizing: border-box; margin: 0; padding: 0; }
 
-        /* Fixed 500px app shell (#1043). The app declares its own height via the
-           MCP Apps size-changed contract rather than depending on how much content
-           happens to exist; each view pins its header and scrolls its body inside
-           the shell so the host iframe never grows or shrinks with content. */
-        html, body { height: 500px; }
+        /* Fixed-height app shell, tall enough for a human to actually browse.
+           Claude sizes the iframe by reading documentElement's height directly
+           and ignores ui/notifications/size-changed (anthropics/claude-ai-mcp
+           #69), so the height is declared as an INLINE style on <html> (present
+           at first paint, which is what Claude snapshots) in addition to this
+           rule and the size-changed message the app still sends for
+           spec-compliant hosts. The brand bar and each view's head are pinned;
+           the body scrolls inside the shell. Keep this value in sync with the
+           inline style="height:..." on the <html> element above. */
+        html, body { height: 640px; }
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans',
                          Helvetica, Arial, sans-serif;
@@ -65,6 +70,38 @@
             flex-direction: column;
             overflow: hidden;
         }
+
+        /* Brand bar: the platform logo and name, pinned above the views, so the
+           prompt library carries the same brand identity as the platform-info
+           app. */
+        .brandbar {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            flex-shrink: 0;
+            padding: 12px 16px;
+            border-bottom: 1px solid var(--border);
+        }
+        .brand-logo {
+            width: 26px; height: 26px;
+            flex-shrink: 0;
+            color: var(--accent);
+            display: flex; align-items: center; justify-content: center;
+        }
+        .brand-logo svg { width: 26px; height: 26px; display: block; }
+        .brand-logo img { width: 26px; height: 26px; display: block; object-fit: contain; }
+        .brand-logo a { display: flex; align-items: center; color: inherit; text-decoration: none; }
+        .brand-name {
+            font-size: 15px;
+            font-weight: 650;
+            color: var(--text);
+            letter-spacing: -0.01em;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .brand-name a { color: inherit; text-decoration: none; }
+        .brand-name a:hover { text-decoration: underline; text-underline-offset: 3px; }
 
         /* A view fills the shell as a header + scrolling body. */
         .view { flex: 1; min-height: 0; display: flex; flex-direction: column; }
@@ -336,6 +373,11 @@
     </style>
 </head>
 <body>
+    <div id="brandbar" class="brandbar hidden">
+        <span id="brand-logo" class="brand-logo"></span>
+        <span id="brand-name" class="brand-name"></span>
+    </div>
+
     <div id="loading" class="loading">
         <div class="dot"></div><div class="dot"></div><div class="dot"></div>
         <span>Loading prompt library&hellip;</span>
@@ -370,6 +412,68 @@
 
 <script>
     'use strict';
+
+    // ---------------------------------------------------------------------
+    // Brand bar. The platform logo and name are injected server-side into the
+    // #app-config script (the same brand config the platform-info app uses), so
+    // the library carries the same brand identity. Rendered immediately from
+    // config; it does not wait on the MCP handshake or the prompt list.
+    // ---------------------------------------------------------------------
+    var CFG = (function() {
+        try { return JSON.parse(document.getElementById('app-config').textContent); }
+        catch (e) { return {}; }
+    }());
+
+    // DEFAULT_LOGO is the fallback mark when no logo is configured, byte-identical
+    // to the platform-info app so both fall back the same way.
+    var DEFAULT_LOGO = '<svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">'
+        + '<circle cx="20" cy="20" r="4.5" fill="currentColor" opacity=".95"/>'
+        + '<circle cx="6"  cy="11" r="3"   fill="currentColor" opacity=".65"/>'
+        + '<circle cx="34" cy="11" r="3"   fill="currentColor" opacity=".65"/>'
+        + '<circle cx="6"  cy="29" r="3"   fill="currentColor" opacity=".45"/>'
+        + '<circle cx="34" cy="29" r="3"   fill="currentColor" opacity=".45"/>'
+        + '<circle cx="20" cy="4"  r="2.2" fill="currentColor" opacity=".55"/>'
+        + '<circle cx="20" cy="36" r="2.2" fill="currentColor" opacity=".35"/>'
+        + '<line x1="20" y1="20" x2="6"  y2="11" stroke="currentColor" stroke-width="1.4" opacity=".3"/>'
+        + '<line x1="20" y1="20" x2="34" y2="11" stroke="currentColor" stroke-width="1.4" opacity=".3"/>'
+        + '<line x1="20" y1="20" x2="6"  y2="29" stroke="currentColor" stroke-width="1.4" opacity=".22"/>'
+        + '<line x1="20" y1="20" x2="34" y2="29" stroke="currentColor" stroke-width="1.4" opacity=".22"/>'
+        + '<line x1="20" y1="20" x2="20" y2="4"  stroke="currentColor" stroke-width="1.4" opacity=".28"/>'
+        + '<line x1="20" y1="20" x2="20" y2="36" stroke="currentColor" stroke-width="1.4" opacity=".18"/>'
+        + '</svg>';
+
+    function escAttr(s) {
+        return String(s).replace(/[&<>"']/g, function(c) {
+            return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+        });
+    }
+
+    // renderBrand fills the brand bar from CFG: inline SVG preferred, then a URL
+    // image, then the default mark; the logo and name link to brand_url when set.
+    function renderBrand() {
+        var brandUrl = CFG.brand_url || '';
+        var brandName = CFG.brand_name || 'MCP Data Platform';
+        var logoSvg = CFG.logo_svg || '';
+        var logoUrl = CFG.logo_url || '';
+        var logoMarkup = logoSvg
+            ? logoSvg
+            : (logoUrl
+                ? '<img src="' + escAttr(logoUrl) + '" alt="' + escAttr(brandName)
+                    + '" onerror="this.parentElement.innerHTML=DEFAULT_LOGO;this.remove();">'
+                : DEFAULT_LOGO);
+        var logoEl = document.getElementById('brand-logo');
+        logoEl.innerHTML = brandUrl
+            ? '<a href="' + escAttr(brandUrl) + '">' + logoMarkup + '</a>'
+            : logoMarkup;
+        var nameEl = document.getElementById('brand-name');
+        if (brandUrl) {
+            nameEl.innerHTML = '<a href="' + escAttr(brandUrl) + '">' + escAttr(brandName) + '</a>';
+        } else {
+            nameEl.textContent = brandName;
+        }
+        document.getElementById('brandbar').classList.remove('hidden');
+    }
+    renderBrand();
 
     // ---------------------------------------------------------------------
     // MCP Apps bridge. Supports two host protocols:

--- a/internal/platform/promptlayer/show.go
+++ b/internal/platform/promptlayer/show.go
@@ -40,12 +40,14 @@ func (h *Handle) RegisterShowPromptsTool(server *mcp.Server) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:  ToolNameShowPrompts,
 		Title: "Show Prompt Library",
-		Description: "Displays the user's prompt library as an interactive browser for the human to look at. " +
-			"Call this ONLY when the human wants to see, browse, or pick from their prompts visually " +
-			"(\"show me my prompts\", \"open my prompt library\"). It renders a UI panel and does no data " +
-			"work, so never call it for your own reasoning or as a way to read prompt data. For running, " +
-			"creating, editing, or listing prompts as part of your work, use manage_prompt, which returns " +
-			"data and renders no UI.",
+		Description: "Open the user's prompt library as an interactive visual browser (search, filter, " +
+			"preview, and one-click run). This is the correct tool whenever the human asks to see, list, " +
+			"view, show, browse, or pick their prompts, or asks what prompts they have or what is in their " +
+			"library: \"list my prompts\", \"show me my prompts\", \"view my prompts\", \"what prompts do I " +
+			"have\", \"open my prompt library\", \"browse my prompts\". Prefer it over manage_prompt for any " +
+			"human-facing request to view prompts; it renders the library for the human and needs no " +
+			"follow-up tool calls. Use manage_prompt only to run, create, or edit a prompt, or when you need " +
+			"prompt data for your own reasoning rather than to show it to the human.",
 		InputSchema: showPromptsSchema(),
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, input showPromptsInput) (*mcp.CallToolResult, any, error) {
 		return h.handleShowPrompts(ctx, input)

--- a/internal/platform/promptlayer/tool.go
+++ b/internal/platform/promptlayer/tool.go
@@ -100,6 +100,10 @@ func (h *Handle) RegisterTool(server *mcp.Server) {
 		Name:  ToolNameManagePrompt,
 		Title: "Manage Prompts",
 		Description: "Create, update, delete, list, get, or use prompts. " +
+			"When the human asks to see, list, view, browse, or pick their prompts, or asks what prompts " +
+			"they have, call show_prompts instead: it opens the visual prompt library for them. The 'list' " +
+			"command here is for reading prompt data into your own reasoning, not for showing the human " +
+			"their library. " +
 			"When a user names a report, procedure, or recurring task ('run the daily sales report'), " +
 			"resolve it against the prompt library first with the 'use' command instead of listing: " +
 			"'use' accepts a prompt name, display name, mcp:prompt:<id> reference, or free text, and " +

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -1930,6 +1930,16 @@ func (p *Platform) initMCPApps() error {
 	if err != nil {
 		return err
 	}
+	// The prompt browser presents the same brand as platform-info: its logo and
+	// name. When the operator has not configured the prompt-browser app itself,
+	// it inherits platform-info's already-resolved brand config (registered just
+	// above), and the portal logo is injected into whichever config it ends up
+	// with, so both built-in apps show one logo rather than the browser rendering
+	// bare.
+	if promptBrowser.Config == nil {
+		promptBrowser.Config = p.config.MCPApps.Apps[builtinPlatformInfoName].Config
+	}
+	promptBrowser.Config = p.branding.InjectPortalLogo(promptBrowser.Config)
 	if err := registerBuiltinApp(p.mcpAppsRegistry, promptBrowser); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Three fixes to the prompt-browser MCP App: the agent now opens the visual library when a human asks to see their prompts, the app renders at a real usable height in Claude instead of a ~50-100px strip, and the library carries the platform brand like the platform-info app does.

## Fix 1: the agent opens the prompt library instead of dumping a text table

### The problem

Asking "list my prompts" (or view / see / show them) made the agent call `manage_prompt` and render a text table, and it only opened the visual browser after being explicitly told to. The prompt browser is bound to a separate presentation-only tool, `show_prompts` (this split is deliberate, from #1040: binding the app to `manage_prompt` would pop the UI on every agent prompt operation). But `show_prompts`'s own description worked against it: it said to call it "ONLY when the human wants to see... visually" and explicitly routed "listing" to `manage_prompt`. So the word "list" matched `manage_prompt`'s `list` command, and the agent never reached for the app.

### Exactly how it is fixed

Two tool descriptions are rebalanced so the model routes on human-display intent versus agent-internal data need:

- `show_prompts` (`internal/platform/promptlayer/show.go`) now claims every phrasing a human uses to view their prompts, by example: "list my prompts", "show me my prompts", "view my prompts", "what prompts do I have", "open my prompt library", "browse my prompts". It states it is the correct tool for any human-facing request to view prompts and needs no follow-up calls.
- `manage_prompt` (`internal/platform/promptlayer/tool.go`) now says that when the human asks to see, list, view, browse, or pick their prompts, call `show_prompts` instead, and that its own `list` command is for reading prompt data into the agent's reasoning, not for showing the human their library.

This is a tool-selection steering change. It removes the "only... visually" hedge and the "listing goes to manage_prompt" instruction that were causing the misroute, and gives the model the exact trigger phrases. The definitive confirmation is behavioral: asking to see prompts should now open the browser without being told.

## Fix 2: the app renders at a real height in Claude

### Exactly why it was broken

Claude does not size an MCP App iframe from the `ui/notifications/size-changed` notification the MCP Apps spec defines. It loads the app as a same-origin `blob:` URL and reads the rendered DOM height directly, and it snapshots that height early (before async content loads) and does not re-read. This is documented in Anthropic's own tracker: [claude-ai-mcp #69](https://github.com/anthropics/claude-ai-mcp/issues/69), whose reproduction is that hardcoding `document.documentElement.style.height = "900px"` makes the iframe grow to 900px on the spot.

The old app code did the two things Claude ignores and none of the one thing it reads: it declared height via a stylesheet rule (`html, body { height: 500px }`) and sent the `size-changed` message. A stylesheet rule does not populate `documentElement.style.height`, and the message is ignored, so Claude read the short early snapshot (the loading spinner) and froze the frame at ~50-100px.

### Exactly how it is fixed

The height is declared as an inline style on the `<html>` element, present in the DOM at first paint, which is what Claude snapshots: `<html style="height: 640px">`, alongside the existing `html, body { height: 640px }` rule. The `size-changed` message is kept as a fallback for spec-compliant hosts (goose and others honor it).

This makes the rendered document a fixed-height box from the first byte, so every way Claude could be measuring the DOM lands on the same value:

- `document.documentElement.style.height` (the inline attribute, the #69 reproduction) is `"640px"`
- `document.documentElement.offsetHeight` (the element box) is 640
- `document.body.scrollHeight` (rendered content height, the value that grows when platform-info is padded with text) is 640, because the box is forced to 640 regardless of how much content has loaded

That last point is the ground truth this fix stands on: making the iframe taller in Claude is already a proven, everyday fact (a content-heavy platform-info renders tall because Claude reads content height). This change is the deterministic form of that same mechanism, a fixed 640px box instead of relying on how much content happens to exist, and it does not collapse to the loading-state snapshot because the box is 640px before any data arrives. The prompt browser uses 640px because a library needs room to browse; platform-info gets the same inline-height treatment at its existing 500px.

The one thing not yet done is watching it render inside Claude's own frame. Whether the frame can be made taller is not in question; this uses the mechanism that already works. The value is a single constant on the `<html>` element and the CSS rule (kept in sync, noted in a comment) if it needs tuning.

## Fix 3: the prompt library carries the platform brand

### The problem

The library rendered with no logo or brand name while platform-info shows both. The server auto-injects the portal logo into the platform-info app config (`InjectPortalLogo`), but the prompt-browser registration skipped that call, so its app config carried no brand.

### Exactly how it is fixed

- Server (`pkg/platform/platform.go`): after building the prompt-browser app definition, its config inherits platform-info's already-resolved brand config when the operator has not configured the prompt-browser app itself, and the portal logo is injected into it, so both built-in apps resolve to one logo and name.
- App (`apps/prompt-browser/index.html`): a brand bar reads the same server-injected `#app-config` (`brand_name`, `logo_svg`, `logo_url`, `brand_url`) and renders the logo and name above the library, using the byte-identical default-logo mark and the same inline-SVG / URL-image / default fallback order as platform-info.

## Verification

Rendered in a real Chromium browser through the app test harness with mock data:

- `document.documentElement.style.height` reads `640px` at first paint, before any data loads
- the full library renders at 640px with the brand bar (logo and name) and browsable prompt cards, complete with scope badges, versions, run counts, approvers, and tags, versus the cramped strip before

`make verify` is green (fmt, race tests, real-DB tests, frontend and e2e, lint, security, semgrep, codeql, coverage, patch coverage, doc gates, dead code, goreleaser dry-run).

## Files changed

- `internal/platform/promptlayer/show.go`, `internal/platform/promptlayer/tool.go`: tool descriptions (fix 1)
- `apps/prompt-browser/index.html`, `apps/platform-info/index.html`: inline height and, for the browser, the brand bar (fixes 2 and 3)
- `pkg/platform/platform.go`: inject the brand into the prompt-browser app config (fix 3)
