### PR TITLE
chore(deps): rollup of 7 open Dependabot PRs (go-sdk, pgvector-go, checkout, login-action, codeql-action)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history so golangci-lint's --new-from-rev (below) can diff against
           # the base commit locally. Shallow (default depth 1) has no base to diff.
@@ -65,7 +65,7 @@ jobs:
           --health-interval 5s --health-timeout 5s --health-retries 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -113,7 +113,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -134,7 +134,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -171,7 +171,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -199,7 +199,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -28,15 +28,15 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: go
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:go"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -64,7 +64,7 @@ jobs:
       LOAD_CONFIG: test/load/config/platform.load-ci.yaml
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       attestations: write  # Required for GitHub attestations
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -37,6 +37,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -444,6 +444,8 @@ enrichment:
 | `server.streamable.session_timeout` | duration | `30m` | How long an idle Streamable HTTP session persists before cleanup |
 | `server.streamable.stateless` | bool | `false` | Disable session tracking (no `Mcp-Session-Id` validation) |
 
+The MCP SDK caps each Streamable HTTP request body at 4 MiB and rejects a larger one with `413 Request Entity Too Large` (`request body exceeds 4194304 bytes`). It bounds inbound JSON-RPC bodies, so it bounds tool-call arguments; tool results, managed-resource uploads, and asset exports travel other paths with their own limits.
+
 ## Database Configuration
 
 | Field | Type | Default | Description |
@@ -1530,6 +1532,8 @@ When `store: database`:
 - Multiple replicas share the same session store
 
 Session hijack prevention: each session stores a SHA-256 hash of the creation token. Requests with a different token get HTTP 403.
+
+Session termination is served by `SessionAwareHandler` itself: `DELETE /` with an `Mcp-Session-Id` removes the row and answers `204 No Content`; a `DELETE` without the header answers `400`. The request is not forwarded to the SDK, whose stateless handler serves `POST` only (SEP-2575, go-sdk v1.7.0) and would answer `405 Method Not Allowed` for a termination that had already succeeded.
 
 ### Server-pushed notifications (`tools`/`prompts`/`resources` `list_changed`)
 

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -247,6 +247,8 @@ server:
 | `session_timeout` | duration | `30m` | How long an idle session persists before cleanup |
 | `stateless` | bool | `false` | Disable session tracking (no `Mcp-Session-Id` validation) |
 
+The MCP SDK caps each Streamable HTTP request body at 4 MiB and rejects a larger one with `413 Request Entity Too Large`. The limit applies to inbound JSON-RPC bodies, so it bounds tool-call arguments; it does not bound tool results, managed-resource uploads, or asset exports, which travel other paths with their own limits.
+
 ## Authentication Configuration
 
 ```yaml

--- a/docs/server/session-externalization.md
+++ b/docs/server/session-externalization.md
@@ -41,6 +41,8 @@ When `store: database` is set:
 
 Clients see no change. The `Mcp-Session-Id` header works transparently.
 
+Session termination is served by the same handler: `DELETE /` with an `Mcp-Session-Id` removes the row and answers `204 No Content`, and a `DELETE` without that header is a `400`. The request is not forwarded to the SDK, whose stateless handler serves `POST` only and would answer `405 Method Not Allowed` for a termination that had already succeeded.
+
 ## Configuration
 
 ```yaml

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/google/jsonschema-go v0.4.3
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.12.3
-	github.com/modelcontextprotocol/go-sdk v1.6.1
-	github.com/pgvector/pgvector-go v0.4.0
+	github.com/modelcontextprotocol/go-sdk v1.7.0
+	github.com/pgvector/pgvector-go v0.4.1
 	github.com/prometheus/client_golang v1.24.1
 	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/http-swagger/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
