### PR TITLE
docs(bench): record the deferred knowledge-layer study extensions

### DIFF
--- a/bench/docs/findings-register.md
+++ b/bench/docs/findings-register.md
@@ -22,6 +22,28 @@ the same PR as the finding it records.
 | Supersede-reliability report (from the knowledge-layer report's wide supersede CIs, duplicate rate CI [14, 86] on n=7) | Premise probe at 3x the pilot denominator found the mechanism at ceiling: supersede 8/8 clean, duplicates 0/8, update correctness 8/8 — the wide CIs were small-n noise, not a defect | `results/knowledge-use/s5-supersede-probe/` (the probe surfaced capture mis-filing instead, which entered the knowledge-use report and motivated #1057/#1060) | This register; the probe archive's README |
 | API-connection architecture study (#1027: per-endpoint tools vs lexical vs hybrid search+invoke vs code mode) | Saturated by construction: the design held its discriminating variable (discovery difficulty) at an easy setting, so every arm converged and the comparison measured a foregone conclusion | `results/api-study-pilot/` | Postmortem on issue #1027; banner in `api-connection-study-design.md` |
 
+## Deferred study extensions (proposed, never probed)
+
+Extensions of the published knowledge-layer study that were written down as
+follow-up work, then deferred without a probe. They differ from the retired
+candidates above: nothing was measured and nothing was falsified, so none of
+them is concluded. They are recorded here rather than left open because each
+would cost a full run and none has a product question waiting on its answer,
+and an open ticket nobody can act on reads as work in flight.
+
+Reviving one means the same gate as any other study: a cheap probe of its
+headline effect first, and a stated decision on whether its result revises the
+published report (a v2 of `benchmark-report.md`, whose v1.1 DOI is frozen) or
+forms a new study in the series with its own protocol.
+
+| Extension | Deferred because | What would revive it |
+| --- | --- | --- |
+| Teaching-order invariance (#980 A1): run the six cold-start lessons shuffled and reversed | The per-class trajectories (knowledge-layer report, Figure 2) already suggest order-invariance; a run that confirms the expected answer buys a stronger claim, not a decision | A cold-start result that only makes sense if order matters, or a reviewer challenging the single-order design |
+| Adversarial and conflicting curricula (#980 A2): correction taught mid-curve | No product question waits on it. Was once folded into #1054's RQ4, which never ran when H1a was falsified | Evidence that mid-curve corrections do not propagate in a real deployment, which would make this a defect hunt rather than a completeness run |
+| Multi-model cold-start climb (#980 A3): repeat the curve on three or more models | The largest spend in the set. Single-model generalization is an acknowledged limit of the published report (Section 7), stated as such rather than hidden | A decision to publish a generalization claim, or a second model showing a materially different climb by accident |
+| Forgetting and decay after supersede (#980 A5) | Depends on the A2 harness, and the supersede mechanism already probed at ceiling (see the supersede-reliability row above) | The A2 harness existing for another reason, or a stale value resurfacing in production |
+| Channel ablation, sink x discovery mode (#980 A6) | Existed to arbitrate the two #1131 levers. #1131 now takes the platform-controlled lever on the report's own evidence that platform search delivers, so the matrix no longer gates a decision | Wanting to close the sink-delivery confound the report flagged (Section 6) as a publication goal in its own right |
+
 ## Platform decisions taken on benchmark evidence
 
 | Decision | Direction | Evidence |
@@ -31,7 +53,8 @@ the same PR as the finding it records.
 | Steer capture toward dated observations | Do not build — already the behavior | The capture corpus shows dated, self-refreshing notes on the empty-state path (`results/knowledge-use/pk-corpus/`) |
 | Strict tool-argument schemas (reject unknown fields) | Built — #1060 | An agent burned calls on a silently-ignored misnamed field (capture corpus); the S5 probe's mis-filing decomposition reinforced the filing-reliability theme |
 | Capture-guidance priority: conventions and definitions over world-state observations | Adopt in curation guidance | Conventions are the only knowledge class used by every tier and the only class that suppresses fabrication (knowledge-use report, sections 4, 5, 8) |
-| Supersede invalidation / propagation repair (#980 A2/A5) | Still open — unmeasured | RQ4 never ran; A2/A5 reverted to open on #980 |
+| Supersede invalidation / propagation repair (#980 A2/A5) | Unmeasured — deferred, not concluded | RQ4 never ran; the measurement that would settle it is deferred (see the deferred-extensions section above) |
+| Cross-identity reach of applied insights (#980 B2, #1130) | Built — applied insights are searchable across identities | The knowledge-layer report's 46.7% transfer rate against 84.4% personal recall (Section 5); the mechanism was confirmed in source before the change, and the effect is unmeasured until #1139 runs |
 
 ## The study lifecycle these entries follow
 


### PR DESCRIPTION
## What this changes

One file: `bench/docs/findings-register.md` gains a section recording five knowledge-layer study extensions that were proposed and then deferred, corrects a row that overstated the supersede work as open, and adds a row for the decision #1129 acted on.

No harness code, no protocol, no run data, no report text.

## Why the register and not the issue tracker

The five extensions came out of the #980 roadmap: vary the cold-start teaching order, teach a correction mid-curve, repeat the climb across models, measure decay after supersede, and the sink-by-discovery-mode channel ablation. Each would cost a full benchmark run, and none has a product question waiting on its answer. Left open they read as work in flight; closed with no record they would be re-proposed from the report's limits section within a release or two.

This file already exists for exactly that: "A finding that says something is not worth a report is still a finding; this file is where it lives so the work is never repeated unknowingly."

They are recorded as their own section rather than as rows among the retired candidates, because the distinction is the substance. A retired candidate was probed and its premise died, and the register can say what was learned: the API-connection study saturated by construction, the perishable-knowledge H1a was falsified at first empirical contact, the supersede mechanism probed at ceiling. These five were never measured. Nothing about them is concluded, and filing them beside genuine negative results would misrepresent both.

Each row names why it was deferred and what would revive it, so a future session can tell a deliberate deferral from an oversight.

## The gate this restores

The register states the study lifecycle: "Probe before protocol: no study is proposed without a cheap empirical probe of its headline effect, and the probe result travels with the proposal."

All five were filed straight from roadmap prose without that probe. The new section's preamble states the revival condition in those terms, and adds the constraint none of the five addressed: the knowledge-layer study is published at report v1.1 with a frozen concept DOI, and `bench/README.md` requires every artifact to belong to exactly one study, so any of these runs implies a decision about whether its result revises that report to a v2 or forms a new study with its own protocol. That decision has to be made before the run, not discovered after it.

## The one deferral on different grounds

The channel ablation is not deferred for lack of a consumer in the same way as the other four. It existed to arbitrate the two candidate levers on #1131, and #1131 now takes the platform-controlled lever on the report's own evidence that the platform's search delivers. The matrix would have quantified how much each lever helps; it was never what established that this one works. Its row says so, and names closing the report's Section 6 sink-delivery confound as a publication goal in its own right as the thing that would revive it.

## Two corrections to existing rows

The supersede invalidation row read "Still open — unmeasured", which was true when #1054's RQ4 was expected to run. RQ4 never ran and the measurement is now deferred, so "open" overstated it. It now reads as deferred rather than concluded, pointing at the new section.

A row is added for the cross-identity reach of applied insights, built in #1129 against the report's 46.7% transfer rate versus 84.4% personal recall. It states plainly that the mechanism was confirmed in source before the change and that the effect is unmeasured until #1139 runs, so the register does not imply a measured improvement that nobody has measured.

## Verification

`make verify` green. Documentation gates pass, including the check that benchmark reference pages cite only registered tools. Patch-scoped lint reports 0 issues.

## Scope

Refs #980. Records the closure of #1133, #1134, #1135, #1137 and #1138; closes nothing itself, and the epic stays open on the work that remains.
