### PR TITLE
Resolve database config overrides on read instead of caching them per process

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Each feature links to its full documentation.
 | [Session externalization](https://mcp-data-platform.txn2.com/server/session-externalization/) | PostgreSQL-backed sessions for zero-downtime restarts, horizontal scaling, and live tool-inventory updates |
 | [Explicit session handles](https://mcp-data-platform.txn2.com/server/configuration/#explicit-session-handles) | `platform_info` mints a `session_id` the agent threads on every call, making orientation unskippable and readying the platform for the sessionless MCP 2026-07-28 protocol |
 | [Multi-provider](https://mcp-data-platform.txn2.com/server/multi-provider/) | Multiple instances of each service behind one endpoint, with isolated failure domains |
-| [Operating modes](https://mcp-data-platform.txn2.com/server/operating-modes/) | Standalone (no database) or file + database with hot-reloaded config overrides |
+| [Operating modes](https://mcp-data-platform.txn2.com/server/operating-modes/) | Standalone (no database) or file + database with live config overrides resolved per read |
 | [Deployment shapes](https://mcp-data-platform.txn2.com/server/deployment-shapes/) | Which backends you need: the semantic stack for cross-enrichment, PostgreSQL alone for the gateways and knowledge layer, or both |
 | [Email notifications](https://mcp-data-platform.txn2.com/server/notifications/) | Branded emails for shares and feedback: admin-configured SMTP, per-user preferences (immediate, daily digest, or off), durable queue with retries |
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -453,7 +453,7 @@ Setting `dsn` enables audit logging, knowledge capture, session externalization,
 
 ## Config Store
 
-When a database is available (`database.dsn` is set), individual config entries in the `config_entries` table override file defaults for whitelisted keys. Changes via the admin API take effect immediately (hot-reload) without restart. Deleting a database entry restores the file default.
+When a database is available (`database.dsn` is set), individual config entries in the `config_entries` table override file defaults for whitelisted keys. The store is the authority: every read resolves the key from it and falls back to the file value when no row exists, so a change via the admin API is in force on every replica as soon as it commits, without restart. Deleting a database entry restores the file default everywhere on the next read. If the store cannot be read, the file-config value is used.
 
 **Whitelisted keys (phase 1):** `server.description`, `server.agent_instructions`
 

--- a/docs/server/admin-api.md
+++ b/docs/server/admin-api.md
@@ -539,7 +539,7 @@ Returns a single config entry by key. Returns `404 Not Found` if the key has no 
 PUT /api/v1/admin/config/entries/{key}
 ```
 
-Sets a config entry for a whitelisted key. The change takes effect immediately (hot-reload) without restart. Requires a database connection. Returns `400 Bad Request` for non-whitelisted keys and `409 Conflict` when no database is configured.
+Sets a config entry for a whitelisted key. The change takes effect immediately on every replica, without restart: the platform resolves these keys from the store on each read rather than caching them per process. Requires a database connection. Returns `400 Bad Request` for non-whitelisted keys and `409 Conflict` when no database is configured.
 
 **Whitelisted keys (phase 1):** `server.description`, `server.agent_instructions`
 

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -380,7 +380,11 @@ database:
 
 ## Config Store
 
-When a database is available (`database.dsn` is set), the platform uses a granular key/value config store. Individual config entries in the `config_entries` table override file defaults for whitelisted keys. Changes made via the admin API take effect immediately (hot-reload) without restart. Deleting a database entry restores the file default for that key.
+When a database is available (`database.dsn` is set), the platform uses a granular key/value config store. Individual config entries in the `config_entries` table override file defaults for whitelisted keys.
+
+The store is the authority for these keys: nothing is copied into memory at startup and nothing is patched in place on a write. Every read resolves the key from the store and falls back to the file value when no row exists. A change made through the admin API is therefore in force on every replica as soon as it commits, with no restart and no cross-replica notification, and deleting a row restores the file default everywhere on the next read.
+
+If the store cannot be read, the file-config value is used. A database outage degrades to the YAML the operator shipped rather than to an empty value, so agent instructions and deny patterns survive it.
 
 **Whitelisted keys (phase 1):**
 

--- a/internal/apidocs/docs.go
+++ b/internal/apidocs/docs.go
@@ -2777,7 +2777,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Creates or updates a database-backed config override entry and hot-reloads it into the live config.",
+                "description": "Creates or updates a database-backed config override entry. The stored value is authoritative and is in force on every replica from the next read.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2836,7 +2836,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Removes a database-backed config override entry, reverting the live config to the file default if one exists.",
+                "description": "Removes a database-backed config override entry. Subsequent reads on every replica fall through to the file-config default.",
                 "produces": [
                     "application/json"
                 ],

--- a/internal/apidocs/swagger.json
+++ b/internal/apidocs/swagger.json
@@ -2771,7 +2771,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Creates or updates a database-backed config override entry and hot-reloads it into the live config.",
+                "description": "Creates or updates a database-backed config override entry. The stored value is authoritative and is in force on every replica from the next read.",
                 "consumes": [
                     "application/json"
                 ],
@@ -2830,7 +2830,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Removes a database-backed config override entry, reverting the live config to the file default if one exists.",
+                "description": "Removes a database-backed config override entry. Subsequent reads on every replica fall through to the file-config default.",
                 "produces": [
                     "application/json"
                 ],

--- a/internal/apidocs/swagger.yaml
+++ b/internal/apidocs/swagger.yaml
@@ -5894,8 +5894,8 @@ paths:
       - Config
   /admin/config/entries/{key}:
     delete:
-      description: Removes a database-backed config override entry, reverting the
-        live config to the file default if one exists.
+      description: Removes a database-backed config override entry. Subsequent reads
+        on every replica fall through to the file-config default.
       parameters:
       - description: Config entry key
         in: path
@@ -5957,8 +5957,9 @@ paths:
     put:
       consumes:
       - application/json
-      description: Creates or updates a database-backed config override entry and
-        hot-reloads it into the live config.
+      description: Creates or updates a database-backed config override entry. The
+        stored value is authoritative and is in force on every replica from the next
+        read.
       parameters:
       - description: Config entry key
         in: path

--- a/internal/platform/promptlayer/promptlayer.go
+++ b/internal/platform/promptlayer/promptlayer.go
@@ -76,10 +76,14 @@ type Config struct {
 	// PromptsDir is the directory the tuning prompt manager loads file prompts
 	// from (empty is valid: the manager loads nothing).
 	PromptsDir string
-	// ServerName / ServerDescription title and seed the auto-generated
-	// platform-overview prompt (an empty description skips it).
-	ServerName        string
-	ServerDescription string
+	// ServerName titles the auto-generated platform-overview prompt.
+	ServerName string
+	// ServerDescription supplies that prompt's body text. It is a function
+	// because the description is admin-editable and database-backed, so the
+	// text must be resolved when the prompt is served rather than baked in
+	// at registration. Nil skips the prompt entirely; the caller passes nil
+	// when no description exists and none can appear later.
+	ServerDescription func(ctx context.Context) string
 	// AdminPersona is the persona name that grants admin authority over prompts
 	// at every scope; matched against the caller's persona in each command.
 	AdminPersona string
@@ -107,7 +111,7 @@ type Handle struct {
 	registry      ToolkitRegistry
 
 	serverName        string
-	serverDescription string
+	serverDescription func(ctx context.Context) string
 	adminPersona      string
 	operatorPrompts   []PromptSpec
 	builtinPrompts    map[string]bool

--- a/internal/platform/promptlayer/register.go
+++ b/internal/platform/promptlayer/register.go
@@ -71,14 +71,16 @@ func (h *Handle) RegisterPlatformPrompts(server *mcp.Server) {
 	h.registerDatabasePrompts()
 }
 
-// registerAutoPrompt registers the auto-generated "platform-overview" prompt when
-// the server description is non-empty. It is skipped if an operator-configured
-// prompt already uses the name "platform-overview".
+// registerAutoPrompt registers the auto-generated "platform-overview" prompt
+// when a server description resolver is configured. It is skipped if an
+// operator-configured prompt already uses the name "platform-overview".
 //
-// The content is built dynamically based on enabled toolkits, listing what the
-// user can do with this platform.
+// The content is built per request, not at registration: both the description
+// (admin-editable, database-backed) and the toolkit capability bullets are
+// resolved when the prompt is served, so an operator's edit is reflected in
+// the next prompts/get on every replica.
 func (h *Handle) registerAutoPrompt(server *mcp.Server) {
-	if h.serverDescription == "" {
+	if h.serverDescription == nil {
 		return
 	}
 
@@ -87,14 +89,12 @@ func (h *Handle) registerAutoPrompt(server *mcp.Server) {
 		return
 	}
 
-	content := h.buildDynamicOverviewContent()
-
 	server.AddPrompt(&mcp.Prompt{
 		Name:        autoPromptName,
 		Title:       h.serverName,
 		Description: "Overview of this data platform — what it covers and how to use it",
-	}, func(_ context.Context, _ *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
-		return buildPromptResult(content), nil
+	}, func(ctx context.Context, _ *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		return buildPromptResult(h.buildDynamicOverviewContent(ctx)), nil
 	})
 
 	// platform-overview is auto-invoked; it is not included in promptInfos
@@ -102,11 +102,17 @@ func (h *Handle) registerAutoPrompt(server *mcp.Server) {
 }
 
 // buildDynamicOverviewContent builds the platform overview content dynamically
-// based on the server description and enabled toolkits.
-func (h *Handle) buildDynamicOverviewContent() string {
+// from the server description in force for ctx and the enabled toolkits. A
+// description that resolves empty is omitted rather than written as a blank
+// leading paragraph, so the overview still lists capabilities.
+func (h *Handle) buildDynamicOverviewContent(ctx context.Context) string {
 	var b strings.Builder
-	b.WriteString(h.serverDescription)
-	b.WriteString("\n\n")
+	if h.serverDescription != nil {
+		if desc := h.serverDescription(ctx); desc != "" {
+			b.WriteString(desc)
+			b.WriteString("\n\n")
+		}
+	}
 
 	capabilities := h.collectCapabilityBullets()
 	if len(capabilities) > 0 {

--- a/internal/platform/promptlayer/register_test.go
+++ b/internal/platform/promptlayer/register_test.go
@@ -15,15 +15,27 @@ import (
 
 // newRegisterHandle builds a Handle for the static/workflow registration path:
 // no store, the given toolkit registry, server name/description, and operator
-// prompt specs.
+// prompt specs. An empty serverDesc becomes a nil resolver, mirroring how the
+// platform composes the handle when no description exists and none can be
+// authored later.
 func newRegisterHandle(serverName, serverDesc string, operator []PromptSpec, reg ToolkitRegistry) *Handle {
+	var describe func(context.Context) string
+	if serverDesc != "" {
+		describe = func(context.Context) string { return serverDesc }
+	}
+	return newRegisterHandleFunc(serverName, describe, operator, reg)
+}
+
+// newRegisterHandleFunc is newRegisterHandle with the description resolver
+// supplied directly, for tests that vary what it returns between calls.
+func newRegisterHandleFunc(serverName string, describe func(context.Context) string, operator []PromptSpec, reg ToolkitRegistry) *Handle {
 	if reg == nil {
 		reg = registry.NewRegistry()
 	}
 	return &Handle{
 		registry:          reg,
 		serverName:        serverName,
-		serverDescription: serverDesc,
+		serverDescription: describe,
 		operatorPrompts:   operator,
 	}
 }
@@ -306,7 +318,7 @@ func TestDynamicOverviewContentWithToolkits(t *testing.T) {
 
 	h := newRegisterHandle("Test Platform", "Test platform for analytics.", nil, reg)
 
-	content := h.buildDynamicOverviewContent()
+	content := h.buildDynamicOverviewContent(context.Background())
 
 	assert.Contains(t, content, "Test platform for analytics.")
 	assert.Contains(t, content, "Explore available data")
@@ -580,4 +592,39 @@ func promptNames(prompts []*mcp.Prompt) []string {
 		names = append(names, p.Name)
 	}
 	return names
+}
+
+// TestRegisterAutoPrompt_ResolvesDescriptionPerRequest guards the staleness the
+// old design baked in: the overview text was built once at registration, so an
+// operator's later edit never reached the prompt, and a description authored
+// after startup produced no prompt at all.
+func TestRegisterAutoPrompt_ResolvesDescriptionPerRequest(t *testing.T) {
+	current := ""
+	h := newRegisterHandleFunc("My Platform", func(context.Context) string { return current }, nil, nil)
+
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+	h.registerAutoPrompt(mcpServer)
+
+	session, cleanup := connectTestClient(t, mcpServer)
+	defer cleanup()
+
+	ctx := context.Background()
+	get := func() string {
+		resp, err := session.GetPrompt(ctx, &mcp.GetPromptParams{Name: autoPromptName})
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.Messages)
+		textContent, ok := resp.Messages[0].Content.(*mcp.TextContent)
+		require.True(t, ok)
+		return textContent.Text
+	}
+
+	// Registered despite an empty description, and serving without a blank
+	// leading paragraph.
+	first := get()
+	assert.NotContains(t, first, "Covers all analytics data.")
+	assert.False(t, strings.HasPrefix(first, "\n"), "empty description must not leave a blank lead")
+
+	// The operator authors one; the very next read carries it.
+	current = "Covers all analytics data."
+	assert.Contains(t, get(), "Covers all analytics data.")
 }

--- a/pkg/admin/config_handler.go
+++ b/pkg/admin/config_handler.go
@@ -23,7 +23,7 @@ const defaultChangelogLimit = 50
 // other paginated store applies.
 const maxChangelogLimit = 200
 
-// Config key aliases for whitelisted, hot-reloadable platform settings.
+// Config key aliases for the whitelisted, database-overridable settings.
 // Source of truth lives in pkg/platform — these are local references so
 // the admin package depends on the same canonical wire-protocol keys
 // the platform reads (a rename on one side without the other would
@@ -186,8 +186,15 @@ func configToMap(v any) (map[string]any, error) {
 // @Security     ApiKeyAuth
 // @Security     BearerAuth
 // @Router       /admin/config [get]
-func (h *Handler) getConfig(w http.ResponseWriter, _ *http.Request) {
-	configMap, err := configToMap(h.deps.Config)
+func (h *Handler) getConfig(w http.ResponseWriter, r *http.Request) {
+	if h.deps.Config == nil {
+		writeError(w, http.StatusInternalServerError, "no config available")
+		return
+	}
+	// Serialized from the effective config, not the file config: the
+	// overridable keys live in the store, and rendering the YAML values here
+	// would hide every override an operator has authored.
+	configMap, err := configToMap(h.deps.Config.EffectiveCopy(r.Context()))
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to process config")
 		return
@@ -241,7 +248,10 @@ func (h *Handler) exportConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	yamlBytes, err := yaml.Marshal(h.deps.Config)
+	// Exported from the effective config so a downloaded platform.yaml
+	// carries the operator's stored overrides rather than the pre-override
+	// file values.
+	yamlBytes, err := yaml.Marshal(h.deps.Config.EffectiveCopy(r.Context()))
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to marshal config")
 		return
@@ -414,7 +424,7 @@ type setConfigEntryRequest struct {
 // setConfigEntry handles PUT /api/v1/admin/config/entries/{key}.
 //
 // @Summary      Set config entry
-// @Description  Creates or updates a database-backed config override entry and hot-reloads it into the live config.
+// @Description  Creates or updates a database-backed config override entry. The stored value is authoritative and is in force on every replica from the next read.
 // @Tags         Config
 // @Accept       json
 // @Produce      json
@@ -446,8 +456,9 @@ func (h *Handler) setConfigEntry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Hot-reload: apply to live config.
-	h.deps.Config.ApplyConfigEntry(key, req.Value)
+	// The store is the authority. Nothing is applied to an in-memory copy
+	// here: the platform resolves this key from the store on every read, so
+	// the write is live for every replica the moment it commits.
 
 	// Return the stored entry.
 	entry, err := h.deps.ConfigStore.Get(r.Context(), key)
@@ -461,7 +472,7 @@ func (h *Handler) setConfigEntry(w http.ResponseWriter, r *http.Request) {
 // deleteConfigEntry handles DELETE /api/v1/admin/config/entries/{key}.
 //
 // @Summary      Delete config entry
-// @Description  Removes a database-backed config override entry, reverting the live config to the file default if one exists.
+// @Description  Removes a database-backed config override entry. Subsequent reads on every replica fall through to the file-config default.
 // @Tags         Config
 // @Produce      json
 // @Param        key  path  string  true  "Config entry key"
@@ -490,13 +501,8 @@ func (h *Handler) deleteConfigEntry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Revert to file default if one exists; otherwise clear the live
-	// override (an empty value tells ApplyConfigEntry to remove it).
-	if fileVal, ok := h.deps.FileDefaults[key]; ok {
-		h.deps.Config.ApplyConfigEntry(key, fileVal)
-	} else {
-		h.deps.Config.ApplyConfigEntry(key, "")
-	}
+	// Removing the row is the whole revert. With the override gone, every
+	// replica's next read falls through to the file-config default.
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/pkg/admin/config_handler_test.go
+++ b/pkg/admin/config_handler_test.go
@@ -289,6 +289,7 @@ func TestSetConfigEntry(t *testing.T) {
 	t.Run("sets whitelisted key", func(t *testing.T) {
 		cs := &mockConfigStore{mode: "database"}
 		cfg := testConfig()
+		cfg.BindOverrideStore(cs)
 		h := NewHandler(Deps{ConfigStore: cs, Config: cfg}, nil)
 
 		body := `{"value":"My Platform"}`
@@ -299,8 +300,9 @@ func TestSetConfigEntry(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, 1, cs.setCalls)
-		// Verify hot-reload applied
-		assert.Equal(t, "My Platform", cfg.Server.Description)
+		// The saved value is what every replica now reads: the platform
+		// resolves the key from the store rather than from a local copy.
+		assert.Equal(t, "My Platform", cfg.ServerDescription(context.Background()))
 	})
 
 	t.Run("rejects non-whitelisted key", func(t *testing.T) {
@@ -339,7 +341,8 @@ func TestDeleteConfigEntry(t *testing.T) {
 			},
 		}
 		cfg := testConfig()
-		cfg.Server.Description = "overridden"
+		cfg.Server.Description = "file-default"
+		cfg.BindOverrideStore(cs)
 		h := NewHandler(Deps{
 			ConfigStore:  cs,
 			Config:       cfg,
@@ -352,8 +355,9 @@ func TestDeleteConfigEntry(t *testing.T) {
 		h.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusNoContent, w.Code)
-		// Should revert to file default
-		assert.Equal(t, "file-default", cfg.Server.Description)
+		// Removing the row is the revert: the next read falls through to
+		// the file default with no in-memory bookkeeping.
+		assert.Equal(t, "file-default", cfg.ServerDescription(context.Background()))
 	})
 
 	t.Run("returns 404 for missing entry", func(t *testing.T) {
@@ -807,6 +811,7 @@ func TestSetConfigEntry_ToolDescriptionOverride(t *testing.T) {
 	makeHandler := func() (*Handler, *platform.Config, *mockConfigStore) {
 		cs := &mockConfigStore{mode: "database"}
 		cfg := testConfig()
+		cfg.BindOverrideStore(cs)
 		reg := &mockToolkitRegistry{
 			allResult: []mockToolkit{
 				{kind: "trino", name: "prod", connection: "prod-trino", tools: []string{"trino_query"}},
@@ -816,7 +821,7 @@ func TestSetConfigEntry_ToolDescriptionOverride(t *testing.T) {
 		return h, cfg, cs
 	}
 
-	t.Run("accepts tool.<known>.description and applies hot-reload", func(t *testing.T) {
+	t.Run("accepts tool.<known>.description and serves it on the next read", func(t *testing.T) {
 		h, cfg, cs := makeHandler()
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodPut,
 			"/api/v1/admin/config/entries/tool.trino_query.description",
@@ -827,8 +832,8 @@ func TestSetConfigEntry_ToolDescriptionOverride(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, 1, cs.setCalls)
-		require.NotNil(t, cfg.Tools.DescriptionOverrides)
-		assert.Equal(t, "custom desc", cfg.Tools.DescriptionOverrides["trino_query"])
+		assert.Equal(t, "custom desc",
+			cfg.ToolDescriptionOverridesSnapshot(context.Background())["trino_query"])
 	})
 
 	t.Run("rejects tool.<unknown>.description", func(t *testing.T) {
@@ -863,6 +868,7 @@ func TestSetConfigEntry_ToolDescriptionOverride(t *testing.T) {
 		// The whitelist must still accept their description-override keys.
 		cs := &mockConfigStore{mode: "database"}
 		cfg := testConfig()
+		cfg.BindOverrideStore(cs)
 		h := NewHandler(Deps{
 			ConfigStore: cs,
 			Config:      cfg,
@@ -881,7 +887,8 @@ func TestSetConfigEntry_ToolDescriptionOverride(t *testing.T) {
 		h.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, "custom", cfg.Tools.DescriptionOverrides["platform_info"])
+		assert.Equal(t, "custom",
+			cfg.ToolDescriptionOverridesSnapshot(context.Background())["platform_info"])
 	})
 }
 
@@ -893,7 +900,7 @@ func TestDeleteConfigEntry_ToolDescriptionOverride(t *testing.T) {
 		},
 	}
 	cfg := testConfig()
-	cfg.Tools.DescriptionOverrides = map[string]string{"trino_query": "old"}
+	cfg.BindOverrideStore(cs)
 	reg := &mockToolkitRegistry{
 		allResult: []mockToolkit{
 			{kind: "trino", name: "prod", connection: "prod-trino", tools: []string{"trino_query"}},
@@ -908,8 +915,8 @@ func TestDeleteConfigEntry_ToolDescriptionOverride(t *testing.T) {
 	h.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNoContent, w.Code)
-	_, exists := cfg.Tools.DescriptionOverrides["trino_query"]
-	assert.False(t, exists, "override should be removed from live config after delete")
+	_, exists := cfg.ToolDescriptionOverridesSnapshot(context.Background())["trino_query"]
+	assert.False(t, exists, "override should be gone from the next read after delete")
 }
 
 func TestExtractToolNameFromDescriptionKey(t *testing.T) {

--- a/pkg/admin/system.go
+++ b/pkg/admin/system.go
@@ -50,7 +50,7 @@ type systemFeatures struct {
 // @Security     ApiKeyAuth
 // @Security     BearerAuth
 // @Router       /admin/system/info [get]
-func (h *Handler) getSystemInfo(w http.ResponseWriter, _ *http.Request) {
+func (h *Handler) getSystemInfo(w http.ResponseWriter, r *http.Request) {
 	cfg := h.deps.Config
 	resp := systemInfoResponse{
 		Version:    mcpserver.Version,
@@ -60,7 +60,7 @@ func (h *Handler) getSystemInfo(w http.ResponseWriter, _ *http.Request) {
 	}
 	if cfg != nil {
 		resp.Name = cfg.Server.Name
-		resp.Description = cfg.Server.Description
+		resp.Description = cfg.ServerDescription(r.Context())
 		resp.Transport = cfg.Server.Transport
 		resp.PortalTitle = cfg.Portal.Title
 		resp.PortalLogo = cfg.Portal.Logo
@@ -152,11 +152,10 @@ func (h *Handler) listTools(w http.ResponseWriter, r *http.Request) {
 
 	var allow, deny []string
 	if h.deps.Config != nil {
-		// Snapshot via accessors — tools.deny is mutated at runtime by
-		// the visibility endpoint and would otherwise race the iteration
-		// inside IsToolVisible.
+		// Resolved per request: tools.deny is admin-editable and lives in
+		// the config store, so a value read once would go stale.
 		allow = h.deps.Config.ToolsAllowSnapshot()
-		deny = h.deps.Config.ToolsDenySnapshot()
+		deny = h.deps.Config.ToolsDenySnapshot(r.Context())
 	}
 
 	tools := h.collectToolkitTools(titleMap, allow, deny)
@@ -291,11 +290,11 @@ type connectionListResponse struct {
 // @Security     ApiKeyAuth
 // @Security     BearerAuth
 // @Router       /admin/connections [get]
-func (h *Handler) listConnections(w http.ResponseWriter, _ *http.Request) {
+func (h *Handler) listConnections(w http.ResponseWriter, r *http.Request) {
 	var allow, deny []string
 	if h.deps.Config != nil {
 		allow = h.deps.Config.ToolsAllowSnapshot()
-		deny = h.deps.Config.ToolsDenySnapshot()
+		deny = h.deps.Config.ToolsDenySnapshot(r.Context())
 	}
 
 	var conns []connectionInfo

--- a/pkg/admin/tools_detail.go
+++ b/pkg/admin/tools_detail.go
@@ -169,7 +169,7 @@ func (h *Handler) getToolDetail(w http.ResponseWriter, r *http.Request) {
 	}
 	h.fillToolPersonaMatrix(r.Context(), name, &detail)
 	if h.deps.Config != nil {
-		if pattern, hidden := matchGlobalDeny(h.deps.Config.ToolsDenySnapshot(), name); hidden {
+		if pattern, hidden := matchGlobalDeny(h.deps.Config.ToolsDenySnapshot(r.Context()), name); hidden {
 			detail.HiddenByGlobalDeny = true
 			detail.GlobalDenyPattern = pattern
 		}
@@ -267,8 +267,8 @@ func (h *Handler) fillDescriptionOverride(ctx context.Context, name string, d *T
 	if err != nil || entry == nil {
 		return
 	}
-	// An entry with empty value is treated by ApplyConfigEntry as a
-	// deletion — the live override is gone, so don't claim it's
+	// An empty value resolves as "no override" — the tool keeps whatever
+	// description it would otherwise carry — so don't claim it is
 	// overridden in the UI just because a stale row exists.
 	if entry.Value == "" {
 		return
@@ -333,12 +333,12 @@ func toolDescriptionConfigKey(toolName string) string {
 
 // toolsDenyConfigKey is the canonical key for the platform-wide tool
 // kill-switch. The value stored in config_entries is a JSON-encoded
-// []string. Centralized so the live-config hot-reload path and the
-// admin UI agree.
+// []string. Centralized so the tools/list read path and the admin UI
+// agree on where the kill-switch lives.
 //
 // CONCURRENCY: any code path that mutates this entry must hold
 // Handler.toolsDenyMu across the read-modify-write critical section
-// (load → modify → save → ApplyConfigEntry). The single mutator today
+// (load → modify → save). The single mutator today
 // is setToolVisibility; future bulk-hide / YAML-import / similar
 // handlers must participate in the same lock or they recreate the
 // lost-update race fixed in #343.
@@ -402,9 +402,12 @@ func (h *Handler) setToolVisibility(w http.ResponseWriter, r *http.Request) {
 // Splitting this out of setToolVisibility keeps the response write
 // (writeJSON) outside the lock — a slow HTTP client must not block
 // other admins from toggling visibility. The lock covers only the
-// load → modify → save → ApplyConfigEntry sequence, which is the
-// full atomicity boundary needed to defeat the lost-update race
-// fixed in #343.
+// load → modify → save sequence, which is the full atomicity boundary
+// needed to defeat the lost-update race fixed in #343.
+//
+// The lock is per-process, so it serializes admins on one replica only.
+// Two replicas writing at the same instant can still lose an update; the
+// durable fix is a conditional write in the store, tracked separately.
 func (h *Handler) applyToolVisibilityChange(r *http.Request, name string, hidden bool) (deny []string, status int, errMsg string) {
 	h.toolsDenyMu.Lock()
 	defer h.toolsDenyMu.Unlock()
@@ -423,9 +426,8 @@ func (h *Handler) applyToolVisibilityChange(r *http.Request, name string, hidden
 	if err := h.deps.ConfigStore.Set(r.Context(), toolsDenyConfigKey, string(encoded), extractAuthor(r)); err != nil {
 		return nil, http.StatusInternalServerError, "failed to save tools.deny"
 	}
-	if h.deps.Config != nil {
-		h.deps.Config.ApplyConfigEntry(toolsDenyConfigKey, string(encoded))
-	}
+	// No in-memory apply: tools/list resolves tools.deny from the store on
+	// every call, so the saved value is in force everywhere immediately.
 	return updated, http.StatusOK, ""
 }
 
@@ -468,7 +470,7 @@ func (h *Handler) loadCurrentToolsDeny(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("loading tools.deny: %w", err)
 	}
 	if h.deps.Config != nil {
-		return h.deps.Config.ToolsDenySnapshot(), nil
+		return h.deps.Config.ToolsDenySnapshot(ctx), nil
 	}
 	return nil, nil
 }

--- a/pkg/admin/tools_detail_test.go
+++ b/pkg/admin/tools_detail_test.go
@@ -412,7 +412,6 @@ func TestUpdateDenyList(t *testing.T) {
 func TestSetToolVisibility(t *testing.T) {
 	makeHandler := func(initial []string) (*Handler, *mockConfigStore, *platform.Config) {
 		cfg := testConfig()
-		cfg.Tools.Deny = append([]string(nil), initial...)
 		cs := &mockConfigStore{mode: "database"}
 		if len(initial) > 0 {
 			buf, _ := json.Marshal(initial)
@@ -420,6 +419,7 @@ func TestSetToolVisibility(t *testing.T) {
 				"tools.deny": {Key: "tools.deny", Value: string(buf)},
 			}
 		}
+		cfg.BindOverrideStore(cs)
 		reg := &mockToolkitRegistry{
 			allResult: []mockToolkit{
 				{kind: "trino", name: "prod", connection: "prod-trino", tools: []string{"trino_query", "trino_execute"}},
@@ -434,7 +434,7 @@ func TestSetToolVisibility(t *testing.T) {
 		return h, cs, cfg
 	}
 
-	t.Run("hidden=true adds to deny list and applies live config", func(t *testing.T) {
+	t.Run("hidden=true adds to deny list and is served on the next read", func(t *testing.T) {
 		h, cs, cfg := makeHandler(nil)
 		body := `{"hidden":true}`
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodPut,
@@ -447,7 +447,7 @@ func TestSetToolVisibility(t *testing.T) {
 		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
 		assert.True(t, resp.Hidden)
 		assert.Equal(t, []string{"trino_query"}, resp.Deny)
-		assert.Equal(t, []string{"trino_query"}, cfg.Tools.Deny)
+		assert.Equal(t, []string{"trino_query"}, cfg.ToolsDenySnapshot(context.Background()))
 
 		stored := cs.entries["tools.deny"]
 		require.NotNil(t, stored)
@@ -469,7 +469,7 @@ func TestSetToolVisibility(t *testing.T) {
 		require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
 		assert.False(t, resp.Hidden)
 		assert.Equal(t, []string{"trino_execute"}, resp.Deny)
-		assert.Equal(t, []string{"trino_execute"}, cfg.Tools.Deny)
+		assert.Equal(t, []string{"trino_execute"}, cfg.ToolsDenySnapshot(context.Background()))
 	})
 
 	t.Run("404 for unknown tool", func(t *testing.T) {

--- a/pkg/middleware/mcp_descriptions.go
+++ b/pkg/middleware/mcp_descriptions.go
@@ -39,26 +39,17 @@ func MergedDescriptionOverrides(configOverrides map[string]string) map[string]st
 	return merged
 }
 
-// MCPDescriptionOverrideMiddleware creates MCP protocol-level middleware that
-// replaces tool descriptions in tools/list responses. This is used to inject
-// workflow guidance (e.g., "call search first") into tool descriptions
+// MCPDescriptionOverrideMiddlewareDynamic creates MCP protocol-level middleware
+// that replaces tool descriptions in tools/list responses. This is used to
+// inject workflow guidance (e.g., "call search first") into tool descriptions
 // that agents see when discovering available tools.
 //
-// Deprecated: prefer MCPDescriptionOverrideMiddlewareDynamic so admin-API
-// edits to tool.<name>.description take effect on the next tools/list call
-// instead of requiring a platform restart.
-func MCPDescriptionOverrideMiddleware(overrides map[string]string) mcp.Middleware {
-	return MCPDescriptionOverrideMiddlewareDynamic(func() map[string]string {
-		return overrides
-	})
-}
-
-// MCPDescriptionOverrideMiddlewareDynamic is a hot-reloading variant that
-// re-resolves the override map on every tools/list call. The getter is
-// expected to merge built-in defaults with the live config overrides.
-// Used by Platform so per-tool description overrides authored from the
-// admin portal take effect immediately.
-func MCPDescriptionOverrideMiddlewareDynamic(getOverrides func() map[string]string) mcp.Middleware {
+// The override map is re-resolved on every tools/list call, against that
+// call's context, so per-tool descriptions authored from the admin portal take
+// effect on the next listing in every replica rather than at the next restart
+// of the one that served the edit. The getter is expected to merge built-in
+// defaults with the stored overrides.
+func MCPDescriptionOverrideMiddlewareDynamic(getOverrides func(ctx context.Context) map[string]string) mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
 			result, err := next(ctx, method, req)
@@ -68,7 +59,7 @@ func MCPDescriptionOverrideMiddlewareDynamic(getOverrides func() map[string]stri
 			if method != methodToolsList {
 				return result, nil
 			}
-			return applyDescriptionOverrides(getOverrides(), result), nil
+			return applyDescriptionOverrides(getOverrides(ctx), result), nil
 		}
 	}
 }

--- a/pkg/middleware/mcp_descriptions_test.go
+++ b/pkg/middleware/mcp_descriptions_test.go
@@ -71,7 +71,7 @@ func TestMCPDescriptionOverrideMiddleware(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mw := MCPDescriptionOverrideMiddleware(tt.overrides)
+			mw := MCPDescriptionOverrideMiddlewareDynamic(staticOverrides(tt.overrides))
 			handler := mw(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
 				return tt.nextResult, nil
 			})
@@ -90,7 +90,7 @@ func TestMCPDescriptionOverrideMiddleware(t *testing.T) {
 }
 
 func TestMCPDescriptionOverrideMiddleware_ErrorPassthrough(t *testing.T) {
-	mw := MCPDescriptionOverrideMiddleware(map[string]string{"trino_query": "overridden"})
+	mw := MCPDescriptionOverrideMiddlewareDynamic(staticOverrides(map[string]string{"trino_query": "overridden"}))
 	handler := mw(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
 		return nil, assert.AnError
 	})
@@ -133,7 +133,7 @@ func TestMCPDescriptionOverrideMiddlewareDynamic(t *testing.T) {
 	// as a successful save.
 	current := map[string]string{"trino_query": "v1"}
 
-	mw := MCPDescriptionOverrideMiddlewareDynamic(func() map[string]string {
+	mw := MCPDescriptionOverrideMiddlewareDynamic(func(context.Context) map[string]string {
 		return current
 	})
 	handler := mw(func(_ context.Context, _ string, _ mcp.Request) (mcp.Result, error) {
@@ -158,4 +158,10 @@ func TestMCPDescriptionOverrideMiddlewareDynamic(t *testing.T) {
 	listResult, ok = result.(*mcp.ListToolsResult)
 	require.True(t, ok)
 	assert.Equal(t, "v2", listResult.Tools[0].Description)
+}
+
+// staticOverrides returns a getter that always yields the same map, for tests
+// that exercise the replacement rather than the re-resolution.
+func staticOverrides(m map[string]string) func(context.Context) map[string]string {
+	return func(context.Context) map[string]string { return m }
 }

--- a/pkg/middleware/mcp_visibility.go
+++ b/pkg/middleware/mcp_visibility.go
@@ -18,9 +18,15 @@ const (
 
 // ToolVisibilityConfig configures tool visibility filtering for tools/list responses.
 type ToolVisibilityConfig struct {
-	// GlobalAllow/GlobalDeny are static glob patterns from the config file.
+	// GlobalAllow holds static glob patterns from the config file.
 	GlobalAllow []string
-	GlobalDeny  []string
+
+	// ResolveGlobalDeny returns the deny globs in force for this request.
+	// It is a function rather than a slice because the deny list is
+	// admin-editable and database-backed: a value captured when the
+	// middleware was registered would ignore every later edit. Nil means
+	// nothing is denied globally.
+	ResolveGlobalDeny func(ctx context.Context) []string
 
 	// Authenticator resolves the caller's identity from the request context.
 	Authenticator Authenticator
@@ -64,16 +70,24 @@ func filterToolVisibility(ctx context.Context, cfg ToolVisibilityConfig, method 
 	}
 
 	roles := resolveRolesIfNeeded(ctx, cfg)
-	listResult.Tools = filterTools(ctx, listResult.Tools, cfg, roles)
+	// Resolved once per tools/list rather than once per tool: the deny list
+	// is one lookup, and every tool in the response must be judged against
+	// the same snapshot of it.
+	var deny []string
+	if cfg.ResolveGlobalDeny != nil {
+		deny = cfg.ResolveGlobalDeny(ctx)
+	}
+	listResult.Tools = filterTools(ctx, listResult.Tools, cfg, roles, deny)
 
 	return listResult, nil
 }
 
 // filterTools applies global and persona-based filtering to a tool list.
-func filterTools(ctx context.Context, tools []*mcp.Tool, cfg ToolVisibilityConfig, roles []string) []*mcp.Tool {
+// deny is the caller-resolved global deny list for this request.
+func filterTools(ctx context.Context, tools []*mcp.Tool, cfg ToolVisibilityConfig, roles, deny []string) []*mcp.Tool {
 	filtered := make([]*mcp.Tool, 0, len(tools))
 	for _, tool := range tools {
-		if !IsToolVisible(tool.Name, cfg.GlobalAllow, cfg.GlobalDeny) {
+		if !IsToolVisible(tool.Name, cfg.GlobalAllow, deny) {
 			continue
 		}
 		if roles != nil && cfg.IsToolAllowedForPersona != nil {

--- a/pkg/middleware/mcp_visibility_test.go
+++ b/pkg/middleware/mcp_visibility_test.go
@@ -224,7 +224,7 @@ func TestFilterToolVisibility(t *testing.T) {
 		result := &mcp.ListToolsResult{
 			Tools: makeTools(testAuditToolName, "s3_delete_object", "datahub_search"),
 		}
-		got, err := filterToolVisibility(context.Background(), ToolVisibilityConfig{GlobalDeny: []string{"s3_delete_*"}}, "tools/list", result)
+		got, err := filterToolVisibility(context.Background(), ToolVisibilityConfig{ResolveGlobalDeny: staticDeny("s3_delete_*")}, "tools/list", result)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -242,7 +242,7 @@ func TestFilterToolVisibility(t *testing.T) {
 		result := &mcp.ListToolsResult{
 			Tools: makeTools(testAuditToolName, "trino_delete_table", "datahub_search", "s3_list_objects"),
 		}
-		got, err := filterToolVisibility(context.Background(), ToolVisibilityConfig{GlobalAllow: []string{"trino_*"}, GlobalDeny: []string{"*_delete_*"}}, "tools/list", result)
+		got, err := filterToolVisibility(context.Background(), ToolVisibilityConfig{GlobalAllow: []string{"trino_*"}, ResolveGlobalDeny: staticDeny("*_delete_*")}, "tools/list", result)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -366,8 +366,8 @@ func TestFilterToolVisibility_PersonaFiltering(t *testing.T) {
 		}
 
 		cfg := ToolVisibilityConfig{
-			GlobalDeny:    []string{"*_delete*"},
-			Authenticator: &NoopAuthenticator{},
+			ResolveGlobalDeny: staticDeny("*_delete*"),
+			Authenticator:     &NoopAuthenticator{},
 			IsToolAllowedForPersona: func(_ context.Context, _ []string, toolName string) bool {
 				return toolName != "s3_list_objects"
 			},
@@ -406,4 +406,10 @@ func TestFilterToolVisibility_PersonaFiltering(t *testing.T) {
 		require.True(t, ok)
 		assert.Len(t, listResult.Tools, 2)
 	})
+}
+
+// staticDeny returns a ResolveGlobalDeny that always yields the given
+// patterns, for tests that do not exercise the resolution itself.
+func staticDeny(patterns ...string) func(context.Context) []string {
+	return func(context.Context) []string { return patterns }
 }

--- a/pkg/middleware/middleware_chain_test.go
+++ b/pkg/middleware/middleware_chain_test.go
@@ -1998,7 +1998,9 @@ func TestMiddlewareChain_ToolVisibility_DenyOnly(t *testing.T) {
 	}
 
 	// Deny s3_delete_* only
-	server.AddReceivingMiddleware(middleware.MCPToolVisibilityMiddleware(middleware.ToolVisibilityConfig{GlobalDeny: []string{"s3_delete_*"}}))
+	server.AddReceivingMiddleware(middleware.MCPToolVisibilityMiddleware(middleware.ToolVisibilityConfig{
+		ResolveGlobalDeny: func(context.Context) []string { return []string{"s3_delete_*"} },
+	}))
 
 	ctx := context.Background()
 	session, err := connectClientServer(ctx, server)
@@ -2383,7 +2385,7 @@ func TestDescriptionOverrides_ToolsList(t *testing.T) {
 
 	// Add description override middleware (uses built-in defaults)
 	overrides := middleware.MergedDescriptionOverrides(nil)
-	server.AddReceivingMiddleware(middleware.MCPDescriptionOverrideMiddleware(overrides))
+	server.AddReceivingMiddleware(middleware.MCPDescriptionOverrideMiddlewareDynamic(func(context.Context) map[string]string { return overrides }))
 
 	ctx := context.Background()
 	session, err := connectClientServer(ctx, server)

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -6,13 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"maps"
 	"net/http"
 	"os"
 	"reflect"
 	"regexp"
 	"strings"
-	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -133,11 +131,17 @@ type Config struct {
 	APIGateway           APIGatewayConfig    `yaml:"apigateway"`
 	Observability        ObservabilityConfig `yaml:"observability"`
 
-	// runtimeMu guards fields that can be mutated at runtime via the admin
-	// API (Tools.DescriptionOverrides, Tools.Deny). Other fields are
-	// loaded once from YAML and not protected here. Unexported so YAML
-	// marshaling ignores it.
-	runtimeMu sync.RWMutex
+	// overrides resolves the database-overridable settings (server
+	// description, agent instructions, tools.deny, per-tool description
+	// overrides) on every read. No field of this struct is mutated after
+	// load: an override lives in the store, never in a copy here, so
+	// replicas sharing one database cannot disagree. Nil means file config
+	// only.
+	//
+	// Held behind a pointer so Config itself carries no lock and stays
+	// copyable — the admin export builds a copy with the resolved values
+	// substituted. Unexported so YAML marshaling ignores it.
+	overrides *overrideBinding
 }
 
 // ConfigMeta holds meta-configuration controlling how the config file itself is
@@ -1893,99 +1897,6 @@ func applySessionDefaults(cfg *Config) {
 	if cfg.Sessions.CleanupInterval == 0 {
 		cfg.Sessions.CleanupInterval = defaultCleanupInterval
 	}
-}
-
-// ApplyConfigEntry updates a live config field for a whitelisted config entry key.
-//
-// In addition to the static keys, any key matching tool.<name>.description
-// is treated as a per-tool description override and written into
-// Tools.DescriptionOverrides. An empty value removes the override so the
-// tool reverts to its default (built-in or file-config) description.
-//
-// The "tools.deny" key carries a JSON-encoded []string. An empty/blank
-// value clears the deny list. A malformed JSON value is logged and
-// IGNORED — the existing live slice is left untouched so a corrupt
-// config_entries row can't silently open up tools that were supposed to
-// be hidden by the file config.
-//
-// Writes to the runtime-mutable Tools.* fields go through the runtimeMu
-// lock so concurrent reads (notably the description-override middleware
-// and tools.deny visibility checks) see consistent state.
-func (c *Config) ApplyConfigEntry(key, value string) {
-	switch key {
-	case cfgKeyServerDescription:
-		c.Server.Description = value
-		return
-	case cfgKeyServerAgentInstructions:
-		c.Server.AgentInstructions = value
-		return
-	case ConfigKeyToolsDeny:
-		deny, err := parseToolsDenyValue(value)
-		if err != nil {
-			slog.Warn("ignoring malformed tools.deny config entry; live deny list unchanged",
-				"error", err)
-			return
-		}
-		c.SetToolsDeny(deny)
-		return
-	}
-	if name, ok := toolDescriptionKey(key); ok {
-		c.SetToolDescriptionOverride(name, value)
-	}
-}
-
-// SetToolDescriptionOverride writes a single per-tool description override
-// under the runtime lock. An empty value removes the override.
-func (c *Config) SetToolDescriptionOverride(name, value string) {
-	c.runtimeMu.Lock()
-	defer c.runtimeMu.Unlock()
-	if c.Tools.DescriptionOverrides == nil {
-		c.Tools.DescriptionOverrides = make(map[string]string)
-	}
-	if value == "" {
-		delete(c.Tools.DescriptionOverrides, name)
-		return
-	}
-	c.Tools.DescriptionOverrides[name] = value
-}
-
-// ToolDescriptionOverridesSnapshot returns a shallow copy of the live
-// description overrides map. Callers may mutate the returned map without
-// affecting the live config.
-func (c *Config) ToolDescriptionOverridesSnapshot() map[string]string {
-	c.runtimeMu.RLock()
-	defer c.runtimeMu.RUnlock()
-	return maps.Clone(c.Tools.DescriptionOverrides)
-}
-
-// SetToolsDeny replaces the tools.deny slice atomically under the runtime lock.
-func (c *Config) SetToolsDeny(deny []string) {
-	c.runtimeMu.Lock()
-	defer c.runtimeMu.Unlock()
-	c.Tools.Deny = deny
-}
-
-// ToolsDenySnapshot returns a copy of the current tools.deny slice.
-// Callers may mutate the returned slice without affecting the live config.
-func (c *Config) ToolsDenySnapshot() []string {
-	c.runtimeMu.RLock()
-	defer c.runtimeMu.RUnlock()
-	if len(c.Tools.Deny) == 0 {
-		return nil
-	}
-	return append([]string(nil), c.Tools.Deny...)
-}
-
-// ToolsAllowSnapshot returns a copy of tools.allow. Currently allow is
-// not mutable at runtime, but callers should still go through this
-// accessor in case that changes.
-func (c *Config) ToolsAllowSnapshot() []string {
-	c.runtimeMu.RLock()
-	defer c.runtimeMu.RUnlock()
-	if len(c.Tools.Allow) == 0 {
-		return nil
-	}
-	return append([]string(nil), c.Tools.Allow...)
 }
 
 // parseToolsDenyValue decodes the JSON-encoded []string stored in the

--- a/pkg/platform/config_overrides.go
+++ b/pkg/platform/config_overrides.go
@@ -1,0 +1,182 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"maps"
+	"slices"
+	"sync"
+
+	"github.com/txn2/mcp-data-platform/pkg/configstore"
+)
+
+// overrideStore is the read half of configstore.Store that Config needs to
+// resolve database-backed overrides. Config depends on this narrowed shape
+// rather than the full store so it cannot write, and so a test double does
+// not have to implement Set/Delete/Changelog. Unexported deliberately:
+// callers pass any store satisfying it without naming it, and the platform's
+// public surface gains a behavior, not a type.
+type overrideStore interface {
+	Get(ctx context.Context, key string) (*configstore.Entry, error)
+	List(ctx context.Context) ([]configstore.Entry, error)
+}
+
+// overrideBinding holds the bound store behind its own lock, keeping Config
+// free of a mutex so it stays copyable.
+type overrideBinding struct {
+	mu    sync.RWMutex
+	store overrideStore
+}
+
+// BindOverrideStore installs the store consulted on every read of a
+// database-overridable setting. Passing nil unbinds it, which makes every
+// such read resolve to the file config.
+//
+// The store is the authority: nothing is copied into Config at bind time and
+// nothing is written back to it later, so two processes sharing one database
+// resolve the same value without any cross-process notification. Must be
+// called during setup, before the server begins handling requests.
+func (c *Config) BindOverrideStore(s overrideStore) {
+	if c.overrides == nil {
+		c.overrides = &overrideBinding{}
+	}
+	c.overrides.mu.Lock()
+	defer c.overrides.mu.Unlock()
+	c.overrides.store = s
+}
+
+// boundOverrides returns the bound store, or nil when none is bound.
+func (c *Config) boundOverrides() overrideStore {
+	if c.overrides == nil {
+		return nil
+	}
+	c.overrides.mu.RLock()
+	defer c.overrides.mu.RUnlock()
+	return c.overrides.store
+}
+
+// EffectiveCopy returns a copy of the config with every database-overridable
+// field replaced by the value in force for ctx. It exists for the admin
+// surfaces that serialize the whole config: without it they would render the
+// file values and silently omit the operator's stored overrides.
+//
+// The copy is shallow apart from the fields it replaces, so callers must treat
+// it as read-only.
+func (c *Config) EffectiveCopy(ctx context.Context) *Config {
+	out := *c
+	out.Server.Description = c.ServerDescription(ctx)
+	out.Server.AgentInstructions = c.ServerAgentInstructions(ctx)
+	out.Tools.Deny = c.ToolsDenySnapshot(ctx)
+	out.Tools.DescriptionOverrides = c.ToolDescriptionOverridesSnapshot(ctx)
+	return &out
+}
+
+// resolve returns the stored override for key. found is false when no store is
+// bound, no row exists, or the lookup fails.
+//
+// A failed lookup is deliberately indistinguishable from an absent row: both
+// fall back to the operator's file config. A database outage must not blank out
+// agent instructions or drop a deny pattern, so the failure mode is "the YAML
+// the operator shipped", never "empty".
+func (c *Config) resolve(ctx context.Context, key string) (value string, found bool) {
+	store := c.boundOverrides()
+	if store == nil {
+		return "", false
+	}
+	entry, err := store.Get(ctx, key)
+	if err != nil {
+		if !errors.Is(err, configstore.ErrNotFound) {
+			slog.WarnContext(ctx, "config override lookup failed; falling back to file config",
+				"key", key, "error", err)
+		}
+		return "", false
+	}
+	return entry.Value, true
+}
+
+// ServerDescription returns the effective server description: the stored
+// override when one exists, otherwise the file-config value.
+func (c *Config) ServerDescription(ctx context.Context) string {
+	if v, ok := c.resolve(ctx, ConfigKeyServerDescription); ok {
+		return v
+	}
+	return c.Server.Description
+}
+
+// ServerAgentInstructions returns the effective agent instructions: the stored
+// override when one exists, otherwise the file-config value.
+func (c *Config) ServerAgentInstructions(ctx context.Context) string {
+	if v, ok := c.resolve(ctx, ConfigKeyServerAgentInstructions); ok {
+		return v
+	}
+	return c.Server.AgentInstructions
+}
+
+// ToolsDenySnapshot returns the effective platform-wide tool deny patterns.
+// Callers may mutate the returned slice.
+//
+// A stored row wins over the file config even when it decodes to an empty
+// list: that is an operator who deliberately cleared the deny list, which is
+// not the same as having no override at all. A malformed row is ignored in
+// favor of the file config, so a corrupt value cannot silently un-hide tools
+// the YAML denies.
+func (c *Config) ToolsDenySnapshot(ctx context.Context) []string {
+	if v, ok := c.resolve(ctx, ConfigKeyToolsDeny); ok {
+		deny, err := parseToolsDenyValue(v)
+		if err == nil {
+			return deny
+		}
+		slog.WarnContext(ctx, "ignoring malformed tools.deny override; falling back to file config",
+			"error", err)
+	}
+	if len(c.Tools.Deny) == 0 {
+		return nil
+	}
+	return slices.Clone(c.Tools.Deny)
+}
+
+// ToolsAllowSnapshot returns a copy of tools.allow. Allow is file-only: there
+// is no config_entries key for it, so this is a plain copy of the loaded YAML.
+func (c *Config) ToolsAllowSnapshot() []string {
+	if len(c.Tools.Allow) == 0 {
+		return nil
+	}
+	return slices.Clone(c.Tools.Allow)
+}
+
+// ToolDescriptionOverridesSnapshot returns the effective per-tool description
+// overrides: the file-config map with every stored tool.<name>.description row
+// layered on top. Callers may mutate the returned map.
+//
+// A stored row with an empty value removes the entry, reverting that tool to
+// whatever description it would otherwise carry.
+func (c *Config) ToolDescriptionOverridesSnapshot(ctx context.Context) map[string]string {
+	merged := maps.Clone(c.Tools.DescriptionOverrides)
+
+	store := c.boundOverrides()
+	if store == nil {
+		return merged
+	}
+	entries, err := store.List(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "config override list failed; falling back to file config", "error", err)
+		return merged
+	}
+
+	for _, e := range entries {
+		name, ok := toolDescriptionKey(e.Key)
+		if !ok {
+			continue
+		}
+		if e.Value == "" {
+			delete(merged, name)
+			continue
+		}
+		if merged == nil {
+			merged = make(map[string]string)
+		}
+		merged[name] = e.Value
+	}
+	return merged
+}

--- a/pkg/platform/config_overrides_integration_test.go
+++ b/pkg/platform/config_overrides_integration_test.go
@@ -1,0 +1,145 @@
+package platform
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/configstore"
+)
+
+// newOverrideReplica assembles a Platform whose MCP server carries the real
+// visibility and description-override middleware, wired exactly as
+// finalizeSetup wires them, with cfg bound to the shared store.
+//
+// This is the point of the test: it exercises the production registration
+// path. A unit test calling Config.ToolsDenySnapshot directly would pass even
+// if platform.go handed the middleware a slice captured at startup, which is
+// the defect being fixed.
+func newOverrideReplica(t *testing.T, store *mutableOverrideStore, tools ...string) *Platform {
+	t.Helper()
+
+	cfg := &Config{}
+	cfg.BindOverrideStore(store)
+
+	p := &Platform{
+		config: cfg,
+		// A non-nil config store is what tells the registration path that
+		// overrides can be authored later; the bound override store is what
+		// actually resolves them.
+		configStore: configstore.NewFileStore(map[string]string{}),
+		mcpServer:   mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0.0"}, nil),
+	}
+
+	for _, name := range tools {
+		p.mcpServer.AddTool(
+			&mcp.Tool{
+				Name:        name,
+				Description: "original " + name,
+				InputSchema: &jsonschema.Schema{Type: "object"},
+			},
+			func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				return &mcp.CallToolResult{}, nil
+			},
+		)
+	}
+
+	p.addDescriptionOverrideMiddleware()
+	p.addToolVisibilityMiddleware()
+	return p
+}
+
+// listTools connects an in-memory client and returns name → description.
+func listTools(t *testing.T, p *Platform) map[string]string {
+	t.Helper()
+	ctx := context.Background()
+
+	t1, t2 := mcp.NewInMemoryTransports()
+	serverSession, err := p.mcpServer.Connect(ctx, t1, nil)
+	require.NoError(t, err)
+	defer func() { _ = serverSession.Close() }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0"}, nil)
+	clientSession, err := client.Connect(ctx, t2, nil)
+	require.NoError(t, err)
+	defer func() { _ = clientSession.Close() }()
+
+	resp, err := clientSession.ListTools(ctx, &mcp.ListToolsParams{})
+	require.NoError(t, err)
+
+	got := make(map[string]string, len(resp.Tools))
+	for _, tool := range resp.Tools {
+		got[tool.Name] = tool.Description
+	}
+	return got
+}
+
+// TestToolsListReflectsOverridesAcrossReplicas is the end-to-end regression
+// test for #1106.
+//
+// Two Platforms stand in for two replicas sharing one database. An admin edit
+// lands in the store (as the admin API's Set does) and both replicas must
+// serve it on their next tools/list — including the replica that never saw
+// the write.
+func TestToolsListReflectsOverridesAcrossReplicas(t *testing.T) {
+	shared := newMutableOverrideStore()
+
+	replicaA := newOverrideReplica(t, shared, "trino_query", "s3_delete_object")
+	replicaB := newOverrideReplica(t, shared, "trino_query", "s3_delete_object")
+
+	const authored = "operator authored description"
+
+	before := listTools(t, replicaB)
+	require.Contains(t, before, "s3_delete_object")
+	// trino_query carries a built-in description override, so the baseline is
+	// that default rather than the registered text. What matters is that it is
+	// not yet the operator's.
+	require.NotEmpty(t, before["trino_query"])
+	require.NotEqual(t, authored, before["trino_query"])
+
+	// Admin hides a tool and rewrites a description, served by replica A.
+	shared.set(ConfigKeyToolsDeny, `["s3_delete_object"]`)
+	shared.set("tool.trino_query.description", authored)
+
+	for name, p := range map[string]*Platform{"A": replicaA, "B": replicaB} {
+		got := listTools(t, p)
+		assert.NotContains(t, got, "s3_delete_object",
+			"replica %s still lists a tool the operator hid", name)
+		assert.Equal(t, authored, got["trino_query"],
+			"replica %s serves a stale tool description", name)
+	}
+
+	// Un-hiding is equally live: no restart, no notification between replicas.
+	shared.set(ConfigKeyToolsDeny, `[]`)
+	assert.Contains(t, listTools(t, replicaB), "s3_delete_object")
+}
+
+// TestPlatformInfoReflectsOverridesAcrossReplicas covers the description and
+// agent-instruction halves through Platform's own read path, which is what
+// platform_info serves.
+func TestPlatformInfoReflectsOverridesAcrossReplicas(t *testing.T) {
+	ctx := context.Background()
+	shared := newMutableOverrideStore()
+
+	cfgA := &Config{}
+	cfgA.Server.Description = "file default"
+	cfgA.BindOverrideStore(shared)
+
+	cfgB := &Config{}
+	cfgB.Server.Description = "file default"
+	cfgB.BindOverrideStore(shared)
+
+	shared.set(ConfigKeyServerDescription, "operator authored")
+	shared.set(ConfigKeyServerAgentInstructions, "operator guidance")
+
+	for name, cfg := range map[string]*Config{"A": cfgA, "B": cfgB} {
+		assert.Equal(t, "operator authored", cfg.ServerDescription(ctx),
+			"replica %s serves a stale description", name)
+		assert.Equal(t, "operator guidance", cfg.ServerAgentInstructions(ctx),
+			"replica %s serves stale agent instructions", name)
+	}
+}

--- a/pkg/platform/config_overrides_test.go
+++ b/pkg/platform/config_overrides_test.go
@@ -1,0 +1,255 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/pkg/configstore"
+)
+
+// failingOverrideStore stands in for a database that is down or unreachable.
+type failingOverrideStore struct{ err error }
+
+func (s failingOverrideStore) Get(context.Context, string) (*configstore.Entry, error) {
+	return nil, s.err
+}
+
+func (s failingOverrideStore) List(context.Context) ([]configstore.Entry, error) {
+	return nil, s.err
+}
+
+func boundConfig(t *testing.T, entries map[string]string) *Config {
+	t.Helper()
+	store := newMutableOverrideStore()
+	for k, v := range entries {
+		store.set(k, v)
+	}
+	cfg := &Config{}
+	cfg.BindOverrideStore(store)
+	return cfg
+}
+
+func TestServerDescription_Resolution(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no store bound returns file config", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.Server.Description = "from yaml"
+		assert.Equal(t, "from yaml", cfg.ServerDescription(ctx))
+	})
+
+	t.Run("stored override wins over file config", func(t *testing.T) {
+		cfg := boundConfig(t, map[string]string{ConfigKeyServerDescription: "from db"})
+		cfg.Server.Description = "from yaml"
+		assert.Equal(t, "from db", cfg.ServerDescription(ctx))
+	})
+
+	t.Run("absent row falls back to file config", func(t *testing.T) {
+		cfg := boundConfig(t, nil)
+		cfg.Server.Description = "from yaml"
+		assert.Equal(t, "from yaml", cfg.ServerDescription(ctx))
+	})
+
+	t.Run("stored empty string wins", func(t *testing.T) {
+		// An operator who saves an empty description means it. Falling back
+		// to the YAML here would make the field impossible to clear.
+		cfg := boundConfig(t, map[string]string{ConfigKeyServerDescription: ""})
+		cfg.Server.Description = "from yaml"
+		assert.Empty(t, cfg.ServerDescription(ctx))
+	})
+
+	t.Run("store failure falls back to file config", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.Server.Description = "from yaml"
+		cfg.BindOverrideStore(failingOverrideStore{err: errors.New("db down")})
+		assert.Equal(t, "from yaml", cfg.ServerDescription(ctx))
+	})
+
+	t.Run("unbinding restores file config", func(t *testing.T) {
+		cfg := boundConfig(t, map[string]string{ConfigKeyServerDescription: "from db"})
+		cfg.Server.Description = "from yaml"
+		require.Equal(t, "from db", cfg.ServerDescription(ctx))
+		cfg.BindOverrideStore(nil)
+		assert.Equal(t, "from yaml", cfg.ServerDescription(ctx))
+	})
+}
+
+func TestServerAgentInstructions_Resolution(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("stored override wins", func(t *testing.T) {
+		cfg := boundConfig(t, map[string]string{ConfigKeyServerAgentInstructions: "db guidance"})
+		cfg.Server.AgentInstructions = "yaml guidance"
+		assert.Equal(t, "db guidance", cfg.ServerAgentInstructions(ctx))
+	})
+
+	t.Run("store failure keeps operator guidance", func(t *testing.T) {
+		// The failure that matters: agent instructions carry the operator's
+		// data-safety rules. A database blip must not serve a session with
+		// none of them.
+		cfg := &Config{}
+		cfg.Server.AgentInstructions = "never return credentials"
+		cfg.BindOverrideStore(failingOverrideStore{err: errors.New("db down")})
+		assert.Equal(t, "never return credentials", cfg.ServerAgentInstructions(ctx))
+	})
+}
+
+func TestToolsDenySnapshot_Resolution(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no store bound returns file config copy", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.Tools.Deny = []string{"trino_admin_kill"}
+		got := cfg.ToolsDenySnapshot(ctx)
+		assert.Equal(t, []string{"trino_admin_kill"}, got)
+
+		got[0] = "mutated"
+		assert.Equal(t, []string{"trino_admin_kill"}, cfg.Tools.Deny, "caller must not alias live config")
+	})
+
+	t.Run("stored override wins", func(t *testing.T) {
+		cfg := boundConfig(t, map[string]string{ConfigKeyToolsDeny: `["s3_delete_object"]`})
+		cfg.Tools.Deny = []string{"trino_admin_kill"}
+		assert.Equal(t, []string{"s3_delete_object"}, cfg.ToolsDenySnapshot(ctx))
+	})
+
+	t.Run("stored empty array clears the file deny list", func(t *testing.T) {
+		cfg := boundConfig(t, map[string]string{ConfigKeyToolsDeny: `[]`})
+		cfg.Tools.Deny = []string{"trino_admin_kill"}
+		assert.Empty(t, cfg.ToolsDenySnapshot(ctx))
+	})
+
+	t.Run("malformed row keeps the file deny list", func(t *testing.T) {
+		// A corrupt row must not silently un-hide tools the YAML denies.
+		cfg := boundConfig(t, map[string]string{ConfigKeyToolsDeny: "not json"})
+		cfg.Tools.Deny = []string{"trino_admin_kill"}
+		assert.Equal(t, []string{"trino_admin_kill"}, cfg.ToolsDenySnapshot(ctx))
+	})
+
+	t.Run("store failure keeps the file deny list", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.Tools.Deny = []string{"trino_admin_kill"}
+		cfg.BindOverrideStore(failingOverrideStore{err: errors.New("db down")})
+		assert.Equal(t, []string{"trino_admin_kill"}, cfg.ToolsDenySnapshot(ctx))
+	})
+}
+
+func TestToolDescriptionOverridesSnapshot_Resolution(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no store bound returns file config copy", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.Tools.DescriptionOverrides = map[string]string{"trino_query": "from yaml"}
+		got := cfg.ToolDescriptionOverridesSnapshot(ctx)
+		assert.Equal(t, "from yaml", got["trino_query"])
+
+		got["trino_query"] = "mutated"
+		assert.Equal(t, "from yaml", cfg.Tools.DescriptionOverrides["trino_query"],
+			"caller must not alias live config")
+	})
+
+	t.Run("stored rows layer over file config", func(t *testing.T) {
+		cfg := boundConfig(t, map[string]string{
+			"tool.trino_query.description":     "from db",
+			"tool.s3_list_objects.description": "also from db",
+			ConfigKeyServerDescription:         "unrelated key is ignored",
+		})
+		cfg.Tools.DescriptionOverrides = map[string]string{
+			"trino_query":    "from yaml",
+			"datahub_search": "yaml only",
+		}
+		got := cfg.ToolDescriptionOverridesSnapshot(ctx)
+		assert.Equal(t, "from db", got["trino_query"])
+		assert.Equal(t, "also from db", got["s3_list_objects"])
+		assert.Equal(t, "yaml only", got["datahub_search"])
+		assert.NotContains(t, got, "server")
+	})
+
+	t.Run("stored empty value removes the override", func(t *testing.T) {
+		cfg := boundConfig(t, map[string]string{"tool.trino_query.description": ""})
+		cfg.Tools.DescriptionOverrides = map[string]string{"trino_query": "from yaml"}
+		assert.NotContains(t, cfg.ToolDescriptionOverridesSnapshot(ctx), "trino_query")
+	})
+
+	t.Run("populates from stored rows with no file overrides", func(t *testing.T) {
+		cfg := boundConfig(t, map[string]string{"tool.trino_query.description": "from db"})
+		assert.Equal(t, "from db", cfg.ToolDescriptionOverridesSnapshot(ctx)["trino_query"])
+	})
+
+	t.Run("store failure keeps the file overrides", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.Tools.DescriptionOverrides = map[string]string{"trino_query": "from yaml"}
+		cfg.BindOverrideStore(failingOverrideStore{err: errors.New("db down")})
+		assert.Equal(t, "from yaml", cfg.ToolDescriptionOverridesSnapshot(ctx)["trino_query"])
+	})
+}
+
+// TestOverrides_SharedStoreAcrossConfigs is the regression test for #1106.
+//
+// Two Config values stand in for two replicas of the same deployment: separate
+// processes, separate memory, one shared store. A write that lands in the store
+// (as an admin PUT served by replica A does) must be visible to replica B on
+// its very next read, with no notification between them and no restart.
+func TestOverrides_SharedStoreAcrossConfigs(t *testing.T) {
+	ctx := context.Background()
+	shared := newMutableOverrideStore()
+
+	replicaA := &Config{}
+	replicaA.Server.Description = "file default"
+	replicaA.BindOverrideStore(shared)
+
+	replicaB := &Config{}
+	replicaB.Server.Description = "file default"
+	replicaB.BindOverrideStore(shared)
+
+	require.Equal(t, "file default", replicaA.ServerDescription(ctx))
+	require.Equal(t, "file default", replicaB.ServerDescription(ctx))
+
+	// Admin PUT served by replica A.
+	shared.set(ConfigKeyServerDescription, "operator authored")
+
+	assert.Equal(t, "operator authored", replicaA.ServerDescription(ctx))
+	assert.Equal(t, "operator authored", replicaB.ServerDescription(ctx),
+		"replica that did not serve the write must still see it")
+
+	// Same for the other overridable keys.
+	shared.set(ConfigKeyServerAgentInstructions, "operator guidance")
+	shared.set(ConfigKeyToolsDeny, `["s3_delete_object"]`)
+	shared.set("tool.trino_query.description", "operator description")
+
+	assert.Equal(t, "operator guidance", replicaB.ServerAgentInstructions(ctx))
+	assert.Equal(t, []string{"s3_delete_object"}, replicaB.ToolsDenySnapshot(ctx))
+	assert.Equal(t, "operator description",
+		replicaB.ToolDescriptionOverridesSnapshot(ctx)["trino_query"])
+}
+
+func TestEffectiveCopy(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := boundConfig(t, map[string]string{
+		ConfigKeyServerDescription:       "stored description",
+		ConfigKeyServerAgentInstructions: "stored guidance",
+		ConfigKeyToolsDeny:               `["s3_delete_object"]`,
+		"tool.trino_query.description":   "stored tool description",
+	})
+	cfg.Server.Name = "unchanged"
+	cfg.Server.Description = "file description"
+	cfg.Server.AgentInstructions = "file guidance"
+	cfg.Tools.Deny = []string{"file_denied"}
+
+	got := cfg.EffectiveCopy(ctx)
+
+	assert.Equal(t, "stored description", got.Server.Description)
+	assert.Equal(t, "stored guidance", got.Server.AgentInstructions)
+	assert.Equal(t, []string{"s3_delete_object"}, got.Tools.Deny)
+	assert.Equal(t, "stored tool description", got.Tools.DescriptionOverrides["trino_query"])
+	assert.Equal(t, "unchanged", got.Server.Name, "non-overridable fields are carried through")
+
+	// The source config keeps its file values: the copy must not write back.
+	assert.Equal(t, "file description", cfg.Server.Description)
+	assert.Equal(t, []string{"file_denied"}, cfg.Tools.Deny)
+}

--- a/pkg/platform/config_race_test.go
+++ b/pkg/platform/config_race_test.go
@@ -1,44 +1,89 @@
 package platform
 
 import (
+	"context"
 	"sync"
 	"testing"
+
+	"github.com/txn2/mcp-data-platform/pkg/configstore"
 )
 
-// TestConfig_RuntimeMutableFields_NoRace asserts that the runtime-mutable
-// fields (description overrides + tools.deny) can be read and written
-// concurrently without the race detector flagging it. This is what makes
-// MCPDescriptionOverrideMiddlewareDynamic safe in production.
-//
-// Run with: go test -race ./pkg/platform/ -run TestConfig_RuntimeMutableFields_NoRace.
-func TestConfig_RuntimeMutableFields_NoRace(_ *testing.T) {
-	cfg := &Config{}
-	cfg.SetToolDescriptionOverride("trino_query", "v1")
-	cfg.SetToolsDeny([]string{"a"})
+// mutableOverrideStore is an in-memory OverrideStore whose contents can change
+// under concurrent readers, standing in for a database another replica is
+// writing to while this process serves requests.
+type mutableOverrideStore struct {
+	mu      sync.RWMutex
+	entries map[string]string
+}
 
+func newMutableOverrideStore() *mutableOverrideStore {
+	return &mutableOverrideStore{entries: map[string]string{}}
+}
+
+func (s *mutableOverrideStore) set(key, value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[key] = value
+}
+
+func (s *mutableOverrideStore) Get(_ context.Context, key string) (*configstore.Entry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.entries[key]
+	if !ok {
+		return nil, configstore.ErrNotFound
+	}
+	return &configstore.Entry{Key: key, Value: v}, nil
+}
+
+func (s *mutableOverrideStore) List(_ context.Context) ([]configstore.Entry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]configstore.Entry, 0, len(s.entries))
+	for k, v := range s.entries {
+		out = append(out, configstore.Entry{Key: k, Value: v})
+	}
+	return out, nil
+}
+
+// TestConfig_ReadThrough_NoRace asserts that the override-backed reads can run
+// concurrently with writes to the underlying store without the race detector
+// flagging it. These reads sit on tools/list and platform_info, so they run on
+// every request goroutine while an admin edit lands in the store.
+//
+// Run with: go test -race ./pkg/platform/ -run TestConfig_ReadThrough_NoRace.
+func TestConfig_ReadThrough_NoRace(_ *testing.T) {
+	store := newMutableOverrideStore()
+	store.set(ConfigKeyToolsDeny, `["a"]`)
+	store.set("tool.trino_query.description", "v1")
+
+	cfg := &Config{}
+	cfg.BindOverrideStore(store)
+
+	ctx := context.Background()
 	var wg sync.WaitGroup
 	const goroutines = 50
 	const iterations = 200
 
-	// Readers — simulate the description-override middleware getter and
-	// admin handlers reading tools.deny on every request.
 	for range goroutines {
 		wg.Go(func() {
 			for range iterations {
-				m := cfg.ToolDescriptionOverridesSnapshot()
+				m := cfg.ToolDescriptionOverridesSnapshot(ctx)
 				_ = m["trino_query"]
-				_ = cfg.ToolsDenySnapshot()
+				_ = cfg.ToolsDenySnapshot(ctx)
 				_ = cfg.ToolsAllowSnapshot()
+				_ = cfg.ServerDescription(ctx)
+				_ = cfg.ServerAgentInstructions(ctx)
 			}
 		})
 	}
 
-	// Writers — simulate concurrent admin PUTs editing both fields.
 	for range goroutines {
 		wg.Go(func() {
 			for range iterations {
-				cfg.ApplyConfigEntry("tool.trino_query.description", "v2")
-				cfg.ApplyConfigEntry("tools.deny", `["a","b"]`)
+				store.set("tool.trino_query.description", "v2")
+				store.set(ConfigKeyToolsDeny, `["a","b"]`)
+				store.set(ConfigKeyServerDescription, "edited")
 			}
 		})
 	}

--- a/pkg/platform/config_test.go
+++ b/pkg/platform/config_test.go
@@ -1855,39 +1855,6 @@ session_gate:
 	}
 }
 
-func TestApplyConfigEntry(t *testing.T) {
-	cfg := &Config{}
-
-	cfg.ApplyConfigEntry("server.description", "test description")
-	if cfg.Server.Description != "test description" {
-		t.Errorf("Description = %q, want %q", cfg.Server.Description, "test description")
-	}
-
-	cfg.ApplyConfigEntry("server.agent_instructions", "test instructions")
-	if cfg.Server.AgentInstructions != "test instructions" {
-		t.Errorf("AgentInstructions = %q, want %q", cfg.Server.AgentInstructions, "test instructions")
-	}
-
-	// Unknown key should be a no-op.
-	cfg.ApplyConfigEntry("unknown.key", "value")
-	if cfg.Server.Description != "test description" {
-		t.Error("unknown key should not modify config")
-	}
-
-	// tool.<name>.description writes into Tools.DescriptionOverrides
-	// (lazy-init the map on first use).
-	cfg.ApplyConfigEntry("tool.trino_query.description", "custom desc")
-	if got := cfg.Tools.DescriptionOverrides["trino_query"]; got != "custom desc" {
-		t.Errorf("DescriptionOverrides[trino_query] = %q, want %q", got, "custom desc")
-	}
-
-	// Empty value removes the override.
-	cfg.ApplyConfigEntry("tool.trino_query.description", "")
-	if _, exists := cfg.Tools.DescriptionOverrides["trino_query"]; exists {
-		t.Error("empty value should remove the override")
-	}
-}
-
 func TestParseToolsDenyValue(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1920,30 +1887,6 @@ func TestParseToolsDenyValue(t *testing.T) {
 				t.Errorf("%s: parseToolsDenyValue(%q)[%d] = %q, want %q", tc.name, tc.value, i, got[i], tc.want[i])
 			}
 		}
-	}
-}
-
-func TestApplyConfigEntry_ToolsDeny_PreservesOnMalformed(t *testing.T) {
-	// Bug guard: a corrupt tools.deny config_entry must NOT clobber the
-	// live deny list. Otherwise a bad row could silently open up tools
-	// the file config wanted hidden.
-	cfg := &Config{}
-	cfg.Tools.Deny = []string{"trino_admin_kill"}
-	cfg.ApplyConfigEntry("tools.deny", "not valid json")
-	if len(cfg.Tools.Deny) != 1 || cfg.Tools.Deny[0] != "trino_admin_kill" {
-		t.Errorf("malformed tools.deny clobbered live slice: got %v", cfg.Tools.Deny)
-	}
-}
-
-func TestApplyConfigEntry_ToolsDeny(t *testing.T) {
-	cfg := &Config{}
-	cfg.ApplyConfigEntry("tools.deny", `["trino_admin_kill","s3_delete"]`)
-	if len(cfg.Tools.Deny) != 2 || cfg.Tools.Deny[0] != "trino_admin_kill" {
-		t.Errorf("Tools.Deny = %v, want [trino_admin_kill s3_delete]", cfg.Tools.Deny)
-	}
-	cfg.ApplyConfigEntry("tools.deny", `[]`)
-	if len(cfg.Tools.Deny) != 0 {
-		t.Errorf("Tools.Deny after empty array = %v, want []", cfg.Tools.Deny)
 	}
 }
 

--- a/pkg/platform/info_tool.go
+++ b/pkg/platform/info_tool.go
@@ -235,7 +235,7 @@ func (p *Platform) handleInfo(ctx context.Context, _ *mcp.CallToolRequest) (*mcp
 
 	// Apply the persona description override; the persona's agent-instruction
 	// tuning is applied to the admin layer inside ComposeForCaller below.
-	description := p.config.Server.Description
+	description := p.config.ServerDescription(ctx)
 	var caller *personapkg.Persona
 	if persona != nil {
 		if full, ok := p.personaRegistry.Get(persona.Name); ok {
@@ -258,7 +258,7 @@ func (p *Platform) handleInfo(ctx context.Context, _ *mcp.CallToolRequest) (*mcp
 		notes = append(notes, instructions.ResourcesNote(accessibleTools))
 	}
 	agentInstructions := instructions.ComposeForCaller(
-		p.config.Server.AgentInstructions,
+		p.config.ServerAgentInstructions(ctx),
 		p.toolkitRegistry.AllTools(),
 		caller,
 		p.personaRegistry,

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -382,7 +382,8 @@ func (p *Platform) initDataInfra(opts *Options) error {
 	p.initPersonaStore()
 	p.initAPIKeyStore()
 	p.initUserStore()
-	return p.initConfigStore()
+	p.initConfigStore()
+	return nil
 }
 
 // initExtensions initializes optional extension toolkits and apps.
@@ -880,11 +881,20 @@ func (p *Platform) initAPIKeyStore() {
 // configured. The embedding provider and portal share lister are bound later
 // (finalizeSetup), once those subsystems exist.
 func (p *Platform) initPromptStore() {
+	// The overview prompt is worth registering when a description exists now
+	// or could be authored later through the admin API; its text is resolved
+	// per request. Without a config store and without a file description
+	// there is nothing to describe, so it stays unregistered.
+	var describe func(context.Context) string
+	if p.configStore != nil || p.config.Server.Description != "" {
+		describe = p.config.ServerDescription
+	}
+
 	p.prompts = promptlayer.New(promptlayer.Config{
 		DB:                p.db,
 		PromptsDir:        p.config.Tuning.PromptsDir,
 		ServerName:        p.config.Server.Name,
-		ServerDescription: p.config.Server.Description,
+		ServerDescription: describe,
 		AdminPersona:      p.config.Admin.Persona,
 		OperatorPrompts:   promptSpecsFromConfig(p.config.Server.Prompts),
 		BuiltinPrompts:    p.config.Server.BuiltinPrompts,
@@ -952,32 +962,30 @@ func decodeEncryptionKey(keyStr string) []byte {
 	return []byte(keyStr)
 }
 
-// initConfigStore initializes the config store. When a database is available,
-// DB entries override file config for whitelisted keys with hot-reload support.
-func (p *Platform) initConfigStore() error {
-	// Capture file defaults before any DB overlay.
+// initConfigStore initializes the config store. When a database is available it
+// becomes the authority for the overridable keys, consulted on every read.
+//
+// Nothing is copied into the live Config here. An earlier design loaded the
+// entries once at startup and patched the struct in place on each admin write,
+// which meant a change reached only the replica that served it and every other
+// replica served the pre-change value until restart (issue #1106).
+func (p *Platform) initConfigStore() {
+	// File defaults back the read-through fallback and the no-database store.
 	p.fileDefaults = p.buildConfigEntryMap()
 
 	if p.db != nil {
 		store := configpostgres.New(p.db)
-		entries, err := store.List(context.Background())
-		if err != nil {
-			return fmt.Errorf("loading config entries from database: %w", err)
-		}
-		for _, e := range entries {
-			p.applyConfigEntry(e.Key, e.Value)
-		}
 		p.configStore = store
-		if len(entries) > 0 {
-			slog.Info("config store: applied database overrides", logKeyCount, len(entries))
-		}
+		p.config.BindOverrideStore(store)
+		slog.Info("config store: database overrides resolved at read time")
 	} else {
 		p.configStore = configstore.NewFileStore(p.fileDefaults)
 	}
-	return nil
 }
 
-// buildConfigEntryMap extracts the current whitelisted config values as a key/value map.
+// buildConfigEntryMap extracts the file-config values for the whitelisted keys
+// as a key/value map. These are the defaults an override falls back to, and the
+// backing data for the no-database file store.
 // Encodes tools.deny as a JSON array so it round-trips through the
 // string-valued config_entries store.
 func (p *Platform) buildConfigEntryMap() map[string]string {
@@ -991,11 +999,6 @@ func (p *Platform) buildConfigEntryMap() map[string]string {
 		}
 	}
 	return m
-}
-
-// applyConfigEntry updates a live config field for a whitelisted key.
-func (p *Platform) applyConfigEntry(key, value string) {
-	p.config.ApplyConfigEntry(key, value)
 }
 
 // oauthSigningKeys bundles the active OAuth JWT signing key with the verify-only
@@ -2388,9 +2391,12 @@ func (p *Platform) addSessionHandleSchemaMiddleware() {
 // so agents only see tools they're authorized to use.
 func (p *Platform) addToolVisibilityMiddleware() {
 	cfg := middleware.ToolVisibilityConfig{
-		GlobalAllow:   p.config.Tools.Allow,
-		GlobalDeny:    p.config.Tools.Deny,
-		Authenticator: p.authenticator,
+		GlobalAllow: p.config.ToolsAllowSnapshot(),
+		// Resolved per call, not captured here: tools.deny is admin-editable,
+		// and a slice captured at registration would pin every replica to the
+		// boot-time value for the life of the process (issue #1106).
+		ResolveGlobalDeny: p.config.ToolsDenySnapshot,
+		Authenticator:     p.authenticator,
 	}
 
 	// Wire persona-based filtering via the authorizer. The same
@@ -2429,23 +2435,15 @@ func (p *Platform) addPromptVisibilityMiddleware() {
 // (loaded from the file or the database-backed config_entries store) can
 // customize or extend them.
 //
-// The dynamic variant re-resolves the override map on every tools/list call
-// so admin-API edits to tool.<name>.description take effect immediately,
-// without a platform restart. The cost is a tiny map allocation per
-// tools/list — negligible compared to the surrounding RPC.
+// The override map is re-resolved on every tools/list call so an admin-API
+// edit to tool.<name>.description takes effect on the next listing in every
+// replica, without a restart.
+//
+// Registered unconditionally: the built-in overrides are always present, and
+// a stored one can be authored at any time after startup.
 func (p *Platform) addDescriptionOverrideMiddleware() {
-	// Snapshot through the runtime lock on every tools/list call so admin
-	// API edits to tool.<name>.description take effect immediately AND
-	// concurrent writes don't race the iteration in MergedDescriptionOverrides.
-	getOverrides := func() map[string]string {
-		return middleware.MergedDescriptionOverrides(p.config.ToolDescriptionOverridesSnapshot())
-	}
-	if len(getOverrides()) == 0 {
-		// No defaults and no overrides configured at startup. The map can
-		// later be populated via admin API, but skipping the middleware
-		// here matches the prior behavior for the empty-config case.
-		// Re-evaluate on the next platform restart.
-		return
+	getOverrides := func(ctx context.Context) map[string]string {
+		return middleware.MergedDescriptionOverrides(p.config.ToolDescriptionOverridesSnapshot(ctx))
 	}
 	p.mcpServer.AddReceivingMiddleware(middleware.MCPDescriptionOverrideMiddlewareDynamic(getOverrides))
 }

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -3725,18 +3725,6 @@ func TestBuildConfigEntryMap(t *testing.T) {
 	}
 }
 
-func TestApplyConfigEntryPlatform(t *testing.T) {
-	p := &Platform{config: &Config{}}
-	p.applyConfigEntry("server.description", "new desc")
-	if p.config.Server.Description != "new desc" {
-		t.Errorf("Description = %q, want %q", p.config.Server.Description, "new desc")
-	}
-	p.applyConfigEntry("server.agent_instructions", "new instr")
-	if p.config.Server.AgentInstructions != "new instr" {
-		t.Errorf("AgentInstructions = %q, want %q", p.config.Server.AgentInstructions, "new instr")
-	}
-}
-
 func TestFileDefaults(t *testing.T) {
 	p := &Platform{
 		fileDefaults: map[string]string{
@@ -3758,9 +3746,7 @@ func TestInitConfigStoreNoDatabase(t *testing.T) {
 			},
 		},
 	}
-	if err := p.initConfigStore(); err != nil {
-		t.Fatalf("initConfigStore() error = %v", err)
-	}
+	p.initConfigStore()
 	if p.configStore == nil {
 		t.Fatal("configStore should not be nil")
 	}
@@ -3769,6 +3755,43 @@ func TestInitConfigStoreNoDatabase(t *testing.T) {
 	}
 	if p.fileDefaults["server.description"] != "file desc" {
 		t.Errorf("fileDefaults[server.description] = %q, want %q", p.fileDefaults["server.description"], "file desc")
+	}
+	// Without a database there is nothing to override with, so reads resolve
+	// straight from the file config.
+	if got := p.config.ServerDescription(context.Background()); got != "file desc" {
+		t.Errorf("ServerDescription() = %q, want %q", got, "file desc")
+	}
+}
+
+func TestInitConfigStoreWithDatabase(t *testing.T) {
+	// No query expectations: initConfigStore constructs the store and binds
+	// it, and must not read anything at startup.
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	p := &Platform{
+		db: db,
+		config: &Config{
+			Server: ServerConfig{Description: "file desc"},
+		},
+	}
+	p.initConfigStore()
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("startup must not query the config store: %v", err)
+	}
+	if p.configStore == nil {
+		t.Fatal("configStore should not be nil")
+	}
+	if p.configStore.Mode() != "database" {
+		t.Errorf("Mode() = %q, want %q", p.configStore.Mode(), "database")
+	}
+	// Bound, and failing safe: the mock has no rows or expectations, so the
+	// read must fall back to the file config rather than to empty.
+	if got := p.config.ServerDescription(context.Background()); got != "file desc" {
+		t.Errorf("ServerDescription() = %q, want %q", got, "file desc")
 	}
 }
 

--- a/pkg/platform/validation.go
+++ b/pkg/platform/validation.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"context"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -25,8 +26,11 @@ var toolTokenPattern = regexp.MustCompile(`\b([a-z][a-z0-9]*(?:_[a-z0-9]+)+)\b`)
 // validateAgentInstructions scans the agent_instructions text for tokens that
 // look like tool names and logs warnings for any that don't match registered tools.
 // This helps catch stale references after tool renames or removals.
+//
+// Startup-only, so it lints the value in force at boot. An override authored
+// later is not re-linted; the warning is a developer aid, not a gate.
 func (p *Platform) validateAgentInstructions() {
-	instructions := p.config.Server.AgentInstructions
+	instructions := p.config.ServerAgentInstructions(context.Background())
 	if instructions == "" {
 		return
 	}


### PR DESCRIPTION
Closes #1106

## What this changes

The config store is the authority for the database-overridable settings. Every read of `server.description`, `server.agent_instructions`, `tools.deny`, and `tool.<name>.description` resolves the key from the store, falling back to the file-config value when no row exists.

Nothing is loaded into the `Config` struct at startup and nothing is patched into it on a write. Two replicas sharing one database therefore resolve the same value by construction, and an admin edit is in force everywhere from the next read: no restart, no cross-replica notification, no invalidation to get wrong.

## Why read-through rather than a broadcast

The previous design loaded `config_entries` once at boot (`initConfigStore`) and patched the live struct on each admin write (`setConfigEntry`, `deleteConfigEntry`, the tool-visibility endpoint). The reload bus added in #501 carries connection, catalog, persona, and API-key events; there was no config event, so a change reached only the replica that served it and every other replica served the pre-change value until it restarted.

Adding a `platform/reload/config` event would have been the smaller diff. It was rejected because it preserves the shape of the defect: authoritative state cached per process, correctness riding on a best-effort broadcast whose publish failure is only a logged warning, and a fresh opportunity for the same bug each time a key joins the whitelist.

The cost of resolving on read is negligible here. The whitelist is four keys. `server.description` and `server.agent_instructions` are read once per `platform_info` call; the `tools.*` keys once per `tools/list` and on the admin tool views. Every one of those requests already makes several Postgres round trips for session lookup and audit.

## Failure behavior

A failed lookup is deliberately indistinguishable from an absent row: both fall back to the operator's YAML. A database outage degrades to the shipped config rather than to empty, so agent instructions stay populated and deny patterns stay in force. A malformed `tools.deny` row is ignored in favor of the file value, so a corrupt value cannot silently un-hide a tool the YAML denies.

A stored row wins over the file config even when it is empty or decodes to an empty list. That is an operator who deliberately cleared the field, which is distinct from having no override at all; treating the two alike would make these fields impossible to clear.

## Two values that were frozen at registration

Both are resolved per request as part of this change. Neither depended on having more than one replica.

`ToolVisibilityConfig` now carries `ResolveGlobalDeny func(ctx) []string` in place of a `GlobalDeny` slice. The slice was captured when the middleware was registered, so an admin `tools.deny` edit never reached `tools/list` on any replica, while the admin tool detail view read live config and reported the same tool as hidden. The two surfaces disagreed about whether a tool was reachable.

`promptlayer.Config.ServerDescription` is now `func(ctx) string`. The `platform-overview` prompt baked the description into its content at registration and was skipped outright when the description was empty at boot, so a description authored afterwards produced no prompt at all. The prompt now registers whenever a description exists or could be authored later, and builds its body when served.

## Behavior changes

- Startup performs no config-store read, so it no longer fails when that read fails.
- `GET /admin/config` and `GET /admin/config/export` serialize the effective config through `Config.EffectiveCopy`, so a downloaded `platform.yaml` carries the operator's stored overrides rather than the pre-override file values.
- `GET /admin/config` returns 500 rather than a null body when no config is loaded, matching `/admin/config/export`.
- The description-override middleware registers unconditionally. The built-in overrides are always present and a stored one can appear at any time, so the previous startup emptiness check could only cause a miss.

## API surface

Removed: `Config.ApplyConfigEntry`, `Config.SetToolsDeny`, `Config.SetToolDescriptionOverride`, and the runtime lock they guarded. Also removed the deprecated `MCPDescriptionOverrideMiddleware` wrapper, which had no non-test callers.

Added: `Config.BindOverrideStore`, `Config.ServerDescription(ctx)`, `Config.ServerAgentInstructions(ctx)`, and `Config.EffectiveCopy(ctx)`. `ToolsDenySnapshot` and `ToolDescriptionOverridesSnapshot` now take a context.

The store interface Config depends on is the read half of `configstore.Store` and is unexported, so `Config` cannot write through it and callers pass a value satisfying it without naming the type. `pkg/platform` reached 151 of its 150-export budget mid-change; this is how it came back under, rather than by raising the budget.

The lock guarding the store binding lives behind a pointer, which leaves `Config` copyable. `EffectiveCopy` needs that to build a copy with the resolved values substituted for serialization.

## Tests

`TestOverrides_SharedStoreAcrossConfigs` and `TestToolsListReflectsOverridesAcrossReplicas` are the regression guards. Each builds two instances over one shared store, standing in for two replicas, writes through one, and asserts the other serves the new value on its next read.

The `tools/list` case goes through the real `addToolVisibilityMiddleware` and `addDescriptionOverrideMiddleware` registration path against a live `mcp.Server` and in-memory transport, so a value captured at registration fails it. A unit test calling the accessor directly would pass against the frozen-slice bug and prove nothing.

Also covered: every fallback branch (no store bound, absent row, store failure, malformed value, explicit clear), that a returned slice or map does not alias live config, that `EffectiveCopy` does not write back to its source, that startup issues no query against the store, and that the overview prompt reflects a description authored after registration.

The admin handler tests now bind the mock store to the config they assert against, so they verify what a subsequent read returns rather than that a struct field was assigned.

All nine functions in the new file are at 100% statement coverage; the repository total is 91.1%. `make verify` passes.

## Follow-up, scoped separately

Connections, catalogs, personas, and API keys use the same per-process-cache pattern and propagate only because a publish is remembered on each write path; a dropped publish fails the same silent way. They are materially more expensive to rebuild than a config string, so read-through may not be the right answer for them, but the choice should be deliberate rather than inherited.

The tool-visibility read-modify-write is serialized by a per-process mutex, so it orders admins on one replica only. Two replicas writing simultaneously can still lose an update; the durable fix is a conditional write in the store.
