### PR TITLE
A connection lookup that names no instance resolves to the same one on every start

### DIFF
--- a/configs/platform.yaml
+++ b/configs/platform.yaml
@@ -218,6 +218,8 @@ toolkits:
         host: "trino-staging.example.com"
         port: 8080
         description: "Staging environment for testing queries before production"
+    # Which instance a request that names no connection means. Required
+    # once a kind configures more than one instance.
     default: production
     config:
       default_limit: 1000
@@ -235,6 +237,8 @@ toolkits:
         token: "${DATAHUB_TOKEN}"
         debug: false            # Enable debug logging for GraphQL operations
         read_only: true         # Restrict to read operations
+    # Which instance a request that names no connection means. Required
+    # once a kind configures more than one instance.
     default: primary
     config:
       default_limit: 50
@@ -255,6 +259,8 @@ toolkits:
         #                                           # signed against it instead of endpoint. Data traffic
         #                                           # keeps using endpoint. Empty falls back to endpoint.
         # use_path_style: true                      # required for SeaweedFS / MinIO style addressing
+    # Which instance a request that names no connection means. Required
+    # once a kind configures more than one instance.
     default: data_lake
     config:
       read_only: true

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1642,7 +1642,7 @@ Execute a read-only SQL query against Trino. Write operations are rejected. Anno
 |-----------|------|----------|---------|-------------|
 | `query` | string | Yes | - | SQL query to execute (read-only) |
 | `limit` | integer | No | 1000 | Maximum rows to return |
-| `connection` | string | No | first configured | Trino connection name |
+| `connection` | string | No | the kind's `default:` | Trino connection name |
 
 ### trino_execute
 
@@ -1652,7 +1652,7 @@ Execute any SQL against Trino including write operations (INSERT, UPDATE, DELETE
 |-----------|------|----------|---------|-------------|
 | `query` | string | Yes | - | SQL query to execute |
 | `limit` | integer | No | 1000 | Maximum rows to return |
-| `connection` | string | No | first configured | Trino connection name |
+| `connection` | string | No | the kind's `default:` | Trino connection name |
 
 ### trino_explain
 
@@ -1661,7 +1661,7 @@ Get the execution plan for a SQL query.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `query` | string | Yes | - | SQL query to explain |
-| `connection` | string | No | first configured | Trino connection name |
+| `connection` | string | No | the kind's `default:` | Trino connection name |
 
 ### trino_browse
 
@@ -1674,7 +1674,7 @@ Get table schema and metadata.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `table` | string | Yes | - | Table name (can be `catalog.schema.table`) |
-| `connection` | string | No | first configured | Trino connection name |
+| `connection` | string | No | the kind's `default:` | Trino connection name |
 
 ### trino_export
 

--- a/docs/reference/tools-api.md
+++ b/docs/reference/tools-api.md
@@ -79,7 +79,7 @@ Execute a read-only SQL query against the Trino cluster. Write operations (INSER
 |-----------|------|----------|---------|-------------|
 | `query` | string | Yes | - | SQL query to execute (read-only) |
 | `limit` | integer | No | 1000 | Maximum rows to return (capped by max_limit config) |
-| `connection` | string | No | first configured | Trino connection name |
+| `connection` | string | No | the kind's `default:` | Trino connection name |
 
 **Response Schema:**
 
@@ -136,7 +136,7 @@ Execute any SQL against the Trino cluster, including write operations (INSERT, U
 |-----------|------|----------|---------|-------------|
 | `query` | string | Yes | - | SQL query to execute |
 | `limit` | integer | No | 1000 | Maximum rows to return (capped by max_limit config) |
-| `connection` | string | No | first configured | Trino connection name |
+| `connection` | string | No | the kind's `default:` | Trino connection name |
 
 **Response Schema:** Same as `trino_query`.
 
@@ -151,7 +151,7 @@ Get the execution plan for a SQL query.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `query` | string | Yes | - | SQL query to explain |
-| `connection` | string | No | first configured | Trino connection name |
+| `connection` | string | No | the kind's `default:` | Trino connection name |
 
 **Response Schema:**
 
@@ -175,7 +175,7 @@ Browse the Trino catalog hierarchy. Omit all parameters to list catalogs. Provid
 | `catalog` | string | No | - | Catalog name. Omit to list all catalogs |
 | `schema` | string | No | - | Schema name. Requires `catalog`. Omit to list schemas |
 | `pattern` | string | No | - | LIKE pattern to filter tables (only when listing tables) |
-| `connection` | string | No | first configured | Trino connection name |
+| `connection` | string | No | the kind's `default:` | Trino connection name |
 
 **Response Schema (list catalogs):**
 
@@ -219,7 +219,7 @@ Get table schema and metadata.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `table` | string | Yes | - | Table name (can be `catalog.schema.table`) |
-| `connection` | string | No | first configured | Trino connection name |
+| `connection` | string | No | the kind's `default:` | Trino connection name |
 
 **Response Schema:**
 

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -1349,7 +1349,7 @@ resources:
 |-------|------|---------|-------------|
 | `enabled` | bool | auto | Enable managed resources. Unset means enabled whenever a database is configured; set `false` to disable the subsystem outright |
 | `uri_scheme` | string | `mcp` | Scheme of the URIs minted for managed resources (`<scheme>://global/<category>/<filename>`, and the persona/user equivalents). Changing it after resources exist changes the URIs the platform serves for them |
-| `s3_connection` | string | first configured S3 instance | Name of the S3 toolkit instance used for blob storage |
+| `s3_connection` | string | the S3 kind's `default:` | Name of the S3 toolkit instance used for blob storage |
 | `s3_bucket` | string | `managed-resources` | Bucket the uploaded bytes are written to |
 | `max_versions` | int | `10` | Content revisions a resource keeps, counting the current one. A revision past the cap prunes the oldest stored file; live content is never pruned. A non-positive value selects the default, and anything below `2` is raised to `2`, since a cap of `1` would keep no history at all |
 

--- a/docs/server/multi-provider.md
+++ b/docs/server/multi-provider.md
@@ -114,21 +114,33 @@ Use the `*_list_connections` tools to see configured instances:
 
 ## Default Connection
 
-The first instance configured becomes the default. You can rely on this behavior or explicitly specify which instance to use for semantic providers:
+The Trino, DataHub and S3 kinds name their default with a `default:` key beside their `instances:` block. One of them configuring more than one instance without it is refused at startup, listing the instances it found:
+
+```
+validating config: config validation errors: toolkits.datahub.default is required when more than one instance is configured (instances: legacy, primary)
+```
+
+Which catalog or warehouse a request means when it names none is a deployment decision, so the platform asks for it rather than picking one. A kind with a single instance needs no `default:` — there is nothing to choose between. The gateway kinds (`mcp`, `api`) never need one: every tool they proxy is namespaced by its connection, so no request resolves a default for them.
+
+A kind that is configured but not enabled is still asked for a default. The semantic, query and storage providers read an instance's settings through the same lookup whether or not the kind registers tools, so a catalog used only for enrichment still has to say which of its instances the enrichment reads.
+
+The `default:` answers the lookups that name no instance: the provider blocks below when their `instance` is left unset, `knowledge.apply.datahub_connection`, `resources.managed.s3_connection`, and the connection a Trino tool call uses when it passes no `connection` parameter.
 
 ```yaml
 semantic:
   provider: datahub
-  instance: primary    # Use the "primary" DataHub instance
+  instance: primary    # optional; without it, toolkits.datahub.default is used
 
 query:
   provider: trino
-  instance: production # Use the "production" Trino instance
+  instance: production # optional; without it, toolkits.trino.default is used
 
 storage:
   provider: s3
-  instance: data_lake  # Use the "data_lake" S3 instance
+  instance: data_lake  # optional; without it, toolkits.s3.default is used
 ```
+
+Connections added through the admin UI are held in the database and join the toolkit config after startup validation, so they arrive too late to be checked by it. They cannot take over a lookup a configured instance already answers: whatever the file resolves to is pinned before they merge. For a kind whose instances all come from the database, a lookup that names no instance resolves to the first instance name in alphabetical order, which is the same one on every replica and after every restart.
 
 ## Cross-Enrichment with Multiple Providers
 

--- a/internal/platform/notices/notices.go
+++ b/internal/platform/notices/notices.go
@@ -42,9 +42,6 @@ type Handle struct {
 	shares  portaldomain.ShareStore
 	threads threads.ThreadStore
 	marks   WatermarkStore
-	// now is the clock, replaced in tests so a digest's watermark arithmetic is
-	// deterministic.
-	now func() time.Time
 }
 
 // New builds the digest assembler over db and the portal stores. It returns nil
@@ -59,7 +56,6 @@ func New(db *sql.DB, assets portaldomain.AssetStore, shares portaldomain.ShareSt
 		shares:  shares,
 		threads: ts,
 		marks:   NewPostgresWatermarkStore(db),
-		now:     time.Now,
 	}
 }
 
@@ -107,7 +103,11 @@ func (h *Handle) Build(ctx context.Context, pc *middleware.PlatformContext) *Dig
 	if !ok {
 		return nil
 	}
-	now := h.now()
+	now, err := h.marks.Now(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "platform_info: notice clock unavailable", logKeyError, err)
+		return nil
+	}
 	since, err := h.since(ctx, c.key, now)
 	if err != nil {
 		slog.WarnContext(ctx, "platform_info: notice watermark unavailable", logKeyError, err)

--- a/internal/platform/notices/notices_test.go
+++ b/internal/platform/notices/notices_test.go
@@ -111,12 +111,15 @@ func (*fakeThreads) CountSignoffs(context.Context, string, string) (int, error) 
 // fakeMarks is an in-memory watermark store that records every advance.
 type fakeMarks struct {
 	mark    *time.Time
+	nowErr  error
 	getErr  error
 	setErr  error
 	setKey  string
 	setAt   time.Time
 	setCall int
 }
+
+func (f *fakeMarks) Now(context.Context) (time.Time, error) { return testNow, f.nowErr }
 
 func (f *fakeMarks) Get(context.Context, string) (*time.Time, error) { return f.mark, f.getErr }
 
@@ -145,7 +148,6 @@ func testHandle(a *fakeAssets, s *fakeShares, t *fakeThreads, m *fakeMarks) *Han
 		shares:  s,
 		threads: t,
 		marks:   m,
-		now:     func() time.Time { return testNow },
 	}
 }
 
