### PR TITLE
Cite the platform when the repository is cited, the report when a result is

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,20 @@
-# Citation metadata for mcp-data-platform and its knowledge-layer benchmark
-# report. Format: Citation File Format 1.2.0 (https://citation-file-format.github.io).
-# GitHub renders a "Cite this repository" button from this file.
+# Citation metadata for mcp-data-platform and the benchmark report series
+# published from it. Format: Citation File Format 1.2.0
+# (https://citation-file-format.github.io).
+#
+# GitHub renders a "Cite this repository" button from this file. The top-level
+# entry below is the software, so that button cites the platform. The three
+# benchmark reports are separate publications with their own Zenodo deposits and
+# are listed under `references:`; cite the report, not the repository, when the
+# thing being cited is a measurement.
+#
+# Report DOIs here are concept DOIs (they always resolve to the newest version);
+# each report's version DOIs are listed beneath it.
 cff-version: 1.2.0
-message: "If you use this software or cite its benchmark report, please cite it as below."
+message: >-
+  If you use this software in your work, please cite it as below. If you are
+  citing a benchmark result rather than the software, cite the corresponding
+  report under `references`.
 title: mcp-data-platform
 abstract: >-
   A composable, semantic-first MCP server platform composing DataHub, Trino, and
@@ -17,30 +29,78 @@ authors:
 repository-code: "https://github.com/txn2/mcp-data-platform"
 url: "https://mcp-data-platform.txn2.com"
 license: Apache-2.0
