### PR TITLE
Page the catalog index by rows returned, not rows requested

### DIFF
--- a/internal/platform/datasetindex/source.go
+++ b/internal/platform/datasetindex/source.go
@@ -22,9 +22,13 @@ type Lister interface {
 // threshold applied.
 const listQuery = "*"
 
-// pageSize is how many datasets one enumeration round trip asks for. Large
-// enough that a few-thousand-dataset catalog is a handful of calls, small
-// enough that one response stays a reasonable payload.
+// pageSize is how many datasets one enumeration round trip asks for: large
+// enough to keep a few-thousand-dataset catalog to tens of calls, small enough
+// that one response stays a reasonable payload. It is a request, not a
+// guarantee — a lister may serve fewer, and the DataHub client clamps every
+// search to its own MaxLimit, 100 by default, which is what makes one sweep of
+// the default 5000-entry cap up to 50 round trips — so enumerate pages by what
+// came back rather than by this.
 const pageSize = 200
 
 // Source implements indexjobs.Source for the catalog-datasets kind. The unit is
@@ -80,48 +84,78 @@ func (s *Source) LoadItems(ctx context.Context, _ string) ([]indexjobs.Item, err
 // repeat an entry when the underlying set shifts between calls, and a repeated
 // item id would make the mirrored count disagree with the item count.
 //
-// Reaching the cap is logged rather than passed over: coverage is reported
-// against the mirror, so a truncated corpus would otherwise read as full
-// coverage on the Indexing dashboard. The log fires whenever the cap stopped
-// the paging, including the boundary case where the catalog holds exactly
-// max_entries datasets and nothing was actually dropped — asking the catalog
-// for one more page to tell those apart would cost a round trip on every sweep
-// of every capped deployment.
+// Paging advances by how many rows came back, never by how many were asked for,
+// and only an empty page ends the enumeration. A lister is free to return fewer
+// rows than requested — the DataHub client clamps every search to its own
+// MaxLimit, which is below pageSize by default — so treating a short page as the
+// end of the corpus truncates it at the first response (#1231). Advancing by the
+// returned length is correct whatever any layer below clamps to.
+//
+// A page that carries no indexable URN the corpus does not already hold ends the
+// enumeration as an error, not as a result: a lister that ignores Offset would
+// otherwise return the same rows forever, and stopping successfully would hand
+// LoadItems a corpus that is short through no decision of its own — which the
+// Sink's atomic replace would then prune the rest of the mirror down to. Failing
+// keeps the previous sweep's mirror intact and leaves the unit for the next
+// reconciler sweep, which is the fail-closed contract LoadItems documents.
+//
+// Reaching the cap is a decision rather than a surprise, so it returns what it
+// has and logs: coverage is reported against the mirror, so a truncated corpus
+// would otherwise read as full coverage on the Indexing dashboard. The log fires
+// whenever the cap stopped the paging, including the boundary case where the
+// catalog holds exactly max_entries datasets and nothing was actually dropped —
+// asking the catalog for one more page to tell those apart would cost a round
+// trip on every sweep of every capped deployment.
 func (s *Source) enumerate(ctx context.Context) ([]Entry, error) {
 	var (
 		out  []Entry
 		seen = make(map[string]bool)
 	)
-	for offset := 0; offset < s.maxEntries; offset += pageSize {
-		limit := min(pageSize, s.maxEntries-offset)
+	for offset := 0; offset < s.maxEntries; {
 		results, err := s.lister.SearchTables(ctx, semantic.SearchFilter{
 			Query:  listQuery,
-			Limit:  limit,
+			Limit:  min(pageSize, s.maxEntries-offset),
 			Offset: offset,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("catalogSource: enumerate catalog at offset %d: %w", offset, err)
 		}
-		for i := range results {
-			if results[i].URN == "" || seen[results[i].URN] {
-				continue
-			}
-			seen[results[i].URN] = true
-			out = append(out, Entry{
-				URN:         results[i].URN,
-				Name:        results[i].Name,
-				Description: results[i].Description,
-				Tags:        results[i].Tags,
-				Domain:      results[i].Domain,
-			})
-		}
-		if len(results) < limit {
+		if len(results) == 0 {
 			return out, nil
 		}
+		before := len(out)
+		out = appendUnseen(out, seen, results)
+		if len(out) == before {
+			return nil, fmt.Errorf(
+				"catalogSource: enumerate stalled at offset %d: a page of %d rows held no dataset that was not already indexed, so the catalog is repeating rows or returning them without a URN (indexed %d)",
+				offset, len(results), len(out))
+		}
+		offset += len(results)
 	}
-	slog.Warn("catalog index: entry cap reached; any catalog datasets beyond it are not indexed",
+	slog.Warn("catalog index: enumeration stopped: entry cap reached; any catalog datasets beyond it are not indexed",
 		"max_entries", s.maxEntries, "indexed", len(out))
 	return out, nil
+}
+
+// appendUnseen appends an entry for every result carrying a URN not already in
+// seen, marking those URNs seen, and returns the extended slice. An unchanged
+// length means the page held nothing the corpus does not already have, which is
+// what ends the enumeration.
+func appendUnseen(out []Entry, seen map[string]bool, results []semantic.TableSearchResult) []Entry {
+	for i := range results {
+		if results[i].URN == "" || seen[results[i].URN] {
+			continue
+		}
+		seen[results[i].URN] = true
+		out = append(out, Entry{
+			URN:         results[i].URN,
+			Name:        results[i].Name,
+			Description: results[i].Description,
+			Tags:        results[i].Tags,
+			Domain:      results[i].Domain,
+		})
+	}
+	return out
 }
 
 // OnSucceeded is a no-op: the ranked search reads catalog_datasets directly on

--- a/internal/platform/datasetindex/source_test.go
+++ b/internal/platform/datasetindex/source_test.go
@@ -1,8 +1,10 @@
 package datasetindex
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"strconv"
 	"testing"
 
@@ -62,24 +64,106 @@ func TestLoadItemsMirrorsAndComposesText(t *testing.T) {
 	assert.Equal(t, 0, lister.filters[0].Offset)
 }
 
+// corpusLister serves a corpus by offset and clamps every request to clampAt
+// rows, which is what the real lister does: the DataHub client clamps a search
+// to its own MaxLimit (100 by default), below the pageSize this package asks
+// for, so a page never comes back as long as it was requested.
+type corpusLister struct {
+	corpus  []semantic.TableSearchResult
+	clampAt int
+	filters []semantic.SearchFilter
+}
+
+func (c *corpusLister) SearchTables(_ context.Context, f semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
+	c.filters = append(c.filters, f)
+	if f.Offset >= len(c.corpus) {
+		return nil, nil
+	}
+	return c.corpus[f.Offset:min(f.Offset+min(f.Limit, c.clampAt), len(c.corpus))], nil
+}
+
+func corpusOf(n int) []semantic.TableSearchResult {
+	out := make([]semantic.TableSearchResult, n)
+	for i := range out {
+		out[i] = result("urn:"+strconv.Itoa(i), "t", "d")
+	}
+	return out
+}
+
 func TestLoadItemsPagesUntilExhausted(t *testing.T) {
 	t.Parallel()
 	store, mock, done := newMockStore(t)
 	defer done()
 
-	full := make([]semantic.TableSearchResult, pageSize)
-	for i := range full {
-		full[i] = result("urn:"+strconv.Itoa(i), "t", "d")
-	}
-	lister := &stubLister{pages: [][]semantic.TableSearchResult{full, {result("urn:last", "t", "d")}}}
-	expectSyncOf(mock, pageSize+1)
+	// Pages are short of what was asked for, as the real lister's always are.
+	lister := &corpusLister{corpus: corpusOf(5), clampAt: 2}
+	expectSyncOf(mock, 5)
 
 	items, err := NewSource(store, lister, 10_000).LoadItems(context.Background(), SourceID)
 	require.NoError(t, err)
-	assert.Len(t, items, pageSize+1)
-	require.Len(t, lister.filters, 2)
-	assert.Equal(t, pageSize, lister.filters[1].Offset, "the second page continues where the first ended")
+	assert.Len(t, items, 5)
+	require.Len(t, lister.filters, 4, "four calls: three that returned rows, one that found the end")
+	assert.Equal(t, []int{0, 2, 4, 5}, []int{
+		lister.filters[0].Offset, lister.filters[1].Offset,
+		lister.filters[2].Offset, lister.filters[3].Offset,
+	}, "each page resumes at the end of what the previous one actually returned")
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestLoadItemsEnumeratesPastAClampedPageSize is #1231: the DataHub client
+// clamps every search to 100 rows while the loop asks for pageSize (200). Paging
+// by the requested size read the first short page as the end of the corpus, so
+// every deployment indexed exactly 100 datasets and reported full coverage.
+func TestLoadItemsEnumeratesPastAClampedPageSize(t *testing.T) {
+	t.Parallel()
+	store, mock, done := newMockStore(t)
+	defer done()
+
+	const clamp = 100
+	lister := &corpusLister{corpus: corpusOf(250), clampAt: clamp}
+	expectSyncOf(mock, 250)
+
+	items, err := NewSource(store, lister, 10_000).LoadItems(context.Background(), SourceID)
+	require.NoError(t, err)
+	assert.Len(t, items, 250, "the whole corpus is indexed even though no page is ever as long as requested")
+	require.NotEmpty(t, lister.filters)
+	assert.Equal(t, pageSize, lister.filters[0].Limit, "the loop still asks for a full page; the lister is what clamps")
+	assert.Equal(t, clamp, lister.filters[1].Offset, "the second page resumes at what the first returned, not at what it asked for")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// stuckLister ignores Offset and returns the same page forever, the failure mode
+// that a length-advanced offset alone cannot terminate. It errors past maxCalls
+// so a regression fails the test instead of hanging it.
+type stuckLister struct {
+	page     []semantic.TableSearchResult
+	calls    int
+	maxCalls int
+}
+
+func (s *stuckLister) SearchTables(_ context.Context, _ semantic.SearchFilter) ([]semantic.TableSearchResult, error) {
+	s.calls++
+	if s.calls > s.maxCalls {
+		return nil, errors.New("lister called past the point enumeration should have stopped")
+	}
+	return s.page, nil
+}
+
+func TestLoadItemsFailsClosedOnAListerThatIgnoresOffset(t *testing.T) {
+	t.Parallel()
+	store, mock, done := newMockStore(t)
+	defer done()
+
+	lister := &stuckLister{
+		page:     []semantic.TableSearchResult{result("urn:a", "a", ""), result("urn:b", "b", "")},
+		maxCalls: 8,
+	}
+
+	_, err := NewSource(store, lister, 10_000).LoadItems(context.Background(), SourceID)
+	require.ErrorContains(t, err, "stalled at offset 2",
+		"a corpus that stopped growing is short through no decision of ours: reporting it as complete would let the Sink's replace prune the mirror down to it")
+	assert.Equal(t, 2, lister.calls, "the second page adds nothing new, which is the stop condition")
+	assert.NoError(t, mock.ExpectationsWereMet(), "nothing is written when enumeration could not finish")
 }
 
 func TestLoadItemsStopsAtEntryCap(t *testing.T) {
@@ -99,6 +183,28 @@ func TestLoadItemsStopsAtEntryCap(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestEntryCapTruncationIsLogged covers the one stop that reports a knowingly
+// short corpus as a success. Coverage is computed against the mirror, so that
+// corpus reads as full coverage on the Indexing dashboard and the log is the only
+// signal that recall is bounded. Not parallel: it swaps the default logger.
+func TestEntryCapTruncationIsLogged(t *testing.T) {
+	store, mock, done := newMockStore(t)
+	defer done()
+	expectSyncOf(mock, 1)
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
+
+	lister := &corpusLister{corpus: corpusOf(5), clampAt: 2}
+	_, err := NewSource(store, lister, 1).LoadItems(context.Background(), SourceID)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "entry cap reached")
+	assert.Contains(t, buf.String(), "indexed=1", "the log states how much was indexed")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestLoadItemsDeduplicatesRepeatedURNs(t *testing.T) {
 	t.Parallel()
 	store, mock, done := newMockStore(t)
@@ -106,17 +212,20 @@ func TestLoadItemsDeduplicatesRepeatedURNs(t *testing.T) {
 
 	// A live catalog can repeat an entry across pages when the underlying set
 	// shifts; a repeated item id would make the mirrored count disagree with
-	// the item count the framework embeds.
-	first := make([]semantic.TableSearchResult, pageSize)
-	for i := range first {
-		first[i] = result("urn:dup", "t", "d")
-	}
-	lister := &stubLister{pages: [][]semantic.TableSearchResult{first, {result("urn:dup", "t", "d")}}}
-	expectSyncOf(mock, 1)
+	// the item count the framework embeds. A repeat must be dropped without
+	// ending the enumeration, so the last page's new URN has to survive it.
+	dup := result("urn:dup", "t", "d")
+	lister := &stubLister{pages: [][]semantic.TableSearchResult{
+		{dup, dup},
+		{dup, result("urn:new", "t", "d")},
+	}}
+	expectSyncOf(mock, 2)
 
 	items, err := NewSource(store, lister, 10_000).LoadItems(context.Background(), SourceID)
 	require.NoError(t, err)
-	assert.Len(t, items, 1)
+	require.Len(t, items, 2)
+	assert.Equal(t, "urn:new", items[1].ItemID, "paging continued past the page that repeated an entry")
+	assert.Equal(t, 3, lister.calls, "the third call is the empty page that ends the corpus")
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 


### PR DESCRIPTION
Closes #1231

The catalog dataset index enumerated exactly 100 datasets on every deployment and reported full coverage: `items_done: 100`, `expected: 100`, `indexed: 100`, `verdict: healthy`, every sweep, indefinitely.

It asked for `pageSize = 200` rows and treated a page shorter than that as the end of the corpus. The request never arrives as 200. `pkg/semantic/datahub` builds its client from `dhclient.DefaultConfig()` (`pkg/semantic/datahub/adapter.go:114`, setting only URL, token, timeout and debug), whose `MaxLimit` is 100 (`mcp-datahub@v1.15.0/pkg/client/config.go:57`), and `buildBaseSearchInput` clamps every search to it (`mcp-datahub@v1.15.0/pkg/client/search_across.go:195-196`). So the loop asked for 200, received 100, read `100 < 200` as the end of the catalog, and returned after one page. The `max_entries` budget was never consulted a second time.

What that cost is the semantically ranked arm for everything past the first 100 datasets. `CatalogProvider.searchByText` merges the platform index with DataHub keyword search, so the rest of the corpus was still present through the keyword arm and by URN; what was gone was intent-phrased discovery for the majority of a real catalog, with nothing in the admin API, the dashboard or the logs to say so.

Enumeration now advances the offset by what the lister actually returned and stops only on an empty page, so it is correct whatever any layer below clamps to. The entry cap remains the outer bound and keeps its warning naming how many datasets were indexed.

## A page that adds nothing fails the sweep rather than shortening it

The ticket asks enumeration to terminate when a page contributes no new URN, so a lister that ignores the offset cannot spin. That stop returns an error rather than a short corpus.

Reporting a knowingly partial enumeration as a success is destructive, not merely lossy. `LoadItems` success reaches `Sink.Upsert` and `Store.ReplaceVectors`, which runs `DELETE FROM catalog_datasets WHERE NOT (urn = ANY($1))` (`internal/platform/datasetindex/store.go:165`). A short-but-successful return would prune the mirror down to the partial set while `Coverage` still reported 100 percent, so a catalog that repeated one page mid-enumeration would lose every dataset past it. Failing keeps the previous sweep's mirror intact, records the failure on the unit, and leaves it for the next reconciler sweep — the fail-closed contract `LoadItems` documents at `source.go:57-61`. The loop still cannot spin and still cannot duplicate entries.

## The paging tests could not fail

`TestLoadItemsPagesUntilExhausted` built its first page with exactly `pageSize` entries, so its stub returned precisely what the loop asked for and the short-page branch was never taken. The real lister can never return `pageSize` entries, so the fake modelled a contract production does not have and the test passed on behaviour that never occurs.

The paging tests now run against a lister that serves a corpus by offset and clamps every request below what was asked, the way the real client does. A 250-dataset corpus behind a 100-row clamp indexes all 250; both that test and the rewritten exhaustion test fail against the previous implementation. The offset-ignoring lister has its own test, and errors past a call bound so a regression fails rather than hangs. The deduplication fixture now carries a new URN on the page that repeats an entry, so it proves paging continues past a repeat rather than passing because enumeration stopped there.

## Verification

`make verify` green. Patch coverage 100 percent (25 of 25 changed lines); `enumerate`, `appendUnseen` and `LoadItems` each at 100 percent.

The remaining acceptance criterion — a deployment whose catalog exceeds 100 datasets reporting `indexed` above 100 through `GET /api/v1/admin/index-jobs` — can only be checked once this ships.

## The same clamp, elsewhere

Filed as #1238, not fixed here: `internal/platform/completionlayer` sets `fetchLimit = MaxValues + 1 = 101` so a full page proves more matches exist, but the client caps at 100, so `pageWasBounded` is never true. The dataset completion arm returns `Total: 100` with `HasMore: false` for a catalog with 500 matches. That probe depends on requesting one over the cap, so the repair used here is not available to it; it needs the seam to stop hiding the effective limit.