-github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
@@ -244,8 +244,8 @@ github.com/opencontainers/runc v1.3.1 h1:c/yY0oh2wK7tzDuD56REnSxyU8ubh8hoAIOLGLr
 github.com/opencontainers/runc v1.3.1/go.mod h1:9wbWt42gV+KRxKRVVugNP6D5+PQciRbenB4fLVsqGPs=
 github.com/ory/dockertest/v3 v3.12.0 h1:3oV9d0sDzlSQfHtIaB5k6ghUCVMVLpAY8hwrqoCyRCw=
 github.com/ory/dockertest/v3 v3.12.0/go.mod h1:aKNDTva3cp8dwOWwb9cWuX84aH5akkxXRvO7KCwWVjE=
-github.com/pgvector/pgvector-go v0.4.0 h1:879hQCnuix1bkfa5TQISnnK9ik4Fo+cHj2vuZSgW5v4=
-github.com/pgvector/pgvector-go v0.4.0/go.mod h1:4fSXyjl1TYAIdByAql6JazKWRr2s7J0g4hcRY5cBFCk=
+github.com/pgvector/pgvector-go v0.4.1 h1:Oaj0mC0Ky8KaTweNHHpLwyFlN6a0nUFoo1vgSFTEhPI=
+github.com/pgvector/pgvector-go v0.4.1/go.mod h1:4fSXyjl1TYAIdByAql6JazKWRr2s7J0g4hcRY5cBFCk=
 github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/session/handler.go
