### PR TITLE
A connection resolves its DataHub source under the name a call binds it by

### DIFF
--- a/bench/config/platform.bench.a0.yaml
+++ b/bench/config/platform.bench.a0.yaml
@@ -404,7 +404,6 @@ toolkits:
         user: "bench"
         catalog: "memory"
         schema: "bench"
-        connection_name: "e2e-trino"
     config:
       default_limit: 1000
       max_limit: 10000

--- a/bench/config/platform.bench.a1.yaml
+++ b/bench/config/platform.bench.a1.yaml
@@ -416,7 +416,6 @@ toolkits:
         user: "bench"
         catalog: "memory"
         schema: "bench"
-        connection_name: "e2e-trino"
     config:
       default_limit: 1000
       max_limit: 10000

--- a/bench/config/platform.bench.a2.yaml
+++ b/bench/config/platform.bench.a2.yaml
@@ -412,7 +412,6 @@ toolkits:
         user: "bench"
         catalog: "memory"
         schema: "bench"
-        connection_name: "e2e-trino"
     config:
       default_limit: 1000
       max_limit: 10000

--- a/bench/config/platform.bench.a3.yaml
+++ b/bench/config/platform.bench.a3.yaml
@@ -437,7 +437,6 @@ toolkits:
         user: "bench"
         catalog: "memory"
         schema: "bench"
-        connection_name: "e2e-trino"
     config:
       default_limit: 1000
       max_limit: 10000

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2045,7 +2045,7 @@ personas:
       deny: ["prod-admin-*"]
 ```
 
-Connections are deny-by-default: if the `connections` block is omitted or `allow` is empty, the persona reaches no connection at all. Connection patterns use the same wildcard syntax as tool patterns.
+Connections are deny-by-default: if the `connections` block is omitted or `allow` is empty, the persona reaches no connection at all. Connection patterns use the same wildcard syntax as tool patterns. A pattern matches the name a call binds the connection by, which `list_connections` reports as `connection`: the `instances:` key of the toolkit instance, or the `connection_name` a DataHub or S3 instance sets in its place. A `connection_name` on a Trino instance has no effect (the server warns about it at startup): Trino routes by the `instances:` key, so that key is its connection's name everywhere. Before #1396 an unqualified Trino call bound the `connection_name` instead, so a persona that lists one must be changed to list the `instances:` key.
 
 Discovery applies the same rules through the same predicate, so what a caller can find and what a caller can call never disagree. `search` omits catalog datasets, connections, and API endpoints belonging to connections the persona is not granted; `fetch` returns `found: false` for such a reference, so a citation cannot read around what search omitted; `list_connections` enumerates only the granted connections; the portal search shares the router and behaves identically. A dataset is attributed to a connection through its DataHub platform name — a dataset that maps to no configured connection stays visible, and one reachable through any granted connection stays visible.
 

--- a/docs/personas/overview.md
+++ b/docs/personas/overview.md
@@ -324,6 +324,8 @@ Discovery evaluates the same rules against the same persona, so what a caller ca
 
 Connections are **deny-by-default**, mirroring the tool axis: a persona reaches a connection only when a `connections.allow` pattern matches its name. If the `connections` block is omitted or `allow` is empty, the persona is granted **no** connections, so every tool call that targets a connection is denied. Grant each persona exactly the connections it needs (the admin persona typically uses `allow: ["*"]`).
 
+The name a pattern matches is the name a call binds the connection by, which `list_connections` reports as `connection`: the `instances:` key, or the `connection_name` a DataHub or S3 instance sets in its place. See [Connection Names](../server/multi-provider.md#connection-names).
+
 ### What Discovery Shows
 
 The same rules narrow what a persona can see, not only what it can call:

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -767,7 +767,6 @@ toolkits:
         default_limit: 1000
         max_limit: 10000
         read_only: false
-        connection_name: primary
     default: primary
 ```
 
@@ -785,7 +784,7 @@ toolkits:
 | `default_limit` | int | `1000` | Default row limit for queries |
 | `max_limit` | int | `10000` | Maximum allowed row limit |
 | `read_only` | bool | `false` | Reject write SQL on this connection. Set per instance: the other instances of the same toolkit are unaffected, and a call that omits `connection` is judged by the default instance's setting |
