### PR TITLE
bench: grow the identity pool to 320 and make the size one enforced fact

### DIFF
--- a/bench/benchrun/main.go
+++ b/bench/benchrun/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/txn2/mcp-data-platform/bench/internal/lifecycle"
 	"github.com/txn2/mcp-data-platform/bench/internal/llm"
 	"github.com/txn2/mcp-data-platform/bench/internal/pipeline"
+	"github.com/txn2/mcp-data-platform/bench/internal/pool"
 	"github.com/txn2/mcp-data-platform/bench/internal/report"
 	"github.com/txn2/mcp-data-platform/bench/internal/target"
 	"github.com/txn2/mcp-data-platform/bench/internal/task"
@@ -101,7 +102,7 @@ func parseFlags() config {
 	flag.DurationVar(&cfg.llmTimeout, "llm-timeout", 5*time.Minute, "model API request timeout")
 	flag.DurationVar(&cfg.auditTimeout, "audit-timeout", 15*time.Second, "audit read-back timeout per session")
 	flag.DurationVar(&cfg.sinkTimeout, "sink-timeout", 0, "post-apply sink read-back window for promotions (0 = the promote default, 15s); raise for a store that serves reads slowly")
-	flag.IntVar(&cfg.identityKeys, "identity-keys", 264, "per-attempt identity pool size matching the arm config (0 = single identity)")
+	flag.IntVar(&cfg.identityKeys, "identity-keys", pool.Size, "per-attempt identity pool size matching the arm config (0 = single identity)")
 	flag.StringVar(&cfg.summarize, "summarize", "", "print the human summary of an existing results JSON and exit")
 	flag.StringVar(&cfg.compare, "compare", "", "comma-separated per-arm results JSON files: render the cross-arm comparison and exit")
 	flag.StringVar(&cfg.compareOut, "compare-out", "", "write the cross-arm comparison markdown to this path (with -compare)")

--- a/bench/config/platform.bench.a0.yaml
+++ b/bench/config/platform.bench.a0.yaml
@@ -300,6 +300,62 @@ auth:
       - {key: "${API_KEY_ADMIN}-262", name: "bench-agent-262", roles: ["admin"]}
       - {key: "${API_KEY_ADMIN}-263", name: "bench-agent-263", roles: ["admin"]}
       - {key: "${API_KEY_ADMIN}-264", name: "bench-agent-264", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-265", name: "bench-agent-265", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-266", name: "bench-agent-266", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-267", name: "bench-agent-267", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-268", name: "bench-agent-268", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-269", name: "bench-agent-269", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-270", name: "bench-agent-270", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-271", name: "bench-agent-271", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-272", name: "bench-agent-272", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-273", name: "bench-agent-273", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-274", name: "bench-agent-274", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-275", name: "bench-agent-275", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-276", name: "bench-agent-276", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-277", name: "bench-agent-277", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-278", name: "bench-agent-278", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-279", name: "bench-agent-279", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-280", name: "bench-agent-280", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-281", name: "bench-agent-281", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-282", name: "bench-agent-282", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-283", name: "bench-agent-283", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-284", name: "bench-agent-284", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-285", name: "bench-agent-285", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-286", name: "bench-agent-286", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-287", name: "bench-agent-287", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-288", name: "bench-agent-288", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-289", name: "bench-agent-289", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-290", name: "bench-agent-290", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-291", name: "bench-agent-291", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-292", name: "bench-agent-292", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-293", name: "bench-agent-293", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-294", name: "bench-agent-294", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-295", name: "bench-agent-295", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-296", name: "bench-agent-296", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-297", name: "bench-agent-297", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-298", name: "bench-agent-298", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-299", name: "bench-agent-299", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-300", name: "bench-agent-300", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-301", name: "bench-agent-301", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-302", name: "bench-agent-302", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-303", name: "bench-agent-303", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-304", name: "bench-agent-304", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-305", name: "bench-agent-305", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-306", name: "bench-agent-306", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-307", name: "bench-agent-307", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-308", name: "bench-agent-308", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-309", name: "bench-agent-309", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-310", name: "bench-agent-310", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-311", name: "bench-agent-311", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-312", name: "bench-agent-312", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-313", name: "bench-agent-313", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-314", name: "bench-agent-314", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-315", name: "bench-agent-315", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-316", name: "bench-agent-316", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-317", name: "bench-agent-317", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-318", name: "bench-agent-318", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-319", name: "bench-agent-319", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-320", name: "bench-agent-320", roles: ["admin"]}
 
 database:
   dsn: "postgres://platform:platform_secret@localhost:5432/mcp_platform?sslmode=disable"

--- a/bench/config/platform.bench.a1.yaml
+++ b/bench/config/platform.bench.a1.yaml
@@ -303,6 +303,62 @@ auth:
       - {key: "${API_KEY_ADMIN}-262", name: "bench-agent-262", roles: ["admin"]}
       - {key: "${API_KEY_ADMIN}-263", name: "bench-agent-263", roles: ["admin"]}
       - {key: "${API_KEY_ADMIN}-264", name: "bench-agent-264", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-265", name: "bench-agent-265", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-266", name: "bench-agent-266", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-267", name: "bench-agent-267", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-268", name: "bench-agent-268", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-269", name: "bench-agent-269", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-270", name: "bench-agent-270", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-271", name: "bench-agent-271", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-272", name: "bench-agent-272", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-273", name: "bench-agent-273", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-274", name: "bench-agent-274", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-275", name: "bench-agent-275", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-276", name: "bench-agent-276", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-277", name: "bench-agent-277", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-278", name: "bench-agent-278", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-279", name: "bench-agent-279", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-280", name: "bench-agent-280", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-281", name: "bench-agent-281", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-282", name: "bench-agent-282", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-283", name: "bench-agent-283", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-284", name: "bench-agent-284", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-285", name: "bench-agent-285", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-286", name: "bench-agent-286", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-287", name: "bench-agent-287", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-288", name: "bench-agent-288", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-289", name: "bench-agent-289", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-290", name: "bench-agent-290", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-291", name: "bench-agent-291", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-292", name: "bench-agent-292", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-293", name: "bench-agent-293", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-294", name: "bench-agent-294", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-295", name: "bench-agent-295", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-296", name: "bench-agent-296", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-297", name: "bench-agent-297", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-298", name: "bench-agent-298", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-299", name: "bench-agent-299", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-300", name: "bench-agent-300", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-301", name: "bench-agent-301", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-302", name: "bench-agent-302", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-303", name: "bench-agent-303", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-304", name: "bench-agent-304", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-305", name: "bench-agent-305", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-306", name: "bench-agent-306", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-307", name: "bench-agent-307", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-308", name: "bench-agent-308", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-309", name: "bench-agent-309", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-310", name: "bench-agent-310", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-311", name: "bench-agent-311", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-312", name: "bench-agent-312", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-313", name: "bench-agent-313", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-314", name: "bench-agent-314", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-315", name: "bench-agent-315", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-316", name: "bench-agent-316", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-317", name: "bench-agent-317", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-318", name: "bench-agent-318", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-319", name: "bench-agent-319", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-320", name: "bench-agent-320", roles: ["admin"]}
 
 database:
   dsn: "postgres://platform:platform_secret@localhost:5432/mcp_platform?sslmode=disable"

--- a/bench/config/platform.bench.a2.yaml
+++ b/bench/config/platform.bench.a2.yaml
@@ -298,6 +298,62 @@ auth:
       - {key: "${API_KEY_ADMIN}-262", name: "bench-agent-262", roles: ["admin"]}
       - {key: "${API_KEY_ADMIN}-263", name: "bench-agent-263", roles: ["admin"]}
       - {key: "${API_KEY_ADMIN}-264", name: "bench-agent-264", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-265", name: "bench-agent-265", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-266", name: "bench-agent-266", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-267", name: "bench-agent-267", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-268", name: "bench-agent-268", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-269", name: "bench-agent-269", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-270", name: "bench-agent-270", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-271", name: "bench-agent-271", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-272", name: "bench-agent-272", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-273", name: "bench-agent-273", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-274", name: "bench-agent-274", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-275", name: "bench-agent-275", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-276", name: "bench-agent-276", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-277", name: "bench-agent-277", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-278", name: "bench-agent-278", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-279", name: "bench-agent-279", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-280", name: "bench-agent-280", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-281", name: "bench-agent-281", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-282", name: "bench-agent-282", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-283", name: "bench-agent-283", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-284", name: "bench-agent-284", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-285", name: "bench-agent-285", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-286", name: "bench-agent-286", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-287", name: "bench-agent-287", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-288", name: "bench-agent-288", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-289", name: "bench-agent-289", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-290", name: "bench-agent-290", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-291", name: "bench-agent-291", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-292", name: "bench-agent-292", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-293", name: "bench-agent-293", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-294", name: "bench-agent-294", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-295", name: "bench-agent-295", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-296", name: "bench-agent-296", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-297", name: "bench-agent-297", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-298", name: "bench-agent-298", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-299", name: "bench-agent-299", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-300", name: "bench-agent-300", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-301", name: "bench-agent-301", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-302", name: "bench-agent-302", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-303", name: "bench-agent-303", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-304", name: "bench-agent-304", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-305", name: "bench-agent-305", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-306", name: "bench-agent-306", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-307", name: "bench-agent-307", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-308", name: "bench-agent-308", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-309", name: "bench-agent-309", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-310", name: "bench-agent-310", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-311", name: "bench-agent-311", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-312", name: "bench-agent-312", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-313", name: "bench-agent-313", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-314", name: "bench-agent-314", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-315", name: "bench-agent-315", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-316", name: "bench-agent-316", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-317", name: "bench-agent-317", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-318", name: "bench-agent-318", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-319", name: "bench-agent-319", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-320", name: "bench-agent-320", roles: ["admin"]}
 
 database:
   dsn: "postgres://platform:platform_secret@localhost:5432/mcp_platform?sslmode=disable"

--- a/bench/config/platform.bench.a3.yaml
+++ b/bench/config/platform.bench.a3.yaml
@@ -301,6 +301,62 @@ auth:
       - {key: "${API_KEY_ADMIN}-262", name: "bench-agent-262", roles: ["admin"]}
       - {key: "${API_KEY_ADMIN}-263", name: "bench-agent-263", roles: ["admin"]}
       - {key: "${API_KEY_ADMIN}-264", name: "bench-agent-264", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-265", name: "bench-agent-265", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-266", name: "bench-agent-266", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-267", name: "bench-agent-267", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-268", name: "bench-agent-268", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-269", name: "bench-agent-269", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-270", name: "bench-agent-270", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-271", name: "bench-agent-271", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-272", name: "bench-agent-272", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-273", name: "bench-agent-273", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-274", name: "bench-agent-274", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-275", name: "bench-agent-275", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-276", name: "bench-agent-276", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-277", name: "bench-agent-277", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-278", name: "bench-agent-278", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-279", name: "bench-agent-279", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-280", name: "bench-agent-280", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-281", name: "bench-agent-281", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-282", name: "bench-agent-282", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-283", name: "bench-agent-283", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-284", name: "bench-agent-284", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-285", name: "bench-agent-285", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-286", name: "bench-agent-286", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-287", name: "bench-agent-287", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-288", name: "bench-agent-288", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-289", name: "bench-agent-289", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-290", name: "bench-agent-290", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-291", name: "bench-agent-291", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-292", name: "bench-agent-292", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-293", name: "bench-agent-293", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-294", name: "bench-agent-294", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-295", name: "bench-agent-295", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-296", name: "bench-agent-296", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-297", name: "bench-agent-297", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-298", name: "bench-agent-298", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-299", name: "bench-agent-299", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-300", name: "bench-agent-300", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-301", name: "bench-agent-301", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-302", name: "bench-agent-302", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-303", name: "bench-agent-303", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-304", name: "bench-agent-304", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-305", name: "bench-agent-305", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-306", name: "bench-agent-306", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-307", name: "bench-agent-307", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-308", name: "bench-agent-308", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-309", name: "bench-agent-309", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-310", name: "bench-agent-310", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-311", name: "bench-agent-311", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-312", name: "bench-agent-312", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-313", name: "bench-agent-313", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-314", name: "bench-agent-314", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-315", name: "bench-agent-315", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-316", name: "bench-agent-316", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-317", name: "bench-agent-317", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-318", name: "bench-agent-318", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-319", name: "bench-agent-319", roles: ["admin"]}
+      - {key: "${API_KEY_ADMIN}-320", name: "bench-agent-320", roles: ["admin"]}
 
 database:
   dsn: "postgres://platform:platform_secret@localhost:5432/mcp_platform?sslmode=disable"

--- a/bench/docs/knowledge-layer-protocol.md
+++ b/bench/docs/knowledge-layer-protocol.md
@@ -94,15 +94,17 @@ Two independence guarantees keep attempts comparable:
 
 - **Identity pool.** The search-first gate keys discovery on the
   authenticated USER, not the MCP session, so every attempt authenticates as
-  its own pool identity (`<key>-001`..`-264`, defined in the arm configs;
+  its own pool identity (`<key>-001`..`-320`, defined in the arm configs;
   `-identity-keys` must match, and a run refuses to start when tasks x k
-  exceeds the pool). The pool is sized to the full phase-2 task set at k=3 (87
-  tasks x 3 = 261 attempts); to resize it, run this from `bench/` (and set the
-  matching `-identity-keys`):
+  exceeds the pool). The pool is sized to the thirty-protocol lifecycle suite at
+  k=5, its largest single consumer (30 protocols x 5 x 2 identities = 300
+  attempts), which also covers the full phase-2 task set at k=3 (87 tasks x 3 =
+  261 attempts); to resize it, run this from `bench/` (and set the matching
+  `-identity-keys`):
 
   ```python
   import re, glob
-  N = 264  # >= tasks x k for the largest single run
+  N = 320  # >= identities needed by the largest single run
   entries = "\n".join(
       f'      - {{key: "${{API_KEY_ADMIN}}-{i:03d}", name: "bench-agent-{i:03d}", roles: ["admin"]}}'
       for i in range(1, N + 1)) + "\n"
@@ -352,19 +354,19 @@ treat the k = 5 column as the floor for a headline claim, not a guarantee.
 learner), so a run needs `2 × protocols × k` keys and refuses to start otherwise.
 For the thirty-protocol set:
 
-| k | identities needed (2 × 30 × k) | fits the 264-key pool? |
+| k | identities needed (2 × 30 × k) | fits the 320-key pool? |
 | --- | --- | --- |
 | 3 | 180 | yes |
 | 4 | 240 | yes |
-| 5 | 300 | no — grow the pool |
+| 5 | 300 | yes |
 
-The committed pool in `bench/config/platform.bench.a*.yaml` is 264 keys (sized for
-the S1–S3 task set, 87 × 3 = 261). It covers the thirty-protocol lifecycle through
-k = 4. A k = 5 run — the size the power analysis recommends for a firm transfer
-claim — needs the pool grown to ≥ 300 (round to 320 for headroom) across the four
-arm configs; `-identity-keys` must be raised to match. That pool growth is the one
-prerequisite for the budget-gated k = 5 evaluation run and is intentionally left
-to that run rather than pre-committed here.
+The committed pool in `bench/config/platform.bench.a*.yaml` is 320 keys, grown from
+264 for the k = 5 lifecycle run (#1139) — the size the power analysis recommends
+for a firm transfer claim, needing 300 identities, with the remainder as headroom
+against a protocol set that grows again. The `-identity-keys` default matches it
+(`bench/benchrun/main.go`), so the lifecycle target, which passes no such flag,
+inherits the right pool. A run that would exceed the pool refuses to start rather
+than sharing a discovery scope between attempts.
 
 ## Supersede sub-benchmark (#964)
 

--- a/bench/internal/pool/pool.go
+++ b/bench/internal/pool/pool.go
@@ -15,6 +15,15 @@ import "fmt"
 // credential rotation couples to the same convention.
 const NamePrefix = "bench-agent"
 
+// Size is the number of identities the committed arm configs define, and the
+// default for benchrun's -identity-keys. The flag is a claim ABOUT the configs:
+// a runner only checks its own flag against what a run needs, so a flag larger
+// than the real pool authenticates an attempt as an identity no config defines
+// and fails partway through a paid run. TestArmConfigsDefineExactlySize keeps
+// the two in step. Sized for the thirty-protocol lifecycle at k=5 (30 x 5 x 2 =
+// 300 identities) with headroom; see bench/docs/knowledge-layer-protocol.md.
+const Size = 320
+
 // Credential returns the bearer token for one attempt: the base credential when
 // identity rotation is off (identityKeys == 0), or the zero-padded pool key
 // "<base>-NNN" matching the arm configs' pool.

--- a/bench/internal/pool/pool_test.go
+++ b/bench/internal/pool/pool_test.go
@@ -1,6 +1,52 @@
 package pool
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestArmConfigsDefineExactlySize is the guard behind Size: every arm config
+// must define identities 001..Size, contiguously and with no extras. A pool
+// smaller than the flag default is the expensive failure — the runner checks
+// its flag against what a run needs, never against the configs, so an attempt
+// authenticates as an identity nobody defined and a paid run dies partway in.
+// A pool larger than the default is quieter but still wrong: those identities
+// are unreachable, so a run that should have refused to start proceeds.
+func TestArmConfigsDefineExactlySize(t *testing.T) {
+	t.Parallel()
+	configs, err := filepath.Glob(filepath.Join("..", "..", "config", "platform.bench.a*.yaml"))
+	if err != nil {
+		t.Fatalf("glob arm configs: %v", err)
+	}
+	// A glob that matches nothing would pass every assertion below without
+	// reading a single config.
+	if len(configs) != 4 {
+		t.Fatalf("found %d arm configs (%v), want the four a0-a3 configs", len(configs), configs)
+	}
+	for _, path := range configs {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			t.Parallel()
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			body := string(b)
+			for seq := 1; seq <= Size; seq++ {
+				want := fmt.Sprintf("name: %q", fmt.Sprintf("%s-%03d", NamePrefix, seq))
+				if !strings.Contains(body, want) {
+					t.Fatalf("%s does not define identity %d (looked for %s); the pool is smaller than pool.Size=%d, so a run at the default -identity-keys authenticates as an identity that does not exist", path, seq, want, Size)
+				}
+			}
+			absent := fmt.Sprintf("name: %q", fmt.Sprintf("%s-%03d", NamePrefix, Size+1))
+			if strings.Contains(body, absent) {
+				t.Errorf("%s defines identity %d, beyond pool.Size=%d; raise Size so -identity-keys can reach it, or drop the extras", path, Size+1, Size)
+			}
+		})
+	}
+}
 
 func TestCredential(t *testing.T) {
 	// Rotation off (identityKeys == 0): the base credential is used verbatim.
@@ -8,10 +54,10 @@ func TestCredential(t *testing.T) {
 		t.Errorf("Credential rotation off = %q, want base-key", got)
 	}
 	// Rotation on: zero-padded three-digit pool key.
-	if got := Credential("base-key", 7, 264); got != "base-key-007" {
+	if got := Credential("base-key", 7, Size); got != "base-key-007" {
 		t.Errorf("Credential rotation on = %q, want base-key-007", got)
 	}
-	if got := Credential("base-key", 123, 264); got != "base-key-123" {
+	if got := Credential("base-key", 123, Size); got != "base-key-123" {
 		t.Errorf("Credential = %q, want base-key-123", got)
 	}
 }


### PR DESCRIPTION
Closes #1148. Part of #1139, which stays open until the run it unblocks is published.

## Why the pool had to grow

Every lifecycle attempt consumes two pool identities, a teacher and a learner (`identitiesPerRun`, `bench/internal/lifecycle/runner.go:30`), because the search-first gate keys discovery on the authenticated user and a shared identity would leak discovery scope between attempts. The thirty-protocol suite at k=5 therefore needs `30 x 5 x 2 = 300` identities, and the committed pool held 264.

That is not a soft limit. The runner computes `need := len(protocols) * opts.K * identitiesPerRun` and refuses to start when it exceeds the pool (`runner.go:98-99`), so a k=5 run could not begin at all. k=4 fits at 240 but resolves only much larger effects on the supersede and transfer denominators, which is why the protocol document's power analysis names k=5 as the floor for a firm transfer claim rather than a nicety.

All four arm configs now define 320 identities: 300 for the run, the remainder as headroom against a protocol set that grows again. The number is the one the protocol document already prescribed before this change ("round to 320 for headroom").

## The second defect, which is the more expensive one

The `-identity-keys` default was a bare `264` literal that only *claimed* to describe the configs. Nothing checked that claim, and the check that exists cannot catch it: the runner compares the flag against what a run needs, never against the configs themselves. A default larger than the real pool therefore passes every precondition, and then the first attempt past the end of the pool authenticates as an identity no config defines. The failure lands partway through a run that costs real money, which is the worst possible place for it.

The pool size is now one named fact, `pool.Size`, that the flag default reads, and `TestArmConfigsDefineExactlySize` asserts every arm config defines exactly `001..Size`. It fails in both directions:

- A config **smaller** than `Size` fails with the specific identity it could not find, and says why it matters.
- A config **larger** than `Size` also fails, because those identities are unreachable at the default and a run that should have refused to start would instead proceed.

The test also asserts it matched four config files, so a glob that silently matches nothing cannot pass every other assertion in the test by vacuity.

## Verification

- **The guard bites.** With `Size` temporarily raised to 321, the test fails naming `bench-agent-321` as missing from `platform.bench.a2.yaml`; restored to 320, it passes. Checked rather than assumed, because a test over config files that always passes is worse than no test.
- **The configs are well formed.** Each of the four parses as YAML and contains 320 identities, contiguous `001` through `320`, with zero duplicates.
- **Nothing existing changes behavior.** The pool is a superset of the old one, so k=3 and k=4 runs are unaffected, and the API-gateway and perishable-knowledge make targets pass `-identity-keys 150` explicitly and are untouched. `bench-lifecycle` passes no such flag and inherits the new default, which is the point.
- **`make verify` passes** on this exact diff, ending in `=== All checks passed ===` with a real zero exit code. It covers this module through the `bench-test` and `bench-lint` targets, since `bench/` is a separate Go module the root lint never reaches.

One honest note on the run that produced that green: an earlier attempt failed in `pkg/knowledge` when testcontainers timed out reaching the Docker socket with thirteen containers already up on the machine. That test passes in 3.7 seconds in isolation and is untouchable from a change confined to `bench/`, so the gate was re-run clean rather than declared green around a failure.

## Documentation

`bench/docs/knowledge-layer-protocol.md` carried the old size in four places: the identity-pool description, the resize recipe's `N`, the k-vs-pool table (which marked k=5 "no — grow the pool"), and the paragraph describing the growth as work deliberately left to the future run. All four now state what the configs hold, and the table reads k=5 as fitting.

## Deliberately not changed

`docs/reference/benchmark-report.md:160` says "The committed pool holds 264 keys". That sentence is true of the deposited report v1.1 and its runs, and editing prose inside a published, DOI-deposited version to track a repository change would make the page diverge from the deposit for no reader's benefit. It gets restated in the report's next version alongside the platform builds each result set came from.
