### PR TITLE
feat(bench): promote capture rate to a first-class metric (#1136)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -200,6 +200,7 @@ bench/
     ├── agent/           model-driven tool loop with budget
     ├── mcpc/            MCP session, handle mint, session_id threading
     ├── auditapi/        admin audit API read-back + metrics (+ enrichment coverage)
+    ├── capture/         capture attempt signal, miss attribution, attempted/landed split (S5 + cold-start)
     ├── lifecycleapi/    admin insights + changesets read-back, approve + apply drivers
     ├── promote/         shared reviewer-promotion path (approve + apply_knowledge + verify)
     ├── grade/           deterministic graders (numeric, entity, execution-result)
@@ -209,6 +210,6 @@ bench/
     ├── coldstart/       cold-start curriculum runner, learning-curve metrics, results model
     ├── pool/            identity-pool allocation
     ├── report/          results model, aggregates, cross-arm comparison
-    ├── stats/           bootstrap confidence intervals
+    ├── stats/           bootstrap confidence intervals + the shared num/den rate type
     └── target/          endpoint + Bearer auth
 ```

--- a/bench/benchrun/main.go
+++ b/bench/benchrun/main.go
@@ -162,7 +162,13 @@ func runReadOnly(cfg config) (bool, error) {
 }
 
 // runSummarize prints the human summary of an existing results JSON, choosing
-// the result shape from the run-mode flags.
+// the result shape from the run-mode flags. The lifecycle, supersede, and
+// cold-start summaries re-aggregate from the per-attempt records the file
+// carries before printing, so a results file written by an older harness renders
+// under the CURRENT metric definitions instead of showing a zero for a metric
+// that did not exist when it was written (the capture decomposition, #1136).
+// Aggregation is deterministic and derives only from those records, so
+// re-deriving never changes what a file written by this harness reports.
 func runSummarize(cfg config) error {
 	switch {
 	case cfg.coldStart:
@@ -170,18 +176,21 @@ func runSummarize(cfg config) error {
 		if err != nil {
 			return err
 		}
+		res.Aggregate()
 		fmt.Print(res.HumanSummary())
 	case cfg.supersede:
 		res, err := lifecycle.LoadSupersedeJSON(cfg.summarize)
 		if err != nil {
 			return err
 		}
+		res.Aggregate()
 		fmt.Print(res.HumanSummary())
 	case cfg.lifecycle:
 		res, err := lifecycle.LoadJSON(cfg.summarize)
 		if err != nil {
 			return err
 		}
+		res.Aggregate()
 		fmt.Print(res.HumanSummary())
 	default:
 		res, err := report.LoadJSON(cfg.summarize)

--- a/bench/benchrun/main_test.go
+++ b/bench/benchrun/main_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/txn2/mcp-data-platform/bench/internal/coldstart"
 	"github.com/txn2/mcp-data-platform/bench/internal/lifecycle"
 	"github.com/txn2/mcp-data-platform/bench/internal/report"
 )
@@ -375,5 +377,94 @@ func TestGateOnBaselineRejectsArmMismatch(t *testing.T) {
 	cand := results("a0", report.SuiteSummary{Suite: "s3", Graded: 10, Accuracy: 0.43, PassKRate: 0.40, MedianToolCalls: 16})
 	if err := gateOnBaseline(cand, baselineFile(t, base)); err == nil {
 		t.Fatal("cross-arm baseline was accepted")
+	}
+}
+
+// captureStdout runs fn with os.Stdout redirected and returns what it printed.
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	runErr := fn()
+	os.Stdout = orig
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runErr != nil {
+		t.Fatalf("summarize: %v", runErr)
+	}
+	return string(out)
+}
+
+// TestSummarizeRederivesMetricsFromRecords proves -summarize re-aggregates
+// before printing, so a results file written by an older harness renders under
+// the current metric definitions. Written without any capture decomposition
+// (the pre-#1136 shape), the file must still summarize with a capture rate and
+// an attributed miss, both derived from the lesson records it does carry.
+func TestSummarizeRederivesMetricsFromRecords(t *testing.T) {
+	res := &coldstart.Results{
+		Manifest: coldstart.Manifest{CurriculumID: "cs-test", Arm: "a3", K: 1},
+		Lessons: []coldstart.LessonRecord{
+			{LessonID: "cs-a", Captured: new(true), CaptureAttempted: new(true), BudgetExhausted: new(false)},
+			{LessonID: "cs-b", Captured: new(false), CaptureAttempted: new(false), BudgetExhausted: new(true)},
+		},
+	}
+	// Deliberately NOT aggregated: the stored metrics block is the zero value,
+	// exactly as an older harness's file looks for a metric it never computed.
+	path := filepath.Join(t.TempDir(), "cold.json")
+	if err := res.WriteJSON(path); err != nil {
+		t.Fatal(err)
+	}
+	out := captureStdout(t, func() error {
+		return runSummarize(config{coldStart: true, summarize: path})
+	})
+	if !strings.Contains(out, "capture rate") || !strings.Contains(out, "(1/2)") {
+		t.Errorf("summary did not re-derive the capture rate from the lesson records:\n%s", out)
+	}
+	if !strings.Contains(out, "capture misses (1)") {
+		t.Errorf("summary did not attribute the capture miss:\n%s", out)
+	}
+}
+
+// TestSummarizeLifecycleRederivesMetrics is the lifecycle and supersede half of
+// the same contract: both summaries re-derive their scorecard from the stored
+// protocol runs, so an older file reports the capture decomposition too.
+func TestSummarizeLifecycleRederivesMetrics(t *testing.T) {
+	runs := []lifecycle.ProtocolRun{
+		{ProtocolID: "lc-a", Captured: new(true), CaptureAttempted: new(true), TeachBudgetExhausted: new(false), RecallCorrect: new(true)},
+		{ProtocolID: "lc-b", Captured: new(false), CaptureAttempted: new(false), TeachBudgetExhausted: new(true)},
+	}
+	dir := t.TempDir()
+
+	life := &lifecycle.Results{Manifest: lifecycle.Manifest{Arm: "a3", K: 1}, Runs: runs}
+	lifePath := filepath.Join(dir, "life.json")
+	if err := life.WriteJSON(lifePath); err != nil {
+		t.Fatal(err)
+	}
+	out := captureStdout(t, func() error {
+		return runSummarize(config{lifecycle: true, summarize: lifePath})
+	})
+	if !strings.Contains(out, "capture rate") || !strings.Contains(out, "capture misses (1)") {
+		t.Errorf("lifecycle summary did not re-derive the capture decomposition:\n%s", out)
+	}
+
+	sup := &lifecycle.SupersedeResults{Manifest: lifecycle.Manifest{Arm: "a3", K: 1}, Runs: runs}
+	supPath := filepath.Join(dir, "sup.json")
+	if err := sup.WriteJSON(supPath); err != nil {
+		t.Fatal(err)
+	}
+	out = captureStdout(t, func() error {
+		return runSummarize(config{supersede: true, summarize: supPath})
+	})
+	if !strings.Contains(out, "capture attempted") || !strings.Contains(out, "capture misses (1)") {
+		t.Errorf("supersede summary did not re-derive the capture decomposition:\n%s", out)
 	}
 }

--- a/bench/docs/knowledge-layer-protocol.md
+++ b/bench/docs/knowledge-layer-protocol.md
@@ -208,7 +208,12 @@ Metrics (each a numerator/denominator over the applicable, non-harness-failed
 runs): **capture rate**, **personal recall**, **unprompted surface**, **transfer
 rate**, **update correctness**, **update capture rate**, **duplicate rate**
 (lower is better), and **abstention rate**, plus **pass^k** over protocols (all
-k attempts pass the full applicable lifecycle). The duplicate rate counts only
+k attempts pass the full applicable lifecycle). Capture leads the scorecard
+because it caps every metric under it: an insight that was never recorded can be
+neither recalled nor promoted, so a capture miss removes the attempt from the
+downstream stages rather than merely lowering one number. It is therefore
+reported with its own confidence interval and a decomposition (below), not as a
+supporting count. The duplicate rate counts only
 attempts whose correction capture actually executed: an update episode that
 never called capture left one live insight and the supersede gate never ran, so
 it is an update-capture miss (measured on its own rate, and a pass^k failure),
@@ -252,6 +257,45 @@ The **capture-budget lever** `-teach-budget N` overrides the per-episode tool-ca
 budget for the capture-bearing stages (teach and update), so the capture-rate
 lift from a larger teach budget can be measured directly against the same
 protocol set.
+
+### Capture decomposition and miss attribution (#1136)
+
+Capture is a headline metric with an interval in both the S5 lifecycle and the
+cold-start suite, and both report the same decomposition under
+`metrics.capture_split`, built by `bench/internal/capture`:
+
+- **capture attempted** (`capture_split.attempt_rate`) is, over the same graded
+  denominator as the capture rate, the fraction of teach episodes that actually
+  executed a capture call. A budget-refused request never ran, so it does not
+  count as an attempt. The one case where its denominator is smaller than the
+  capture rate's is a results file written before the attempt signal existed:
+  those outcomes are excluded rather than assumed not-attempted, and any miss
+  among them is reported as `unattributed` with a warning.
+- **landed given attempt** (`capture_split.given_attempted`) is, among those
+  attempts, the fraction that produced an entity-linked insight.
+- **capture misses** (`capture_split.misses`) attributes every graded miss to
+  exactly one cause, and reports the total so the buckets can be checked to sum:
+  `attempted_failed` (capture ran, nothing landed — the capture path itself),
+  `budget_starved` (never executed, budget spent — a harness-budget concept, so
+  no platform change follows from it), `never_attempted` (never executed with
+  budget to spare — the model or its steering), and `budget_unobservable`
+  (never executed on the claude-cli path, whose turn budget the harness cannot
+  see, so the miss is attributed as far as the evidence allows and no further).
+  A fifth bucket, `unattributed`, exists only for results written before the
+  attempt signal did; a run from this harness leaves it zero.
+
+The three real causes imply fixes in different layers, which is the point of
+splitting them: a run that reports mostly `never_attempted` argues for a
+platform-side nudge, one that reports mostly `budget_starved` argues for a
+harness budget change and nothing product-side, and one that reports mostly
+`attempted_failed` argues for the capture path. Cold-start additionally names
+the cause on each missed lesson in its summary, since a lesson that misses
+capture is never promoted and its trap class stays flat for the rest of the
+curve.
+
+Like the other #964 diagnostics, the decomposition is deliberately **not**
+gated by `-baseline`: its denominators are small enough that gating would trip
+on noise. It exists to explain a capture regression, not to define one.
 
 ### Harness hardening (#966)
 
@@ -391,8 +435,15 @@ trap class — the harness:
    knowledge. This isolates the delivery of *promoted* knowledge (the coupling
    between the lifecycle and the enrichment layer), not an evaluator's own memory.
 
-The report is a **learning curve**: per checkpoint, the eval set's accuracy, a
-per-trap-class breakdown (which lesson unlocked which class), and the
+The report leads with the **capture rate** — the fraction of lessons whose teach
+episode landed an entity-linked insight, with a confidence interval, the
+attempted/landed split, and every miss attributed to a cause (see the capture
+decomposition above). Capture bounds the whole curve: a lesson that misses
+capture is never promoted, so its trap class stays flat for every checkpoint
+after it, and a bare captured-lesson count cannot say which layer to fix.
+
+The rest of the report is the **learning curve**: per checkpoint, the eval set's
+accuracy, a per-trap-class breakdown (which lesson unlocked which class), and the
 delivery-side **enrichment coverage** (the fraction of tool calls whose response
 carried cross-enrichment, from the audit trail). Lesson order is the x-axis, run
 foundational-first (units before net-revenue, then the calendar/freshness/tier/

--- a/bench/internal/capture/capture.go
+++ b/bench/internal/capture/capture.go
@@ -1,0 +1,250 @@
+// Package capture holds the knowledge-capture instrumentation shared by the S5
+// lifecycle suite and the cold-start suite (issue #1136). Capture caps every
+// downstream metric — an insight that was never recorded can be neither recalled
+// nor promoted — so both suites report it as a headline rate and must attribute
+// every miss to a cause rather than leaving it a bare count.
+//
+// Both the attempt signal and the miss attribution are derived from the
+// provider-agnostic transcript, so the in-process agent loop and the claude-cli
+// path cannot diverge on what "the agent called capture" means, and the two
+// suites cannot diverge on what a capture miss is.
+package capture
+
+import (
+	"fmt"
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used -- bootstrap-CI resampling for benchmark statistics; not security-sensitive, and a seedable PRNG is required for reproducible intervals.
+	"math/rand"
+	"strings"
+
+	"github.com/txn2/mcp-data-platform/bench/internal/agent"
+	"github.com/txn2/mcp-data-platform/bench/internal/llm"
+	"github.com/txn2/mcp-data-platform/bench/internal/stats"
+)
+
+// Attempted reports whether an episode actually executed a knowledge-capture
+// call. A capture request the budget refused (emitted only after the tool-call
+// budget was spent, so it never ran) does NOT count: it is a budget-starvation
+// miss, not an attempt that failed to land. This keeps the attribution honest —
+// an agent that only reaches for capture after burning its budget on discovery
+// is starved, not a landing failure.
+func Attempted(msgs []llm.Message) bool {
+	captureIDs := map[string]bool{}
+	for _, m := range msgs {
+		for _, c := range m.ToolCalls {
+			if IsTool(c.Name) {
+				captureIDs[c.ID] = true
+			}
+		}
+	}
+	if len(captureIDs) == 0 {
+		return false
+	}
+	for _, m := range msgs {
+		for _, r := range m.ToolResults {
+			// A capture call ran when its paired result is present and is not the
+			// budget-refusal sentinel. A server-side capture error still counts as
+			// executed (that is a landing failure, a different bucket).
+			if captureIDs[r.CallID] && r.Text != agent.BudgetRefusalText {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsTool reports whether a tool name is the knowledge-capture tool. The suffix
+// match tolerates a renamed or namespaced capture tool without silently
+// classifying every teach episode as a capture miss.
+func IsTool(name string) bool {
+	return name == "memory_capture" || strings.HasSuffix(name, "_capture")
+}
+
+// Cause is the attributed cause of one capture miss. Every graded miss carries
+// exactly one, which is the point of the decomposition: a miss that "never
+// attempted" points at the model or its steering, one that is budget-starved
+// points at the harness budget, and one that attempted and failed points at the
+// capture path itself. The three imply different fixes in different layers, so
+// an unattributed miss cannot motivate any of them.
+type Cause string
+
+// Miss causes. CauseNone marks a graded outcome that is not a miss.
+const (
+	CauseNone Cause = ""
+	// CauseAttemptedFailed: capture executed, but no linked insight landed.
+	CauseAttemptedFailed Cause = "attempted_failed"
+	// CauseBudgetStarved: capture never executed and the episode exhausted its
+	// tool-call budget (the discovery-budget-exhaustion failure mode).
+	CauseBudgetStarved Cause = "budget_starved"
+	// CauseNeverAttempted: capture never executed with budget left over — the
+	// agent had the calls available and did not try.
+	CauseNeverAttempted Cause = "never_attempted"
+	// CauseBudgetUnobservable: capture never executed and budget exhaustion is not
+	// observable (the claude-cli path runs its own turn budget), so the miss is
+	// attributed as far as the evidence allows and no further.
+	CauseBudgetUnobservable Cause = "budget_unobservable"
+	// CauseUnattributed: a miss with no attempt signal at all, which only arises
+	// for results written before the attempt signal existed. It is counted
+	// separately rather than folded into a real cause, so a legacy file cannot
+	// silently inflate one.
+	CauseUnattributed Cause = "unattributed"
+)
+
+// String renders the cause as the phrase used in terminal summaries.
+func (c Cause) String() string {
+	switch c {
+	case CauseAttemptedFailed:
+		return "attempted, insight did not land"
+	case CauseBudgetStarved:
+		return "never attempted, budget exhausted"
+	case CauseNeverAttempted:
+		return "never attempted, budget remained"
+	case CauseBudgetUnobservable:
+		return "never attempted, budget not observable"
+	case CauseUnattributed:
+		return "unattributed (no attempt signal recorded)"
+	case CauseNone:
+		return ""
+	default:
+		return string(c)
+	}
+}
+
+// Classify attributes one graded capture outcome. captured is the graded
+// outcome (nil when capture was never reached, e.g. a harness abort — such an
+// outcome is excluded from the metrics entirely and classifies as CauseNone);
+// attempted is whether the episode executed a capture call (nil only for
+// results written before the signal existed); budgetExhausted is whether the
+// episode hit its tool-call budget (nil when that is not observable).
+func Classify(captured, attempted, budgetExhausted *bool) Cause {
+	if captured == nil || *captured {
+		return CauseNone
+	}
+	switch {
+	case attempted == nil:
+		return CauseUnattributed
+	case *attempted:
+		return CauseAttemptedFailed
+	case budgetExhausted == nil:
+		return CauseBudgetUnobservable
+	case *budgetExhausted:
+		return CauseBudgetStarved
+	default:
+		return CauseNeverAttempted
+	}
+}
+
+// Misses counts graded capture misses by attributed cause. Total is the sum of
+// the buckets, so a reader can confirm at a glance that every miss in the run
+// was attributed.
+type Misses struct {
+	Total              int `json:"total"`
+	AttemptedFailed    int `json:"attempted_failed"`
+	BudgetStarved      int `json:"budget_starved"`
+	NeverAttempted     int `json:"never_attempted"`
+	BudgetUnobservable int `json:"budget_unobservable"`
+	Unattributed       int `json:"unattributed,omitempty"`
+}
+
+// add folds one cause into the counts. CauseNone (not a miss) is ignored.
+func (m *Misses) add(c Cause) {
+	switch c {
+	case CauseAttemptedFailed:
+		m.AttemptedFailed++
+	case CauseBudgetStarved:
+		m.BudgetStarved++
+	case CauseNeverAttempted:
+		m.NeverAttempted++
+	case CauseBudgetUnobservable:
+		m.BudgetUnobservable++
+	case CauseUnattributed:
+		m.Unattributed++
+	case CauseNone:
+		return
+	default:
+		return
+	}
+	m.Total++
+}
+
+// counts pairs each cause with its bucket, in report order.
+func (m Misses) counts() []struct {
+	cause Cause
+	n     int
+} {
+	return []struct {
+		cause Cause
+		n     int
+	}{
+		{CauseAttemptedFailed, m.AttemptedFailed},
+		{CauseBudgetStarved, m.BudgetStarved},
+		{CauseNeverAttempted, m.NeverAttempted},
+		{CauseBudgetUnobservable, m.BudgetUnobservable},
+		{CauseUnattributed, m.Unattributed},
+	}
+}
+
+// Split is the capture decomposition both suites report alongside their capture
+// rate: among graded capture outcomes, how many episodes executed a capture call
+// (AttemptRate), how many of those landed an insight (GivenAttempted), and what
+// every miss is attributed to (Misses). AttemptRate shares the capture rate's
+// denominator, so the two read as a decomposition of the same population — with
+// one exception it must not hide: an outcome recorded before the attempt signal
+// existed is excluded from AttemptRate (and counted as an unattributed miss),
+// which is the only way the two denominators can differ.
+type Split struct {
+	AttemptRate    stats.Rate `json:"attempt_rate"`
+	GivenAttempted stats.Rate `json:"given_attempted"`
+	Misses         Misses     `json:"misses"`
+}
+
+// Add folds one graded capture outcome into the split. An outcome that was never
+// reached (captured == nil) is excluded from every denominator, mirroring how
+// the suites exclude harness failures from their rates. A legacy outcome with no
+// attempt signal (attempted == nil) is excluded from the attempt denominators —
+// counting it as "not attempted" would fabricate evidence — and, when it is a
+// miss, lands in the unattributed bucket.
+func (s *Split) Add(captured, attempted, budgetExhausted *bool) {
+	if captured == nil {
+		return
+	}
+	s.Misses.add(Classify(captured, attempted, budgetExhausted))
+	if attempted == nil {
+		return
+	}
+	s.AttemptRate.Add(attempted)
+	s.GivenAttempted.AddConditional(*attempted, *captured)
+}
+
+// FillCIs attaches bootstrap intervals to the split's rates, threading the
+// caller's seeded RNG so the scorecard stays reproducible from one seed.
+func (s *Split) FillCIs(rng *rand.Rand) {
+	stats.FillCIs(rng, &s.AttemptRate, &s.GivenAttempted)
+}
+
+// Rows renders the two split rates as scorecard lines under a capture-rate row.
+func (s Split) Rows() string {
+	return s.AttemptRate.Row("  capture attempted") + s.GivenAttempted.Row("  landed given attempt")
+}
+
+// MissBlock renders the miss attribution, or "" when nothing missed. Every miss
+// is listed under exactly one cause, so the counts sum to the total shown. An
+// unattributed miss carries a warning rather than a silent bucket: for a file
+// this harness wrote it would mean the attempt signal stopped being recorded,
+// which is a wiring regression, not a measurement.
+func (s Split) MissBlock() string {
+	if s.Misses.Total == 0 {
+		return ""
+	}
+	var parts []string
+	for _, c := range s.Misses.counts() {
+		if c.n > 0 {
+			parts = append(parts, fmt.Sprintf("%s %d", c.cause, c.n))
+		}
+	}
+	block := fmt.Sprintf("  capture misses (%d): %s\n", s.Misses.Total, strings.Join(parts, " | "))
+	if s.Misses.Unattributed > 0 {
+		block += fmt.Sprintf("  WARNING: %d capture miss(es) carry no attempt signal, so they are excluded from the attempted/landed split; expect this only for a results file written before the signal existed\n",
+			s.Misses.Unattributed)
+	}
+	return block
+}

--- a/bench/internal/capture/capture_test.go
+++ b/bench/internal/capture/capture_test.go
@@ -1,0 +1,192 @@
+package capture
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/txn2/mcp-data-platform/bench/internal/agent"
+	"github.com/txn2/mcp-data-platform/bench/internal/llm"
+	"github.com/txn2/mcp-data-platform/bench/internal/stats"
+)
+
+// executedCapture is a two-turn transcript: an assistant capture request paired
+// with a non-refusal tool result, i.e. a capture that actually ran.
+func executedCapture(name string) []llm.Message {
+	return []llm.Message{
+		{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "c1", Name: name}}},
+		{Role: "user", ToolResults: []llm.ToolResult{{CallID: "c1", Text: "captured in-1"}}},
+	}
+}
+
+func TestAttempted(t *testing.T) {
+	// A capture request the budget refused (only its refusal result is present)
+	// must not count as an executed capture.
+	budgetRefused := []llm.Message{
+		{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "memory_capture"}}},
+		{Role: "user", ToolResults: []llm.ToolResult{{CallID: "c1", Text: agent.BudgetRefusalText, IsError: true}}},
+	}
+	// A capture that ran but errored server-side still counts (a landing failure,
+	// not a budget-starvation miss).
+	serverError := []llm.Message{
+		{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "memory_capture"}}},
+		{Role: "user", ToolResults: []llm.ToolResult{{CallID: "c1", Text: "capture failed: entity not found", IsError: true}}},
+	}
+	cases := []struct {
+		name string
+		msgs []llm.Message
+		want bool
+	}{
+		{"empty", nil, false},
+		{"only search", []llm.Message{{Role: "assistant", ToolCalls: []llm.ToolCall{{Name: "search"}}}}, false},
+		{"executed memory_capture", executedCapture("memory_capture"), true},
+		{"executed suffix capture", executedCapture("knowledge_capture"), true},
+		{"namespaced claude-cli capture", executedCapture("mcp__bench__memory_capture"), true},
+		{"apply is not capture", []llm.Message{{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "apply_knowledge"}}},
+			{Role: "user", ToolResults: []llm.ToolResult{{CallID: "c1", Text: "applied"}}}}, false},
+		{"capture requested but never executed (no result)",
+			[]llm.Message{{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "memory_capture"}}}}, false},
+		{"capture budget-refused", budgetRefused, false},
+		{"capture ran but errored", serverError, true},
+	}
+	for _, c := range cases {
+		if got := Attempted(c.msgs); got != c.want {
+			t.Errorf("%s: Attempted = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestClassify(t *testing.T) {
+	cases := []struct {
+		name                              string
+		captured, attempted, budgetExhaus *bool
+		want                              Cause
+	}{
+		{"never reached", nil, new(true), new(false), CauseNone},
+		{"captured", new(true), new(true), new(false), CauseNone},
+		{"captured despite no observed attempt", new(true), new(false), new(true), CauseNone},
+		{"attempted and failed", new(false), new(true), new(false), CauseAttemptedFailed},
+		{"attempted and failed, budget also exhausted", new(false), new(true), new(true), CauseAttemptedFailed},
+		{"never attempted, budget exhausted", new(false), new(false), new(true), CauseBudgetStarved},
+		{"never attempted, budget remained", new(false), new(false), new(false), CauseNeverAttempted},
+		{"never attempted, budget unobservable", new(false), new(false), nil, CauseBudgetUnobservable},
+		{"legacy record with no attempt signal", new(false), nil, new(true), CauseUnattributed},
+	}
+	for _, c := range cases {
+		if got := Classify(c.captured, c.attempted, c.budgetExhaus); got != c.want {
+			t.Errorf("%s: Classify = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// TestSplitAttributesEveryMiss is the issue #1136 acceptance criterion: every
+// graded capture miss lands in exactly one cause bucket, and the buckets sum to
+// the miss total, so a run can never report a miss it cannot attribute.
+func TestSplitAttributesEveryMiss(t *testing.T) {
+	var s Split
+	outcomes := []struct{ captured, attempted, budget *bool }{
+		{new(true), new(true), new(false)},   // captured
+		{new(true), new(true), new(false)},   // captured
+		{new(false), new(true), new(false)},  // attempted, did not land
+		{new(false), new(false), new(true)},  // budget starved
+		{new(false), new(false), new(false)}, // never attempted, budget left
+		{new(false), new(false), nil},        // claude-cli: budget unobservable
+		{new(false), nil, nil},               // legacy record
+		{nil, new(false), new(false)},        // never reached: excluded entirely
+	}
+	for _, o := range outcomes {
+		s.Add(o.captured, o.attempted, o.budget)
+	}
+
+	m := s.Misses
+	if m.Total != 5 {
+		t.Fatalf("miss total = %d, want 5", m.Total)
+	}
+	if sum := m.AttemptedFailed + m.BudgetStarved + m.NeverAttempted + m.BudgetUnobservable + m.Unattributed; sum != m.Total {
+		t.Errorf("cause buckets sum to %d, want %d — a miss was left unattributed", sum, m.Total)
+	}
+	want := Misses{Total: 5, AttemptedFailed: 1, BudgetStarved: 1, NeverAttempted: 1, BudgetUnobservable: 1, Unattributed: 1}
+	if m != want {
+		t.Errorf("misses = %+v, want %+v", m, want)
+	}
+	// The attempt denominator counts the six outcomes with an attempt signal that
+	// were graded; the legacy record (no signal) and the never-reached run are
+	// both excluded rather than counted as "not attempted".
+	if s.AttemptRate.Num != 3 || s.AttemptRate.Den != 6 {
+		t.Errorf("attempt rate = %d/%d, want 3/6", s.AttemptRate.Num, s.AttemptRate.Den)
+	}
+	if s.GivenAttempted.Num != 2 || s.GivenAttempted.Den != 3 {
+		t.Errorf("landed given attempt = %d/%d, want 2/3", s.GivenAttempted.Num, s.GivenAttempted.Den)
+	}
+}
+
+func TestSplitFillCIsAndRender(t *testing.T) {
+	var s Split
+	for range 4 {
+		s.Add(new(true), new(true), new(false))
+	}
+	s.Add(new(false), new(false), new(true))
+	s.FillCIs(stats.NewRNG())
+	if s.AttemptRate.CILow == s.AttemptRate.CIHigh {
+		t.Errorf("attempt rate CI = [%v, %v], want a non-degenerate interval on a mixed sample",
+			s.AttemptRate.CILow, s.AttemptRate.CIHigh)
+	}
+	rows := s.Rows()
+	for _, want := range []string{"capture attempted", "landed given attempt", "95% CI"} {
+		if !strings.Contains(rows, want) {
+			t.Errorf("split rows missing %q:\n%s", want, rows)
+		}
+	}
+	block := s.MissBlock()
+	if !strings.Contains(block, "capture misses (1)") || !strings.Contains(block, CauseBudgetStarved.String()) {
+		t.Errorf("miss block did not attribute the miss:\n%s", block)
+	}
+}
+
+// TestUnattributedMissWarns proves an unattributed miss is flagged rather than
+// silently bucketed: for a file this harness wrote it would mean the attempt
+// signal stopped being recorded, which is a wiring regression.
+func TestUnattributedMissWarns(t *testing.T) {
+	var s Split
+	s.Add(new(false), nil, nil)
+	block := s.MissBlock()
+	if !strings.Contains(block, "WARNING: 1 capture miss(es) carry no attempt signal") {
+		t.Errorf("miss block did not warn about the unattributed miss:\n%s", block)
+	}
+	// A fully attributed run carries no warning.
+	var clean Split
+	clean.Add(new(false), new(false), new(true))
+	if strings.Contains(clean.MissBlock(), "WARNING") {
+		t.Errorf("attributed miss must not warn:\n%s", clean.MissBlock())
+	}
+}
+
+func TestMissBlockEmptyWhenNothingMissed(t *testing.T) {
+	var s Split
+	s.Add(new(true), new(true), new(false))
+	if got := s.MissBlock(); got != "" {
+		t.Errorf("miss block = %q, want empty when nothing missed", got)
+	}
+}
+
+func TestCauseString(t *testing.T) {
+	if got := CauseNone.String(); got != "" {
+		t.Errorf("CauseNone.String() = %q, want empty", got)
+	}
+	if got := Cause("future_cause").String(); got != "future_cause" {
+		t.Errorf("unknown cause = %q, want its raw value", got)
+	}
+	for _, c := range []Cause{CauseAttemptedFailed, CauseBudgetStarved, CauseNeverAttempted, CauseBudgetUnobservable, CauseUnattributed} {
+		if c.String() == "" || c.String() == string(c) {
+			t.Errorf("cause %q has no human phrase", c)
+		}
+	}
+}
+
+func TestMissesAddIgnoresNonMiss(t *testing.T) {
+	var m Misses
+	m.add(CauseNone)
+	m.add(Cause("unknown"))
+	if m.Total != 0 {
+		t.Errorf("miss total = %d, want 0 for non-miss causes", m.Total)
+	}
+}

--- a/bench/internal/coldstart/episode.go
+++ b/bench/internal/coldstart/episode.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/txn2/mcp-data-platform/bench/internal/agent"
 	"github.com/txn2/mcp-data-platform/bench/internal/auditapi"
+	"github.com/txn2/mcp-data-platform/bench/internal/capture"
 	"github.com/txn2/mcp-data-platform/bench/internal/claudecli"
 	"github.com/txn2/mcp-data-platform/bench/internal/grade"
 	"github.com/txn2/mcp-data-platform/bench/internal/llm"
@@ -105,9 +106,19 @@ type episodeResult struct {
 	toolErrors   int
 	searchCalled bool
 	memoryWrites int
-	wallMS       int64
-	usage        llm.Usage
-	audit        auditapi.Metrics
+	// captureAttempted is true when the episode executed a knowledge-capture call
+	// (a budget-refused request does not count). On a teach episode it separates a
+	// capture miss where the agent never tried from one where capture ran and the
+	// insight did not land (issue #1136).
+	captureAttempted bool
+	// budgetExhausted is whether the episode hit its tool-call budget, and nil
+	// when that is not observable: the claude-cli path runs its own turn budget,
+	// so a claude-cli miss is attributed no further than "never attempted" rather
+	// than being falsely asserted not-starved.
+	budgetExhausted *bool
+	wallMS          int64
+	usage           llm.Usage
+	audit           auditapi.Metrics
 	// auditReadErr records a failed audit read-back on an otherwise-successful
 	// episode. The attempt still grades, but its zero audit metrics must not
 	// pass for "no enrichment": pooled coverage is a documented pass criterion,
@@ -238,6 +249,10 @@ func (e *runEnv) runEpisode(ctx context.Context, spec episodeSpec) episodeResult
 	res.usage = result.Usage
 	res.finalAnswer = result.FinalAnswer
 	res.memoryWrites = countMemoryWrites(result.Transcript)
+	res.captureAttempted = capture.Attempted(result.Transcript)
+	// The loop owns the tool-call budget here, so its exhaustion is observable.
+	exhausted := result.BudgetExhausted
+	res.budgetExhausted = &exhausted
 	e.writeTranscript(spec, result.Transcript)
 	if runErr != nil {
 		res.err = fmt.Sprintf("agent loop: %v", runErr)
@@ -272,6 +287,9 @@ func (e *runEnv) runClaudeCLIEpisode(ctx context.Context, spec episodeSpec) epis
 	res.toolErrors = cres.ToolErrors
 	res.searchCalled = cres.SearchCalled
 	res.memoryWrites = countMemoryWrites(cres.Transcript)
+	// budgetExhausted stays nil: claude manages its own turn budget, so the
+	// harness cannot observe exhaustion on this path.
+	res.captureAttempted = capture.Attempted(cres.Transcript)
 	res.usage = cres.Usage
 	res.finalAnswer = cres.FinalText
 	e.recordPlatformVersion(cres.PlatformVersion)

--- a/bench/internal/coldstart/report.go
+++ b/bench/internal/coldstart/report.go
@@ -10,12 +10,16 @@ package coldstart
 import (
 	"encoding/json"
 	"fmt"
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used -- bootstrap-CI resampling for benchmark statistics; not security-sensitive, and a seedable PRNG is required for reproducible intervals.
+	"math/rand"
 	"os"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/txn2/mcp-data-platform/bench/internal/auditapi"
+	"github.com/txn2/mcp-data-platform/bench/internal/capture"
+	"github.com/txn2/mcp-data-platform/bench/internal/stats"
 )
 
 // Manifest pins the run so results are attributable and reproducible.
@@ -76,6 +80,14 @@ type LessonRecord struct {
 
 	Captured *bool `json:"captured,omitempty"` // insight recorded and entity-linked
 	Promoted *bool `json:"promoted,omitempty"` // applied + changeset links the insight
+
+	// Capture-miss attribution (issue #1136), read from the teach episode. Nil
+	// when the episode never ran (harness abort before teach).
+	CaptureAttempted *bool `json:"capture_attempted,omitempty"` // teach episode executed a capture call
+	// BudgetExhausted is nil when budget exhaustion is not observable (the
+	// claude-cli path runs its own turn budget), which attributes a miss on that
+	// path no further than "never attempted".
+	BudgetExhausted *bool `json:"budget_exhausted,omitempty"` // teach episode hit its tool-call budget (loop path only)
 
 	Episode EpisodeRecord `json:"episode"`
 	Error   string        `json:"error,omitempty"` // harness failure in the teach/promote
@@ -191,6 +203,17 @@ type Metrics struct {
 	Checkpoints     int `json:"checkpoints"`
 	EvalTasks       int `json:"eval_tasks"`
 	HarnessFailures int `json:"harness_failures"`
+
+	// CaptureRate is the headline capture metric with a confidence interval:
+	// among lessons whose capture outcome was graded, the fraction that landed an
+	// entity-linked insight. A lesson that misses capture is never promoted, so
+	// its trap class stays flat for the rest of the curve — capture caps the
+	// whole run, which is why it carries an interval and a decomposition rather
+	// than the bare LessonsCaptured count alone. Capture splits it into attempted
+	// versus landed and attributes every miss to a cause (issue #1136).
+	CaptureRate stats.Rate    `json:"capture_rate"`
+	Capture     capture.Split `json:"capture_split"`
+
 	// EvalMemoryWrites totals evaluator memory writes across every attempt. Any
 	// non-zero value flags the curve's validity: an evaluator taught itself
 	// something a later checkpoint's evaluators may have read.
@@ -245,12 +268,26 @@ func (res *Results) Aggregate() {
 		m.AccuracyLift = last.Accuracy - first.Accuracy
 		m.BaselineCoverage, m.FinalCoverage = first.EnrichmentCoverage, last.EnrichmentCoverage
 	}
+	m.fillCIs(stats.NewRNG())
 	res.Metrics = m
+}
+
+// fillCIs attaches a bootstrap confidence interval to the capture rates,
+// threading one seeded RNG in a fixed order so the scorecard is reproducible
+// from a single seed, exactly as the S1-S3 and S5 reports are. The curve's
+// accuracy points carry no interval here: they are per-checkpoint aggregates
+// over k evaluators answering a fixed eval set, which the report renders with
+// its own resampling.
+func (m *Metrics) fillCIs(rng *rand.Rand) {
+	stats.FillCIs(rng, &m.CaptureRate)
+	m.Capture.FillCIs(rng)
 }
 
 // foldLesson accumulates one lesson's outcome, validity signals, and token
 // spend into the scorecard.
 func (m *Metrics) foldLesson(l LessonRecord) {
+	m.CaptureRate.Add(l.Captured)
+	m.Capture.Add(l.Captured, l.CaptureAttempted, l.BudgetExhausted)
 	if boolTrue(l.Captured) {
 		m.LessonsCaptured++
 	}
@@ -353,6 +390,13 @@ func (res *Results) HumanSummary() string {
 	fmt.Fprintf(&b, "tokens: input %d  output %d  cache read %d  cache write %d (apply current model pricing for cost)\n\n",
 		mt.TotalInputTokens, mt.TotalOutputTokens, mt.TotalCacheReadTokens, mt.TotalCacheCreationTokens)
 
+	// Capture leads the scorecard: a lesson that misses capture is never
+	// promoted, so it caps every accuracy point downstream of it.
+	b.WriteString(mt.CaptureRate.Row("capture rate"))
+	b.WriteString(mt.Capture.Rows())
+	b.WriteString(mt.Capture.MissBlock())
+	b.WriteString("\n")
+
 	b.WriteString("learning curve (accuracy and enrichment coverage vs promoted knowledge):\n")
 	fmt.Fprintf(&b, "  %-4s %-22s %-9s %-8s %-9s\n", "idx", "lesson promoted", "promoted", "accuracy", "coverage")
 	for _, c := range res.Checkpoints {
@@ -400,7 +444,7 @@ func (res *Results) writeLessonFailures(b *strings.Builder) {
 		case l.Error != "":
 			lines = append(lines, fmt.Sprintf("  %s: %s", l.LessonID, l.Error))
 		case !boolTrue(l.Captured):
-			lines = append(lines, fmt.Sprintf("  %s: not captured", l.LessonID))
+			lines = append(lines, fmt.Sprintf("  %s: %s", l.LessonID, captureMissLine(l)))
 		case !boolTrue(l.Promoted):
 			lines = append(lines, fmt.Sprintf("  %s: captured but not promoted", l.LessonID))
 		}
@@ -410,6 +454,18 @@ func (res *Results) writeLessonFailures(b *strings.Builder) {
 	}
 	b.WriteString("\nlesson gaps (knowledge not delivered, so its class stays flat):\n")
 	b.WriteString(strings.Join(lines, "\n") + "\n")
+}
+
+// captureMissLine describes one lesson's capture miss, naming the attributed
+// cause so a reader sees which layer the miss points at (the agent, the harness
+// budget, or the capture path) without opening the transcript. A record whose
+// capture outcome was never graded carries no cause and is reported bare.
+func captureMissLine(l LessonRecord) string {
+	cause := capture.Classify(l.Captured, l.CaptureAttempted, l.BudgetExhausted)
+	if cause == capture.CauseNone {
+		return "not captured"
+	}
+	return "not captured (" + cause.String() + ")"
 }
 
 // short truncates a hash for display.

--- a/bench/internal/coldstart/report_test.go
+++ b/bench/internal/coldstart/report_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/txn2/mcp-data-platform/bench/internal/auditapi"
+	"github.com/txn2/mcp-data-platform/bench/internal/capture"
 )
 
 // sampleResults builds a two-lesson curve: a baseline where nothing is
@@ -159,6 +160,93 @@ func TestAuditReadFailuresWarn(t *testing.T) {
 	}
 	if !strings.Contains(res.HumanSummary(), "WARNING: 2 episode(s) lost their audit read-back") {
 		t.Errorf("summary missing the audit-read-back coverage warning\n%s", res.HumanSummary())
+	}
+}
+
+// TestCaptureRateIsHeadlineAndAttributed is the issue #1136 acceptance
+// criterion for the cold-start suite: capture is reported as a rate with a
+// confidence interval and an attempted/landed split, and every miss is
+// attributed to exactly one cause — on the run's summary and on the lesson that
+// missed. A capture miss keeps its lesson off the curve for good, so a bare
+// "captured 5 of 6" cannot say which layer to fix.
+func TestCaptureRateIsHeadlineAndAttributed(t *testing.T) {
+	res := sampleResults()
+	res.Lessons = append(res.Lessons,
+		// never reached capture, budget spent on discovery
+		LessonRecord{LessonID: "cs-starved", Captured: new(false), CaptureAttempted: new(false), BudgetExhausted: new(true)},
+		// capture ran; no linked insight landed
+		LessonRecord{LessonID: "cs-misfiled", Captured: new(false), CaptureAttempted: new(true), BudgetExhausted: new(false)},
+		// never called capture with budget to spare
+		LessonRecord{LessonID: "cs-untried", Captured: new(false), CaptureAttempted: new(false), BudgetExhausted: new(false)},
+		// claude-cli path: budget exhaustion is not observable
+		LessonRecord{LessonID: "cs-cli", Captured: new(false), CaptureAttempted: new(false)},
+	)
+	// The first two lessons predate the attempt signal in this fixture; they
+	// captured, so they carry no miss and only widen the rate's denominator.
+	res.Aggregate()
+	m := res.Metrics
+
+	if m.CaptureRate.Num != 2 || m.CaptureRate.Den != 6 {
+		t.Fatalf("capture rate = %d/%d, want 2/6", m.CaptureRate.Num, m.CaptureRate.Den)
+	}
+	if m.CaptureRate.CILow == m.CaptureRate.CIHigh {
+		t.Errorf("capture rate CI = [%v, %v], want a non-degenerate interval on a mixed run",
+			m.CaptureRate.CILow, m.CaptureRate.CIHigh)
+	}
+	if m.Capture.AttemptRate.Num != 1 || m.Capture.AttemptRate.Den != 4 {
+		t.Errorf("capture attempted = %d/%d, want 1/4 (the two lessons with no attempt signal are excluded)",
+			m.Capture.AttemptRate.Num, m.Capture.AttemptRate.Den)
+	}
+	if m.Capture.GivenAttempted.Num != 0 || m.Capture.GivenAttempted.Den != 1 {
+		t.Errorf("landed given attempt = %d/%d, want 0/1", m.Capture.GivenAttempted.Num, m.Capture.GivenAttempted.Den)
+	}
+	want := capture.Misses{Total: 4, AttemptedFailed: 1, BudgetStarved: 1, NeverAttempted: 1, BudgetUnobservable: 1}
+	if m.Capture.Misses != want {
+		t.Errorf("capture misses = %+v, want %+v", m.Capture.Misses, want)
+	}
+	// LessonsCaptured stays the plain count it always was, consistent with the rate.
+	if m.LessonsCaptured != m.CaptureRate.Num {
+		t.Errorf("lessons captured = %d, disagrees with the capture rate numerator %d", m.LessonsCaptured, m.CaptureRate.Num)
+	}
+
+	out := res.HumanSummary()
+	for _, w := range []string{
+		"capture rate", "capture attempted", "landed given attempt", "capture misses (4)",
+		"cs-starved: not captured (" + capture.CauseBudgetStarved.String() + ")",
+		"cs-misfiled: not captured (" + capture.CauseAttemptedFailed.String() + ")",
+		"cs-cli: not captured (" + capture.CauseBudgetUnobservable.String() + ")",
+	} {
+		if !strings.Contains(out, w) {
+			t.Errorf("summary missing %q\n%s", w, out)
+		}
+	}
+}
+
+// TestCaptureMissWithoutAttemptSignal covers a results file written before the
+// attempt signal existed: the miss is reported as unattributed rather than
+// silently counted as one of the real causes.
+func TestCaptureMissWithoutAttemptSignal(t *testing.T) {
+	res := &Results{Lessons: []LessonRecord{{LessonID: "cs-legacy", Captured: new(false)}}}
+	res.Aggregate()
+	if got := res.Metrics.Capture.Misses; got.Total != 1 || got.Unattributed != 1 {
+		t.Errorf("misses = %+v, want 1 unattributed", got)
+	}
+	if res.Metrics.Capture.AttemptRate.Den != 0 {
+		t.Errorf("attempt denominator = %d, want 0 — a record with no signal must not count as not-attempted",
+			res.Metrics.Capture.AttemptRate.Den)
+	}
+	if !strings.Contains(res.HumanSummary(), "cs-legacy: not captured ("+capture.CauseUnattributed.String()+")") {
+		t.Errorf("summary did not mark the legacy miss unattributed\n%s", res.HumanSummary())
+	}
+	if !strings.Contains(res.HumanSummary(), "WARNING: 1 capture miss(es) carry no attempt signal") {
+		t.Errorf("summary did not warn about the unattributed miss\n%s", res.HumanSummary())
+	}
+	// A lesson whose capture outcome was never graded carries no cause at all,
+	// and must not be rendered with an empty parenthetical.
+	ungraded := &Results{Lessons: []LessonRecord{{LessonID: "cs-ungraded"}}}
+	ungraded.Aggregate()
+	if !strings.Contains(ungraded.HumanSummary(), "cs-ungraded: not captured\n") {
+		t.Errorf("ungraded lesson should render bare\n%s", ungraded.HumanSummary())
 	}
 }
 

--- a/bench/internal/coldstart/runner.go
+++ b/bench/internal/coldstart/runner.go
@@ -307,6 +307,10 @@ func (e *runEnv) teachAndPromote(ctx context.Context, lesson curriculum.Lesson, 
 		prompt: lesson.Teach.Prompt, system: teachScaffold, budget: lesson.BudgetToolCalls,
 	})
 	lr.Episode = teachEpisode(rec)
+	// Record the miss attribution before the abort check: a teach episode that
+	// ran and then failed a later step still says whether capture was attempted.
+	attempted := rec.captureAttempted
+	lr.CaptureAttempted, lr.BudgetExhausted = &attempted, rec.budgetExhausted
 	if rec.err != "" {
 		lr.Error = rec.err
 		return lr

--- a/bench/internal/coldstart/runner_test.go
+++ b/bench/internal/coldstart/runner_test.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/txn2/mcp-data-platform/bench/internal/auditapi"
+	"github.com/txn2/mcp-data-platform/bench/internal/capture"
 	"github.com/txn2/mcp-data-platform/bench/internal/claudecli"
 	"github.com/txn2/mcp-data-platform/bench/internal/curriculum"
 	"github.com/txn2/mcp-data-platform/bench/internal/lifecycleapi"
@@ -949,6 +950,72 @@ func TestTeachAndPromoteBranches(t *testing.T) {
 			}
 			assertBoolPtr(t, "captured", lr.Captured, tc.wantCaptured)
 			assertBoolPtr(t, "promoted", lr.Promoted, tc.wantPromoted)
+		})
+	}
+}
+
+// TestCaptureMissAttributionWiring drives the real teach path and asserts each
+// capture miss carries the signals its cause is derived from (issue #1136): a
+// teacher that never reaches capture under a spent budget is starved, one that
+// files the insight against another entity attempted and did not land, and a
+// clean capture leaves no miss at all. Attribution is derived from the
+// transcript the episode actually produced, so this is what a paid run records.
+func TestCaptureMissAttributionWiring(t *testing.T) {
+	lesson := testCurriculum().Lessons[0]
+	starved := lesson
+	starved.BudgetToolCalls = 1 // one search spends it; the capture call is refused
+
+	cases := []struct {
+		name      string
+		lesson    curriculum.Lesson
+		factory   AdapterFactory
+		wantCause capture.Cause
+	}{
+		{
+			name: "budget starved before capture", lesson: starved,
+			factory: func(string, string) (llm.Adapter, error) {
+				return llm.NewScripted([]llm.Step{
+					{ToolCalls: []llm.ToolCall{{Name: "search", Args: map[string]any{"query": "orders"}}}},
+					{ToolCalls: []llm.ToolCall{{Name: "memory_capture", Args: map[string]any{
+						"text": "cents", "category": "business_context", "entity_urns": []any{ordersURN}}}}},
+					{FinalText: "ran out of calls"},
+				}), nil
+			},
+			wantCause: capture.CauseBudgetStarved,
+		},
+		{
+			name: "capture executed against the wrong entity", lesson: lesson,
+			factory: func(string, string) (llm.Adapter, error) {
+				return &knowledgeAdapter{mode: StageTeach, class: lesson.TrapClass,
+					urn: "urn:li:dataset:(urn:li:dataPlatform:trino,memory.bench.other,PROD)"}, nil
+			},
+			wantCause: capture.CauseAttemptedFailed,
+		},
+		{
+			name: "never attempted with budget to spare", lesson: lesson,
+			factory: func(string, string) (llm.Adapter, error) {
+				return llm.NewScripted([]llm.Step{{FinalText: "noted"}}), nil
+			},
+			wantCause: capture.CauseNeverAttempted,
+		},
+		{
+			name: "clean capture", lesson: lesson, factory: capturingTeachFactory(lesson),
+			wantCause: capture.CauseNone,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fp := newFakePlatform(t)
+			env := newTestEnv(fp, tc.factory)
+			lr := env.teachAndPromote(context.Background(), tc.lesson, 1)
+			if lr.Error != "" {
+				t.Fatalf("unexpected harness error: %s", lr.Error)
+			}
+			got := capture.Classify(lr.Captured, lr.CaptureAttempted, lr.BudgetExhausted)
+			if got != tc.wantCause {
+				t.Fatalf("cause = %q, want %q (captured=%v attempted=%v budgetExhausted=%v)",
+					got, tc.wantCause, lr.Captured, lr.CaptureAttempted, lr.BudgetExhausted)
+			}
 		})
 	}
 }

--- a/bench/internal/lifecycle/diagnosis_test.go
+++ b/bench/internal/lifecycle/diagnosis_test.go
@@ -2,10 +2,14 @@ package lifecycle
 
 import (
 	"context"
+	"maps"
+	"strings"
 	"testing"
 
+	"github.com/txn2/mcp-data-platform/bench/internal/capture"
 	"github.com/txn2/mcp-data-platform/bench/internal/llm"
 	"github.com/txn2/mcp-data-platform/bench/internal/protocol"
+	"github.com/txn2/mcp-data-platform/bench/internal/stats"
 )
 
 // TestAggregateDecomposition verifies the transfer-gap and capture-budget
@@ -41,6 +45,96 @@ func TestAggregateDecomposition(t *testing.T) {
 	// Capture misses are runs d and e; only d was budget-starved before capture.
 	if m.CaptureBudgetStarved.Num != 1 || m.CaptureBudgetStarved.Den != 2 {
 		t.Errorf("capture budget-starved = %d/%d, want 1/2", m.CaptureBudgetStarved.Num, m.CaptureBudgetStarved.Den)
+	}
+}
+
+// TestCaptureSplitAttribution is the issue #1136 acceptance criterion on the S5
+// scorecard: capture is reported with an attempted/landed split over the same
+// denominator as the headline rate, and every capture miss in the run is
+// attributed to exactly one cause.
+func TestCaptureSplitAttribution(t *testing.T) {
+	res := &Results{
+		Manifest: Manifest{K: 1},
+		Runs: []ProtocolRun{
+			{ProtocolID: "a", Captured: new(true), CaptureAttempted: new(true), TeachBudgetExhausted: new(false)},
+			{ProtocolID: "b", Captured: new(true), CaptureAttempted: new(true), TeachBudgetExhausted: new(false)},
+			// miss: capture ran, the insight did not land (the capture path itself)
+			{ProtocolID: "c", Captured: new(false), CaptureAttempted: new(true), TeachBudgetExhausted: new(false)},
+			// miss: never reached capture, budget spent on discovery (the harness budget)
+			{ProtocolID: "d", Captured: new(false), CaptureAttempted: new(false), TeachBudgetExhausted: new(true)},
+			// miss: never called capture with budget to spare (the model or its steering)
+			{ProtocolID: "e", Captured: new(false), CaptureAttempted: new(false), TeachBudgetExhausted: new(false)},
+			// miss on the claude-cli path: budget exhaustion is not observable
+			{ProtocolID: "f", Captured: new(false), CaptureAttempted: new(false)},
+			// harness failure: excluded from every capture denominator
+			{ProtocolID: "g", Error: "teach: connect refused"},
+		},
+	}
+	res.Aggregate()
+	m := res.Metrics
+
+	if m.CaptureRate.Num != 2 || m.CaptureRate.Den != 6 {
+		t.Errorf("capture rate = %d/%d, want 2/6", m.CaptureRate.Num, m.CaptureRate.Den)
+	}
+	if m.Capture.AttemptRate.Num != 3 || m.Capture.AttemptRate.Den != 6 {
+		t.Errorf("capture attempted = %d/%d, want 3/6 (same denominator as the capture rate)",
+			m.Capture.AttemptRate.Num, m.Capture.AttemptRate.Den)
+	}
+	if m.Capture.GivenAttempted.Num != 2 || m.Capture.GivenAttempted.Den != 3 {
+		t.Errorf("landed given attempt = %d/%d, want 2/3", m.Capture.GivenAttempted.Num, m.Capture.GivenAttempted.Den)
+	}
+	misses := m.Capture.Misses
+	want := capture.Misses{Total: 4, AttemptedFailed: 1, BudgetStarved: 1, NeverAttempted: 1, BudgetUnobservable: 1}
+	if misses != want {
+		t.Errorf("capture misses = %+v, want %+v", misses, want)
+	}
+	if sum := misses.AttemptedFailed + misses.BudgetStarved + misses.NeverAttempted + misses.BudgetUnobservable + misses.Unattributed; sum != misses.Total {
+		t.Errorf("cause buckets sum to %d of %d misses — a miss was left unattributed", sum, misses.Total)
+	}
+	// The breakdown must agree with the #964 starvation rate it decomposes: both
+	// count the same starved miss, over the three misses whose budget is observable.
+	if m.CaptureBudgetStarved.Num != misses.BudgetStarved || m.CaptureBudgetStarved.Den != 3 {
+		t.Errorf("capture budget-starved = %d/%d, want %d/3 (must agree with the miss breakdown)",
+			m.CaptureBudgetStarved.Num, m.CaptureBudgetStarved.Den, misses.BudgetStarved)
+	}
+	// The split carries the same uncertainty signal the headline rate does.
+	if m.Capture.AttemptRate.CILow == m.Capture.AttemptRate.CIHigh {
+		t.Errorf("capture attempt rate CI = [%v, %v], want a non-degenerate interval on a mixed sample",
+			m.Capture.AttemptRate.CILow, m.Capture.AttemptRate.CIHigh)
+	}
+
+	summary := res.HumanSummary()
+	for _, w := range []string{"capture rate", "capture attempted", "landed given attempt", "capture misses (4)"} {
+		if !strings.Contains(summary, w) {
+			t.Errorf("summary missing %q:\n%s", w, summary)
+		}
+	}
+}
+
+// TestCaptureRateCIsUnaffectedByTheSplit pins the reproducibility contract the
+// split had to preserve: the capture-split rates are filled from the shared RNG
+// LAST, so adding them left every previously reported interval identical.
+func TestCaptureRateCIsUnaffectedByTheSplit(t *testing.T) {
+	runs := []ProtocolRun{
+		{ProtocolID: "a", Captured: new(true), RecallCorrect: new(true), CaptureAttempted: new(true), TeachBudgetExhausted: new(false)},
+		{ProtocolID: "b", Captured: new(false), RecallCorrect: new(false), CaptureAttempted: new(false), TeachBudgetExhausted: new(true)},
+		{ProtocolID: "c", Captured: new(true), RecallCorrect: new(false), CaptureAttempted: new(true), TeachBudgetExhausted: new(false)},
+	}
+	withSplit := &Results{Manifest: Manifest{K: 1}, Runs: runs}
+	withSplit.Aggregate()
+
+	// The pre-#1136 fill order, reproduced exactly: the twelve scorecard rates in
+	// their original sequence, with no capture-split rates drawn from the RNG.
+	m := withSplit.Metrics
+	stats.FillCIs(stats.NewRNG(),
+		&m.CaptureRate, &m.PersonalRecall, &m.UnpromptedSurface,
+		&m.TransferRate, &m.TransferSurfaced, &m.TransferUsedGivenSurfaced,
+		&m.UpdateCorrectness, &m.UpdateCaptureRate, &m.DuplicateRate, &m.AbstentionRate,
+		&m.CaptureBudgetStarved, &m.PassK,
+	)
+	if m.CaptureRate != withSplit.Metrics.CaptureRate || m.PersonalRecall != withSplit.Metrics.PersonalRecall {
+		t.Errorf("adding the capture split shifted an existing interval:\n capture   %+v vs %+v\n recall    %+v vs %+v",
+			m.CaptureRate, withSplit.Metrics.CaptureRate, m.PersonalRecall, withSplit.Metrics.PersonalRecall)
 	}
 }
 
@@ -132,6 +226,76 @@ func TestCaptureBudgetStarvation(t *testing.T) {
 	if res.Metrics.CaptureBudgetStarved.Num != 1 || res.Metrics.CaptureBudgetStarved.Den != 1 {
 		t.Fatalf("capture budget-starved = %d/%d, want 1/1",
 			res.Metrics.CaptureBudgetStarved.Num, res.Metrics.CaptureBudgetStarved.Den)
+	}
+}
+
+// misfiledProtocol teaches with enough budget to reach capture; its script files
+// the insight against the wrong entity, so the capture executes but no linked
+// insight lands — the attempted-and-failed miss, which points at the capture
+// path rather than at the budget or the agent's willingness to try.
+func misfiledProtocol() protocol.Protocol {
+	p := okProtocol()
+	p.ID = "lc-misfile"
+	p.Transfer = nil
+	return p
+}
+
+func misfiledScript() map[string]llm.Script {
+	misfiled := llm.Step{ToolCalls: []llm.ToolCall{{Name: "memory_capture", Args: map[string]any{
+		"text": "net revenue fact", "entity_urns": []any{"urn:li:dataset:(urn:li:dataPlatform:trino,bench.other.table,PROD)"},
+		"category": "definition",
+	}}}}
+	return map[string]llm.Script{
+		"lc-misfile": {
+			StageTeach:   {misfiled, {FinalText: "saved"}},
+			StageRecall:  {searchStep(), {FinalText: "FINAL ANSWER: 999.99"}},
+			StageAbstain: {{FinalText: "FINAL ANSWER: INSUFFICIENT INFORMATION"}},
+		},
+	}
+}
+
+// TestCaptureMissAttributionEndToEnd drives the real runner over two protocols
+// that miss capture for different reasons and asserts the run attributes each
+// one to its own cause — the issue #1136 criterion that a miss is never just a
+// count. The two causes imply fixes in different layers, so conflating them
+// would misdirect any capture work that follows.
+func TestCaptureMissAttributionEndToEnd(t *testing.T) {
+	fp := newFakePlatform(t)
+	dir := t.TempDir()
+	writeProtocols(t, dir, starvedProtocol(), misfiledProtocol())
+	scripts := starvedScript()
+	maps.Copy(scripts, misfiledScript())
+	res, err := Run(context.Background(), runOptions(fp, dir, scriptFactory(scripts)))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	byProtocol := map[string]ProtocolRun{}
+	for _, r := range res.Runs {
+		if r.Error != "" {
+			t.Fatalf("%s: unexpected harness error: %s", r.ProtocolID, r.Error)
+		}
+		byProtocol[r.ProtocolID] = r
+	}
+	starved, misfiled := byProtocol["lc-starve"], byProtocol["lc-misfile"]
+	assertFalse(t, "starved captured", starved.Captured)
+	assertFalse(t, "starved capture attempted", starved.CaptureAttempted)
+	assertFalse(t, "misfiled captured", misfiled.Captured)
+	assertTrue(t, "misfiled capture attempted", misfiled.CaptureAttempted)
+
+	m := res.Metrics
+	if m.CaptureRate.Num != 0 || m.CaptureRate.Den != 2 {
+		t.Fatalf("capture rate = %d/%d, want 0/2", m.CaptureRate.Num, m.CaptureRate.Den)
+	}
+	if m.Capture.AttemptRate.Num != 1 || m.Capture.AttemptRate.Den != 2 {
+		t.Errorf("capture attempted = %d/%d, want 1/2", m.Capture.AttemptRate.Num, m.Capture.AttemptRate.Den)
+	}
+	if m.Capture.GivenAttempted.Num != 0 || m.Capture.GivenAttempted.Den != 1 {
+		t.Errorf("landed given attempt = %d/%d, want 0/1", m.Capture.GivenAttempted.Num, m.Capture.GivenAttempted.Den)
+	}
+	want := capture.Misses{Total: 2, AttemptedFailed: 1, BudgetStarved: 1}
+	if m.Capture.Misses != want {
+		t.Errorf("capture misses = %+v, want %+v", m.Capture.Misses, want)
 	}
 }
 

--- a/bench/internal/lifecycle/instrument.go
+++ b/bench/internal/lifecycle/instrument.go
@@ -3,7 +3,7 @@ package lifecycle
 import (
 	"strings"
 
-	"github.com/txn2/mcp-data-platform/bench/internal/agent"
+	"github.com/txn2/mcp-data-platform/bench/internal/capture"
 	"github.com/txn2/mcp-data-platform/bench/internal/llm"
 	"github.com/txn2/mcp-data-platform/bench/internal/protocol"
 )
@@ -23,52 +23,11 @@ import (
 // derivation.
 func (rec *EpisodeRecord) recordInstrumentation(spec episodeSpec, transcript []llm.Message, budgetExhausted bool) {
 	rec.BudgetExhausted = budgetExhausted
-	rec.CaptureAttempted = captureToolCalled(transcript)
+	rec.CaptureAttempted = capture.Attempted(transcript)
 	if spec.surfaceFact != "" {
 		s := factSurfaced(spec.surfaceFact, transcript)
 		rec.FactSurfaced = &s
 	}
-}
-
-// captureToolCalled reports whether the episode actually executed a knowledge
-// capture call. A capture request the budget refused (emitted only after the
-// tool-call budget was spent, so it never ran) does NOT count: it is a
-// budget-starvation miss, not an "attempted capture that failed to land". This
-// keeps the capture-budget diagnosis honest — a teacher that only reaches for
-// capture after burning its budget on discovery is starved, not a landing
-// failure. It distinguishes a capture miss caused by never reaching an executed
-// capture (budget starvation) from one where capture ran but the insight did
-// not land.
-func captureToolCalled(msgs []llm.Message) bool {
-	captureIDs := map[string]bool{}
-	for _, m := range msgs {
-		for _, c := range m.ToolCalls {
-			if isCaptureTool(c.Name) {
-				captureIDs[c.ID] = true
-			}
-		}
-	}
-	if len(captureIDs) == 0 {
-		return false
-	}
-	for _, m := range msgs {
-		for _, r := range m.ToolResults {
-			// A capture call ran when its paired result is present and is not the
-			// budget-refusal sentinel. A server-side capture error still counts as
-			// executed (that is a landing failure, a different bucket).
-			if captureIDs[r.CallID] && r.Text != agent.BudgetRefusalText {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// isCaptureTool reports whether a tool name is the knowledge-capture tool. The
-// suffix match tolerates a renamed or namespaced capture tool without silently
-// classifying every teach episode as a capture miss.
-func isCaptureTool(name string) bool {
-	return name == "memory_capture" || strings.HasSuffix(name, "_capture")
 }
 
 // factSurfaced reports whether the promoted fact appeared in any tool result the

--- a/bench/internal/lifecycle/instrument_test.go
+++ b/bench/internal/lifecycle/instrument_test.go
@@ -3,7 +3,6 @@ package lifecycle
 import (
 	"testing"
 
-	"github.com/txn2/mcp-data-platform/bench/internal/agent"
 	"github.com/txn2/mcp-data-platform/bench/internal/llm"
 	"github.com/txn2/mcp-data-platform/bench/internal/protocol"
 )
@@ -22,51 +21,6 @@ func TestNormalizeText(t *testing.T) {
 	for _, c := range cases {
 		if got := normalizeText(c.in); got != c.want {
 			t.Errorf("normalizeText(%q) = %q, want %q", c.in, got, c.want)
-		}
-	}
-}
-
-// executedCapture is a two-turn transcript: an assistant capture request paired
-// with a non-refusal tool result, i.e. a capture that actually ran.
-func executedCapture(name string) []llm.Message {
-	return []llm.Message{
-		{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "c1", Name: name}}},
-		{Role: "user", ToolResults: []llm.ToolResult{{CallID: "c1", Text: "captured in-1"}}},
-	}
-}
-
-func TestCaptureToolCalled(t *testing.T) {
-	// A capture request the budget refused (only its refusal result is present)
-	// must not count as an executed capture.
-	budgetRefused := []llm.Message{
-		{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "memory_capture"}}},
-		{Role: "user", ToolResults: []llm.ToolResult{{CallID: "c1", Text: agent.BudgetRefusalText, IsError: true}}},
-	}
-	// A capture that ran but errored server-side still counts (a landing failure,
-	// not a budget-starvation miss).
-	serverError := []llm.Message{
-		{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "memory_capture"}}},
-		{Role: "user", ToolResults: []llm.ToolResult{{CallID: "c1", Text: "capture failed: entity not found", IsError: true}}},
-	}
-	cases := []struct {
-		name string
-		msgs []llm.Message
-		want bool
-	}{
-		{"empty", nil, false},
-		{"only search", []llm.Message{{Role: "assistant", ToolCalls: []llm.ToolCall{{Name: "search"}}}}, false},
-		{"executed memory_capture", executedCapture("memory_capture"), true},
-		{"executed suffix capture", executedCapture("knowledge_capture"), true},
-		{"apply is not capture", []llm.Message{{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "apply_knowledge"}}},
-			{Role: "user", ToolResults: []llm.ToolResult{{CallID: "c1", Text: "applied"}}}}, false},
-		{"capture requested but never executed (no result)",
-			[]llm.Message{{Role: "assistant", ToolCalls: []llm.ToolCall{{ID: "c1", Name: "memory_capture"}}}}, false},
-		{"capture budget-refused", budgetRefused, false},
-		{"capture ran but errored", serverError, true},
-	}
-	for _, c := range cases {
-		if got := captureToolCalled(c.msgs); got != c.want {
-			t.Errorf("%s: captureToolCalled = %v, want %v", c.name, got, c.want)
 		}
 	}
 }

--- a/bench/internal/lifecycle/report.go
+++ b/bench/internal/lifecycle/report.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/txn2/mcp-data-platform/bench/internal/auditapi"
+	"github.com/txn2/mcp-data-platform/bench/internal/capture"
 	"github.com/txn2/mcp-data-platform/bench/internal/stats"
 )
 
@@ -172,72 +173,10 @@ func boolTrue(b *bool) bool { return b != nil && *b }
 // omits a stage is not penalized for it.
 func optPass(b *bool) bool { return b == nil || *b }
 
-// Rate is one metric's numerator, denominator, and ratio. Denominator counts
-// only the runs where the outcome was applicable and reached.
-type Rate struct {
-	Num  int     `json:"num"`
-	Den  int     `json:"den"`
-	Rate float64 `json:"rate"`
-	// CILow/CIHigh are the 95% percentile-bootstrap confidence interval on the
-	// rate (issue #965), resampled from num/den with a fixed seed so the interval
-	// is reproducible. Both zero when the denominator is empty — the metric was
-	// not exercised, so it carries no interval. The bootstrap treats each
-	// applicable outcome as an independent draw (like the S1-S3 report); it does
-	// not model protocol-level correlation across the k replicates, so a narrow
-	// interval on a small, few-protocol denominator still warrants caution.
-	CILow  float64 `json:"ci_low"`
-	CIHigh float64 `json:"ci_high"`
-}
-
-// fillCI attaches a bootstrap confidence interval to the rate from its num/den.
-// The caller threads one seeded RNG across a scorecard's rates so the whole
-// report is reproducible from a single seed (issue #965).
-func (r *Rate) fillCI(rng *rand.Rand) {
-	r.CILow, r.CIHigh = stats.ProportionCI(r.Num, r.Den, rng)
-}
-
-// add folds one applicable outcome into the rate.
-func (r *Rate) add(v *bool) {
-	if v == nil {
-		return
-	}
-	r.Den++
-	if *v {
-		r.Num++
-	}
-	if r.Den > 0 {
-		r.Rate = float64(r.Num) / float64(r.Den)
-	}
-}
-
-// addConditional folds one outcome into a conditional rate: the run counts
-// toward the denominator only when it belongs to the conditioning subset (e.g.
-// "among transfer attempts where the fact surfaced"). It backs the transfer-gap
-// and capture-budget decompositions, whose denominators are subsets of the
-// attempts rather than a single nil-able outcome.
-func (r *Rate) addConditional(applicable, value bool) {
-	if !applicable {
-		return
-	}
-	r.Den++
-	if value {
-		r.Num++
-	}
-	if r.Den > 0 {
-		r.Rate = float64(r.Num) / float64(r.Den)
-	}
-}
-
-// complement returns the rate of the opposite outcome over the same
-// denominator, so a pair like supersede/duplicate is stored once and derived
-// once rather than accumulated twice (which could silently drift apart).
-func (r Rate) complement() Rate {
-	c := Rate{Num: r.Den - r.Num, Den: r.Den}
-	if c.Den > 0 {
-		c.Rate = float64(c.Num) / float64(c.Den)
-	}
-	return c
-}
+// Rate is one metric's numerator, denominator, and ratio, with its bootstrap
+// confidence interval. It is the shared stats type: the cold-start suite reports
+// the same shape, so the two suites cannot drift into two rate implementations.
+type Rate = stats.Rate
 
 // captureMissed reports whether capture was applicable to a run and failed.
 func captureMissed(captured *bool) bool { return captured != nil && !*captured }
@@ -277,7 +216,14 @@ type Metrics struct {
 	TotalCacheReadTokens     int64 `json:"total_cache_read_tokens"`
 	TotalCacheCreationTokens int64 `json:"total_cache_creation_tokens"`
 
-	CaptureRate       Rate `json:"capture_rate"`
+	// CaptureRate is the headline capture metric: among graded runs, the fraction
+	// whose teach episode landed an entity-linked insight. It caps every metric
+	// below it — an insight that was never recorded can be neither recalled nor
+	// promoted — so Capture decomposes it into attempted versus landed and
+	// attributes every miss to a cause (issue #1136).
+	CaptureRate Rate          `json:"capture_rate"`
+	Capture     capture.Split `json:"capture_split"`
+
 	PersonalRecall    Rate `json:"personal_recall"`
 	UnpromptedSurface Rate `json:"unprompted_surface"` // among captured runs, search surfaced the memory
 	TransferRate      Rate `json:"transfer_rate"`
@@ -341,17 +287,18 @@ func (res *Results) Aggregate() {
 			continue
 		}
 		m.Attempts++
-		m.CaptureRate.add(r.Captured)
-		m.PersonalRecall.add(r.RecallCorrect)
-		m.UnpromptedSurface.add(r.RecallSurfaced)
-		m.TransferRate.add(r.TransferCorrect)
-		m.TransferSurfaced.add(r.TransferSurfaced)
-		m.TransferUsedGivenSurfaced.addConditional(boolTrue(r.TransferSurfaced), boolTrue(r.TransferCorrect))
-		m.UpdateCorrectness.add(r.UpdateCorrect)
-		m.UpdateCaptureRate.add(r.UpdateCaptured)
-		m.DuplicateRate.add(r.Duplicated)
-		m.AbstentionRate.add(r.AbstainCorrect)
-		m.CaptureBudgetStarved.addConditional(captureBudgetObservable(r), budgetStarved(r))
+		m.CaptureRate.Add(r.Captured)
+		m.PersonalRecall.Add(r.RecallCorrect)
+		m.UnpromptedSurface.Add(r.RecallSurfaced)
+		m.TransferRate.Add(r.TransferCorrect)
+		m.TransferSurfaced.Add(r.TransferSurfaced)
+		m.TransferUsedGivenSurfaced.AddConditional(boolTrue(r.TransferSurfaced), boolTrue(r.TransferCorrect))
+		m.UpdateCorrectness.Add(r.UpdateCorrect)
+		m.UpdateCaptureRate.Add(r.UpdateCaptured)
+		m.DuplicateRate.Add(r.Duplicated)
+		m.AbstentionRate.Add(r.AbstainCorrect)
+		m.CaptureBudgetStarved.AddConditional(captureBudgetObservable(r), budgetStarved(r))
+		m.Capture.Add(r.Captured, r.CaptureAttempted, r.TeachBudgetExhausted)
 	}
 	m.Protocols = len(order)
 	m.PassK = passKRate(order, byProtocol, res.Manifest.K)
@@ -363,16 +310,19 @@ func (res *Results) Aggregate() {
 // scorecard, threading one RNG in a fixed order so the whole report is
 // reproducible from a single seed (issue #965). The #964 diagnostic
 // decompositions carry intervals too — a reader weighing "surfaced but not used"
-// against noise needs the same uncertainty signal the headline rates carry.
+// against noise needs the same uncertainty signal the headline rates carry, and
+// so does one weighing the capture attempted/landed split (#1136). The RNG
+// advances per rate, so the capture-split rates are filled LAST: appending them
+// leaves every previously reported interval reproducible from the same seed,
+// which inserting them next to the capture rate would not.
 func (m *Metrics) fillCIs(rng *rand.Rand) {
-	for _, r := range []*Rate{
+	stats.FillCIs(rng,
 		&m.CaptureRate, &m.PersonalRecall, &m.UnpromptedSurface,
 		&m.TransferRate, &m.TransferSurfaced, &m.TransferUsedGivenSurfaced,
 		&m.UpdateCorrectness, &m.UpdateCaptureRate, &m.DuplicateRate, &m.AbstentionRate,
 		&m.CaptureBudgetStarved, &m.PassK,
-	} {
-		r.fillCI(rng)
-	}
+	)
+	m.Capture.FillCIs(rng)
 }
 
 // passKRate computes the fraction of protocols whose every one of the k attempts
@@ -446,6 +396,8 @@ func (res *Results) HumanSummary() string {
 	fmt.Fprintf(&b, "tokens: input %d  output %d  cache read %d  cache write %d (apply current model pricing for cost)\n\n",
 		mt.TotalInputTokens, mt.TotalOutputTokens, mt.TotalCacheReadTokens, mt.TotalCacheCreationTokens)
 	writeMetric(&b, "capture rate", mt.CaptureRate)
+	b.WriteString(mt.Capture.Rows())
+	b.WriteString(mt.Capture.MissBlock())
 	writeMetric(&b, "personal recall", mt.PersonalRecall)
 	writeMetric(&b, "unprompted surface", mt.UnpromptedSurface)
 	writeMetric(&b, "transfer rate", mt.TransferRate)
@@ -466,21 +418,10 @@ func (res *Results) HumanSummary() string {
 	return b.String()
 }
 
-// writeMetric renders one rate row. The 95% CI bracket is shown only when the
-// interval has width (CILow != CIHigh). A zero-width interval carries no
-// uncertainty and is omitted: it arises for an unexercised metric (empty
-// denominator), for an all-failure rate whose bootstrap collapses to a point at
-// zero AND for an all-success rate that collapses to a point at one (both ends,
-// not just zero), and for a pre-#965 results file whose stored metrics carry no
-// interval (the fields default to zero) — all of which would otherwise print a
-// meaningless [x.x-x.x] bracket the count already conveys.
+// writeMetric renders one rate row, in the shared scorecard format both suites
+// print (see stats.Rate.Row for how the CI bracket is handled).
 func writeMetric(b *strings.Builder, label string, r Rate) {
-	if r.CILow == r.CIHigh {
-		fmt.Fprintf(b, "  %-22s %5.1f%%  (%d/%d)\n", label, r.Rate*100, r.Num, r.Den)
-		return
-	}
-	fmt.Fprintf(b, "  %-22s %5.1f%%  95%% CI [%.1f-%.1f]  (%d/%d)\n",
-		label, r.Rate*100, r.CILow*100, r.CIHigh*100, r.Num, r.Den)
+	b.WriteString(r.Row(label))
 }
 
 // harnessFailures lists runs that errored rather than completing.

--- a/bench/internal/lifecycle/supersede_report.go
+++ b/bench/internal/lifecycle/supersede_report.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/txn2/mcp-data-platform/bench/internal/capture"
 	"github.com/txn2/mcp-data-platform/bench/internal/stats"
 )
 
@@ -38,10 +39,15 @@ type SupersedeMetrics struct {
 	TotalCacheReadTokens     int64 `json:"total_cache_read_tokens"`
 	TotalCacheCreationTokens int64 `json:"total_cache_creation_tokens"`
 
-	CaptureRate       Rate `json:"capture_rate"`
-	SupersedeRate     Rate `json:"supersede_rate"`     // among executed supersedes, the original was superseded (higher is better)
-	DuplicateRate     Rate `json:"duplicate_rate"`     // among executed supersedes, a duplicate was left (lower is better)
-	UpdateCorrectness Rate `json:"update_correctness"` // post-correction recall flipped to the new value
+	// CaptureRate gates this sub-benchmark: an attempt that never captured never
+	// reaches the supersede stage at all. Capture carries the same attempted/landed
+	// split and miss attribution the full S5 scorecard reports (issue #1136), so a
+	// thin supersede denominator can be read against why capture missed.
+	CaptureRate       Rate          `json:"capture_rate"`
+	Capture           capture.Split `json:"capture_split"`
+	SupersedeRate     Rate          `json:"supersede_rate"`     // among executed supersedes, the original was superseded (higher is better)
+	DuplicateRate     Rate          `json:"duplicate_rate"`     // among executed supersedes, a duplicate was left (lower is better)
+	UpdateCorrectness Rate          `json:"update_correctness"` // post-correction recall flipped to the new value
 	// UpdateCaptureRate is, among update stages that ran, the fraction whose
 	// correction capture executed. Its misses never enter the supersede/duplicate
 	// denominator: with no correction on the platform the supersede gate never
@@ -94,15 +100,16 @@ func (res *SupersedeResults) Aggregate() {
 		}
 		m.Attempts++
 		foldSupersedeStat(stat, r)
-		m.CaptureRate.add(r.Captured)
-		m.UpdateCaptureRate.add(r.UpdateCaptured)
-		m.DuplicateRate.add(r.Duplicated)
-		m.UpdateCorrectness.add(r.UpdateCorrect)
+		m.CaptureRate.Add(r.Captured)
+		m.Capture.Add(r.Captured, r.CaptureAttempted, r.TeachBudgetExhausted)
+		m.UpdateCaptureRate.Add(r.UpdateCaptured)
+		m.DuplicateRate.Add(r.Duplicated)
+		m.UpdateCorrectness.Add(r.UpdateCorrect)
 	}
 	// SupersedeRate is the complement of DuplicateRate over the same denominator
 	// (captured attempts whose supersede ran), derived once so the two can never
 	// drift out of the complement relationship the report advertises.
-	m.SupersedeRate = m.DuplicateRate.complement()
+	m.SupersedeRate = m.DuplicateRate.Complement()
 	m.Protocols = len(order)
 	m.PassK = supersedePassKRate(order, res.Runs, res.Manifest.K)
 	for _, id := range order {
@@ -123,11 +130,10 @@ func (res *SupersedeResults) Aggregate() {
 // denominator) DuplicateRate has no interval, so SupersedeRate keeps its
 // zero-width default rather than reflecting into a spurious [1, 1].
 func (m *SupersedeMetrics) fillCIs(rng *rand.Rand) {
-	for _, r := range []*Rate{
-		&m.CaptureRate, &m.UpdateCaptureRate, &m.DuplicateRate, &m.UpdateCorrectness, &m.PassK,
-	} {
-		r.fillCI(rng)
-	}
+	stats.FillCIs(rng, &m.CaptureRate, &m.UpdateCaptureRate, &m.DuplicateRate, &m.UpdateCorrectness, &m.PassK)
+	// Appended after the original five so every previously reported interval
+	// stays reproducible from the same seed (the RNG advances per rate).
+	m.Capture.FillCIs(rng)
 	if m.DuplicateRate.Den > 0 {
 		m.SupersedeRate.CILow = 1 - m.DuplicateRate.CIHigh
 		m.SupersedeRate.CIHigh = 1 - m.DuplicateRate.CILow
@@ -236,6 +242,8 @@ func (res *SupersedeResults) HumanSummary() string {
 	fmt.Fprintf(&b, "tokens: input %d  output %d  cache read %d  cache write %d (apply current model pricing for cost)\n\n",
 		mt.TotalInputTokens, mt.TotalOutputTokens, mt.TotalCacheReadTokens, mt.TotalCacheCreationTokens)
 	writeMetric(&b, "capture rate", mt.CaptureRate)
+	b.WriteString(mt.Capture.Rows())
+	b.WriteString(mt.Capture.MissBlock())
 	writeMetric(&b, "update capture rate", mt.UpdateCaptureRate)
 	writeMetric(&b, "supersede rate", mt.SupersedeRate)
 	writeMetric(&b, "duplicate rate", mt.DuplicateRate)

--- a/bench/internal/lifecycle/supersede_test.go
+++ b/bench/internal/lifecycle/supersede_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/txn2/mcp-data-platform/bench/internal/capture"
 	"github.com/txn2/mcp-data-platform/bench/internal/lifecycleapi"
 	"github.com/txn2/mcp-data-platform/bench/internal/llm"
 	"github.com/txn2/mcp-data-platform/bench/internal/target"
@@ -37,6 +38,36 @@ func TestSupersedeCIComplement(t *testing.T) {
 	empty.Aggregate()
 	if sr := empty.Metrics.SupersedeRate; sr.CILow != 0 || sr.CIHigh != 0 {
 		t.Fatalf("empty supersede CI = [%v,%v], want [0,0]", sr.CILow, sr.CIHigh)
+	}
+}
+
+// TestSupersedeCaptureSplit proves the sub-benchmark carries the same capture
+// decomposition the full S5 scorecard does (issue #1136): capture gates every
+// supersede attempt, so a thin supersede denominator must be readable against
+// why capture missed rather than against a bare rate.
+func TestSupersedeCaptureSplit(t *testing.T) {
+	res := &SupersedeResults{Manifest: Manifest{K: 1}, Runs: []ProtocolRun{
+		{ProtocolID: "lc-a", Captured: new(true), CaptureAttempted: new(true), TeachBudgetExhausted: new(false), Duplicated: new(false)},
+		{ProtocolID: "lc-b", Captured: new(false), CaptureAttempted: new(true), TeachBudgetExhausted: new(false)},
+		{ProtocolID: "lc-c", Captured: new(false), CaptureAttempted: new(false), TeachBudgetExhausted: new(true)},
+	}}
+	res.Aggregate()
+	m := res.Metrics
+	if m.Capture.AttemptRate.Num != 2 || m.Capture.AttemptRate.Den != 3 {
+		t.Errorf("capture attempted = %d/%d, want 2/3", m.Capture.AttemptRate.Num, m.Capture.AttemptRate.Den)
+	}
+	if got, want := m.Capture.Misses, (capture.Misses{Total: 2, AttemptedFailed: 1, BudgetStarved: 1}); got != want {
+		t.Errorf("capture misses = %+v, want %+v", got, want)
+	}
+	// The supersede/duplicate intervals must be untouched by the appended split.
+	if m.DuplicateRate.Den != 1 || m.SupersedeRate.CILow != 1-m.DuplicateRate.CIHigh {
+		t.Errorf("supersede CI drifted from the duplicate complement: %+v vs %+v", m.SupersedeRate, m.DuplicateRate)
+	}
+	out := res.HumanSummary()
+	for _, w := range []string{"capture attempted", "landed given attempt", "capture misses (2)"} {
+		if !strings.Contains(out, w) {
+			t.Errorf("supersede summary missing %q:\n%s", w, out)
+		}
 	}
 }
 

--- a/bench/internal/stats/rate.go
+++ b/bench/internal/stats/rate.go
@@ -1,0 +1,100 @@
+package stats
+
+import (
+	"fmt"
+	// nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used -- bootstrap-CI resampling for benchmark statistics; not security-sensitive, and a seedable PRNG is required for reproducible intervals.
+	"math/rand"
+)
+
+// Rate is one metric's numerator, denominator, and ratio. Denominator counts
+// only the outcomes where the metric was applicable and reached. It lives here
+// rather than in a suite package because the S5 lifecycle and the cold-start
+// suite both report num/den rates with the same bootstrap interval: one shared
+// rate type, not a per-suite fork that could drift on how an inapplicable
+// outcome or an empty denominator is handled.
+type Rate struct {
+	Num  int     `json:"num"`
+	Den  int     `json:"den"`
+	Rate float64 `json:"rate"`
+	// CILow/CIHigh are the 95% percentile-bootstrap confidence interval on the
+	// rate (issue #965), resampled from num/den with a fixed seed so the interval
+	// is reproducible. Both zero when the denominator is empty — the metric was
+	// not exercised, so it carries no interval. The bootstrap treats each
+	// applicable outcome as an independent draw (like the S1-S3 report); it does
+	// not model protocol-level correlation across the k replicates, so a narrow
+	// interval on a small, few-protocol denominator still warrants caution.
+	CILow  float64 `json:"ci_low"`
+	CIHigh float64 `json:"ci_high"`
+}
+
+// FillCI attaches a bootstrap confidence interval to the rate from its num/den.
+// The caller threads one seeded RNG across a scorecard's rates so the whole
+// report is reproducible from a single seed (issue #965).
+func (r *Rate) FillCI(rng *rand.Rand) {
+	r.CILow, r.CIHigh = ProportionCI(r.Num, r.Den, rng)
+}
+
+// FillCIs attaches an interval to each rate in order, threading one RNG so a
+// scorecard is reproducible from a single seed. Order is part of the contract:
+// the RNG advances per rate, so a rate inserted ahead of an existing one changes
+// the draws every later rate sees and can move their intervals. Append new rates
+// at the end — that is the only placement guaranteed to leave every previously
+// reported interval identical.
+func FillCIs(rng *rand.Rand, rates ...*Rate) {
+	for _, r := range rates {
+		r.FillCI(rng)
+	}
+}
+
+// Add folds one applicable outcome into the rate. A nil outcome (the metric was
+// not applicable, or was never reached) is excluded from the denominator.
+func (r *Rate) Add(v *bool) {
+	if v == nil {
+		return
+	}
+	r.AddConditional(true, *v)
+}
+
+// AddConditional folds one outcome into a conditional rate: the outcome counts
+// toward the denominator only when it belongs to the conditioning subset (e.g.
+// "among transfer attempts where the fact surfaced"). It backs the decompositions
+// whose denominators are subsets of the attempts rather than a single nil-able
+// outcome.
+func (r *Rate) AddConditional(applicable, value bool) {
+	if !applicable {
+		return
+	}
+	r.Den++
+	if value {
+		r.Num++
+	}
+	r.Rate = float64(r.Num) / float64(r.Den)
+}
+
+// Complement returns the rate of the opposite outcome over the same denominator,
+// so a pair like supersede/duplicate is stored once and derived once rather than
+// accumulated twice (which could silently drift apart).
+func (r Rate) Complement() Rate {
+	c := Rate{Num: r.Den - r.Num, Den: r.Den}
+	if c.Den > 0 {
+		c.Rate = float64(c.Num) / float64(c.Den)
+	}
+	return c
+}
+
+// Row renders one metric line for a terminal scorecard, newline-terminated. The
+// 95% CI bracket is shown only when the interval has width (CILow != CIHigh). A
+// zero-width interval carries no uncertainty and is omitted: it arises for an
+// unexercised metric (empty denominator), for an all-failure rate whose
+// bootstrap collapses to a point at zero AND for an all-success rate that
+// collapses to a point at one (both ends, not just zero), and for a pre-#965
+// results file whose stored metrics carry no interval (the fields default to
+// zero) — all of which would otherwise print a meaningless [x.x-x.x] bracket the
+// count already conveys.
+func (r Rate) Row(label string) string {
+	if r.CILow == r.CIHigh {
+		return fmt.Sprintf("  %-22s %5.1f%%  (%d/%d)\n", label, r.Rate*100, r.Num, r.Den)
+	}
+	return fmt.Sprintf("  %-22s %5.1f%%  95%% CI [%.1f-%.1f]  (%d/%d)\n",
+		label, r.Rate*100, r.CILow*100, r.CIHigh*100, r.Num, r.Den)
+}

--- a/bench/internal/stats/rate_test.go
+++ b/bench/internal/stats/rate_test.go
@@ -1,0 +1,99 @@
+package stats
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRateAdd(t *testing.T) {
+	var r Rate
+	r.Add(nil) // not applicable: excluded from the denominator
+	if r.Den != 0 || r.Rate != 0 {
+		t.Fatalf("nil outcome entered the rate: %+v", r)
+	}
+	r.Add(new(true))
+	r.Add(new(false))
+	r.Add(new(true))
+	if r.Num != 2 || r.Den != 3 || r.Rate != 2.0/3.0 {
+		t.Errorf("rate = %d/%d (%v), want 2/3", r.Num, r.Den, r.Rate)
+	}
+}
+
+func TestRateAddConditional(t *testing.T) {
+	var r Rate
+	r.AddConditional(false, true) // outside the conditioning subset
+	if r.Den != 0 {
+		t.Fatalf("inapplicable outcome entered the denominator: %+v", r)
+	}
+	r.AddConditional(true, true)
+	r.AddConditional(true, false)
+	if r.Num != 1 || r.Den != 2 || r.Rate != 0.5 {
+		t.Errorf("conditional rate = %d/%d (%v), want 1/2", r.Num, r.Den, r.Rate)
+	}
+}
+
+func TestRateComplement(t *testing.T) {
+	c := Rate{Num: 3, Den: 4, Rate: 0.75}.Complement()
+	if c.Num != 1 || c.Den != 4 || c.Rate != 0.25 {
+		t.Errorf("complement = %d/%d (%v), want 1/4 (0.25)", c.Num, c.Den, c.Rate)
+	}
+	// An empty denominator has no complement rate to report.
+	if e := (Rate{}).Complement(); e.Den != 0 || e.Rate != 0 {
+		t.Errorf("empty complement = %+v, want zero", e)
+	}
+}
+
+func TestRateFillCI(t *testing.T) {
+	mixed := Rate{Num: 6, Den: 10, Rate: 0.6}
+	mixed.FillCI(NewRNG())
+	if !(mixed.CILow < 0.6 && 0.6 < mixed.CIHigh) {
+		t.Errorf("CI [%v, %v] does not bracket 0.6", mixed.CILow, mixed.CIHigh)
+	}
+	// An unexercised metric carries no interval.
+	empty := Rate{}
+	empty.FillCI(NewRNG())
+	if empty.CILow != 0 || empty.CIHigh != 0 {
+		t.Errorf("empty rate CI = [%v, %v], want [0, 0]", empty.CILow, empty.CIHigh)
+	}
+}
+
+// TestFillCIsAppendPreservesEarlierIntervals pins the contract a scorecard
+// relies on when it grows a new rate: the RNG advances per rate, so only a rate
+// APPENDED after the existing ones is guaranteed to leave every earlier
+// interval identical. (An inserted rate shifts the draws every later rate sees;
+// their quantiles may or may not land on the same value, which is exactly why
+// appending is the rule rather than a hope.)
+func TestFillCIsAppendPreservesEarlierIntervals(t *testing.T) {
+	a1, b1 := Rate{Num: 6, Den: 10}, Rate{Num: 3, Den: 10}
+	FillCIs(NewRNG(), &a1, &b1)
+	if a1.CILow == a1.CIHigh || b1.CILow == b1.CIHigh {
+		t.Fatalf("degenerate intervals, the test cannot detect a shift: %+v %+v", a1, b1)
+	}
+
+	a2, b2, appended := Rate{Num: 6, Den: 10}, Rate{Num: 3, Den: 10}, Rate{Num: 1, Den: 10}
+	FillCIs(NewRNG(), &a2, &b2, &appended)
+	if a1 != a2 || b1 != b2 {
+		t.Errorf("appending a rate shifted an earlier interval: %+v/%+v vs %+v/%+v", a1, b1, a2, b2)
+	}
+	if appended.CILow == appended.CIHigh && appended.Den > 0 {
+		t.Errorf("appended rate got no interval: %+v", appended)
+	}
+}
+
+func TestRateRow(t *testing.T) {
+	withCI := Rate{Num: 2, Den: 4, Rate: 0.5, CILow: 0.1, CIHigh: 0.9}
+	row := withCI.Row("capture rate")
+	for _, want := range []string{"capture rate", "50.0%", "95% CI [10.0-90.0]", "(2/4)"} {
+		if !strings.Contains(row, want) {
+			t.Errorf("row %q missing %q", row, want)
+		}
+	}
+	if !strings.HasSuffix(row, "\n") {
+		t.Errorf("row %q is not newline-terminated", row)
+	}
+	// A zero-width interval prints no bracket: it carries no uncertainty the
+	// counts do not already convey.
+	if got := (Rate{Num: 4, Den: 4, Rate: 1, CILow: 1, CIHigh: 1}).Row("x"); strings.Contains(got, "CI") {
+		t.Errorf("degenerate interval printed a bracket: %q", got)
+	}
+}


### PR DESCRIPTION
Capture caps every metric under it: an insight that was never recorded can be neither recalled nor promoted, so a capture miss removes the attempt from the downstream stages rather than merely lowering one number. It is now a headline rate with a confidence interval, decomposed into attempted versus landed, and every miss is attributed to exactly one cause.

## Miss attribution

`bench/internal/capture` owns the attempt signal (moved out of the lifecycle instrumentation, so one definition serves every suite) and the taxonomy. A capture request the budget refused never ran, so it counts as starvation, not as an attempt that failed to land.

| cause | meaning | what it points at |
| --- | --- | --- |
| `attempted_failed` | capture executed, no linked insight landed | the capture path itself |
| `budget_starved` | never executed, the episode spent its tool-call budget | the harness budget, which is a bench concept; no platform change follows |
| `never_attempted` | never executed with budget to spare | the model or its steering |
| `budget_unobservable` | never executed on the claude-cli path, whose turn budget the harness cannot see | attributed as far as the evidence allows and no further |
| `unattributed` | a miss with no attempt signal at all | only a results file written before the signal existed; carries a warning rather than a silent bucket |

`Misses.Total` equals the sum of the buckets, so a run can never report a miss it cannot attribute. The three real causes imply fixes in different layers, which is the point of splitting them.

## Scorecards

The S5 lifecycle, the isolated supersede sub-benchmark, and the cold-start suite all report the decomposition under `metrics.capture_split` (`attempt_rate`, `given_attempted`, `misses`), with `attempt_rate` sharing the capture rate's graded denominator.

Cold-start had the larger gap: it carried only a `lessons_captured` count, no interval, and did not record the attempt signal at all. It now leads its summary with the rate, the split, and the attribution, and names the cause on each missed lesson in the lesson-gaps list, since a lesson that misses capture is never promoted and its trap class stays flat for the rest of the curve.

```
  capture rate            50.0%  95% CI [0.0-100.0]  (2/4)
    capture attempted     50.0%  95% CI [0.0-100.0]  (1/2)
    landed given attempt   0.0%  (0/1)
  capture misses (2): attempted, insight did not land 1 | never attempted, budget exhausted 1
...
lesson gaps (knowledge not delivered, so its class stays flat):
  cs-starved: not captured (never attempted, budget exhausted)
  cs-misfiled: not captured (attempted, insight did not land)
```

The S5 breakdown agrees with the `capture_budget_starved` rate it decomposes; a test asserts the two count the same starved miss rather than letting them drift.

## Shared rate type

The num/den rate with its bootstrap interval moves to `bench/internal/stats`, so cold-start reports the same shape as the other suites instead of a second implementation. `lifecycle` aliases it, so its results JSON is unchanged.

The capture-split rates are filled from the shared seeded RNG last. The RNG advances per rate, so appending is the only placement guaranteed to leave every previously reported interval reproducible; `TestCaptureRateCIsUnaffectedByTheSplit` pins that against the pre-change fill order.

## Archived results

`benchrun -summarize` printed the stored metrics block, which would have rendered the new rate as `0/0` on every archived run while the line above it reported captured lessons. The lifecycle, supersede, and cold-start summaries now re-aggregate from the per-attempt records first. Aggregation is deterministic and derives only from those records, so re-deriving never changes what a file written by this harness reports.

## Not gated

Like the other per-stage diagnostics, the decomposition is deliberately excluded from the `-baseline` regression gate: its denominators are small enough that gating would trip on noise. It explains a capture regression; it does not define one.

## Verification

`make verify` green. Coverage on the new code is 100% of statements in both `internal/capture` and `internal/stats/rate.go`. Beyond the unit tests, the attribution is exercised end to end through the real runners: the S5 test drives two protocols that miss capture for different reasons in one run and asserts each lands in its own bucket, and the cold-start test drives the real teach path for a starved episode, a capture filed against the wrong entity, a never-attempted episode, and a clean capture.

Documentation: the metric list, a new "Capture decomposition and miss attribution (#1136)" section, and the cold-start report section in `bench/docs/knowledge-layer-protocol.md`, plus the package lines in `bench/README.md`. The published report is untouched.

Closes #1136