-| `connection_name` | string | instance name | Display name for this connection |
+| `connection_name` | string | - | No effect; accepted for compatibility and warned about at startup. Trino routes by the `instances:` key, so that key is the name `list_connections` advertises, a `connection` parameter carries, an audit row records and a persona rule matches. See [Connection Names](multi-provider.md#connection-names) |
 | `descriptions` | map | `{}` | Override tool descriptions for this instance (key: tool name, value: description text) |
 
 `read_only` became per connection in #1269. Before that it was read from the
@@ -828,7 +827,7 @@ toolkits:
 | `default_limit` | int | `10` | Default search result limit |
 | `max_limit` | int | `100` | Maximum search result limit |
 | `max_lineage_depth` | int | `5` | Maximum lineage traversal depth |
-| `connection_name` | string | instance name | Display name for this connection |
+| `connection_name` | string | instance name | The name a call binds this connection by: what an audit row records, what a persona's `connections.allow` / `connections.deny` rules match, and what the semantic layer resolves its platform and catalog mapping through. See [Connection Names](multi-provider.md#connection-names) |
 | `read_only` | bool | `false` | Restrict to read operations (disables write tools) |
 | `descriptions` | map | `{}` | Override tool descriptions for this instance (key: tool name, value: description text) |
 
@@ -873,7 +872,7 @@ toolkits:
 | `read_only` | bool | `false` | Restrict to read operations |
 | `max_get_size` | int64 | `10485760` | Max bytes to read from objects |
 | `max_put_size` | int64 | `104857600` | Max bytes to write to objects |
-| `connection_name` | string | instance name | Display name for this connection |
+| `connection_name` | string | instance name | The name a call binds this connection by: what an audit row records, what a persona's `connections.allow` / `connections.deny` rules match, and what the semantic layer resolves its platform and catalog mapping through. See [Connection Names](multi-provider.md#connection-names) |
 | `bucket_prefix` | string | - | Only show buckets with this prefix |
 | `descriptions` | map | `{}` | Override tool descriptions for this instance (key: tool name, value: description text) |
 

--- a/docs/server/multi-provider.md
+++ b/docs/server/multi-provider.md
@@ -21,7 +21,6 @@ toolkits:
         user: analyst
         ssl: true
         catalog: hive
-        connection_name: Production
 
       staging:
         host: trino-staging.example.com
@@ -29,7 +28,6 @@ toolkits:
         user: analyst
         ssl: true
         catalog: hive
-        connection_name: Staging
 
       warehouse:
         host: trino-dw.example.com
@@ -37,7 +35,6 @@ toolkits:
         user: analyst
         ssl: true
         catalog: iceberg
-        connection_name: Data Warehouse
     default: production
 
   datahub:
@@ -71,6 +68,37 @@ toolkits:
     default: data_lake
 ```
 
+## Connection Names
+
+An instance has two names, and which one a caller uses depends on the kind.
+
+The `instances:` key (`primary`, `data_lake`) is the configuration identity. It
+is the name `default:`, `semantic.instance`, `query.instance`,
+`storage.instance`, `knowledge.apply.datahub_connection` and
+`resources.managed.s3_connection` resolve, and the name a knowledge page cites a
+connection by (`mcp:connection:(datahub,primary)`).
+
+`connection_name` renames the connection for callers of the DataHub and S3
+kinds: it is what an audit row records, what a persona's `connections.allow` /
+`connections.deny` rules match, and the connection the semantic layer resolves a
+dataset's platform and catalog mapping through. Set it to give a connection a
+readable name; leave it out and the instance key is used for all of these.
+
+Trino is different: it routes by the `instances:` key, so that key is the name
+`list_connections` advertises, the name a `connection` parameter carries, and
+the connection's identity everywhere else — in audit rows, in persona rules and
+in the semantic layer. A `connection_name` on a Trino instance has no effect,
+and the server logs a warning at startup naming the instance and the value to
+use in its place.
+
+Before #1396, an unqualified Trino call — one that passes no `connection` — was
+recorded and authorized under the instance's `connection_name` instead, a name
+`list_connections` never advertised and a `connection` parameter could never
+carry. A deployment that set `connection_name` on a Trino instance and listed
+that name in a persona's `connections.allow` must list the `instances:` key
+there instead; without the change the same persona could not authorize a call
+that named the connection explicitly.
+
 ## Using Connections in Tools
 
 Every tool accepts a `connection` parameter to specify which instance to use:
@@ -85,11 +113,10 @@ Tool call: `trino_query` with:
 
 ## Listing Available Connections
 
-Use the `*_list_connections` tools to see configured instances:
-
-- `trino_list_connections` - Lists all Trino connections
-- `datahub_list_connections` - Lists all DataHub connections
-- `s3_list_connections` - Lists all S3 connections
+`list_connections` enumerates every connection across every kind, narrowed to
+the ones the caller's persona is granted. It replaces the per-toolkit
+`trino_list_connections`, `datahub_list_connections` and `s3_list_connections`
+tools, which the platform does not register.
 
 **Example response:**
 
@@ -97,20 +124,28 @@ Use the `*_list_connections` tools to see configured instances:
 {
   "connections": [
     {
+      "kind": "trino",
       "name": "production",
-      "display_name": "Production",
-      "host": "trino-prod.example.com",
-      "catalog": "hive"
+      "connection": "production",
+      "reference": "mcp:connection:(trino,production)",
+      "is_default": true,
+      "datahub_source_name": "trino"
     },
     {
-      "name": "staging",
-      "display_name": "Staging",
-      "host": "trino-staging.example.com",
-      "catalog": "hive"
+      "kind": "s3",
+      "name": "data_lake",
+      "connection": "Data Lake",
+      "reference": "mcp:connection:(s3,data_lake)",
+      "datahub_source_name": "s3"
     }
-  ]
+  ],
+  "count": 2
 }
 ```
+
+`connection` is the value to pass as a tool's `connection` parameter;
+`reference` is the citation a knowledge page uses, which keys on the
+`instances:` name.
 
 ## Default Connection
 

--- a/internal/platform/connsource/connsource.go
+++ b/internal/platform/connsource/connsource.go
@@ -4,7 +4,20 @@
 // platform re-exports Source and Map as type aliases for its existing callers.
 package connsource
 
-import "strings"
+import (
+	"strings"
+	"sync"
+)
+
+// keySep joins a connection's kind and name into its map key.
+const keySep = "/"
+
+// The toolkit kinds whose connections carry a DataHub platform.
+const (
+	kindTrino   = "trino"
+	kindS3      = "s3"
+	kindDataHub = "datahub"
+)
 
 // Source holds the DataHub mapping for a single connection.
 type Source struct {
@@ -30,7 +43,16 @@ type Source struct {
 
 // Map provides forward and reverse lookups between connections and DataHub URN
 // components.
+//
+// One map is shared for the life of the process: tool-call goroutines read it
+// on every enrichment and URN build, while the admin connection routes add,
+// overlay and remove entries from HTTP goroutines. Go maps are not safe for
+// concurrent read and write — that pair is a fatal runtime error, not a
+// recoverable one — so every accessor takes the lock, and the readers that
+// answer with a slice answer with their own copy of it.
 type Map struct {
+	mu sync.RWMutex
+
 	// byConnection maps "kind/name" to its DataHub source info.
 	byConnection map[string]*Source
 
@@ -50,23 +72,127 @@ func NewMap() *Map {
 // If the same connection (kind+name) already exists, the old entry is
 // replaced so that bySourceName never contains duplicates.
 func (m *Map) Add(src Source) {
-	key := src.Kind + "/" + src.Name
-	if _, exists := m.byConnection[key]; exists {
-		m.Remove(src.Kind, src.Name)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.addLocked(src)
+}
+
+// addLocked registers a mapping. The caller holds the write lock.
+func (m *Map) addLocked(src Source) {
+	k := key(src.Kind, src.Name)
+	if _, exists := m.byConnection[k]; exists {
+		m.removeLocked(src.Kind, src.Name)
 	}
-	m.byConnection[key] = &src
+	m.byConnection[k] = &src
 	m.bySourceName[src.DataHubSourceName] = append(m.bySourceName[src.DataHubSourceName], &src)
+}
+
+// key is the map key a connection is filed under.
+func key(kind, name string) string { return kind + keySep + name }
+
+// Overlay files a stored connection's mapping over the entry the map holds for
+// the same connection: a field the stored config leaves unset keeps the value
+// already there, and the kind's default answers only when nothing else did.
+//
+// The entry it overlays MUST be the one the running configuration derives —
+// call Seed first, or overlay onto a map the registry arm has just populated.
+// Two behaviors depend on that. Replacing the entry outright would lose the
+// deployment's urn_mapping on every boot after the first, because the
+// connection backfill seeds a config-less row for each file-configured
+// connection and a row with nothing to say must not out-rank the file. And
+// overlaying onto a previous overlay would make a field unclearable: an
+// operator who removes datahub_source_name from a stored connection would keep
+// reading the value they deleted until the next restart (#1396).
+func (m *Map) Overlay(src Source) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if base := m.byConnection[key(src.Kind, src.Name)]; base != nil {
+		if src.DataHubSourceName == "" {
+			src.DataHubSourceName = base.DataHubSourceName
+		}
+		if src.CatalogMapping == nil {
+			src.CatalogMapping = base.CatalogMapping
+		}
+		if src.Description == "" {
+			src.Description = base.Description
+		}
+	}
+	if src.DataHubSourceName == "" {
+		src.DataHubSourceName = DefaultSourceName(src.Kind)
+	}
+	m.addLocked(src)
+}
+
+// Seed files the entry the running configuration derives for one connection,
+// replacing whatever the map held. It is what an Overlay must land on and what
+// a deleted stored override falls back to, so a connection is never left
+// carrying a value no configuration states.
+func (m *Map) Seed(entries []Source) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, src := range entries {
+		m.addLocked(src)
+	}
+}
+
+// DefaultSourceName returns the DataHub platform a kind's datasets carry when
+// nothing overrides it. An unmapped kind returns "", which leaves its
+// connections out of every URN's candidate set rather than in the wrong one.
+func DefaultSourceName(kind string) string {
+	switch kind {
+	case kindTrino, kindS3, kindDataHub:
+		return kind
+	default:
+		return ""
+	}
+}
+
+// RegistryEntries returns the source entries a live toolkit of the given kind
+// contributes: one per connection name it serves, all sharing the kind's
+// mapping. urnPlatform and catalogMapping are the deployment's semantic
+// urn_mapping, which only the query engine's kind carries. A kind that names no
+// DataHub platform contributes nothing.
+//
+// It is the one derivation of "what does the running configuration say about
+// this connection", so the startup build and the admin path that has to restore
+// it after a stored override is deleted cannot answer differently (#1396).
+func RegistryEntries(kind string, names []string, urnPlatform string, catalogMapping map[string]string) []Source {
+	src := Source{Kind: kind, DataHubSourceName: DefaultSourceName(kind)}
+	if src.DataHubSourceName == "" {
+		return nil
+	}
+	if kind == kindTrino {
+		if urnPlatform != "" {
+			src.DataHubSourceName = urnPlatform
+		}
+		src.CatalogMapping = catalogMapping
+	}
+
+	out := make([]Source, 0, len(names))
+	for _, name := range names {
+		src.Name = name
+		out = append(out, src)
+	}
+	return out
 }
 
 // Remove deletes a connection's DataHub source mapping.
 func (m *Map) Remove(kind, name string) {
-	key := kind + "/" + name
-	src, ok := m.byConnection[key]
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.removeLocked(kind, name)
+}
+
+// removeLocked deletes a mapping. The caller holds the write lock.
+func (m *Map) removeLocked(kind, name string) {
+	k := key(kind, name)
+	src, ok := m.byConnection[k]
 	if !ok {
 		return
 	}
 
-	delete(m.byConnection, key)
+	delete(m.byConnection, k)
 
 	// Remove from the bySourceName slice.
 	dsn := src.DataHubSourceName
@@ -96,7 +222,9 @@ func (m *Map) ForConnection(kind, name string) *Source {
 	if m == nil {
 		return nil
 	}
-	return m.byConnection[kind+"/"+name]
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.byConnection[key(kind, name)]
 }
 
 // DataHubSourceName returns the DataHub source name mapped to a connection, or ""
@@ -114,7 +242,22 @@ func (m *Map) ConnectionsForSource(datahubSourceName string) []*Source {
 	if m == nil {
 		return nil
 	}
-	return m.bySourceName[datahubSourceName]
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.sourcesFor(datahubSourceName)
+}
+
+// sourcesFor copies the entries filed under a source name, so a caller iterating
+// the result cannot be racing an Add that appends to the stored slice. The
+// caller holds the read lock. A source name with no entries answers nil.
+func (m *Map) sourcesFor(datahubSourceName string) []*Source {
+	entries := m.bySourceName[datahubSourceName]
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]*Source, len(entries))
+	copy(out, entries)
+	return out
 }
 
 // ConnectionsForURN parses a DataHub URN and returns all connections whose
@@ -127,7 +270,9 @@ func (m *Map) ConnectionsForURN(urn string) []*Source {
 	if platform == "" {
 		return nil
 	}
-	return m.bySourceName[platform]
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.sourcesFor(platform)
 }
 
 // PlatformFromURN extracts the platform name from a DataHub URN.

--- a/internal/platform/connsource/connsource_test.go
+++ b/internal/platform/connsource/connsource_test.go
@@ -1,6 +1,10 @@
 package connsource
 
-import "testing"
+import (
+	"strconv"
+	"sync"
+	"testing"
+)
 
 func TestPlatformFromURN(t *testing.T) {
 	tests := []struct {
@@ -83,5 +87,180 @@ func TestMap_SharedNameResolvesByKind(t *testing.T) {
 					kind, src.DataHubSourceName, kind)
 			}
 		}
+	}
+}
+
+func TestOverlay(t *testing.T) {
+	t.Run("a stored row that states nothing leaves the configured mapping standing", func(t *testing.T) {
+		m := NewMap()
+		m.Add(Source{
+			Kind: "trino", Name: "warehouse", DataHubSourceName: "hive",
+			CatalogMapping: map[string]string{"rdbms": "postgres"}, Description: "from file",
+		})
+
+		m.Overlay(Source{Kind: "trino", Name: "warehouse"})
+
+		got := m.ForConnection("trino", "warehouse")
+		if got == nil || got.DataHubSourceName != "hive" {
+			t.Fatalf("DataHubSourceName = %+v, want hive", got)
+		}
+		if got.CatalogMapping["rdbms"] != "postgres" {
+			t.Errorf("CatalogMapping = %v", got.CatalogMapping)
+		}
+		if got.Description != "from file" {
+			t.Errorf("Description = %q", got.Description)
+		}
+	})
+
+	t.Run("a stored row that states a mapping overrides field by field", func(t *testing.T) {
+		m := NewMap()
+		m.Add(Source{
+			Kind: "trino", Name: "warehouse", DataHubSourceName: "hive",
+			CatalogMapping: map[string]string{"rdbms": "postgres"}, Description: "from file",
+		})
+
+		m.Overlay(Source{
+			Kind: "trino", Name: "warehouse", DataHubSourceName: "postgres",
+			Description: "from admin",
+		})
+
+		got := m.ForConnection("trino", "warehouse")
+		if got.DataHubSourceName != "postgres" || got.Description != "from admin" {
+			t.Errorf("stated fields not applied: %+v", got)
+		}
+		if got.CatalogMapping["rdbms"] != "postgres" {
+			t.Errorf("unstated CatalogMapping should survive: %v", got.CatalogMapping)
+		}
+	})
+
+	t.Run("with no entry to overlay the kind default answers", func(t *testing.T) {
+		m := NewMap()
+		m.Overlay(Source{Kind: "s3", Name: "lake"})
+		if got := m.ForConnection("s3", "lake"); got == nil || got.DataHubSourceName != "s3" {
+			t.Errorf("ForConnection = %+v, want the s3 default", got)
+		}
+
+		m.Overlay(Source{Kind: "mystery", Name: "x"})
+		if got := m.ForConnection("mystery", "x"); got == nil || got.DataHubSourceName != "" {
+			t.Errorf("an unmapped kind names no platform: %+v", got)
+		}
+	})
+}
+
+func TestDefaultSourceNameFn(t *testing.T) {
+	for kind, want := range map[string]string{"trino": "trino", "s3": "s3", "datahub": "datahub", "mcp": "", "": ""} {
+		if got := DefaultSourceName(kind); got != want {
+			t.Errorf("DefaultSourceName(%q) = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+func TestRegistryEntries(t *testing.T) {
+	t.Run("trino carries the deployment urn_mapping across every connection", func(t *testing.T) {
+		mapping := map[string]string{"rdbms": "postgres"}
+		got := RegistryEntries("trino", []string{"warehouse", "staging"}, "hive", mapping)
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2", len(got))
+		}
+		for _, src := range got {
+			if src.DataHubSourceName != "hive" || src.CatalogMapping["rdbms"] != "postgres" {
+				t.Errorf("entry = %+v", src)
+			}
+		}
+		if got[0].Name != "warehouse" || got[1].Name != "staging" {
+			t.Errorf("names = %q %q", got[0].Name, got[1].Name)
+		}
+	})
+
+	t.Run("trino with no urn_mapping falls back to its own platform name", func(t *testing.T) {
+		got := RegistryEntries("trino", []string{"warehouse"}, "", nil)
+		if len(got) != 1 || got[0].DataHubSourceName != "trino" {
+			t.Errorf("entries = %+v", got)
+		}
+	})
+
+	t.Run("s3 and datahub name themselves and ignore the query mapping", func(t *testing.T) {
+		for _, kind := range []string{"s3", "datahub"} {
+			got := RegistryEntries(kind, []string{"one"}, "hive", map[string]string{"a": "b"})
+			if len(got) != 1 || got[0].DataHubSourceName != kind || got[0].CatalogMapping != nil {
+				t.Errorf("%s entries = %+v", kind, got)
+			}
+		}
+	})
+
+	t.Run("a kind with no DataHub platform contributes nothing", func(t *testing.T) {
+		if got := RegistryEntries("mcp", []string{"vendor"}, "hive", nil); got != nil {
+			t.Errorf("entries = %+v, want nil", got)
+		}
+	})
+}
+
+// TestMapConcurrentAccess is the regression for the shared map's locking: one
+// map serves tool-call goroutines reading on every enrichment and URN build
+// while the admin connection routes add, overlay and remove from HTTP
+// goroutines. Concurrent read and write of a Go map is a fatal runtime error,
+// so this must hold under -race and in a plain run.
+func TestMapConcurrentAccess(t *testing.T) {
+	m := NewMap()
+	m.Seed(RegistryEntries("trino", []string{"warehouse"}, "hive", map[string]string{"rdbms": "postgres"}))
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(4)
+
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			m.Overlay(Source{Kind: "trino", Name: "warehouse", Description: strconv.Itoa(i)})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			m.Add(Source{Kind: "s3", Name: strconv.Itoa(i), DataHubSourceName: "s3"})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			m.Remove("s3", strconv.Itoa(i))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			_ = m.ForConnection("trino", "warehouse")
+			_ = m.DataHubSourceName("trino", "warehouse")
+			for _, src := range m.ConnectionsForURN("urn:li:dataset:(urn:li:dataPlatform:s3,b/k,PROD)") {
+				_ = src.Name
+			}
+			_ = m.ConnectionsForSource("hive")
+		}
+	}()
+
+	wg.Wait()
+
+	if got := m.ForConnection("trino", "warehouse"); got == nil || got.DataHubSourceName != "hive" {
+		t.Errorf("the seeded mapping survived the traffic: %+v", got)
+	}
+}
+
+func TestSeed(t *testing.T) {
+	m := NewMap()
+	m.Seed(RegistryEntries("trino", []string{"warehouse"}, "hive", nil))
+	m.Overlay(Source{Kind: "trino", Name: "warehouse", DataHubSourceName: "postgres"})
+
+	// Re-seeding replaces the overlay, which is what a deleted stored override
+	// falls back to.
+	m.Seed(RegistryEntries("trino", []string{"warehouse"}, "hive", nil))
+	if got := m.ForConnection("trino", "warehouse"); got == nil || got.DataHubSourceName != "hive" {
+		t.Errorf("ForConnection = %+v, want hive", got)
+	}
+
+	// Seeding nothing is a no-op, not a panic.
+	m.Seed(nil)
+	m.Seed(RegistryEntries("mcp", []string{"vendor"}, "", nil))
+	if got := m.ForConnection("mcp", "vendor"); got != nil {
+		t.Errorf("an unmapped kind seeds nothing: %+v", got)
 	}
 }

--- a/internal/platform/toolkitcfg/toolkitcfg.go
+++ b/internal/platform/toolkitcfg/toolkitcfg.go
@@ -50,18 +50,23 @@ type DataHub struct {
 
 // Trino holds extracted Trino configuration.
 type Trino struct {
-	Host           string
-	Port           int
-	User           string
-	Password       string // #nosec G117 -- Trino connection credential from admin config
-	Catalog        string
-	Schema         string
-	SSL            bool
-	SSLVerify      bool
-	Timeout        time.Duration
-	DefaultLimit   int
-	MaxLimit       int
-	ReadOnly       bool
+	Host         string
+	Port         int
+	User         string
+	Password     string // #nosec G117 -- Trino connection credential from admin config
+	Catalog      string
+	Schema       string
+	SSL          bool
+	SSLVerify    bool
+	Timeout      time.Duration
+	DefaultLimit int
+	MaxLimit     int
+	ReadOnly     bool
+	// ConnectionName is the name a call binds this connection by: the resolved
+	// `instances:` key, which is what the Trino toolkit routes on. The query
+	// provider stamps it onto every availability answer, so it is the name an
+	// agent is told to pass as `connection` — a label the router does not know
+	// would send the agent to a connection that refuses it (#1396).
 	ConnectionName string
 }
 
@@ -218,8 +223,14 @@ func DataHubConfig(toolkits map[string]any, instance string) *DataHub {
 
 // TrinoConfig extracts Trino configuration for the named instance (or the
 // default instance when instance is ""). Returns nil if not configured.
+//
+// ConnectionName is the resolved instance name rather than the instance's
+// `connection_name`: Trino routes by instance, so that key is the name a
+// `connection` argument carries and a persona rule matches, and it is what the
+// toolkit reports as its connection. Reading `connection_name` here published a
+// name no call could bind, and reading nothing published an empty one (#1396).
 func TrinoConfig(toolkits map[string]any, instance string) *Trino {
-	instanceCfg := InstanceConfig(toolkits, kindTrino, instance)
+	instanceCfg, resolved := resolveInstance(toolkits, kindTrino, instance)
 	if instanceCfg == nil {
 		return nil
 	}
@@ -237,7 +248,7 @@ func TrinoConfig(toolkits map[string]any, instance string) *Trino {
 		DefaultLimit:   cfgmap.Int(instanceCfg, "default_limit", DefaultTrinoQueryLimit),
 		MaxLimit:       cfgmap.Int(instanceCfg, "max_limit", DefaultTrinoMaxLimit),
 		ReadOnly:       cfgmap.Bool(instanceCfg, "read_only"),
-		ConnectionName: cfgmap.String(instanceCfg, "connection_name"),
+		ConnectionName: resolved,
 	}
 }
 

--- a/internal/platform/toolkitcfg/toolkitcfg_test.go
+++ b/internal/platform/toolkitcfg/toolkitcfg_test.go
@@ -139,8 +139,31 @@ func TestTrinoConfig(t *testing.T) {
 		cfg := TrinoConfig(toolkits, "primary")
 		if cfg == nil || cfg.Port != 9090 || cfg.Catalog != "c" || cfg.Schema != "s" ||
 			!cfg.SSL || cfg.SSLVerify || !cfg.ReadOnly ||
-			cfg.DefaultLimit != 50 || cfg.MaxLimit != 500 || cfg.ConnectionName != "cn" {
+			cfg.DefaultLimit != 50 || cfg.MaxLimit != 500 {
 			t.Errorf("TrinoConfig = %+v", cfg)
+		}
+		// The query provider stamps ConnectionName onto every availability
+		// answer as the name to pass as `connection`. Trino routes by instance,
+		// so the instance key is that name and the instance's connection_name
+		// ("cn" here) is not (#1396).
+		if cfg.ConnectionName != "primary" {
+			t.Errorf("ConnectionName = %q, want the routed instance 'primary'", cfg.ConnectionName)
+		}
+	})
+	t.Run("an unnamed instance resolves the default rather than an empty label", func(t *testing.T) {
+		toolkits := map[string]any{"trino": map[string]any{
+			"default": "warehouse",
+			"instances": map[string]any{
+				"warehouse": map[string]any{"host": "h", "user": "u"},
+				"staging":   map[string]any{"host": "s", "user": "u"},
+			},
+		}}
+		cfg := TrinoConfig(toolkits, "")
+		if cfg == nil {
+			t.Fatal("TrinoConfig returned nil")
+		}
+		if cfg.ConnectionName != "warehouse" {
+			t.Errorf("ConnectionName = %q, want 'warehouse'", cfg.ConnectionName)
 		}
 	})
 }

--- a/pkg/admin/connection_handler.go
+++ b/pkg/admin/connection_handler.go
@@ -8,11 +8,14 @@ import (
 	"log/slog"
 	"maps"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/txn2/mcp-data-platform/internal/logsan"
+	"github.com/txn2/mcp-data-platform/internal/platform/connsource"
 	"github.com/txn2/mcp-data-platform/pkg/connoauth"
 	"github.com/txn2/mcp-data-platform/pkg/connreconcile"
+	"github.com/txn2/mcp-data-platform/pkg/connview"
 	"github.com/txn2/mcp-data-platform/pkg/platform"
 	"github.com/txn2/mcp-data-platform/pkg/platform/fieldcrypt"
 	"github.com/txn2/mcp-data-platform/pkg/registry"
@@ -305,9 +308,14 @@ func (h *Handler) deleteConnectionInstance(w http.ResponseWriter, r *http.Reques
 	// Hot-remove: if the toolkit supports dynamic connections, remove it live.
 	h.hotRemoveConnection(kind, name)
 
-	// Update the connection source map.
+	// Update the connection source map, under the name it was filed by, and
+	// put back whatever the running configuration still says about the
+	// connection: deleting a stored override must not leave a connection its
+	// toolkit still serves with no mapping at all until the next restart.
 	if h.deps.ConnectionSources != nil {
-		h.deps.ConnectionSources.Remove(kind, name)
+		bound := h.connectionBindingName(kind, name)
+		h.deps.ConnectionSources.Remove(kind, bound)
+		h.seedConfiguredSource(kind, bound)
 	}
 
 	if hadToken {
@@ -695,11 +703,60 @@ func nestedMapHasRedacted(raw any) bool {
 
 // activateConnection hot-adds the connection to its toolkit and updates the
 // connection source map. Extracted to reduce setConnectionInstance complexity.
+//
+// The entry is filed under the name a call binds, which is the stored instance
+// name unless a live single-connection toolkit renames it with a
+// connection_name; filing it under the instance would leave the operator's
+// mapping unreachable by every lookup. The configured entry is seeded first so
+// the overlay lands on what the running configuration states rather than on the
+// previous save: without that a new connection would carry a kind default
+// instead of the deployment's urn_mapping, and a field the operator cleared
+// would keep answering with the value they deleted (#1396).
 func (h *Handler) activateConnection(inst platform.ConnectionInstance) {
 	h.hotAddConnection(inst.Kind, inst.Name, inst.Config)
-	if h.deps.ConnectionSources != nil {
-		h.deps.ConnectionSources.Add(platform.ConnectionSourceFromInstance(inst))
+	if h.deps.ConnectionSources == nil {
+		return
 	}
+	bound := h.connectionBindingName(inst.Kind, inst.Name)
+	h.seedConfiguredSource(inst.Kind, bound)
+	src := platform.ConnectionSourceFromInstance(inst)
+	src.Name = bound
+	h.deps.ConnectionSources.Overlay(src)
+}
+
+// seedConfiguredSource files the entry the running configuration derives for a
+// connection: the base an overlay lands on, and what a deleted stored override
+// falls back to. A connection no live toolkit serves contributes nothing, which
+// is what leaving it unmapped means — for a kind that supports hot-remove, a
+// deleted connection is already gone from its toolkit by the time this runs.
+func (h *Handler) seedConfiguredSource(kind, connection string) {
+	if h.deps.ToolkitRegistry == nil {
+		return
+	}
+	// A deployment with no config block maps nothing, which is the zero value.
+	// Bailing out instead would skip the seed entirely and leave an overlay
+	// landing on the previous save, so a cleared field could never clear.
+	var mapping platform.URNMappingConfig
+	if h.deps.Config != nil {
+		mapping = h.deps.Config.Semantic.URNMapping
+	}
+	for _, tk := range h.deps.ToolkitRegistry.All() {
+		if tk.Kind() != kind || !slices.Contains(connview.ConnectionNames(tk), connection) {
+			continue
+		}
+		h.deps.ConnectionSources.Seed(connsource.RegistryEntries(
+			kind, []string{connection}, mapping.Platform, mapping.CatalogMapping))
+		return
+	}
+}
+
+// connectionBindingName resolves a stored instance name to the name a call
+// binds it by. A nil registry leaves the instance name unchanged.
+func (h *Handler) connectionBindingName(kind, instance string) string {
+	if h.deps.ToolkitRegistry == nil {
+		return instance
+	}
+	return connview.BindingName(h.deps.ToolkitRegistry.All(), kind, instance)
 }
 
 // findConnectionManager returns the ConnectionManager for the given toolkit kind,

--- a/pkg/admin/connection_handler_test.go
+++ b/pkg/admin/connection_handler_test.go
@@ -1220,3 +1220,174 @@ func TestSetConnectionInstance_APICatalogValidation(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
 }
+
+// TestActivateConnectionFilesSourceUnderBoundName covers the runtime half of
+// #1396: a stored connection is keyed by the toolkit instance it configures,
+// while every lookup asks by the name a call binds. When a live
+// single-connection toolkit renames it with a connection_name, filing the
+// operator's mapping under the instance leaves it unreachable.
+func TestActivateConnectionFilesSourceUnderBoundName(t *testing.T) {
+	reg := &mockToolkitRegistry{allResult: []mockToolkit{
+		{kind: "s3", name: "data_lake", connection: "Data Lake"},
+		{kind: "datahub", name: "primary"},
+	}}
+	sources := platform.NewConnectionSourceMap()
+	h := NewHandler(Deps{ToolkitRegistry: reg, ConnectionSources: sources}, nil)
+
+	h.activateConnection(platform.ConnectionInstance{
+		Kind:   "s3",
+		Name:   "data_lake",
+		Config: map[string]any{"datahub_source_name": "minio"},
+	})
+
+	src := sources.ForConnection("s3", "Data Lake")
+	require.NotNil(t, src, "the stored mapping answers the name a call binds")
+	assert.Equal(t, "minio", src.DataHubSourceName)
+	assert.Nil(t, sources.ForConnection("s3", "data_lake"),
+		"the instance key is not a second entry for the same connection")
+
+	// A toolkit that carries no connection_name keeps its instance name.
+	h.activateConnection(platform.ConnectionInstance{
+		Kind: "datahub", Name: "primary", Config: map[string]any{"datahub_source_name": "dh"},
+	})
+	dh := sources.ForConnection("datahub", "primary")
+	require.NotNil(t, dh)
+	assert.Equal(t, "dh", dh.DataHubSourceName)
+
+	// Saving the same connection with the key removed clears it, rather than
+	// overlaying onto the previous save and answering with a deleted value.
+	h.activateConnection(platform.ConnectionInstance{
+		Kind: "datahub", Name: "primary", Config: map[string]any{},
+	})
+	cleared := sources.ForConnection("datahub", "primary")
+	require.NotNil(t, cleared)
+	assert.Equal(t, "datahub", cleared.DataHubSourceName,
+		"the cleared field falls back to what the configuration states")
+
+	// And the removal path drops the entry it filed, not a name that was never used.
+	assert.Equal(t, "Data Lake", h.connectionBindingName("s3", "data_lake"))
+	assert.Equal(t, "unclaimed", h.connectionBindingName("s3", "unclaimed"),
+		"an instance no live toolkit claims keeps its own name")
+
+	noReg := NewHandler(Deps{ConnectionSources: sources}, nil)
+	assert.Equal(t, "data_lake", noReg.connectionBindingName("s3", "data_lake"),
+		"a handler with no registry cannot translate, so it leaves the name alone")
+}
+
+// TestSeedConfiguredSource covers what a deleted override falls back to: the
+// mapping the running configuration still supplies for a connection the file
+// configures, rather than no mapping at all until the next restart.
+func TestSeedConfiguredSource(t *testing.T) {
+	reg := &mockToolkitRegistry{rawToolkits: []registry.Toolkit{
+		mockToolkit{kind: "s3", name: "data_lake", connection: "Data Lake"},
+		mockMultiConnectionToolkit{
+			mockToolkit: mockToolkit{kind: "trino", name: "warehouse", connection: "warehouse"},
+			connections: []toolkit.ConnectionDetail{{Name: "warehouse"}},
+		},
+	}}
+	cfg := &platform.Config{}
+	cfg.Semantic.URNMapping = platform.URNMappingConfig{
+		Platform:       "hive",
+		CatalogMapping: map[string]string{"rdbms": "postgres"},
+	}
+	sources := platform.NewConnectionSourceMap()
+	h := NewHandler(Deps{ToolkitRegistry: reg, ConnectionSources: sources, Config: cfg}, nil)
+
+	h.seedConfiguredSource("s3", "Data Lake")
+	s3src := sources.ForConnection("s3", "Data Lake")
+	require.NotNil(t, s3src, "a connection the toolkit still serves keeps a mapping")
+	assert.Equal(t, "s3", s3src.DataHubSourceName)
+
+	h.seedConfiguredSource("trino", "warehouse")
+	trinoSrc := sources.ForConnection("trino", "warehouse")
+	require.NotNil(t, trinoSrc)
+	assert.Equal(t, "hive", trinoSrc.DataHubSourceName, "the deployment's urn_mapping is restored, not a kind default")
+	assert.Equal(t, "postgres", trinoSrc.CatalogMapping["rdbms"])
+
+	h.seedConfiguredSource("s3", "gone")
+	assert.Nil(t, sources.ForConnection("s3", "gone"),
+		"a connection no live toolkit serves stays unmapped")
+
+	// A connection added at runtime carries the deployment's urn_mapping, not a
+	// kind default: activateConnection seeds the configured entry before the
+	// stored override lands on it.
+	added := NewHandler(Deps{ToolkitRegistry: reg, ConnectionSources: sources, Config: cfg}, nil)
+	added.activateConnection(platform.ConnectionInstance{
+		Kind: "trino", Name: "warehouse", Config: map[string]any{},
+	})
+	runtimeSrc := sources.ForConnection("trino", "warehouse")
+	require.NotNil(t, runtimeSrc)
+	assert.Equal(t, "hive", runtimeSrc.DataHubSourceName)
+	assert.Equal(t, "postgres", runtimeSrc.CatalogMapping["rdbms"])
+
+	// Missing wiring is a no-op, never a panic.
+	NewHandler(Deps{ConnectionSources: sources}, nil).seedConfiguredSource("s3", "Data Lake")
+	NewHandler(Deps{ToolkitRegistry: reg, ConnectionSources: sources}, nil).seedConfiguredSource("s3", "Data Lake")
+	if got := sources.ForConnection("s3", "Data Lake"); got == nil || got.DataHubSourceName != "s3" {
+		t.Errorf("a nil Config maps nothing rather than skipping the seed: %+v", got)
+	}
+}
+
+// TestDeleteConnectionInstanceRefilesConfiguredSource drives the real DELETE
+// endpoint rather than the source-map helpers alone, so the three steps the
+// handler strings together are proven to run in order: resolve the bound name,
+// drop the stored entry, and put back what the running configuration still
+// states for a connection its toolkit continues to serve (#1396).
+func TestDeleteConnectionInstanceRefilesConfiguredSource(t *testing.T) {
+	reg := &mockToolkitRegistry{allResult: []mockToolkit{
+		{kind: "s3", name: "data_lake", connection: "Data Lake"},
+	}}
+	sources := platform.NewConnectionSourceMap()
+	// What the operator's override left in the map before the delete.
+	sources.Add(platform.ConnectionSource{
+		Kind: "s3", Name: "Data Lake", DataHubSourceName: "minio",
+	})
+
+	h := NewHandler(Deps{
+		Config:            testConfig(),
+		ConnectionStore:   &mockConnectionStore{},
+		ConfigStore:       &mockConfigStore{mode: "database"},
+		ToolkitRegistry:   reg,
+		ConnectionSources: sources,
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
+		"/api/v1/admin/connection-instances/s3/data_lake", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d %s", w.Code, w.Body.String())
+	}
+
+	src := sources.ForConnection("s3", "Data Lake")
+	require.NotNil(t, src, "the connection its toolkit still serves keeps a mapping")
+	assert.Equal(t, "s3", src.DataHubSourceName,
+		"the deleted override gives way to what the configuration states")
+}
+
+// TestDeleteConnectionInstanceLeavesAnAbsentConnectionUnmapped covers the other
+// outcome of the same block: a connection no live toolkit serves is left with
+// no entry, rather than one no configuration states.
+func TestDeleteConnectionInstanceLeavesAnAbsentConnectionUnmapped(t *testing.T) {
+	sources := platform.NewConnectionSourceMap()
+	sources.Add(platform.ConnectionSource{Kind: "s3", Name: "gone", DataHubSourceName: "minio"})
+
+	h := NewHandler(Deps{
+		Config:            testConfig(),
+		ConnectionStore:   &mockConnectionStore{},
+		ConfigStore:       &mockConfigStore{mode: "database"},
+		ToolkitRegistry:   &mockToolkitRegistry{},
+		ConnectionSources: sources,
+	}, nil)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
+		"/api/v1/admin/connection-instances/s3/gone", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d %s", w.Code, w.Body.String())
+	}
+	assert.Nil(t, sources.ForConnection("s3", "gone"))
+}

--- a/pkg/connview/connview.go
+++ b/pkg/connview/connview.go
@@ -98,6 +98,28 @@ func ConnectionNames(tk registry.Toolkit) []string {
 	return []string{policyName(tk)}
 }
 
+// BindingName returns the name a call binds the connection that an `instances:`
+// key configures, given the live toolkits.
+//
+// The two are the same for a multi-connection toolkit, which routes on the
+// instance key, and for a single-connection toolkit that sets no
+// connection_name. They differ for one that does, and the difference matters
+// wherever something keyed by the instance — a connection_instances row, and so
+// any stored override read off one — has to answer a lookup a call makes
+// (#1396). An instance no live toolkit claims keeps its own name.
+func BindingName(toolkits []registry.Toolkit, kind, instance string) string {
+	for _, tk := range toolkits {
+		if tk.Kind() != kind || tk.Name() != instance {
+			continue
+		}
+		if _, ok := tk.(toolkit.ConnectionLister); ok {
+			return instance
+		}
+		return policyName(tk)
+	}
+	return instance
+}
+
 // policyName is the identity a persona's connection rules match on for a
 // single-connection toolkit: its configured connection name, or its instance
 // name when it carries none.
@@ -176,13 +198,18 @@ func appendFallback(entries []Entry, tk registry.Toolkit, src SourceResolver, pe
 	}
 	// A single-connection toolkit's persona/audit identity is its configured
 	// connection name, which may differ from its instance name; filter on the
-	// former so discovery keys on exactly what the authorizer checks.
-	if !permit.allows(kind, policyName(tk)) {
+	// former so discovery keys on exactly what the authorizer checks. The
+	// source map is keyed the same way, so one name answers both (#1396).
+	conn := policyName(tk)
+	if !permit.allows(kind, conn) {
 		return entries, 1
 	}
+	// Name and Reference stay on the INSTANCE name: the reference FKs to the
+	// connection_instances row the backfill seeds, and that row's name is the
+	// key a stored connection is merged back into toolkit config under.
 	e := Entry{Kind: kind, Name: tk.Name(), Connection: tk.Connection(), Reference: knowledgepage.ConnectionRef(kind, tk.Name())}
 	if src != nil {
-		e.DataHubSourceName = src.DataHubSourceName(kind, tk.Name())
+		e.DataHubSourceName = src.DataHubSourceName(kind, conn)
 	}
 	return append(entries, e), 0
 }

--- a/pkg/connview/connview_test.go
+++ b/pkg/connview/connview_test.go
@@ -88,18 +88,50 @@ func TestBuild_KnowledgeBoundedByCap(t *testing.T) {
 }
 
 func TestBuild_FallbackKindFilterAndSource(t *testing.T) {
+	// s3 and datahub are the kinds that reach appendFallback: neither lists
+	// connections, and either may carry a connection_name that differs from its
+	// instance name. Trino always implements ConnectionLister.
 	toolkits := []registry.Toolkit{
-		&mockTK{kind: "trino", name: "warehouse", conn: "warehouse-conn"}, // data kind -> entry
-		&mockTK{kind: "api", name: "gw", conn: "gw-conn"},                 // not a data kind -> skipped
+		&mockTK{kind: "s3", name: "data_lake", conn: "Data Lake"}, // data kind -> entry
+		&mockTK{kind: "api", name: "gw", conn: "gw-conn"},         // not a data kind -> skipped
 	}
-	src := fakeSource{names: map[string]string{"trino/warehouse": "trino_src"}}
+	// The source map is keyed by the connection name a call binds, not by the
+	// toolkit's instance name (#1396).
+	src := fakeSource{names: map[string]string{"s3/Data Lake": "s3_src", "s3/data_lake": "wrong"}}
 	out := Build(context.Background(), toolkits, src, nil, nil)
 
 	require.Len(t, out.Connections, 1, "non-data kinds are dropped in the fallback path")
-	assert.Equal(t, "trino", out.Connections[0].Kind)
-	assert.Equal(t, "mcp:connection:(trino,warehouse)", out.Connections[0].Reference, "fallback path emits the canonical reference")
-	assert.Equal(t, "trino_src", out.Connections[0].DataHubSourceName)
+	assert.Equal(t, "s3", out.Connections[0].Kind)
+	assert.Equal(t, "data_lake", out.Connections[0].Name, "the entry keeps the instance identity")
+	assert.Equal(t, "Data Lake", out.Connections[0].Connection, "and reports the name a call binds")
+	assert.Equal(t, "mcp:connection:(s3,data_lake)", out.Connections[0].Reference, "fallback path emits the canonical reference")
+	assert.Equal(t, "s3_src", out.Connections[0].DataHubSourceName)
 	assert.Equal(t, 1, out.Count)
+}
+
+// TestBindingName covers the translation from the name an instance is
+// configured and stored under to the name a call binds it by (#1396).
+func TestBindingName(t *testing.T) {
+	toolkits := []registry.Toolkit{
+		&mockTK{kind: "s3", name: "data_lake", conn: "Data Lake"},
+		&mockTK{kind: "datahub", name: "primary"},
+		&listerTK{
+			mockTK: mockTK{kind: "trino", name: "warehouse", conn: "warehouse"},
+			conns:  []toolkit.ConnectionDetail{{Name: "warehouse"}, {Name: "staging"}},
+		},
+	}
+
+	assert.Equal(t, "Data Lake", BindingName(toolkits, "s3", "data_lake"),
+		"a single-connection toolkit binds by its connection name")
+	assert.Equal(t, "primary", BindingName(toolkits, "datahub", "primary"),
+		"one that carries no connection name binds by its instance")
+	assert.Equal(t, "warehouse", BindingName(toolkits, "trino", "warehouse"),
+		"a multi-connection toolkit routes on the instance key, so it is already the bound name")
+	assert.Equal(t, "data_lake", BindingName(toolkits, "datahub", "data_lake"),
+		"the match is per kind, so a name another kind carries is not borrowed")
+	assert.Equal(t, "unclaimed", BindingName(toolkits, "s3", "unclaimed"),
+		"an instance no live toolkit claims keeps its own name")
+	assert.Equal(t, "data_lake", BindingName(nil, "s3", "data_lake"))
 }
 
 func TestBuild_NoEnrichmentWhenLookupNilOrEmpty(t *testing.T) {

--- a/pkg/platform/connection_scope.go
+++ b/pkg/platform/connection_scope.go
@@ -42,15 +42,11 @@ func connectionScopeFor(reg *persona.Registry, sources *ConnectionSourceMap, too
 // whether the caller's persona reaches any of them).
 //
 // It walks the LIVE connections rather than the source map's entries, because
-// the two are not the same set: the map keys a file-configured multi-connection
-// toolkit by its instance, while a persona's rules and a tool call's
-// `connection` argument name each connection that toolkit serves. Resolving
-// through the map alone would attribute a dataset to a name no persona grants —
-// and would miss a connection added after startup. Each connection's platform
-// comes from its own map entry when it has one (the DB-backed case, where a
-// connection may override its DataHub source name) and otherwise from its
-// toolkit's; a connection with neither is not a candidate, which leaves the URN
-// unattributable rather than attributed by guess.
+// the two are not the same set: the map is built once at startup, so it does
+// not hold a connection added to a toolkit after it. Each connection's platform
+// comes from its own map entry when it has one and otherwise from its toolkit's
+// instance entry; a connection with neither is not a candidate, which leaves
+// the URN unattributable rather than attributed by guess.
 func connectionNamesForURN(sources *ConnectionSourceMap, toolkits []registry.Toolkit, urn string) []string {
 	platform := connsource.PlatformFromURN(urn)
 	if platform == "" || sources == nil {

--- a/pkg/platform/connection_source.go
+++ b/pkg/platform/connection_source.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/txn2/mcp-data-platform/internal/platform/connsource"
+	"github.com/txn2/mcp-data-platform/pkg/connview"
 )
 
 // ConnectionSource is re-exported from the connsource package (extracted for the
@@ -27,36 +28,34 @@ func (p *Platform) buildConnectionSourceMap() *ConnectionSourceMap {
 	return m
 }
 
-// addRegistryConnections populates the source map from the live toolkit registry.
+// addRegistryConnections populates the source map from the live toolkit registry,
+// one entry per connection the toolkit serves.
+//
+// The key is the name a lookup arrives with — the connection name a tool call
+// carries, which enrichment and the URN builder read off PlatformContext — not
+// the toolkit's `instances:` key. For a toolkit configured with a
+// connection_name the two differ, and keying by the instance meant every lookup
+// missed and the caller silently fell back to the query-provider mapping
+// (#1396). connview.ConnectionNames is the one enumeration of those names, so
+// discovery, the persona boundary and this map cannot drift apart.
 func (p *Platform) addRegistryConnections(m *ConnectionSourceMap) {
+	mapping := p.config.Semantic.URNMapping
 	for _, tk := range p.toolkitRegistry.All() {
-		kind := tk.Kind()
-		src := ConnectionSource{
-			Kind: kind,
-			Name: tk.Name(),
+		entries := connsource.RegistryEntries(
+			tk.Kind(), connview.ConnectionNames(tk), mapping.Platform, mapping.CatalogMapping)
+		for _, src := range entries {
+			m.Add(src)
 		}
-
-		switch kind {
-		case kindTrino:
-			src.DataHubSourceName = p.config.Semantic.URNMapping.Platform
-			if src.DataHubSourceName == "" {
-				src.DataHubSourceName = kindTrino
-			}
-			src.CatalogMapping = p.config.Semantic.URNMapping.CatalogMapping
-		case kindS3:
-			src.DataHubSourceName = kindS3
-		case kindDataHub:
-			src.DataHubSourceName = kindDataHub
-		default:
-			continue
-		}
-
-		m.Add(src)
 	}
 }
 
 // addDBConnections loads connection instances from the database and adds them
-// to the source map, overriding any registry entries with the same key.
+// to the source map, overriding the registry entry for the same connection.
+//
+// A stored row is keyed by the toolkit instance it configures; the map is keyed
+// by the name a call binds. BindingName translates between them, so an
+// operator's stored datahub_source_name reaches the lookup enrichment makes
+// even when the instance carries a connection_name (#1396).
 func (p *Platform) addDBConnections(m *ConnectionSourceMap) {
 	if p.connectionStore == nil {
 		return
@@ -68,12 +67,21 @@ func (p *Platform) addDBConnections(m *ConnectionSourceMap) {
 		return
 	}
 
+	toolkits := p.toolkitRegistry.All()
 	for _, inst := range instances {
-		m.Add(ConnectionSourceFromInstance(inst))
+		src := ConnectionSourceFromInstance(inst)
+		src.Name = connview.BindingName(toolkits, inst.Kind, inst.Name)
+		m.Overlay(src)
 	}
 }
 
 // ConnectionSourceFromInstance builds a ConnectionSource from a DB instance.
+//
+// It reports only what the stored config states: a field the row does not set
+// is left zero rather than filled with a kind default, so Overlay can tell
+// "this connection is mapped to s3" from "this row says nothing". The backfill
+// seeds a config-less row for every file-configured connection, and those rows
+// must not out-rank the file (#1396).
 func ConnectionSourceFromInstance(inst ConnectionInstance) ConnectionSource {
 	src := ConnectionSource{
 		Kind:        inst.Kind,
@@ -81,10 +89,8 @@ func ConnectionSourceFromInstance(inst ConnectionInstance) ConnectionSource {
 		Description: inst.Description,
 	}
 
-	if dsn, ok := inst.Config["datahub_source_name"].(string); ok && dsn != "" {
+	if dsn, ok := inst.Config["datahub_source_name"].(string); ok {
 		src.DataHubSourceName = dsn
-	} else {
-		src.DataHubSourceName = defaultSourceNameForKind(inst.Kind)
 	}
 
 	if cm, ok := inst.Config["catalog_mapping"].(map[string]any); ok {
@@ -97,16 +103,4 @@ func ConnectionSourceFromInstance(inst ConnectionInstance) ConnectionSource {
 	}
 
 	return src
-}
-
-// defaultSourceNameForKind returns the default DataHub source name for a toolkit kind.
-func defaultSourceNameForKind(kind string) string {
-	switch kind {
-	case kindTrino:
-		return kindTrino
-	case kindS3:
-		return kindS3
-	default:
-		return ""
-	}
 }

--- a/pkg/platform/connection_source_test.go
+++ b/pkg/platform/connection_source_test.go
@@ -5,6 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/txn2/mcp-data-platform/internal/platform/connsource"
+	"github.com/txn2/mcp-data-platform/pkg/registry"
+	"github.com/txn2/mcp-data-platform/pkg/toolkit"
 )
 
 func TestConnectionSourceMap_AddAndForConnection(t *testing.T) {
@@ -106,7 +110,10 @@ func TestConnectionSourceFromInstance(t *testing.T) {
 		assert.Equal(t, "hdfs", src.CatalogMapping["hive"])
 	})
 
-	t.Run("without datahub_source_name uses default", func(t *testing.T) {
+	// A row that states no source name reports none, so Overlay can tell it
+	// apart from one that states the kind default and must not out-rank the
+	// file config the registry arm resolved (#1396).
+	t.Run("without datahub_source_name states none", func(t *testing.T) {
 		inst := ConnectionInstance{
 			Kind:   "s3",
 			Name:   "lake",
@@ -114,11 +121,11 @@ func TestConnectionSourceFromInstance(t *testing.T) {
 		}
 
 		src := ConnectionSourceFromInstance(inst)
-		assert.Equal(t, "s3", src.DataHubSourceName)
+		assert.Empty(t, src.DataHubSourceName)
 		assert.Nil(t, src.CatalogMapping)
 	})
 
-	t.Run("empty config uses defaults", func(t *testing.T) {
+	t.Run("empty config states nothing", func(t *testing.T) {
 		inst := ConnectionInstance{
 			Kind:   "trino",
 			Name:   "dev",
@@ -126,15 +133,84 @@ func TestConnectionSourceFromInstance(t *testing.T) {
 		}
 
 		src := ConnectionSourceFromInstance(inst)
-		assert.Equal(t, "trino", src.DataHubSourceName)
+		assert.Empty(t, src.DataHubSourceName)
 	})
 }
 
-func TestDefaultSourceNameForKind(t *testing.T) {
-	assert.Equal(t, "trino", defaultSourceNameForKind("trino"))
-	assert.Equal(t, "s3", defaultSourceNameForKind("s3"))
-	assert.Equal(t, "", defaultSourceNameForKind("unknown"))
-	assert.Equal(t, "", defaultSourceNameForKind(""))
+// TestBuildConnectionSourceMap_BackfillRowKeepsConfiguredMapping is the
+// regression for the second boot of a DB-backed deployment: connbackfill seeds
+// a config-less connection_instances row for every file-configured connection,
+// and reading those rows back must not replace the deployment's urn_mapping
+// with a kind default (#1396).
+func TestBuildConnectionSourceMap_BackfillRowKeepsConfiguredMapping(t *testing.T) {
+	reg := registry.NewRegistry()
+	require.NoError(t, reg.Register(&mockConnectionListerToolkit{
+		mockToolkit: mockToolkit{kind: "trino", name: "warehouse", tools: []string{"trino_query"}},
+		connections: []toolkit.ConnectionDetail{{Name: "warehouse"}, {Name: "staging"}},
+	}))
+
+	p := &Platform{
+		toolkitRegistry: reg,
+		config:          &Config{},
+		connectionStore: &mockConnectionStoreForTest{instances: []ConnectionInstance{
+			// What the backfill writes: a credential-free, config-less row.
+			{Kind: "trino", Name: "warehouse", Config: map[string]any{}},
+			{Kind: "trino", Name: "staging", Config: map[string]any{}},
+		}},
+	}
+	p.config.Semantic.URNMapping = URNMappingConfig{
+		Platform:       "hive",
+		CatalogMapping: map[string]string{"rdbms": "postgres"},
+	}
+	m := p.buildConnectionSourceMap()
+
+	for _, name := range []string{"warehouse", "staging"} {
+		src := m.ForConnection("trino", name)
+		require.NotNil(t, src, "connection %q resolves", name)
+		assert.Equal(t, "hive", src.DataHubSourceName,
+			"a row that states no source name leaves the configured urn_mapping standing")
+		assert.Equal(t, "postgres", src.CatalogMapping["rdbms"])
+	}
+}
+
+// TestBuildConnectionSourceMap_StoredMappingStillWins guards the other
+// direction: a row that does state a mapping overrides the file.
+func TestBuildConnectionSourceMap_StoredMappingStillWins(t *testing.T) {
+	reg := registry.NewRegistry()
+	require.NoError(t, reg.Register(&mockConnectionListerToolkit{
+		mockToolkit: mockToolkit{kind: "trino", name: "warehouse", tools: []string{"trino_query"}},
+		connections: []toolkit.ConnectionDetail{{Name: "warehouse"}},
+	}))
+
+	p := &Platform{
+		toolkitRegistry: reg,
+		config:          &Config{},
+		connectionStore: &mockConnectionStoreForTest{instances: []ConnectionInstance{{
+			Kind: "trino",
+			Name: "warehouse",
+			Config: map[string]any{
+				"datahub_source_name": "postgres",
+				"catalog_mapping":     map[string]any{"rdbms": "warehouse"},
+			},
+		}}},
+	}
+	p.config.Semantic.URNMapping = URNMappingConfig{
+		Platform:       "hive",
+		CatalogMapping: map[string]string{"rdbms": "postgres"},
+	}
+
+	src := p.buildConnectionSourceMap().ForConnection("trino", "warehouse")
+	require.NotNil(t, src)
+	assert.Equal(t, "postgres", src.DataHubSourceName)
+	assert.Equal(t, "warehouse", src.CatalogMapping["rdbms"])
+}
+
+func TestDefaultSourceName(t *testing.T) {
+	assert.Equal(t, "trino", connsource.DefaultSourceName("trino"))
+	assert.Equal(t, "s3", connsource.DefaultSourceName("s3"))
+	assert.Equal(t, "datahub", connsource.DefaultSourceName("datahub"))
+	assert.Equal(t, "", connsource.DefaultSourceName("unknown"))
+	assert.Equal(t, "", connsource.DefaultSourceName(""))
 }
 
 func TestConnectionSourceMap_AddDeduplicates(t *testing.T) {
@@ -154,4 +230,116 @@ func TestConnectionSourceMap_Nil(t *testing.T) {
 	assert.Nil(t, m.ForConnection("trino", "prod"))
 	assert.Nil(t, m.ConnectionsForSource("trino"))
 	assert.Nil(t, m.ConnectionsForURN("urn:li:dataset:(urn:li:dataPlatform:trino,c.s.t,PROD)"))
+}
+
+// TestBuildConnectionSourceMap_KeysByConnectionName is the regression for
+// #1396: a toolkit configured with a connection_name is keyed in the source map
+// by the name a lookup arrives with, not by its instances: key. Every lookup
+// (enrichment's catalog mapping, the URN builder's platform) reads the
+// connection name off PlatformContext, so keying by the instance meant the
+// documented multi-provider shape resolved nothing and silently fell back to
+// the query-provider mapping.
+func TestBuildConnectionSourceMap_KeysByConnectionName(t *testing.T) {
+	reg := registry.NewRegistry()
+	require.NoError(t, reg.Register(&mockToolkit{
+		kind: "datahub", name: "primary", connection: "Primary Catalog", tools: []string{"datahub_browse"},
+	}))
+	require.NoError(t, reg.Register(&mockToolkit{
+		kind: "s3", name: "data_lake", connection: "Data Lake", tools: []string{"s3_list_buckets"},
+	}))
+
+	p := &Platform{toolkitRegistry: reg, config: &Config{}}
+	m := p.buildConnectionSourceMap()
+
+	dh := m.ForConnection("datahub", "Primary Catalog")
+	require.NotNil(t, dh, "the connection resolves under the name a tool call carries")
+	assert.Equal(t, "datahub", dh.DataHubSourceName)
+
+	s3 := m.ForConnection("s3", "Data Lake")
+	require.NotNil(t, s3)
+	assert.Equal(t, "s3", s3.DataHubSourceName)
+
+	assert.Nil(t, m.ForConnection("datahub", "primary"),
+		"the instances: key is not a name any lookup arrives with")
+	assert.Nil(t, m.ForConnection("s3", "data_lake"))
+}
+
+// TestBuildConnectionSourceMap_EveryServedConnection proves a multi-connection
+// toolkit contributes one entry per connection it serves, not a single entry
+// under the toolkit instance: a call naming any of them resolves the mapping.
+func TestBuildConnectionSourceMap_EveryServedConnection(t *testing.T) {
+	reg := registry.NewRegistry()
+	require.NoError(t, reg.Register(&mockConnectionListerToolkit{
+		mockToolkit: mockToolkit{kind: "trino", name: "warehouse", tools: []string{"trino_query"}},
+		connections: []toolkit.ConnectionDetail{{Name: "warehouse"}, {Name: "staging"}},
+	}))
+
+	p := &Platform{toolkitRegistry: reg, config: &Config{}}
+	p.config.Semantic.URNMapping = URNMappingConfig{
+		Platform:       "hive",
+		CatalogMapping: map[string]string{"rdbms": "postgres"},
+	}
+	m := p.buildConnectionSourceMap()
+
+	for _, name := range []string{"warehouse", "staging"} {
+		src := m.ForConnection("trino", name)
+		require.NotNil(t, src, "connection %q resolves", name)
+		assert.Equal(t, "hive", src.DataHubSourceName)
+		assert.Equal(t, "postgres", src.CatalogMapping["rdbms"])
+	}
+}
+
+// TestDatasetURNFor_UsesConnectionMapping is the end-to-end assertion behind
+// #1396: the map built from the live registry is read by the platform's one
+// answer to "which catalog entity is this table", keyed by the connection name
+// the middleware puts on PlatformContext. Before the fix the lookup missed and
+// the URN carried the query-provider fallback instead of the connection's own
+// platform and catalog mapping.
+func TestDatasetURNFor_UsesConnectionMapping(t *testing.T) {
+	reg := registry.NewRegistry()
+	require.NoError(t, reg.Register(&mockToolkit{
+		kind: "s3", name: "lake", connection: "Data Lake", tools: []string{"s3_list_buckets"},
+	}))
+
+	p := &Platform{toolkitRegistry: reg, config: &Config{}}
+	p.config.Query.URNMapping = URNMappingConfig{Platform: "fallback-platform"}
+	p.connectionSources = p.buildConnectionSourceMap()
+
+	urn := p.datasetURNFor("s3", "Data Lake", "bucket", "raw", "events")
+	assert.Contains(t, urn, "urn:li:dataPlatform:s3",
+		"the connection's own source name builds the URN")
+	assert.NotContains(t, urn, "fallback-platform")
+
+	assert.Contains(t, p.datasetURNFor("s3", "unknown", "bucket", "raw", "events"), "fallback-platform",
+		"an unknown connection still falls back, so the fix narrows nothing")
+}
+
+// TestBuildConnectionSourceMap_StoredOverrideReachesTheBoundName proves the DB
+// arm files its entry under the same name the registry arm does. A stored row
+// is keyed by the toolkit instance it configures; a call binds the connection
+// name. Filing the override under the instance left it unreachable by every
+// lookup while the registry default answered in its place (#1396).
+func TestBuildConnectionSourceMap_StoredOverrideReachesTheBoundName(t *testing.T) {
+	reg := registry.NewRegistry()
+	require.NoError(t, reg.Register(&mockToolkit{
+		kind: "s3", name: "data_lake", connection: "Data Lake", tools: []string{"s3_list_buckets"},
+	}))
+
+	p := &Platform{
+		toolkitRegistry: reg,
+		config:          &Config{},
+		connectionStore: &mockConnectionStoreForTest{instances: []ConnectionInstance{{
+			Kind:   "s3",
+			Name:   "data_lake",
+			Config: map[string]any{"datahub_source_name": "minio"},
+		}}},
+	}
+	m := p.buildConnectionSourceMap()
+
+	src := m.ForConnection("s3", "Data Lake")
+	require.NotNil(t, src, "the stored connection resolves under the name a call binds")
+	assert.Equal(t, "minio", src.DataHubSourceName,
+		"the operator's stored source name overrides the kind default")
+	assert.Nil(t, m.ForConnection("s3", "data_lake"),
+		"the instance key is not a second entry for the same connection")
 }

--- a/pkg/toolkits/trino/toolkit.go
+++ b/pkg/toolkits/trino/toolkit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/txn2/mcp-trino/pkg/multiserver"
 	trinotools "github.com/txn2/mcp-trino/pkg/tools"
 
+	"github.com/txn2/mcp-data-platform/internal/logsan"
 	"github.com/txn2/mcp-data-platform/pkg/query"
 	"github.com/txn2/mcp-data-platform/pkg/semantic"
 	"github.com/txn2/mcp-data-platform/pkg/toolkit"
@@ -248,10 +249,15 @@ func warnInertConnectionName(instance, connectionName string) {
 	if connectionName == "" || connectionName == instance {
 		return
 	}
+	// Both values come from deployment configuration, which an admin API write
+	// can reach, so they are stripped of control characters before they reach a
+	// log field or the sentence built from them.
+	safeInstance := logsan.SanitizeForLog(instance)
+	safeName := logsan.SanitizeForLog(connectionName)
 	slog.Warn("trino connection_name has no effect; the connection is named by its instance",
-		"instance", instance,
-		"connection_name", connectionName,
-		"remedy", "list "+instance+" wherever "+connectionName+" is named, including persona connections rules",
+		"instance", safeInstance,
+		"connection_name", safeName,
+		"remedy", "list "+safeInstance+" wherever "+safeName+" is named, including persona connections rules",
 	)
 }
 

--- a/pkg/toolkits/trino/toolkit.go
+++ b/pkg/toolkits/trino/toolkit.go
@@ -4,6 +4,7 @@ package trino
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -56,18 +57,21 @@ const (
 
 // Config holds Trino toolkit configuration.
 type Config struct {
-	Host           string                      `yaml:"host"`
-	Port           int                         `yaml:"port"`
-	User           string                      `yaml:"user"`
-	Password       string                      `yaml:"password"` // #nosec G117 -- Trino credential from admin YAML config
-	Catalog        string                      `yaml:"catalog"`
-	Schema         string                      `yaml:"schema"`
-	SSL            bool                        `yaml:"ssl"`
-	SSLVerify      bool                        `yaml:"ssl_verify"`
-	Timeout        time.Duration               `yaml:"timeout"`
-	DefaultLimit   int                         `yaml:"default_limit"`
-	MaxLimit       int                         `yaml:"max_limit"`
-	ReadOnly       bool                        `yaml:"read_only"`
+	Host         string        `yaml:"host"`
+	Port         int           `yaml:"port"`
+	User         string        `yaml:"user"`
+	Password     string        `yaml:"password"` // #nosec G117 -- Trino credential from admin YAML config
+	Catalog      string        `yaml:"catalog"`
+	Schema       string        `yaml:"schema"`
+	SSL          bool          `yaml:"ssl"`
+	SSLVerify    bool          `yaml:"ssl_verify"`
+	Timeout      time.Duration `yaml:"timeout"`
+	DefaultLimit int           `yaml:"default_limit"`
+	MaxLimit     int           `yaml:"max_limit"`
+	ReadOnly     bool          `yaml:"read_only"`
+	// ConnectionName is accepted for compatibility and has no effect. The
+	// platform identifies a Trino connection by its instance name, which is
+	// what the manager routes on and what Connection() reports (#1396).
 	ConnectionName string                      `yaml:"connection_name"`
 	Description    string                      `yaml:"description"` // Human-readable description of this connection's purpose
 	Titles         map[string]string           `yaml:"titles"`
@@ -143,6 +147,7 @@ func New(name string, cfg Config) (*Toolkit, error) {
 		return nil, err
 	}
 
+	warnInertConnectionName(name, cfg.ConnectionName)
 	cfg = applyDefaults(name, cfg)
 
 	client, err := createClient(cfg)
@@ -199,6 +204,7 @@ func NewMulti(cfg MultiConfig) (*Toolkit, error) {
 		if err := validateConfig(instCfg); err != nil {
 			return nil, fmt.Errorf("instance %s: %w", name, err)
 		}
+		warnInertConnectionName(name, instCfg.ConnectionName)
 	}
 
 	// Build multiserver config from instance configs.
@@ -230,6 +236,23 @@ func NewMulti(cfg MultiConfig) (*Toolkit, error) {
 	}, opts...)
 
 	return t, nil
+}
+
+// warnInertConnectionName reports a connection_name the platform cannot honor.
+//
+// Connections are deny-by-default, so a persona whose connections.allow lists a
+// Trino instance's connection_name reaches nothing: the name a call binds is the
+// instance name (#1396). Dropping the key silently turns that into a refusal
+// with no stated cause, so it is named here with the value to list instead.
+func warnInertConnectionName(instance, connectionName string) {
+	if connectionName == "" || connectionName == instance {
+		return
+	}
+	slog.Warn("trino connection_name has no effect; the connection is named by its instance",
+		"instance", instance,
+		"connection_name", connectionName,
+		"remedy", "list "+instance+" wherever "+connectionName+" is named, including persona connections rules",
+	)
 }
 
 // buildConnectionRequired creates a ConnectionRequiredMiddleware when multiple
@@ -474,9 +497,18 @@ func (t *Toolkit) Name() string {
 	return t.name
 }
 
-// Connection returns the connection name for audit logging.
+// Connection returns the name a tool call binds when it names none: the
+// identity audit records it under, a persona's connection rules match, and the
+// connection source map is keyed by.
+//
+// That name is the instance name in both modes. The multi-connection manager
+// routes by instance, and this toolkit reports its connections by instance
+// through ListConnections, so config.ConnectionName is a label nothing else in
+// the platform can reach: returning it named a connection no persona rule could
+// match, no `connection` argument could carry, and no source-map lookup could
+// resolve (#1396).
 func (t *Toolkit) Connection() string {
-	return t.config.ConnectionName
+	return t.name
 }
 
 // RegisterTools registers Trino tools with the MCP server.
@@ -529,7 +561,8 @@ func (t *Toolkit) SetQueryProvider(provider query.Provider) {
 // Implements toolkit.ConnectionLister.
 func (t *Toolkit) ListConnections() []toolkit.ConnectionDetail {
 	if t.manager == nil {
-		// Single-client mode: one connection.
+		// Single-client mode: one connection, advertised under the name a call
+		// binds it by, which is what Connection() reports.
 		return []toolkit.ConnectionDetail{{
 			Name:        t.name,
 			Description: t.config.Description,
@@ -558,6 +591,8 @@ func (t *Toolkit) AddConnection(name string, config map[string]any) error {
 	if t.manager == nil {
 		return errors.New("dynamic connections require multi-connection mode")
 	}
+
+	warnInertConnectionName(name, getString(config, "connection_name"))
 
 	conn := multiserver.ConnectionConfig{
 		Host:     getString(config, "host"),

--- a/pkg/toolkits/trino/toolkit_test.go
+++ b/pkg/toolkits/trino/toolkit_test.go
@@ -1,7 +1,10 @@
 package trino
 
 import (
+	"bytes"
+	"log/slog"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -293,8 +296,11 @@ func TestToolkit_KindAndName(t *testing.T) {
 	if tk.Name() != "test-toolkit" {
 		t.Errorf("Name() = %q", tk.Name())
 	}
-	if tk.Connection() != trinoTestConnectionName {
-		t.Errorf("Connection() = %q, want 'test'", tk.Connection())
+	// A Trino connection is named by its instance whatever connection_name the
+	// config carries: that is the name the manager routes on, ListConnections
+	// advertises, and a persona rule matches (#1396).
+	if tk.Connection() != "test-toolkit" {
+		t.Errorf("Connection() = %q, want 'test-toolkit'", tk.Connection())
 	}
 }
 
@@ -986,4 +992,85 @@ func TestBuildToolkitOptions(t *testing.T) {
 			t.Errorf("expected %d options, got %d", baseline+8, len(opts))
 		}
 	})
+}
+
+// TestConnectionIsAdvertised holds the invariant #1396 restored: the name an
+// unqualified call binds is one of the names the toolkit advertises. Multi
+// mode routes by instance key, so a config connection_name the router never
+// sees cannot be the answer — returning it named a connection no persona rule
+// could match, no source-map lookup could resolve, and list_connections never
+// showed.
+func TestConnectionIsAdvertised(t *testing.T) {
+	t.Run("multi mode binds the routed default instance", func(t *testing.T) {
+		tk, err := NewMulti(MultiConfig{
+			DefaultConnection: trinoTestWarehouse,
+			Instances: map[string]Config{
+				"warehouse": {
+					Host: "wh.example.com", User: "trino", Port: trinoTestPort443, SSL: true,
+					ConnectionName: "Data Warehouse",
+				},
+				"staging": {Host: "st.example.com", User: "trino", Port: trinoTestPort443, SSL: true},
+			},
+		})
+		if err != nil {
+			t.Fatalf("NewMulti error: %v", err)
+		}
+		if got := tk.Connection(); got != trinoTestWarehouse {
+			t.Errorf("Connection() = %q, want %q", got, trinoTestWarehouse)
+		}
+		assertAdvertised(t, tk)
+	})
+
+	t.Run("single mode binds its instance, and connection_name does not move it", func(t *testing.T) {
+		tk := &Toolkit{name: "prod", config: Config{ConnectionName: "Production"}}
+		if got := tk.Connection(); got != "prod" {
+			t.Errorf("Connection() = %q, want 'prod'", got)
+		}
+		assertAdvertised(t, tk)
+	})
+
+	t.Run("single mode with no connection name", func(t *testing.T) {
+		tk := &Toolkit{name: "prod"}
+		if got := tk.Connection(); got != "prod" {
+			t.Errorf("Connection() = %q, want 'prod'", got)
+		}
+		assertAdvertised(t, tk)
+	})
+}
+
+// TestWarnInertConnectionName covers the diagnosis path for a connection_name
+// the platform cannot honor: it fires only when the config carries a name that
+// differs from the instance a call actually binds.
+func TestWarnInertConnectionName(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	warnInertConnectionName("prod", "")
+	warnInertConnectionName("prod", "prod")
+	if buf.Len() != 0 {
+		t.Errorf("expected no warning for an absent or matching name, got %q", buf.String())
+	}
+
+	warnInertConnectionName("prod", "Production")
+	out := buf.String()
+	for _, want := range []string{"prod", "Production", "remedy"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("warning %q missing %q", out, want)
+		}
+	}
+}
+
+// assertAdvertised fails unless Connection() names one of the connections
+// ListConnections advertises.
+func assertAdvertised(t *testing.T, tk *Toolkit) {
+	t.Helper()
+	conn := tk.Connection()
+	for _, c := range tk.ListConnections() {
+		if c.Name == conn {
+			return
+		}
+	}
+	t.Errorf("Connection() = %q is advertised by no entry of ListConnections()", conn)
 }

--- a/test/e2e/helpers/platform.go
+++ b/test/e2e/helpers/platform.go
@@ -86,12 +86,11 @@ func buildPlatformConfig(e2eCfg *E2EConfig) *platform.Config {
 				"enabled": true,
 				"instances": map[string]any{
 					"e2e": map[string]any{
-						"host":            e2eCfg.TrinoHost,
-						"port":            e2eCfg.TrinoPort,
-						"user":            "e2e-test",
-						"catalog":         "memory",
-						"schema":          "e2e_test",
-						"connection_name": "e2e-trino",
+						"host":    e2eCfg.TrinoHost,
+						"port":    e2eCfg.TrinoPort,
+						"user":    "e2e-test",
+						"catalog": "memory",
+						"schema":  "e2e_test",
 					},
 				},
 			},

--- a/test/load/config/platform.load-ci.yaml
+++ b/test/load/config/platform.load-ci.yaml
@@ -80,7 +80,6 @@ toolkits:
         user: "load-test"
         catalog: "memory"
         schema: "e2e_test"
-        connection_name: "e2e-trino"
     config:
       default_limit: 1000
       max_limit: 10000

--- a/test/load/config/platform.load.yaml
+++ b/test/load/config/platform.load.yaml
@@ -100,7 +100,6 @@ toolkits:
         user: "load-test"
         catalog: "memory"
         schema: "e2e_test"
-        connection_name: "e2e-trino"
     config:
       default_limit: 1000
       max_limit: 10000

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -401,6 +401,7 @@ pkg/admin -> internal/admin/settingsapi
 pkg/admin -> internal/httpjson
 pkg/admin -> internal/logsan
 pkg/admin -> internal/platform/callrecord
+pkg/admin -> internal/platform/connsource
 pkg/admin -> internal/platform/reviewalert
 pkg/admin -> internal/server
 pkg/admin -> pkg/audit
@@ -411,6 +412,7 @@ pkg/admin -> pkg/browsersession
 pkg/admin -> pkg/configstore
 pkg/admin -> pkg/connoauth
 pkg/admin -> pkg/connreconcile
+pkg/admin -> pkg/connview
 pkg/admin -> pkg/embedding
 pkg/admin -> pkg/indexjobs
 pkg/admin -> pkg/middleware

--- a/testdata/allowed_internal_imports.txt
+++ b/testdata/allowed_internal_imports.txt
@@ -732,6 +732,7 @@ pkg/toolkits/search -> pkg/query
 pkg/toolkits/search -> pkg/semantic
 pkg/toolkits/search -> pkg/toolkit
 pkg/toolkits/tools/toolsindex -> pkg/indexjobs
+pkg/toolkits/trino -> internal/logsan
 pkg/toolkits/trino -> internal/sqltables
 pkg/toolkits/trino -> pkg/mcpcontext
 pkg/toolkits/trino -> pkg/query


### PR DESCRIPTION
A connection is keyed in the connection source map by the name a call binds it by, so a configured `connection_name` resolves its DataHub source and catalog mapping instead of falling back to the query-provider defaults.

## The defect

`addRegistryConnections` populated the map under each toolkit's `instances:` key. Every lookup asks by the connection name that `GetToolkitForTool` puts on `PlatformContext`, which is `Toolkit.Connection()`. For an instance that sets `connection_name` those are different strings, so `ForConnection` missed and the caller used the query-provider mapping instead of the connection's own.

That is the shape `docs/server/multi-provider.md` documents, and the shape the repository's own bench and load configs used.

Registry entries are now keyed by `connview.ConnectionNames`, the single enumeration of the names a call can bind. A multi-instance Trino consequently gets one entry per connection rather than a single entry under its default instance, which closes a second miss on the same lookup.

## Trino's connection identity

The multiserver manager routes by instance name and `ListConnections` reports instance names, but `Toolkit.Connection()` returned `config.ConnectionName`. That value named a connection no persona rule could match, no `connection` argument could carry, and `list_connections` never advertised. It is now the instance name in both toolkit modes, and each of the three construction paths (`NewMulti`, `New`, `AddConnection`) warns when an instance carries a `connection_name`, naming the value to use in its place.

`toolkitcfg.TrinoConfig` returns the resolved instance name rather than the raw `connection_name`. The query provider stamps that field onto every `TableAvailability` and `TableIdentifier` as the name an agent is told to pass as `connection`, where it was previously unroutable when the key was set and empty when it was not — `S3Config` already defaulted to the instance name; `TrinoConfig` did not.

## Stored connections overlay the configured entry

`connbackfill` seeds a credential-free, config-less `connection_instances` row for every file-configured connection so that `mcp:connection:(kind,name)` references resolve. `addDBConnections` read those rows back and replaced the registry entry outright, so a deployment with `semantic.urn_mapping.platform: hive` and a catalog mapping resolved `hive` on its first boot and `trino` with no mapping on every boot after.

`Map.Overlay` applies only the fields a stored row states, over the entry the running configuration derives. `ConnectionSourceFromInstance` no longer fills a kind default, so "this row says nothing" is distinguishable from "this row says s3".

The admin add path seeds the configured entry before overlaying. Without that, a connection added at runtime carried the literal kind default instead of the deployment's `urn_mapping`, and a field an operator cleared kept answering with the value they deleted until the next restart. The delete path seeds the same entry after removing the stored one, so a connection its toolkit still serves is not left unmapped.

## Concurrency

One `connsource.Map` is shared for the life of the process: tool-call goroutines read it on every enrichment and URN build, while the admin connection routes add, overlay and remove from HTTP goroutines. It held two plain Go maps with no lock. Concurrent read and write of a Go map is a fatal runtime error rather than a recoverable one, so an admin connection write concurrent with any tool call could take the process down.

Every accessor now takes an `RWMutex`, and the readers that answer with a slice answer with their own copy so a caller iterating a result cannot race an append. `TestMapConcurrentAccess` covers it; removing the locks makes it report races.

## One derivation

`connsource.RegistryEntries` is the only place that answers "what does the running configuration say about this connection". The startup build and the admin restore path both call it, replacing two hand-written derivations that had drifted apart.

`connview.BindingName` is the only translation from a stored instance name to the name a call binds, used by the startup DB arm and by both admin mutation paths.

## Names that did not change

`connview.Entry.Name` and the `mcp:connection:(kind,name)` reference stay on the instance name. The reference is a foreign key to the `connection_instances` row the backfill seeds, and that row's name is the key `toolkitcfg.MergeInstance` merges a stored connection back into toolkit config under. Filing them under the connection name would have created a phantom empty instance on the next boot. `internal/platform/connreach` already relies on this split: `Name` is the configuration identity, `Connection` is the bound name.

## Upgrade note

A deployment that set `connection_name` on a Trino instance and listed that name in a persona's `connections.allow` must list the `instances:` key there instead. Connections are deny-by-default, so the old value now matches nothing. Before this change the same persona could not authorize a call that named the connection explicitly, because the `connection` argument only ever carried the instance name. The server logs a warning at startup naming the instance and the value to use.

`connection_name` on a DataHub or S3 instance is unaffected and continues to name the connection.

## Documentation

`docs/server/multi-provider.md` gains a Connection Names section stating which of an instance's two names each caller uses, and its Listing Available Connections section now describes the unified `list_connections` with a response matching `connview.Entry`; it previously documented `trino_list_connections`, `datahub_list_connections` and `s3_list_connections`, none of which the platform registers, with fields that do not exist.

`docs/server/configuration.md` describes what `connection_name` governs per kind, `docs/personas/overview.md` states which name a `connections.allow` pattern matches, and `docs/llms-full.txt` carries the same.

The four bench arm configs and the three e2e and load harness configs drop a Trino `connection_name` that no longer has an effect.

## Verification

`make verify` passes: 154/154 executable changed lines covered (threshold 80), race detector green on every touched package, gosec, govulncheck, semgrep, CodeQL and the GoReleaser dry-run clean, `mkdocs build --strict` clean.

Two new import edges are ratcheted in `testdata/allowed_internal_imports.txt`: `pkg/admin -> pkg/connview` and `pkg/admin -> internal/platform/connsource`. Both exist because the admin mutation paths call the shared derivations rather than repeating them.

Closes #1396
