### PR TITLE
bench(context-economics): the protocol pre-registration and the decomposition toolchain (#1170)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -57,11 +57,12 @@ jobs:
       - name: Build, vet, and test the harness
         run: make bench-test
 
-      - name: Recompute the published reports from the archives
-        # Pins the published headline numbers to bench/results/ (stdlib
-        # python3, offline). A drift between the archives, the recompute
-        # toolchain, and the published report pages fails here instead of
-        # reaching a reader. Also part of `make verify` (bench-report-check).
+      - name: Recompute the reports and pre-registrations from the archives
+        # Pins the published headline numbers, and the figures the
+        # context-economics protocol cites, to bench/results/ (stdlib python3,
+        # offline). A drift between the archives, a recompute toolchain, and a
+        # committed page fails here instead of reaching a reader. Also part of
+        # `make verify` (bench-report-check).
         run: make bench-report-check
 
       - name: Lint the harness

--- a/Makefile
+++ b/Makefile
@@ -1337,6 +1337,10 @@ bench-report-check:
 	@echo "Recomputing the knowledge-use report tables (smoke: script must run clean)..."
 	@python3 bench/reports/knowledge-use/pk_tables.py > /dev/null || \
 		{ echo "FAIL: bench/reports/knowledge-use/pk_tables.py no longer runs against bench/results/knowledge-use/."; exit 1; }
+	@echo "Recomputing the context-economics decomposition (pins the frozen probe, its summary, and the protocol)..."
+	@python3 bench/reports/context-economics/decompose.py > /dev/null || \
+		{ echo "FAIL: bench/reports/context-economics/decompose.py — the archives no longer reproduce a committed artifact."; \
+		  python3 bench/reports/context-economics/decompose.py | grep -E "^  FAIL|check\(s\) FAILED"; exit 1; }
 	@echo "OK: report toolchains reproduce from the committed archives."
 
 ## bench-calibrate: Run the judge calibration and print its human-agreement rate (needs ANTHROPIC_API_KEY; uses the rubric's pinned model)

--- a/bench/README.md
+++ b/bench/README.md
@@ -15,22 +15,20 @@ answers "how much" (throughput, latency, memory). This one answers "how well".
 Every artifact belongs to exactly one study. Run-family directories under
 [`results/`](results/) are never shared between them.
 
-| | Knowledge-layer effectiveness | Knowledge use | Knowledge pollution | API-connection architecture |
-| --- | --- | --- | --- | --- |
-| **Question** | Does a semantic knowledge layer make an agent measurably more correct? | When an agent is handed stored knowledge, does it use it? | When a stored insight is wrong, do other identities adopt it over a co-present correct source? | Does connection architecture change an agent's accuracy over a large API? |
-| **Published report** | [`benchmark-report.md`](../docs/reference/benchmark-report.md) ([site](https://mcp-data-platform.txn2.com/reference/benchmark-report/)) | [`benchmark-report-knowledge-use.md`](../docs/reference/benchmark-report-knowledge-use.md) ([site](https://mcp-data-platform.txn2.com/reference/benchmark-report-knowledge-use/)) | [`benchmark-report-knowledge-pollution.md`](../docs/reference/benchmark-report-knowledge-pollution.md) ([site](https://mcp-data-platform.txn2.com/reference/benchmark-report-knowledge-pollution/)) | none |
-| **DOI** | [10.5281/zenodo.21438044](https://doi.org/10.5281/zenodo.21438044) (concept) | [10.5281/zenodo.21614059](https://doi.org/10.5281/zenodo.21614059) | [10.5281/zenodo.21834813](https://doi.org/10.5281/zenodo.21834813) | none |
-| **Protocol** | [`docs/knowledge-layer-protocol.md`](docs/knowledge-layer-protocol.md) | [`docs/knowledge-use-protocol.md`](docs/knowledge-use-protocol.md) | [`docs/knowledge-pollution-study-design.md`](docs/knowledge-pollution-study-design.md) | [`docs/api-connection-study-design.md`](docs/api-connection-study-design.md) |
-| **Pre-registration** | issues #930, #942-#945 | [`docs/perishable-knowledge-study-design.md`](docs/perishable-knowledge-study-design.md), [fixture](docs/perishable-knowledge-fixture.md), [estimator audit](docs/perishable-knowledge-estimator-audit.md) | issue #1163 (filed after its premise probe held), then [`docs/knowledge-pollution-study-design.md`](docs/knowledge-pollution-study-design.md) (the confirmatory matrix, its estimator audit in section 6) | the protocol above |
-| **Toolchain** | [`reports/knowledge-layer/`](reports/knowledge-layer/) — `make bench-report-knowledge-layer-pdf` | [`reports/knowledge-use/`](reports/knowledge-use/) — `make bench-report-knowledge-use-pdf` | [`reports/knowledge-pollution/`](reports/knowledge-pollution/) — `make bench-report-knowledge-pollution-pdf` | none |
-| **Run data** | top-level families under [`results/`](results/) | [`results/knowledge-use/`](results/knowledge-use/) | [`results/knowledge-pollution/`](results/knowledge-pollution/) | [`results/api-study-pilot/`](results/api-study-pilot/) |
-| **Status** | published, report version 2.0 | published, report version 1.0, pinned to v1.116.0 | published, report version 1.0, commit-pinned builds | closed not planned; postmortem on #1027 |
+| | Knowledge-layer effectiveness | Knowledge use | Knowledge pollution | Context economics | API-connection architecture |
+| --- | --- | --- | --- | --- | --- |
+| **Question** | Does a semantic knowledge layer make an agent measurably more correct? | When an agent is handed stored knowledge, does it use it? | When a stored insight is wrong, do other identities adopt it over a co-present correct source? | What does the platform's context surface cost per turn, and which existing levers move it? | Does connection architecture change an agent's accuracy over a large API? |
+| **Published report** | [`benchmark-report.md`](../docs/reference/benchmark-report.md) ([site](https://mcp-data-platform.txn2.com/reference/benchmark-report/)) | [`benchmark-report-knowledge-use.md`](../docs/reference/benchmark-report-knowledge-use.md) ([site](https://mcp-data-platform.txn2.com/reference/benchmark-report-knowledge-use/)) | [`benchmark-report-knowledge-pollution.md`](../docs/reference/benchmark-report-knowledge-pollution.md) ([site](https://mcp-data-platform.txn2.com/reference/benchmark-report-knowledge-pollution/)) | none yet (#1172) | none |
+| **DOI** | [10.5281/zenodo.21438044](https://doi.org/10.5281/zenodo.21438044) (concept) | [10.5281/zenodo.21614059](https://doi.org/10.5281/zenodo.21614059) | [10.5281/zenodo.21834813](https://doi.org/10.5281/zenodo.21834813) | none yet (#1172) | none |
+| **Protocol** | [`docs/knowledge-layer-protocol.md`](docs/knowledge-layer-protocol.md) | [`docs/knowledge-use-protocol.md`](docs/knowledge-use-protocol.md) | [`docs/knowledge-pollution-study-design.md`](docs/knowledge-pollution-study-design.md) | [`docs/context-economics-study-design.md`](docs/context-economics-study-design.md) | [`docs/api-connection-study-design.md`](docs/api-connection-study-design.md) |
+| **Pre-registration** | issues #930, #942-#945 | [`docs/perishable-knowledge-study-design.md`](docs/perishable-knowledge-study-design.md), [fixture](docs/perishable-knowledge-fixture.md), [estimator audit](docs/perishable-knowledge-estimator-audit.md) | issue #1163 (filed after its premise probe held), then [`docs/knowledge-pollution-study-design.md`](docs/knowledge-pollution-study-design.md) (the confirmatory matrix, its estimator audit in section 6) | issue #1164 (filed after its archival premise probe held), then the protocol above (separation analysis in section 4, measurement spec in section 6) | the protocol above |
+| **Toolchain** | [`reports/knowledge-layer/`](reports/knowledge-layer/) — `make bench-report-knowledge-layer-pdf` | [`reports/knowledge-use/`](reports/knowledge-use/) — `make bench-report-knowledge-use-pdf` | [`reports/knowledge-pollution/`](reports/knowledge-pollution/) — `make bench-report-knowledge-pollution-pdf` | [`reports/context-economics/`](reports/context-economics/) — `make bench-report-check` | none |
+| **Run data** | top-level families under [`results/`](results/) | [`results/knowledge-use/`](results/knowledge-use/) | [`results/knowledge-pollution/`](results/knowledge-pollution/) | [`results/context-economics/`](results/context-economics/) | [`results/api-study-pilot/`](results/api-study-pilot/) |
+| **Status** | published, report version 2.0 | published, report version 1.0, pinned to v1.116.0 | published, report version 1.0, commit-pinned builds | pre-registered; controlled runs pending (#1171) | closed not planned; postmortem on #1027 |
 
 A study earns a column once it has a protocol or a report. Context economics
-(epic #1164) has neither yet and so is absent above, while its premise probe is
-already archived under
-[`results/context-economics/`](results/context-economics/); its column lands
-with its protocol.
+earned its column with the protocol above; the only run data under its slug so
+far is the archival premise probe, and its own arms land with #1171.
 
 Negative results and evidence-backed platform decisions are indexed in
 [`docs/findings-register.md`](docs/findings-register.md) — a retired study
@@ -188,6 +186,18 @@ reachability have been read back; both refuse rather than report a state they
 could not verify. Planting writes to the stack, so run it against a database a
 measured run will not reuse without a reset.
 
+**Context economics** ([protocol](docs/context-economics-study-design.md)) — the
+same stack as the knowledge-layer study, on its own `ce-*` arm configs. Those
+configs and the run recipes land with #1171; until then the study's only
+artifacts are its protocol, its decomposition toolchain, and the archival
+premise probe. The toolchain runs today against the archives it re-analyzes and
+needs no stack at all:
+
+```bash
+python3 bench/reports/context-economics/decompose.py    # tables, then the pins
+make bench-report-check                                 # the same run, as a gate
+```
+
 Every run writes into its own timestamped directory under
 `build/bench-results/`, and the runners refuse an output path that already
 exists, so a re-run can never overwrite paid-for results.
@@ -220,9 +230,10 @@ real runs) a model API. Do not add the stack-dependent `bench-*` run targets
 runs, the `bench-pk-*` targets) to the `verify` target; `bench-test`,
 `bench-lint`, and `bench-report-check` are the only exceptions because they
 touch nothing outside the repository — the last one recomputes the published
-reports' headline numbers from the committed archives (stdlib python3,
-offline) so a drift between the archives, a report toolchain, and a published
-page fails the build instead of reaching a reader.
+reports' headline numbers, and the context-economics protocol's cited figures,
+from the committed archives (stdlib python3, offline) so a drift between the
+archives, a report toolchain, and a committed page fails the build instead of
+reaching a reader.
 
 ## Layout
 
@@ -234,6 +245,7 @@ bench/
 │   ├── perishable-knowledge-study-design.md    pre-registration (#1054)
 │   ├── perishable-knowledge-fixture.md         fixture reference
 │   ├── perishable-knowledge-estimator-audit.md treatment-string audit
+│   ├── context-economics-study-design.md       pre-registration (#1170)
 │   ├── api-connection-study-design.md          closed study (#1027)
 │   └── findings-register.md
 ├── reports/             per-study recompute + render toolchains

--- a/bench/docs/context-economics-study-design.md
+++ b/bench/docs/context-economics-study-design.md
@@ -1,0 +1,756 @@
+# Context economics: a pre-registered study of what an MCP platform's context surface costs per turn, and what it buys
+
+> **Status: pre-registration in review.** Hypotheses, arms, decision rules, and
+> minimum-effect thresholds are fixed here, before the controlled runs in
+> #1171. Nothing in this document reports a result. The separation analysis in
+> section 4 is work item zero and requires user sign-off on issue #1170 before
+> the protocol merges; the banner changes to "pre-registered, runs pending
+> (#1171)" at that point.
+
+Study protocol for issue #1170, sub-ticket of epic #1164. It follows the
+knowledge-pollution pre-registration (`knowledge-pollution-study-design.md`) in
+structure, and like that one it is written after its premise probe rather than
+before, which is the findings register's lifecycle rule: probe before protocol,
+so a study is pre-registered only once its phenomenon is known to exist. What
+is pre-registered here is the confirmatory matrix and its decision rules, not
+the existence of the effect.
+
+The measurement machinery is committed with this protocol:
+[`bench/reports/context-economics/decompose.py`](../reports/context-economics/decompose.py)
+and its [README](../reports/context-economics/README.md). Every number this
+document quotes from the archives is recomputed by that script and pinned by
+`make bench-report-check`, so the protocol cannot drift away from the data it
+cites.
+
+**Framing rule, binding on every artifact in this study** (protocol, run
+archives, report, register rows, commit messages, PR bodies). This is a cost
+and benefit study of our own architecture, published with its mitigation story.
+The benefit side is already published and is treated here as a manipulation
+check, not re-litigated. No security-negative framing, and no vocabulary that
+casts the platform's own context as an attack surface: the words this study
+uses are *cost*, *payload*, *per-turn context*, *static surface*, and
+*population*.
+
+## 1. The scientific object
+
+An MCP server publishes a surface before any work happens: tool definitions,
+instructions, and whatever its discovery tools return. A client re-sends that
+surface, plus everything accumulated so far, on every turn. The object of this
+study is the bill that produces, decomposed into parts a deployment can act on
+separately, and the boundary at which each part starts paying for itself.
+
+The knowledge-layer report established the benefit side: delivered business
+context lifts trap accuracy by 56 points and is accuracy-neutral where it is
+not needed
+([`docs/reference/benchmark-report.md`](../../docs/reference/benchmark-report.md),
+DOI 10.5281/zenodo.21438044). It did not price that benefit. This study
+supplies the price, per component, at current code, and states where the two
+curves cross.
+
+The unit of interest is **per-turn context, not per-episode tokens**. Those are
+different quantities with different levers, and conflating them is the mistake
+this study exists to correct. A token written once when a session's prefix is
+established is billed once. A token in the prefix is billed again on every
+turn, multiplied by episode length. Section 6 defines the decomposition; the
+short form is that the second quantity is where the money is, and that it
+splits again into a static part the server charges for existing and an
+accumulated part the conversation earns.
+
+### 1.1 Position in the field, and the seam
+
+The survey is the epic's (#1164), restated rather than re-derived. The
+context-cost conversation in the literature is framed almost entirely around
+**tool-definition count**: RAG-MCP (arXiv 2505.03275) and LongFuncEval
+(2505.10570) both measure degradation as the published tool list grows, and
+client-side tool search reports selection accuracy rising from 49 to 74 percent
+when the list is retrieved rather than sent whole. The closest controlled work
+on result content varies tool *descriptions* (2602.14878: median +5.85 points
+of success, +67 percent execution steps, regressions in 16.7 percent of cases).
+The MCP specification's own discussion of result metadata cites no behavioral
+data at all.
+
+The seam, stated precisely: **the server-side result-payload axis, decomposed
+into the components that bill differently, measured against the benefit the
+same platform's published study already established, with the decomposition
+procedure published as a reusable instrument.** No surveyed work separates
+static surface from accumulated payload, and none prices either.
+
+The honest scope is empirical and methodological. Absolute figures here are
+properties of this platform, this model, and this fixture. Section 9 states
+which claims travel.
+
+## 2. Motivating evidence: the archival re-analysis
+
+The premise probe was archival and cost nothing: a re-analysis of the
+knowledge-layer study's four-arm phase-2 matrix (raw API, Sonnet, n=261
+attempts per arm), read in place under the cross-study re-analysis convention
+in [`bench/README.md`](../README.md). Provenance table:
+[`bench/results/context-economics/probe/README.md`](../results/context-economics/probe/README.md).
+
+Re-analysis motivates and never confirms. Everything in this section describes
+a build from 2026-07-14 (`v1.102.0-9-gadfb9d90-dirty`) under an instrument
+defect since fixed (#1176: every arm persona denied `fetch`, so every body an
+agent read had to arrive inside a search result). No number here is cited as a
+property of current code. Each one is a reason to go and measure.
+
+### 2.1 What the archives show
+
+Median per attempt, and the same components priced at Sonnet 5 rates:
+
+| Arm | Total tokens | cache creation | cache read | Static prefix bound | Median spend | xa0 |
+| --- | --- | --- | --- | --- | --- | --- |
+| a0 raw toolkits | 23,696 | 1,683 | 21,373 | 2,585 | $0.0169 | 1.0x |
+| a1 + enrichment | 26,396 | 2,889 | 22,476 | 2,508 | $0.0199 | 1.2x |
+| a2 + discovery | 57,329 | 4,201 | 52,443 | 5,127 | $0.0323 | 1.9x |
+| a3 + lifecycle tools | 148,079 | 5,906 | 141,911 | 9,809 | $0.0573 | 3.4x |
+
+Four observations shape the design, and two of them correct the probe's own
+reading of its numbers. The probe is archived unedited; the corrections live in
+its README and here.
+
+**The token ratio is not the cost ratio.** a0 to a3 is 6.2x in tokens and 3.4x
+in dollars, because cache read bills at a tenth of input while output bills at
+five times it. Every cost claim this study makes is stated in dollars, with the
+token figure beside it. Spend is computed per episode and then summarized,
+never as a sum of component medians -- the median of sums is not the sum of
+medians, and on these archives the shortcut moves the headline ratio.
+
+**Cache creation does not measure the static surface.** The probe read the
+modest growth in `cache_creation` (1,683 to 5,906) as evidence that the static
+tool surface is not the multiplier. That inference does not hold: cache
+creation counts tokens *written* to cache, and a prefix shared by hundreds of
+attempts in one run is written once and read thereafter. The static surface
+shows up instead as the floor of per-turn context, and that floor nearly
+quadruples across the arms (2,585 to 9,809 tokens, section 6.2). It is
+multiplied by turn count, so it is not a rounding error: on the a3 arm the
+static prefix alone accounts for roughly 60 percent of the median per-request
+context.
+
+**On the tasks that need knowledge, the cheap surface is the expensive arm.**
+Pooled figures hide a reversal the whole study turns on. On the trap suite the
+median episode costs $0.0665 at a0 and $0.0419 at a2 (means $0.0849 and
+$0.0469): the arm with the smallest published surface costs 59 percent more per
+episode than the arm with the largest, because without discovery an agent takes
+a mean of 19.0 tool calls against a2's 11.4 and re-reads a growing conversation
+on each one. On the suite where knowledge is not needed the order is the
+expected one, a0 at $0.0138 against a2 at $0.0215.
+
+The cost of a context surface is therefore not the surface. It is the surface
+minus the work the surface saves, and both terms have to be measured on the
+same tasks. This is also where the minimum effects in section 4 come from: the
+archived a0-to-a1 difference is $0.0116 per episode on the traps and $0.0004 on
+the knowledge-not-needed suite, so a threshold of $0.005 sits between the two
+by a comfortable margin in both directions.
+
+**The a2-to-a3 gap is not attributable, and population is not the leading
+candidate.** The probe named a confound (store population versus arm
+configuration) and treated population as the likely explanation. The archives
+do not support that ranking. The two runs differ in at least four ways, and one
+of them is decisive-looking on its own: a3's config declares a
+`memory.embedding` block and a2's does not, and the platform hands that
+provider to the search router
+(`knowledge.NewRouter(cfg.Embedding, ...)`, `internal/platform/searchfed/searchfed.go:157`),
+so it is a search-*ranking* lever and not only a memory feature. The
+transcripts show exactly that split: a2 ranked `lexical` on 1,027 of its 1,028
+federated searches and a3 ranked `hybrid` on 979 of 982. Under lexical ranking
+the `endpoints` group matched **zero** candidates across the entire a2 run,
+against 12,700 across a3, and `knowledge_pages` matched 853 against 7,716.
+Whether the stores also differed cannot be recovered from these archives.
+
+The consequence for the design is direct: an RQ1 that varies population while
+letting ranking mode vary with it would reproduce the confound rather than
+close it. Section 4.1 holds the embedder constant.
+
+### 2.2 The result-set shape, which sets a ceiling
+
+The search tool allocates a display budget across sources (default 10 hits,
+caller-settable to 50; `pkg/knowledge/router.go`). What the arms did with that
+budget differs qualitatively:
+
+| Arm | Federated searches | Returned nothing | Median hits | At the display budget |
+| --- | --- | --- | --- | --- |
+| a2 | 1,028 | 398 | 1 | 22 |
+| a3 | 982 | 262 | 10 | 637 |
+
+a2's searches mostly came back nearly empty; a3's mostly came back full. That
+is the difference behind the payload figures (median search result 601 chars at
+a2, 3,393 at a3), and it carries a pre-registrable prediction: **payload growth
+with population has a ceiling at budget saturation.** Once a search fills its
+display budget, adding more material to the stores changes which hits are shown
+but not how many, so cost stops tracking population and starts tracking per-hit
+size. An RQ1 whose cells both sit above saturation would measure that ceiling
+and report a null that says nothing about the effect. Section 4.1's cells
+straddle it deliberately.
+
+One shape must not be confused with the other. A `search` call that passes
+exactly one source and no intent *enumerates* that source, and the answer is a
+paged envelope the display budget never touches, at five times the page size.
+a2 issued 32 such calls and a3 issued 8; the toolchain counts them apart, and
+so must any arm that reports "search payload".
+
+## 3. Apparatus
+
+### 3.1 The four archived arms, and what actually differs between them
+
+Verified by diffing the committed configs at commit `a373ff7f`, which every
+archived manifest pins. The probe's claim that a2 and a3 differ only in the
+persona allow-list is wrong, and the correction is load-bearing for section 2.1.
+
+| | a0 | a1 | a2 | a3 |
+| --- | --- | --- | --- | --- |
+| Persona allow-list | `trino_*`, `s3_*` | same as a0 | + `search`, `fetch`, `list_connections`, `datahub_*` | + `memory_*`, `apply_knowledge`, `manage_feedback` |
+| Semantic provider | none | DataHub | DataHub | DataHub |
+| `enrichment.*` | the four cross-enrichment switches off | defaults (on) | defaults (on) | defaults (on) |
+| `workflow.require_search` | false | false | default (on) | default (on) |
+| `memory.embedding` | absent | absent | absent | Ollama, `nomic-embed-text` |
+| `knowledge` block | absent | absent | absent | `enabled`, `apply.enabled` |
+
+### 3.2 Mechanisms this study may vary, each verified present
+
+An arm may only name a mechanism the platform has. The list below is the whole
+inventory; anything outside it is a product candidate, not an arm.
+
+| Mechanism | Where | Default |
+| --- | --- | --- |
+| `enrichment.column_context_filtering` | `pkg/platform/config.go:736` | on (`*bool`, nil = enabled) |
+| `workflow.require_search` | `pkg/platform/config.go:1271` | on (`*bool`, nil = enabled) |
+| Persona tool allow-lists | arm config `personas:` | per arm |
+| Search display budget | `pkg/knowledge/router.go`, caller `limit` | 10, max 50 |
+| Embedding provider (search ranking) | `memory.embedding`, wired at `internal/platform/searchfed/searchfed.go:157` | absent = lexical ranking |
+| Knowledge-page population | `bench/seed/postgres/knowledge_pages.sql` (4 pages), skipped by `BENCH_SEED_PAGES=0` | seeded by `make bench-up` |
+| Catalog population | `make bench-seed-datahub`, empty baseline `bench-seed-datahub-empty` | seeded |
+| API-catalog population | `bench/apisetup` registers a spec as a connection | none beyond the built-in |
+| Prompt population | platform prompt store: `POST /api/v1/portal/prompts` or the `manage_prompt` tool | built-ins only |
+
+Two floors are not removable and must be recorded rather than eliminated. The
+platform seeds its own `platform-admin` API catalog from the OpenAPI document
+embedded in the binary whenever an API-gateway toolkit and a catalog store are
+both present (migration `000058_api_catalog_embedded_source`), and it registers
+its own built-in prompts. So "empty" in this study means *no study-seeded
+material*, and every cell's actual store counts are dumped into the archive.
+
+**Not an arm: a server-side per-group result cap.** It does not exist. The
+allocator gives each matching source a floor of one slot and caps any one
+source at half the display budget during the balanced fill, then relaxes the
+ceiling to spend leftover budget (`pkg/knowledge/allocator.go`), but none of
+that is operator-configurable and there is no relevance threshold. If RQ1
+confirms a population effect, a product ticket may propose one on this study's
+evidence. It is never an arm here.
+
+### 3.3 Instrument differences from the archives, disclosed
+
+- The archived runs denied `fetch` to every persona (#1176). Current configs
+  grant it, and `bench/config/config_test.go` now refuses a config that grants
+  `search` without `fetch` and `list_connections`. New runs are therefore
+  fetch-capable where the motivating re-analysis was not, which is one reason
+  the comparison stays motivating-only.
+- Every archived arm ran with lexical search ranking except a3. Every arm in
+  this study runs with the same embedding provider configured, so ranking mode
+  is constant across all cells.
+
+## 4. Hypotheses, decision rules, and the separation analysis
+
+Separation analysis is work item zero and gates everything downstream. For each
+research question this section names the divergence mechanism, the design
+variable that produces it, confirmation that the design varies that variable
+rather than holding it at its easy setting, the pre-stated decision rule with
+its minimum effect, and what falsifies the premise. An arm with no nameable
+divergence mechanism is dropped here rather than carried into a run; section
+4.2 exercises that rule.
+
+**Minimum effects are stated in dollars per episode, not in significance.** A
+contrast whose interval excludes zero but whose median difference is below its
+stated threshold is reported as "measurable but not material", and that is a
+finding, not a redesign trigger.
+
+### 4.1 RQ1: does store population alone reproduce the per-turn payload growth?
+
+**Divergence mechanism.** Federated search payload exists only when a store has
+material to return. A populated store fills display-budget slots that an empty
+one leaves empty, the filled slots enter the conversation prefix, and the
+prefix is re-read on every subsequent turn. The mechanism is mechanical, not
+behavioral: it does not depend on the agent choosing to do anything.
+
+**Design variable.** Study-seeded store population, varied across three cells
+under a **byte-identical config file**. Everything section 3.2 lists as a
+config lever is held fixed, the embedding provider among them, so all three
+cells rank `hybrid`.
+
+**Confirmation the design varies it, and does not hold it easy.** The probe's
+a2 cell sat below display-budget saturation (median 1 hit) and its a3 cell sat
+at it (median 10). Two cells both above saturation would measure the ceiling of
+section 2.2 rather than the effect. The three cells therefore straddle it:
+
+| Cell | Knowledge pages | DataHub | API specs | Prompts | Expected regime |
+| --- | --- | --- | --- | --- | --- |
+| P0 empty | none (`BENCH_SEED_PAGES=0`) | `bench-seed-datahub-empty` | built-in only | built-in only | below saturation |
+| P1 typical | the 4 seeded pages | `bench-seed-datahub` | one registered fixture spec | 10 seeded | near saturation |
+| P2 saturating | 40 pages | `bench-seed-datahub` | one registered fixture spec | 40 seeded | at saturation |
+
+P1 is the shipped bench fixture. P2 adds more of the same *kinds* of material
+through the same seeding paths -- further `portal_knowledge_pages` inserts
+beside `bench/seed/postgres/knowledge_pages.sql`, further prompts through the
+prompt store -- and no new kind, so a P1-to-P2 difference can never be
+attributed to a federated group appearing that was absent before.
+
+Two constraints on the added material, both of which #1171 must satisfy before
+the cell counts:
+
+- **It must not answer the tasks.** A page that helps changes accuracy as well
+  as cost, which would confound the cost measurement with the benefit this
+  study is not re-litigating. Added pages and prompts are about subjects the
+  task set does not touch.
+- **It must be reachable by the bench identities.** A prompt created as
+  personal is visible only to its owner
+  (`pkg/knowledge/provider_prompts.go`), so a personal prompt would inflate the
+  store count without reaching a single search result. Seeded prompts are
+  shared, and the cell's first search result is inspected to confirm the group
+  appears.
+
+Store counts per cell are dumped into the archive before the first episode. An
+RQ1 cell whose population is undocumented is unusable, and the run ticket
+treats a missing dump as a failed arm.
+
+**H1a (population moves per-turn cost below saturation).** Median per-episode
+spend at P1 exceeds P0.
+
+*Rule.* HOLDS if the paired median difference is at least **$0.005 per episode**
+(roughly a third of the archived a0 baseline) and its bootstrap interval
+excludes zero. FALSIFIED if the interval lies entirely below $0.005: population
+would then be measurable, or not measurable at all, but not material. Either
+outcome is a finding and neither reopens the design.
+
+**H1b (the effect has a ceiling at budget saturation).** The P1-to-P2 spend
+difference is materially smaller than the P0-to-P1 difference.
+
+*Rule.* HOLDS if the P1-to-P2 median difference is under half the P0-to-P1
+difference **and** the share of federated searches at the display budget rises
+from P1 to P2. FALSIFIED if P1-to-P2 is at least as large as P0-to-P1, which
+would mean per-hit size grows with population faster than the budget bounds it.
+
+**H1c (the static prefix does not move).** The static-prefix bound is
+indistinguishable across the three cells.
+
+*Mechanism.* Config is identical and the tool list is identical, so the
+published surface is identical. This is a **manipulation check on the design**,
+not a finding: a moving static prefix means something other than population
+changed between cells, and the arm is invalid.
+
+*Rule.* The primary check is exact rather than statistical: #1171 dumps the
+`tools/list` response for each cell before its first episode, and the arm is
+INVALID if the three dumps are not byte-identical. The static-prefix bound is
+reported beside them as a secondary read, with the caveat that it is a minimum
+over episodes and so can move a little when the shortest episode in a cell
+carries a differently sized first result; a bound differing by more than 15
+percent between cells is investigated before the cell's numbers are used. This
+check takes precedence over H1a and H1b.
+
+**Premise falsifier.** If P0, P1, and P2 are indistinguishable in per-episode
+spend while their store counts differ by the pinned amounts and their search
+payloads differ, then on this platform population does not reach the bill, RQ1
+publishes as a negative finding with a register row, and the epic's
+deployment-relevant claim is retired.
+
+### 4.2 RQ2: the enrichment boundary
+
+**H2a (enrichment is cheap where it is not needed and pays where it binds)**,
+tested as an a0-versus-a1 contrast at current code with per-component
+decomposition.
+
+*Mechanism.* Enrichment adds semantic context to `trino_describe_table` and
+`trino_query` results, which enters the prefix and is re-read. The archives put
+the payload effect at a doubling of the median describe result (1,074 to 2,601
+chars) and the pooled end-to-end effect at +11 percent in median tokens and +19
+percent in spend, with the trap suite going the other way: median tokens down
+27 percent (73,534 to 53,467) and published trap accuracy up 14.6 points (42.7
+to 57.3). Two opposed effects of that size cannot both be artifacts of the same
+nuisance.
+
+*Design variable.* The a0/a1 config pair, unchanged. Neither persona grants
+`search`, so the #1176 delivery-surface correction does not touch them and the
+contrast is the published one re-run on current code.
+
+*Rule.* Two conditions, both on paired median spend differences. HOLDS if on
+s1 (knowledge not needed) a1 costs no more than a0 by **$0.005 per episode**,
+and on s3 (traps) a1 costs *less* than a0 by at least **$0.005 per episode**.
+FALSIFIED if a1 costs more than a0 on s3 by at least $0.005: enrichment would
+then be paying nothing back where it is supposed to bind. A result that meets
+one condition and not the other is reported as the split it is, and the arm's
+conclusion is stated per suite rather than pooled.
+
+*Manipulation check.* s3 accuracy must reproduce the published direction (a1
+above a0). If it does not, the cost result is reported without the benefit
+claim and the divergence from the published report is stated.
+
+**H2b (`column_context_filtering` reduces enrichment payload) — DROPPED as an
+episode arm, with a survivor.**
+
+The rule is that an arm with no nameable divergence mechanism at the fixture in
+hand is dropped before it costs a run, and the drop is recorded. This is that
+record.
+
+The flag limits column-level enrichment to the columns a query references, and
+its documented purpose is a **wide** table whose queries touch a subset. The
+bench warehouse has no wide table: `memory.bench.customers` has five columns
+and `memory.bench.orders` has six (`bench/seed/trino/setup.sql`). The most the
+flag can remove on this fixture is the context for four columns of a six-column
+table, a few hundred characters per describe call against a median episode of
+tens of thousands of tokens. An episode-level arm here is a guaranteed null
+that would say nothing about the mechanism, which is precisely the failure the
+separation-analysis rule exists to prevent.
+
+**The survivor is a payload measurement with no model in the loop.** The same
+scripted tool sequence (`-llm scripted`, no API key, no spend) runs against two
+configs differing only in the flag, and the difference in describe-result size
+is reported as an exact bound on what the flag can save on this fixture. That
+is a real number, it is cheap, and it is honest about its scope.
+
+*Rule.* The measurement is reported whatever it shows. It is never generalized
+past this fixture. The wide-table question is filed as a deferred study
+extension in `findings-register.md`, with the fixture work it would need.
+
+### 4.3 RQ3: what the discovery workflow costs
+
+**H3a (the search-first gate has a measurable cost where discovery is not
+needed).** On the s1 suite, per-episode spend is lower with
+`workflow.require_search: false` than with the shipped default.
+
+*Mechanism.* The gate refuses query tools until a discovery tool has been
+called, so every episode pays for at least one search result in its prefix,
+re-read on every later turn, whether or not the task needed discovery. With the
+gate off the agent may skip search entirely.
+
+*Design variable.* One config pair differing only in that flag, the same
+single-deviation pattern as `bench/config/platform.bench.pk-gateoff.yaml`. The
+suite is s1, whose tasks are answerable from the raw catalog, so the mechanism
+has room to act.
+
+*Rule.* HOLDS if the median spend difference is at least **$0.003 per episode**
+with an interval excluding zero. FALSIFIED if gate-off is not cheaper.
+
+*The live uncertainty, stated rather than assumed.* With the gate off the
+search tool is still published and still described as the way to discover, so
+agents may call it anyway. If they do, the gate's marginal cost is near zero
+and that is the finding. The observed search-call rate per cell is reported
+beside the spend difference in either case.
+
+*Manipulation check.* s3 accuracy with the gate off must not fall materially.
+A cost saving bought with accuracy is reported as such, never as a saving.
+
+**H3b (persona scope sets the static prefix).** A narrower persona allow-list
+lowers the static-prefix bound proportionally to the tool definitions it
+withholds.
+
+*Mechanism.* Persona filtering removes tools from the published list, and the
+list is part of the prefix every request re-reads. The archives already show
+the size of this effect across arms that differ in their tool lists (2,508
+tokens at a1 against 5,127 at a2), though those arms differ in other ways too.
+
+*Design variable.* One config, two personas, differing only in the allow-list.
+The narrow persona keeps `search`, `fetch`, and `list_connections` together,
+which `bench/config/config_test.go` enforces and which #1176 is the reason for.
+
+*Rule.* HOLDS if the static-prefix bound differs between the two personas by at
+least 15 percent, in the direction of the narrower list. FALSIFIED if it does
+not move, which would mean the published tool list is not what dominates the
+static prefix and would redirect the mitigation story to instructions instead.
+
+This arm needs very few episodes: the static-prefix bound is a property of the
+published surface, not of what an agent does. The bound is looser the fewer
+episodes it is taken over, so both cells run the same tasks at the same k and
+the comparison is between two equally loose bounds rather than between a tight
+one and a loose one.
+
+### 4.4 RQ4: the decomposition as a reusable instrument
+
+**Claim.** The decomposition procedure -- separating cache creation from
+per-turn cache read, bounding the static prefix inside the latter, and
+attributing the remainder to tool results and their federated groups -- is a
+general method for any MCP server that records per-attempt usage, not a
+property of this platform.
+
+*Deliverable.* The committed toolchain and the "Applying this to another
+server" procedure in its README, both landing with this protocol.
+
+*Rule.* HOLDS if the committed script reproduces the frozen probe
+decomposition from the archives (already demonstrated: `decompose.py` table T7
+compares every key and every value and `make bench-report-check` fails the
+build otherwise) **and** the same functions run unmodified against #1171's
+archives, changing only the family path. FALSIFIED if #1171's data needs a
+different estimator, in which case the method claim narrows to this harness and
+the report says so.
+
+RQ4 is the only research question that can be settled without spending
+anything, and half of it is settled by this PR.
+
+## 5. Design, cells, and episode counts
+
+### 5.1 Configs
+
+New configs use a `ce-` prefix rather than extending the `a*` family. This is
+not cosmetic: `bench/internal/pool/pool_test.go` globs `platform.bench.a*.yaml`
+and requires exactly four matches, so a config named `platform.bench.a2-gateoff.yaml`
+would break the identity-pool guard. Extending that guard to cover the `ce-*`
+configs is a pre-run requirement on #1171, because the failure it prevents is a
+paid run dying partway through on an identity nobody defined.
+
+| Config | Derived from | Single deviation |
+| --- | --- | --- |
+| `platform.bench.ce-pop.yaml` | a2 | adds `memory.embedding` (Ollama, `nomic-embed-text`) so ranking is hybrid |
+| `platform.bench.ce-gateoff.yaml` | `ce-pop` | `workflow.require_search: false` |
+| `platform.bench.ce-narrow.yaml` | `ce-pop` | persona allow-list narrowed to the discovery surface plus `trino_*` |
+| `platform.bench.ce-nocolfilter.yaml` | a1 | `enrichment.column_context_filtering: false` |
+
+`make bench-up BENCH_ARM=ce-pop` resolves the config path by convention
+(`BENCH_CONFIG ?= bench/config/platform.bench.$(BENCH_ARM).yaml`), so no
+Makefile change is needed to run them.
+
+### 5.2 The matrix
+
+| RQ | Cells | s1 | s3 | Episodes per cell | Total | Driver |
+| --- | --- | --- | --- | --- | --- | --- |
+| RQ1 | P0, P1, P2 on `ce-pop` | k=3 (51) | k=1 (25) | 76 | 228 | raw API |
+| RQ2 H2a | a0, a1 | k=3 (51) | k=3 (75) | 126 | 252 | raw API |
+| RQ2 H2b | a1, `ce-nocolfilter` | scripted tool sequence | — | — | 0 metered | scripted |
+| RQ3 H3a | `ce-pop`, `ce-gateoff` | k=3 (51) | k=1 (25) | 76 | 152 | raw API |
+| RQ3 H3b | `ce-pop`, `ce-narrow` | k=1 (17) | — | 17 | 34 | raw API |
+
+s1 is 17 tasks and s3 is 25 (`bench/tasks/`). The s2 suite is omitted
+throughout: it is the largest at 45 tasks and adds no contrast any hypothesis
+here needs.
+
+**Why s3 runs at k=3 in one place and k=1 elsewhere.** On RQ2 the trap-suite
+cost *is* the hypothesis, so it needs the same replication as s1. Everywhere
+else s3 is only an accuracy manipulation check, and the published effect it
+checks for is large (42.7 against 98.7 points). A k=1 check over 25 tasks is
+coarse: it detects a collapse and would miss a few-point drift, and the report
+states that limit rather than implying a sensitivity the design does not have.
+This is also where most of the spend saving comes from — s3 costs three to five
+times an s1 episode on every archived arm.
+
+Every cell outside RQ1 runs at the P1 population, the shipped bench fixture, so
+a gate or persona contrast is never also a population contrast.
+
+### 5.3 Pairing
+
+Every contrast is paired by task and attempt index: the same task set, the same
+seed, the same k, so a per-task difference is a difference in the platform and
+not in the task mix. The analysis in section 7 is on paired differences for
+that reason.
+
+## 6. Measurement specification
+
+The instrument is `bench/reports/context-economics/decompose.py`. Definitions
+below are the ones it implements; its README carries the full argument for each.
+
+### 6.1 What is recorded per attempt
+
+`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`,
+`tool_calls`, `wall_ms`, and a transcript path. The `-llm anthropic` path
+already records all of these
+(verified in `bench/results/phase2-anthropic-k3/full-a0/results.json`). #1171
+verifies them present and non-zero in a one-episode dry run before each metered
+block, because a summed total is not recoverable into components after the
+fact.
+
+A missing counter counts as zero. This is not a formality: 18 of 261 attempts
+in `full-a0` carry no `cache_creation_tokens` key, and excluding them instead
+moves that arm's median cache creation from 1,683 to 1,898.
+
+### 6.2 The static-prefix bound, and why it is a bound
+
+`cache_read` on an attempt is the sum, over that episode's model requests, of
+the prefix each request re-read. That reading depends on uncached input being
+negligible, which holds throughout these archives: `input_tokens` has a median
+of 12 to 18 and a maximum of 52 across all four arms, so essentially the whole
+prefix is served from cache every turn.
+
+Dividing by the request count gives the average prefix that episode re-read.
+The smallest such value in a cell is the tightest **upper bound** on the
+static prefix, the system prompt and tool definitions every request carries
+before any conversation accumulates: no episode can average below the static
+prefix, because every request's prefix contains it.
+
+It is reported as a bound and never as an estimate. #1171 checks
+`input_tokens` per cell before using it, and a cell where uncached input is not
+negligible reports the bound with that caveat attached.
+
+### 6.3 Denominators
+
+Per-turn context is reported under both denominators, because they are not the
+same number: an assistant turn can carry several tool calls, and on the
+archives the two counts differ on more than half the attempts in every arm. The
+frozen probe divided by tool calls; the request count is the one that
+corresponds to what was billed. Any cost claim names which it used.
+
+### 6.4 Payload attribution
+
+Every tool result is mapped back to its call through the call id, and result
+sizes are summed per tool. Search results are decomposed further by federated
+group, counting the three response shapes apart: the federated envelope, the
+paged browse envelope, and tool errors. Folding an error into "returned
+nothing" would overstate how often a populated store had nothing to say.
+
+### 6.5 Pricing
+
+Each counter is multiplied by its own rate, at rates dated in the script.
+Ratios are reported in dollars with the token ratio beside them.
+
+### 6.6 Accuracy
+
+Accuracy is graded by the existing deterministic graders and is a
+**manipulation check only**. It references the published knowledge-layer
+results and never appears as a headline of this study. Where a cost saving
+coincides with an accuracy drop, both are reported together.
+
+## 7. Analysis plan
+
+Per contrast: the paired per-task median difference in per-episode spend, with
+a 95 percent percentile-bootstrap interval from the shared
+`bench/internal/stats` package at a fixed seed, compared against the arm's
+pre-stated minimum effect. The components are reported beside the total --
+median cache read, median cache creation, median output, and the cell's
+static-prefix bound -- so a total that fails to move because two components
+moved against each other is visible rather than read as "no effect".
+
+No p-values, no significance thresholds. An interval and a minimum effect are
+what a cost decision needs.
+
+Every table in the report is produced by `decompose.py` from the committed
+archives, offline. Numbers are not transcribed by hand into prose: the pin
+list in the script is extended to cover every figure the report states, exactly
+as it already covers this protocol's section 2.
+
+## 8. Confounds and threats to validity
+
+**Ranking mode.** The confound section 2.1 identifies in the archives. Closed
+by configuring the same embedding provider in every cell and verified by the
+recorded `ranking` field, which must read `hybrid` on the overwhelming majority
+of federated searches in every cell. A cell that ranks lexical is invalid.
+
+**Cross-episode cache state.** Attempts in a run share a cached prefix, so
+`cache_creation` depends on run order and cache TTL and is not a per-episode
+property. It is reported, never used as the basis of a claim about surface
+size. The static-prefix bound is the quantity used for that.
+
+**Store drift within a cell.** A run that writes to the stores it is measuring
+changes its own population mid-block. The RQ1 cells use personas without
+capture or apply tools, so no episode writes to the knowledge stores, and store
+counts are dumped again after the block; a post-count that differs from the
+pre-count invalidates the cell.
+
+**Population is not one dimension.** Pages, prompts, catalog entities, and API
+endpoints federate through different providers with different per-hit sizes.
+P2 multiplies only pages and prompts, so the study measures depth of population
+and not breadth. A breadth claim would need a cell that adds a federated group
+the other cells lack, which is a different design and is out of scope here.
+
+**Task mix.** s1 and s3 are what this study measures; s2 is omitted. Costs are
+reported per suite as well as pooled, so a pooled figure is never read as a
+property of an unmeasured task distribution.
+
+**Model.** One model, Sonnet 5, on the raw-API path. Absolute dollars are
+properties of that model's rates. Component *ratios* are more portable than
+absolute figures, and the report says which is which.
+
+**The archives cannot be compared to the new runs.** Different build, different
+delivery surface (#1176), different ranking mode. Section 2 is motivating
+evidence; no result in this study is stated as a change from it.
+
+## 9. Generalization and external validity
+
+Travels: the decomposition method, the finding that static surface is billed
+per turn and that cache creation does not measure it, the existence of a
+saturation ceiling in a budgeted federated search, and the gap between token
+ratios and cost ratios.
+
+Does not travel: absolute dollars, the specific saturation point (a property of
+the display budget and this fixture's hit sizes), the enrichment payoff on the
+trap suite (a property of these tasks), and anything about wide-table column
+filtering, which this fixture cannot reach.
+
+## 10. Client surface and driver policy
+
+**Every token-fidelity arm runs on the raw-API in-process path**
+(`benchrun -llm anthropic`, default model `claude-sonnet-5`). The claude-cli
+adapter inserts client-side context the harness does not control, which
+confounds exactly the totals this study measures, so it is never used for a
+cost claim. If an arm needs the client surface for some other reason it is
+labelled and excluded from every cost table.
+
+Build provenance is decided before the first arm, not after: either a tag-build
+worktree (the knowledge-use v1.116.0 precedent) or commit pinning with
+per-block provenance recorded in every manifest (the knowledge-pollution
+precedent). If commit-pinned, main is not merged into the run branch mid-block.
+
+## 11. Spend plan
+
+Every figure below is an estimate: episodes multiplied by the archived
+per-suite **mean** spend of the closest arm. The mean, not the median, because
+a budget needs the mean and these distributions are heavy-tailed enough that
+the median would understate a block by roughly half. The rates behind them live
+in the toolchain, dated.
+
+**#1171 may not run an arm whose cap box below is unchecked.** The boxes are
+checked by the user on issue #1170, not here.
+
+| Arm | Episodes | Closest archived arm | Estimate | Cap | Approved |
+| --- | --- | --- | --- | --- | --- |
+| RQ1 P0 | 76 | a2 (sparse stores, hybrid ranking) | $2.50 | $4 | [ ] |
+| RQ1 P1 | 76 | a3 (populated stores) | $4.41 | $7 | [ ] |
+| RQ1 P2 | 76 | a3 | $4.41 | $7 | [ ] |
+| RQ2 H2a a0 | 126 | a0 | $7.18 | $10 | [ ] |
+| RQ2 H2a a1 | 126 | a1 | $7.01 | $10 | [ ] |
+| RQ2 H2b | 0 metered | scripted, no model | $0 | n/a | n/a |
+| RQ3 H3a `ce-pop` | 76 | a3 | $4.41 | $7 | [ ] |
+| RQ3 H3a `ce-gateoff` | 76 | a3 (an upper bound; the arm should be cheaper) | $4.41 | $7 | [ ] |
+| RQ3 H3b, both cells | 34 | a3, s1 only | $1.67 | $3 | [ ] |
+| **Total** | **666** | | **$36** | **$55** | |
+
+For scale: the four archived arms cost $9.23, $9.49, $9.45, and $16.64 for 261
+episodes each, so this whole matrix is roughly the cost of one archived arm and
+a half.
+
+A cell that exhausts its cap stops and reports what it has. Partial archives
+are kept, never discarded or overwritten, and the family README records where
+the block stopped.
+
+## 12. Platform decisions this study settles
+
+- Whether store population reaches the bill, and whether it keeps doing so past
+  display-budget saturation. If it does and the ceiling is real, the display
+  budget is already the control and no new knob is needed; if it does and there
+  is no ceiling, a per-group cap or relevance threshold becomes a justified
+  product proposal with evidence behind it.
+- Whether the search-first gate costs anything where discovery is unnecessary,
+  which is the evidence a persona-scoped or task-scoped gate would need.
+- Whether persona scope is a real cost lever, which is what a deployment can act
+  on today without any code change.
+- Whether `enrichment.column_context_filtering` can matter at all on a narrow
+  fixture, which decides whether a wide-table study extension is worth filing.
+
+## 13. Reproducibility, artifacts, and publication commitment
+
+- Protocol: this document, pre-registered before #1171's data.
+- Toolchain: `bench/reports/context-economics/`, stdlib python3, offline,
+  exercised by `make bench-report-check` in `make verify` and in CI.
+- Run data: `bench/results/context-economics/<family>/`, each family with a
+  README stating what it does and does not establish, manifests carrying build
+  pin, config file, model, k, and the store-count dump for RQ1 cells.
+- Report: `docs/reference/benchmark-report-context-economics.md` with its own
+  concept DOI (#1172). It revises no published report.
+- Findings register: one row per finding including every null against a
+  pre-stated threshold and every arm dropped by rule, section 4.2 among them.
+- The published report states negative and null results with the same
+  prominence as positive ones. A cost study that only reported the costs it
+  found would be an advertisement.
+
+## 14. Work plan
+
+1. This PR (#1170): protocol, decomposition toolchain, `bench-report-check`
+   wiring, series-table column. No runs.
+2. User sign-off on the separation analysis and the spend caps, as a comment on
+   #1170. The status banner changes on sign-off.
+3. #1171: the configs in section 5.1, the pool-guard extension, the arms in
+   section 5.2, archives and register rows. No report claims.
+4. #1172: report page, DOI, register backfill.

--- a/bench/docs/findings-register.md
+++ b/bench/docs/findings-register.md
@@ -37,10 +37,10 @@ done about the published record — which is not always a re-run.
 
 ## Deferred study extensions (proposed, never probed)
 
-Extensions of the published knowledge-layer study that were written down as
-follow-up work, then deferred without a probe. They differ from the retired
-candidates above: nothing was measured and nothing was falsified, so none of
-them is concluded. They are recorded here rather than left open because each
+Extensions written down as follow-up work, then deferred without a probe; all
+but the last are extensions of the published knowledge-layer study. They differ
+from the retired candidates above: nothing was measured and nothing was
+falsified, so none of them is concluded. They are recorded here rather than left open because each
 would cost a full run and none has a product question waiting on its answer,
 and an open ticket nobody can act on reads as work in flight.
 
@@ -56,6 +56,7 @@ forms a new study in the series with its own protocol.
 | Multi-model cold-start climb (#980 A3): repeat the curve on three or more models | The largest spend in the set. Single-model generalization is an acknowledged limit of the published report (Section 7), stated as such rather than hidden | A decision to publish a generalization claim, or a second model showing a materially different climb by accident |
 | Forgetting and decay after supersede (#980 A5) | Depends on the A2 harness, and the supersede mechanism already probed at ceiling (see the supersede-reliability row above) | The A2 harness existing for another reason, or a stale value resurfacing in production |
 | Channel ablation, sink x discovery mode (#980 A6) | Existed to arbitrate the two #1131 levers. #1131 now takes the platform-controlled lever on the report's own evidence that platform search delivers, so the matrix no longer gates a decision | Wanting to close the sink-delivery confound the report flagged (Section 6) as a publication goal in its own right |
+| Wide-table `column_context_filtering` (context-economics H2b): what the flag saves when a query touches a subset of a wide table | The bench warehouse has no wide table — `memory.bench.customers` has five columns and `memory.bench.orders` six (`bench/seed/trino/setup.sql`) — so the flag can withhold context for at most four columns per describe call, against a median episode of tens of thousands of tokens. An episode-level arm on this fixture is a guaranteed null that would say nothing about the mechanism, so the protocol drops it as a metered arm and keeps a zero-spend scripted payload measurement in its place (`context-economics-study-design.md`, section 4.2) | A fixture with a genuinely wide table and tasks whose SQL touches a small subset of it, which is fixture work in its own right; or a deployment reporting enrichment payload as a material cost on wide tables |
 | Standalone memory suite (#982 section 3): generalize S5 out of the data-analysis framing into long multi-session arcs with no warehouse dependency | The mechanisms it would measure — capture, personal recall, cross-identity transfer, supersede correctness and duplicate rate, abstention — are the ones S5 already measures inside the knowledge-layer study, so the delta is external validity for memory-primary deployments rather than a decision nobody can otherwise make. The cost is the whole of it: a second seeded, airgapped ground-truth corpus with no warehouse in it. Its retention-and-decay axis depends on the A2 harness, deferred in its own row above | A memory-primary deployment needing a citable number that the warehouse framing would not support, or an S5 metric that turns out to be an artifact of the warehouse dataset rather than a property of the memory layer |
 
 ## Platform decisions taken on benchmark evidence

--- a/bench/reports/context-economics/README.md
+++ b/bench/reports/context-economics/README.md
@@ -1,0 +1,155 @@
+# Context-economics toolchain
+
+The recompute for the context-economics study (epic [#1164](https://github.com/txn2/mcp-data-platform/issues/1164)).
+It decomposes what one agent episode costs against an MCP platform, and where
+the cost goes: how much context each turn re-reads, how much of that is the
+static surface the server publishes before any work happens, and how much
+arrives as tool-result payload.
+
+```bash
+python3 bench/reports/context-economics/decompose.py          # every table, then the pins
+python3 bench/reports/context-economics/decompose.py --emit   # the decomposition as JSON
+```
+
+Stdlib python3, offline, no API key, no network — the same contract
+[`knowledge-pollution/pollution_tables.py`](../knowledge-pollution/pollution_tables.py)
+and [`knowledge-use/pk_tables.py`](../knowledge-use/pk_tables.py) honor. `make
+bench-report-check` runs it, in `make verify` and in CI's harness job.
+
+## What it reads, and whose data it is
+
+Today the only archives it reads belong to another study. The four arms of
+`bench/results/phase2-anthropic-k3/` are the knowledge-layer study's phase-2
+matrix, published at
+[`docs/reference/benchmark-report.md`](../../../docs/reference/benchmark-report.md),
+DOI [10.5281/zenodo.21438044](https://doi.org/10.5281/zenodo.21438044). They
+are read in place, never copied or modified, under the cross-study re-analysis
+convention in [`bench/README.md`](../../README.md); the provenance table is
+[`bench/results/context-economics/probe/README.md`](../../results/context-economics/probe/README.md).
+
+Re-analysis motivates and never confirms. Every number this script prints today
+describes a build from 2026-07-14 (`v1.102.0-9-gadfb9d90-dirty`) under an
+instrument defect since fixed ([#1176](https://github.com/txn2/mcp-data-platform/issues/1176):
+every arm persona denied `fetch`, so every body an agent read had to arrive
+inside a search result). The study's own runs land with
+[#1171](https://github.com/txn2/mcp-data-platform/issues/1171), and this script
+reads them through the same functions — `results.json` and the transcript
+schema are the harness's, not the archive's.
+
+## What it computes
+
+| Table | Content |
+| --- | --- |
+| T1 | Token components per attempt: total, cache creation, cache read, input, output, tool calls. |
+| T2 | Median total tokens by suite, so a single hard suite is visible rather than folded into one median. |
+| T2b | Mean tool calls per episode by suite: the work an arm needed, beside what it paid. |
+| T3 | Per-turn context under both denominators, and the static-prefix bound. |
+| T4 | Tool-call counts and median result size per tool. |
+| T5 | Search payload by federated group, and the shape of the result set. |
+| T6 | Per-episode spend: median, mean, arm total, and mean by suite. |
+| T7 | The frozen probe decomposition, reproduced from the archives, every key and every value. |
+| T8 | The numbers the probe `SUMMARY.md` states in prose that these archives can produce. |
+| T9 | The numbers the protocol quotes from the archives, including every one this toolchain derived rather than inherited. |
+
+### The definitions that are not obvious
+
+**A missing token counter is zero.** 18 of 261 attempts in `full-a0` and
+`full-a1`, 2 in `full-a2`, and 1 in `full-a3` carry no `cache_creation_tokens`
+key. Excluding them instead moves a0's median cache creation from 1,683 to
+1,898 and its median total from 23,696 to 24,288.
+
+**`median_ctx_per_turn` divides by tool calls.** That is the frozen probe's
+definition and T7 reproduces it. T3 reports the same quantity divided by
+assistant turns beside it, because the two are not the same number: an
+assistant turn can carry several tool calls, and on these archives the counts
+differ on more than half the attempts in every arm. A cost claim should name
+which denominator it used.
+
+**The static-prefix bound is a bound, not an estimate.** `cache_read` on an
+attempt is the sum over that episode's requests of the prefix each request
+re-read, because `input_tokens` is negligible throughout (median 12–18, maximum
+52 across all four arms) — essentially the whole prefix is served from cache
+every turn. Dividing by the request count gives the average prefix that episode
+re-read; the smallest such value in an arm is the tightest upper bound on the
+static prefix, the system prompt and tool definitions every request carries
+before any conversation accumulates. No attempt can average below it.
+
+**Cache creation understates the static surface.** It counts tokens written to
+cache, and a prefix shared by hundreds of attempts in one run is written once
+and read thereafter, so a large static surface shows up as a large `cache_read`
+and a small `cache_creation`. The bound above is what makes the static
+component visible.
+
+**A search call answers in two shapes.** The federated envelope groups hits from
+every reachable source across a display budget (default 10; `pkg/knowledge/router.go`).
+Passing exactly one source with no intent enumerates that source instead, and
+the answer is a paged envelope the display budget never touches, at five times
+the page size. T5 counts the two apart, and counts tool errors as neither —
+folding an error into "returned nothing" would overstate how often a populated
+store had nothing to say.
+
+**Dollars, not tokens.** Cache read bills at a tenth of input and output at five
+times it, so an arm that multiplies tokens mostly through cache read multiplies
+spend by much less. On these archives the a0→a3 token ratio is 6.2x and the
+spend ratio is 3.4x. Every cost claim in this study is stated in dollars for
+that reason. Rates are pinned in the script with the date they were in effect.
+
+Spend is computed per attempt and then summarized, never as a sum of component
+medians: the median of sums is not the sum of medians. Both the median and the
+mean are reported, because they answer different questions and differ by a
+factor of two on some arms — a typical-episode claim needs the median, and a
+budget estimate needs the mean, since a block's total is n times the mean.
+
+## Applying this to another server
+
+The decomposition is not specific to this platform. It needs one thing from a
+harness: **per-attempt usage, recorded separately per counter.** Given that,
+the procedure below runs against any MCP server.
+
+1. **Record per attempt**: `input_tokens`, `output_tokens`, `cache_read_tokens`,
+   `cache_creation_tokens`, the tool-call count, and a transcript of
+   `(role, text | tool_calls | tool_results)` with a call id linking each result
+   to its call. A summed "total tokens" is not enough — the four counters bill
+   at four different rates, and the whole method is separating them.
+2. **Hold the arm's configuration fixed and vary one thing.** Everything below
+   is a difference between two arms; nothing is interpretable from one.
+3. **Compute the per-turn context** as `cache_read / requests`. State the
+   denominator. This is the number multiplied by episode length, and it is
+   usually the largest line in the bill.
+4. **Bound the static prefix** as the minimum per-attempt `cache_read /
+   requests` in the arm. The gap between that bound and the arm's median
+   per-turn context is what the conversation accumulated; the bound itself is
+   what the server charged for existing.
+5. **Attribute the accumulated part** by mapping every tool result back to its
+   tool through the call id, then summing result sizes per tool. Where one tool
+   returns a structured envelope (a federated search, a paged listing),
+   decompose it further by the field that names its origin — here, the group
+   source.
+6. **Price it.** Multiply each counter by its own rate, at rates dated in the
+   script, and report the ratio in dollars beside the ratio in tokens.
+7. **Pin what you publish.** Every number a committed page states goes in a pin
+   list the recompute checks, and the recompute runs in the build. A report
+   toolchain no gate exercises is the defect
+   [#1168](https://github.com/txn2/mcp-data-platform/issues/1168) fixed.
+
+Step 4 is the one that needs the caveat repeated: it is a bound only while
+uncached input is negligible. Check `input_tokens` before trusting it. If a
+harness does not cache prompts at all, the same decomposition still works with
+`input_tokens` in place of `cache_read_tokens`, and the static prefix is then
+billed at full rate rather than a tenth.
+
+## The gate
+
+`make bench-report-check` runs this script and fails the build on any pin
+mismatch. Three artifacts are pinned: the frozen `decomposition.json` (compared
+whole, every key and every value), the numbers the probe `SUMMARY.md` states in
+prose, and the numbers the protocol
+[`bench/docs/context-economics-study-design.md`](../../docs/context-economics-study-design.md)
+quotes. So a drift between the archives, this script, and a committed page
+fails in CI instead of reaching a reader.
+
+The frozen file is compared as canonical JSON — the same bytes for the same
+values, with key sequence normalized on both sides. Its own key order is the
+directory-iteration order of the uncommitted script that produced it on
+2026-08-01, which varies by filesystem and which no portable recompute
+reproduces.

--- a/bench/reports/context-economics/decompose.py
+++ b/bench/reports/context-economics/decompose.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""Decompose the per-episode context cost of an MCP platform arm from its run archive.
+
+Reads run archives in place and prints the context-economics decomposition:
+token components per arm, per-turn context, the static prefix bound, tool-call
+and result-size distributions, search payload by federated group, and the same
+components priced in USD. No network, no API key, stdlib only -- the contract
+every report toolchain in this series honors (pollution_tables.py, pk_tables.py).
+
+    python3 bench/reports/context-economics/decompose.py          # tables + pins
+    python3 bench/reports/context-economics/decompose.py --emit   # the decomposition as JSON
+
+The archives read here belong to the knowledge-layer study
+(docs/reference/benchmark-report.md, DOI 10.5281/zenodo.21438044) and are read
+in place under the cross-study re-analysis convention in bench/README.md. The
+provenance table is bench/results/context-economics/probe/README.md.
+
+The final section is the gate: every number this script computes that a
+committed artifact also states -- the frozen decomposition.json, the frozen
+probe SUMMARY.md, and the protocol bench/docs/context-economics-study-design.md
+-- is recomputed here and compared. `make bench-report-check` runs it, so a
+drift between the archives, this script, and a committed page fails the build
+instead of reaching a reader. Exits nonzero on any mismatch.
+
+The procedure is documented for reuse against any MCP server that records
+per-attempt usage in README.md, section "Applying this to another server".
+"""
+import glob
+import json
+import os
+import statistics
+import sys
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while os.path.basename(_d) != "bench" and os.path.dirname(_d) != _d:
+    _d = os.path.dirname(_d)
+if os.path.basename(_d) != "bench":
+    sys.exit("decompose.py must live under bench/; it resolves the archives relative to that directory")
+BENCH = _d
+RESULTS = os.path.join(BENCH, "results")
+
+# The four archived arms of the knowledge-layer study's phase-2 matrix, in
+# increasing platform surface: raw toolkits, + semantic enrichment, + the
+# discovery layer, + the lifecycle tools. Verified deltas are in the protocol,
+# section 3.
+ARMS = ("a0", "a1", "a2", "a3")
+FAMILY = os.path.join(RESULTS, "phase2-anthropic-k3")
+FROZEN = os.path.join(RESULTS, "context-economics", "probe", "decomposition.json")
+
+# USD per million tokens for the model every archived arm ran on, at the rates
+# in effect on the recompute date (2026-08-07; Sonnet 5 introductory pricing
+# through 2026-08-31). Same table and same convention as
+# reports/knowledge-pollution/pollution_tables.py: cache read is 0.1x input,
+# 5-minute cache write is 1.25x input.
+PRICE_IN, PRICE_OUT = 2.00, 10.00
+CACHE_READ_MULT, CACHE_WRITE_MULT = 0.1, 1.25
+
+# The platform's search display budget: hits allocated across all federated
+# sources for one search (pkg/knowledge/router.go, defaultLimit and maxLimit).
+# A search that returns as many hits as its budget allowed was bound by the
+# budget rather than by what the stores hold, which is the distinction T5
+# reports. A caller may raise it per call, so the effective budget is resolved
+# from the call's own arguments (display_budget).
+DISPLAY_BUDGET = 10
+MAX_DISPLAY_BUDGET = 50
+
+TOKEN_FIELDS = ("input_tokens", "output_tokens", "cache_read_tokens", "cache_creation_tokens")
+
+
+_CACHE = {}
+
+
+def load(arm):
+    """Return (attempts, transcripts) for one archived arm, read once.
+
+    Transcripts are returned in directory-iteration order rather than sorted,
+    because the frozen decomposition.json carries the insertion order of that
+    iteration in its per-tool and per-source maps. Nothing downstream depends
+    on the order for a value, only for key sequence, and the frozen-file
+    comparison is order-insensitive (see check_frozen)."""
+    if arm in _CACHE:
+        return _CACHE[arm]
+    base = os.path.join(FAMILY, f"full-{arm}")
+    with open(os.path.join(base, "results.json")) as f:
+        attempts = json.load(f)["attempts"]
+    transcripts = []
+    for p in glob.glob(os.path.join(base, "transcripts", "*.json")):
+        with open(p) as f:
+            transcripts.append(json.load(f))
+    _CACHE[arm] = (attempts, transcripts)
+    return _CACHE[arm]
+
+
+def total_tokens(a):
+    """Billable tokens for one attempt: every counter the API reports.
+
+    A missing counter is zero. That is not a formality: 18 of 261 attempts in
+    full-a0 and full-a1, 2 in full-a2, and 1 in full-a3 carry no
+    cache_creation_tokens key at all, and excluding them instead of coercing
+    them moves a0's median cache creation from 1,683 to 1,898."""
+    return sum(a.get(f, 0) or 0 for f in TOKEN_FIELDS)
+
+
+def median(values):
+    return statistics.median(values) if values else 0
+
+
+def median_int(values):
+    """Median truncated to a whole number.
+
+    Result sizes are counted in characters and reported as integers, so an
+    even-length sample whose two middle values differ by an odd amount is
+    truncated rather than left at a half character. This is also what
+    reproduces the frozen probe file: median_low would round the other way on
+    five of its entries."""
+    return int(median(values))
+
+
+def iter_results(t):
+    """Yield (tool_name, result_text) for every tool result in one transcript."""
+    for name, _, text in iter_calls(t):
+        yield name, text
+
+
+def iter_calls(t):
+    """Yield (tool_name, call_args, result_text) for every answered tool call.
+
+    The args travel with the result because a search result cannot be read
+    without them: the caller's `limit` sets the display budget the platform
+    allocated, so whether a result set was bound by the budget or by the stores
+    is only answerable against the call that produced it."""
+    names, args = {}, {}
+    for turn in t["transcript"]:
+        for tc in turn.get("tool_calls") or []:
+            names[tc["id"]] = tc["name"]
+            args[tc["id"]] = tc.get("args") or {}
+    for turn in t["transcript"]:
+        for tr in turn.get("tool_results") or []:
+            call_id = tr.get("call_id")
+            name = names.get(call_id)
+            if name:
+                yield name, args.get(call_id, {}), (tr.get("text") or "")
+
+
+def display_budget(args):
+    """The display budget the platform allocated for one search call.
+
+    Mirrors clampInt in pkg/knowledge/router.go: a limit at or below zero (or
+    absent) takes the default, anything above the maximum is clamped to it, and
+    anything between is honored as given."""
+    limit = args.get("limit")
+    if not isinstance(limit, int) or limit <= 0:
+        return DISPLAY_BUDGET
+    return min(limit, MAX_DISPLAY_BUDGET)
+
+
+def assistant_turns(t):
+    """Model requests that produced content: the denominator for per-request cost.
+
+    Distinct from the tool-call count, which the frozen file uses. One assistant
+    turn can carry several tool calls, so the two diverge; on these archives the
+    counts differ on more than half the attempts in every arm."""
+    return sum(1 for turn in t["transcript"] if turn["role"] == "assistant")
+
+
+def search_shape_of(text):
+    """Classify one search result payload: "federated", "browse", or "error".
+
+    The search tool answers in two shapes. The usual one is the federated
+    envelope: groups of hits from every source the caller can reach, allocated
+    across a display budget. Passing exactly one source with no intent instead
+    enumerates that source, and the answer is a paged envelope (source, total,
+    offset, limit, items) that the display budget never touches -- its page
+    size is the browse limit, five times larger.
+
+    Anything else is an error: a rejected argument type, an unbrowsable source,
+    an exhausted call budget. The three are counted apart because they cost
+    differently and because folding errors into "returned nothing" would
+    overstate how often a populated store had nothing to say."""
+    try:
+        payload = json.loads(text)
+    except (ValueError, TypeError):
+        return "error", None
+    if not isinstance(payload, dict):
+        return "error", None
+    if "groups" in payload:
+        return "federated", payload
+    if "items" in payload:
+        return "browse", payload
+    return "error", None
+
+
+def search_groups(text):
+    """Yield (source, hits) for every group in one federated search payload."""
+    kind, payload = search_shape_of(text)
+    if kind != "federated":
+        return
+    for group in payload.get("groups") or []:
+        yield group.get("source"), (group.get("hits") or [])
+
+
+def decompose(arm):
+    """The per-arm decomposition, in the schema of the frozen probe file.
+
+    Token components come from results.json (what the API billed); call counts,
+    result sizes, and federated-group payload come from the transcripts (what
+    the platform actually returned). Keeping the two sources separate is the
+    point of the method: the bill and the payload are independently recorded,
+    so an explanation that links them can be checked rather than assumed."""
+    attempts, transcripts = load(arm)
+    totals = [total_tokens(a) for a in attempts]
+    suites = sorted({a["suite"] for a in attempts})
+
+    calls, chars, hits, hit_chars, searches = {}, {}, {}, {}, 0
+    for t in transcripts:
+        for turn in t["transcript"]:
+            for tc in turn.get("tool_calls") or []:
+                calls[tc["name"]] = calls.get(tc["name"], 0) + 1
+        for name, text in iter_results(t):
+            chars.setdefault(name, []).append(len(text))
+            if name != "search":
+                continue
+            searches += 1
+            for source, group_hits in search_groups(text):
+                hits[source] = hits.get(source, 0) + len(group_hits)
+                hit_chars[source] = hit_chars.get(source, 0) + sum(
+                    len(json.dumps(h)) for h in group_hits
+                )
+
+    return {
+        "n": len(attempts),
+        "median_total_tokens": median(totals),
+        "mean_total_tokens": round(statistics.mean(totals)),
+        "per_suite_median_tokens": {
+            s: median([total_tokens(a) for a in attempts if a["suite"] == s]) for s in suites
+        },
+        "median_cache_creation": median([a.get("cache_creation_tokens", 0) for a in attempts]),
+        "median_cache_read": median([a.get("cache_read_tokens", 0) for a in attempts]),
+        "median_input": median([a.get("input_tokens", 0) for a in attempts]),
+        "median_output": median([a.get("output_tokens", 0) for a in attempts]),
+        "median_tool_calls": median([a["tool_calls"] for a in attempts]),
+        "median_ctx_per_turn": median(
+            [a.get("cache_read_tokens", 0) / a["tool_calls"] for a in attempts if a["tool_calls"]]
+        ),
+        "tool_calls_by_name": dict(sorted(calls.items(), key=lambda kv: -kv[1])),
+        "median_result_chars_by_tool": {k: median_int(v) for k, v in chars.items()},
+        "total_result_chars_by_tool": {k: sum(v) for k, v in chars.items()},
+        "search_results": searches,
+        "search_hits_by_source": hits,
+        "search_chars_by_source": hit_chars,
+    }
+
+
+def per_request(arm):
+    """Per-request context and the static-prefix bound for one arm.
+
+    cache_read on an attempt is the sum over that episode's requests of the
+    prefix each request re-read, because input_tokens is negligible on every
+    attempt in these archives (median 12-18, maximum 52 across all four arms):
+    essentially the whole prefix is served from cache on every turn. Dividing
+    by the request count therefore gives the average prefix that turn re-read.
+
+    The smallest such value in an arm is the tightest upper bound on the arm's
+    STATIC prefix -- the system prompt, platform instructions, and tool
+    definitions that every request carries before any conversation accumulates.
+    It is an upper bound, not an estimate: every request's prefix is at least
+    the static prefix, so no attempt can average below it."""
+    attempts, transcripts = load(arm)
+    by_key = {(a["task_id"], a["attempt"]): a for a in attempts}
+    per = []
+    for t in transcripts:
+        a = by_key[(t["task_id"], t["attempt"])]
+        turns = assistant_turns(t)
+        if turns:
+            per.append(a.get("cache_read_tokens", 0) / turns)
+    return {
+        "median_ctx_per_request": median(per),
+        "static_prefix_bound": min(per) if per else 0,
+    }
+
+
+def search_shape(arm):
+    """Hits per search and how often the display budget bound the result.
+
+    The platform allocates a display budget across sources (default 10, caller
+    settable up to 50; pkg/knowledge/router.go). Whether an arm's searches
+    reach that budget is what separates "the stores had nothing to return" from
+    "the stores saturated the response", and the two have different cost
+    curves: below saturation payload tracks population, at saturation it stops
+    growing with population and tracks per-hit size instead."""
+    _, transcripts = load(arm)
+    counts, browse, errors, at_budget = [], 0, 0, 0
+    ranking, matched = {}, {}
+    for t in transcripts:
+        for name, args, text in iter_calls(t):
+            if name != "search":
+                continue
+            kind, payload = search_shape_of(text)
+            if kind == "browse":
+                browse += 1
+                continue
+            if kind == "error":
+                errors += 1
+                continue
+            hits = sum(len(h) for _, h in search_groups(text))
+            counts.append(hits)
+            at_budget += 1 if hits >= display_budget(args) else 0
+            mode = payload.get("ranking")
+            ranking[mode] = ranking.get(mode, 0) + 1
+            for cov in payload.get("coverage") or []:
+                src = cov.get("source")
+                matched[src] = matched.get(src, 0) + (cov.get("matched") or 0)
+    return {
+        "searches": len(counts) + browse + errors,
+        "federated": len(counts),
+        "browse": browse,
+        "errors": errors,
+        "median_hits": median(counts),
+        "empty": sum(1 for c in counts if c == 0),
+        "at_budget": at_budget,
+        "ranking": dict(sorted(ranking.items(), key=lambda kv: -kv[1])),
+        "matched_by_source": dict(sorted(matched.items(), key=lambda kv: -kv[1])),
+    }
+
+
+def attempt_usd(a):
+    """What one attempt cost, at the pinned rates."""
+    return (
+        a.get("input_tokens", 0) * PRICE_IN
+        + a.get("output_tokens", 0) * PRICE_OUT
+        + (a.get("cache_read_tokens", 0) or 0) * PRICE_IN * CACHE_READ_MULT
+        + (a.get("cache_creation_tokens", 0) or 0) * PRICE_IN * CACHE_WRITE_MULT
+    ) / 1e6
+
+
+def cost_usd(arm):
+    """Per-episode spend for one arm, at the pinned rates.
+
+    Reported because a token ratio is not a cost ratio: cache read bills at a
+    tenth of input and output bills at five times it, so an arm that multiplies
+    tokens mostly through cache read multiplies dollars by much less. Any cost
+    claim this study makes is stated in dollars for that reason.
+
+    Spend is computed per attempt and then summarized, never as a sum of
+    component medians: the median of sums is not the sum of medians, and the
+    difference is large enough here to move a headline ratio. The mean is
+    reported beside the median because a budget estimate needs the mean (total
+    = n x mean) while a typical-episode claim needs the median, and the
+    distribution is heavy-tailed enough that the two differ by a factor of two
+    on some arms.
+
+    Both are also reported per suite. Pooling hides the effect this study exists
+    to find: on these archives the cheap-surface arm is the expensive one
+    wherever the tasks need knowledge, and a pooled median averages that
+    reversal away."""
+    attempts, _ = load(arm)
+    per = [attempt_usd(a) for a in attempts]
+    by_suite = {}
+    for suite in sorted({a["suite"] for a in attempts}):
+        sub = [attempt_usd(a) for a in attempts if a["suite"] == suite]
+        by_suite[suite] = {"median": median(sub), "mean": statistics.mean(sub)}
+    return {
+        "median": median(per),
+        "mean": statistics.mean(per),
+        "total": sum(per),
+        "by_suite": by_suite,
+    }
+
+
+def workload(arm):
+    """Mean tool calls per episode, by suite.
+
+    The work an arm needed, beside what it paid. A surface that costs more per
+    turn can still cost less per episode by removing turns, and the two suites
+    here move in opposite directions, so a pooled tool-call figure would hide
+    exactly the effect worth reporting."""
+    attempts, _ = load(arm)
+    return {
+        suite: statistics.mean([a["tool_calls"] for a in attempts if a["suite"] == suite])
+        for suite in sorted({a["suite"] for a in attempts})
+    }
+
+
+def canonical(obj):
+    """Canonical serialization: the same bytes for the same values, whatever
+    order the keys were inserted in."""
+    return json.dumps(obj, indent=2, sort_keys=True)
+
+
+def section(title):
+    print(f"\n=== {title} ===")
+
+
+def table_tokens(dec):
+    section("T1: token components per attempt (median; mean total in parentheses)")
+    print("  arm   total            cache_creation  cache_read  input  output  tool_calls")
+    for arm in ARMS:
+        d = dec[arm]
+        print(f"  {arm}    {d['median_total_tokens']:>7,} ({d['mean_total_tokens']:>7,})"
+              f"  {d['median_cache_creation']:>14,}  {d['median_cache_read']:>10,}"
+              f"  {d['median_input']:>5}  {d['median_output']:>6,}  {d['median_tool_calls']:>10}")
+
+    section("T2: median total tokens by suite")
+    suites = sorted(dec["a0"]["per_suite_median_tokens"])
+    print("  arm   " + "  ".join(f"{s:>8}" for s in suites))
+    for arm in ARMS:
+        row = dec[arm]["per_suite_median_tokens"]
+        print(f"  {arm}    " + "  ".join(f"{row[s]:>8,}" for s in suites))
+
+
+def table_per_turn(req):
+    section("T3: per-turn context, and how much of it is static")
+    print("  (ctx/tool-call is the frozen probe's definition; ctx/request divides by model")
+    print("   requests instead, and the static bound is the smallest per-request average in the arm)")
+    print("  arm   ctx/tool-call  ctx/request  static prefix bound")
+    for arm in ARMS:
+        r = req[arm]
+        print(f"  {arm}    {r['ctx_per_tool_call']:>13,.1f}  {r['median_ctx_per_request']:>11,.1f}"
+              f"  {r['static_prefix_bound']:>19,.0f}")
+
+
+def table_payload(dec, shape):
+    section("T4: tool calls and result size (top five tools by call count)")
+    for arm in ARMS:
+        d = dec[arm]
+        top = list(d["tool_calls_by_name"].items())[:5]
+        parts = [f"{n} {c}x/{d['median_result_chars_by_tool'].get(n, 0):,.0f}ch" for n, c in top]
+        print(f"  {arm}: " + "  ".join(parts))
+
+    section("T5: search payload by federated group (hits / chars over the arm)")
+    for arm in ARMS:
+        d, s = dec[arm], shape[arm]
+        if not d["search_results"]:
+            print(f"  {arm}: no search tool on this arm")
+            continue
+        groups = sorted(d["search_hits_by_source"].items(), key=lambda kv: -kv[1])
+        parts = [f"{src} {n:,}/{d['search_chars_by_source'][src]:,}ch" for src, n in groups]
+        print(f"  {arm}: {d['search_results']:,} search calls = {s['federated']:,} federated"
+              f" + {s['browse']} browse + {s['errors']} error; median result"
+              f" {d['median_result_chars_by_tool']['search']:,.0f} chars")
+        print(f"       federated: median hits {s['median_hits']:.0f},"
+              f" {s['empty']:,} returned nothing, {s['at_budget']:,} at the display budget;"
+              f" ranking " + ", ".join(f"{m} {n:,}" for m, n in s["ranking"].items()))
+        print("       shown:   " + "  ".join(parts))
+        print("       matched: " + "  ".join(
+            f"{src} {n:,}" for src, n in s["matched_by_source"].items()))
+
+
+def table_workload(work):
+    section("T2b: mean tool calls per episode, by suite")
+    suites = sorted(work["a0"])
+    print("  arm   " + "  ".join(f"{s:>8}" for s in suites))
+    for arm in ARMS:
+        print(f"  {arm}    " + "  ".join(f"{work[arm][s]:>8.2f}" for s in suites))
+
+
+def table_cost(cost):
+    section("T6: per-episode spend, USD at Sonnet 5 rates (2026-08-07)")
+    print("  (input $2.00/MTok, output $10.00/MTok, cache read 0.1x input, cache write 1.25x input)")
+    suites = sorted(cost["a0"]["by_suite"])
+    print("  arm    median     mean   xa0(median)   arm total   "
+          + "  ".join(f"{s} median/mean" for s in suites))
+    base = cost["a0"]["median"]
+    for arm in ARMS:
+        c = cost[arm]
+        print(f"  {arm}   ${c['median']:.5f}  ${c['mean']:.5f}   {c['median'] / base:>5.2f}x"
+              f"      ${c['total']:>7.2f}   "
+              + "  ".join(f"${c['by_suite'][s]['median']:.4f}/${c['by_suite'][s]['mean']:.4f}"
+                          for s in suites))
+
+
+def check_frozen(dec):
+    """Reproduce the frozen probe decomposition from the archives.
+
+    Compared as canonical JSON: the same bytes for the same values. The frozen
+    file's own key order is the directory-iteration order of the uncommitted
+    script that produced it on 2026-08-01, which no portable recompute
+    reproduces (it varies by filesystem), so key sequence is normalized on both
+    sides and every key and every value is compared exactly."""
+    section("T7: frozen probe decomposition reproduced from the archives")
+    with open(FROZEN) as f:
+        frozen = json.load(f)
+    failed = 0
+    for arm in ARMS:
+        if arm not in frozen:
+            failed += 1
+            print(f"  FAIL: decomposition.json has no {arm} entry to compare against")
+            continue
+        got, want = canonical(dec[arm]), canonical(frozen[arm])
+        ok = got == want
+        failed += 0 if ok else 1
+        print(f"  {'PASS' if ok else 'FAIL'}: {arm} reproduces decomposition.json")
+        if not ok:
+            for key in sorted(set(dec[arm]) | set(frozen[arm])):
+                a, b = dec[arm].get(key), frozen[arm].get(key)
+                if a != b:
+                    print(f"    {key}: got {a}, frozen {b}")
+    extra = set(frozen) - set(ARMS)
+    if extra:
+        failed += 1
+        print(f"  FAIL: decomposition.json carries arms this script does not recompute: {sorted(extra)}")
+    return failed
+
+
+def pins(dec, req, shape, cost, work):
+    """Every number a committed artifact states, recomputed from the archives.
+
+    Two artifacts are pinned beyond the frozen file. The probe SUMMARY.md
+    states numbers in prose that decomposition.json does not carry as fields.
+    The protocol quotes the per-request and cost decompositions, which are new
+    here -- pinning them is what stops the protocol's motivating section from
+    drifting away from the archives it cites."""
+    summary = [
+        ("median total tokens 23.7k / 26.4k / 57.3k / 148.1k",
+         [dec[a]["median_total_tokens"] for a in ARMS], [23696, 26396, 57329, 148079]),
+        ("cache creation 1,683 -> 5,906 across the arms",
+         [dec[a]["median_cache_creation"] for a in ARMS], [1683, 2889, 4201, 5906]),
+        ("ctx per turn 3,360 -> 15,831 at the frozen definition",
+         [round(dec[a]["median_ctx_per_turn"], 1) for a in ARMS],
+         [3359.7, 3741.0, 5954.4, 15830.6]),
+        ("a3 median search result 3,393 chars against a2 601",
+         [dec[a]["median_result_chars_by_tool"]["search"] for a in ("a3", "a2")], [3393, 601]),
+        ("search payload 2.43M chars at a3 against 0.92M at a2",
+         [dec[a]["total_result_chars_by_tool"]["search"] for a in ("a3", "a2")], [2428524, 918132]),
+        ("a3 prompts 1,759 hits / 409,850 chars",
+         [dec["a3"]["search_hits_by_source"]["prompts"], dec["a3"]["search_chars_by_source"]["prompts"]],
+         [1759, 409850]),
+        ("a3 endpoints 1,903 hits / 347,353 chars",
+         [dec["a3"]["search_hits_by_source"]["endpoints"], dec["a3"]["search_chars_by_source"]["endpoints"]],
+         [1903, 347353]),
+        ("knowledge_pages hits 791 at a2 against 2,549 at a3",
+         [dec[a]["search_hits_by_source"]["knowledge_pages"] for a in ("a2", "a3")], [791, 2549]),
+        ("a3 lifecycle tools barely used: 1 memory_manage, 13 apply_knowledge, 0 captures",
+         [dec["a3"]["tool_calls_by_name"].get(t, 0)
+          for t in ("memory_manage", "apply_knowledge", "memory_capture")], [1, 13, 0]),
+        ("fetch refused on every arm but a3, where it was called 3 times (#1176)",
+         [dec[a]["tool_calls_by_name"].get("fetch", 0) for a in ARMS], [0, 0, 0, 3]),
+    ]
+
+    protocol = [
+        ("static prefix bound 2,585 / 2,508 / 5,127 / 9,809 tokens per request",
+         [round(req[a]["static_prefix_bound"]) for a in ARMS], [2585, 2508, 5127, 9809]),
+        ("median context per request 3,562 / 3,766 / 6,699 / 16,358 tokens",
+         [round(req[a]["median_ctx_per_request"]) for a in ARMS], [3562, 3766, 6699, 16358]),
+        ("a2 search calls 1,061 = 1,028 federated + 32 browse + 1 error",
+         [shape["a2"]["searches"], shape["a2"]["federated"],
+          shape["a2"]["browse"], shape["a2"]["errors"]], [1061, 1028, 32, 1]),
+        ("a2 federated: median 1 hit, 398 returned nothing, 22 at the display budget",
+         [round(shape["a2"]["median_hits"]), shape["a2"]["empty"], shape["a2"]["at_budget"]],
+         [1, 398, 22]),
+        ("a3 search calls 993 = 982 federated + 8 browse + 3 error",
+         [shape["a3"]["searches"], shape["a3"]["federated"],
+          shape["a3"]["browse"], shape["a3"]["errors"]], [993, 982, 8, 3]),
+        ("a3 federated: median 10 hits, 262 returned nothing, 642 at the display budget",
+         [round(shape["a3"]["median_hits"]), shape["a3"]["empty"], shape["a3"]["at_budget"]],
+         [10, 262, 642]),
+        ("a2 ranked lexical on 1,027 of 1,028 federated searches; a3 hybrid on 979 of 982",
+         [shape["a2"]["ranking"].get("lexical", 0), shape["a2"]["ranking"].get("hybrid", 0),
+          shape["a3"]["ranking"].get("hybrid", 0), shape["a3"]["ranking"].get("lexical", 0)],
+         [1027, 0, 979, 0]),
+        ("endpoints matched 0 candidates across the a2 run and 12,700 across a3",
+         [shape["a2"]["matched_by_source"].get("endpoints", 0),
+          shape["a3"]["matched_by_source"].get("endpoints", 0)], [0, 12700]),
+        ("knowledge_pages matched 853 candidates at a2 against 7,716 at a3",
+         [shape["a2"]["matched_by_source"]["knowledge_pages"],
+          shape["a3"]["matched_by_source"]["knowledge_pages"]], [853, 7716]),
+        ("median episode spend $0.0169 at a0 against $0.0573 at a3, a 3.4x ratio",
+         [round(cost["a0"]["median"], 4), round(cost["a3"]["median"], 4),
+          round(cost["a3"]["median"] / cost["a0"]["median"], 1)], [0.0169, 0.0573, 3.4]),
+        ("the token ratio over the same pair is 6.2x, nearly twice the cost ratio",
+         [round(dec["a3"]["median_total_tokens"] / dec["a0"]["median_total_tokens"], 1)], [6.2]),
+        ("on the trap suite the raw arm is the expensive one: mean $0.0849 at a0 against $0.0469 at a2",
+         [round(cost["a0"]["by_suite"]["s3"]["mean"], 4), round(cost["a2"]["by_suite"]["s3"]["mean"], 4)],
+         [0.0849, 0.0469]),
+        ("mean spend per s1 episode 0.0158 / 0.0147 / 0.0261 / 0.0491 across the arms",
+         [round(cost[a]["by_suite"]["s1"]["mean"], 4) for a in ARMS],
+         [0.0158, 0.0147, 0.0261, 0.0491]),
+        ("mean spend per s3 episode 0.0849 / 0.0834 / 0.0469 / 0.0762 across the arms",
+         [round(cost[a]["by_suite"]["s3"]["mean"], 4) for a in ARMS],
+         [0.0849, 0.0834, 0.0469, 0.0762]),
+        ("s3 mean tool calls 19.0 at a0 against 11.4 at a2, which is why a0 costs more there",
+         [round(work["a0"]["s3"], 1), round(work["a2"]["s3"], 1)], [19.0, 11.4]),
+        ("the archived arms cost $9.23 / $9.49 / $9.45 / $16.64 for 261 episodes each",
+         [round(cost[a]["total"], 2) for a in ARMS], [9.23, 9.49, 9.45, 16.64]),
+        ("median s3 episode $0.0665 at a0, $0.0549 at a1, $0.0419 at a2",
+         [round(cost[a]["by_suite"]["s3"]["median"], 4) for a in ("a0", "a1", "a2")],
+         [0.0665, 0.0549, 0.0419]),
+        ("median s1 episode $0.0138 at a0, $0.0142 at a1, $0.0215 at a2",
+         [round(cost[a]["by_suite"]["s1"]["median"], 4) for a in ("a0", "a1", "a2")],
+         [0.0138, 0.0142, 0.0215]),
+    ]
+
+    failed = 0
+    for title, group in (
+        ("T8: probe SUMMARY.md prose, recomputed", summary),
+        ("T9: protocol motivating section, recomputed", protocol),
+    ):
+        section(title)
+        for label, got, want in group:
+            ok = got == want
+            failed += 0 if ok else 1
+            print(f"  {'PASS' if ok else 'FAIL'}: {label}" + ("" if ok else f"  (got {got}, want {want})"))
+    return failed
+
+
+def main():
+    dec = {a: decompose(a) for a in ARMS}
+    if "--emit" in sys.argv[1:]:
+        print(canonical(dec))
+        return 0
+
+    req = {}
+    for arm in ARMS:
+        req[arm] = per_request(arm)
+        req[arm]["ctx_per_tool_call"] = dec[arm]["median_ctx_per_turn"]
+    shape = {a: search_shape(a) for a in ARMS}
+    cost = {a: cost_usd(a) for a in ARMS}
+    work = {a: workload(a) for a in ARMS}
+
+    table_tokens(dec)
+    table_workload(work)
+    table_per_turn(req)
+    table_payload(dec, shape)
+    table_cost(cost)
+    failed = check_frozen(dec) + pins(dec, req, shape, cost, work)
+    if failed:
+        print(f"\n  {failed} check(s) FAILED: the archives no longer reproduce a committed artifact.")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/results/README.md
+++ b/bench/results/README.md
@@ -56,10 +56,12 @@ by [`knowledge-pollution/README.md`](knowledge-pollution/README.md).
 
 ## Context economics (in progress)
 
-Epic: issue #1164. No protocol and no report yet, so nothing under this slug is
-pre-registered. Its one family is an archival re-analysis of another study's
-archives, kept here under the cross-study re-analysis convention in
-[`../README.md`](../README.md).
+Epic: issue #1164; protocol
+[`../docs/context-economics-study-design.md`](../docs/context-economics-study-design.md).
+The study's own arms land with #1171, so its one family so far is an archival
+re-analysis of another study's archives, kept here under the cross-study
+re-analysis convention in [`../README.md`](../README.md) and reproduced by
+[`../reports/context-economics/`](../reports/context-economics/).
 
 Families are indexed by
 [`context-economics/README.md`](context-economics/README.md).

--- a/bench/results/context-economics/README.md
+++ b/bench/results/context-economics/README.md
@@ -13,7 +13,14 @@ convention in [`../../README.md`](../../README.md), so it carries a provenance
 table naming the source study, its DOI, and the exact paths read. It is
 motivating evidence and is never cited as a confirmatory result.
 
-No protocol document and no report exist yet. The protocol, the rerunnable
-decomposition toolchain, and the measured arms land on later sub-tickets of the
-epic; nothing here is pre-registered until that protocol is committed and
-signed.
+The protocol
+([`bench/docs/context-economics-study-design.md`](../../docs/context-economics-study-design.md))
+and the rerunnable decomposition toolchain
+([`bench/reports/context-economics/`](../../reports/context-economics/)) are
+committed. The toolchain reproduces `probe/decomposition.json` from the
+archives it re-analyzes, and `make bench-report-check` fails the build if it
+stops doing so.
+
+The measured arms land with #1171, so no family here carries this study's own
+runs yet, and no report exists (#1172). The probe README records two readings
+in the frozen summary that the fuller decomposition corrects.

--- a/bench/results/context-economics/probe/README.md
+++ b/bench/results/context-economics/probe/README.md
@@ -59,18 +59,60 @@ gives roughly 2,939 for a0 against the archived 3,359.67.
 
 ## Regenerability
 
-`decomposition.json` is a frozen snapshot. The script that produced it ran
-inline in the session that produced the file and was not committed, so nothing
-in this directory regenerates today. `SUMMARY.md` calls the numbers
-"regenerable from the archived results.json + transcripts" and names no
-committed script; read that as a statement about the inputs, not as a claim
-that the repository contains the procedure. It does not.
+`decomposition.json` is a frozen snapshot, and it is now reproducible.
+[`bench/reports/context-economics/decompose.py`](../../../reports/context-economics/decompose.py)
+recomputes it from the four archives above and compares every key and every
+value against this file; `make bench-report-check` runs that comparison in
+`make verify` and in CI, so a drift between the archives and this snapshot
+fails the build. It also recomputes the numbers `SUMMARY.md` states only in
+prose.
 
-The rerunnable recompute lands with the protocol and decomposition toolchain
-(#1170), whose acceptance condition is that it reproduces this file byte for
-byte from the same four archives, under the metric definitions above. Until
-then, treat the numbers here as a record of what was computed, not as a result a
-reader can independently reproduce from this repository.
+Two details of that reproduction are worth recording, because both were
+rediscovered rather than documented. `median_result_chars_by_tool` truncates
+the median rather than rounding it, which is what reproduces five of its
+entries. And the key *order* in this file is the directory-iteration order of
+the original uncommitted script, which varies by filesystem and which no
+portable recompute reproduces; the comparison therefore normalizes key sequence
+on both sides and is byte-for-byte on canonical JSON.
+
+When the original ran, `SUMMARY.md` called the numbers "regenerable from the
+archived results.json + transcripts" while naming no committed script. That was
+a statement about the inputs rather than about the repository. It is now true of
+the repository as well.
+
+## Corrections from the recompute
+
+Two readings in `SUMMARY.md` do not survive the fuller decomposition. The
+frozen file keeps them; the protocol
+([`bench/docs/context-economics-study-design.md`](../../../docs/context-economics-study-design.md),
+section 2.1) carries these corrections forward, and both are recomputed and
+pinned by the toolchain.
+
+**Cache creation is not a measurement of static surface size.** Finding 2 reads
+the modest growth in `cache_creation` (1,683 to 5,906) as evidence that the
+static tool surface is not the multiplier. Cache creation counts tokens
+*written* to cache, and a prefix shared by hundreds of attempts in one run is
+written once and read thereafter, so a large static surface appears as a large
+`cache_read` and a small `cache_creation`. The static prefix, bounded from
+above by the smallest per-request average context in each arm, is 2,585 /
+2,508 / 5,127 / 9,809 tokens across a0 to a3 — it nearly quadruples, and it is
+re-read on every turn. The epic (#1164) already recorded that this finding does
+not retire a tool-surface arm; the bound is why.
+
+**Population is not the leading explanation of the a2-to-a3 gap.** Finding 3
+attributes the federation-breadth difference to what was populated in the
+shared platform at run time. The archives do not support that ranking. a3's
+config declares a `memory.embedding` block that a2's does not, and the platform
+hands that provider to the search router
+(`knowledge.NewRouter(cfg.Embedding, ...)`, `internal/platform/searchfed/searchfed.go:157`),
+so it is a search-*ranking* lever. The transcripts show the split directly: a2
+ranked `lexical` on 1,027 of its 1,028 federated searches and a3 ranked
+`hybrid` on 979 of 982. Under lexical ranking the `endpoints` group matched
+zero candidates across the entire a2 run, against 12,700 across a3, and
+`knowledge_pages` matched 853 against 7,716. Whether the stores also differed
+cannot be recovered from these archives — which is the point: the gap is
+unattributable, and an RQ1 that varied population while letting ranking mode
+vary with it would reproduce the confound rather than close it.
 
 ## What it establishes
 


### PR DESCRIPTION
Closes #1170. Part of #1164 (context-economics study).

Pre-registers the context-economics study and commits the instrument that measures it. Hypotheses, arms, decision rules, and minimum-effect thresholds are fixed here, before the controlled runs in #1171, so a null or adverse result is a finding rather than a reason to redesign. Nothing in this PR reports a result and nothing in it spends anything.

## What is in the branch

`bench/docs/context-economics-study-design.md` is the pre-registration: the scientific object and its position in the field, the motivating archival evidence with its corrections, the verified mechanism inventory, the separation analysis for each research question, the matrix and episode counts, the measurement specification, the analysis plan, confounds, generalization limits, driver policy, the spend plan, and the work plan.

`bench/reports/context-economics/decompose.py` is the decomposition toolchain: stdlib python3, offline, no API key, no network, running in about a quarter of a second. It reproduces the probe's frozen `decomposition.json` from the four knowledge-layer archives, compared as canonical JSON so every key and every value has to match, and it recomputes every number the probe `SUMMARY.md` and the protocol state in prose.

`bench/reports/context-economics/README.md` carries the metric definitions that are not obvious from the field names, and the RQ4 deliverable: a documented procedure for applying the decomposition to any MCP server that records per-attempt usage.

The rest is wiring and index maintenance: `make bench-report-check` now runs the new script (in `make verify` and in CI's harness job), context economics earns its column in the `bench/README.md` series table, the probe README records the corrections the fuller recompute found, and the findings register gets a deferred-extension row for the one arm this PR drops.

## The gate

`make bench-report-check` fails the build on any pin mismatch, so a drift between the archives, the toolchain, and a committed page fails in CI instead of reaching a reader. Three artifacts are pinned: the frozen `decomposition.json` compared whole, the numbers the probe summary states only in prose, and the numbers the protocol quotes. A report toolchain that no gate exercises is the defect #1168 fixed, and this one is exercised from the day it lands.

Two details of the reproduction were rediscovered rather than documented, and are now recorded in the probe README and in the script: the per-tool result medians truncate rather than round (five entries disagree under `median_low`), and the frozen file's key order is the directory-iteration order of the original uncommitted script, which varies by filesystem and which no portable recompute reproduces. Key sequence is normalized on both sides and the comparison is byte-for-byte on canonical JSON.

## What the fuller decomposition corrects

The probe is archived unedited. Two of its readings do not survive, and both change the design.

**Cache creation does not measure the static surface.** It counts tokens written to cache, and a prefix shared by hundreds of attempts in one run is written once and read thereafter, so a large static surface shows up as a large `cache_read` and a small `cache_creation`. The static prefix, bounded above by the smallest per-request average context in each arm, runs 2,585 / 2,508 / 5,127 / 9,809 tokens across a0 to a3. It nearly quadruples, and it is multiplied by turn count: on a3 it is about 60 percent of the median per-request context. The bound is licensed by uncached input being negligible throughout these archives, median 12 to 18 tokens and maximum 52 across all four arms.

**Population is not the leading explanation of the a2-to-a3 federation gap.** a2 ranked `lexical` on 1,027 of its 1,028 federated searches and a3 ranked `hybrid` on 979 of 982, because a3's config declares a `memory.embedding` block that a2's does not and the platform hands that provider to the search router (`knowledge.NewRouter(cfg.Embedding, ...)`, `internal/platform/searchfed/searchfed.go:157`). Under lexical ranking the `endpoints` group matched zero candidates across the entire a2 run against 12,700 across a3, and `knowledge_pages` matched 853 against 7,716. Whether the stores also differed cannot be recovered from these archives, which is the point: the gap is unattributable, and an RQ1 that varied population while letting ranking mode vary with it would reproduce the confound rather than close it.

## Two figures that reframe what the study measures

**Spend is computed per episode and then summarized, never as a sum of component medians.** The median of sums is not the sum of medians, and the shortcut moves the headline: the a0-to-a3 ratio is 3.40x on true per-episode medians ($0.0169 against $0.0573) where the component-median shortcut gives 3.26x. Against a token ratio of 6.2x, either way the cost ratio is roughly half the token ratio, because cache read bills at a tenth of input while output bills at five times it. Every cost claim in this study is stated in dollars with the token figure beside it.

**The pooled figures hide a reversal the study turns on.** On the trap suite the median episode costs $0.0665 at a0 and $0.0419 at a2, so the arm with the smallest published surface costs 59 percent more per episode than the arm with the largest, because without discovery an agent takes a mean of 19.0 tool calls against a2's 11.4 and re-reads a growing conversation on each one. On the suite where knowledge is not needed the order is the expected one, $0.0138 against $0.0215. The cost of a context surface is not the surface; it is the surface minus the work the surface saves, and both terms have to be measured on the same tasks.

That pair is also where the protocol's minimum effects come from. The archived a0-to-a1 difference is $0.0116 per episode on the traps and $0.0004 on the knowledge-not-needed suite, so a $0.005 threshold sits between the two with comfortable margin in both directions.

## The separation analysis, and the arm it drops

Separation analysis is work item zero. Each research question names the mechanism by which cells diverge, the design variable that produces it, confirmation that the design varies that variable rather than holding it at its easy setting, the decision rule with its minimum effect, and the falsifier.

RQ1 varies store population across three cells under a byte-identical config with the embedder configured in all three. The cells straddle display-budget saturation deliberately: a2's federated searches returned a median of 1 hit with 398 of 1,028 returning nothing, while a3's returned a median of 10 with 642 at the display budget. Two cells both above saturation would measure the ceiling rather than the effect, and H1b pre-registers that ceiling as a prediction. H1c is a manipulation check on the design itself, a byte-identical `tools/list` dump per cell, which takes precedence over the other two.

RQ2's `column_context_filtering` arm is **dropped before it costs a run**, and the drop is recorded. The flag's documented purpose is a wide table whose queries touch a subset, and the bench warehouse has none: `memory.bench.customers` has five columns and `memory.bench.orders` six. The most the flag can withhold is context for four columns of a six-column table, a few hundred characters against a median episode of tens of thousands of tokens. An episode-level arm there is a guaranteed null that would say nothing about the mechanism. The survivor is a payload measurement with no model in the loop, scripted and zero-spend, and the wide-table question gets a deferred row in `findings-register.md` with the fixture work it would need.

RQ3 splits into the gate's cost where discovery is unnecessary and persona scope as a static-prefix lever, both with the live uncertainty stated rather than assumed: with the gate off the search tool is still published and agents may call it anyway, and if they do, the gate's marginal cost is near zero and that is the finding.

RQ4 is the method claim, and half of it is settled by this PR: the committed script already reproduces the frozen decomposition under a build gate. The other half is that the same functions run unmodified against #1171's archives.

## A trap for #1171, closed here

`bench/internal/pool/pool_test.go` globs `platform.bench.a*.yaml` and requires exactly four matches, so a config named `platform.bench.a2-gateoff.yaml` would break the identity-pool guard whose whole purpose is to stop a paid run dying partway through on an identity nobody defined. The protocol names the new configs with a `ce-` prefix and makes extending that guard to cover them a pre-run requirement on #1171.

## Spend

The plan itemizes 666 episodes at $36 estimated against $55 in caps, one row and one unchecked box per metered arm. Estimates are episodes multiplied by the archived per-suite mean spend of the closest arm, because a budget needs the mean and these distributions are heavy-tailed enough that the median would understate a block by roughly half. For scale, the four archived arms cost $9.23, $9.49, $9.45 and $16.64 for 261 episodes each, so the whole matrix is about the cost of one archived arm and a half.

Token-fidelity arms run the raw-API in-process path. The claude-cli adapter inserts client-side context the harness does not control, which confounds exactly the totals this study measures, so it is never used for a cost claim.

## Status of the pre-registration

The protocol carries the banner "pre-registration in review". It becomes "pre-registered, runs pending (#1171)" once the separation analysis is signed off on #1170, which is where that sign-off and the per-arm spend caps are recorded. #1171 runs no metered arm whose cap is unapproved.

## Verification

`make bench-test`, `make bench-lint` (0 issues), `make bench-report-check`, `go test .` for the root documentation gates, and `make doc-check` all pass. The diff touches no root-module Go code. The `bench-report-check` failure path was exercised directly by breaking a pin and confirming the target fails with the mismatch printed.