-preferred-citation:
-  type: report
-  title: >-
-    Does a Semantic Knowledge Layer Make an Agent Measurably Better? A
-    Reproducible Benchmark of the mcp-data-platform Knowledge Layer
-  authors:
-    - family-names: Johnston
-      given-names: Craig
-      email: cj@imti.co
-      affiliation: "Deasil Works, Inc."
-  year: 2026
-  month: 7
-  institution:
-    name: "Deasil Works, Inc. / txn2"
-  url: "https://mcp-data-platform.txn2.com/reference/benchmark-report/"
-  version: "2.0.1"
-  doi: 10.5281/zenodo.21438044
-  identifiers:
-    - type: doi
-      value: 10.5281/zenodo.21751635
-      description: "Version DOI for the v2.0.1 snapshot"
-    - type: doi
-      value: 10.5281/zenodo.21751050
-      description: "Version DOI for the v2.0 snapshot (PDF had a typesetting defect; superseded by v2.0.1)"
-    - type: doi
-      value: 10.5281/zenodo.21438045
-      description: "Version DOI for the v1.0 snapshot"
+version: 1.119.0
+date-released: "2026-08-04"
+keywords:
+  - Model Context Protocol
+  - semantic layer
+  - data catalog
+  - knowledge layer
+  - agent tooling
+references:
+  - type: report
+    title: >-
+      Does a Semantic Knowledge Layer Make an Agent Measurably Better? A
+      Reproducible Benchmark of the mcp-data-platform Knowledge Layer
+    authors:
+      - family-names: Johnston
+        given-names: Craig
+        email: cj@imti.co
+        affiliation: "Deasil Works, Inc."
+    year: 2026
+    month: 7
+    institution:
+      name: "Deasil Works, Inc. / txn2"
+    url: "https://mcp-data-platform.txn2.com/reference/benchmark-report/"
+    version: "2.0.1"
+    doi: 10.5281/zenodo.21438044
+    identifiers:
+      - type: doi
+        value: 10.5281/zenodo.21751635
+        description: "Version DOI for the v2.0.1 snapshot"
+      - type: doi
+        value: 10.5281/zenodo.21751050
+        description: "Version DOI for the v2.0 snapshot (PDF had a typesetting defect; superseded by v2.0.1)"
+      - type: doi
+        value: 10.5281/zenodo.21438045
+        description: "Version DOI for the v1.0 snapshot"
+  - type: report
+    title: >-
+      When Do Agents Use Stored Knowledge? Derivability, Capability, and the
+      Limits of a Knowledge Layer
+    authors:
+      - family-names: Johnston
+        given-names: Craig
+        email: cj@imti.co
+        affiliation: "Deasil Works, Inc."
+    year: 2026
+    month: 7
+    institution:
+      name: "Deasil Works, Inc. / txn2"
+    url: "https://mcp-data-platform.txn2.com/reference/benchmark-report-knowledge-use/"
+    version: "1.0"
+    doi: 10.5281/zenodo.21614058
+    identifiers:
+      - type: doi
+        value: 10.5281/zenodo.21614059
+        description: "Version DOI for the v1.0 snapshot"
+  - type: report
+    title: >-
+      Knowledge Pollution: Verification Displacement, Capability, and the Price
+      of a Curation Gate
+    authors:
+      - family-names: Johnston
+        given-names: Craig
+        email: cj@imti.co
+        affiliation: "Deasil Works, Inc."
+    year: 2026
+    month: 8
+    institution:
+      name: "Deasil Works, Inc. / txn2"
+    url: "https://mcp-data-platform.txn2.com/reference/benchmark-report-knowledge-pollution/"
+    version: "1.0"
+    doi: 10.5281/zenodo.21834812
+    identifiers:
+      - type: doi
+        value: 10.5281/zenodo.21834813
+        description: "Version DOI for the v1.0 snapshot"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 [![Signed by Cosign](https://img.shields.io/badge/artifacts-signed_by_cosign-blue?logo=sigstore&logoColor=white)](https://github.com/sigstore/cosign)
 [![Docker](https://img.shields.io/badge/ghcr.io-txn2%2Fmcp--data--platform-blue?logo=docker)](https://github.com/txn2/mcp-data-platform/pkgs/container/mcp-data-platform)
 [![Benchmark Report: Knowledge Layer](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21438044-blue?label=Report%3A%20Knowledge%20Layer)](https://doi.org/10.5281/zenodo.21438044)
-[![Benchmark Report: Knowledge Use](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21614059-blue?label=Report%3A%20Knowledge%20Use)](https://doi.org/10.5281/zenodo.21614059)
+[![Benchmark Report: Knowledge Use](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21614058-blue?label=Report%3A%20Knowledge%20Use)](https://doi.org/10.5281/zenodo.21614058)
+[![Benchmark Report: Knowledge Pollution](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21834812-blue?label=Report%3A%20Knowledge%20Pollution)](https://doi.org/10.5281/zenodo.21834812)
 
 **[Documentation](https://mcp-data-platform.txn2.com/)** | **[Installation](https://mcp-data-platform.txn2.com/server/installation/)** | **[Quick Start](#quick-start)** | **[Go Library](https://mcp-data-platform.txn2.com/library/overview/)**
 


### PR DESCRIPTION
## Summary

Two citation defects, both in the metadata that represents this repository to anyone who wants to cite it.

**GitHub's "Cite this repository" button returned a benchmark report, not the platform.** The popup is captioned "If you use this software in your work, please cite it using the following metadata" and then rendered `Johnston, C. (2026). Does a Semantic Knowledge Layer Make an Agent Measurably Better?...`. GitHub renders `preferred-citation` in preference to the software entry whenever that key is present, and `CITATION.cff` set it to the first benchmark report. Someone citing the software was being handed a study.

**The README carried badges for two of three published reports.** The Knowledge Pollution report (published 2026-08-07, `docs/reference/benchmark-report-knowledge-pollution.md:19`) had no badge. The two badges that existed were inconsistent with each other: Knowledge Layer used a concept DOI, Knowledge Use used a version DOI that pins to the v1.0 snapshot forever.

## What changed

### `CITATION.cff`

`preferred-citation` is removed, so the button renders the top-level software entry. That entry gains `version: 1.119.0` and `date-released: "2026-08-04"` (the latest tag and its commit date) because without `date-released` a CFF software citation renders with no year. The rendered result:

```
Johnston C. (2026). mcp-data-platform (version 1.119.0).
URL: https://mcp-data-platform.txn2.com
```

All three reports now appear under `references:`. Reports two and three were absent from the file entirely before this change; the file knew only about the Knowledge Layer report and its three version snapshots. Each reference carries its **concept** DOI as `doi:` with its version DOIs beneath as `identifiers:`, so the primary identifier always resolves to the newest version of that report while every snapshot stays recorded. Report one's three version DOIs (`21751635`, `21751050`, `21438045`) are carried across unchanged, including the note that the v2.0 PDF had a typesetting defect.

`message:` now distinguishes the two cases: cite the software from the top-level entry, cite the corresponding report under `references` when the thing being cited is a measurement.

### `README.md`

| Badge | Before | After |
| --- | --- | --- |
| Knowledge Layer | `10.5281/zenodo.21438044` (concept) | unchanged |
| Knowledge Use | `10.5281/zenodo.21614059` (version 1.0) | `10.5281/zenodo.21614058` (concept) |
| Knowledge Pollution | absent | `10.5281/zenodo.21834812` (concept) |

All three badges now resolve to the newest version of their report rather than pinning to a snapshot.

## Concept DOIs

The concept DOIs were read from the Zenodo API rather than assumed. `GET /api/records/<id>` returns `conceptdoi` alongside the version `doi`:

| Report | Version record | `conceptdoi` |
| --- | --- | --- |
| Knowledge Layer | 21751635 (v2.0.1) | `10.5281/zenodo.21438044` |
| Knowledge Use | 21614059 (v1.0) | `10.5281/zenodo.21614058` |
| Knowledge Pollution | 21834813 (v1.0) | `10.5281/zenodo.21834812` |

Both newly-referenced concept DOIs were confirmed to resolve: `https://doi.org/10.5281/zenodo.21614058` and `https://doi.org/10.5281/zenodo.21834812` each return 302 to their Zenodo record.

## Verification

- `cffconvert --validate` reports `Citation metadata are valid according to schema version 1.2.0`.
- `cffconvert -f apalike` renders the software citation quoted above, confirming the button no longer yields a report.
- `make doc-check` passes with no warnings; all hard documentation gates report OK.
- No Go source, Makefile target, or CI workflow reads `CITATION.cff` (verified by grep across `*.go`, `Makefile`, `*.yml`, `*.py`), so no gate depends on the removed `preferred-citation` key.

Both files are documentation; there is no code change and no test surface.

## Deliberately unchanged

**`.zenodo.json`** still describes the first report's deposit (`upload_type: publication`, `publication_type: report`, `doi: 10.5281/zenodo.21438044`). That remains accurate: it is the metadata for that deposit, not for the software.

**No Zenodo software deposit, and no release-archiving webhook.** The repository has 294 `v*` tags, so webhook archiving would mint roughly 294 version DOIs under one concept and one more per release. It would also apply `.zenodo.json` to every release archive, depositing each one as a copy of the first report. The software is citable without a DOI after this change; a software DOI would add a persistent identifier that survives a repository move, which is a separate decision and does not require the webhook.

## Known stale prose, not corrected here

Three files state that the repository-level metadata carries only the series' first deposit. That is still true of `.zenodo.json` and no longer true of `CITATION.cff`:

- `docs/reference/benchmark-report-knowledge-use.md:351`
- `docs/reference/benchmark-report-knowledge-pollution.md:491`

Both are published, DOI-pinned reports, so editing them would make the repository copy diverge from the archived PDF at the deposited DOI. They are left as deposited.

- `bench/reports/knowledge-layer/README.md:72` makes the same claim and is internal toolchain documentation with no deposit behind it. It is correctable without diverging from any archive.

Separately, the study table at `bench/README.md:22` lists version DOIs for studies two and three, where concept DOIs would now match the README badges.
