### PR TITLE
fix(knowledge): merge DataHub aspects instead of replacing them

### DIFF
--- a/docs/reference/tools-api.md
+++ b/docs/reference/tools-api.md
@@ -695,8 +695,8 @@ Additional parameters vary by `what` value — see the [mcp-datahub documentatio
 
 | `what` | `action` | Description |
 |--------|----------|-------------|
-| `description` | — | Set entity description |
-| `column_description` | — | Set schema field description |
+| `description` | — | Set entity description from `value` |
+| `column_description` | — | Set schema field description from `value` |
 | `tag` | add/remove | Add or remove a tag |
 | `glossary_term` | add/remove | Add or remove a glossary term |
 | `link` | add/remove | Add or remove a link |

--- a/docs/server/tools.md
+++ b/docs/server/tools.md
@@ -364,8 +364,8 @@ Additional parameters vary by `what` value — see the [mcp-datahub documentatio
 
 | `what` | `action` | Description |
 |--------|----------|-------------|
-| `description` | — | Set entity description |
-| `column_description` | — | Set schema field description |
+| `description` | — | Set entity description from `value` |
+| `column_description` | — | Set schema field description from `value` |
 | `tag` | add/remove | Add or remove a tag |
 | `glossary_term` | add/remove | Add or remove a glossary term |
 | `link` | add/remove | Add or remove a link |

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/ollama v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
-	github.com/txn2/mcp-datahub v1.12.0
+	github.com/txn2/mcp-datahub v1.13.0
 	github.com/txn2/mcp-s3 v1.3.0
 	github.com/txn2/mcp-trino v1.3.1
 	github.com/wneessen/go-mail v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/tmc/langchaingo v0.1.5 h1:PNPFu54wn5uVPRt9GS/quRwdFZW4omSab9/dcFAsGmU
 github.com/tmc/langchaingo v0.1.5/go.mod h1:RLtnUED/hH2v765vdjS9Z6gonErZAXURuJHph0BttqM=
 github.com/trinodb/trino-go-client v0.333.0 h1:+bsW8/uLFNF00MEL9JZJym94LlUnle25VgDlWGPEZos=
 github.com/trinodb/trino-go-client v0.333.0/go.mod h1:91okdYtRUZoj3XJu/tqdzu11sNliQuN4A+vMFEB8GVE=
-github.com/txn2/mcp-datahub v1.12.0 h1:ETiPw8QFCpq3FfObB8x+J5RkIIVVJ1+gIXk9BMfwgwA=
-github.com/txn2/mcp-datahub v1.12.0/go.mod h1:zNhJ1JJoVrwIC8DU9fTywVSdCjG7gnnrzbNWL746JYM=
+github.com/txn2/mcp-datahub v1.13.0 h1:ovPsD4qeAgtH9fCG56bJZiWCGTDuVLEPsqT0smXNlLI=
+github.com/txn2/mcp-datahub v1.13.0/go.mod h1:zNhJ1JJoVrwIC8DU9fTywVSdCjG7gnnrzbNWL746JYM=
 github.com/txn2/mcp-s3 v1.3.0 h1:T2FlZGSU5pJi78ts+rE9kzZpIg1HD/lciwWqInYXXO0=
 github.com/txn2/mcp-s3 v1.3.0/go.mod h1:sI18zzBkOxGO07DSHap7baPwtEEw+pYBJhT1BGQnYRc=
 github.com/txn2/mcp-trino v1.3.1 h1:A9Ki3Q7S+soLKCOKuVXCi/DO2dvgZRh7h+mDPT1WOCw=

--- a/pkg/toolkits/knowledge/datahub_client_writer.go
+++ b/pkg/toolkits/knowledge/datahub_client_writer.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"golang.org/x/sync/errgroup"
 
@@ -323,23 +324,47 @@ func readAspect[T any](ctx context.Context, w *DataHubClientWriter, entityType, 
 	return parseAspect[T](body)
 }
 
-// parseAspect unmarshals a REST aspect GET response (a {"value": <aspect>} envelope)
-// into *T, returning a zero-valued *T when the aspect is absent (empty or null value).
+// parseAspect unmarshals a REST aspect GET response into *T, returning a
+// zero-valued *T when the aspect is absent (empty or null value).
+//
+// Two envelopes are in play. The OpenAPI v3 endpoint answers {"value": <aspect>};
+// the legacy Rest.li endpoint answers {"version":N,"aspect":{"<FQCN>": <aspect>}},
+// keyed by the aspect's fully-qualified PDL class name. Parsing only the v3 shape
+// made every Rest.li read-modify-write start from an empty merge base, so a write
+// replaced the stored aspect instead of merging into it: column descriptions, tags,
+// and glossary terms written by earlier calls were silently discarded (#1102).
+// Nothing sets APIVersion, so Rest.li is the path every deployment takes.
 func parseAspect[T any](body []byte) (*T, error) {
-	var aspectResp struct {
-		Value json.RawMessage `json:"value"`
+	var envelope struct {
+		Value  json.RawMessage            `json:"value"`
+		Aspect map[string]json.RawMessage `json:"aspect"`
 	}
-	if err := json.Unmarshal(body, &aspectResp); err != nil {
+	if err := json.Unmarshal(body, &envelope); err != nil {
 		return nil, fmt.Errorf("unmarshal response: %w", err)
 	}
 	out := new(T)
-	if len(aspectResp.Value) == 0 || string(bytes.TrimSpace(aspectResp.Value)) == "null" {
+	value := envelope.Value
+	if isAbsentAspect(value) {
+		// The Rest.li "aspect" object holds exactly one entry; take its value
+		// whatever the class name is.
+		for _, raw := range envelope.Aspect {
+			value = raw
+			break
+		}
+	}
+	if isAbsentAspect(value) {
 		return out, nil
 	}
-	if err := json.Unmarshal(aspectResp.Value, out); err != nil {
+	if err := json.Unmarshal(value, out); err != nil {
 		return nil, fmt.Errorf("unmarshal aspect: %w", err)
 	}
 	return out, nil
+}
+
+// isAbsentAspect reports whether a raw aspect value carries no aspect.
+func isAbsentAspect(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) == 0 || string(trimmed) == "null"
 }
 
 // readEditableSchema reads the current editableSchemaMetadata aspect via REST.
@@ -398,7 +423,10 @@ func (w *DataHubClientWriter) postIngestProposal(ctx context.Context, entityType
 	var err error
 
 	if cfg.APIVersion == dhclient.APIVersionV3 {
-		reqURL = fmt.Sprintf("%s/openapi/v3/entity/%s/%s/%s",
+		// createIfNotExists=false forces UPSERT. DataHub defaults the OpenAPI v3
+		// aspect write to CREATE, which fails once the aspect exists; every write
+		// here is a read-modify-write, so create-only semantics are never wanted.
+		reqURL = fmt.Sprintf("%s/openapi/v3/entity/%s/%s/%s?createIfNotExists=false",
 			base, entityType, url.PathEscape(urn), aspectName)
 		jsonBody, err = json.Marshal(struct {
 			Value any `json:"value"`
@@ -425,7 +453,7 @@ func (w *DataHubClientWriter) postIngestProposal(ctx context.Context, entityType
 		proposal.Proposal.EntityURN = urn
 		proposal.Proposal.ChangeType = "UPSERT"
 		proposal.Proposal.AspectName = aspectName
-		proposal.Proposal.Aspect.Value = string(aspectJSON)
+		proposal.Proposal.Aspect.Value = escapeNonASCII(aspectJSON)
 		proposal.Proposal.Aspect.ContentType = "application/json"
 		jsonBody, err = json.Marshal(proposal)
 	}
@@ -457,6 +485,58 @@ func (w *DataHubClientWriter) postIngestProposal(ctx context.Context, entityType
 		return fmt.Errorf("rest post status %d: %s", resp.StatusCode, truncateBody(body))
 	}
 	return nil
+}
+
+// escapeNonASCII returns the JSON with every non-ASCII rune replaced by its
+// \uXXXX escape. The Rest.li GenericAspect.value field is typed as bytes and
+// encoded Avro-style, admitting U+0000-U+00FF only, so a description carrying a
+// curly quote, an em dash, or an accented name fails ingestProposal validation
+// when sent raw. Non-ASCII bytes in JSON can only occur inside string values, so
+// escaping every non-ASCII rune preserves the document.
+func escapeNonASCII(data []byte) string {
+	if isASCII(data) {
+		return string(data)
+	}
+	var buf strings.Builder
+	buf.Grow(len(data))
+	for i := 0; i < len(data); {
+		r, size := utf8.DecodeRune(data[i:])
+		switch {
+		case r <= maxASCIIRune:
+			_ = buf.WriteByte(data[i])
+		case r <= maxBMPRune:
+			// strings.Builder writes never fail.
+			_, _ = fmt.Fprintf(&buf, `\u%04x`, r)
+		default:
+			// Supplementary plane: emit the UTF-16 surrogate pair.
+			r -= supplementaryBase
+			_, _ = fmt.Fprintf(&buf, `\u%04x\u%04x`,
+				highSurrogateBase+(r>>surrogateShift), lowSurrogateBase+(r&surrogateMask))
+		}
+		i += size
+	}
+	return buf.String()
+}
+
+// UTF-16 escaping bounds used by escapeNonASCII.
+const (
+	maxASCIIRune      = 0x7F
+	maxBMPRune        = 0xFFFF
+	supplementaryBase = 0x10000
+	highSurrogateBase = 0xD800
+	lowSurrogateBase  = 0xDC00
+	surrogateShift    = 10
+	surrogateMask     = 0x3FF
+)
+
+// isASCII reports whether data holds only ASCII bytes.
+func isASCII(data []byte) bool {
+	for _, b := range data {
+		if b > maxASCIIRune {
+			return false
+		}
+	}
+	return true
 }
 
 const maxBodyTruncate = 200

--- a/pkg/toolkits/knowledge/datahub_client_writer_restli_test.go
+++ b/pkg/toolkits/knowledge/datahub_client_writer_restli_test.go
@@ -1,0 +1,341 @@
+package knowledge
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	dhclient "github.com/txn2/mcp-datahub/pkg/client"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// restliFQCN maps an aspect name to the fully-qualified PDL class name the legacy
+// Rest.li aspect GET keys its response envelope by.
+var restliFQCN = map[string]string{
+	"editableSchemaMetadata": "com.linkedin.schema.EditableSchemaMetadata",
+	"globalTags":             "com.linkedin.common.GlobalTags",
+	"glossaryTerms":          "com.linkedin.common.GlossaryTerms",
+}
+
+// restliGMS is a fake DataHub GMS speaking the legacy Rest.li protocol that the
+// client selects whenever APIVersion is not "v3" - which is every deployment,
+// since nothing sets it. Aspect GETs answer with the
+// {"version":0,"aspect":{"<FQCN>": ...}} envelope a real Rest.li endpoint
+// returns, and ingestProposal POSTs store the aspect so a later GET observes it.
+//
+// Modeling the real envelope is the point of this fake: one that answers the
+// OpenAPI v3 {"value": ...} shape hides every read-modify-write defect on the v1
+// path, because the merge base parses as empty and a full-replace write then
+// looks indistinguishable from a merge (#1102).
+type restliGMS struct {
+	mu      sync.Mutex
+	aspects map[string]json.RawMessage
+}
+
+func newRestliGMS() *restliGMS {
+	return &restliGMS{aspects: map[string]json.RawMessage{}}
+}
+
+// seed stores an aspect as if a previous write had persisted it.
+func (g *restliGMS) seed(aspectName, value string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.aspects[aspectName] = json.RawMessage(value)
+}
+
+// stored returns the aspect value currently held, or "" when absent.
+func (g *restliGMS) stored(aspectName string) string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return string(g.aspects[aspectName])
+}
+
+func (g *restliGMS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method == http.MethodGet {
+		g.serveGet(w, r)
+		return
+	}
+	g.servePost(w, r)
+}
+
+func (g *restliGMS) serveGet(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("aspect")
+	g.mu.Lock()
+	value, ok := g.aspects[name]
+	g.mu.Unlock()
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	fqcn := restliFQCN[name]
+	if fqcn == "" {
+		fqcn = "com.linkedin.Unknown"
+	}
+	_, _ = w.Write([]byte(`{"version":0,"aspect":{"` + fqcn + `":` + string(value) + `}}`))
+}
+
+// servePost decodes an ingestProposal and stores its GenericAspect value.
+func (g *restliGMS) servePost(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	var req struct {
+		Proposal struct {
+			AspectName string `json:"aspectName"`
+			Aspect     struct {
+				Value string `json:"value"`
+			} `json:"aspect"`
+		} `json:"proposal"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	// A real GMS rejects raw non-ASCII in GenericAspect.value: the PDL type is
+	// bytes and Rest.li applies Avro-style encoding that admits U+0000-U+00FF
+	// only. Reject it here so a write that would fail in production fails here.
+	for i := range len(req.Proposal.Aspect.Value) {
+		if req.Proposal.Aspect.Value[i] > maxASCIIRune {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"message":"Failed to parse GenericAspect value"}`))
+			return
+		}
+	}
+	g.mu.Lock()
+	g.aspects[req.Proposal.AspectName] = json.RawMessage(req.Proposal.Aspect.Value)
+	g.mu.Unlock()
+	w.WriteHeader(http.StatusOK)
+}
+
+// newRestliWriter starts a fake Rest.li GMS and returns a writer bound to it.
+func newRestliWriter(t *testing.T) (*DataHubClientWriter, *restliGMS) {
+	t.Helper()
+	gms := newRestliGMS()
+	server := httptest.NewServer(gms)
+	t.Cleanup(server.Close)
+	return NewDataHubClientWriter(newTestClient(t, server.URL)), gms
+}
+
+// columnDescriptions reads back the stored editableSchemaMetadata as fieldPath ->
+// description.
+func columnDescriptions(t *testing.T, gms *restliGMS) map[string]string {
+	t.Helper()
+	raw := gms.stored("editableSchemaMetadata")
+	require.NotEmpty(t, raw, "editableSchemaMetadata was never written")
+	var aspect editableSchemaAspect
+	require.NoError(t, json.Unmarshal([]byte(raw), &aspect))
+	out := make(map[string]string, len(aspect.EditableSchemaFieldInfo))
+	for _, f := range aspect.EditableSchemaFieldInfo {
+		out[f.FieldPath] = f.Description
+	}
+	return out
+}
+
+// TestUpdateColumnDescriptionBatch_MergesAcrossCalls is the #1102 reproduction: a
+// second batch must add to the columns an earlier batch documented, not replace
+// them. Replacing caps a table at one batch (20 changes) of documented columns
+// and silently discards everything written before.
+func TestUpdateColumnDescriptionBatch_MergesAcrossCalls(t *testing.T) {
+	writer, gms := newRestliWriter(t)
+	ctx := context.Background()
+
+	require.NoError(t, writer.UpdateColumnDescriptionBatch(ctx, testURN, map[string]string{
+		"order_id":   "Order identifier",
+		"customer":   "Customer name",
+		"order_date": "Date the order was placed",
+	}))
+	require.NoError(t, writer.UpdateColumnDescriptionBatch(ctx, testURN, map[string]string{
+		"amount": "Gross amount",
+		"status": "Fulfillment status",
+	}))
+
+	assert.Equal(t, map[string]string{
+		"order_id":   "Order identifier",
+		"customer":   "Customer name",
+		"order_date": "Date the order was placed",
+		"amount":     "Gross amount",
+		"status":     "Fulfillment status",
+	}, columnDescriptions(t, gms))
+}
+
+// TestUpdateColumnDescriptionBatch_OverwritesSameColumn confirms merging does not
+// duplicate a re-documented column: the newest description wins, once.
+func TestUpdateColumnDescriptionBatch_OverwritesSameColumn(t *testing.T) {
+	writer, gms := newRestliWriter(t)
+	ctx := context.Background()
+
+	require.NoError(t, writer.UpdateColumnDescriptionBatch(ctx, testURN, map[string]string{
+		"order_id": "Old text",
+		"customer": "Customer name",
+	}))
+	require.NoError(t, writer.UpdateColumnDescriptionBatch(ctx, testURN, map[string]string{
+		"order_id": "New text",
+		"amount":   "Gross amount",
+	}))
+
+	assert.Equal(t, map[string]string{
+		"order_id": "New text",
+		"customer": "Customer name",
+		"amount":   "Gross amount",
+	}, columnDescriptions(t, gms))
+}
+
+// TestUpdateColumnDescriptionBatch_NonASCII covers descriptions carrying non-ASCII
+// text (curly quotes, em dashes, accented names). The Rest.li GenericAspect value
+// must be \u-escaped or the proposal is rejected.
+func TestUpdateColumnDescriptionBatch_NonASCII(t *testing.T) {
+	writer, gms := newRestliWriter(t)
+
+	require.NoError(t, writer.UpdateColumnDescriptionBatch(context.Background(), testURN, map[string]string{
+		"customer": "Customer’s legal name — as filed",
+		"region":   "Región de ventas",
+		"status":   "Fulfillment state 🚚 (supplementary plane)",
+	}))
+
+	assert.Equal(t, map[string]string{
+		"customer": "Customer’s legal name — as filed",
+		"region":   "Región de ventas",
+		"status":   "Fulfillment state 🚚 (supplementary plane)",
+	}, columnDescriptions(t, gms))
+}
+
+// TestApplyTagChanges_PreservesExistingTags covers the same merge base for the
+// globalTags aspect: adding a tag must not drop the tags already on the entity.
+func TestApplyTagChanges_PreservesExistingTags(t *testing.T) {
+	writer, gms := newRestliWriter(t)
+	gms.seed("globalTags", `{"tags":[{"tag":"urn:li:tag:PII"},{"tag":"urn:li:tag:Curated"}]}`)
+
+	require.NoError(t, writer.ApplyTagChanges(context.Background(), testURN, []string{"urn:li:tag:Reviewed"}, nil))
+
+	var aspect globalTagsAspect
+	require.NoError(t, json.Unmarshal([]byte(gms.stored("globalTags")), &aspect))
+	urns := make([]string, 0, len(aspect.Tags))
+	for _, raw := range aspect.Tags {
+		urns = append(urns, tagURNOf(raw))
+	}
+	assert.Equal(t, []string{"urn:li:tag:PII", "urn:li:tag:Curated", "urn:li:tag:Reviewed"}, urns)
+}
+
+// TestApplyGlossaryTermChanges_PreservesExistingTerms is the glossaryTerms
+// counterpart of TestApplyTagChanges_PreservesExistingTags.
+func TestApplyGlossaryTermChanges_PreservesExistingTerms(t *testing.T) {
+	writer, gms := newRestliWriter(t)
+	gms.seed("glossaryTerms", `{"terms":[{"urn":"urn:li:glossaryTerm:Revenue"}]}`)
+
+	require.NoError(t, writer.ApplyGlossaryTermChanges(
+		context.Background(), testURN, []string{"urn:li:glossaryTerm:Margin"}, nil))
+
+	var aspect glossaryTermsAspect
+	require.NoError(t, json.Unmarshal([]byte(gms.stored("glossaryTerms")), &aspect))
+	urns := make([]string, 0, len(aspect.Terms))
+	for _, raw := range aspect.Terms {
+		urns = append(urns, glossaryTermURNOf(raw))
+	}
+	assert.Equal(t, []string{"urn:li:glossaryTerm:Revenue", "urn:li:glossaryTerm:Margin"}, urns)
+}
+
+// TestReadTagURNs_RestliEnvelope covers the read that feeds resulting_state and the
+// rollback before-image: an empty before-image lets a rollback strip tags the
+// entity already carried.
+func TestReadTagURNs_RestliEnvelope(t *testing.T) {
+	writer, gms := newRestliWriter(t)
+	gms.seed("globalTags", `{"tags":[{"tag":"urn:li:tag:PII"}]}`)
+
+	urns, err := writer.readTagURNs(context.Background(), "dataset", testURN)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"urn:li:tag:PII"}, urns)
+}
+
+func TestParseAspect_Envelopes(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{
+			name: "restli envelope keyed by fully-qualified class name",
+			body: `{"version":0,"aspect":{"com.linkedin.common.GlobalTags":{"tags":[{"tag":"urn:li:tag:a"}]}}}`,
+			want: []string{"urn:li:tag:a"},
+		},
+		{
+			name: "openapi v3 value envelope",
+			body: `{"value":{"tags":[{"tag":"urn:li:tag:b"}]}}`,
+			want: []string{"urn:li:tag:b"},
+		},
+		{
+			name: "restli envelope with an absent aspect",
+			body: `{"version":0,"aspect":{}}`,
+			want: []string{},
+		},
+		{
+			name: "null value",
+			body: `{"value":null}`,
+			want: []string{},
+		},
+		{
+			name: "null restli aspect body",
+			body: `{"version":0,"aspect":{"com.linkedin.common.GlobalTags":null}}`,
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			aspect, err := parseGlobalTags([]byte(tt.body))
+			require.NoError(t, err)
+			urns := make([]string, 0, len(aspect.Tags))
+			for _, raw := range aspect.Tags {
+				urns = append(urns, tagURNOf(raw))
+			}
+			assert.Equal(t, tt.want, urns)
+		})
+	}
+}
+
+func TestParseAspect_MalformedRestliAspect(t *testing.T) {
+	_, err := parseGlobalTags([]byte(`{"aspect":{"com.linkedin.common.GlobalTags":"not-an-object"}}`))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal aspect")
+}
+
+// TestPostIngestProposal_V3ForcesUpsert pins the OpenAPI v3 write to UPSERT
+// semantics. DataHub defaults the v3 aspect write to CREATE, which fails with
+// HTTP 400 once the aspect exists - and every write here is a read-modify-write.
+func TestPostIngestProposal_V3ForcesUpsert(t *testing.T) {
+	var gotURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			gotURL = r.URL.String()
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	cfg := dhclient.DefaultConfig()
+	cfg.URL = server.URL
+	cfg.Token = "test-token"
+	cfg.RetryMax = 0
+	cfg.APIVersion = dhclient.APIVersionV3
+	c, err := dhclient.New(cfg)
+	require.NoError(t, err)
+	writer := NewDataHubClientWriter(c)
+
+	require.NoError(t, writer.UpdateColumnDescriptionBatch(context.Background(), testURN, map[string]string{
+		"order_id": "Order identifier",
+		"customer": "Customer name",
+	}))
+
+	assert.Contains(t, gotURL, "createIfNotExists=false", "v3 aspect write must force UPSERT")
+}


### PR DESCRIPTION
Closes #1102

## Summary

Catalog writes now merge into the aspect DataHub already holds instead of replacing it, and a `datahub_update` description call can no longer erase the text it was meant to set.

Two defects sat behind the report. The first is in this repo: every read-modify-write against the DataHub REST aspect API began from an empty merge base, so each write replaced the stored aspect. The second is upstream and ships here as a dependency bump to mcp-datahub v1.13.0.

## The aspect read never parsed the response it gets

`parseAspect` in `pkg/toolkits/knowledge/datahub_client_writer.go` read only the OpenAPI v3 envelope, `{"value": <aspect>}`. The legacy Rest.li aspect GET answers `{"version":0,"aspect":{"<fully.qualified.ClassName>": <aspect>}}`, keyed by the aspect's PDL class name.

Rest.li is the endpoint every deployment uses. The one place a DataHub client is constructed, `createClient` in `pkg/toolkits/datahub/toolkit.go`, never sets `APIVersion`, and the client selects Rest.li for any value other than `v3`. So the read returned a zero-valued aspect on every call, the merge produced only the incoming items, and the write replaced everything the entity carried.

The read is shared, so the effect reached all three aspects that go through it:

- **`editableSchemaMetadata`** — `apply_knowledge` discarded every column description an earlier call had written. With the `changes` array capped at 20, a table could hold no more descriptions than a single batch.
- **`globalTags`** — a tag add dropped the tags already on the entity. The batching from #721 kept the tags within one call, which is why the behavior looked correct.
- **`glossaryTerms`** — the same for terms, and the same reason it went unseen after #729.
- **The tag and term read behind `resulting_state` and the rollback before-image** returned nothing, so a rollback recorded an empty before-image of associations the entity actually had.

`parseAspect` now accepts both envelopes: the v3 `value` when present, otherwise the single entry under the Rest.li `aspect` object, whatever its class name.

## Two further defects in the same REST block

This package carries its own copy of the REST read and write because the upstream helpers are unexported. Two corrections upstream made against a live DataHub had never reached the copy.

**The OpenAPI v3 write omitted `createIfNotExists=false`.** DataHub defaults the v3 aspect write to CREATE, which fails once the aspect exists, and every write here is a read-modify-write. The parameter now forces UPSERT.

**The Rest.li `ingestProposal` sent raw non-ASCII bytes in `GenericAspect.value`.** The field is typed as bytes and encoded Avro-style, admitting U+0000 through U+00FF only. A real GMS answers `HTTP 400: "..." is not a valid string representation of bytes`, so any description carrying a curly apostrophe, an em dash, or an accented name failed the write outright. `escapeNonASCII` now emits `\uXXXX` escapes, including surrogate pairs for supplementary-plane characters.

## Description updates through datahub_update

`datahub_update` with `what: description` or `what: column_description` took the new text from `value`, while the same tool schema exposes a `description` parameter for `what: query`, `incident`, and `structured_property`. Text sent as `description` left `value` empty, and the empty write was destructive: the editable field's `description` is `omitempty`, so the entry was rewritten without one and the column's existing text was gone, while the response reported `updated`.

Fixed upstream in txn2/mcp-datahub#194 and released in [v1.13.0](https://github.com/txn2/mcp-datahub/releases/tag/v1.13.0), taken here as a `go.mod` bump. The text now resolves from `value`, or from `description` when `value` is empty; a disagreement between the two is rejected; and an update carrying no text at all is refused instead of written. One behavior change follows from that: `what=description value=""` no longer clears a description.

The `datahub_update` tables in `docs/server/tools.md` and `docs/reference/tools-api.md` name `value` as the source of the description text.

## Why the tests were green through all of it

Every fake in `datahub_client_writer_test.go` answers the v3 `{"value": ...}` shape while the client under test speaks Rest.li, and none of them reject raw non-ASCII. A fake that models neither contract cannot fail on a defect in either.

`datahub_client_writer_restli_test.go` adds a `restliGMS` fake that stores what is written, serves it back in the Rest.li envelope, and refuses raw non-ASCII the way a real GMS does. Against it:

- Two column-description batches leave all five columns documented, and re-documenting a column replaces its text once rather than duplicating the entry.
- Descriptions carrying curly quotes, accented characters, and a supplementary-plane character round-trip.
- A tag add and a glossary-term add each preserve what the entity already carried.
- The tag read that feeds `resulting_state` and the rollback before-image returns the stored tags.
- `parseAspect` reads both envelopes and treats an absent, null, or empty aspect as no aspect.
- The v3 write carries `createIfNotExists=false`.

Each of these fails against the previous writer.

## Verification

`make verify` green: lint 0 issues, patch coverage 100% (49/49 changed lines, threshold 80), total coverage 91.0%, gosec, govulncheck, Semgrep, CodeQL, documentation gates, doc-check, dead-code, and the release dry-run.

Behavior was also confirmed against a real DataHub v1.6.0 GMS. Two column-description batches of three and two: before the change the server held two columns, after it holds five. The non-ASCII write returns `HTTP 400` before and succeeds after. A column documented by one `datahub_update` call read back as `{"fieldPath": "order_id"}` after a second call whose text went to `description`.

## Note on the OpenAPI v3 path

Nothing in this repo can select the v3 API today; there is no configuration surface for the DataHub client's `APIVersion`. The v3 branches are corrected here but stay unreachable until that surface exists.