@@ -345,6 +347,17 @@ func TestBuildAFailedHalfIsReportedButTheWatermarkHolds(t *testing.T) {
 				"a half that failed to load must be reported next session, not silently dropped")
 		})
 	}
+}
+
+// Without a clock the digest has no boundary, so it reports nothing rather
+// than guessing one and reading out notices the caller has already seen.
+func TestBuildUnreadableClockReportsNothingRatherThanEverything(t *testing.T) {
+	marks := &fakeMarks{mark: &testMark, nowErr: errors.New("db down")}
+	h := testHandle(&fakeAssets{owned: ownedAsset()}, &fakeShares{refs: newShare()},
+		&fakeThreads{found: openThread()}, marks)
+
+	assert.Nil(t, h.Build(context.Background(), testCaller()))
+	assert.Zero(t, marks.setCall, "a digest that was never built must not advance the watermark")
 }
 
 func TestBuildUnreadableWatermarkReportsNothingRatherThanEverything(t *testing.T) {

--- a/internal/platform/notices/watermark.go
+++ b/internal/platform/notices/watermark.go
@@ -12,6 +12,15 @@ import (
 // to them. Get answers nil (not an error) for a caller who has never been
 // briefed; Set is what makes delivery single-shot.
 type WatermarkStore interface {
+	// Now returns the clock the watermark is kept on.
+	//
+	// A digest compares its boundary against timestamps the database stamped
+	// (portal_shares.created_at defaults to NOW()), so the boundary has to be
+	// read from that same clock. Stamping it from the process clock instead
+	// compares two clocks: a few milliseconds of skew between the application
+	// host and the database server is enough to place an already-delivered
+	// share after the watermark and read it out to the caller a second time.
+	Now(ctx context.Context) (time.Time, error)
 	Get(ctx context.Context, userKey string) (*time.Time, error)
 	Set(ctx context.Context, userKey string, at time.Time) error
 }
@@ -24,6 +33,16 @@ type PostgresWatermarkStore struct {
 // NewPostgresWatermarkStore returns a watermark store over db.
 func NewPostgresWatermarkStore(db *sql.DB) *PostgresWatermarkStore {
 	return &PostgresWatermarkStore{db: db}
+}
+
+// Now returns the database server's current time, which is the clock every
+// timestamp a digest compares against was stamped from.
+func (s *PostgresWatermarkStore) Now(ctx context.Context) (time.Time, error) {
+	var at time.Time
+	if err := s.db.QueryRowContext(ctx, `SELECT NOW()`).Scan(&at); err != nil {
+		return time.Time{}, fmt.Errorf("reading the database clock: %w", err)
+	}
+	return at, nil
 }
 
 // Get returns when this caller was last briefed, or nil if never.

--- a/internal/platform/notices/watermark_test.go
+++ b/internal/platform/notices/watermark_test.go
@@ -104,3 +104,33 @@ func TestNewBuildsAWatermarkBackedHandle(t *testing.T) {
 	assert.Nil(t, New(db, &fakeAssets{}, nil, &fakeThreads{}))
 	assert.Nil(t, New(db, &fakeAssets{}, &fakeShares{}, nil))
 }
+
+// The digest's boundary must come from the database, because every timestamp
+// it is compared against was stamped there.
+func TestPostgresWatermarkNowReadsTheDatabaseClock(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	at := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT NOW()")).
+		WillReturnRows(sqlmock.NewRows([]string{"now"}).AddRow(at))
+
+	got, err := NewPostgresWatermarkStore(db).Now(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, at, got)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPostgresWatermarkNowReportsAFailure(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT NOW()")).WillReturnError(errors.New("connection reset"))
+
+	_, err = NewPostgresWatermarkStore(db).Now(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading the database clock")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/platform/toolkitcfg/merge.go
+++ b/internal/platform/toolkitcfg/merge.go
@@ -1,0 +1,96 @@
+package toolkitcfg
+
+import "log/slog"
+
+// Config schema key for the per-kind enable flag.
+const keyEnabled = "enabled"
+
+// AutoEnableKind ensures toolkits[kind] exists with enabled=true so the toolkit
+// loader will instantiate it. Idempotent and non-overriding: if the operator has
+// already declared the kind block (enabled OR disabled), their explicit choice
+// is respected.
+//
+// Logs at Debug, not Info: this is the platform's documented default behavior,
+// not an exceptional condition that requires operator attention. Operators who
+// want to silence the path entirely can set the kind explicitly in YAML (with
+// either enabled state).
+func AutoEnableKind(toolkits map[string]any, kind string) {
+	if _, exists := toolkits[kind]; exists {
+		return
+	}
+	toolkits[kind] = map[string]any{keyEnabled: true}
+	slog.Debug("auto-enabled toolkit kind (requirements met, no explicit YAML)",
+		"kind", kind)
+}
+
+// MergeInstance merges one stored connection into the toolkit config map under
+// its kind's instances. It is a no-op when the kind is absent or disabled, and
+// when the kind already carries an instance of that name: file config takes
+// precedence over a connection held in the database.
+//
+// Instances merged here arrive after Config.Validate has run, so they are not
+// covered by MissingDefaults: a kind can hold several of them with no
+// "default", which is why ResolveDefaultInstance resolves deterministically
+// rather than relying on that refusal.
+func MergeInstance(toolkits map[string]any, kind, name string, cfg map[string]any) {
+	kindMap, ok := toolkits[kind].(map[string]any)
+	if !ok || !KindEnabled(kindMap) {
+		return
+	}
+
+	kindInstances, ok := kindMap[keyInstances].(map[string]any)
+	if !ok {
+		kindInstances = make(map[string]any)
+		kindMap[keyInstances] = kindInstances
+	}
+
+	if _, exists := kindInstances[name]; !exists {
+		kindInstances[name] = cfg
+		slog.Info("merged DB connection into toolkit config", "kind", kind, "name", name)
+	}
+}
+
+// PinDeclaredDefaults records, for every kind that declares instances without a
+// "default", the instance its config resolves to today. Call it once before
+// merging connections held in the database.
+//
+// Without it, a kind that declares a single instance and needs no "default"
+// changes meaning when an admin-UI connection whose name sorts earlier joins
+// the same map: the next restart resolves the unqualified lookup to the new
+// connection and moves a provider, or managed-resource blob storage, off the
+// connection the file pointed at. Pinning first is the same rule MergeInstance
+// already follows, that file config outranks a stored connection.
+func PinDeclaredDefaults(toolkits map[string]any) {
+	for _, kindCfg := range toolkits {
+		kindMap, ok := kindCfg.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, ok := kindMap[keyDefault].(string); ok && name != "" {
+			continue
+		}
+		instances, ok := kindMap[keyInstances].(map[string]any)
+		if !ok || len(instances) == 0 {
+			continue
+		}
+		kindMap[keyDefault] = ResolveDefaultInstance(kindMap, instances)
+	}
+}
+
+// KindEnabled reports whether a toolkit kind map has enabled=true. It handles
+// both bool and string values, because environment-variable expansion produces
+// strings.
+func KindEnabled(kindMap map[string]any) bool {
+	v, ok := kindMap[keyEnabled]
+	if !ok {
+		return false
+	}
+	switch val := v.(type) {
+	case bool:
+		return val
+	case string:
+		return val == "true"
+	default:
+		return false
+	}
+}

--- a/internal/platform/toolkitcfg/merge_test.go
+++ b/internal/platform/toolkitcfg/merge_test.go
@@ -1,0 +1,166 @@
+package toolkitcfg
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAutoEnableKind(t *testing.T) {
+	t.Run("absent kind is enabled", func(t *testing.T) {
+		toolkits := map[string]any{}
+		AutoEnableKind(toolkits, "s3")
+		if !reflect.DeepEqual(toolkits["s3"], map[string]any{"enabled": true}) {
+			t.Errorf("toolkits[s3] = %#v, want enabled=true", toolkits["s3"])
+		}
+	})
+	t.Run("an explicit choice is never overridden", func(t *testing.T) {
+		for _, declared := range []any{true, false} {
+			toolkits := map[string]any{"s3": map[string]any{"enabled": declared, "instances": map[string]any{}}}
+			AutoEnableKind(toolkits, "s3")
+			kindMap, ok := toolkits["s3"].(map[string]any)
+			if !ok {
+				t.Fatalf("toolkits[s3] = %#v, want a map", toolkits["s3"])
+			}
+			if kindMap["enabled"] != declared {
+				t.Errorf("enabled = %#v, want %#v", kindMap["enabled"], declared)
+			}
+			if _, kept := kindMap["instances"]; !kept {
+				t.Error("AutoEnableKind replaced the declared kind block")
+			}
+		}
+	})
+}
+
+func TestMergeInstance(t *testing.T) {
+	cfg := map[string]any{"region": "us-east-1"}
+
+	t.Run("merged into an enabled kind", func(t *testing.T) {
+		toolkits := map[string]any{"s3": map[string]any{"enabled": true}}
+		MergeInstance(toolkits, "s3", "lake", cfg)
+		if got := InstanceConfig(toolkits, "s3", "lake"); !reflect.DeepEqual(got, cfg) {
+			t.Errorf("InstanceConfig = %#v, want %#v", got, cfg)
+		}
+	})
+	t.Run("file config wins over a stored connection", func(t *testing.T) {
+		fileCfg := map[string]any{"region": "eu-west-1"}
+		toolkits := map[string]any{"s3": map[string]any{
+			"enabled":   true,
+			"instances": map[string]any{"lake": fileCfg},
+		}}
+		MergeInstance(toolkits, "s3", "lake", cfg)
+		if got := InstanceConfig(toolkits, "s3", "lake"); !reflect.DeepEqual(got, fileCfg) {
+			t.Errorf("InstanceConfig = %#v, want the file config %#v", got, fileCfg)
+		}
+	})
+	t.Run("no-op for an absent or disabled kind", func(t *testing.T) {
+		for name, toolkits := range map[string]map[string]any{
+			"absent":   {},
+			"disabled": {"s3": map[string]any{"enabled": false}},
+		} {
+			MergeInstance(toolkits, "s3", "lake", cfg)
+			if got := InstanceConfig(toolkits, "s3", "lake"); got != nil {
+				t.Errorf("%s: InstanceConfig = %#v, want nil", name, got)
+			}
+		}
+	})
+	t.Run("several merged instances still resolve deterministically", func(t *testing.T) {
+		// Stored connections merge after Config.Validate has run, so
+		// MissingDefaults never sees them and the kind can hold several with
+		// no "default". The resolution must still not move between restarts.
+		const want = "archive"
+		for range 100 {
+			toolkits := map[string]any{"s3": map[string]any{"enabled": true}}
+			for _, name := range []string{"lake", "archive", "warehouse"} {
+				MergeInstance(toolkits, "s3", name, cfg)
+			}
+			kindMap, ok := toolkits["s3"].(map[string]any)
+			if !ok {
+				t.Fatalf("toolkits[s3] = %#v, want a map", toolkits["s3"])
+			}
+			instances, ok := kindMap["instances"].(map[string]any)
+			if !ok {
+				t.Fatalf("instances = %#v, want a map", kindMap["instances"])
+			}
+			if got := ResolveDefaultInstance(kindMap, instances); got != want {
+				t.Fatalf("ResolveDefaultInstance = %q, want %q", got, want)
+			}
+		}
+	})
+}
+
+func TestKindEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		kindMap map[string]any
+		want    bool
+	}{
+		{name: "absent key", kindMap: map[string]any{}},
+		{name: "bool true", kindMap: map[string]any{"enabled": true}, want: true},
+		{name: "bool false", kindMap: map[string]any{"enabled": false}},
+		{name: "expanded string true", kindMap: map[string]any{"enabled": "true"}, want: true},
+		{name: "expanded string false", kindMap: map[string]any{"enabled": "false"}},
+		{name: "unusable type", kindMap: map[string]any{"enabled": 1}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := KindEnabled(tt.kindMap); got != tt.want {
+				t.Errorf("KindEnabled(%#v) = %v, want %v", tt.kindMap, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPinDeclaredDefaults(t *testing.T) {
+	t.Run("a declared instance keeps the lookup a merged one would take", func(t *testing.T) {
+		// One declared instance needs no "default", so nothing recorded which
+		// connection the file meant. An admin-UI connection sorting earlier
+		// would answer the unqualified lookup at the next restart.
+		toolkits := map[string]any{"s3": map[string]any{
+			"enabled":   true,
+			"instances": map[string]any{"lake": map[string]any{"region": "us-east-1"}},
+		}}
+		PinDeclaredDefaults(toolkits)
+		MergeInstance(toolkits, "s3", "archive", map[string]any{"region": "us-west-2"})
+
+		cfg := S3Config(toolkits, "")
+		if cfg == nil {
+			t.Fatal("S3Config returned nil")
+		}
+		if cfg.ConnectionName != "lake" {
+			t.Errorf("ConnectionName = %q, want lake", cfg.ConnectionName)
+		}
+		if _, merged := InstanceConfig(toolkits, "s3", "archive")["region"]; !merged {
+			t.Error("the stored connection was not merged")
+		}
+	})
+	t.Run("a named default is never overwritten", func(t *testing.T) {
+		toolkits := map[string]any{"s3": map[string]any{
+			"default":   "archive",
+			"instances": map[string]any{"archive": nil, "lake": nil},
+		}}
+		PinDeclaredDefaults(toolkits)
+		kindMap, ok := toolkits["s3"].(map[string]any)
+		if !ok {
+			t.Fatalf("toolkits[s3] = %#v, want a map", toolkits["s3"])
+		}
+		if kindMap["default"] != "archive" {
+			t.Errorf("default = %#v, want archive", kindMap["default"])
+		}
+	})
+	t.Run("nothing to pin", func(t *testing.T) {
+		// A kind whose instances all come from the database has no declared
+		// instance to protect, so no default is invented for it.
+		toolkits := map[string]any{
+			"s3":  map[string]any{"enabled": true},
+			"mcp": "not-a-map",
+		}
+		PinDeclaredDefaults(toolkits)
+		kindMap, ok := toolkits["s3"].(map[string]any)
+		if !ok {
+			t.Fatalf("toolkits[s3] = %#v, want a map", toolkits["s3"])
+		}
+		if _, pinned := kindMap["default"]; pinned {
+			t.Errorf("default = %#v, want none", kindMap["default"])
+		}
+	})
+}

--- a/internal/platform/toolkitcfg/toolkitcfg.go
+++ b/internal/platform/toolkitcfg/toolkitcfg.go
@@ -10,6 +10,10 @@
 package toolkitcfg
 
 import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/txn2/mcp-data-platform/internal/platform/cfgmap"
@@ -76,19 +80,28 @@ type S3 struct {
 // instance is "" it resolves the default (or first) instance. Returns nil if
 // the kind, its instances map, or the named instance is absent or malformed.
 func InstanceConfig(toolkits map[string]any, kind, instance string) map[string]any {
+	instanceCfg, _ := resolveInstance(toolkits, kind, instance)
+	return instanceCfg
+}
+
+// resolveInstance returns one instance's config map along with the instance
+// name it resolved to. Callers that label a connection need the name: with an
+// empty instance the caller does not know which one it was handed, and naming
+// it "" leaves every downstream connection label blank.
+func resolveInstance(toolkits map[string]any, kind, instance string) (instanceCfg map[string]any, resolved string) {
 	toolkitsCfg, ok := toolkits[kind]
 	if !ok {
-		return nil
+		return nil, ""
 	}
 
 	kindCfg, ok := toolkitsCfg.(map[string]any)
 	if !ok {
-		return nil
+		return nil, ""
 	}
 
 	instances, ok := kindCfg[keyInstances].(map[string]any)
 	if !ok {
-		return nil
+		return nil, ""
 	}
 
 	// If no instance name specified, try to get the default
@@ -96,25 +109,88 @@ func InstanceConfig(toolkits map[string]any, kind, instance string) map[string]a
 		instance = ResolveDefaultInstance(kindCfg, instances)
 	}
 
-	instanceCfg, ok := instances[instance].(map[string]any)
+	instanceCfg, ok = instances[instance].(map[string]any)
 	if !ok {
-		return nil
+		return nil, ""
 	}
 
-	return instanceCfg
+	return instanceCfg, instance
 }
 
-// ResolveDefaultInstance determines which instance to use: the one named by the
-// kind's "default" key, else the first instance, else "".
+// ResolveDefaultInstance determines which instance a lookup that names none
+// means: the one named by the kind's "default" key, else the lexicographically
+// first instance, else "".
+//
+// The fallback compares names rather than taking whatever a map range hands
+// back first. Go randomizes map iteration order, so ranging resolved a
+// different instance on every process start: two replicas built from one
+// config disagreed about which connection an unqualified lookup meant, and a
+// restart could point managed-resource blob storage at a different S3
+// connection than the one existing resources were written through. The
+// multi-connection Trino toolkit picks its own default the same way
+// (pkg/toolkits/trino/toolkit.go).
+//
+// An empty "default" is treated as absent, so it agrees with MissingDefaults
+// about which configs have named an instance.
 func ResolveDefaultInstance(kindCfg, instances map[string]any) string {
-	if defaultName, ok := kindCfg[keyDefault].(string); ok {
+	if defaultName, ok := kindCfg[keyDefault].(string); ok && defaultName != "" {
 		return defaultName
 	}
-	// Use the first instance
+	first := ""
 	for name := range instances {
-		return name
+		if first == "" || name < first {
+			first = name
+		}
 	}
-	return ""
+	return first
+}
+
+// resolvedKinds are the toolkit kinds an unqualified lookup can land on: they
+// are the kinds InstanceConfig is called with, by the semantic, query and
+// storage providers, by apply_knowledge and by managed resources. The gateway
+// kinds are absent because nothing resolves a default for them — every proxied
+// tool is namespaced by its connection — so requiring one there would refuse a
+// config over a key that changes nothing.
+var resolvedKinds = []string{kindDataHub, kindS3, kindTrino}
+
+// MissingDefaults returns one message per toolkit kind that configures more
+// than one instance without a "default" key naming which of them a lookup that
+// omits the instance means. Kinds and the instance names within a message are
+// sorted, so the same config produces the same messages on every run. Callers
+// treat a non-empty result as a config error; Config.Validate does.
+//
+// Two DataHub catalogs with no default is not a deployment that chose either
+// one: whichever the platform picks binds the semantic provider, the query
+// provider and the managed-resource blob store to a connection the operator
+// never named. Naming the candidates lets them make that choice.
+//
+// A kind is checked whether or not it is enabled, because the providers read
+// an instance's config through InstanceConfig without consulting the enable
+// flag: a catalog used only for enrichment registers no tools and still has to
+// say which of its instances the enrichment reads.
+//
+// This covers only the instances a config declares. Connections held in the
+// database merge into the toolkits config after validation; PinDeclaredDefaults
+// keeps them from taking over the lookup a declared instance answers today.
+func MissingDefaults(toolkits map[string]any) []string {
+	var msgs []string
+	for _, kind := range resolvedKinds {
+		kindCfg, ok := toolkits[kind].(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, ok := kindCfg[keyDefault].(string); ok && name != "" {
+			continue
+		}
+		instances, ok := kindCfg[keyInstances].(map[string]any)
+		if !ok || len(instances) < 2 {
+			continue
+		}
+		msgs = append(msgs, fmt.Sprintf(
+			"toolkits.%s.default is required when more than one instance is configured (instances: %s)",
+			kind, strings.Join(slices.Sorted(maps.Keys(instances)), ", ")))
+	}
+	return msgs
 }
 
 // DataHubConfig extracts DataHub configuration for the named instance (or the
@@ -169,7 +245,7 @@ func TrinoConfig(toolkits map[string]any, instance string) *Trino {
 // instance when instance is ""). Returns nil if not configured. When the
 // instance omits connection_name it defaults to the instance name.
 func S3Config(toolkits map[string]any, instance string) *S3 {
-	instanceCfg := InstanceConfig(toolkits, kindS3, instance)
+	instanceCfg, resolved := resolveInstance(toolkits, kindS3, instance)
 	if instanceCfg == nil {
 		return nil
 	}
@@ -185,7 +261,7 @@ func S3Config(toolkits map[string]any, instance string) *S3 {
 	}
 
 	if cfg.ConnectionName == "" {
-		cfg.ConnectionName = instance
+		cfg.ConnectionName = resolved
 	}
 
 	return cfg

--- a/internal/platform/toolkitcfg/toolkitcfg_test.go
+++ b/internal/platform/toolkitcfg/toolkitcfg_test.go
@@ -1,6 +1,7 @@
 package toolkitcfg
 
 import (
+	"slices"
 	"testing"
 	"time"
 )
@@ -172,4 +173,164 @@ func TestS3Config(t *testing.T) {
 			t.Errorf("S3Config connection_name = %+v, want myinstance", cfg)
 		}
 	})
+}
+
+func TestResolveDefaultInstanceIsStableAcrossRestarts(t *testing.T) {
+	// Go randomizes map iteration order, so a fallback that ranged the
+	// instances map resolved a different instance on each process start: two
+	// replicas built from one config disagreed about which connection an
+	// unqualified lookup meant. Building the map fresh each round models a
+	// restart; the answer must not move. A single resolution would pass by
+	// luck.
+	newInstances := func() map[string]any {
+		return map[string]any{"zeta": nil, "delta": nil, "alpha": nil, "omega": nil, "beta": nil}
+	}
+	const want = "alpha"
+	for i := range 200 {
+		if got := ResolveDefaultInstance(map[string]any{}, newInstances()); got != want {
+			t.Fatalf("round %d: ResolveDefaultInstance = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestResolveDefaultInstanceUnusableDefaultKey(t *testing.T) {
+	// An empty or non-string "default" has named nothing, so it falls through
+	// to the deterministic pick rather than resolving to "".
+	instances := map[string]any{"beta": nil, "alpha": nil}
+	for name, kindCfg := range map[string]map[string]any{
+		"empty string": {"default": ""},
+		"not a string": {"default": 7},
+	} {
+		if got := ResolveDefaultInstance(kindCfg, instances); got != "alpha" {
+			t.Errorf("%s: ResolveDefaultInstance = %q, want alpha", name, got)
+		}
+	}
+}
+
+func TestMissingDefaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolkits map[string]any
+		want     []string
+	}{
+		{name: "nil config"},
+		{
+			name: "single instance needs no default",
+			toolkits: map[string]any{"s3": map[string]any{
+				"instances": map[string]any{"only": nil},
+			}},
+		},
+		{
+			name: "several instances with a default",
+			toolkits: map[string]any{"s3": map[string]any{
+				"default":   "archive",
+				"instances": map[string]any{"archive": nil, "lake": nil},
+			}},
+		},
+		{
+			name: "several instances without a default",
+			toolkits: map[string]any{"s3": map[string]any{
+				"instances": map[string]any{"lake": nil, "archive": nil},
+			}},
+			want: []string{"toolkits.s3.default is required when more than one instance is configured (instances: archive, lake)"},
+		},
+		{
+			name: "empty default does not count as named",
+			toolkits: map[string]any{"datahub": map[string]any{
+				"default":   "",
+				"instances": map[string]any{"primary": nil, "secondary": nil},
+			}},
+			want: []string{"toolkits.datahub.default is required when more than one instance is configured (instances: primary, secondary)"},
+		},
+		{
+			name: "every offending kind is reported, sorted",
+			toolkits: map[string]any{
+				"trino": map[string]any{
+					"instances": map[string]any{"staging": nil, "production": nil},
+				},
+				"datahub": map[string]any{
+					"instances": map[string]any{"b": nil, "a": nil},
+				},
+				"s3": map[string]any{
+					"default":   "lake",
+					"instances": map[string]any{"lake": nil, "archive": nil},
+				},
+			},
+			want: []string{
+				"toolkits.datahub.default is required when more than one instance is configured (instances: a, b)",
+				"toolkits.trino.default is required when more than one instance is configured (instances: production, staging)",
+			},
+		},
+		{
+			// The gateway kinds namespace every proxied tool by its
+			// connection, so nothing resolves a default for them and
+			// requiring one would refuse a config over an inert key.
+			name: "gateway kinds are not asked for a default",
+			toolkits: map[string]any{
+				"mcp": map[string]any{
+					"enabled":   true,
+					"instances": map[string]any{"upstream_a": nil, "upstream_b": nil},
+				},
+				"api": map[string]any{
+					"enabled":   true,
+					"instances": map[string]any{"billing": nil, "crm": nil},
+				},
+			},
+		},
+		{
+			// The providers read an instance through InstanceConfig without
+			// consulting the enable flag, so a disabled kind is still asked
+			// which of its instances an unqualified lookup means.
+			name: "a disabled kind is still ambiguous",
+			toolkits: map[string]any{"datahub": map[string]any{
+				"enabled":   false,
+				"instances": map[string]any{"primary": nil, "legacy": nil},
+			}},
+			want: []string{"toolkits.datahub.default is required when more than one instance is configured (instances: legacy, primary)"},
+		},
+		{
+			name:     "malformed kind block is not a default problem",
+			toolkits: map[string]any{"s3": "not-a-map"},
+		},
+		{
+			name: "malformed instances block is not a default problem",
+			toolkits: map[string]any{"s3": map[string]any{
+				"instances": []string{"lake", "archive"},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MissingDefaults(tt.toolkits)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("MissingDefaults() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestS3ConfigNamesTheResolvedConnection(t *testing.T) {
+	// An instance that omits connection_name is labeled by the instance name.
+	// Resolving through the default used to hand back the caller's empty
+	// string instead, leaving every downstream connection label blank.
+	toolkits := map[string]any{"s3": map[string]any{
+		"default": "archive",
+		"instances": map[string]any{
+			"archive": map[string]any{"region": "us-west-2"},
+			"lake":    map[string]any{"region": "us-east-1"},
+		},
+	}}
+	cfg := S3Config(toolkits, "")
+	if cfg == nil {
+		t.Fatal("S3Config returned nil")
+	}
+	if cfg.ConnectionName != "archive" {
+		t.Errorf("ConnectionName = %q, want archive", cfg.ConnectionName)
+	}
+	if cfg.Region != "us-west-2" {
+		t.Errorf("Region = %q, want us-west-2", cfg.Region)
+	}
+	if named := S3Config(toolkits, "lake"); named == nil || named.ConnectionName != "lake" {
+		t.Errorf("S3Config(lake) = %+v, want ConnectionName lake", named)
+	}
 }

--- a/pkg/embedding/ollama.go
+++ b/pkg/embedding/ollama.go
@@ -132,12 +132,33 @@ func NewOllamaProvider(cfg OllamaConfig) Provider {
 	}
 
 	return &ollamaProvider{
-		client:        &http.Client{Timeout: cfg.Timeout},
+		client:        &http.Client{Timeout: cfg.Timeout, Transport: cloneTransport(http.DefaultTransport)},
 		url:           cfg.URL,
 		model:         cfg.Model,
 		dim:           DefaultDimension,
 		maxInputBytes: cfg.MaxInputBytes,
 	}
+}
+
+// cloneTransport returns an independent copy of rt so the provider runs on its
+// own connection pool rather than the process-wide one.
+//
+// A pool shared with every other HTTP client in the process is not the
+// provider's to manage, and anything that empties it empties the provider's
+// connections too. httptest.Server.Close does exactly that: it calls
+// CloseIdleConnections on http.DefaultTransport as a convenience for its users
+// (net/http/httptest/server.go). A request already holding a pooled connection
+// then fails with "http: CloseIdleConnections called" rather than reaching its
+// server, which is how a parallel test elsewhere could break an embedding
+// request that had nothing to do with it.
+//
+// A RoundTripper the caller installed in place of the standard transport is
+// returned as it is: whatever pooling it does is its own.
+func cloneTransport(rt http.RoundTripper) http.RoundTripper {
+	if t, ok := rt.(*http.Transport); ok {
+		return t.Clone()
+	}
+	return rt
 }
 
 // ollamaRequest is the JSON body sent to Ollama's /api/embeddings endpoint.

--- a/pkg/embedding/ollama_test.go
+++ b/pkg/embedding/ollama_test.go
@@ -3,6 +3,7 @@ package embedding
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -237,6 +238,47 @@ func TestOllamaProvider_EmbedBatch_FallbackOn404(t *testing.T) {
 	require.Len(t, results2, 2)
 	assert.Equal(t, 1, batchCallCount, "second call must skip /api/embed entirely")
 	assert.Equal(t, 5, singularCallCount, "second call adds two more /api/embeddings calls")
+}
+
+// The provider must not run on the process-wide connection pool. Anything that
+// empties http.DefaultTransport's idle connections empties the provider's too,
+// and httptest.Server.Close empties it on every close, so a parallel test
+// elsewhere could break an embedding request that had nothing to do with it.
+func TestOllamaProviderDoesNotShareTheDefaultTransport(t *testing.T) {
+	t.Parallel()
+
+	p, ok := NewOllamaProvider(OllamaConfig{URL: "http://ollama.example.com"}).(*ollamaProvider)
+	require.True(t, ok, "NewOllamaProvider returns *ollamaProvider")
+	require.NotNil(t, p.client.Transport, "a nil Transport falls back to http.DefaultTransport")
+	assert.NotSame(t, http.DefaultTransport, p.client.Transport)
+}
+
+// errStubRoundTrip is what stubRoundTripper answers with. The stub exists to be
+// recognized by type, never to carry a request, so it refuses every one.
+var errStubRoundTrip = errors.New("stub round tripper carries no request")
+
+// stubRoundTripper stands in for a RoundTripper a caller installed in place of
+// the standard transport.
+type stubRoundTripper struct{}
+
+func (stubRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errStubRoundTrip
+}
+
+func TestCloneTransport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("the standard transport is copied", func(t *testing.T) {
+		t.Parallel()
+		got := cloneTransport(http.DefaultTransport)
+		assert.NotSame(t, http.DefaultTransport, got)
+		assert.IsType(t, &http.Transport{}, got)
+	})
+	t.Run("any other RoundTripper is left alone", func(t *testing.T) {
+		t.Parallel()
+		rt := stubRoundTripper{}
+		assert.Equal(t, rt, cloneTransport(rt))
+	})
 }
 
 func TestOllamaProvider_EmbedBatch_FallbackPropagatesSequentialError(t *testing.T) {

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/txn2/mcp-data-platform/internal/platform/reflexivecapture"
 	"github.com/txn2/mcp-data-platform/internal/platform/scriptexec"
 	"github.com/txn2/mcp-data-platform/internal/platform/toolargs"
+	"github.com/txn2/mcp-data-platform/internal/platform/toolkitcfg"
 	"github.com/txn2/mcp-data-platform/pkg/browsersession"
 	"github.com/txn2/mcp-data-platform/pkg/portal/knowledgepage"
 	datahubsemantic "github.com/txn2/mcp-data-platform/pkg/semantic/datahub"
@@ -1978,6 +1979,13 @@ func (c *Config) Validate() error {
 	if c.Auth.OIDC.Enabled && c.Auth.OIDC.Issuer == "" {
 		errs = append(errs, "auth.oidc.issuer is required when OIDC is enabled")
 	}
+
+	// A kind with several instances and no "default" leaves the platform to
+	// pick which connection an unqualified lookup (semantic.instance,
+	// query.instance, storage.instance, knowledge.apply.datahub_connection)
+	// means. Refuse here and name the candidates rather than resolve to one
+	// the operator did not choose.
+	errs = append(errs, toolkitcfg.MissingDefaults(c.Toolkits)...)
 
 	errs = c.validateOAuth(errs)
 	errs = c.validateSessions(errs)

--- a/pkg/platform/config_test.go
+++ b/pkg/platform/config_test.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2219,6 +2220,48 @@ func TestConfigValidate_RejectsBadAuditDelivery(t *testing.T) {
 	if !strings.Contains(err.Error(), "audit.delivery") {
 		t.Errorf("expected error to mention audit.delivery, got %v", err)
 	}
+}
+
+// TestConfigValidate_RequiresDefaultForMultipleInstances covers the refusal
+// that keeps the platform from choosing a connection the operator never named.
+// Which instance an unqualified lookup (semantic.instance, query.instance,
+// storage.instance, knowledge.apply.datahub_connection) means is undefined when
+// a kind holds several with no "default", so the config is refused at startup
+// with the candidates named rather than resolved to one of them.
+func TestConfigValidate_RequiresDefaultForMultipleInstances(t *testing.T) {
+	twoInstances := func(extra map[string]any) map[string]any {
+		kind := map[string]any{"instances": map[string]any{
+			"primary":   map[string]any{"url": "https://a.example.com"},
+			"secondary": map[string]any{"url": "https://b.example.com"},
+		}}
+		maps.Copy(kind, extra)
+		return map[string]any{"datahub": kind}
+	}
+
+	t.Run("refused with the candidates named", func(t *testing.T) {
+		err := (&Config{Toolkits: twoInstances(nil)}).Validate()
+		if err == nil {
+			t.Fatal("expected Validate to refuse two datahub instances with no default")
+		}
+		for _, want := range []string{"toolkits.datahub.default", "primary, secondary"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("expected error to mention %q, got %v", want, err)
+			}
+		}
+	})
+	t.Run("accepted once an instance is named", func(t *testing.T) {
+		if err := (&Config{Toolkits: twoInstances(map[string]any{"default": "primary"})}).Validate(); err != nil {
+			t.Errorf("Validate() = %v, want nil once default names an instance", err)
+		}
+	})
+	t.Run("a single instance needs no default", func(t *testing.T) {
+		cfg := &Config{Toolkits: map[string]any{"s3": map[string]any{
+			"instances": map[string]any{"lake": map[string]any{"region": "us-east-1"}},
+		}}}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate() = %v, want nil for a single instance", err)
+		}
+	})
 }
 
 // TestScriptsConfig_IsWorkerEnabled covers the switch that separates the

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -3024,8 +3024,8 @@ func (p *Platform) ConnectionSources() *ConnectionSourceMap {
 //
 //  2. Trino and S3 toolkit kinds auto-enable when an operator saves their
 //     first DB instance via the admin UI. Pre-fix, the saved row was
-//     orphaned: the kind block didn't exist, isToolkitEnabled returned
-//     false, mergeConnectionInstance was a no-op, and the toolkit loader
+//     orphaned: the kind block didn't exist, toolkitcfg.KindEnabled
+//     returned false, the merge was a no-op, and the toolkit loader
 //     never instantiated anything.
 //
 // Operator-set values are never overridden — if the YAML explicitly sets
@@ -3053,6 +3053,11 @@ func (p *Platform) mergeDBConnectionsIntoConfig() {
 		p.config.Toolkits = make(map[string]any)
 	}
 
+	// Pin what the file already resolves to before anything from the database
+	// joins the instance maps, so a stored connection cannot take over the
+	// lookup a declared instance answers today.
+	toolkitcfg.PinDeclaredDefaults(p.config.Toolkits)
+
 	// (1) The gateway toolkits need no instance config to be useful —
 	// auto-enable so the admin UI's "Add Connection" path produces a
 	// live toolkit on the next request. Both the MCP gateway (#338)
@@ -3060,8 +3065,8 @@ func (p *Platform) mergeDBConnectionsIntoConfig() {
 	// connections are added dynamically through the admin UI rather
 	// than via YAML 'instances' blocks, so the kind has to be
 	// pre-enabled for saves to land in a live toolkit.
-	p.autoEnableToolkitKind(kindMCP)
-	p.autoEnableToolkitKind(kindAPI)
+	toolkitcfg.AutoEnableKind(p.config.Toolkits, kindMCP)
+	toolkitcfg.AutoEnableKind(p.config.Toolkits, kindAPI)
 
 	instances, err := p.connectionStore.List(context.Background())
 	if err != nil {
@@ -3084,65 +3089,9 @@ func (p *Platform) mergeDBConnectionsIntoConfig() {
 	for _, inst := range instances {
 		if manageableKinds[inst.Kind] {
 			// (2) Auto-enable the kind so the merge actually has effect.
-			p.autoEnableToolkitKind(inst.Kind)
-			mergeConnectionInstance(p.config.Toolkits, inst)
+			toolkitcfg.AutoEnableKind(p.config.Toolkits, inst.Kind)
+			toolkitcfg.MergeInstance(p.config.Toolkits, inst.Kind, inst.Name, inst.Config)
 		}
-	}
-}
-
-// autoEnableToolkitKind ensures p.config.Toolkits[kind] exists with
-// enabled=true so the toolkit loader will instantiate it. Idempotent and
-// non-overriding: if the operator has already declared the kind block
-// (enabled OR disabled), their explicit choice is respected.
-//
-// Logs at Debug, not Info: this is the platform's documented default
-// behavior, not an exceptional condition that requires operator
-// attention. Operators who want to silence the path entirely can set
-// the kind explicitly in YAML (with either enabled state).
-func (p *Platform) autoEnableToolkitKind(kind string) {
-	if _, exists := p.config.Toolkits[kind]; exists {
-		return
-	}
-	p.config.Toolkits[kind] = map[string]any{cfgKeyEnabled: true}
-	slog.Debug("auto-enabled toolkit kind (requirements met, no explicit YAML)",
-		"kind", kind)
-}
-
-// mergeConnectionInstance merges a single DB connection instance into the
-// toolkit config map. File config takes precedence over DB connections.
-func mergeConnectionInstance(toolkits map[string]any, inst ConnectionInstance) {
-	kindMap, ok := toolkits[inst.Kind].(map[string]any)
-	if !ok || !isToolkitEnabled(kindMap) {
-		return
-	}
-
-	kindInstances, ok := kindMap[cfgKeyInstances].(map[string]any)
-	if !ok {
-		kindInstances = make(map[string]any)
-		kindMap[cfgKeyInstances] = kindInstances
-	}
-
-	// Only add if not already present (file config takes precedence)
-	if _, exists := kindInstances[inst.Name]; !exists {
-		kindInstances[inst.Name] = inst.Config
-		slog.Info("merged DB connection into toolkit config", "kind", inst.Kind, "name", inst.Name)
-	}
-}
-
-// isToolkitEnabled checks if a toolkit kind map has enabled=true.
-// Handles both bool and string values (env var expansion produces strings).
-func isToolkitEnabled(kindMap map[string]any) bool {
-	v, ok := kindMap[cfgKeyEnabled]
-	if !ok {
-		return false
-	}
-	switch val := v.(type) {
-	case bool:
-		return val
-	case string:
-		return val == "true"
-	default:
-		return false
 	}
 }
 

--- a/pkg/platform/platform_test.go
+++ b/pkg/platform/platform_test.go
@@ -3858,6 +3858,43 @@ func TestMergeDBConnectionsIntoConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("a stored connection does not take over the declared default", func(t *testing.T) {
+		// The file declares one S3 instance, so it needs no "default" and
+		// nothing recorded which connection it meant. Merging an admin-UI
+		// connection whose name sorts earlier used to hand the unqualified
+		// lookup to the stored one at the next restart, moving managed-resource
+		// blob storage off the connection the file pointed at.
+		p := &Platform{
+			config: &Config{
+				Toolkits: map[string]any{
+					"s3": map[string]any{
+						cfgKeyEnabled: true,
+						cfgKeyInstances: map[string]any{
+							"lake": map[string]any{"region": "us-east-1"},
+						},
+					},
+				},
+			},
+			connectionStore: &mockConnectionStoreForTest{
+				instances: []ConnectionInstance{
+					{Kind: "s3", Name: "archive", Config: map[string]any{"region": "us-west-2"}},
+				},
+			},
+		}
+		p.mergeDBConnectionsIntoConfig()
+
+		cfg := toolkitcfg.S3Config(p.config.Toolkits, "")
+		if cfg == nil {
+			t.Fatal("S3Config returned nil")
+		}
+		if cfg.ConnectionName != "lake" {
+			t.Errorf("unqualified lookup resolved to %q, want lake", cfg.ConnectionName)
+		}
+		if toolkitcfg.S3Config(p.config.Toolkits, "archive") == nil {
+			t.Error("the stored connection should still have merged")
+		}
+	})
+
 	t.Run("skips disabled toolkit kind", func(t *testing.T) {
 		p := &Platform{
 			config: &Config{

--- a/pkg/registry/loader.go
+++ b/pkg/registry/loader.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"fmt"
 	"log/slog"
 	"maps"
 )
@@ -134,6 +135,14 @@ func mergeMapInstances(instances, kindConfig map[string]any) map[string]map[stri
 }
 
 // loadAggregate invokes an aggregate factory and registers the resulting toolkit.
+//
+// A failure here is fatal, unlike the per-instance loop above, because the two
+// failures are not the same size: one bad instance of a per-instance kind costs
+// that instance, while an aggregate kind builds every one of its connections in
+// a single toolkit, so a failed factory costs all of them. Reporting that as a
+// warning left a deployment serving no Trino tools at all with nothing but a
+// log line to say why — a mistyped toolkits.trino.default is enough to trigger
+// it, and the operator sees a platform that simply cannot query.
 func (l *Loader) loadAggregate(
 	kind, defaultName string,
 	instances map[string]map[string]any,
@@ -141,9 +150,7 @@ func (l *Loader) loadAggregate(
 ) error {
 	toolkit, err := factory(defaultName, instances)
 	if err != nil {
-		slog.Warn("skipping aggregate toolkit",
-			"kind", kind, "error", err)
-		return nil
+		return fmt.Errorf("building the %s toolkit: %w", kind, err)
 	}
 	return l.registry.Register(toolkit)
 }

--- a/pkg/registry/loader_test.go
+++ b/pkg/registry/loader_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -176,7 +177,11 @@ func TestLoader_Load(t *testing.T) {
 		}
 	})
 
-	t.Run("aggregate factory error skipped", func(t *testing.T) {
+	// An aggregate kind holds every one of its connections in one toolkit, so a
+	// failed factory costs all of them, not one instance. Reported as a warning
+	// it left the deployment serving none of that kind's tools with only a log
+	// line to say why.
+	t.Run("aggregate factory error is reported", func(t *testing.T) {
 		reg := NewRegistry()
 		reg.RegisterAggregateFactory("failing", func(_ string, _ map[string]map[string]any) (Toolkit, error) {
 			return nil, fmt.Errorf("aggregate creation failed")
@@ -193,8 +198,13 @@ func TestLoader_Load(t *testing.T) {
 		}
 
 		err := loader.Load(cfg)
-		if err != nil {
-			t.Errorf("expected error to be skipped, got: %v", err)
+		if err == nil {
+			t.Fatal("expected the aggregate factory failure to be reported")
+		}
+		for _, want := range []string{"failing", "aggregate creation failed"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("expected the error to name %q, got: %v", want, err)
+			}
 		}
 		if len(reg.All()) != 0 {
 			t.Errorf("expected 0 toolkits, got %d", len(reg.All()))
@@ -358,7 +368,7 @@ func TestLoader_LoadFromMap(t *testing.T) {
 		}
 	})
 
-	t.Run("aggregate factory error from map skipped", func(t *testing.T) {
+	t.Run("aggregate factory error from map is reported", func(t *testing.T) {
 		reg := NewRegistry()
 		reg.RegisterAggregateFactory("fail-map", func(_ string, _ map[string]map[string]any) (Toolkit, error) {
 			return nil, fmt.Errorf("map aggregate failed")
@@ -373,8 +383,13 @@ func TestLoader_LoadFromMap(t *testing.T) {
 		}
 
 		err := loader.LoadFromMap(toolkits)
-		if err != nil {
-			t.Errorf("expected error to be skipped, got: %v", err)
+		if err == nil {
+			t.Fatal("expected the aggregate factory failure to be reported")
+		}
+		for _, want := range []string{"fail-map", "map aggregate failed"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("expected the error to name %q, got: %v", want, err)
+			}
 		}
 		if len(reg.All()) != 0 {
 			t.Errorf("expected 0 toolkits, got %d", len(reg.All()))


### PR DESCRIPTION
Closes #1395

## A lookup that names no instance

`toolkits.<kind>.default` names the instance an unqualified lookup resolves to: the semantic, query and storage provider blocks when their `instance` is unset, `knowledge.apply.datahub_connection`, `resources.managed.s3_connection`, and the connection a Trino tool call uses when it passes no `connection` parameter.

With no `default:` key, `ResolveDefaultInstance` ranged a Go map for the "first" instance. Map iteration order is randomized, so the answer was decided per process. Two replicas built from one config disagreed about which catalog they were reading, and a restart could point managed-resource blob storage at a different S3 connection than the one existing resources were written through. The fallback now compares names, which is how the multi-connection Trino toolkit has always picked its own default (`pkg/toolkits/trino/toolkit.go:183`).

Determinism alone still answers a question the operator never answered. `Config.Validate` now refuses a Trino, DataHub or S3 kind that configures more than one instance without a `default:`, listing the instances it found:

```
validating config: config validation errors: toolkits.datahub.default is required when more than one instance is configured (instances: legacy, primary)
```

Those three kinds are the ones `InstanceConfig` resolves. The gateway kinds are exempt: every tool they proxy is namespaced by its connection, so a `default:` there would change nothing. A kind is checked whether or not it is enabled, because the providers read an instance's settings through the same lookup without consulting the enable flag, so a catalog used only for enrichment registers no tools and still has to say which of its instances the enrichment reads.

Connections held in the database merge into the toolkit config during `initRegistries`, after `Config.Validate` has run in the composition root, so validation cannot see them. `PinDeclaredDefaults` records what the file resolves to before any of them merge. A kind that declares one instance needs no `default:` today; without pinning, an admin-UI connection whose name sorts earlier would answer that kind's lookups from the next restart onward.

## Three defects on the same path

`S3Config` with an empty instance returned an empty `ConnectionName`. `InstanceConfig` resolved the default internally and discarded the name, so the `connection_name` fallback assigned `""` and every `DatasetIdentifier.Connection` and `DatasetAvailability.Connection` downstream came back blank. It now reports the instance it resolved to.

An aggregate toolkit factory that fails is reported instead of logged and skipped. A per-instance kind loses one instance when one instance is bad; an aggregate kind builds all of its connections in a single toolkit, so a failed factory loses all of them. A mistyped `toolkits.trino.default` was enough to leave a deployment serving no Trino tools at all, with a single warning line to say why — and making `default:` mandatory makes that typo easier to write.

The session-start notice watermark is kept on the database clock. `portal_shares.created_at` defaults to `NOW()`, so a digest compared timestamps the database stamped against a boundary stamped from the process clock. A few milliseconds of skew between the application host and the database server placed an already-delivered share after the watermark and read it out to the caller a second time. `WatermarkStore` gained `Now(ctx)`, backed by `SELECT NOW()`, and both sides of the comparison now come from one clock.

## Package placement

`autoEnableToolkitKind`, `mergeConnectionInstance` and `isToolkitEnabled` move from `pkg/platform` into `internal/platform/toolkitcfg` as `AutoEnableKind`, `MergeInstance` and `KindEnabled`. They write the toolkit config map that package already reads, and `pkg/platform` was at its `TestPackageSizeBudget` ceiling. Their tests reach them through `mergeDBConnectionsIntoConfig`, which stays where it is, so no test moved with them.

## What the docs said

`docs/server/multi-provider.md` documented the bug as a feature: "The first instance configured becomes the default. You can rely on this behavior." That section now describes the `default:` key, the refusal, and what happens to a kind whose instances all come from the database. The `connection` parameter rows in `docs/reference/tools-api.md` are corrected for Trino only — for DataHub and S3 the default connection is decided by the upstream toolkit rather than by `toolkits.<kind>.default`, and neither the old wording nor the new one describes those kinds accurately.

## Verification

`make verify` passes: lint clean against the merge base on a cold cache, patch coverage 100% (97/97 changed lines), race suite, real-DB gate, gosec, govulncheck, semgrep, CodeQL, goreleaser, 199 portal e2e.

`TestResolveDefaultInstanceIsStableAcrossRestarts` builds the instance map fresh 200 times and asserts the same answer each round; it fails on the previous implementation at round 0. A single resolution passes by luck.