+++ b/pkg/session/handler.go
@@ -88,6 +88,11 @@ type HandlerConfig struct {
 // AwareHandler wraps an HTTP handler to manage MCP sessions against
 // an external Store. It is used when the SDK runs in stateless mode to
 // provide session persistence (e.g. for zero-downtime restarts).
+//
+// The wrapped handler must be a stateless SDK handler. AwareHandler owns the
+// session lifecycle end to end: it mints the ID, validates ownership, and
+// terminates on DELETE without consulting inner, so a stateful inner handler
+// would keep a session map this one never updates.
 type AwareHandler struct {
 	inner       http.Handler
 	store       Store
@@ -426,15 +431,23 @@ func writeSSEEvent(w http.ResponseWriter, ev Event) error {
 	return nil
 }
 
-// handleDelete removes the session and forwards the DELETE to the SDK.
+// handleDelete terminates the session: 204 once the row is gone, 400 when the
+// session-ID header is absent. A store failure is logged but not fatal, since
+// the row expires at TTL regardless.
+//
+// The request is answered here rather than forwarded, because a stateless SDK
+// handler serves POST only and rejects DELETE with 405 (go-sdk v1.7.0,
+// SEP-2575) — which would report failure for a termination that succeeded.
 func (h *AwareHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.Header.Get(sessionIDHeader)
-	if sessionID != "" {
-		if err := h.store.Delete(r.Context(), sessionID); err != nil {
-			slog.Debug("session: delete failed", sessionIDKey, logsan.SanitizeForLog(sessionID), slogKeyError, err) // #nosec G706 -- sessionID sanitized via logsan.SanitizeForLog
-		}
+	if sessionID == "" {
+		http.Error(w, "Bad Request: DELETE requires an Mcp-Session-Id header", http.StatusBadRequest)
+		return
 	}
-	h.inner.ServeHTTP(w, r)
+	if err := h.store.Delete(r.Context(), sessionID); err != nil {
+		slog.Debug("session: delete failed", sessionIDKey, logsan.SanitizeForLog(sessionID), slogKeyError, err) // #nosec G706 -- sessionID sanitized via logsan.SanitizeForLog
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // reviveSession recreates an expired or missing session using the same ID.

--- a/pkg/session/handler_test.go
+++ b/pkg/session/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -352,7 +353,9 @@ func TestHandler_Delete(t *testing.T) {
 
 	handler.ServeHTTP(w, req)
 
-	assert.True(t, inner.wasCalled(), "inner handler should be called for DELETE")
+	assert.Equal(t, http.StatusNoContent, w.Code, "successful termination reports 204")
+	assert.False(t, inner.wasCalled(),
+		"DELETE is answered by AwareHandler; the stateless inner handler rejects non-POST")
 
 	got, err := store.Get(ctx, "delete-me")
 	require.NoError(t, err)
@@ -367,7 +370,42 @@ func TestHandler_Delete_NoSessionID(t *testing.T) {
 
 	handler.ServeHTTP(w, req)
 
-	assert.True(t, inner.wasCalled(), "DELETE without session ID should still forward to inner")
+	assert.Equal(t, http.StatusBadRequest, w.Code, "DELETE without a session ID is a bad request")
+	assert.False(t, inner.wasCalled(), "DELETE without session ID must not reach inner")
+}
+
+// TestHandler_Delete_RealStatelessSDK pins the DELETE contract against the
+// actual SDK handler AwareHandler is mounted over in database-session mode,
+// not a stub. go-sdk v1.7.0 made stateless servers POST-only (SEP-2575), so a
+// forwarded DELETE returns 405 with Allow: POST — this asserts the client
+// still sees 204 for a termination that did in fact remove the stored session.
+func TestHandler_Delete_RealStatelessSDK(t *testing.T) {
+	ctx := context.Background()
+	mcpServer := mcp.NewServer(&mcp.Implementation{Name: "session-test", Version: "0.0.1"}, nil)
+	stateless := mcp.NewStreamableHTTPHandler(
+		func(*http.Request) *mcp.Server { return mcpServer },
+		&mcp.StreamableHTTPOptions{Stateless: true},
+	)
+
+	store := NewMemoryStore(handlerTestTTL)
+	handler := NewAwareHandler(stateless, HandlerConfig{Store: store, TTL: handlerTestTTL})
+
+	sess := newTestSession("real-sdk-delete", handlerTestTTL)
+	sess.UserID = ""
+	require.NoError(t, store.Create(ctx, sess))
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodDelete, handlerTestPath, http.NoBody)
+	req.Header.Set(sessionIDHeader, "real-sdk-delete")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Empty(t, w.Header().Get("Allow"), "no 405 Allow header should leak through")
+
+	got, err := store.Get(ctx, "real-sdk-delete")
+	require.NoError(t, err)
+	assert.Nil(t, got, "session row is gone")
 }
 
 func TestSessionIDWriter_Flush(_ *testing.T) {
@@ -697,7 +735,9 @@ func TestHandler_ReviveSession_CreateError(t *testing.T) {
 
 // TestHandler_Delete_StoreError exercises the delete-failure branch: a
 // store Delete error is logged (session ID sanitized via logsan) but is
-// non-fatal, so the DELETE still forwards to the inner handler.
+// non-fatal, so the client still sees 204. Termination is best effort — the
+// row expires at TTL regardless — and this is the status the request received
+// before the handler stopped forwarding to the SDK.
 func TestHandler_Delete_StoreError(t *testing.T) {
 	es := &errStore{
 		MemoryStore: NewMemoryStore(handlerTestTTL),
@@ -712,7 +752,8 @@ func TestHandler_Delete_StoreError(t *testing.T) {
 
 	handler.ServeHTTP(w, req)
 
-	assert.True(t, inner.wasCalled(), "DELETE should still forward to inner even when store delete fails")
+	assert.Equal(t, http.StatusNoContent, w.Code, "store failure is non-fatal for termination")
+	assert.False(t, inner.wasCalled(), "DELETE is never forwarded to the stateless inner handler")
 }
 
 // flushRecorder is httptest.ResponseRecorder + http.Flusher so the SSE


### PR DESCRIPTION
Rolls the seven open Dependabot PRs into one branch so the bumps land as a single CI run and a single merge commit rather than seven sequential rebases against a moving `main`.

Sixteen files: nine workflow files, `go.mod`, `go.sum`, three documentation files, and one non-test Go source file with its test. The Go change is `pkg/session/handler.go`, and it is here because the go-sdk bump removes the HTTP method the session handler was forwarding to. That is not incidental cleanup carried along with a dependency bump — without it this rollup regresses session termination in the deployment shape the platform runs in production. It gets its own section below.

The branch is cut from `15d73926`. `main` has since advanced to `168ab501` (#1190), which touches only `bench/` documentation and shares no file with this change.

## GitHub Actions

All action references stay SHA-pinned per the project's pinned-dependency rule.

| Action | From | To | Dependabot PR | Where |
| --- | --- | --- | --- | --- |
| `actions/checkout` | v7.0.0 | v7.0.1 | #1184 | 16 steps across `bench.yml` (2), `ci.yml` (6), `codeql.yml`, `docs.yml`, `e2e-nightly.yml`, `load.yml` (2), `mutation.yml`, `release.yml`, `scorecard.yml` |
| `docker/login-action` | v4.5.1 | v4.6.0 | #1182 | `.github/workflows/release.yml:42` |
| `github/codeql-action/init` | v4.37.3 | v4.37.4 | #1189 | `.github/workflows/codeql.yml:31` |
| `github/codeql-action/autobuild` | v4.37.3 | v4.37.4 | none | `.github/workflows/codeql.yml:37` |
| `github/codeql-action/analyze` | v4.37.3 | v4.37.4 | #1188 | `.github/workflows/codeql.yml:40` |
| `github/codeql-action/upload-sarif` | v4.37.3 | v4.37.4 | #1187 | `.github/workflows/scorecard.yml:40` |

### codeql-action/autobuild

`autobuild` has no Dependabot PR of its own, but it sits in `.github/workflows/codeql.yml` between `init` and `analyze` and was on the same v4.37.3 commit. Taking only the two PRs would leave one CodeQL job running two different codeql-action versions. It moves to the same v4.37.4 commit as the rest, matching how the same split was handled in #1098.

### SHA provenance

Every new pin was resolved against its upstream tag rather than trusted from the Dependabot diff:

- `github/codeql-action` v4.37.4 is an annotated tag object (`ea14db8afdef5d462e69d78c4ca45002d4522418`) that dereferences to commit `f205ea1c3313d32999d8d6a48b4f6530d4437b38`, the SHA pinned in all four codeql-action steps. `autobuild/action.yml` is present at that commit.
- `actions/checkout` v7.0.1 points directly at commit `3d3c42e5aac5ba805825da76410c181273ba90b1`.
- `docker/login-action` v4.6.0 points directly at commit `dbcb813823bdd20940b903addbd779551569679f`.

A repo-wide grep confirms no reference to any of the three superseded SHAs remains.

## Go modules

| Module | From | To | Dependabot PR |
| --- | --- | --- | --- |
| `github.com/modelcontextprotocol/go-sdk` | v1.6.1 | v1.7.0 | #1183 |
| `github.com/pgvector/pgvector-go` | v0.4.0 | v0.4.1 | #1185 |

`go mod tidy` pulls no transitive changes: the `go.mod` and `go.sum` diffs are exactly the four `go.sum` lines and two `go.mod` lines of #1183 and #1185 combined, and the recorded hashes match those PRs line for line.

`pgvector-go` v0.4.1 keeps the same `go.mod` hash as v0.4.0, so its dependency graph is unchanged.

The three txn2 toolkits (`mcp-trino` v1.3.1, `mcp-datahub` v1.15.0, `mcp-s3` v1.3.0) each require go-sdk v1.6.1; minimal version selection resolves the build to v1.7.0 for all of them, and every package builds and tests against it.

## go-sdk v1.7.0 behavior review

v1.7.0 is the protocol `2026-07-28` release (SEP-2575 stateless/sessionless, SEP-2322 multi-round-trip requests, SEP-2549 cacheable lists, SEP-2243 HTTP header standardization). It is a minor version and the Go API is source-compatible — the tree builds unchanged — but two runtime defaults move, and this platform runs the SDK in the mode both of them affect.

`sessions.store: database` forces `server.streamable.stateless: true` on the SDK (`internal/platform/sessionsync/sessionsync.go:137-149`) and wraps the handler with `pkg/session.AwareHandler`, which owns the session against PostgreSQL. That is the production shape, so stateless-mode changes reach it directly.

### Stateless DELETE now returns 405, and the session handler no longer forwards it

In v1.7.0 a stateless streamable handler serves `POST` only; every other method gets `405 Method Not Allowed` with `Allow: POST`. `DELETE` survives only behind the `MCPGODEBUG=allowsessionsinstateless=1` escape hatch, which is scheduled for removal in v1.9.0.

`AwareHandler.handleDelete` deleted the session row and then forwarded the request to that handler. Measured against both SDK versions with the same stateless handler and the same request:

| go-sdk | Client-visible status for `DELETE /` with `Mcp-Session-Id` |
| --- | --- |
| v1.6.1 | `204 No Content` |
| v1.7.0 | `405 Method Not Allowed`, `Allow: POST` |

The session row was removed in both cases, so the bump alone would have reported failure for a termination that had in fact succeeded.

`handleDelete` now answers the request itself: `204` after removing the row, `400` when the `Mcp-Session-Id` header is absent. Those are the two statuses the SDK returned for a stateless `DELETE` before v1.7.0, so the client-visible contract is unchanged from v1.6.1. Not forwarding is safe because a stateless SDK handler has no session map to clean — in v1.6.1 its `sessInfo` was already nil on this path and the branch did nothing but write the 204. The `AwareHandler` type doc now states the stateless-inner-handler requirement that this relies on.

`TestHandler_Delete_RealStatelessSDK` pins the contract against a real `mcp.NewStreamableHTTPHandler(..., &mcp.StreamableHTTPOptions{Stateless: true})` rather than the package's stub inner handler. The stub is why the existing DELETE tests stayed green through the bump: they asserted that the inner handler was called, never what the client received. Those two tests now assert status codes, and `handleDelete` is at 100% statement coverage.

### New 4 MiB request-body cap

v1.7.0 adds `StreamableHTTPOptions.MaxRequestBodyBytes`, defaulting to 4 MiB when left at zero. The platform does not set it, so inbound Streamable HTTP bodies over 4 MiB are now rejected with `413 Request Entity Too Large` and `request body exceeds 4194304 bytes` (measured, not quoted from the release notes). Previously the body was unbounded.

The default is kept. It bounds inbound JSON-RPC bodies, which means tool-call arguments; it does not bound tool results, managed-resource uploads (`/api/v1/resources`, already capped by `pkg/resource.MaxUploadBytes`), or asset exports. Bounding this surface also matches what the platform already does on every REST write path it owns — `pkg/admin/decode.go`, `pkg/oauth/server.go:705`, `internal/admin/catalogapi/catalogapi.go:860`, `internal/httpserver/versionhttp/collections.go:350`. It is documented in `docs/server/configuration.md` rather than made configurable, which would be a feature rather than a rollup.

### What does not change

- **Protocol negotiation.** `2026-07-28` is accepted over HTTP only when `Stateless = true`. Deployments that leave `sessions.store: memory` keep stateful sessions and negotiate down to `2025-11-25`; backward compatibility with `2025-11-25` and earlier is preserved on every endpoint.
- **Session ID propagation.** v1.7.0 stateless handlers ignore `Mcp-Session-Id` entirely. `AwareHandler` already owned that header end to end — it mints the ID, validates ownership against the store, and injects it on the response through `sessionIDWriter` — and `resolveSessionID` (`pkg/middleware/mcp.go:395-419`) already treats "stateless HTTP that issues initialize but does not surface a session through the SDK request" as its documented case 2. Neither path depended on the SDK propagating the ID.
- **The legacy SSE endpoints** (`/sse`, `/message`) are untouched by the stateless changes.

## Documentation

- `docs/server/session-externalization.md` — the `DELETE` contract, alongside the existing list of what the database-store shape changes.
- `docs/server/configuration.md` — the 4 MiB Streamable HTTP body cap under the streamable table.
- `docs/llms-full.txt` — both of the above, mirrored into the config and session-externalization sections.

`docs/llms.txt` is an index of pages and no page was added, so it is unchanged.

## Verification

`make verify` passes on this tree, exit code 0, ending in `=== All checks passed ===`. Every gate in the target ran: tools-check, fmt, swagger-check, embed-clean, race tests, migrate-check, the real-DB round-trip gate, frontend test/lint/e2e, golangci-lint, bench test/lint, gosec and govulncheck, semgrep, CodeQL, coverage, patch coverage, the documentation gates, dead-code, and the GoReleaser dry-run.

Gate results worth quoting:

- Total coverage 91.4%, against the 82% floor.
- Patch coverage `pkg/session/handler.go 7/7 (100.0%)` — every changed executable line is covered, against the 80% threshold.
- CodeQL: `no new blocking issues (3 baselined)`.
- The hard documentation gates all report OK, including the retired-tool-name and posture-claim checks.
- golangci-lint ran `Linting against merge-base 15d7392685 (from origin/main) — includes uncommitted changes`, so CI's `only-new-issues: true` behavior was mirrored rather than skipped.

`make verify` runs pre-commit by policy, so at the time it ran `HEAD` was still the merge base and doc-check's diff-based **soft** warning reported `SKIP: HEAD is the merge base (on main or no new commits)`. Its hard gates, which are not diff-based, all ran and passed. The soft gate has nothing to flag on this diff in any case: it warns when documentation-worthy changes arrive without doc updates, and the three documentation files listed above are part of this commit.

### How the two behavior changes were established

Neither was taken on the release notes' word. Both were measured by running the real SDK handler under each module version in turn, in a throwaway module pinned alternately to v1.6.1 and v1.7.0:

- **Stateless `DELETE`**: the same `mcp.NewStreamableHTTPHandler(..., Stateless: true)` and the same request, returning `204` on v1.6.1 and `405` with `Allow: POST` on v1.7.0.
- **Body cap**: a 5 MiB POST to a default-configured streamable handler, returning `413` with the body `request body exceeds 4194304 bytes`.

This matters as a method, not just as evidence. The release notes describe the `DELETE` change as spec compliance (a stateless server should not pretend to own sessions), which is a fair description of the SDK's behavior and says nothing about what happens to a caller wrapping it. The build stayed green, the release notes read as an improvement, and the existing tests passed. Only exercising the real handler surfaced it.

## Risk

The behavior change is confined to `DELETE /` in deployments running `sessions.store: database`, and it restores the v1.6.1 status codes rather than introducing new ones, so a client that worked before this bump works after it.

The 4 MiB body cap is the one change a deployment could notice without any code path in this repo being at fault: a client sending more than 4 MiB of tool-call arguments in a single request now receives a `413` where it previously succeeded. Nothing in the platform's own tool surface is expected to approach that in an argument payload — the large-payload paths (resource upload, asset export, query results) do not traverse this handler — but the ceiling is real and it is new, which is why it is documented rather than left to be discovered.

Reverting is a single `git revert` of this commit; it carries no migration, no schema change, and no persisted state.

## Where to look

Most of the diff is mechanical SHA and version substitution. The parts that carry judgment:

- `pkg/session/handler.go` — `handleDelete` no longer forwards, and the `AwareHandler` type doc now states the stateless-inner-handler requirement that this depends on. The question to press: is `AwareHandler` ever mounted over a stateful handler? `internal/httpserver/server.go:268` gates the wrap on `hcfg.streamableCfg.Stateless`, and `sessions.store: database` forces that flag on, so within this repo the answer is no. `NewAwareHandler` is exported, hence the doc contract rather than an assertion.
- `pkg/session/handler_test.go` — whether `TestHandler_Delete_RealStatelessSDK` actually exercises the real thing, and whether the two rewritten assertions test the client-visible contract rather than the stub's internals.
- `.github/workflows/codeql.yml` — the `autobuild` step moved without a Dependabot PR behind it.

## Supersedes

#1182, #1183, #1184, #1185, #1187, #1188, #1189

These are pull requests rather than issues, so closing keywords do not apply. Dependabot retires its own PRs once it observes these versions on `main`.
