### PR TITLE
fix(mcpapps): defer prompt-browser height until content renders

### DIFF
--- a/apps/prompt-browser/index.html
+++ b/apps/prompt-browser/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" style="height: 640px">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -507,17 +507,31 @@
     // ResizeObserver, mirroring the SDK's useAutoResize pattern. Kept
     // byte-identical to the platform-info app so both speak one contract.
     // ---------------------------------------------------------------------
-    var APP_HEIGHT = 500;
+    var APP_HEIGHT = 640;
+    var sizeLocked = false;
     function sendSize() {
         // Report height only. These apps are laid out at the host's conversation
         // width, so width stays host-controlled (fluid); we own only the height.
         send({ jsonrpc: '2.0', method: 'ui/notifications/size-changed',
                params: { height: APP_HEIGHT } });
     }
-    function watchSize() {
+    // lockSize declares the app's height AFTER its real content has rendered.
+    // Claude sizes the iframe by reading documentElement's height directly and
+    // snapshots it once, early; a size signal (a set height or a ResizeObserver
+    // firing) sent BEFORE content renders locks the frame at the pre-render
+    // spinner height (anthropics/claude-ai-mcp #69). This browser needs two round
+    // trips (handshake, then the prompt list), so at init it is still a spinner,
+    // which is why setting the height at init did nothing. The height and the
+    // observer are therefore established only here, on the first content paint.
+    // size-changed is also sent for spec-compliant hosts that honor it.
+    function lockSize() {
+        document.documentElement.style.height = APP_HEIGHT + 'px';
         sendSize();
-        if (typeof ResizeObserver === 'function') {
-            new ResizeObserver(function() { sendSize(); }).observe(document.documentElement);
+        if (!sizeLocked) {
+            sizeLocked = true;
+            if (typeof ResizeObserver === 'function') {
+                new ResizeObserver(function() { sendSize(); }).observe(document.documentElement);
+            }
         }
     }
 
@@ -544,7 +558,7 @@
         params: {
             protocolVersion: '2025-01-09',
             appInfo: { name: 'Prompt Library', version: '1.0.0' },
-            appCapabilities: { availableDisplayModes: ['inline', 'fullscreen'] }
+            appCapabilities: { availableDisplayModes: ['inline', 'pip'] }
         }
     });
 
@@ -555,7 +569,6 @@
         isLegacy = !hostCaps;
         canMessage = !!(hostCaps && hostCaps.message);
         send({ jsonrpc: '2.0', method: 'ui/notifications/initialized', params: {} });
-        watchSize();
         boot();
     }
 
@@ -873,11 +886,17 @@
                 state.ranked = !!query && d.ranking !== undefined;
                 hide('loading');
                 renderBrowser();
+                // Real content is now on screen; declare the height so Claude's
+                // DOM-height read lands on the rendered library, not the spinner.
+                lockSize();
             })
             .catch(function(err) {
                 if (seq !== listSeq || isCanceled(err)) { return; }
                 hide('loading');
                 showError(err.message, function() { loadList(state.query); });
+                // Even an error state is a real render; size to it rather than
+                // leaving the frame locked at the spinner height.
+                lockSize();
             });
     }
 


### PR DESCRIPTION
## Summary

Fixes the prompt-browser MCP App rendering at a cramped height in Claude. The v1.113.1 attempt (#1049) shipped and failed in Claude; this replaces it with the approach documented in Anthropic's own tracker, targeting the actual measured difference between the browser and the working platform-info app.

## Why v1.113.1 failed

The v1.113.1 fix declared the iframe height at init: an inline `<html>` height, a `ui/notifications/size-changed` message, and a `ResizeObserver` installed in `onInitialized`. Reading the served HTML from the deployment confirmed all of that is live, and it still rendered cramped, so the approach was wrong, not un-deployed.

Claude sizes an MCP App iframe by reading the DOM height directly, once, at an early snapshot, and ignores `size-changed` ([anthropics/claude-ai-mcp #69](https://github.com/anthropics/claude-ai-mcp/issues/69)). Per that issue, a size signal sent **before** content renders (a set height, or a `ResizeObserver` that fires early) locks the frame at the pre-render height.

Measurement ruled out the theories that would have been easier:

- Content height is not it: platform-info's pre-data natural content is 92px, *shorter* than the browser's 152px, yet platform-info renders tall.
- Display mode is not it per the spec: `availableDisplayModes` does not govern inline iframe sizing.

The one real difference: platform-info fetches its content in a single round trip, while the browser needs two (the `platform_info` handshake, then the `manage_prompt` list). At the moment Claude snapshots the height, the browser is still on its loading spinner, so it locks small. Declaring the height at init did nothing because the content was not there yet.

## Change

The app no longer signals its size at init.

- `onInitialized` no longer calls the size watcher.
- A new `lockSize()` sets `document.documentElement.style.height` and installs the `ResizeObserver`, and it is called on the first content paint (the list-loaded path and the error path), never before.
- The premature inline `<html>` height is removed.
- `ui/notifications/size-changed` is still sent for spec-compliant hosts.
- `availableDisplayModes` is changed from `['inline','fullscreen']` to `['inline','pip']` to match the working platform-info app (harmless; not claimed as the fix), and `APP_HEIGHT` is set to 640 to match the shell.

## Verification

Verified in a local browser render through the app test harness: the height is set to 640px only **after** the prompt list loads (not at init), with no console errors, and the brand bar and cards render.

Not verified in Claude's blob-iframe host. That render is the only real confirmation and cannot be reproduced locally, which is why the previous two attempts passed local checks and still failed. Recommended: mount this single HTML file via the prompt-browser app's `assets_path` and reload in Claude before this is trusted or released. `make verify` is green.
