### PR TITLE
test(connauth): make the refresher Stop deadline assertion deterministic

### DIFF
--- a/internal/platform/connauth/connauth_test.go
+++ b/internal/platform/connauth/connauth_test.go
@@ -35,6 +35,48 @@ func (stubResolver) MaxLifetime(_ context.Context, _ connoauth.Key) time.Duratio
 	return 0
 }
 
+// blockingStore is a connoauth.Store whose List parks the refresher inside its
+// first tick until the test releases it. That is the only way to assert Stop's
+// deadline branch deterministically: the loop fires a tick immediately on
+// start, so a loop left to run can reach its deferred close(done) before Stop
+// selects, leaving both of Stop's cases ready and the outcome to the runtime's
+// uniform choice among them.
+type blockingStore struct {
+	entered chan struct{} // closed once the loop is inside List
+	release chan struct{} // closed by the test to let List return
+}
+
+func newBlockingStore() *blockingStore {
+	return &blockingStore{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+// List reports that the loop has reached its first tick and then blocks. It
+// deliberately ignores ctx: returning on cancellation would let the loop exit
+// and close done, which is the race this fake exists to remove. Called once per
+// test — the refresher's next tick is a full interval out.
+func (s *blockingStore) List(_ context.Context) ([]connoauth.PersistedToken, error) {
+	close(s.entered)
+	<-s.release
+	return nil, nil
+}
+
+// The remaining Store methods are unreachable from this test: the loop blocks
+// in List and never gets a row to process.
+func (*blockingStore) Get(_ context.Context, _ connoauth.Key) (*connoauth.PersistedToken, error) {
+	return nil, connoauth.ErrTokenNotFound
+}
+
+func (*blockingStore) Set(_ context.Context, _ connoauth.PersistedToken) error { return nil }
+
+func (*blockingStore) Delete(_ context.Context, _ connoauth.Key) error { return nil }
+
+func (*blockingStore) Lock(_ context.Context, _ connoauth.Key) (func(), error) {
+	return func() {}, nil
+}
+
 // newHandle builds a Handle over a sqlmock-backed *sql.DB and registers cleanup
 // that closes both the handle (reaping the prune goroutine) and the mock db.
 // The prune routine's first tick is 24h out, so the mock is never queried by it.
@@ -168,21 +210,34 @@ func TestStartRefresher_IdempotentDoesNotLeak(t *testing.T) {
 	}
 }
 
-func TestStop_WrapsErrorWhenContextAlreadyDone(t *testing.T) {
-	// Not parallel: the refresher loop goroutine is left to wind down on its
-	// own (Stop canceled its context but returned before the loop closed done);
-	// TestMain's goleak check retries long enough for it to exit.
+func TestStop_WrapsErrorWhenTheLoopDoesNotSettleBeforeTheDeadline(t *testing.T) {
+	// Not parallel: after the assertion the loop goroutine is released and winds
+	// down on its own; TestMain's goleak check retries long enough for it to exit.
 	h := newHandle(t)
+	store := newBlockingStore()
+	h.store = store
 	h.StartRefresher(stubResolver{}, connoauth.NoopLocker{})
-	// A pre-canceled wait context: Stop calls cancel() on the loop and then
-	// selects between the loop's done channel and ctx.Done(). done cannot have
-	// closed yet (the loop goroutine has not been scheduled), so the already-done
-	// ctx wins and Stop returns the wrapped error rather than a clean nil.
+	// Registered before the wait below so a loop that never ticks cannot strand
+	// this test on a channel nobody closes. By the time it runs, Stop has
+	// canceled the loop's context, so the loop exits as soon as List returns and
+	// goleak can reap it.
+	defer close(store.release)
+	// Park the loop inside its first tick. Stop cancels the loop's context and
+	// then selects between the loop's done channel and the wait context; holding
+	// the loop in List is what keeps done open, so the expired wait context is
+	// the only ready case and the assertion below is not a race against the
+	// scheduler.
+	select {
+	case <-store.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("refresher loop never reached its first tick")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	err := h.Stop(ctx)
 	if err == nil {
-		t.Fatal("Stop with an already-canceled context must return the wrapped error")
+		t.Fatal("Stop must return the wrapped error when the loop has not settled before the deadline")
 	}
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("Stop error = %v, want a wrapped context.Canceled", err)


### PR DESCRIPTION
## What this fixes

`TestStop_WrapsErrorWhenContextAlreadyDone` in `internal/platform/connauth` is a flaky test, and it took CI on `main` red for the last two runs: `c52e7a57` (run 30681865603) and `2cb2cf59` (run 30683580923), the latter being the commit `v1.118.0` is tagged from. Both failures are the same test, in the same package, with every other job green.

## Why it fails

`Refresher.loop` fires one tick immediately on start, before entering its ticker select (`pkg/connoauth/refresher.go:284`). Against the package's sqlmock-backed store, which has no registered expectations, `tick` gets an immediate `List` error and returns, so the loop goroutine can reach its deferred `close(done)` while the test's next statement is still being executed.

`Stop` then cancels the loop and selects between the loop's `done` channel and the caller's wait context (`pkg/connoauth/refresher.go:271-276`). When the loop has already exited, **both cases are ready**, and Go's select chooses uniformly among ready cases. The test asserted that the expired context branch wins, so it was a coin flip decided by the scheduler.

The old test's own comment stated the false premise it rested on: "done cannot have closed yet (the loop goroutine has not been scheduled)". CI's log disproves it directly in the same failing run, which contains that tick's output:

```
WARN connoauth: refresher: list rows failed error="connoauth: list rows: all expectations were already fulfilled, call to Query ... was not expected"
    connauth_test.go:185: Stop with an already-canceled context must return the wrapped error
--- FAIL: TestStop_WrapsErrorWhenContextAlreadyDone (0.00s)
```

The loop was not merely scheduled, it had run a full tick.

## The change

The test now installs a `blockingStore` whose `List` parks the refresher inside its first tick and holds it there until the test releases it. While the loop is parked it provably cannot reach `close(done)`, so `Stop`'s select has exactly one ready case and the assertion is deterministic rather than a race against the scheduler. The fake deliberately ignores its context in `List`, because returning on cancellation would let the loop exit and reintroduce the race the fake exists to remove.

Renamed to `TestStop_WrapsErrorWhenTheLoopDoesNotSettleBeforeTheDeadline`, which is the contract it actually proves: `Handle.Stop` reports a wrapped error, preserving `context.Canceled`, when an in-flight refresh does not settle before the caller's deadline. That is the behavior the platform depends on when it bounds shutdown to fit the K8s termination grace period.

The release channel is closed in a `defer` registered before the test blocks, so a loop that never ticks cannot strand the test on a channel nobody closes, and the parked goroutine always gets released for the package's `goleak.VerifyTestMain`. The wait itself is bounded at five seconds with an explicit failure message, so a regression that stops the loop from ticking fails fast instead of hanging until the package test timeout.

## Product code is unchanged, and correct as it stands

`Stop` returning nil when the loop has already exited is the right answer: the loop is stopped, which is what the caller asked for. There is no product defect here and no behavior change in this PR, so `v1.118.0` is a faithful build and does not need re-tagging. The only file touched is `internal/platform/connauth/connauth_test.go`.

## Verification

Both directions were checked with controls rather than assumed, since the old test also passed locally and that is exactly what let it through `make verify` in the first place.

- **The diagnosis reproduces.** A temporary control replaying the old assertion with a sleep that forces the CI condition, so the loop has certainly exited, failed with `Stop returned nil - done won the select` in 1 of 40 local iterations. Rare on an idle laptop, roughly a coin flip on a contended runner, which matches two consecutive CI failures.
- **The new test still bites.** With the error wrapping removed from `Handle.Stop`, it fails 5 of 5 runs; with the wrapping restored it passes 20 of 20. It cannot pass vacuously.
- **It is stable under scheduling pressure.** 30 runs at default parallelism, plus 20 runs each at `GOMAXPROCS` 1, 2, and 4, all green under `-race`.
- **`make verify` passes**, ending in `=== All checks passed ===` with a real zero exit code: race tests, coverage gates, patch-scoped lint at 0 issues, gosec and govulncheck, Semgrep, CodeQL with no new blocking findings, dead-code analysis, and the GoReleaser dry-run.

Coverage is unaffected: Go instruments only non-test files, and no product source changed.

## Scope

The sibling assertion in `pkg/connoauth` (`TestRefresherStartStop`, `pkg/connoauth/refresher_test.go:157`) was checked for the same shape and does not have it. It waits on `Stop` with a two-second deadline and asserts a clean exit, so a loop that has already closed `done` satisfies it either way. This was the only test relying on losing that select.
